### PR TITLE
charls: add version 2.4.1

### DIFF
--- a/recipes/charls/all/conandata.yml
+++ b/recipes/charls/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.1":
+    url: "https://github.com/team-charls/charls/archive/2.4.1.tar.gz"
+    sha256: "f313f556b5acb9215961d9718c21235aafcd43bce6b357bf66f772e5692bba75"
   "2.4.0":
     url: "https://github.com/team-charls/charls/archive/2.4.0.tar.gz"
     sha256: "721f4fd6a8dc3ec6a334d1c3c15d1cb9faa149afddd0eff703466c20e775c294"

--- a/recipes/charls/config.yml
+++ b/recipes/charls/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.1":
+    folder: all
   "2.4.0":
     folder: all
   "2.3.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **charls/2.4.1**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
