### PR TITLE
civetweb: fix evaluation of openssl version in conan 2

### DIFF
--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -105,7 +105,7 @@ class CivetwebConan(ConanFile):
         tc = CMakeToolchain(self)
 
         if self.options.with_ssl:
-            openssl_version = Version(self.dependencies["openssl"].ref.version[:-1])
+            openssl_version = Version(str(self.dependencies["openssl"].ref.version)[:-1])
             tc.variables["CIVETWEB_ENABLE_SSL"] = self.options.with_ssl
             tc.variables["CIVETWEB_ENABLE_SSL_DYNAMIC_LOADING"] = self.options.ssl_dynamic_loading
             tc.variables["CIVETWEB_SSL_OPENSSL_API_1_0"] = openssl_version.minor == "0"

--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -99,7 +99,7 @@ class CivetwebConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder="src")
 
     def generate(self):
         tc = CMakeToolchain(self)


### PR DESCRIPTION
Specify library name and version:  **civetweb/all**

The type of the version object differs in Conan 1.x and Conan 2.x. This PR fixes the following error when using Conan 2.
```
ERROR: civetweb/1.15: Error in generate() method, line 108
        openssl_version = Version(str(self.dependencies["openssl"].ref.version[:-1]))
        TypeError: 'Version' object is not subscriptable
```
