### PR TITLE
tsl-robin-map: add version 1.2.1

### DIFF
--- a/recipes/tsl-robin-map/all/conandata.yml
+++ b/recipes/tsl-robin-map/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.1":
+    url: "https://github.com/Tessil/robin-map/archive/v1.2.1.tar.gz"
+    sha256: "2b54d2c1de2f73bea5c51d5dcbd64813a08caf1bfddcfdeee40ab74e9599e8e3"
   "1.0.1":
     url: "https://github.com/Tessil/robin-map/archive/v1.0.1.tar.gz"
     sha256: "b2ffdb623727cea852a66bddcb7fa6d938538a82b40e48294bb581fe086ef005"

--- a/recipes/tsl-robin-map/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tsl-robin-map/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(tsl-robin-map REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE tsl::robin_map)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/tsl-robin-map/config.yml
+++ b/recipes/tsl-robin-map/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.1":
+    folder: all
   "1.0.1":
     folder: all
   "0.6.3":


### PR DESCRIPTION
Specify library name and version:  **tsl-robin-map/1.2.1**

- add version 1.2.1
- use `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
