### PR TITLE
odbc: add package type attribute and fix dependency trait in test_package

### DIFF
--- a/recipes/odbc/all/conanfile.py
+++ b/recipes/odbc/all/conanfile.py
@@ -10,6 +10,7 @@ required_conan_version = ">=1.53.0"
 
 class OdbcConan(ConanFile):
     name = "odbc"
+    package_type = "library"
     description = "Package providing unixODBC"
     topics = ("odbc", "database", "dbms", "data-access")
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/odbc/all/test_package/conanfile.py
+++ b/recipes/odbc/all/test_package/conanfile.py
@@ -13,7 +13,7 @@ class TestPackageConan(ConanFile):
         cmake_layout(self)
 
     def requirements(self):
-        self.requires(self.tested_reference_str)
+        self.requires(self.tested_reference_str, run=True)
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **odbc/all**

This package contains both library and executables, assuming that this one is primarily to be consumed as a library.
The `test_package` consumes it as a library (to build the test project against it), but it also launches an executable from the package - in this case, the consumer needs to express that it also requires the the runtime components of odbc.

This PR fixes the test_package when run with Conan 2. 