### PR TITLE
capnproto: add version 0.10.3 (for CVE-2022-46149)

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.3":
+    url: "https://github.com/capnproto/capnproto/archive/v0.10.3.tar.gz"
+    sha256: "e07446f56043c983e009038e69d18ff86a2924909f0b518ccf47eccf5ac03919"
   "0.10.1":
     url: "https://github.com/capnproto/capnproto/archive/v0.10.1.tar.gz"
     sha256: "2e9c918f02c198557c75ca7c635fe281337c9755b752a6ab3a841bcc1cf5176b"
@@ -15,6 +18,8 @@ sources:
     url: "https://github.com/capnproto/capnproto/archive/v0.7.0.tar.gz"
     sha256: 76c7114a3d142ad08b7208b3964a26e72a6320ee81331d3f0b87569fc9c47a28
 patches:
+  "0.10.3":
+    - patch_file: patches/0014-disable-tests-for-0.10.1.patch
   "0.10.1":
     - patch_file: patches/0014-disable-tests-for-0.10.1.patch
   "0.10.0":

--- a/recipes/capnproto/config.yml
+++ b/recipes/capnproto/config.yml
@@ -1,6 +1,8 @@
 versions:
   "0.10.3":
     folder: all
+  "0.10.1":
+    folder: all
   "0.10.0":
     folder: all
   "0.9.1":

--- a/recipes/capnproto/config.yml
+++ b/recipes/capnproto/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.10.1":
+  "0.10.3":
     folder: all
   "0.10.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **capnproto/0.10.3**

There is a patch for security advisory.
https://github.com/capnproto/capnproto/blob/master/security-advisories/2022-11-30-0-pointer-list-bounds.md

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
