### PR TITLE
at-spi2-core: Add version 2.47.1 and support for Conan v2

### DIFF
--- a/recipes/at-spi2-core/config.yml
+++ b/recipes/at-spi2-core/config.yml
@@ -17,3 +17,5 @@ versions:
     folder: new
   "2.46.0":
     folder: new
+  "2.47.1":
+    folder: new

--- a/recipes/at-spi2-core/new/conandata.yml
+++ b/recipes/at-spi2-core/new/conandata.yml
@@ -13,14 +13,10 @@ sources:
     url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.45/at-spi2-core-2.45.1.tar.xz"
 patches:
   "2.47.1":
-    - base_path: "source_subfolder"
-      patch_file: "patches/93.patch"
+    - patch_file: "patches/93.patch"
   "2.46.0":
-    - base_path: "source_subfolder"
-      patch_file: "patches/93.patch"
+    - patch_file: "patches/93.patch"
   "2.45.90":
-    - base_path: "source_subfolder"
-      patch_file: "patches/93.patch"
+    - patch_file: "patches/93.patch"
   "2.45.1":
-    - base_path: "source_subfolder"
-      patch_file: "patches/93.patch"
+    - patch_file: "patches/93.patch"

--- a/recipes/at-spi2-core/new/conandata.yml
+++ b/recipes/at-spi2-core/new/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.47.1":
+    url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.47/at-spi2-core-2.47.1.tar.xz"
+    sha256: "c6ba7c160434edebf09d2936933569c936f6ec972301766f2bdac5a4d418153c"
   "2.46.0":
     url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.46/at-spi2-core-2.46.0.tar.xz"
     sha256: "aa0c86c79f7a8d67bae49a5b7a5ab08430c608cffe6e33bf47a72f41ab03c3d0"
@@ -9,6 +12,9 @@ sources:
     sha256: "ba95f346e93108fbb3462c62437081d582154db279b4052dedc52a706828b192"
     url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.45/at-spi2-core-2.45.1.tar.xz"
 patches:
+  "2.47.1":
+    - base_path: "source_subfolder"
+      patch_file: "patches/93.patch"
   "2.46.0":
     - base_path: "source_subfolder"
       patch_file: "patches/93.patch"

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.scm import Version
 import os
 
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 class AtSpi2CoreConan(ConanFile):
     name = "at-spi2-core"
     description = "It provides a Service Provider Interface for the Assistive Technologies available on the GNOME platform and a library against which applications can be linked"

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -94,25 +94,25 @@ class AtSpi2CoreConan(ConanFile):
         self.copy(pattern="COPYING", dst="licenses", src=self.source_folder)
         meson = Meson(self)
         meson.install()
-        rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        rmdir(os.path.join(self.package_folder, "etc"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "etc"))
 
 
     def package_info(self):
         self.cpp_info.components["atspi"].libs = ['atspi']
         self.cpp_info.components["atspi"].includedirs = ["include/at-spi-2.0"]
         self.cpp_info.components["atspi"].requires = ["dbus::dbus", "glib::glib"]
-        self.cpp_info.components["atspi"].names["pkg_config"] = "atspi-2"
+        self.cpp_info.components["atspi"].set_property("pkg_config_name", "atspi-2")
         
         self.cpp_info.components["atk"].libs = ["atk-1.0"]
         self.cpp_info.components["atk"].includedirs = ['include/atk-1.0']
         self.cpp_info.components["atk"].requires = ["glib::glib"]
-        self.cpp_info.components["atk"].names['pkg_config'] = 'atk'
+        self.cpp_info.components["atk"].set_property("pkg_config_name", 'atk')
 
         self.cpp_info.components["atk-bridge"].libs = ['atk-bridge-2.0']
         self.cpp_info.components["atk-bridge"].includedirs = [os.path.join('include', 'at-spi2-atk', '2.0')]
         self.cpp_info.components["atk-bridge"].requires = ["dbus::dbus", "atk", "glib::glib", "atspi"]
-        self.cpp_info.components["atk-bridge"].names['pkg_config'] = 'atk-bridge-2.0'
+        self.cpp_info.components["atk-bridge"].set_property("pkg_config_name", 'atk-bridge-2.0')
 
     def package_id(self):
         self.info.requires["glib"].full_package_mode()

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -61,8 +61,8 @@ class AtSpi2CoreConan(ConanFile):
             raise ConanInvalidConfiguration("only linux is supported by this recipe")
 
     def layout(self):
