### PR TITLE
libheif: add version 1.14.1, support conan v2

### DIFF
--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -16,7 +16,7 @@ sources:
     sha256: "5f65ca2bd2510eed4e13bdca123131c64067e9dd809213d7aef4dc5e37948bca"
 patches:
   "1.14.1":
-    - patch_file: "patches/0001-cmake-1.14.0.patch"
+    - patch_file: "patches/0001-cmake-1.14.1.patch"
       patch_description: "use cci package"
       patch_type: "conan"
   "1.13.0":

--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.14.0":
-    url: "https://github.com/strukturag/libheif/releases/download/v1.14.0/libheif-1.14.0.tar.gz"
-    sha256: "9a2b969d827e162fa9eba582ebd0c9f6891f16e426ef608d089b1f24962295b5"
+  "1.14.1":
+    url: "https://github.com/strukturag/libheif/releases/download/v1.14.1/libheif-1.14.1.tar.gz"
+    sha256: "0634646587454f95e9638ca472a37321aa519fca2ec7405d0e02a74d7ee581db"
   "1.13.0":
     url: "https://github.com/strukturag/libheif/releases/download/v1.13.0/libheif-1.13.0.tar.gz"
     sha256: "c20ae01bace39e89298f6352f1ff4a54b415b33b9743902da798e8a1e51d7ca1"
@@ -15,7 +15,7 @@ sources:
     url: "https://github.com/strukturag/libheif/releases/download/v1.9.1/libheif-1.9.1.tar.gz"
     sha256: "5f65ca2bd2510eed4e13bdca123131c64067e9dd809213d7aef4dc5e37948bca"
 patches:
-  "1.14.0":
+  "1.14.1":
     - patch_file: "patches/0001-cmake-1.14.0.patch"
       patch_description: "use cci package"
       patch_type: "conan"

--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.14.0":
+    url: "https://github.com/strukturag/libheif/releases/download/v1.14.0/libheif-1.14.0.tar.gz"
+    sha256: "9a2b969d827e162fa9eba582ebd0c9f6891f16e426ef608d089b1f24962295b5"
   "1.13.0":
     url: "https://github.com/strukturag/libheif/releases/download/v1.13.0/libheif-1.13.0.tar.gz"
     sha256: "c20ae01bace39e89298f6352f1ff4a54b415b33b9743902da798e8a1e51d7ca1"
@@ -12,11 +15,23 @@ sources:
     url: "https://github.com/strukturag/libheif/releases/download/v1.9.1/libheif-1.9.1.tar.gz"
     sha256: "5f65ca2bd2510eed4e13bdca123131c64067e9dd809213d7aef4dc5e37948bca"
 patches:
+  "1.14.0":
+    - patch_file: "patches/0001-cmake-1.14.0.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "1.13.0":
     - patch_file: "patches/0001-cmake_1.13.0.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "1.12.0":
     - patch_file: "patches/0001-cmake_1.12.0.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "1.11.0":
     - patch_file: "patches/0001-cmake_1.11.0.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "1.9.1":
     - patch_file: "patches/0001-cmake-1.9.1.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"

--- a/recipes/libheif/all/conanfile.py
+++ b/recipes/libheif/all/conanfile.py
@@ -6,17 +6,16 @@ from conan.tools.scm import Version
 from conans import tools as tools_legacy
 import os
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.53.0"
 
 
 class LibheifConan(ConanFile):
     name = "libheif"
     description = "libheif is an HEIF and AVIF file format decoder and encoder."
-    topics = ("libheif", "heif", "codec", "video")
+    license = ("LGPL-3.0-only", "GPL-3.0-or-later", "MIT")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/strukturag/libheif"
-    license = ("LGPL-3.0-only", "GPL-3.0-or-later", "MIT")
-
+    topics = ("libheif", "heif", "codec", "video")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -45,7 +44,7 @@ class LibheifConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
     def requirements(self):
         if self.options.with_libde265:
