### PR TITLE
minizip-ng: add version 3.0.8, update xz_utils

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.8":
+    url: "https://github.com/zlib-ng/minizip-ng/archive/3.0.8.tar.gz"
+    sha256: "27cc2f62cd02d79b71b346fc6ace02728385f8ba9c6b5f124062b0790a04629a"
   "3.0.7":
     url: "https://github.com/zlib-ng/minizip-ng/archive/3.0.7.tar.gz"
     sha256: "39981a0db1bb6da504909bce63d7493286c5e50825c056564544c990d15c55cf"
@@ -21,6 +24,14 @@ sources:
     url: "https://github.com/zlib-ng/minizip-ng/archive/3.0.1.tar.gz"
     sha256: "96c95b274dd535984ce0e87691691388f2b976106e8cf8d527b15da552ac94e4"
 patches:
+  "3.0.8":
+    - patch_file: "patches/3.0.8-0001-fix-cmake-project.patch"
+      patch_description: "CMake: declare project() sooner"
+      patch_type: "conan"
+    - patch_file: "patches/3.0.6-0002-fix-lzma-libdir.patch"
+      patch_description: "CMake: inject libdir of lzma"
+      patch_type: "conan"
+      patch_source: "https://github.com/zlib-ng/minizip-ng/pull/658"
   "3.0.7":
     - patch_file: "patches/3.0.7-0001-fix-cmake-project.patch"
       patch_description: "CMake: declare project() sooner"

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -85,7 +85,7 @@ class MinizipNgConan(ConanFile):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:
-            self.requires("xz_utils/5.2.5")
+            self.requires("xz_utils/5.4.0")
         if self.options.with_zstd:
             self.requires("zstd/1.5.2")
         if self.options.with_openssl:

--- a/recipes/minizip-ng/all/patches/3.0.8-0001-fix-cmake-project.patch
+++ b/recipes/minizip-ng/all/patches/3.0.8-0001-fix-cmake-project.patch
@@ -1,0 +1,20 @@
+diff --git a/a/CMakeLists.txt b/b/CMakeLists.txt
+index a073919..7ff2b58 100644
+--- a/a/CMakeLists.txt
++++ b/b/CMakeLists.txt
+@@ -70,6 +70,7 @@ enable_language(C)
+ 
+ # Library version
+ set(VERSION "3.0.8")
++project(minizip${MZ_PROJECT_SUFFIX} VERSION ${VERSION} LANGUAGES C)
+ 
+ # API version
+ set(SOVERSION "3")
+@@ -663,7 +664,6 @@ endif()
+ list(APPEND MINIZIP_INC ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+ # Create minizip library
+-project(minizip${MZ_PROJECT_SUFFIX} LANGUAGES C VERSION ${VERSION})
+ 
+ if(NOT ${MZ_PROJECT_SUFFIX} STREQUAL "")
+     message(STATUS "Project configured as ${PROJECT_NAME}")

--- a/recipes/minizip-ng/config.yml
+++ b/recipes/minizip-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.8":
+    folder: all
   "3.0.7":
     folder: all
   "3.0.6":


### PR DESCRIPTION
Specify library name and version:  **minizip-ng/3.0.8**

- add version 3.0.8
- update xz_utils


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
