### PR TITLE
vorbis: fix required_conan_version

### DIFF
--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, get, rmdir
 import os
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.52.0"
 
 
 class VorbisConan(ConanFile):


### PR DESCRIPTION
Specify library name and version:  **vorbis/all**

This recipe uses [requirement traits](https://docs.conan.io/en/2.0/reference/conanfile/methods.html#requirement-traits) (`transitive_headers=True`) which were introduced in [Conan 1.52.0](https://github.com/conan-io/conan/pull/11934).


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
