### PR TITLE
qt5: Apple OSs don't require CROSS_COMPILE option

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -22,6 +22,8 @@ sources:
     sha256: "5a97827bdf9fd515f43bc7651defaf64fecb7a55e051c79b8f80510d0e990f06"
 patches:
   "5.15.7":
+    - patch_file: "patches/337f28c9ab.patch"
+      base_path: "qt5/qtbase"
     - patch_file: "patches/aa2a39dea5.diff"
       base_path: "qt5/qtbase"
     - patch_file: "patches/c72097e.diff"
@@ -45,6 +47,8 @@ patches:
     - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
   "5.15.6":
+    - patch_file: "patches/337f28c9ab.patch"
+      base_path: "qt5/qtbase"
     - patch_file: "patches/aa2a39dea5.diff"
       base_path: "qt5/qtbase"
     - patch_file: "patches/c72097e.diff"
@@ -68,6 +72,8 @@ patches:
     - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
   "5.15.5":
+    - patch_file: "patches/337f28c9ab-5.15.5.patch"
+      base_path: "qt5/qtbase"
     - patch_file: "patches/aa2a39dea5.diff"
       base_path: "qt5/qtbase"
     - patch_file: "patches/c72097e.diff"

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -346,7 +346,7 @@ class QtConan(ConanFile):
         if self.settings.os in ['Linux', 'FreeBSD'] and self.options.with_gssapi:
             raise ConanInvalidConfiguration("gssapi cannot be enabled until conan-io/conan-center-index#4102 is closed")
 
-        if cross_building(self) and self.options.cross_compile == "None":
+        if cross_building(self) and self.options.cross_compile == "None" and not is_apple_os(self):
             raise ConanInvalidConfiguration("option cross_compile must be set for cross compilation "
                                             "cf https://doc.qt.io/qt-5/configure-options.html#cross-compilation-options")
 

--- a/recipes/qt/5.x.x/patches/337f28c9ab-5.15.5.patch
+++ b/recipes/qt/5.x.x/patches/337f28c9ab-5.15.5.patch
@@ -1,0 +1,40 @@
+From 337f28c9abb12f28538cfe2f49e5afc460578b32 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Arne=20Vestb=C3=B8?= <tor.arne.vestbo@qt.io>
+Date: Tue, 5 Jul 2022 15:38:33 +0200
+Subject: Darwin: Replace deprecated symbol kIOMasterPortDefault with
+ equivalent
+
+We can't use the replacement kIOMainPortDefault yet, as it's not
+available in operating system versions we still support, but the
+kIOMasterPortDefault documentation explicitly says that passing
+NULL as a port argument indicates "use the default".
+
+As the underlying type of a mach_port_t is potentially either
+a pointer or an unsigned int, we initialize the default to 0.
+
+Pick-to: 6.2 6.3 6.4 5.15
+Change-Id: I288aa94b8f2fbda47fd1cbaf329799db7ab988a0
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ src/corelib/global/qglobal.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+(limited to 'src/corelib/global/qglobal.cpp')
+
+diff --git a/src/corelib/global/qglobal.cpp b/src/corelib/global/qglobal.cpp
+index 738e39658f..c894471ad6 100644
+--- a/src/corelib/global/qglobal.cpp
++++ b/src/corelib/global/qglobal.cpp
+@@ -3059,7 +3059,8 @@ QByteArray QSysInfo::machineUniqueId()
+ {
+ #if defined(Q_OS_DARWIN) && __has_include(<IOKit/IOKitLib.h>)
+     char uuid[UuidStringLen + 1];
+-    io_service_t service = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
++    static const mach_port_t defaultPort = 0; // Effectively kIOMasterPortDefault/kIOMainPortDefault
++    io_service_t service = IOServiceGetMatchingService(defaultPort, IOServiceMatching("IOPlatformExpertDevice"));
+     QCFString stringRef = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kIOPlatformUUIDKey), kCFAllocatorDefault, 0);
+     CFStringGetCString(stringRef, uuid, sizeof(uuid), kCFStringEncodingMacRoman);
+     return QByteArray(uuid);
+-- 
+cgit v1.2.1
+

--- a/recipes/qt/5.x.x/patches/337f28c9ab.patch
+++ b/recipes/qt/5.x.x/patches/337f28c9ab.patch
@@ -1,0 +1,40 @@
+From 337f28c9abb12f28538cfe2f49e5afc460578b32 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Arne=20Vestb=C3=B8?= <tor.arne.vestbo@qt.io>
+Date: Tue, 5 Jul 2022 15:38:33 +0200
+Subject: Darwin: Replace deprecated symbol kIOMasterPortDefault with
+ equivalent
+
+We can't use the replacement kIOMainPortDefault yet, as it's not
+available in operating system versions we still support, but the
+kIOMasterPortDefault documentation explicitly says that passing
+NULL as a port argument indicates "use the default".
+
+As the underlying type of a mach_port_t is potentially either
+a pointer or an unsigned int, we initialize the default to 0.
+
+Pick-to: 6.2 6.3 6.4 5.15
+Change-Id: I288aa94b8f2fbda47fd1cbaf329799db7ab988a0
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ src/corelib/global/qglobal.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+(limited to 'src/corelib/global/qglobal.cpp')
+
+diff --git a/src/corelib/global/qglobal.cpp b/src/corelib/global/qglobal.cpp
+index 738e39658f..c894471ad6 100644
+--- a/src/corelib/global/qglobal.cpp
++++ b/src/corelib/global/qglobal.cpp
+@@ -3067,7 +3067,8 @@ QByteArray QSysInfo::machineUniqueId()
+ {
+ #if defined(Q_OS_DARWIN) && __has_include(<IOKit/IOKitLib.h>)
+     char uuid[UuidStringLen + 1];
+-    io_service_t service = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
++    static const mach_port_t defaultPort = 0; // Effectively kIOMasterPortDefault/kIOMainPortDefault
++    io_service_t service = IOServiceGetMatchingService(defaultPort, IOServiceMatching("IOPlatformExpertDevice"));
+     QCFString stringRef = (CFStringRef)IORegistryEntryCreateCFProperty(service, CFSTR(kIOPlatformUUIDKey), kCFAllocatorDefault, 0);
+     CFStringGetCString(stringRef, uuid, sizeof(uuid), kCFStringEncodingMacRoman);
+     return QByteArray(uuid);
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
Specify library name and version:  **qt/5.x**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

after #14020 it's no longer possible to cross-compile from macOS to iOS as well as from macOS Intel to macOS ARM. These scenarios don't require passing `CROSS_COMPILE` option, see e.g. https://doc.qt.io/qt-5/ios-building-from-source.html. The only valid option there I'm aware of is `-device-option QMAKE_APPLE_DEVICE_ARCHS=arm64` which Conan already passes.

Also added patch to fix building qtbase for iOS with Xcode 14.x. Had to modify the line number in the [original patch](https://code.qt.io/cgit/qt/qtbase.git/commit/src/corelib/global/qglobal.cpp?id=337f28c9abb12f28538cfe2f49e5afc460578b32) because Conan's patch applier is quite strict unlike the standard `patch` program.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
