### PR TITLE
roaring: add version 0.8.1

### DIFF
--- a/recipes/roaring/all/conandata.yml
+++ b/recipes/roaring/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.1":
+    url: "https://github.com/RoaringBitmap/CRoaring/archive/v0.8.1.tar.gz"
+    sha256: "5359f2a051f10e42cea5edc3cb3650fd272e9125e6a0538901cf30619939d4f8"
   "0.8.0":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/v0.8.0.tar.gz"
     sha256: "cd6c4770baccfea385c0c6891a8a80133ba26093209740ca0a3eea348aff1a20"

--- a/recipes/roaring/config.yml
+++ b/recipes/roaring/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.1":
+    folder: all
   "0.8.0":
     folder: all
   "0.7.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **roaring/0.8.1**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
