### PR TITLE
m4: add package_type attribute

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -12,6 +12,7 @@ required_conan_version = ">=1.52.0"
 
 class M4Conan(ConanFile):
     name = "m4"
+    package_type = "application"
     description = "GNU M4 is an implementation of the traditional Unix macro processor"
     topics = ("macro", "preprocessor")
     homepage = "https://www.gnu.org/software/m4/"


### PR DESCRIPTION
Specify library name and version:  **m4/all**

In Conan 2, this is required for downstream consumers to be exposed to PATH/m4 variables from this recipe, when `m4` is a transitive dependency (i.e., not direct).
