### PR TITLE
wayland-protocols: Bump Meson version to 1.0.0

### DIFF
--- a/recipes/wayland-protocols/all/conanfile.py
+++ b/recipes/wayland-protocols/all/conanfile.py
@@ -27,7 +27,7 @@ class WaylandProtocolsConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} only supports Linux")
 
     def build_requirements(self):
-        self.tool_requires("meson/0.64.1")
+        self.tool_requires("meson/1.0.0")
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/wayland-protocols/all/test_package/conanfile.py
+++ b/recipes/wayland-protocols/all/test_package/conanfile.py
@@ -20,7 +20,7 @@ class TestPackageConan(ConanFile):
         self.requires("wayland/1.21.0")
 
     def build_requirements(self):
-        self.tool_requires("meson/0.64.1")
+        self.tool_requires("meson/1.0.0")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/1.9.3")
         self.tool_requires("wayland/1.21.0")

--- a/recipes/wayland-protocols/all/test_v1_package/conanfile.py
+++ b/recipes/wayland-protocols/all/test_v1_package/conanfile.py
@@ -10,7 +10,7 @@ class TestPackageConan(ConanFile):
 
     def build_requirements(self):
         self.build_requires("wayland/1.21.0")
-        self.build_requires("meson/0.64.1")
+        self.build_requires("meson/1.0.0")
 
     def requirements(self):
         self.requires("wayland/1.21.0")


### PR DESCRIPTION
Specify library name and version:  **wayland-protocols/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
