### PR TITLE
avahi: Make glib a tool_requires for glib-mkenums

### DIFF
--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conan import ConanFile
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rmdir, rm
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
@@ -33,12 +34,15 @@ class AvahiConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.75.0")
+        self.requires("glib/2.75.2")
         self.requires("expat/2.5.0")
         self.requires("libdaemon/0.14")
         self.requires("dbus/1.15.2")
         self.requires("gdbm/1.19")
         self.requires("libevent/2.1.12")
+
+    def build_requirements(self):
+        self.tool_requires("glib/2.75.2")
 
     def validate(self):
         if self.info.settings.os != "Linux":
@@ -54,6 +58,8 @@ class AvahiConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
         tc = AutotoolsToolchain(self)
         tc.configure_args.append("--enable-compat-libdns_sd")
         tc.configure_args.append("--disable-gtk3")


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Fixes Avahi being unable to build due to not finding `glib-mkenums`.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
