### PR TITLE
libsodium: fix a regression of x86 msvc build

### DIFF
--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -149,6 +149,7 @@ class LibsodiumConan(ConanFile):
             "Dyn" if self.options.shared else "Static",
             "Debug" if self.settings.build_type == "Debug" else "Release",
         )
+        msbuild.platform = "Win32" if self.settings.arch == "x86" else msbuild.platform
         msbuild.build(os.path.join(msvc_sln_folder, "libsodium.sln"))
 
     def build(self):


### PR DESCRIPTION
In https://github.com/conan-io/conan-center-index/pull/15041, I've removed micro management of `msbuild.platform` when arch is x86. It was a mistake, the default value in `MSBuild` helper is not correct for libsodium. It must be `Win32` (instead of the default value of `MSBuild` which is `x86`).


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
