### PR TITLE
[sentry-native/0.5.3] Bump version + conan v2 migration

### DIFF
--- a/recipes/sentry-native/all/CMakeLists.txt
+++ b/recipes/sentry-native/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory("source_subfolder")

--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -14,6 +14,4 @@ sources:
 patches:
   "0.2.6":
     - patch_file: "patches/0.2.6-0001-remove-sentry-handler-dependency.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/0.2.6-0002-set-cmake-cxx-standard-14.patch"
-      base_path: "source_subfolder"

--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -5,15 +5,6 @@ sources:
   "0.4.18":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.18/sentry-native.zip"
     sha256: "41fdf6499cd8576142beb03104badcc9e0b80b8ef27080ca71cd4408cc1d7ece"
-  "0.4.17":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.17/sentry-native.zip"
-    sha256: "38c9e180c29b6561c5f91ada154e191eabe9d7c270734cff81e55532878ec273"
-  "0.4.15":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.15/sentry-native.zip"
-    sha256: "ae3ac4efa76d431d8734d7b0b1bf9bbedaf2cbdb18dfc5c95e2411a67808cf29"
-  "0.4.13":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.13/sentry-native.zip"
-    sha256: "85e0e15d7fb51388d967ab09e7ee1b95f82330a469a93c65d964ea1afd5e6127"
   "0.2.6":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
     sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"

--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.5.3":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.5.3/sentry-native.zip"
+    sha256: "d9a2434783e558bc9e074518ce155bda129bfa12d376dde939e6a732c92f9757"
   "0.5.0":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.5.0/sentry-native.zip"
     sha256: "1a65767a7c6c368a6dea44125eb268ed8374100f33168829f21df78cbfa8632b"

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.files import apply_conandata_patches, export_conandata_patches,
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
 import os
 
 required_conan_version = ">=1.43.0"
@@ -132,9 +133,9 @@ class SentryNativeConan(ConanFile):
 
     def build_requirements(self):
         if Version(self.version) >= "0.4.0" and self.settings.os == "Windows":
-            self.build_requires("cmake/3.22.0")
+            self.tool_requires("cmake/3.22.0")
         if self.options.backend == "breakpad":
-            self.build_requires("pkgconf/1.7.4")
+            self.tool_requires("pkgconf/1.7.4")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version])
@@ -153,6 +154,8 @@ class SentryNativeConan(ConanFile):
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate(scope="build")
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -1,6 +1,9 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
-import functools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
 required_conan_version = ">=1.43.0"
@@ -40,14 +43,8 @@ class SentryNativeConan(ConanFile):
         "performance": False,
     }
 
-    generators = "cmake", "cmake_find_package", "cmake_find_package_multi", "pkg_config"
-
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _minimum_compilers_version(self):
+    def _compilers_minimum_version(self):
         return {
             "Visual Studio": "15",
             "gcc": "5",
@@ -56,9 +53,7 @@ class SentryNativeConan(ConanFile):
         }
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -73,7 +68,7 @@ class SentryNativeConan(ConanFile):
             self.options.transport = "none"
 
         # Configure default backend
-        if self.settings.os == "Windows" or self.settings.os == "Macos":  # Don't use tools.is_apple_os(os) here
+        if self.settings.os in ('Windows', 'Macos'):  # Don't use is_apple_os(os) here
             # FIXME: for self.version < 0.4: default backend is "breakpad" when building with MSVC for Windows xp; else: backend=none
             self.options.backend = "crashpad"
         elif self.settings.os in ("FreeBSD", "Linux"):
@@ -85,89 +80,92 @@ class SentryNativeConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
         if self.options.backend != "crashpad":
-            del self.options.with_crashpad
+            self.options.rm_safe("with_crashpad")
         if self.options.backend != "breakpad":
-            del self.options.with_breakpad
+            self.options.rm_safe("with_breakpad")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.transport == "curl":
-            self.requires("libcurl/7.80.0")
+            self.requires("libcurl/7.86.0")
         if self.options.backend == "crashpad":
             if self.options.with_crashpad == "sentry":
-                self.requires("sentry-crashpad/{}".format(self.version))
+                self.requires(f"sentry-crashpad/{self.version}")
             if self.options.with_crashpad == "google":
                 self.requires("crashpad/cci.20210507")
         elif self.options.backend == "breakpad":
             if self.options.with_breakpad == "sentry":
-                self.requires("sentry-breakpad/{}".format(self.version))
+                self.requires(f"sentry-breakpad/{self.version}")
             if self.options.with_breakpad == "google":
                 self.requires("breakpad/cci.20210521")
         if self.options.qt:
-            self.requires("qt/5.15.3")
-            self.requires("openssl/1.1.1n")
-            if tools.Version(self.version) < "0.4.5":
+            self.requires("qt/5.15.7")
+            self.requires("openssl/1.1.1s")
+            if Version(self.version) < "0.4.5":
                 raise ConanInvalidConfiguration("Qt integration available from version 0.4.5")
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 14)
+            check_min_cppstd(self, 14)
 
-        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if not minimum_version:
             self.output.warn("Compiler is unknown. Assuming it supports C++14.")
