### PR TITLE
rapidcheck: fix gmock option

### DIFF
--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -71,7 +71,7 @@ class RapidcheckConan(ConanFile):
             tools.check_min_cppstd(self, 11)
         if self._is_msvc and self.options.shared:
             raise ConanInvalidConfiguration("shared is not supported using Visual Studio")
-        if self.options.enable_gmock and not self.deps_cpp_info["gtest"].build_gmock:
+        if self.options.enable_gmock and not self.options["gtest"].build_gmock:
             raise ConanInvalidConfiguration("The option `rapidcheck:enable_gmock` requires gtest:build_gmock=True`")
 
     def source(self):


### PR DESCRIPTION
Specify library name and version:  **rapidcheck/cci.20220514**

This fixes #14854

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
