### PR TITLE
confu_json: support for c++17

### DIFF
--- a/recipes/confu_json/all/conandata.yml
+++ b/recipes/confu_json/all/conandata.yml
@@ -11,3 +11,4 @@ sources:
   1.0.0:
     url: https://github.com/werto87/confu_json/archive/refs/tags/v1.0.0.tar.gz
     sha256: e7302757c9d74c12f0bd637f3f79237d420e203b577489c196eff3616a05e0e6
+    

--- a/recipes/confu_json/all/conandata.yml
+++ b/recipes/confu_json/all/conandata.yml
@@ -11,4 +11,5 @@ sources:
   1.0.0:
     url: https://github.com/werto87/confu_json/archive/refs/tags/v1.0.0.tar.gz
     sha256: e7302757c9d74c12f0bd637f3f79237d420e203b577489c196eff3616a05e0e6
+
     

--- a/recipes/confu_json/all/conandata.yml
+++ b/recipes/confu_json/all/conandata.yml
@@ -11,5 +11,3 @@ sources:
   1.0.0:
     url: https://github.com/werto87/confu_json/archive/refs/tags/v1.0.0.tar.gz
     sha256: e7302757c9d74c12f0bd637f3f79237d420e203b577489c196eff3616a05e0e6
-
-    

--- a/recipes/confu_json/all/conandata.yml
+++ b/recipes/confu_json/all/conandata.yml
@@ -5,6 +5,9 @@ sources:
   0.0.9:
     url: https://github.com/werto87/confu_json/archive/refs/tags/v0.0.9.tar.gz
     sha256: 29b2940b939cb04f11fdab4964c86bcb23ac75c588550bf54048e024444d2718
-  "0.0.10":
+  0.0.10:
     url: "https://github.com/werto87/confu_json/archive/v0.0.10.tar.gz"
     sha256: "b31aab1bce952c0dc0bfc1f955a7b88be5103350b5a5eee1a4586ccec0e51fc1"
+  1.0.0:
+    url: https://github.com/werto87/confu_json/archive/refs/tags/v1.0.0.tar.gz
+    sha256: e7302757c9d74c12f0bd637f3f79237d420e203b577489c196eff3616a05e0e6

--- a/recipes/confu_json/all/conandata.yml
+++ b/recipes/confu_json/all/conandata.yml
@@ -10,4 +10,4 @@ sources:
     sha256: "b31aab1bce952c0dc0bfc1f955a7b88be5103350b5a5eee1a4586ccec0e51fc1"
   1.0.0:
     url: https://github.com/werto87/confu_json/archive/refs/tags/v1.0.0.tar.gz
-    sha256: e7302757c9d74c12f0bd637f3f79237d420e203b577489c196eff3616a05e0e6
+    sha256: f165172220b440d37a7a8301e490cf791b3b25b0cc3f2a08b355609c5f777db0

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
+from conan.tools import files
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
@@ -63,7 +64,7 @@ class ConfuJson(ConanFile):
         self.requires("magic_enum/0.8.0")
 
     def source(self):
-        tools.files.get(self, **self.conan_data["sources"][self.version],
+        files.get(self, **self.conan_data["sources"][self.version],
         destination=self._source_subfolder, strip_root=True)
 
     def package(self):

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -35,7 +35,7 @@ class ConfuJson(ConanFile):
         if self.settings.compiler == "apple-clang":
             raise ConanInvalidConfiguration(
                 "apple-clang is not supported. Pull request welcome")
-        if Version(self.version) <= "1.0.0":
+        if Version(self.version) >= "1.0.0":
             if self.settings.compiler.get_safe("cppstd"):
                 check_min_cppstd(self, 17)
         else:

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -36,13 +36,13 @@ class ConfuJson(ConanFile):
                 "apple-clang is not supported. Pull request welcome")
         if Version(self.version) <= "1.0.0":
             if self.settings.compiler.get_safe("cppstd"):
-                tools.build.check_min_cppstd(self, 17)
+                check_min_cppstd(self, 17)
         else:
             if is_msvc(self) and Version(self.version) < "0.0.9":
                 raise ConanInvalidConfiguration(
                     "Visual Studio is not supported in versions before confu_json/0.0.9")
             if self.settings.compiler.get_safe("cppstd"):
-                tools.build.check_min_cppstd(self, 20)
+                check_min_cppstd(self, 20)
             min_version = self._minimum_compilers_version.get(
                 str(self.settings.compiler))
             if not min_version:

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile, tools
+from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -33,7 +33,7 @@ class ConfuJson(ConanFile):
         if self.settings.compiler == "apple-clang":
             raise ConanInvalidConfiguration(
                 "apple-clang is not supported. Pull request welcome")
-        if is_msvc(self) and Version(self.version) <= "1.0.0":
+        if Version(self.version) <= "1.0.0":
             if self.settings.compiler.get_safe("cppstd"):
                 tools.build.check_min_cppstd(self, 17)
         else:
@@ -53,7 +53,7 @@ class ConfuJson(ConanFile):
                     raise ConanInvalidConfiguration(
                         "{} requires C++{} support. "
                         "The current compiler {} {} does not support it.".format(
-                            self.name, self._minimum_cpp_standard,
+                            self.name, 20,
                             self.settings.compiler,
                             self.settings.compiler.version))
 

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -38,6 +38,9 @@ class ConfuJson(ConanFile):
         if Version(self.version) >= "1.0.0":
             if self.settings.compiler.get_safe("cppstd"):
                 check_min_cppstd(self, 17)
