### PR TITLE
opentelemetry-cpp: option 'with_logs_preview' to enable experimental Logs

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -22,10 +22,12 @@ class OpenTelemetryCppConan(ConanFile):
     options = {
         "fPIC": [True, False],
         "shared": [True, False],
+        "with_logs_preview": [True, False],
     }
     default_options = {
         "fPIC": True,
         "shared": False,
+        "with_logs_preview": False,
     }
     short_paths = True
 
@@ -100,6 +102,8 @@ class OpenTelemetryCppConan(ConanFile):
         tc.variables["WITH_JAEGER"] = True
         tc.variables["WITH_OTLP"] = True
         tc.variables["WITH_ZIPKIN"] = True
+        if self.options.with_logs_preview:
+            tc.variables["WITH_LOGS_PREVIEW"] = True
         tc.generate()
 
         tc = CMakeDeps(self)
@@ -189,6 +193,14 @@ class OpenTelemetryCppConan(ConanFile):
 
         if Version(self.version) >= "1.7.0":
             libraries.append("opentelemetry_exporter_otlp_grpc_client")
+
+        if self.options.with_logs_preview:
+            libraries.extend([
+                "opentelemetry_logs",
+                "opentelemetry_exporter_ostream_logs",
+                "opentelemetry_exporter_otlp_grpc_log",
+                "opentelemetry_exporter_otlp_http_log",
+            ])
 
         if self.settings.os == "Windows":
             libraries.extend([
@@ -303,6 +315,26 @@ class OpenTelemetryCppConan(ConanFile):
             "opentelemetry_common",
             "opentelemetry_resources",
         ])
+
+        if self.options.with_logs_preview:
+            self.cpp_info.components["opentelemetry_logs"].requires.extend([
+                "opentelemetry_resources",
+                "opentelemetry_common",
+            ])
+
+            self.cpp_info.components["opentelemetry_exporter_ostream_logs"].requires.extend([
+                "opentelemetry_logs",
+            ])
+
+            self.cpp_info.components["opentelemetry_exporter_otlp_grpc_log"].requires.extend([
+                "opentelemetry_otlp_recordable",
+                "opentelemetry_exporter_otlp_grpc_client",
+            ])
+
+            self.cpp_info.components["opentelemetry_exporter_otlp_http_log"].requires.extend([
+                "opentelemetry_otlp_recordable",
+                "opentelemetry_exporter_otlp_http_client",
+            ])
 
         if self.settings.os in ("Linux", "FreeBSD"):
             self.cpp_info.components["opentelemetry_common"].system_libs.extend(["pthread"])


### PR DESCRIPTION
**opentelemetry-cpp/1.0.1**+

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

fixes #15024

Looks like the feature flag has existed since the 1.0.0 release of this library: https://github.com/open-telemetry/opentelemetry-cpp/pull/807
This means that adding the feature flag for all currently supported versions in `conandata.yml` shouldn't be an issue


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
