### PR TITLE
libavrocpp: install either static or shared + fix discovery of Snappy + do not sugget unofficial imported target names

### DIFF
--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -47,7 +47,7 @@ class LibavrocppConan(ConanFile):
         self.requires("snappy/1.1.9")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
 
     def source(self):
@@ -86,12 +86,8 @@ class LibavrocppConan(ConanFile):
                 rm(self, dll_pattern_to_remove, os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
-        # FIXME: avro does not install under a CMake namespace https://github.com/apache/avro/blob/351f589913b9691322966fb77fe72269a0a2ec82/lang/c%2B%2B/CMakeLists.txt#L193
-        target = "avrocpp" if self.options.shared else "avrocpp_s"
-        self.cpp_info.components[target].libs = [target]
-        self.cpp_info.components[target].requires = ["boost::boost", "snappy::snappy"]
+        self.cpp_info.libs = ["avrocpp" if self.options.shared else "avrocpp_s"]
         if self.options.shared:
-            self.cpp_info.components[target].defines.append("AVRO_DYN_LINK")
+            self.cpp_info.defines.append("AVRO_DYN_LINK")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
-

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -15,11 +15,11 @@ class LibavrocppConan(ConanFile):
     topics = ("serialization", "deserialization","avro")
     settings = "os", "arch", "compiler", "build_type"
     options = {
-        "shared": [True, False], 
+        "shared": [True, False],
         "fPIC": [True, False]
     }
     default_options = {
-        "shared": False, 
+        "shared": False,
         "fPIC": True
     }
     short_paths = True
@@ -55,7 +55,7 @@ class LibavrocppConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["SNAPPY_ROOT_DIR"] = self.deps_cpp_info["snappy"].rootpath.replace("\\", "/")
+        tc.variables["SNAPPY_ROOT_DIR"] = self.dependencies["snappy"].package_folder.replace("\\", "/")
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
 

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -4,7 +4,8 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
+
 
 class LibavrocppConan(ConanFile):
     name = "libavrocpp"
@@ -55,7 +56,6 @@ class LibavrocppConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -93,3 +93,7 @@ class LibavrocppConan(ConanFile):
             self.cpp_info.defines.append("AVRO_DYN_LINK")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
+        self.cpp_info.requires = [
+            "boost::headers", "boost::filesystem", "boost::iostreams", "boost::program_options",
+            "boost::regex", "boost::system", "snappy::snappy",
+        ]

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -67,6 +67,11 @@ class LibavrocppConan(ConanFile):
         # Fix discovery & link to Snappy
         replace_in_file(self, cmakelists, "SNAPPY_FOUND", "Snappy_FOUND")
         replace_in_file(self, cmakelists, "${SNAPPY_LIBRARIES}", "Snappy::snappy")
+        replace_in_file(
+            self, cmakelists,
+            "target_include_directories(avrocpp_s PRIVATE ${SNAPPY_INCLUDE_DIR})",
+            "target_link_libraries(avrocpp_s PRIVATE Snappy::snappy)",
+        )
         # Install either static or shared
         target = "avrocpp" if self.options.shared else "avrocpp_s"
         replace_in_file(self, cmakelists, "install (TARGETS avrocpp avrocpp_s" , f"install (TARGETS {target}")

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -67,6 +67,9 @@ class LibavrocppConan(ConanFile):
         # Fix discovery & link to Snappy
         replace_in_file(self, cmakelists, "SNAPPY_FOUND", "Snappy_FOUND")
         replace_in_file(self, cmakelists, "${SNAPPY_LIBRARIES}", "Snappy::snappy")
+        # Install either static or shared
+        target = "avrocpp" if self.options.shared else "avrocpp_s"
+        replace_in_file(self, cmakelists, "install (TARGETS avrocpp avrocpp_s" , f"install (TARGETS {target}")
 
     def build(self):
         self._patch_sources()

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -55,7 +55,6 @@ class LibavrocppConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["SNAPPY_ROOT_DIR"] = self.dependencies["snappy"].package_folder.replace("\\", "/")
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
 
@@ -64,10 +63,10 @@ class LibavrocppConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        replace_in_file(self,
-            os.path.join(self.source_folder, "lang", "c++", "CMakeLists.txt"),
-            "${SNAPPY_LIBRARIES}", "${Snappy_LIBRARIES}"
-        )
+        cmakelists = os.path.join(self.source_folder, "lang", "c++", "CMakeLists.txt")
+        # Fix discovery & link to Snappy
+        replace_in_file(self, cmakelists, "SNAPPY_FOUND", "Snappy_FOUND")
+        replace_in_file(self, cmakelists, "${SNAPPY_LIBRARIES}", "Snappy::snappy")
 
     def build(self):
         self._patch_sources()

--- a/recipes/libavrocpp/all/test_package/CMakeLists.txt
+++ b/recipes/libavrocpp/all/test_package/CMakeLists.txt
@@ -2,12 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
 find_package(libavrocpp REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-
+target_link_libraries(${PROJECT_NAME} PRIVATE libavrocpp::libavrocpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
-
-if(TARGET libavrocpp::avrocpp)
-    target_link_libraries(${PROJECT_NAME} libavrocpp::avrocpp)
-else()
-    target_link_libraries(${PROJECT_NAME} libavrocpp::avrocpp_s)
-endif()

--- a/recipes/libavrocpp/all/test_package/conanfile.py
+++ b/recipes/libavrocpp/all/test_package/conanfile.py
@@ -9,11 +9,11 @@ class TestPackageConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
-    def requirements(self):
-        self.requires(self.tested_reference_str)
-
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
There is no config file upstream, so the rational for defining custom target names was wrong. Upstream logical target names don't matter, only matters imported target names in config file if it's created.

closes https://github.com/conan-io/conan-center-index/issues/15495

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
