### PR TITLE
libsystemd/252.4: bump version

### DIFF
--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -21,11 +21,11 @@ patches:
   "246.16":
     - patch_file: "patches/246.16/0001-Drop-bundled-copy-of-linux-if_arp.h.patch"
       patch_description: "fix build error with Linux headers >= 5.14 by removing a bundled copy of it"
-      patch_type: "backport"
+      patch_type: "portability"
       patch_source: "https://github.com/systemd/systemd-stable/commit/06dea04b38ce506c1436cd4fef9bf9919a34f441"
     - patch_file: "patches/246.16/0002-meson.build-change-operator-combining-bools-from-to-.patch"
       patch_description: "allow to build with meson >= 0.60.0 by fixing syntax error"
-      patch_type: "backport"
+      patch_type: "bugfix"
       patch_source: "https://github.com/systemd/systemd-stable/commit/3d0666d9091dd097022f02fae79890b5746285c1"
     - patch_file: "patches/246.16/0003-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"

--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -14,6 +14,9 @@ sources:
   "251.4":
     url: "https://github.com/systemd/systemd-stable/archive/v251.4.tar.gz"
     sha256: "3459239979f52b8c4ace33734d31c2fb69fa13cf81d04b1b982f7d8d4651e015"
+  "252.4":
+    url: "https://github.com/systemd/systemd-stable/archive/v252.4.tar.gz"
+    sha256: "cf2d27e67663d599a045101c7178cf0ec63d9df2962a54adf7de0d0357724f00"
 patches:
   "246.16":
     - patch_file: "patches/246.16/0001-Drop-bundled-copy-of-linux-if_arp.h.patch"
@@ -46,6 +49,13 @@ patches:
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
   "251.4":
+    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
+      patch_type: "conan"
+    - patch_file: "patches/251.4/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
+  "252.4":
     - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
       patch_type: "conan"

--- a/recipes/libsystemd/config.yml
+++ b/recipes/libsystemd/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "251.4":
     folder: all
+  "252.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libsystemd/252.4**
A new version was released, and the linter suggestions were applied to conandata,yml.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
