### PR TITLE
imgui: add version 1.89.2

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.89.2":
+    url: "https://github.com/ocornut/imgui/archive/v1.89.2.tar.gz"
+    sha256: "e110beffda505e6954feb7b13541d35a7c12a176b9723290c853684713df6a67"
   "1.89.1":
     url: "https://github.com/ocornut/imgui/archive/v1.89.1.tar.gz"
     sha256: "6d02a0079514d869e4b5f8f590f9060259385fcddd93a07ef21298b6a9610cbd"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.89.2":
+    folder: all
   "1.89.1":
     folder: all
   "1.88":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **imgui/1.89.2**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
