### PR TITLE
libraw: add version 0.21.1, support conan v2

### DIFF
--- a/recipes/libraw/all/CMakeLists.txt
+++ b/recipes/libraw/all/CMakeLists.txt
@@ -1,20 +1,24 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
+project(LibRaw LANGUAGES CXX)
 
-project(LibRaw)
+file(GLOB_RECURSE headers "${LIBRAW_SRC_DIR}/libraw/*.h")
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
-file(GLOB_RECURSE headers "source_subfolder/libraw/*.h")
+if(RAW_LIB_VERSION_STRING VERSION_LESS 0.21)
+    set(libraw_LIB_SRCS ${LIBRAW_SRC_DIR}/internal/dcraw_common.cpp
+                        ${LIBRAW_SRC_DIR}/internal/dcraw_fileio.cpp
+                        ${LIBRAW_SRC_DIR}/internal/demosaic_packs.cpp
+                        ${LIBRAW_SRC_DIR}/src/libraw_cxx.cpp
+                        ${LIBRAW_SRC_DIR}/src/libraw_c_api.cpp
+                        ${LIBRAW_SRC_DIR}/src/libraw_datastream.cpp
+    )
+else()
+    file(GLOB_RECURSE libraw_LIB_SRCS CONFIGURE_DEPENDS "${LIBRAW_SRC_DIR}/src/*.cpp")
 
-set(sources
-    "source_subfolder/src/libraw_c_api.cpp"
-    "source_subfolder/src/libraw_cxx.cpp"
-    "source_subfolder/src/libraw_datastream.cpp"
-    "source_subfolder/internal/dcraw_common.cpp"
-    "source_subfolder/internal/dcraw_fileio.cpp"
-    "source_subfolder/internal/demosaic_packs.cpp"
-)
+    # Exclude placeholder (stub) implementations
+    file(GLOB_RECURSE exclude_libraw_LIB_SRCS CONFIGURE_DEPENDS "${LIBRAW_SRC_DIR}/src/*_ph.cpp")
+    list(REMOVE_ITEM libraw_LIB_SRCS ${exclude_libraw_LIB_SRCS})
+endif()
 
 if(WIN32)
     add_definitions(-DWIN32)
@@ -26,32 +30,41 @@ if(WIN32)
     endif()
 endif()
 
-if (TARGET CONAN_PKG::libjpeg OR TARGET CONAN_PKG::libjpeg-turbo)
+find_package(JPEG CONFIG)
+find_package(libjpeg-turbo CONFIG)
+find_package(lcms CONFIG)
+find_package(Jasper CONFIG)
+
+if (TARGET JPEG::JPEG OR TARGET libjpeg-turbo::jpeg OR TARGET libjpeg-turbo::jpeg_static)
     add_definitions(-DUSE_JPEG -DUSE_JPEG8)
 endif ()
-if (TARGET CONAN_PKG::lcms)
+if (TARGET lcms::lcms)
     add_definitions(-DUSE_LCMS2)
 endif ()
-if (TARGET CONAN_PKG::jasper)
+if (TARGET Jasper::Jasper)
     add_definitions(-DUSE_JASPER)
 endif ()
 