-        # src_folder must use the same source folder name the project
         basic_layout(self, src_folder="src")
+        self.cpp.package.resdirs = ["res"]
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -109,7 +109,7 @@ class AtSpi2CoreConan(ConanFile):
         self.cpp_info.components["atspi"].includedirs = ["include/at-spi-2.0"]
         self.cpp_info.components["atspi"].requires = ["dbus::dbus", "glib::glib"]
         self.cpp_info.components["atspi"].set_property("pkg_config_name", "atspi-2")
-        
+
         self.cpp_info.components["atk"].libs = ["atk-1.0"]
         self.cpp_info.components["atk"].includedirs = ['include/atk-1.0']
         self.cpp_info.components["atk"].requires = ["glib::glib"]

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, replace_in_file, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
@@ -42,9 +43,9 @@ class AtSpi2CoreConan(ConanFile):
             self.options["glib"].shared = True
 
     def build_requirements(self):
-        self.build_requires("meson/1.0.0")
+        self.tool_requires("meson/1.0.0")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.build_requires("pkgconf/1.9.3")
+            self.tool_requires("pkgconf/1.9.3")
 
     def requirements(self):
         self.requires("glib/2.75.2")
@@ -68,6 +69,8 @@ class AtSpi2CoreConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
         tc = MesonToolchain(self)
         if Version(self.version) >= "2.47.1":
             tc.project_options["introspection"] = "disabled"

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -1,5 +1,9 @@
-from conans import ConanFile, Meson, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, replace_in_file, rmdir
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
 import os
 
 
@@ -10,7 +14,6 @@ class AtSpi2CoreConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.gnome.org/GNOME/at-spi2-core/"
     license = "LGPL-2.1-or-later"
-    generators = "pkg_config"
 
     provides = "at-spi2-atk", "atk"
 
@@ -26,19 +29,8 @@ class AtSpi2CoreConan(ConanFile):
         "with_x11": False,
         }
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
-    _meson = None
-
     def export_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def configure(self):
         if self.options.shared:
@@ -49,14 +41,15 @@ class AtSpi2CoreConan(ConanFile):
             self.options["glib"].shared = True
 
     def build_requirements(self):
-        self.build_requires("meson/0.62.2")
-        self.build_requires("pkgconf/1.7.4")
+        self.build_requires("meson/1.0.0")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.build_requires("pkgconf/1.9.3")
 
     def requirements(self):
-        self.requires("glib/2.73.0")
+        self.requires("glib/2.75.2")
         if self.options.with_x11:
             self.requires("xorg/system")
-        self.requires("dbus/1.12.20")
+        self.requires("dbus/1.15.2")
 
     def validate(self):
         if self.options.shared and not self.options["glib"].shared:
@@ -66,46 +59,43 @@ class AtSpi2CoreConan(ConanFile):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("only linux is supported by this recipe")
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                    strip_root=True, destination=self._source_subfolder)
+    def layout(self):
+        # src_folder must use the same source folder name the project
+        basic_layout(self, src_folder="src")
 
