### PR TITLE
Add LEAF to Conan Center

### DIFF
--- a/recipes/leaf/all/conandata.yml
+++ b/recipes/leaf/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.81.0":
+    url: "https://github.com/zajo/leaf/archive/refs/tags/1.81.0.tar.gz"
+    sha256: "3ea435e4fc58a8811885cb20140f6921e566e23f4d328a54efd5988908c7ea32"

--- a/recipes/leaf/all/conanfile.py
+++ b/recipes/leaf/all/conanfile.py
@@ -1,0 +1,80 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.build import check_min_cppstd
+from conan.errors import ConanInvalidConfiguration
+import os
+
+
+required_conan_version = ">=1.50.0"
+
+
+class LEAFConan(ConanFile):
+    name = "leaf"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/zajo/leaf"
+    description = ("Lightweight Error Augmentation Framework")
+    topics = ("multi-platform", "multi-threading", "cpp11", "error-handling",
+              "header-only", "low-latency", "no-dependencies", "single-header")
+    settings = "os", "compiler", "arch", "build_type"
+    no_copy_source = True
+
+    def package_id(self):
+        self.info.clear()
+
+    @property
+    def _min_cppstd(self):
+        return "11"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "4.8",
+            "Visual Studio": "17",
+            "msvc": "141",
+            "clang": "3.9",
+            "apple-clang": "10.0.0"
+        }
+
+    def requirements(self):
+        pass
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+        def lazy_lt_semver(v1, v2):
+            lv1 = [int(v) for v in v1.split(".")]
+            lv2 = [int(v) for v in v2.split(".")]
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
+
+        compiler = str(self.settings.compiler)
+        version = str(self.settings.compiler.version)
+        minimum_version = self._compilers_minimum_version.get(compiler, False)
+
+        if minimum_version and lazy_lt_semver(version, minimum_version):
+            raise ConanInvalidConfiguration(
+                f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler ({compiler}-{version}) does not support")
+
+    def layout(self):
+        basic_layout(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE_1_0.txt", dst=os.path.join(
+            self.package_folder, "licenses"),  src=self.source_folder)
+        copy(self, "*.h", dst=os.path.join(self.package_folder, "include"),
+             src=os.path.join(self.source_folder, "include"))
+        copy(self, "*.hpp", dst=os.path.join(self.package_folder,
+             "include"), src=os.path.join(self.source_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []

--- a/recipes/leaf/all/test_package/CMakeLists.txt
+++ b/recipes/leaf/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+find_package(leaf REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
+target_link_libraries(${PROJECT_NAME} PRIVATE leaf::leaf)

--- a/recipes/leaf/all/test_package/conanfile.py
+++ b/recipes/leaf/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/leaf/all/test_package/main.cpp
+++ b/recipes/leaf/all/test_package/main.cpp
@@ -1,0 +1,60 @@
+#include <cstdio>
+#include <leaf/leaf.hpp>
+
+enum custom_error_t
+{
+  err1,
+  err2,
+  err3,
+};
+
+leaf::result<int>
+f1()
+{
+  return 5;
+}
+
+leaf::result<int>
+f2()
+{
+  return 15;
+}
+
+leaf::result<int>
+g(int a, int b)
+{
+  int sum = a + b;
+  if (sum == 20) {
+    return leaf::new_error(custom_error_t::err2);
+  }
+  return sum;
+}
+
+int
+main()
+{
+  leaf::result<int> r = leaf::try_handle_some(
+    []() -> leaf::result<int> {
+      BOOST_LEAF_AUTO(v1, f1());
+      BOOST_LEAF_AUTO(v2, f2());
+
+      return g(v1, v2);
+    },
+    [](leaf::match<custom_error_t, custom_error_t::err1, custom_error_t::err3>)
+      -> leaf::result<int> {
+      exit(1);
+      return -1;
+    },
+    [](custom_error_t e) -> leaf::result<int> {
+      printf("Error value [%d] handled\n", static_cast<int>(e));
+      return 17;
+    });
+
+  if (r) {
+    printf("value of r = %d\n", r.value());
+  } else {
+    printf("r contains an error!\n");
+  }
+
+  return 0;
+}

--- a/recipes/leaf/all/test_v1_package/CMakeLists.txt
+++ b/recipes/leaf/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(leaf REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/main.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
+target_link_libraries(${PROJECT_NAME} PRIVATE leaf::leaf)

--- a/recipes/leaf/all/test_v1_package/conanfile.py
+++ b/recipes/leaf/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class LeafTestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = ("cmake", "cmake_find_package_multi")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join(self.build_folder, "bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/leaf/config.yml
+++ b/recipes/leaf/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.81.0":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version: leaf/1.81.0

I work with and have consent by the author to put LEAF on the Conan Center Index. This library is a dependency of my library libhal.

Original github library can be found here: https://github.com/zajo/leaf

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
