### PR TITLE
vorbis: add dependency trait and fix removal of fPIC options when on Windows

### DIFF
--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -45,7 +45,7 @@ class VorbisConan(ConanFile):
             pass
 
     def requirements(self):
-        self.requires("ogg/1.3.5")
+        self.requires("ogg/1.3.5", transitive_headers=True)
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -34,7 +34,7 @@ class VorbisConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
         try:
             del self.settings.compiler.libcxx
         except Exception:


### PR DESCRIPTION
Specify library name and version:  **vorbis/all**

* Add dependency trait since vorbis consumers transitively require ogg headers (fixes test_package when using Conan 2)
* Safely remove `fPIC` option when building shared library (since on windows it's removed previously)