### PR TITLE
Update qcustomplot to version 2.1.1

### DIFF
--- a/recipes/qcustomplot/all/conandata.yml
+++ b/recipes/qcustomplot/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.1":
+    url: "https://www.qcustomplot.com/release/2.1.1/QCustomPlot-source.tar.gz"
+    sha256: "5e2d22dec779db8f01f357cbdb25e54fbcf971adaee75eae8d7ad2444487182f"
   "2.1.0":
     url: "https://www.qcustomplot.com/release/2.1.0fixed/QCustomPlot-source.tar.gz"
     sha256: "357b78be0f52b2d01c17ec3e2e1271255761810af7e8a9476cef51fccf1a0f44"

--- a/recipes/qcustomplot/config.yml
+++ b/recipes/qcustomplot/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.1":
+    folder: all
   "2.1.0":
     folder: all
   "1.3.2":


### PR DESCRIPTION
Specify library name and version:  **qcustomplot/2.1.1**

This is just a bump to the latest version of QCustomPlot.


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