@@ -72,7 +71,12 @@ class LibheifConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["WITH_LIBDE265"] = self.options.with_libde265
         tc.variables["WITH_X265"] = self.options.with_x265
-        tc.variables["WITH_AOM"] = self.options.with_libaomav1
+        if Version(self.version) < "1.14.0":
+            tc.variables["WITH_AOM"] = self.options.with_libaomav1
+        else:
+            tc.variables["WITH_AOM_ENCODER"] = self.options.with_libaomav1
+            tc.variables["WITH_AOM_DECODER"] = self.options.with_libaomav1
+            tc.variables["WITH_SvtEnc"] = False
         tc.variables["WITH_RAV1E"] = False
         tc.variables["WITH_DAV1D"] = self.options.with_dav1d
         tc.variables["WITH_EXAMPLES"] = False

--- a/recipes/libheif/all/patches/0001-cmake-1.14.0.patch
+++ b/recipes/libheif/all/patches/0001-cmake-1.14.0.patch
@@ -1,0 +1,82 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3ee1517..8d16897 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,15 +35,9 @@ if(NOT MSVC)
+   endif ()
+ endif()
+ 
+-set(CMAKE_CXX_STANDARD 11)
+-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+-set(CMAKE_CXX_EXTENSIONS OFF)
+-
+ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+ 
+-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+-
+ # Create the compile command database for clang by default
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ 
+@@ -64,7 +58,7 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
+     option(WITH_${variableName} "Build ${displayName} ${displayType}" ON)
+     option(WITH_${variableName}_PLUGIN "Build ${displayName} as a plugin" ${defaultPlugin})
+     if (WITH_${variableName})
+-        find_package(${packageName})
++        find_package(${packageName} REQUIRED CONFIG)
+     endif ()
+ 
+     if (${variableName}_FOUND AND WITH_${variableName}_PLUGIN)
+@@ -82,10 +76,10 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
+ endmacro()
+ 
+ plugin_option(LIBDE265 LIBDE265 "libde265" "HEIC decoder" OFF)
+-plugin_option(X265 X265 "x265" "HEIC encoder" OFF)
+-plugin_option(DAV1D DAV1D "Dav1d" "AVIF decoder" OFF)
+-plugin_option(AOM_ENCODER AOM "aom" "AVIF encoder" OFF)
+-plugin_option(AOM_DECODER AOM "aom" "AVIF decoder" OFF)
++plugin_option(X265 libx265 "x265" "HEIC encoder" OFF)
++plugin_option(DAV1D dav1d "Dav1d" "AVIF decoder" OFF)
++plugin_option(AOM_ENCODER libaom-av1 "aom" "AVIF encoder" OFF)
++plugin_option(AOM_DECODER libaom-av1 "aom" "AVIF decoder" OFF)
+ plugin_option(SvtEnc SvtEnc "Svt-av1" "AVIF encoder" ON)
+ plugin_option(RAV1E RAV1E "Rav1e" "AVIF encoder" ON)
+ 
+@@ -96,6 +90,7 @@ set(prefix ${CMAKE_INSTALL_PREFIX})
+ set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+ set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+ set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
++if(0)
+ if (LIBDE265_FOUND)
+     list(APPEND REQUIRES_PRIVATE "libde265")
+     set(have_libde265 yes)
+@@ -130,6 +125,7 @@ if (AOM_ENCODER_FOUND OR RAV1E_FOUND)
+ else()
+     set(have_avif_encoder no)
+ endif()
++endif()
+ list(JOIN REQUIRES_PRIVATE " " REQUIRES_PRIVATE)
+ set(VERSION ${PROJECT_VERSION})
+ 
+@@ -148,8 +144,6 @@ if(WITH_EXAMPLES)
+     add_subdirectory (examples)
+ endif()
+ add_subdirectory (libheif)
+-add_subdirectory (gdk-pixbuf)
+-add_subdirectory (gnome)
+ 
+ 
+ # --- packaging (source code)
+diff --git a/libheif/plugins/CMakeLists.txt b/libheif/plugins/CMakeLists.txt
+index f25effc..d7155be 100644
+--- a/libheif/plugins/CMakeLists.txt
++++ b/libheif/plugins/CMakeLists.txt
+@@ -44,7 +44,7 @@ plugin_compilation(x265 X265 X265 X265)
+ 
+ set(LIBDE265_sources heif_decoder_libde265.cc heif_decoder_libde265.h)
+ set(LIBDE265_extra_plugin_sources ../heif_image.cc ../error.cc)
+-plugin_compilation(libde265 LIBDE265 LIBDE265 LIBDE265)
++plugin_compilation(libde265 libde265 LIBDE265 LIBDE265)
+ 
+ set(DAV1D_sources heif_decoder_dav1d.cc heif_decoder_dav1d.h)
+ set(DAV1D_extra_plugin_sources)

