### PR TITLE
[libjpeg] Update sha256 for 9e

### DIFF
--- a/recipes/libjpeg/all/conandata.yml
+++ b/recipes/libjpeg/all/conandata.yml
@@ -4,10 +4,10 @@ sources:
     sha256: "5d5349c3aacc978dfcbde11f7904d2965395261dd818ce21c15806f736b8911e"
   "9d":
     url: "http://ijg.org/files/jpegsrc.v9d.tar.gz"
-    sha256: "2303a6acfb6cc533e0e86e8a9d29f7e6079e118b9de3f96e07a71a11c082fa6a"
+    sha256: "83d4b17eb45588c6e19405b99038a137c78fe179d8d2f80b7b0f16450d581c31"
   "9c":
     url: "http://ijg.org/files/jpegsrc.v9c.tar.gz"
-    sha256: "682aee469c3ca857c4c38c37a6edadbfca4b04d42e56613b11590ec6aa4a278d"
+    sha256: "4cad9aa32bb3b74594308c082f8e0991e1491b034d3f2dd39f272f0ca89e262c"
 patches:
   "9e":
     - patch_file: "patches/0001-9e-libjpeg-add-msvc-dll-support.patch"

--- a/recipes/libjpeg/all/conandata.yml
+++ b/recipes/libjpeg/all/conandata.yml
@@ -4,10 +4,10 @@ sources:
     sha256: "4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d"
   "9d":
     url: "http://ijg.org/files/jpegsrc.v9d.tar.gz"
-    sha256: "83d4b17eb45588c6e19405b99038a137c78fe179d8d2f80b7b0f16450d581c31"
+    sha256: "2303a6acfb6cc533e0e86e8a9d29f7e6079e118b9de3f96e07a71a11c082fa6a"
   "9c":
     url: "http://ijg.org/files/jpegsrc.v9c.tar.gz"
-    sha256: "4cad9aa32bb3b74594308c082f8e0991e1491b034d3f2dd39f272f0ca89e262c"
+    sha256: "682aee469c3ca857c4c38c37a6edadbfca4b04d42e56613b11590ec6aa4a278d"
 patches:
   "9e":
     - patch_file: "patches/0001-9e-libjpeg-add-msvc-dll-support.patch"

--- a/recipes/libjpeg/all/conandata.yml
+++ b/recipes/libjpeg/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "9e":
     url: "http://ijg.org/files/jpegsrc.v9e.tar.gz"
-    sha256: "5d5349c3aacc978dfcbde11f7904d2965395261dd818ce21c15806f736b8911e"
+    sha256: "4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d"
   "9d":
     url: "http://ijg.org/files/jpegsrc.v9d.tar.gz"
     sha256: "83d4b17eb45588c6e19405b99038a137c78fe179d8d2f80b7b0f16450d581c31"


### PR DESCRIPTION
Specify library name and version:  **libjpeg**

This PR continues https://github.com/conan-io/conan-center-index/pull/15045 and it's related to #4151

closes #13417

/cc @arekmula @mejdys @Wuqiqi123

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
