### PR TITLE
luau: add version 0.558

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.557":
-    url: "https://github.com/Roblox/luau/archive/0.557.tar.gz"
-    sha256: "e99d2097f69fa53eabf91e74de9c319d933725ea94d3a148a64431a7c2e6c179"
+  "0.558":
+    url: "https://github.com/Roblox/luau/archive/0.558.tar.gz"
+    sha256: "3484adddb18872700e033f5917af44d90c266f9e0fff2fac21aec1061f472a06"
   "0.556":
     url: "https://github.com/Roblox/luau/archive/0.556.tar.gz"
     sha256: "dc72f91f4e866a2b25f7608e062c91c84e92a2e5611026e9789f127c3caf39f6"
@@ -31,7 +31,7 @@ sources:
     sha256: "24122d3192083b2133de47d8039fb744b8007c6667fc1b6f254a2a8d72e15d53"
 
 patches:
-  "0.557":
+  "0.558":
     - patch_file: "patches/0.552-0001-fix-cmake.patch"
       patch_description: "enable shared build"
       patch_type: "portability"

--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.557":
+    url: "https://github.com/Roblox/luau/archive/0.557.tar.gz"
+    sha256: "e99d2097f69fa53eabf91e74de9c319d933725ea94d3a148a64431a7c2e6c179"
   "0.556":
     url: "https://github.com/Roblox/luau/archive/0.556.tar.gz"
     sha256: "dc72f91f4e866a2b25f7608e062c91c84e92a2e5611026e9789f127c3caf39f6"
@@ -28,6 +31,13 @@ sources:
     sha256: "24122d3192083b2133de47d8039fb744b8007c6667fc1b6f254a2a8d72e15d53"
 
 patches:
+  "0.557":
+    - patch_file: "patches/0.552-0001-fix-cmake.patch"
+      patch_description: "enable shared build"
+      patch_type: "portability"
+    - patch_file: "patches/0.536-0002-rename-lerp.patch"
+      patch_description: "rename lerp function to avoid name conflict"
+      patch_type: "portability"
   "0.556":
     - patch_file: "patches/0.552-0001-fix-cmake.patch"
       patch_description: "enable shared build"

--- a/recipes/luau/all/conanfile.py
+++ b/recipes/luau/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.microsoft import is_msvc
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
@@ -43,6 +43,8 @@ class LuauConan(ConanFile):
             "gcc": "8" if Version(self.version) < "0.549" else "9",
             "clang": "7",
             "apple-clang": "12",
+            "Visual Studio": "15",
+            "msvc": "191",
         }
 
     def export_sources(self):
@@ -68,7 +70,6 @@ class LuauConan(ConanFile):
     def validate(self):
         if self.info.settings.compiler.cppstd:
             check_min_cppstd(self, self._minimum_cpp_standard)
-        check_min_vs(self, 191)
         minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
         if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(

--- a/recipes/luau/all/conanfile.py
+++ b/recipes/luau/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 class LuauConan(ConanFile):
     name = "luau"
@@ -57,10 +57,7 @@ class LuauConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
+            self.options.rm_safe("fPIC")
         if Version(self.version) < "0.549":
             del self.options.native_code_gen
 

--- a/recipes/luau/all/test_v1_package/CMakeLists.txt
+++ b/recipes/luau/all/test_v1_package/CMakeLists.txt
@@ -4,8 +4,5 @@ project(test_package LANGUAGES CXX)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(Luau REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE Luau::Luau)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.557":
+    folder: all
   "0.556":
     folder: all
   "0.552":

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.557":
+  "0.558":
     folder: all
   "0.556":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **luau/0.557**

- add version 0.558
- use `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
