### PR TITLE
uwebsockets: add version 20.36.0

### DIFF
--- a/recipes/uwebsockets/all/conandata.yml
+++ b/recipes/uwebsockets/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.36.0":
+    url: "https://github.com/uNetworking/uWebSockets/archive/v20.36.0.tar.gz"
+    sha256: "cda266f7ed6abe67ef3cae6e223a580fe5091db9156c1f4123ee328ae21511c9"
   "20.17.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v20.17.0.tar.gz"
     sha256: "62027b0b847563bcc65a760045dc4233328229fc551f97fe5814e518e272141c"

--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -54,6 +54,8 @@ class UwebsocketsConan(ConanFile):
         if self.options.get_safe("with_libdeflate"):
             self.requires("libdeflate/1.14")
 
+        if Version(self.version) >= "20.36.0":
+            self.requires("usockets/0.8.5")
         if Version(self.version) >= "20.15.0":
             self.requires("usockets/0.8.2")
         elif Version(self.version) >= "19.0.0":
@@ -74,7 +76,7 @@ class UwebsocketsConan(ConanFile):
             )
 
         if Version(self.version) >= "20.14.0" and self.settings.compiler == "clang" and str(self.settings .compiler.libcxx) == "libstdc++":
-            raise ConanInvalidConfiguration("{} needs recent libstdc++ with charconv.".format(self.name))
+            raise ConanInvalidConfiguration(f"{self.ref} needs recent libstdc++ with charconv.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/uwebsockets/config.yml
+++ b/recipes/uwebsockets/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.36.0":
+    folder: all
   "20.17.0":
     folder: all
   "20.14.0":


### PR DESCRIPTION
Specify library name and version:  **uwebsockets/20.36.0**

- add version 20.36.0
- use usockets/0.8.5 for uwebsockets/20.36.0
- use self.ref in validation

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