--- a/recipes/libheif/all/patches/0001-cmake-1.14.1.patch
+++ b/recipes/libheif/all/patches/0001-cmake-1.14.1.patch
@@ -1,15 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d88a36a..72dbc2e 100644
+index d88a36a..5e6f116 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -35,15 +35,9 @@ if(NOT MSVC)
-   endif ()
- endif()
- 
--set(CMAKE_CXX_STANDARD 11)
--set(CMAKE_CXX_STANDARD_REQUIRED ON)
--set(CMAKE_CXX_EXTENSIONS OFF)
--
+@@ -42,8 +42,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
  set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
  
@@ -18,7 +11,7 @@ index d88a36a..72dbc2e 100644
  # Create the compile command database for clang by default
  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
  
-@@ -72,7 +66,7 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
+@@ -72,7 +70,7 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
      option(WITH_${variableName} "Build ${displayName} ${displayType}" ON)
      option(WITH_${variableName}_PLUGIN "Build ${displayName} as a plugin" ${defaultPlugin})
      if (WITH_${variableName})
@@ -27,7 +20,7 @@ index d88a36a..72dbc2e 100644
      endif ()
  
      if (${variableName}_FOUND AND WITH_${variableName}_PLUGIN AND PLUGIN_LOADING_SUPPORTED_AND_ENABLED)
-@@ -90,10 +84,10 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
+@@ -90,10 +88,10 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
  endmacro()
  
  plugin_option(LIBDE265 LIBDE265 "libde265" "HEIC decoder" OFF)
@@ -42,7 +35,7 @@ index d88a36a..72dbc2e 100644
  plugin_option(SvtEnc SvtEnc "Svt-av1" "AVIF encoder" ON)
  plugin_option(RAV1E RAV1E "Rav1e" "AVIF encoder" ON)
  
-@@ -112,6 +106,7 @@ if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+@@ -112,6 +110,7 @@ if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
  else()
      set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
  endif()
@@ -50,7 +43,7 @@ index d88a36a..72dbc2e 100644
  if (LIBDE265_FOUND)
      list(APPEND REQUIRES_PRIVATE "libde265")
      set(have_libde265 yes)
-@@ -146,6 +141,7 @@ if (AOM_ENCODER_FOUND OR RAV1E_FOUND)
+@@ -146,6 +145,7 @@ if (AOM_ENCODER_FOUND OR RAV1E_FOUND)
  else()
      set(have_avif_encoder no)
  endif()
@@ -58,7 +51,7 @@ index d88a36a..72dbc2e 100644
  list(JOIN REQUIRES_PRIVATE " " REQUIRES_PRIVATE)
  set(VERSION ${PROJECT_VERSION})
  
-@@ -166,8 +162,6 @@ if(WITH_EXAMPLES)
+@@ -166,8 +166,6 @@ if(WITH_EXAMPLES)
      add_subdirectory (examples)
  endif()
  add_subdirectory (libheif)