-    def _configure_meson(self):
-        if self._meson:
-            return self._meson
-        self._meson = Meson(self)
-        defs = {}
-        defs["introspection"] = "no"
-        defs["docs"] = "false"
-        defs["x11"] = "yes" if self.options.with_x11 else "no"
-        args=[]
-        args.append("--datadir=%s" % os.path.join(self.package_folder, "res"))
-        args.append("--localedir=%s" % os.path.join(self.package_folder, "res"))
-        args.append("--wrap-mode=nofallback")
-        self._meson.configure(defs=defs, build_folder=self._build_subfolder, source_folder=self._source_subfolder, pkg_config_paths=".", args=args)
-        return self._meson
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["introspection"] = "no"
+        tc.project_options["docs"] = "false"
+        tc.project_options["x11"] = "yes" if self.options.with_x11 else "no"
+        tc.generate()
+        tc = PkgConfigDeps(self)
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        tools.replace_in_file(os.path.join(self._source_subfolder, "bus", "meson.build"),
+        apply_conandata_patches(self)
+        replace_in_file(self, os.path.join(self.source_folder, "bus", "meson.build"),
                                 "if x11_dep.found()",
                                 "if x11_option == 'yes'")
-        tools.replace_in_file(os.path.join(self._source_subfolder, 'meson.build'),
+        replace_in_file(self, os.path.join(self.source_folder, 'meson.build'),
             "subdir('tests')",
             "#subdir('tests')")
-        tools.replace_in_file(os.path.join(self._source_subfolder, 'meson.build'),
+        replace_in_file(self, os.path.join(self.source_folder, 'meson.build'),
             "libxml_dep = dependency('libxml-2.0', version: libxml_req_version)",
             "#libxml_dep = dependency('libxml-2.0', version: libxml_req_version)")
-        meson = self._configure_meson()
+        meson = Meson(self)
+        meson.configure()
         meson.build()
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        meson = self._configure_meson()
+        self.copy(pattern="COPYING", dst="licenses", src=self.source_folder)
+        meson = Meson(self)
         meson.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "etc"))
+        rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(os.path.join(self.package_folder, "etc"))
 
 
     def package_info(self):

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -71,10 +71,11 @@ class AtSpi2CoreConan(ConanFile):
         tc = MesonToolchain(self)
         if Version(self.version) >= "2.47.1":
             tc.project_options["introspection"] = "disabled"
+            tc.project_options["x11"] = "enabled" if self.options.with_x11 else "disabled"
         else:
             tc.project_options["introspection"] = "no"
+            tc.project_options["x11"] = "yes" if self.options.with_x11 else "no"
         tc.project_options["docs"] = "false"
-        tc.project_options["x11"] = "yes" if self.options.with_x11 else "no"
         tc.generate()
         tc = PkgConfigDeps(self)
         tc.generate()

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -84,7 +84,7 @@ class AtSpi2CoreConan(ConanFile):
         apply_conandata_patches(self)
         replace_in_file(self, os.path.join(self.source_folder, "bus", "meson.build"),
                                 "if x11_dep.found()",
-                                "if get_option('x11')" if Version(self.version) >= "2.47.1"
+                                "if get_option('x11').enabled()" if Version(self.version) >= "2.47.1"
                                 else "if x11_option == 'yes'")
         replace_in_file(self, os.path.join(self.source_folder, 'meson.build'),
             "subdir('tests')",

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -84,7 +84,8 @@ class AtSpi2CoreConan(ConanFile):
         apply_conandata_patches(self)
         replace_in_file(self, os.path.join(self.source_folder, "bus", "meson.build"),
                                 "if x11_dep.found()",
-                                "if x11_option == 'yes'")
+                                "if get_option('x11')" if Version(self.version) >= "2.47.1"
+                                else "if x11_option == 'yes'")
         replace_in_file(self, os.path.join(self.source_folder, 'meson.build'),
             "subdir('tests')",
             "#subdir('tests')")

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -9,6 +9,7 @@ from conan.tools.scm import Version
 import os
 
 
+required_conan_version = ">=1.52.0"
 class AtSpi2CoreConan(ConanFile):
     name = "at-spi2-core"
     description = "It provides a Service Provider Interface for the Assistive Technologies available on the GNOME platform and a library against which applications can be linked"

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.files import apply_conandata_patches, export_conandata_patches,
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.scm import Version
 import os
 
 
@@ -68,7 +69,10 @@ class AtSpi2CoreConan(ConanFile):
 
     def generate(self):
         tc = MesonToolchain(self)
-        tc.project_options["introspection"] = "no"
+        if Version(self.version) >= "2.47.1":
+            tc.project_options["introspection"] = "disabled"
+        else:
+            tc.project_options["introspection"] = "no"
         tc.project_options["docs"] = "false"
         tc.project_options["x11"] = "yes" if self.options.with_x11 else "no"
         tc.generate()

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, replace_in_file, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
@@ -101,7 +101,7 @@ class AtSpi2CoreConan(ConanFile):
         meson.build()
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self.source_folder)
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
         meson = Meson(self)
         meson.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/at-spi2-core/new/conanfile.py
+++ b/recipes/at-spi2-core/new/conanfile.py
@@ -37,9 +37,9 @@ class AtSpi2CoreConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
         if self.options.shared:
             self.options["glib"].shared = True
 


### PR DESCRIPTION
Specify library name and version:  **at-spi2-core/2.47.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
