### PR TITLE
drogon: update boost, trivial improvement

### DIFF
--- a/recipes/drogon/all/test_package/CMakeLists.txt
+++ b/recipes/drogon/all/test_package/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)
 
 # drogon uses string_view when MSVC_VERSION is greater than 1900.
 # https://github.com/drogonframework/drogon/blob/v1.7.5/lib/inc/drogon/utils/string_view.h#L16
-if(DEFINED MSVC_VERSION AND MSVC_VERSION GREATER 1900)
+if((DEFINED MSVC_VERSION AND MSVC_VERSION GREATER 1900) OR Drogon_VERSION VERSION_GREATER_EQUAL "1.8.2")
     target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 else()
     target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)


### PR DESCRIPTION
Specify library name and version:  **drogon/***

- update boost
- use `rm_safe`
- use `export_conandata_patches`
- use C++17 in drogon/>=1.8.2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
