### PR TITLE
lz4: Fix fPIC unsafe remove in configure

### DIFF
--- a/recipes/lz4/all/conandata.yml
+++ b/recipes/lz4/all/conandata.yml
@@ -11,7 +11,15 @@ sources:
 patches:
   "1.9.3":
     - patch_file: "patches/0003-cmake-minimum-required-first-1.9.3.patch"
+      patch_description: "Move cmake_minimum_required to the top of CMakeFile.txt"
+      patch_type: conan
   "1.9.2":
     - patch_file: "patches/0001-cmake-add-shared-DEFINE_SYMBOL.patch"
+      patch_description: "Add LZ4_DLL_EXPORT to MSVC"
+      patch_type: portability
     - patch_file: "patches/0002-cmake-optional-cli.patch"
+      patch_description: "Add ability not to compile the CLI"
+      patch_type: conan
     - patch_file: "patches/0003-cmake-minimum-required-first-1.9.2.patch"
+      patch_description: "Move cmake_minimum_required to the top of CMakeFile.txt"
+      patch_type: conan

--- a/recipes/lz4/all/conanfile.py
+++ b/recipes/lz4/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.scm import Version
 import os
 import textwrap
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.54.0"
 
 
 class LZ4Conan(ConanFile):

--- a/recipes/lz4/all/conanfile.py
+++ b/recipes/lz4/all/conanfile.py
@@ -15,7 +15,7 @@ class LZ4Conan(ConanFile):
     license = ("BSD-2-Clause", "BSD-3-Clause")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/lz4/lz4"
-    topics = ("lz4", "compression")
+    topics = ("compression")
 
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/lz4/all/conanfile.py
+++ b/recipes/lz4/all/conanfile.py
@@ -37,15 +37,9 @@ class LZ4Conan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/lz4/all/conanfile.py
+++ b/recipes/lz4/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, get, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
@@ -28,8 +28,7 @@ class LZ4Conan(ConanFile):
     }
 
     def export_sources(self):
-        for p in self.conan_data.get("patches", {}).get(self.version, []):
-            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/lz4/all/test_v1_package/conanfile.py
+++ b/recipes/lz4/all/test_v1_package/conanfile.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 from conans import ConanFile, CMake
 from conan.tools.build import cross_building
 import os


### PR DESCRIPTION
Specify library name and version:  **lz4/all**

Additionally, it does some other minor changes:
- Also uses rm_safe for compiler.cppstd & compiler.libcxx
- Cleans its topics up
- Uses `export_conandata_patches`
- Adds info to its patches