--- a/recipes/libheif/all/patches/0001-cmake-1.14.1.patch
+++ b/recipes/libheif/all/patches/0001-cmake-1.14.1.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3ee1517..8d16897 100644
+index d88a36a..72dbc2e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -35,15 +35,9 @@ if(NOT MSVC)
@@ -18,7 +18,7 @@ index 3ee1517..8d16897 100644
  # Create the compile command database for clang by default
  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
  
-@@ -64,7 +58,7 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
+@@ -72,7 +66,7 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
      option(WITH_${variableName} "Build ${displayName} ${displayType}" ON)
      option(WITH_${variableName}_PLUGIN "Build ${displayName} as a plugin" ${defaultPlugin})
      if (WITH_${variableName})
@@ -26,8 +26,8 @@ index 3ee1517..8d16897 100644
 +        find_package(${packageName} REQUIRED CONFIG)
      endif ()
  
-     if (${variableName}_FOUND AND WITH_${variableName}_PLUGIN)
-@@ -82,10 +76,10 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
+     if (${variableName}_FOUND AND WITH_${variableName}_PLUGIN AND PLUGIN_LOADING_SUPPORTED_AND_ENABLED)
+@@ -90,10 +84,10 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
  endmacro()
  
  plugin_option(LIBDE265 LIBDE265 "libde265" "HEIC decoder" OFF)
@@ -42,15 +42,15 @@ index 3ee1517..8d16897 100644
  plugin_option(SvtEnc SvtEnc "Svt-av1" "AVIF encoder" ON)
  plugin_option(RAV1E RAV1E "Rav1e" "AVIF encoder" ON)
  
-@@ -96,6 +90,7 @@ set(prefix ${CMAKE_INSTALL_PREFIX})
- set(exec_prefix ${CMAKE_INSTALL_PREFIX})
- set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
- set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+@@ -112,6 +106,7 @@ if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+ else()
+     set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ endif()
 +if(0)
  if (LIBDE265_FOUND)
      list(APPEND REQUIRES_PRIVATE "libde265")
      set(have_libde265 yes)
-@@ -130,6 +125,7 @@ if (AOM_ENCODER_FOUND OR RAV1E_FOUND)
+@@ -146,6 +141,7 @@ if (AOM_ENCODER_FOUND OR RAV1E_FOUND)
  else()
      set(have_avif_encoder no)
  endif()
@@ -58,7 +58,7 @@ index 3ee1517..8d16897 100644
  list(JOIN REQUIRES_PRIVATE " " REQUIRES_PRIVATE)
  set(VERSION ${PROJECT_VERSION})
  
-@@ -148,8 +144,6 @@ if(WITH_EXAMPLES)
+@@ -166,8 +162,6 @@ if(WITH_EXAMPLES)
      add_subdirectory (examples)
  endif()
  add_subdirectory (libheif)
@@ -68,10 +68,10 @@ index 3ee1517..8d16897 100644
  
  # --- packaging (source code)
 diff --git a/libheif/plugins/CMakeLists.txt b/libheif/plugins/CMakeLists.txt
-index f25effc..d7155be 100644
+index 70dc1b4..75b2aa3 100644
 --- a/libheif/plugins/CMakeLists.txt
 +++ b/libheif/plugins/CMakeLists.txt
-@@ -44,7 +44,7 @@ plugin_compilation(x265 X265 X265 X265)
+@@ -48,7 +48,7 @@ plugin_compilation(x265 X265 X265 X265)
  
  set(LIBDE265_sources heif_decoder_libde265.cc heif_decoder_libde265.h)
  set(LIBDE265_extra_plugin_sources ../heif_image.cc ../error.cc)

--- a/recipes/libheif/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libheif/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(libheif REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE libheif::heif)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.14.0":
+  "1.14.1":
     folder: all
   "1.13.0":
     folder: all

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.14.0":
+    folder: all
   "1.13.0":
     folder: all
   "1.12.0":


### PR DESCRIPTION
Specify library name and version:  **libheif/***

- add version 1.14.1
- support conan v2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
