### PR TITLE
tsl-ordered-map: add version 1.1.0

### DIFF
--- a/recipes/tsl-ordered-map/all/conandata.yml
+++ b/recipes/tsl-ordered-map/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/Tessil/ordered-map/archive/v1.1.0.tar.gz"
+    sha256: "d6070502351646d68f2bbe6078c0da361bc1db733ee8a392e33cfb8b31183e28"
   "1.0.0":
     url: "https://github.com/Tessil/ordered-map/archive/v1.0.0.tar.gz"
     sha256: "49cd436b8bdacb01d5f4afd7aab0c0d6fa57433dfc29d65f08a5f1ed1e2af26b"

--- a/recipes/tsl-ordered-map/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tsl-ordered-map/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(tsl-ordered-map REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE tsl::ordered_map)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/tsl-ordered-map/config.yml
+++ b/recipes/tsl-ordered-map/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **tsl-ordered-map/1.1.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
