### PR TITLE
[doc] Fix yamllint examples

### DIFF
--- a/docs/developing_recipes_locally.md
+++ b/docs/developing_recipes_locally.md
@@ -151,10 +151,8 @@ schema validation. There's are to encourage the best possible quality of recipes
 
   ```sh
   # Lint a recipe:
-  yamllint --config-file linter/yamllint_rules.yml -f standard recipes/fmt/all/conanfile.py
-
-  # Lint the test_package (same command)
-  yamllint --config-file linter/yamllint_rules.yml -f standard recipes/fmt/all/test_package/conanfile.py
+  yamllint --config-file linter/yamllint_rules.yml -f standard recipes/config.yml
+  yamllint --config-file linter/yamllint_rules.yml -f standard recipes/fmt/all/conandata.yml
   ```
 
 ### Yamlschema


### PR DESCRIPTION
I noticed a copy/paste issue when trying to run locally `yamllint`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
