### PR TITLE
rapidcheck: fix gmock option and convert to v2

### DIFF
--- a/recipes/rapidcheck/all/CMakeLists.txt
+++ b/recipes/rapidcheck/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory(source_subfolder)

--- a/recipes/rapidcheck/all/conandata.yml
+++ b/recipes/rapidcheck/all/conandata.yml
@@ -14,13 +14,17 @@ sources:
 patches:
   "cci.20220514":
     - patch_file: "patches/0001-gtest-catch-integration-20220514.patch"
-      base_path: "source_subfolder"
+      patch_description: "Remove dependency on test frameworks for for rapidcheck tests"
+      patch_type: "conan"
   "cci.20210702":
     - patch_file: "patches/0001-gtest-catch-integration-20210702.patch"
-      base_path: "source_subfolder"
+      patch_description: "Remove dependency on test frameworks for for rapidcheck tests"
+      patch_type: "conan"
   "cci.20210107":
     - patch_file: "patches/0001-gtest-catch-integration-20210107.patch"
-      base_path: "source_subfolder"
+      patch_description: "Remove dependency on test frameworks for for rapidcheck tests"
+      patch_type: "conan"
   "cci.20200131":
     - patch_file: "patches/0001-gtest-catch-integration-20200131.patch"
-      base_path: "source_subfolder"
+      patch_description: "Remove dependency on test frameworks for for rapidcheck tests"
+      patch_type: "conan"

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -1,10 +1,14 @@
-from conans import CMake, ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
-import os
-import functools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir, save
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
+from os.path import join
 import textwrap
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.53.0"
 
 
 class RapidcheckConan(ConanFile):
@@ -14,7 +18,7 @@ class RapidcheckConan(ConanFile):
     homepage = "https://github.com/emil-e/rapidcheck"
     license = "BSD-2-Clause"
     topics = ("quickcheck", "testing", "property-testing")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -33,24 +37,12 @@ class RapidcheckConan(ConanFile):
         "enable_gtest": False,
     }
 
-    generators = "cmake", "cmake_find_package"
-
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+    def _min_cppstd(self):
+        return 11
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -58,53 +50,57 @@ class RapidcheckConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.enable_catch:
-            self.requires("catch2/2.13.9")
+            self.requires("catch2/2.13.10")
         if self.options.enable_gmock or self.options.enable_gtest:
-            self.requires("gtest/1.11.0")
+            self.requires("gtest/1.12.1")
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
-        if self._is_msvc and self.options.shared:
-            raise ConanInvalidConfiguration("shared is not supported using Visual Studio")
-        if self.options.enable_gmock and not self.deps_cpp_info["gtest"].build_gmock:
-            raise ConanInvalidConfiguration("The option `rapidcheck:enable_gmock` requires gtest:build_gmock=True`")
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        if is_msvc(self) and self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
+        if self.options.enable_gmock and not self.dependencies["gtest"].options.build_gmock:
+            raise ConanInvalidConfiguration("The option `rapidcheck:enable_gmock` requires `gtest/*:build_gmock=True`")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["RC_ENABLE_RTTI"] = self.options.enable_rtti
-        cmake.definitions["RC_ENABLE_TESTS"] = False
-        cmake.definitions["RC_ENABLE_EXAMPLES"] = False
-        cmake.definitions["RC_ENABLE_CATCH"] = self.options.enable_catch
-        cmake.definitions["RC_ENABLE_GMOCK"] = self.options.enable_gmock
-        cmake.definitions["RC_ENABLE_GTEST"] = self.options.enable_gtest
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["RC_ENABLE_RTTI"] = self.options.enable_rtti
+        tc.variables["RC_ENABLE_TESTS"] = False
+        tc.variables["RC_ENABLE_EXAMPLES"] = False
+        tc.variables["RC_ENABLE_CATCH"] = self.options.enable_catch
+        tc.variables["RC_ENABLE_GMOCK"] = self.options.enable_gmock
+        tc.variables["RC_ENABLE_GTEST"] = self.options.enable_gtest
+        tc.generate()
+
+        tc = CMakeDeps(self)
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE*", src=self._source_subfolder, dst="licenses")
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE*", dst=join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+        rmdir(self, join(self.package_folder, "share"))
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
+            join(self.package_folder, self._module_file_rel_path),
             {
                 "rapidcheck": "rapidcheck::rapidcheck_rapidcheck",
                 "rapidcheck_catch":"rapidcheck::rapidcheck_catch",
@@ -113,8 +109,7 @@ class RapidcheckConan(ConanFile):
             }
         )
 
-    @staticmethod
-    def _create_cmake_module_alias_targets(module_file, targets):
+    def _create_cmake_module_alias_targets(self, module_file, targets):
         content = ""
         for alias, aliased in targets.items():
             content += textwrap.dedent("""\
@@ -123,11 +118,11 @@ class RapidcheckConan(ConanFile):
                     set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
                 endif()
             """.format(alias=alias, aliased=aliased))
-        tools.save(module_file, content)
+        save(self, module_file, content)
 
     @property
     def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", "conan-official-{}-targets.cmake".format(self.name))
+        return join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "rapidcheck")
@@ -135,7 +130,7 @@ class RapidcheckConan(ConanFile):
         self.cpp_info.components["rapidcheck_rapidcheck"].set_property("cmake_target_name", "rapidcheck")
         self.cpp_info.components["rapidcheck_rapidcheck"].libs = ["rapidcheck"]
         version = str(self.version)[4:]
-        if tools.Version(version) < "20201218":
+        if Version(version) < "20201218":
             if self.options.enable_rtti:
                 self.cpp_info.components["rapidcheck_rapidcheck"].defines.append("RC_USE_RTTI")
         else:
@@ -151,6 +146,9 @@ class RapidcheckConan(ConanFile):
         if self.options.enable_gtest:
             self.cpp_info.components["rapidcheck_gtest"].set_property("cmake_target_name", "rapidcheck_gtest")
             self.cpp_info.components["rapidcheck_gtest"].requires = ["rapidcheck_rapidcheck", "gtest::gtest"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.components["rapidcheck_rapidcheck"].build_modules["cmake_find_package"] = [self._module_file_rel_path]

--- a/recipes/rapidcheck/all/test_package/CMakeLists.txt
+++ b/recipes/rapidcheck/all/test_package/CMakeLists.txt
@@ -1,11 +1,9 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.8)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package CXX)
 
 find_package(rapidcheck REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} rapidcheck)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE rapidcheck::rapidcheck)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/rapidcheck/all/test_package/conanfile.py
+++ b/recipes/rapidcheck/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/rapidcheck/all/test_v1_package/CMakeLists.txt
+++ b/recipes/rapidcheck/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/rapidcheck/all/test_v1_package/conanfile.py
+++ b/recipes/rapidcheck/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **rapidcheck/cci.20220514**

This fixes #14854

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