-        elif tools.Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration("Build requires support for C++14. Minimum version for {} is {}"
-                .format(str(self.settings.compiler), minimum_version))
-        if self.options.backend == "inproc" and self.settings.os == "Windows" and tools.Version(self.version) < "0.4":
+        elif Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"Build requires support for C++14. Minimum version for {self.settings.compiler} is {minimum_version}")
+        if self.options.backend == "inproc" and self.settings.os == "Windows" and Version(self.version) < "0.4":
             raise ConanInvalidConfiguration("The in-process backend is not supported on Windows")
         if self.options.transport == "winhttp" and self.settings.os != "Windows":
             raise ConanInvalidConfiguration("The winhttp transport is only supported on Windows")
-        if tools.Version(self.version) >= "0.4.7" and self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) < "10.0":
+        if Version(self.version) >= "0.4.7" and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "10.0":
             raise ConanInvalidConfiguration("apple-clang < 10.0 not supported")
-        if self.options.backend == "crashpad" and tools.Version(self.version) < "0.4.7" and self.settings.os == "Macos" and self.settings.arch == "armv8":
+        if self.options.backend == "crashpad" and Version(self.version) < "0.4.7" and self.settings.os == "Macos" and self.settings.arch == "armv8":
             raise ConanInvalidConfiguration("This version doesn't support ARM compilation")
 
         if self.options.performance:
-            if tools.Version(self.version) < "0.4.14" or tools.Version(self.version) > "0.4.15":
+            if Version(self.version) < "0.4.14" or Version(self.version) > "0.4.15":
                 raise ConanInvalidConfiguration("Performance monitoring is only valid in 0.4.14 and 0.4.15")
 
     def build_requirements(self):
-        if tools.Version(self.version) >= "0.4.0" and self.settings.os == "Windows":
+        if Version(self.version) >= "0.4.0" and self.settings.os == "Windows":
             self.build_requires("cmake/3.22.0")
         if self.options.backend == "breakpad":
             self.build_requires("pkgconf/1.7.4")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version])
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["SENTRY_BACKEND"] = self.options.backend
-        cmake.definitions["SENTRY_CRASHPAD_SYSTEM"] = True
-        cmake.definitions["SENTRY_BREAKPAD_SYSTEM"] = True
-        cmake.definitions["SENTRY_ENABLE_INSTALL"] = True
-        cmake.definitions["SENTRY_TRANSPORT"] = self.options.transport
-        cmake.definitions["SENTRY_PIC"] = self.options.get_safe("fPIC", True)
-        cmake.definitions["SENTRY_INTEGRATION_QT"] = self.options.qt
-        cmake.definitions["SENTRY_PERFORMANCE_MONITORING"] = self.options.performance
-        cmake.configure()
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["PACKAGE_CUSTOM_DEFINITION"] = True
+        tc.variables["SENTRY_BACKEND"] = self.options.backend
+        tc.variables["SENTRY_CRASHPAD_SYSTEM"] = True
+        tc.variables["SENTRY_BREAKPAD_SYSTEM"] = True
+        tc.variables["SENTRY_ENABLE_INSTALL"] = True
+        tc.variables["SENTRY_TRANSPORT"] = self.options.transport
+        tc.variables["SENTRY_PIC"] = self.options.get_safe("fPIC", True)
+        tc.variables["SENTRY_INTEGRATION_QT"] = self.options.qt
+        tc.variables["SENTRY_PERFORMANCE_MONITORING"] = self.options.performance
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*pdb")
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, pattern="*pdb", folder=os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "sentry")
@@ -182,7 +180,7 @@ class SentryNativeConan(ConanFile):
             self.cpp_info.system_libs = ["dl", "log"]
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["shlwapi", "dbghelp"]
-            if tools.Version(self.version) >= "0.4.7":
+            if Version(self.version) >= "0.4.7":
                 self.cpp_info.system_libs.append("Version")
             if self.options.transport == "winhttp":
                 self.cpp_info.system_libs.append("winhttp")

--- a/recipes/sentry-native/all/test_package/CMakeLists.txt
+++ b/recipes/sentry-native/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 find_package(sentry REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} sentry::sentry)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
+target_link_libraries(${PROJECT_NAME} PRIVATE sentry::sentry)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/sentry-native/all/test_package/conanfile.py
+++ b/recipes/sentry-native/all/test_package/conanfile.py
@@ -1,19 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
-    def build_requirements(self):
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            # Workaround for CMake bug with error message:
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
-            self.build_requires("cmake/3.22.0")
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -21,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sentry-native/all/test_v1_package/CMakeLists.txt
+++ b/recipes/sentry-native/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/sentry-native/all/test_v1_package/conanfile.py
+++ b/recipes/sentry-native/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/sentry-native/config.yml
+++ b/recipes/sentry-native/config.yml
@@ -3,11 +3,5 @@ versions:
     folder: all
   "0.4.18":
     folder: all
-  "0.4.17":
-    folder: all
-  "0.4.15":
-    folder: all
-  "0.4.13":
-    folder: all
   "0.2.6":
     folder: all

--- a/recipes/sentry-native/config.yml
+++ b/recipes/sentry-native/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.5.3":
+    folder: all
   "0.5.0":
     folder: all
   "0.4.18":


### PR DESCRIPTION
- Remove version 0.4.13 => 0.4.17
- [sentry-native/0.5.3] Bump version
- Conan v2 migration

Specify library name and version:  **sentry-native/0.5.3**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
