### PR TITLE
Maintenance: temporarily disable message reports from Conan v2 pipeline

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -40,10 +40,11 @@ tasks:
   automatic_merge:
     reviews_required_total: 2  # Reviews that a PR needs so it can be merged
     reviews_required_team: 1  # Reviews from the Conan team that a PR needs so it can be merged
-  cci_wait_for_multibranch:  # CCI jobs should wait for other multibranch job for that same PR
-    job_name: "prod-v2/cci"  # e.g. "cci-v2/cci" -> this means waiting for cci-v2/cci/PR-<number>
-    timeout_seconds: 600  # Maximum time to wait for the multibranch job
-    merge_messages: true  # Merge messages from the multibranch job waited for
+# Temporarily disable feedback from Conan v2
+  # cci_wait_for_multibranch:  # CCI jobs should wait for other multibranch job for that same PR
+  #   job_name: "prod-v2/cci"  # e.g. "cci-v2/cci" -> this means waiting for cci-v2/cci/PR-<number>
+  #   timeout_seconds: 600  # Maximum time to wait for the multibranch job
+  #   merge_messages: true  # Merge messages from the multibranch job waited for
 
 # Profile configurations to build packages
 configurations:


### PR DESCRIPTION
Temporarily disable reporting status from Conan v2 pipeline - it will still run but not report status. 
Will be restored once we fix the bug of the failed tags, as well as making sure the latest beta is used.
