### PR TITLE
quill: add version 2.6.0, remove older versions

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.0":
+    url: "https://github.com/odygrd/quill/archive/v2.6.0.tar.gz"
+    sha256: "d72fd5a01bf8d3e59ed93a789a8f103bc31efe0fb3c09182c74036a2e3a8451b"
   "2.5.1":
     url: "https://github.com/odygrd/quill/archive/v2.5.1.tar.gz"
     sha256: "62227595cc2b4c0c42ed35f17ef5b7487d8231aca9e75234a4c0e346cea19928"
@@ -23,15 +26,6 @@ sources:
   "2.0.2":
     url: "https://github.com/odygrd/quill/archive/v2.0.2.tar.gz"
     sha256: "d2dc9004886b787f8357e97d2f2d0c74a460259f7f95d65ab49d060fe34a9b5c"
-  "2.0.1":
-    url: "https://github.com/odygrd/quill/archive/v2.0.1.tar.gz"
-    sha256: "39527aca74edd02d9df0bba62211df9f6d53984d4f6cca470734e19c4d8b69fb"
   "1.7.3":
     url: "https://github.com/odygrd/quill/archive/v1.7.3.tar.gz"
     sha256: "3fff0c5ffb19bbde5429369079741f84a6acce3a781b504cec5e677b05461208"
-  "1.6.3":
-    url: "https://github.com/odygrd/quill/archive/v1.6.3.tar.gz"
-    sha256: "886120b084db952aafe651c64f459e69fec481b4e189c14daa8c4108afebcba3"
-  "1.5.2":
-    url: "https://github.com/odygrd/quill/archive/v1.5.2.tar.gz"
-    sha256: "e409fda0bd949e997f63de4d422a8f17ccc9cb0d58f11403bd309c7a93aa0d6b"

--- a/recipes/quill/all/test_package/CMakeLists.txt
+++ b/recipes/quill/all/test_package/CMakeLists.txt
@@ -4,7 +4,7 @@ project(test_package LANGUAGES CXX)
 find_package(quill REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} quill::quill)
+target_link_libraries(${PROJECT_NAME} PRIVATE quill::quill)
 if(quill_VERSION VERSION_GREATER_EQUAL "2.0.0")
     target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 else()

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.0":
+    folder: "all"
   "2.5.1":
     folder: "all"
   "2.4.2":
@@ -15,11 +17,5 @@ versions:
     folder: "all"
   "2.0.2":
     folder: "all"
-  "2.0.1":
-    folder: "all"
   "1.7.3":
-    folder: "all"
-  "1.6.3":
-    folder: "all"
-  "1.5.2":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **quill/***

- add version 2.6.0
- remove older versions

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
