### PR TITLE
mailio: update dependencies, support conan v2

### DIFF
--- a/recipes/mailio/all/CMakeLists.txt
+++ b/recipes/mailio/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory(source_subfolder)

--- a/recipes/mailio/all/conandata.yml
+++ b/recipes/mailio/all/conandata.yml
@@ -8,7 +8,9 @@ sources:
 patches:
   "0.21.0":
     - patch_file: "patches/0.21.0-adapt-cmakelists.patch"
-      base_path: "source_subfolder"
+      patch_description: "fix install path"
+      patch_type: "conan"
   "0.20.0":
     - patch_file: "patches/0.20.0-adapt-cmakelists.patch"
-      base_path: "source_subfolder"
+      patch_description: "fix install path"
+      patch_type: "conan"

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -1,17 +1,23 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.53.0"
 
 class mailioConan(ConanFile):
     name = "mailio"
+    description = "mailio is a cross platform C++ library for MIME format and SMTP, POP3 and IMAP protocols."
     license = "BSD-2-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/karastojko/mailio"
-    description = "mailio is a cross platform C++ library for MIME format and SMTP, POP3 and IMAP protocols."
     topics = ("smtp", "imap", "email", "mail", "libraries", "cpp")
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
         "shared": [True, False]
@@ -20,38 +26,24 @@ class mailioConan(ConanFile):
         "fPIC": True,
         "shared": False
     }
-    generators = "cmake", "cmake_find_package"
     short_paths = True
-    _cmake = None
-
-    _compiler_required_cpp17 = {
-        "gcc": "8.3",
-        "clang": "6",
-        "Visual Studio": "15",
-        "apple-clang": "10",
-    }
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 17
 
     @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
-    def _configure_cmake(self):
-        if not self._cmake:
-            self._cmake = CMake(self)
-            self._cmake.definitions["MAILIO_BUILD_SHARED_LIBRARY"] = self.options.shared
-            self._cmake.definitions["MAILIO_BUILD_DOCUMENTATION"] = False
-            self._cmake.definitions["MAILIO_BUILD_EXAMPLES"] = False
-            self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+    def _compiler_required_cpp(self): 
+        return {
+            "gcc": "8.3",
+            "clang": "6",
+            "Visual Studio": "15",
+            "msvc": "191",
+            "apple-clang": "10",
+        }
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -59,41 +51,53 @@ class mailioConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.79.0")
-        self.requires("openssl/1.1.1q")
+        self.requires("boost/1.81.0")
+        self.requires("openssl/1.1.1s")
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
-            tools.check_min_cppstd(self, "17")
+            check_min_cppstd(self, self._min_cppstd)
         try:
-            minimum_required_compiler_version = self._compiler_required_cpp17[str(self.settings.compiler)]
-            if tools.Version(self.settings.compiler.version) < minimum_required_compiler_version:
-                raise ConanInvalidConfiguration("This package requires c++17 support. The current compiler does not support it.")
+            minimum_required_compiler_version = self._compiler_required_cpp[str(self.settings.compiler)]
+            if Version(self.settings.compiler.version) < minimum_required_compiler_version:
+                raise ConanInvalidConfiguration(f"{self.ref} requires c++{self._min_cppstd} support. The current compiler does not support it.")
         except KeyError:
-            self.output.warn("This recipe has no support for the current compiler. Please consider adding it.")
+            self.output.warn(f"{self.ref} has no support for the current compiler. Please consider adding it.")
 
     def build_requirements(self):
         # mailio requires cmake >= 3.16.3
-        self.build_requires("cmake/3.23.2")
+        self.tool_requires("cmake/3.25.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["MAILIO_BUILD_SHARED_LIBRARY"] = self.options.shared
+        tc.variables["MAILIO_BUILD_DOCUMENTATION"] = False
+        tc.variables["MAILIO_BUILD_EXAMPLES"] = False
+        tc.generate()
+
+        dpes = CMakeDeps(self)
+        dpes.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.libs = ["mailio"]

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -102,3 +102,6 @@ class mailioConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["mailio"]
         self.cpp_info.requires = ["boost::system", "boost::date_time", "boost::regex", "openssl::openssl"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")

--- a/recipes/mailio/all/test_package/CMakeLists.txt
+++ b/recipes/mailio/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(mailio REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} mailio::mailio)
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+target_link_libraries(${PROJECT_NAME} PRIVATE mailio::mailio)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/mailio/all/test_package/conanfile.py
+++ b/recipes/mailio/all/test_package/conanfile.py
@@ -1,28 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
-from conans import ConanFile, CMake, tools
 
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
-class mailioTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
-    def build_requirements(self):
-        if hasattr(self, "settings_build") and tools.cross_building(self) and \
-            self.settings.os == "Macos" and self.settings.arch == "armv8":
-            # Workaround for CMake bug with error message:
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
-            self.build_requires("cmake/3.22.0")
-
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/mailio/all/test_v1_package/CMakeLists.txt
+++ b/recipes/mailio/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/mailio/all/test_v1_package/conanfile.py
+++ b/recipes/mailio/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **mailio/***

- update dependencies 
- support conan v2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
