### PR TITLE
bzip3: add version 1.2.2

### DIFF
--- a/recipes/bzip3/all/conandata.yml
+++ b/recipes/bzip3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.2":
+    url: "https://github.com/kspalaiologos/bzip3/archive/1.2.2.tar.gz"
+    sha256: "e7792f3c83f1d9efd0d7b18da2eb6a1f119ffcdeb5515cf441145c2e9b72652e"
   "1.2.1":
     url: "https://github.com/kspalaiologos/bzip3/archive/1.2.1.tar.gz"
     sha256: "f2fc4c9c7679d3b120e8f44d8c4ecd00f03af9981f53e13dc0f956b5996913c9"

--- a/recipes/bzip3/all/conanfile.py
+++ b/recipes/bzip3/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import export_conandata_patches, apply_conandata_patches, copy, get
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class BZip3Conan(ConanFile):
@@ -42,18 +42,9 @@ class BZip3Conan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/bzip3/all/test_v1_package/CMakeLists.txt
+++ b/recipes/bzip3/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(bzip3 REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE bzip3::bzip3)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/bzip3/config.yml
+++ b/recipes/bzip3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.2":
+    folder: all
   "1.2.1":
     folder: all
   "1.2.0":


### PR DESCRIPTION
Specify library name and version:  **bzip3/1.2.2**

- add version 1.2.2
- use `rm_safe`
- use `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
