### PR TITLE
xpack: add version 1.0.3, support conan v2

### DIFF
--- a/recipes/xpack/all/conandata.yml
+++ b/recipes/xpack/all/conandata.yml
@@ -1,4 +1,16 @@
 sources:
+  "1.0.3":
+    url: "https://github.com/xyz347/xpack/archive/v1.0.3.tar.gz"
+    sha256: "dcda8da82a82b30bb2100233e45750de3f29b6be00681c38cb102406f6fe399a"
   "1.0.2":
     url: "https://github.com/xyz347/xpack/archive/v1.0.2.tar.gz"
-    sha256: 50cf82e123ef0a0aeb8d39e21f5f067c259f17bd917493ed8d7b39cd33c80f07
+    sha256: "50cf82e123ef0a0aeb8d39e21f5f067c259f17bd917493ed8d7b39cd33c80f07"
+patches:
+  "1.0.3":
+    - patch_file: "patches/1.0.2-0001-use-cci.patch"
+      patch_description: "use cci packages"
+      patch_type: "conan"
+  "1.0.2":
+    - patch_file: "patches/1.0.2-0001-use-cci.patch"
+      patch_description: "use cci packages"
+      patch_type: "conan"

--- a/recipes/xpack/all/conanfile.py
+++ b/recipes/xpack/all/conanfile.py
@@ -1,28 +1,58 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
+from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=1.33.0"
-
+required_conan_version = ">=1.52.0"
 
 class XpackConan(ConanFile):
     name = "xpack"
     description = "C++ reflection, ability to convert between C++ structures and json/xml."
-    topics = ("xpack", "json", "reflection", "xml")
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/xyz347/xpack"
-    license = "Apache-2.0"
+    topics = ("json", "bson", "reflection", "xml", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 11
+    
+    def export_sources(self):
+        export_conandata_patches(self)
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
-    def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*[.h|.hpp]", dst=os.path.join("include", "xpack"), excludes=["example/*", "gtest/*"], src=self._source_subfolder)
+    def requirements(self):
+        self.requires("rapidjson/cci.20220822", transitive_headers=True)
+        self.requires("rapidxml/1.13", transitive_headers=True)
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        apply_conandata_patches(self)
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.h",
+            dst=os.path.join(self.package_folder, "include", "xpack"),
+            src=self.source_folder,
+            excludes=["example", "gtest", "thirdparty"], 
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/xpack/all/patches/1.0.2-0001-use-cci.patch
+++ b/recipes/xpack/all/patches/1.0.2-0001-use-cci.patch
@@ -1,0 +1,43 @@
+diff --git a/a/json_decoder.h b/b/json_decoder.h
+index 6d5e50c..e66fe8c 100755
+--- a/a/json_decoder.h
++++ b/b/json_decoder.h
+@@ -20,8 +20,8 @@
+ #include <fstream>
+ 
+ #include "rapidjson_custom.h"
+-#include "thirdparty/rapidjson/document.h"
+-#include "thirdparty/rapidjson/error/en.h"
++#include "rapidjson/document.h"
++#include "rapidjson/error/en.h"
+ 
+ #include "xdecoder.h"
+ 
+diff --git a/a/json_encoder.h b/b/json_encoder.h
+index 442d9e0..2be9323 100755
+--- a/a/json_encoder.h
++++ b/b/json_encoder.h
+@@ -20,8 +20,8 @@
+ #include <string>
+ 
+ #include "rapidjson_custom.h"
+-#include "thirdparty/rapidjson/prettywriter.h"
+-#include "thirdparty/rapidjson/stringbuffer.h"
++#include "rapidjson/prettywriter.h"
++#include "rapidjson/stringbuffer.h"
+ 
+ #include "xencoder.h"
+ 
+diff --git a/a/xml_decoder.h b/b/xml_decoder.h
+index d9cb4bb..91530ba 100755
+--- a/a/xml_decoder.h
++++ b/b/xml_decoder.h
+@@ -24,7 +24,7 @@
+ #include <cstdlib>
+ #include <string.h>
+ 
+-#include "thirdparty/rapidxml/rapidxml.hpp"
++#include "rapidxml/rapidxml.hpp"
+ 
+ #include "xdecoder.h"
+ 

--- a/recipes/xpack/all/test_package/CMakeLists.txt
+++ b/recipes/xpack/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(xpack CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} xpack::xpack)
+target_link_libraries(${PROJECT_NAME} PRIVATE xpack::xpack)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/xpack/all/test_package/conanfile.py
+++ b/recipes/xpack/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
-
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/xpack/all/test_v1_package/CMakeLists.txt
+++ b/recipes/xpack/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/xpack/all/test_v1_package/conanfile.py
+++ b/recipes/xpack/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/xpack/config.yml
+++ b/recipes/xpack/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.3":
+    folder: "all"
   "1.0.2":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **xpack/***

- add version 1.0.3
- support conan v2
- use cci packages(rapidjson, rapidxml)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
