### PR TITLE
boost: handle spaces in path to C++ compiler

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1238,10 +1238,8 @@ class BoostConan(ConanFile):
         contents += f'\nusing "{self._toolset}" : {self._toolset_version} : '
 
         cxx_fwd_slahes = self._cxx.replace("\\", "/")
-        if is_msvc(self):
-            contents += f' "{cxx_fwd_slahes}"'
-        else:
-            contents += f' {cxx_fwd_slahes}'
+        if cxx_fwd_slahes:
+            contents += f" \"{cxx_fwd_slahes}\""
 
         if is_apple_os(self):
             if self.settings.compiler == "apple-clang":


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/15070

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
