### PR TITLE
opencv 4.x: fix injection of `cpu_baseline` and `cpu_dispatch` options in case of empty string

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -435,10 +435,10 @@ class OpenCVConan(ConanFile):
         tc.variables["OPENCV_MODULES_PUBLIC"] = "opencv"
         tc.variables["OPENCV_ENABLE_NONFREE"] = self.options.nonfree
 
-        if self.options.cpu_baseline:
+        if self.options.cpu_baseline or self.options.cpu_baseline == "":
             tc.variables["CPU_BASELINE"] = self.options.cpu_baseline
 
-        if self.options.cpu_dispatch:
+        if self.options.cpu_dispatch or self.options.cpu_dispatch == "":
             tc.variables["CPU_DISPATCH"] = self.options.cpu_dispatch
 
         if self.options.get_safe("neon") is not None:


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/13171

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
