### PR TITLE
cpp-httplib: add version 0.11.4, remove older versions

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.4":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.11.4.tar.gz"
+    sha256: "28f76b875a332fb80972c3212980c963f0a7d2e11a8fe94a8ed0d847b9a2256f"
   "0.11.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.11.3.tar.gz"
     sha256: "799b2daa0441d207f6cd1179ae3a34869722084a434da6614978be1682c1e12d"
@@ -17,21 +20,6 @@ sources:
   "0.10.8":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.10.8.tar.gz"
     sha256: "2959ae3669e34ca8934dfe066cd72fc2bfff44ba53bfc26f3b2cb81ed664ca0d"
-  "0.10.7":
-    url: "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.10.7.tar.gz"
-    sha256: "f89e2e74f64821f3cd925750dcee5dde7160600b1122e692253a4ebed8e1b1b1"
-  "0.10.6":
-    url: "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.10.6.tar.gz"
-    sha256: "c9024e1f41881f28ca276f0f35c1916eb34dab8c52b6aa32a3c360d4e40eb440"
-  "0.10.4":
-    url: "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.10.4.tar.gz"
-    sha256: "7719ff9f309c807dd8a574048764836b6a12bcb7d6ae9e129e7e4289cfdb4bd4"
-  "0.10.3":
-    url: "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.10.3.tar.gz"
-    sha256: "2c02fe6bca8407fb260944ecca68de367475e7221912b104f882c278b46d4776"
-  "0.10.1":
-    url: "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.10.1.tar.gz"
-    sha256: "c3fb2019ed77482681b80b9a5d74ddf49df61a024703be1a5379b28fa13dfa2f"
   "0.9.10":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.9.10.tar.gz"
     sha256: "49dfa101ced75f8536ec7c865f872ab8fca157c8b49e29be5ef2d2aa11f716e8"

--- a/recipes/cpp-httplib/all/conanfile.py
+++ b/recipes/cpp-httplib/all/conanfile.py
@@ -12,7 +12,7 @@ class CpphttplibConan(ConanFile):
     name = "cpp-httplib"
     description = "A C++11 single-file header-only cross platform HTTP/HTTPS library."
     license = "MIT"
-    topics = ("cpp-httplib", "http", "https", "header-only")
+    topics = ("http", "https", "header-only")
     homepage = "https://github.com/yhirose/cpp-httplib"
     url = "https://github.com/conan-io/conan-center-index"
 

--- a/recipes/cpp-httplib/all/test_v1_package/CMakeLists.txt
+++ b/recipes/cpp-httplib/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(httplib REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE httplib::httplib)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.4":
+    folder: all
   "0.11.3":
     folder: all
   "0.11.2":
@@ -10,16 +12,6 @@ versions:
   "0.10.9":
     folder: all
   "0.10.8":
-    folder: all
-  "0.10.7":
-    folder: all
-  "0.10.6":
-    folder: all
-  "0.10.4":
-    folder: all
-  "0.10.3":
-    folder: all
-  "0.10.1":
     folder: all
   "0.9.10":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **cpp-httplib/***

- add version 0.11.4
- remove older versions
- remove "cpp-httplib" from topics
- use `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
