### PR TITLE
Make xkeyboard-config v2 compatible

### DIFF
--- a/recipes/xkeyboard-config/all/conanfile.py
+++ b/recipes/xkeyboard-config/all/conanfile.py
@@ -20,7 +20,7 @@ class XkeyboardConfigConan(ConanFile):
             raise ConanInvalidConfiguration("This recipe supports only Linux and FreeBSD")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
 
     def system_requirements(self):
         apt = package_manager.Apt(self)

--- a/recipes/xkeyboard-config/all/conanfile.py
+++ b/recipes/xkeyboard-config/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.gnu import PkgConfig
 from conan.tools.system import package_manager
 from conan.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.47"
+required_conan_version = ">=1.50.0"
 
 
 class XkeyboardConfigConan(ConanFile):


### PR DESCRIPTION
Use clear() instead of header_only() to make it work in v2