### PR TITLE
qt6: 6.4.2 and disable generation of cmake file for libdrm and wayland

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -1,4 +1,12 @@
 sources:
+  "6.4.2":
+    url:
+      - "https://download.qt.io/archive/qt/6.4/6.4.2/single/qt-everywhere-src-6.4.2.tar.xz"
+      - "https://qt-mirror.dannhauer.de/archive/qt/6.4/6.4.2/single/qt-everywhere-src-6.4.2.tar.xz"
+      - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.4/6.4.2/single/qt-everywhere-src-6.4.2.tar.xz"
+      - "https://ftp.fau.de/qtproject/archive/qt/6.4/6.4.2/single/qt-everywhere-src-6.4.2.tar.xz"
+      - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/6.4/6.4.2/single/qt-everywhere-src-6.4.2.tar.xz"
+    sha256: "689f53e6652da82fccf7c2ab58066787487339f28d1ec66a8765ad357f4976be"
   "6.4.1":
     url:
       - "https://download.qt.io/archive/qt/6.4/6.4.1/single/qt-everywhere-src-6.4.1.tar.xz"
@@ -24,6 +32,16 @@ sources:
       - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/6.2/6.2.4/single/qt-everywhere-src-6.2.4.tar.xz"
     sha256: "cfe41905b6bde3712c65b102ea3d46fc80a44c9d1487669f14e4a6ee82ebb8fd"
 patches:
+  "6.4.2":
+    - base_path: "qtbase/cmake"
+      patch_file: "patches/qt6-pri-helpers-fix.diff"
+    - patch_file: "patches/c72097e.diff"
+      base_path: "qtwebengine"
+    - patch_file: "patches/d13958d.diff"
+      base_path: "qtbase"
+      patch_description: "Fix PCRE2 detection"
+      patch_type: "bugfix"
+      patch_source: "https://codereview.qt-project.org/c/qt/qtbase/+/445885"
   "6.4.1":
     - base_path: "qtbase/cmake"
       patch_file: "patches/qt6-pri-helpers-fix.diff"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -361,7 +361,7 @@ class QtConan(ConanFile):
             if is_apple_os(self):
                 self.requires("moltenvk/1.2.0")
         if self.options.with_glib:
-            self.requires("glib/2.75.0")
+            self.requires("glib/2.75.1")
         if self.options.with_doubleconversion and not self.options.multiconfiguration:
             self.requires("double-conversion/3.2.1")
         if self.options.get_safe("with_freetype", False) and not self.options.multiconfiguration:
@@ -410,7 +410,7 @@ class QtConan(ConanFile):
             self.requires("xorg-proto/2022.2")
             self.requires("libxshmfence/1.3")
             self.requires("nss/3.85")
-            self.requires("libdrm/2.4.109")
+            self.requires("libdrm/2.4.114")
         if self.options.get_safe("with_gstreamer", False):
             self.requires("gst-plugins-base/1.19.2")
         if self.options.get_safe("with_pulseaudio", False):
@@ -449,6 +449,7 @@ class QtConan(ConanFile):
         ms.generate()
 
         tc = CMakeDeps(self)
+        tc.set_property("libdrm", "cmake_file_name", "libdrm-DO-NOT-USE")
         tc.generate()
 
         for f in glob.glob("*.cmake"):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -8,7 +8,7 @@ import textwrap
 from conan import ConanFile
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.build import cross_building, check_min_cppstd, build_jobs
+from conan.tools.build import cross_building, check_min_cppstd, build_jobs, default_cppstd
 from conan.tools.env import VirtualBuildEnv, Environment
 from conan.tools.files import get, replace_in_file, apply_conandata_patches, save, rm, rmdir, export_conandata_patches
 from conan.tools.gnu import PkgConfigDeps
@@ -595,6 +595,17 @@ class QtConan(ConanFile):
                                #"set(QT_EXTRA_INCLUDEPATHS ${CONAN_INCLUDE_DIRS})\n"
                                #"set(QT_EXTRA_DEFINES ${CONAN_DEFINES})\n"
                                #"set(QT_EXTRA_LIBDIRS ${CONAN_LIB_DIRS})\n"
