### PR TITLE
coin-utils : added 2.11.6

### DIFF
--- a/recipes/coin-utils/all/conandata.yml
+++ b/recipes/coin-utils/all/conandata.yml
@@ -2,7 +2,13 @@ sources:
   "2.11.4":
     url: "https://github.com/coin-or/CoinUtils/archive/releases/2.11.4.tar.gz"
     sha256: "d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81"
+  "2.11.6":
+    url: "https://github.com/coin-or/CoinUtils/archive/releases/2.11.6.tar.gz"
+    sha256: "6ea31d5214f7eb27fa3ffb2bdad7ec96499dd2aaaeb4a7d0abd90ef852fc79ca"
 patches:
   "2.11.4":
+    - patch_file: "patches/0001-no-check-pkgconfig.patch"
+      base_path: "source_subfolder"
+  "2.11.6":
     - patch_file: "patches/0001-no-check-pkgconfig.patch"
       base_path: "source_subfolder"

--- a/recipes/coin-utils/config.yml
+++ b/recipes/coin-utils/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.11.4":
     folder: "all"
+  "2.11.6":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **coin-utils/2.11.6**

Dependency of coin-cbc/2.10.8 (PR to follow)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
