### PR TITLE
cryptopp: conditionally require cmake

### DIFF
--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -36,9 +36,20 @@ class CryptoPPConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def _cmake_new_enough(self, required_version):
+        try:
+            import re
+            from io import StringIO
+            output = StringIO()
+            self.run("cmake --version", output=output)
+            m = re.search(r'cmake version (\d+\.\d+\.\d+)', output.getvalue())
+            return Version(m.group(1)) >= required_version
+        except:
+            return False
+
     def build_requirements(self):
-        if Version(self.version) >= "8.7.0":
-            self.tool_requires("cmake/3.24.0")
+        if Version(self.version) >= "8.7.0" and not self._cmake_new_enough("3.20"):
+            self.tool_requires("cmake/3.20.6")
 
     def validate(self):
         if self.options.shared and Version(self.version) >= "8.7.0":


### PR DESCRIPTION
Specify library name and version:  **cryptopp/all**

The cryptopp CMake scripts provided by abdes require a "too recent" version of CMake, so this recipe was unconditionally requiring a recent version as a tool requirement. This PR makes a conditional dependencies so that users that already have a CMake version recent enough dont have to download or spend time building CMake from source if binaries can't be found.

Close https://github.com/conan-io/conan-center-index/issues/14868