+
+        current_cpp_std = self.settings.get_safe("compiler.cppstd", default_cppstd(self))
+        current_cpp_std = str(current_cpp_std).replace("gnu", "")
+        cpp_std_map = {
+            "20": "FEATURE_cxx20"
+            }
+        if Version(self.version) >= "6.5.0":
+            cpp_std_map["23"] = "FEATURE_cxx2b"
+
+        tc.variables[cpp_std_map.get(current_cpp_std, "FEATURE_cxx17")] = "ON"
+
         tc.generate()
 
     def source(self):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -449,8 +449,13 @@ class QtConan(ConanFile):
         ms.generate()
 
         tc = CMakeDeps(self)
-        tc.set_property("libdrm", "cmake_file_name", "libdrm-DO-NOT-USE")
-        tc.set_property("wayland", "cmake_file_name", "wayland-DO-NOT-USE")
+        tc.set_property("libdrm", "cmake_file_name", "Libdrm")
+        tc.set_property("libdrm::libdrm_libdrm", "cmake_target_name", "Libdrm::Libdrm")
+        tc.set_property("wayland", "cmake_file_name", "Wayland")
+        tc.set_property("wayland::wayland-client", "cmake_target_name", "Wayland::Client")
+        tc.set_property("wayland::wayland-server", "cmake_target_name", "Wayland::Server")
+        tc.set_property("wayland::wayland-cursor", "cmake_target_name", "Wayland::Cursor")
+        tc.set_property("wayland::wayland-egl", "cmake_target_name", "Wayland::Egl")
         tc.generate()
 
         for f in glob.glob("*.cmake"):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -1026,6 +1026,8 @@ class QtConan(ConanFile):
         self.cpp_info.components["qtPlatform"].includedirs = [os.path.join("res", "archdatadir", "mkspecs", self._xplatform())]
         if Version(self.version) < "6.1.0":
             self.cpp_info.components["qtCore"].libs.append("Qt6Core_qobject%s" % libsuffix)
+        if self.options.with_dbus:
+            _create_module("DBus", ["dbus::dbus"])
         if self.options.gui:
             gui_reqs = []
             if self.options.with_dbus:
@@ -1118,8 +1120,6 @@ class QtConan(ConanFile):
             _create_module("OpenGL", ["Gui"])
         if self.options.widgets and self.options.get_safe("opengl", "no") != "no":
             _create_module("OpenGLWidgets", ["OpenGL", "Widgets"])
-        if self.options.with_dbus:
-            _create_module("DBus", ["dbus::dbus"])
         _create_module("Concurrent")
         _create_module("Xml")
 
@@ -1155,6 +1155,9 @@ class QtConan(ConanFile):
             _create_module("Designer", ["Gui", "UiPlugin", "Widgets", "Xml"])
             _create_module("Help", ["Gui", "Sql", "Widgets"])
 
+        if self.options.qtshadertools and self.options.gui:
+            _create_module("ShaderTools", ["Gui"])
+
         if self.options.qtquick3d and qt_quick_enabled:
             _create_module("Quick3DUtils", ["Gui"])
             _create_module("Quick3DAssetImport", ["Gui", "Qml", "Quick3DUtils"])
@@ -1165,9 +1168,6 @@ class QtConan(ConanFile):
             (self.options.qtdeclarative and Version(self.version) >= "6.2.0")) and qt_quick_enabled:
             _create_module("QuickControls2", ["Gui", "Quick"])
             _create_module("QuickTemplates2", ["Gui", "Quick"])
-
-        if self.options.qtshadertools and self.options.gui:
-            _create_module("ShaderTools", ["Gui"])
 
         if self.options.qtsvg and self.options.gui:
             _create_module("Svg", ["Gui"])

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -348,7 +348,7 @@ class QtConan(ConanFile):
             raise ConanInvalidConfiguration("cross compiling qt 6 is not yet supported. Contributions are welcome")
 
     def layout(self):
-        cmake_layout(self, src_folder="qt6")
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("zlib/1.2.13")

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -450,6 +450,7 @@ class QtConan(ConanFile):
 
         tc = CMakeDeps(self)
         tc.set_property("libdrm", "cmake_file_name", "libdrm-DO-NOT-USE")
+        tc.set_property("wayland", "cmake_file_name", "wayland-DO-NOT-USE")
         tc.generate()
 
         for f in glob.glob("*.cmake"):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -18,7 +18,7 @@ from conan.errors import ConanInvalidConfiguration
 from conans import RunEnvironment, tools
 from conans.model import Generator
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.55.0"
 
 
 class qt(Generator):