+            if is_msvc(self) and Version(self.settings.compiler.version) < 17:
+                raise ConanInvalidConfiguration(
+                    "Visual Studio is not supported in versions before 17")
         else:
             if is_msvc(self) and Version(self.version) < "0.0.9":
                 raise ConanInvalidConfiguration(

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -20,10 +20,6 @@ class ConfuJson(ConanFile):
         return "source_subfolder"
 
     @property
-    def _minimum_cpp_standard(self):
-        return 20
-
-    @property
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "17",
@@ -34,29 +30,32 @@ class ConfuJson(ConanFile):
 
        
     def configure(self):
-        if is_msvc(self) and Version(self.version) < "0.0.9":
-            raise ConanInvalidConfiguration(
-                "Visual Studio is not supported in versions before confu_json/0.0.9")
         if self.settings.compiler == "apple-clang":
             raise ConanInvalidConfiguration(
                 "apple-clang is not supported. Pull request welcome")
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.build.check_min_cppstd(self, self._minimum_cpp_standard)
-
-        min_version = self._minimum_compilers_version.get(
-            str(self.settings.compiler))
-        if not min_version:
-            self.output.warn("{} recipe lacks information about the {} "
-                             "compiler support.".format(
-                                 self.name, self.settings.compiler))
+        if is_msvc(self) and Version(self.version) <= "1.0.0":
+            if self.settings.compiler.get_safe("cppstd"):
+                tools.build.check_min_cppstd(self, 17)
         else:
-            if Version(self.settings.compiler.version) < min_version:
+            if is_msvc(self) and Version(self.version) < "0.0.9":
                 raise ConanInvalidConfiguration(
-                    "{} requires C++{} support. "
-                    "The current compiler {} {} does not support it.".format(
-                        self.name, self._minimum_cpp_standard,
-                        self.settings.compiler,
-                        self.settings.compiler.version))
+                    "Visual Studio is not supported in versions before confu_json/0.0.9")
+            if self.settings.compiler.get_safe("cppstd"):
+                tools.build.check_min_cppstd(self, 20)
+            min_version = self._minimum_compilers_version.get(
+                str(self.settings.compiler))
+            if not min_version:
+                self.output.warn("{} recipe lacks information about the {} "
+                                "compiler support.".format(
+                                    self.name, self.settings.compiler))
+            else:
+                if Version(self.settings.compiler.version) < min_version:
+                    raise ConanInvalidConfiguration(
+                        "{} requires C++{} support. "
+                        "The current compiler {} {} does not support it.".format(
+                            self.name, self._minimum_cpp_standard,
+                            self.settings.compiler,
+                            self.settings.compiler.version))
 
     def requirements(self):
         self.requires("boost/1.79.0")

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -61,7 +61,7 @@ class ConfuJson(ConanFile):
                             self.settings.compiler.version))
 
     def requirements(self):
-        self.requires("boost/1.79.0")
+        self.requires("boost/1.81.0")
         self.requires("magic_enum/0.8.0")
 
     def source(self):

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -35,6 +35,9 @@ class ConfuJson(ConanFile):
         if self.settings.compiler == "apple-clang":
             raise ConanInvalidConfiguration(
                 "apple-clang is not supported. Pull request welcome")
+        if self.settings.compiler == "gcc" and Version(self.version) < "1.0.0":
+            raise ConanInvalidConfiguration(
+                "gcc is only supported in versions greater than or equal 1.0.0.")        
         if Version(self.version) >= "1.0.0":
             if self.settings.compiler.get_safe("cppstd"):
                 check_min_cppstd(self, 17)

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -50,7 +50,7 @@ class ConfuJson(ConanFile):
             min_version = self._minimum_compilers_version.get(
                 str(self.settings.compiler))
             if not min_version:
-                self.output.warn("{} recipe lacks information about the {} "
+                self.output.warning("{} recipe lacks information about the {} "
                                 "compiler support.".format(
                                     self.name, self.settings.compiler))
             else:

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools import files
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.scm import Version
-from conan.tools.microsoft import is_msvc
+from conan.tools.microsoft import is_msvc ,check_min_vs
 
 required_conan_version = ">=1.50.0"
 

--- a/recipes/confu_json/all/conanfile.py
+++ b/recipes/confu_json/all/conanfile.py
@@ -38,9 +38,7 @@ class ConfuJson(ConanFile):
         if Version(self.version) >= "1.0.0":
             if self.settings.compiler.get_safe("cppstd"):
                 check_min_cppstd(self, 17)
-            if is_msvc(self) and Version(self.settings.compiler.version) < 17:
-                raise ConanInvalidConfiguration(
-                    "Visual Studio is not supported in versions before 17")
+            check_min_vs(self, "1930")
         else:
             if is_msvc(self) and Version(self.version) < "0.0.9":
                 raise ConanInvalidConfiguration(

--- a/recipes/confu_json/config.yml
+++ b/recipes/confu_json/config.yml
@@ -3,5 +3,7 @@ versions:
     folder: all
   0.0.9:
     folder: all
-  "0.0.10":
+  0.0.10:
+    folder: all
+  1.0.0:
     folder: all

--- a/recipes/confu_json/config.yml
+++ b/recipes/confu_json/config.yml
@@ -7,5 +7,3 @@ versions:
     folder: all
   1.0.0:
     folder: all
-
-    

--- a/recipes/confu_json/config.yml
+++ b/recipes/confu_json/config.yml
@@ -7,4 +7,5 @@ versions:
     folder: all
   1.0.0:
     folder: all
+
     

--- a/recipes/confu_json/config.yml
+++ b/recipes/confu_json/config.yml
@@ -7,3 +7,4 @@ versions:
     folder: all
   1.0.0:
     folder: all
+    


### PR DESCRIPTION
Specify library name and version:  **confu_json/1.0.0**

removed c++20 dependency. This lib should now compile with c++17

---

- [ x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
