### PR TITLE
foonathan-lexy: add version 2022.12.1

### DIFF
--- a/recipes/foonathan-lexy/all/conandata.yml
+++ b/recipes/foonathan-lexy/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2022.12.1":
+    url: "https://github.com/foonathan/lexy/releases/download/v2022.12.1/lexy-src.zip"
+    sha256: "4c16efd31d03f908c7125352ebacbdb6c028de3788ca56940175e7017dbc6c7f"
   "2022.12.00":
     url: "https://github.com/foonathan/lexy/releases/download/v2022.12.0/lexy-src.zip"
     sha256: "62afda502963abce28f051416b977dcc8f11581ba0773f4b1da39a9b4842b19d"

--- a/recipes/foonathan-lexy/config.yml
+++ b/recipes/foonathan-lexy/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2022.12.1":
+    folder: all
   "2022.12.00":
     folder: all
   "2022.05.01":


### PR DESCRIPTION
Specify library name and version:  **foonathan-lexy/2022.12.1**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
