### PR TITLE
fix libpng package info when compiling with ClangCL

### DIFF
--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -184,7 +184,7 @@ class LibpngConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "libpng")
         self.cpp_info.set_property("pkg_config_aliases", [f"libpng{major_min_version}"])
 
-        prefix = "lib" if is_msvc(self) else ""
+        prefix = "lib" if self.settings.os == "Windows" else ""
         suffix = major_min_version if self.settings.os == "Windows" else ""
         suffix += "d" if self.settings.os == "Windows" and self.settings.build_type == "Debug" else ""
         self.cpp_info.libs = [f"{prefix}png{suffix}"]


### PR DESCRIPTION
Specify library name and version:  **libpng/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

I'm trying to migrate to ClangCL and libpng makes the wrong assumption for detecting windows.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ]xI've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
