### PR TITLE
qt/5.x.x: Fix cross-compilation when using toolchains with custom names

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -450,7 +450,18 @@ class QtConan(ConanFile):
         else:
             return "make"
 
+    def _getenvpath(self, var):
+        val = os.getenv(var)
+        if val and self._settings_build.os == "Windows":
+            val = val.replace("\\", "/")
+            os.environ[var] = val
+        return val
+
     def _xplatform(self):
+        cxx = self._getenvpath("CXX")
+        if cxx:
+            return cxx
+
         if self.settings.os == "Linux":
             if self.settings.compiler == "gcc":
                 return {"x86": "linux-g++-32",
@@ -728,21 +739,14 @@ class QtConan(ConanFile):
         if self.options.cross_compile:
             args += [f"-device-option CROSS_COMPILE={self.options.cross_compile}"]
 
-        def _getenvpath(var):
-            val = os.getenv(var)
-            if val and self._settings_build.os == "Windows":
-                val = val.replace("\\", "/")
-                os.environ[var] = val
-            return val
-
         if not is_msvc(self):
-            value = _getenvpath("CC")
+            value = self._getenvpath("CC")
             if value:
                 args += ['QMAKE_CC="' + value + '"',
                          'QMAKE_LINK_C="' + value + '"',
                          'QMAKE_LINK_C_SHLIB="' + value + '"']
 
-            value = _getenvpath('CXX')
+            value = self._getenvpath('CXX')
             if value:
                 args += ['QMAKE_CXX="' + value + '"',
                          'QMAKE_LINK="' + value + '"',


### PR DESCRIPTION
The Qt 5 recipe currently defaults the value of `-xplatform` when no `device` option is given. The `-xplatform` option expects the C++ cross compiler to be given. The defaults only work for some situations.
When using Yocto, the default values are almost always insufficient.

This PR accounts for this situation.
If `CXX` is set in the environment, this is passed as the value for the `-xplatform` option.

Fixes #15144.

Specify library name and version:  **qt/5.15.7**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
