### PR TITLE
libxlsxwriter: add version 1.1.5, use rm_safe

### DIFF
--- a/recipes/libxlsxwriter/all/conandata.yml
+++ b/recipes/libxlsxwriter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.5":
+    url: "https://github.com/jmcnamara/libxlsxwriter/archive/RELEASE_1.1.5.tar.gz"
+    sha256: "12843587d591cf679e6ec63ecc629245befec2951736804a837696cdb5d61946"
   "1.1.4":
     url: "https://github.com/jmcnamara/libxlsxwriter/archive/RELEASE_1.1.4.tar.gz"
     sha256: "b379eb35fdd9c653ebe72485b9c992f612c7ea66f732784457997d6e782f619b"
@@ -9,6 +12,11 @@ sources:
     url: "https://github.com/jmcnamara/libxlsxwriter/archive/RELEASE_1.0.0.tar.gz"
     sha256: "8b353379333c323d14a9d265cd2491d3a6c0032c8d6ec2141f10b82ab66a087c"
 patches:
+  "1.1.5":
+    - patch_file: "patches/1.1.5-0001-fix-cmake.patch"
+      patch_description: "Fix CMake: robust dependencies discovery & avoid some hardcoded flags"
+      patch_type: "conan"
+      sha256: "54bf92c1f9423d9c7b3820122ff806679e254392d66ae72696f58e7d36e4b16f"
   "1.1.4":
     - patch_file: "patches/1.1.3-0001-fix-cmake.patch"
       patch_description: "Fix CMake: robust dependencies discovery & avoid some hardcoded flags"

--- a/recipes/libxlsxwriter/all/conanfile.py
+++ b/recipes/libxlsxwriter/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class LibxlsxwriterConan(ConanFile):
@@ -46,18 +46,9 @@ class LibxlsxwriterConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/libxlsxwriter/all/patches/1.1.5-0001-fix-cmake.patch
+++ b/recipes/libxlsxwriter/all/patches/1.1.5-0001-fix-cmake.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e656184..b9002e7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -178,9 +178,8 @@ endif()
+ 
+ if(NOT BUILD_SHARED_LIBS)
+     if(UNIX)
+-        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+     elseif(MINGW OR MSYS)
+-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static -static-libgcc -Wno-char-subscripts -Wno-long-long")
++        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-char-subscripts -Wno-long-long")
+         list(APPEND LXW_PRIVATE_COMPILE_DEFINITIONS USE_FILE32API)
+     elseif(MSVC)
+         set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /Fd\"${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pdb\"")
+@@ -219,13 +218,13 @@ enable_language(CXX)
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ 
+ # ZLIB
+-find_package(ZLIB REQUIRED "1.0")
++find_package(ZLIB REQUIRED CONFIG)
+ list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS})
+ message("zlib version: " ${ZLIB_VERSION})
+ 
+ # MINIZIP
+ if (USE_SYSTEM_MINIZIP)
+-    find_package(MINIZIP REQUIRED "1.0")
++    find_package(MINIZIP REQUIRED CONFIG)
+     list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${MINIZIP_INCLUDE_DIRS})
+ endif()
+ 
+@@ -281,7 +280,10 @@ target_sources(${PROJECT_NAME}
+     PRIVATE ${LXW_SOURCES}
+     PUBLIC ${LXW_HEADERS}
+ )
+-target_link_libraries(${PROJECT_NAME} LINK_PUBLIC ${ZLIB_LIBRARIES} ${MINIZIP_LIBRARIES} ${LIB_CRYPTO} ${OPENSSL_CRYPTO_LIBRARY})
++target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB minizip::minizip)
++if(USE_OPENSSL_MD5)
++    target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::Crypto)
++endif()
+ target_compile_definitions(${PROJECT_NAME} PRIVATE ${LXW_PRIVATE_COMPILE_DEFINITIONS})
+ 
+ # /utf-8 needs VS2015 Update 2 or above.

--- a/recipes/libxlsxwriter/config.yml
+++ b/recipes/libxlsxwriter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.5":
+    folder: "all"
   "1.1.4":
     folder: "all"
   "1.1.3":


### PR DESCRIPTION
Specify library name and version:  **libxlsxwriter/***

- add version 1.1.5
- use `rm_safe`
- update minimum conan version to 1.53.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
