### PR TITLE
xxhash: fix (rare) link error

### DIFF
--- a/recipes/xxhash/all/conandata.yml
+++ b/recipes/xxhash/all/conandata.yml
@@ -14,4 +14,4 @@ patches:
     - patch_file: "patches/0.8.1-fix-static-assert-link-error.patch"
       patch_source: "https://github.com/Cyan4973/xxHash/commit/6189ecd3d44a693460f86280ccf49d33cb4b18e1"
       patch_description: "Backport fix for link error"
-      patch_type: backport
+      patch_type: bugfix

--- a/recipes/xxhash/all/conandata.yml
+++ b/recipes/xxhash/all/conandata.yml
@@ -8,3 +8,4 @@ sources:
 patches:
   "0.8.1":
     - patch_file: "patches/0.8.1-fix-cmakelists.patch"
+    - patch_file: "patches/0.8.1-fix-static-assert-link-error.patch"

--- a/recipes/xxhash/all/conandata.yml
+++ b/recipes/xxhash/all/conandata.yml
@@ -8,4 +8,9 @@ sources:
 patches:
   "0.8.1":
     - patch_file: "patches/0.8.1-fix-cmakelists.patch"
+      patch_description: "Update CMakeLists.txt to properly install manuals"
+      patch_type: "conan"
+
     - patch_file: "patches/0.8.1-fix-static-assert-link-error.patch"
+      patch_description: "Backport Cyan4973/xxHash@6189ecd to fix link error"
+      patch_type: "backport"

--- a/recipes/xxhash/all/conandata.yml
+++ b/recipes/xxhash/all/conandata.yml
@@ -9,8 +9,9 @@ patches:
   "0.8.1":
     - patch_file: "patches/0.8.1-fix-cmakelists.patch"
       patch_description: "Update CMakeLists.txt to properly install manuals"
-      patch_type: "conan"
+      patch_type: conan
 
     - patch_file: "patches/0.8.1-fix-static-assert-link-error.patch"
-      patch_description: "Backport Cyan4973/xxHash@6189ecd to fix link error"
-      patch_type: "backport"
+      patch_source: "https://github.com/Cyan4973/xxHash/commit/6189ecd3d44a693460f86280ccf49d33cb4b18e1"
+      patch_description: "Backport fix for link error"
+      patch_type: backport

--- a/recipes/xxhash/all/patches/0.8.1-fix-static-assert-link-error.patch
+++ b/recipes/xxhash/all/patches/0.8.1-fix-static-assert-link-error.patch
@@ -1,0 +1,14 @@
+diff --git a/xxhash.h b/xxhash.h
+index 08ab794..511c4d1 100644
+--- a/xxhash.h
++++ b/xxhash.h
+@@ -1546,8 +1546,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
+ /* note: use after variable declarations */
+ #ifndef XXH_STATIC_ASSERT
+ #  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)    /* C11 */
+-#    include <assert.h>
+-#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
++#    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { _Static_assert((c),m); } while(0)
+ #  elif defined(__cplusplus) && (__cplusplus >= 201103L)            /* C++11 */
+ #    define XXH_STATIC_ASSERT_WITH_MESSAGE(c,m) do { static_assert((c),m); } while(0)
+ #  else


### PR DESCRIPTION
Specify library name and version:  **xxhash/0.8.1**

Fix (rare) link error.
On some systems linking to xxHash built with Conan fails due to error like the following:
```
[ 99%] Linking CXX executable main
/opt/conda/conda-bld/main_1672789533645/_build_env/bin/../lib/gcc/x86_64-conda-linux-gnu/12.2.0/../../../../x86_64-conda-linux-gnu/bin/ld: /root/.conan/data/xxhash/0.8.1/_/_/package/2a19826344ff00be1c04403f2f8e7008ed3a7cc6/lib/libxxhash.a(xxhash.c.o): in function `XXH3_hashLong_64b_default.constprop.0':
xxhash.c:(.text.XXH3_hashLong_64b_default.constprop.0+0x406): undefined reference to `static_assert'
```

This PR backports the bugfix from https://github.com/Cyan4973/xxHash/commit/6189ecd3d44a693460f86280ccf49d33cb4b18e1.

The link error is further described here: https://github.com/Cyan4973/xxHash/issues/671

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
