### PR TITLE
libwebp >= 1.3.0: relocatable shared libs on macOS

### DIFF
--- a/recipes/libwebp/all/conanfile.py
+++ b/recipes/libwebp/all/conanfile.py
@@ -78,7 +78,7 @@ class LibwebpConan(ConanFile):
         if Version(self.version) >= "1.2.1":
             tc.variables["WEBP_BUILD_LIBWEBPMUX"] = True
         tc.variables["WEBP_BUILD_WEBPMUX"] = False
-        if self.options.shared and is_msvc(self):
+        if Version(self.version) < "1.3.0" and self.options.shared and is_msvc(self):
           # Building a dll (see fix-dll-export patch)
           tc.preprocessor_definitions["WEBP_DLL"] = 1
         tc.generate()

--- a/recipes/libwebp/all/conanfile.py
+++ b/recipes/libwebp/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc
@@ -94,6 +95,8 @@ class LibwebpConan(ConanFile):
         copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
+        if Version(self.version) >= "1.3.0":
+            fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "WebP")


### PR DESCRIPTION
I don't know why, but since 1.3.0 libwebp maintainers have decided to follow this horrible autotools/meson convention and hardcode absolute path of install dir into install_name of shared libs in their CMakeLists: https://github.com/webmproject/libwebp/blob/v1.3.0/CMakeLists.txt#L104-L108

So it has to be fixed with `fix_apple_shared_install_name()` (to avoid patching forever).

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
