### PR TITLE
GCC Conan 2.0 compatibility

### DIFF
--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.microsoft import is_msvc
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.55.0"
 
 
 class GccConan(ConanFile):
@@ -83,11 +83,6 @@ class GccConan(ConanFile):
         tc.configure_args.append("--disable-nls")
         tc.configure_args.append("--disable-multilib")
         tc.configure_args.append("--disable-bootstrap")
-        # TODO: Remove --prefix and --libexecdir args when c3i supports conan 1.55.0.
-        # This change should only happen in conjunction with a move to
-        # autotools.install("install-strip")
-        tc.configure_args.append(f"--prefix={self.package_folder}")
-        tc.configure_args.append(f"--libexecdir={os.path.join(self.package_folder, 'bin', 'libexec')}")
         tc.configure_args.append(f"--with-zlib={self.dependencies['zlib'].package_folder}")
         tc.configure_args.append(f"--with-isl={self.dependencies['isl'].package_folder}")
         tc.configure_args.append(f"--with-gmp={self.dependencies['gmp'].package_folder}")
@@ -139,10 +134,7 @@ class GccConan(ConanFile):
 
     def package(self):
         autotools = Autotools(self)
-        # TODO: Use more modern autotools.install(target="install-strip") when c3i supports
-        # conan client version of 1.55.0. Make sure that the minimum conan version is also bumped
-        # when this is changed.
-        autotools.make(target="install-strip")
+        autotools.install(target="install-strip")
 
         rmdir(self, os.path.join(self.package_folder, "share"))
         rm(self, "*.la", self.package_folder, recursive=True)


### PR DESCRIPTION
Specify library name and version:  **gcc//11.3.0**

This PR addresses the remaining compatibility issues with using Conan 2.0 as noted in #15283. More specifically, Conan 2.0 uses a new package_folder paradigm where the package folder is not known until package time. 

As an aside, these changes were provided as feedback to PR #13896, but had to be deferred at the time because CCI was using an older version of Conan 1.x that didn't support the 2.0-compatible behavior.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
