### PR TITLE
qarchive: add version 2.2.4

### DIFF
--- a/recipes/qarchive/all/conandata.yml
+++ b/recipes/qarchive/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.4":
+    url: "https://github.com/antony-jr/QArchive/archive/v2.2.4.tar.gz"
+    sha256: "7c7f0e3bf3d6fb5130aa4632201873511944cd98ab16b273da5072198f53ad7b"
   "2.2.3":
     url: "https://github.com/antony-jr/QArchive/archive/v2.2.3.tar.gz"
     sha256: "2ada10efda34fe96c25744dd67e74ec68587d30ab01cc20be25cbcfb1e6262c4"

--- a/recipes/qarchive/config.yml
+++ b/recipes/qarchive/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.4":
+    folder: all
   "2.2.3":
     folder: all
   "2.1.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **qarchive/2.2.4**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
