### PR TITLE
catch2.x.x: Fix test_package for v2

### DIFF
--- a/recipes/catch2/2.x.x/conandata.yml
+++ b/recipes/catch2/2.x.x/conandata.yml
@@ -1,16 +1,16 @@
 sources:
-  "2.11.3":
-    url: "https://github.com/catchorg/Catch2/archive/v2.11.3.tar.gz"
-    sha256: "9a6967138062688f04374698fce4ce65908f907d8c0fe5dfe8dc33126bd46543"
-  "2.12.4":
-    url: "https://github.com/catchorg/Catch2/archive/v2.12.4.tar.gz"
-    sha256: "5436725bbc6ee131a0bc9545bef31f0adabbb21fbc39fb6f1b2a42c12e4f8107"
-  "2.13.7":
-    url: "https://github.com/catchorg/Catch2/archive/v2.13.7.tar.gz"
-    sha256: "3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae"
-  "2.13.8":
-    url: "https://github.com/catchorg/Catch2/archive/v2.13.8.tar.gz"
-    sha256: "b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a"
   "2.13.9":
     url: "https://github.com/catchorg/Catch2/archive/v2.13.9.tar.gz"
     sha256: "06dbc7620e3b96c2b69d57bf337028bf245a211b3cddb843835bfe258f427a52"
+  "2.13.8":
+    url: "https://github.com/catchorg/Catch2/archive/v2.13.8.tar.gz"
+    sha256: "b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a"
+  "2.13.7":
+    url: "https://github.com/catchorg/Catch2/archive/v2.13.7.tar.gz"
+    sha256: "3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae"
+  "2.12.4":
+    url: "https://github.com/catchorg/Catch2/archive/v2.12.4.tar.gz"
+    sha256: "5436725bbc6ee131a0bc9545bef31f0adabbb21fbc39fb6f1b2a42c12e4f8107"
+  "2.11.3":
+    url: "https://github.com/catchorg/Catch2/archive/v2.11.3.tar.gz"
+    sha256: "9a6967138062688f04374698fce4ce65908f907d8c0fe5dfe8dc33126bd46543"

--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.53.0"
 class Catch2Conan(ConanFile):
     name = "catch2"
     description = "A modern, C++-native, header-only, framework for unit-tests, TDD and BDD"
-    topics = ("catch2", "header-only", "unit-test", "tdd", "bdd")
+    topics = ("header-only", "unit-test", "tdd", "bdd")
     homepage = "https://github.com/catchorg/Catch2"
     url = "https://github.com/conan-io/conan-center-index"
     license = "BSL-1.0"

--- a/recipes/catch2/2.x.x/test_package/conanfile.py
+++ b/recipes/catch2/2.x.x/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
 
     @property
     def _todos_filename(self):
-        return os.path.join(self.recipe_folder, self.folders.generators, "catch2_test_to_do.yml")
+        return os.path.join(self.recipe_folder, "test_output", self.folders.generators, "catch2_test_to_do.yml")
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -22,8 +22,8 @@ class TestPackageConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         catch_opts = self.dependencies[self.tested_reference_str].options
-        tc.variables["WITH_PREFIX"]    = catch_opts.with_prefix
-        tc.variables["WITH_MAIN"]      = catch_opts.with_main
+        tc.variables["WITH_PREFIX"] = catch_opts.with_prefix
+        tc.variables["WITH_MAIN"] = catch_opts.with_main
         tc.variables["WITH_BENCHMARK"] = not catch_opts.with_prefix and catch_opts.with_main and catch_opts.with_benchmark
         tc.generate()
 


### PR DESCRIPTION
This was failing with:
```ERROR: catch2/2.13.9 (test package): Error in generate() method, line 38
	print(os.listdir(os.path.dirname(self._todos_filename)))
	FileNotFoundError: [Errno 2] No such file or directory: '/Users/ruben/coding/conan-center-index/recipes/catch2/2.x.x/test_package/build/generators'```

The test output is going to test_output/build/generators, so the either the path was wrong or there's something else missing. @uilianries any idea?

This might not be the correct fix but at least it now builds locally for me