--- a/recipes/qt/6.x.x/qtmodules6.4.2.conf
+++ b/recipes/qt/6.x.x/qtmodules6.4.2.conf
@@ -1,0 +1,318 @@
+[submodule "qtbase"]
+	path = qtbase
+	url = ../qtbase.git
+	branch = 6.4.2
+	status = essential
+[submodule "qtsvg"]
+	depends = qtbase
+	path = qtsvg
+	url = ../qtsvg.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtdeclarative"]
+	depends = qtbase
+	recommends = qtimageformats qtshadertools qtsvg qtlanguageserver
+	path = qtdeclarative
+	url = ../qtdeclarative.git
+	branch = 6.4.2
+	status = essential
+[submodule "qtactiveqt"]
+	depends = qtbase
+	path = qtactiveqt
+	url = ../qtactiveqt.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtmultimedia"]
+	depends = qtbase qtshadertools
+	recommends = qtdeclarative qtquick3d
+	path = qtmultimedia
+	url = ../qtmultimedia.git
+	branch = 6.4.2
+	status = addon
+[submodule "qttools"]
+	depends = qtbase
+	recommends = qtdeclarative qtactiveqt
+	path = qttools
+	url = ../qttools.git
+	branch = 6.4.2
+	status = essential
+[submodule "qtxmlpatterns"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtxmlpatterns
+	url = ../qtxmlpatterns.git
+	branch = dev
+	status = ignore
+[submodule "qttranslations"]
+	depends = qttools
+	path = qttranslations
+	url = ../qttranslations.git
+	branch = 6.4.2
+	status = essential
+	priority = 30
+[submodule "qtdoc"]
+	depends = qtdeclarative qttools
+	recommends = qtmultimedia
+	path = qtdoc
+	url = ../qtdoc.git
+	branch = 6.4.2
+	status = essential
+	priority = 40
+[submodule "qtrepotools"]
+	path = qtrepotools
+	url = ../qtrepotools.git
+	branch = master
+	status = essential
+	project = -
+[submodule "qtqa"]
+	depends = qtbase
+	path = qtqa
+	url = ../qtqa.git
+	branch = dev
+	status = essential
+	priority = 50
+[submodule "qtlocation"]
+	depends = qtbase qtpositioning
+	recommends = qtdeclarative
+	path = qtlocation
+	url = ../qtlocation.git
+	branch = dev
+	status = ignore
+[submodule "qtpositioning"]
+	depends = qtbase
+	recommends = qtdeclarative qtserialport
+	path = qtpositioning
+	url = ../qtpositioning.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtsensors"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtsensors
+	url = ../qtsensors.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtsystems"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtsystems
+	url = ../qtsystems.git
+	branch = dev
+	status = ignore
+[submodule "qtfeedback"]
+	depends = qtdeclarative
+	recommends = qtmultimedia
+	path = qtfeedback
+	url = ../qtfeedback.git
+	branch = master
+	status = ignore
+[submodule "qtpim"]
+	depends = qtdeclarative
+	path = qtpim
+	url = ../qtpim.git
+	branch = dev
+	status = ignore
+[submodule "qtconnectivity"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtconnectivity
+	url = ../qtconnectivity.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtwayland"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtwayland
+	url = ../qtwayland.git
+	branch = 6.4.2
+	status = addon
+[submodule "qt3d"]
+	depends = qtbase
+	recommends = qtdeclarative qtshadertools
+	path = qt3d
+	url = ../qt3d.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtimageformats"]
+	depends = qtbase
+	path = qtimageformats
+	url = ../qtimageformats.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtserialbus"]
+	depends = qtbase
+	recommends = qtserialport
+	path = qtserialbus
+	url = ../qtserialbus.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtserialport"]
+	depends = qtbase
+	path = qtserialport
+	url = ../qtserialport.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtwebsockets"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtwebsockets
+	url = ../qtwebsockets.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtwebchannel"]
+	depends = qtbase
+	recommends = qtdeclarative qtwebsockets
+	path = qtwebchannel
+	url = ../qtwebchannel.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtwebengine"]
+	depends = qtdeclarative
+	recommends = qtwebchannel qttools qtpositioning
+	path = qtwebengine
+	url = ../qtwebengine.git
+	branch = 6.4.2
+	status = addon
+	priority = 10
+[submodule "qtcanvas3d"]
+	depends = qtdeclarative
+	path = qtcanvas3d
+	url = ../qtcanvas3d.git
+	branch = dev
+	status = ignore
+[submodule "qtwebview"]
+	depends = qtdeclarative
+	recommends = qtwebengine
+	path = qtwebview
+	url = ../qtwebview.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtcharts"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtcharts
+	url = ../qtcharts.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtdatavis3d"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtdatavis3d
+	url = ../qtdatavis3d.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtvirtualkeyboard"]
+	depends = qtbase qtdeclarative qtsvg
+	recommends = qtmultimedia
+	path = qtvirtualkeyboard
+	url = ../qtvirtualkeyboard.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtgamepad"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtgamepad
+	url = ../qtgamepad.git
+	branch = dev
+	status = ignore
+[submodule "qtscxml"]
+	depends = qtbase qtdeclarative
+	path = qtscxml
+	url = ../qtscxml.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtspeech"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtspeech
+	url = ../qtspeech.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtnetworkauth"]
+	depends = qtbase
+	path = qtnetworkauth
+	url = ../qtnetworkauth.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtremoteobjects"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtremoteobjects
+	url = ../qtremoteobjects.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtwebglplugin"]
+	depends = qtbase qtwebsockets
+	recommends = qtdeclarative
+	path = qtwebglplugin
+	url = ../qtwebglplugin.git
+	branch = dev
+	status = ignore
+[submodule "qtlottie"]
+	depends = qtbase qtdeclarative
+	path = qtlottie
+	url = ../qtlottie.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtquicktimeline"]
+	depends = qtbase qtdeclarative
+	path = qtquicktimeline
+	url = ../qtquicktimeline
+	branch = 6.4.2
+	status = addon
+[submodule "qtquick3d"]
+	depends = qtbase qtdeclarative qtshadertools
+	recommends = qtquicktimeline
+	path = qtquick3d
+	url = ../qtquick3d.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtshadertools"]
+	depends = qtbase
+	path = qtshadertools
+	url = ../qtshadertools.git
+	branch = 6.4.2
+	status = addon
+[submodule "qt5compat"]
+	depends = qtbase qtdeclarative
+	path = qt5compat
+	url = ../qt5compat.git
+	branch = 6.4.2
+	status = deprecated
+[submodule "qtcoap"]
+	depends = qtbase
+	path = qtcoap
+	url = ../qtcoap.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtmqtt"]
+	depends = qtbase qtdeclarative
+	path = qtmqtt
+	url = ../qtmqtt.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtopcua"]
+	depends = qtbase qtdeclarative
+	path = qtopcua
+	url = ../qtopcua.git
+	branch = 6.4.2
+	status = addon
+[submodule "qtlanguageserver"]
+	depends = qtbase
+	path = qtlanguageserver
+	url = ../qtlanguageserver.git
+	branch = 6.4.2
+	status = preview
+[submodule "qthttpserver"]
+	depends = qtbase
+	recommends = qtwebsockets
+	path = qthttpserver
+	url = ../qthttpserver.git
+	branch = 6.4.2
+	status = preview
+[submodule "qtquick3dphysics"]
+	depends = qtbase qtdeclarative qtquick3d qtshadertools
+	path = qtquick3dphysics
+	url = ../qtquick3dphysics.git
+	branch = 6.4.2
+	status = preview

--- a/recipes/qt/config.yml
+++ b/recipes/qt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.4.2":
+    folder: 6.x.x
   "6.4.1":
     folder: 6.x.x
   "6.3.2":


### PR DESCRIPTION
it avoids overriding https://github.com/qt/qtbase/blob/3b60534ab9a2f467cd44ee23a1429ed46d6d5a23/cmake/3rdparty/kwin/FindLibdrm.cmake and https://github.com/qt/qtbase/blob/3b60534ab9a2f467cd44ee23a1429ed46d6d5a23/cmake/3rdparty/extra-cmake-modules/find-modules/FindWayland.cmake

related to conan-io/conan-center-index#14884
fixes conan-io/conan-center-index#15001

Specify library name and version:  **qt/6.***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
