### PR TITLE
m4: use positional arguments when calling self.run()

### DIFF
--- a/recipes/m4/all/test_package/conanfile.py
+++ b/recipes/m4/all/test_package/conanfile.py
@@ -32,5 +32,5 @@ class TestPackageConan(ConanFile):
         self.run(f"m4 -R {self.source_folder}/frozen.m4f {self.source_folder}/test.m4")
 
         output = StringIO()
-        self.run(f"m4 -P {self._m4_input_path}", output=output)
+        self.run(f"m4 -P {self._m4_input_path}", output)
         assert "Harry, Jr. met Sally" in output.getvalue()


### PR DESCRIPTION
Specify library name and version:  **m4/all**

Fixes the following issue when testing the package with Conan 2, by using a positional argument for the output variable, instead of a name one (the name differs between Conan 1 and 2).

```
m4/1.4.19 (test package): Error in test() method, line 35
	self.run(f"m4 -P {self._m4_input_path}", output=output)
	TypeError: run() got an unexpected keyword argument 'output'
```