### PR TITLE
Fix libjpeg/9e sha256 signature failed  

### DIFF
--- a/recipes/libjpeg/all/conandata.yml
+++ b/recipes/libjpeg/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "9e":
     url: "http://ijg.org/files/jpegsrc.v9e.tar.gz"
-    sha256: "4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d"
+    sha256: "5d5349c3aacc978dfcbde11f7904d2965395261dd818ce21c15806f736b8911e"
   "9d":
     url: "http://ijg.org/files/jpegsrc.v9d.tar.gz"
     sha256: "2303a6acfb6cc533e0e86e8a9d29f7e6079e118b9de3f96e07a71a11c082fa6a"


### PR DESCRIPTION
Specify library name and version:  **libjpeg/9e**


libjpeg/9e: Configuring sources in C:\Users\runneradmin\.conan\data\libjpeg\9e\_\_\source\src
ERROR: libjpeg/9e: Error in source() method, line 65
	get(self, **self.conan_data["sources"][self.version],
	ConanException: sha256 signature failed for 'jpegsrc.v9e.tar.gz' file. 
 Provided signature: 4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d  
 Computed signature: 5d5349c3aacc978dfcbde11f7904d2965395261dd818ce21c15806f736b8911e

Issue was reported in #15044 

fixes #15044
