### PR TITLE
minizip: add transitive_headers trait to dependencies (v2)

### DIFF
--- a/recipes/minizip/all/conanfile.py
+++ b/recipes/minizip/all/conanfile.py
@@ -55,9 +55,9 @@ class MinizipConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.2.13", transitive_headers=True)
         if self.options.bzip2:
-            self.requires("bzip2/1.0.8")
+            self.requires("bzip2/1.0.8", transitive_headers=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **minizip/all**

Fixes issue when creating the packages with Conan 2, where the `test_package` fails compilation because it cannot find headers from `zlib` or `bz2`. 