-add_library(raw ${headers} ${sources})
-set_property(TARGET raw PROPERTY CXX_STANDARD 11)
-target_include_directories(raw PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/")
+add_library(raw ${headers} ${libraw_LIB_SRCS})
+target_compile_features(raw PRIVATE cxx_std_11)
+target_include_directories(raw PUBLIC "${LIBRAW_SRC_DIR}")
+set_target_properties(raw PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_options(raw PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/W0>)
-if (TARGET CONAN_PKG::libjpeg)
-    target_link_libraries(raw PUBLIC CONAN_PKG::libjpeg)
+if (TARGET JPEG::JPEG)
+    target_link_libraries(raw PUBLIC JPEG::JPEG)
 endif ()
-if (TARGET CONAN_PKG::libjpeg-turbo)
-    target_link_libraries(raw PUBLIC CONAN_PKG::libjpeg-turbo)
+if (TARGET libjpeg-turbo::jpeg)
+    target_link_libraries(raw PUBLIC libjpeg-turbo::jpeg)
 endif ()
-if (TARGET CONAN_PKG::lcms)
-    target_link_libraries(raw PUBLIC CONAN_PKG::lcms)
+if (TARGET libjpeg-turbo::jpeg_static)
+    target_link_libraries(raw PUBLIC libjpeg-turbo::jpeg_static)
 endif ()
-if (TARGET CONAN_PKG::jasper)
-    target_link_libraries(raw PUBLIC CONAN_PKG::jasper)
+if (TARGET lcms::lcms)
+    target_link_libraries(raw PUBLIC lcms::lcms)
+endif ()
+if (TARGET Jasper::Jasper)
+    target_link_libraries(raw PUBLIC Jasper::Jasper)
 endif ()
 
-install(DIRECTORY "source_subfolder/libraw" DESTINATION include)
+install(DIRECTORY "${LIBRAW_SRC_DIR}/libraw" DESTINATION include)
 install(TARGETS raw ARCHIVE DESTINATION lib RUNTIME DESTINATION bin LIBRARY DESTINATION lib)

--- a/recipes/libraw/all/conandata.yml
+++ b/recipes/libraw/all/conandata.yml
@@ -1,10 +1,13 @@
 sources:
-  "0.19.5":
-    url: "https://github.com/LibRaw/LibRaw/archive/0.19.5.tar.gz"
-    sha256: "9a2a40418e4fb0ab908f6d384ff6f9075f4431f8e3d79a0e44e5a6ea9e75abdc"
-  "0.20.0":
-    url: "https://github.com/LibRaw/LibRaw/archive/0.20.0.tar.gz"
-    sha256: "f38cd2620d5adc32d2c9f51cd0dc66d72c75671f1c81dfd13d30c45c6be80d40"
+  "0.21.0":
+    url: "https://github.com/LibRaw/LibRaw/archive/0.21.0.tar.gz"
+    sha256: "686899632de347e01ef27b9a4d186b800384968f2d2fd7e7c2ab182fab1ea9d0"
   "0.20.2":
     url: "https://github.com/LibRaw/LibRaw/archive/0.20.2.tar.gz"
     sha256: "02df7d403b34602b769bb38e5bf7d4258e075eeefbe980b6832e6e1491989d60"
+  "0.20.0":
+    url: "https://github.com/LibRaw/LibRaw/archive/0.20.0.tar.gz"
+    sha256: "f38cd2620d5adc32d2c9f51cd0dc66d72c75671f1c81dfd13d30c45c6be80d40"
+  "0.19.5":
+    url: "https://github.com/LibRaw/LibRaw/archive/0.19.5.tar.gz"
+    sha256: "9a2a40418e4fb0ab908f6d384ff6f9075f4431f8e3d79a0e44e5a6ea9e75abdc"

--- a/recipes/libraw/all/conandata.yml
+++ b/recipes/libraw/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.21.0":
-    url: "https://github.com/LibRaw/LibRaw/archive/0.21.0.tar.gz"
-    sha256: "686899632de347e01ef27b9a4d186b800384968f2d2fd7e7c2ab182fab1ea9d0"
+  "0.21.1":
+    url: "https://github.com/LibRaw/LibRaw/archive/0.21.1.tar.gz"
+    sha256: "b63d7ffa43463f74afcc02f9083048c231349b41cc9255dec0840cf8a67b52e0"
   "0.20.2":
     url: "https://github.com/LibRaw/LibRaw/archive/0.20.2.tar.gz"
     sha256: "02df7d403b34602b769bb38e5bf7d4258e075eeefbe980b6832e6e1491989d60"

--- a/recipes/libraw/all/conanfile.py
+++ b/recipes/libraw/all/conanfile.py
@@ -1,17 +1,19 @@
-from conans import ConanFile, tools, CMake
+from conan import ConanFile
+from conan.tools.files import get, copy, collect_libs
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
+
+required_conan_version = ">=1.53.0"
 
 class LibRawConan(ConanFile):
     name = "libraw"
     description = "LibRaw is a library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)."
-    topics = ["image", "photography", "raw"]
+    license = "CDDL-1.0/LGPL-2.1-only"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.libraw.org/"
-    license = "CDDL-1.0/LGPL-2.1-only"
-    exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
+    topics = ["image", "photography", "raw"]
     settings = "os", "arch", "compiler", "build_type"
-
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -26,12 +28,11 @@ class LibRawConan(ConanFile):
         "with_lcms": True,
         "with_jasper": True
     }
-
-    _cmake = None
+    exports_sources = ["CMakeLists.txt"]
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 11
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -39,48 +40,52 @@ class LibRawConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         # TODO: RawSpeed dependency (-DUSE_RAWSPEED)
         # TODO: DNG SDK dependency (-DUSE_DNGSDK)
         if self.options.with_jpeg == "libjpeg":
-            self.requires("libjpeg/9d")
+            self.requires("libjpeg/9e")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.1.1")
+            self.requires("libjpeg-turbo/2.1.4")
         if self.options.with_lcms:
-            self.requires("lcms/2.12")
+            self.requires("lcms/2.14")
         if self.options.with_jasper:
-            self.requires("jasper/2.0.33")
+            self.requires("jasper/4.0.0")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("LibRaw-" + self.version, self._source_subfolder)
+       get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["RAW_LIB_VERSION_STRING"] = self.version
+        tc.variables["LIBRAW_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.generate()
 
-        self._cmake = CMake(self)
-        self._cmake.configure()
-        return self._cmake
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()
 
     def package(self):
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE*", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, pattern="COPYRIGHT", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
         
-        self.copy("LICENSE.*", src=self._source_subfolder, dst="licenses")
-
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = collect_libs(self)
 
         if self.settings.os == "Windows":
             self.cpp_info.defines.append("WIN32")

--- a/recipes/libraw/all/conanfile.py
+++ b/recipes/libraw/all/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.53.0"
 class LibRawConan(ConanFile):
     name = "libraw"
     description = "LibRaw is a library for reading RAW files obtained from digital photo cameras (CRW/CR2, NEF, RAF, DNG, and others)."
-    license = "CDDL-1.0/LGPL-2.1-only"
+    license = "CDDL-1.0", "LGPL-2.1-only"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.libraw.org/"
     topics = ["image", "photography", "raw"]

--- a/recipes/libraw/all/conanfile.py
+++ b/recipes/libraw/all/conanfile.py
@@ -83,12 +83,13 @@ class LibRawConan(ConanFile):
         copy(self, pattern="COPYRIGHT", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
-        
+
     def package_info(self):
         self.cpp_info.libs = collect_libs(self)
 
         if self.settings.os == "Windows":
             self.cpp_info.defines.append("WIN32")
+            self.cpp_info.system_libs.append("ws2_32")
 
         if not self.options.shared:
             self.cpp_info.defines.append("LIBRAW_NODLL")

--- a/recipes/libraw/all/test_package/CMakeLists.txt
+++ b/recipes/libraw/all/test_package/CMakeLists.txt
@@ -1,9 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(libraw REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE libraw::libraw)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/libraw/all/test_package/conanfile.py
+++ b/recipes/libraw/all/test_package/conanfile.py
@@ -1,9 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
+
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -11,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libraw/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libraw/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/libraw/all/test_v1_package/conanfile.py
+++ b/recipes/libraw/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libraw/config.yml
+++ b/recipes/libraw/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.21.0":
+  "0.21.1":
     folder: all
   "0.20.2":
     folder: all

--- a/recipes/libraw/config.yml
+++ b/recipes/libraw/config.yml
@@ -1,7 +1,9 @@
 versions:
-  "0.19.5":
+  "0.21.0":
+    folder: all
+  "0.20.2":
     folder: all
   "0.20.0":
     folder: all
-  "0.20.2":
+  "0.19.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libraw/***

- add version 0.21.1
- support conan v2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
