### PR TITLE
websocketpp: support gcc 12

### DIFF
--- a/recipes/websocketpp/all/conandata.yml
+++ b/recipes/websocketpp/all/conandata.yml
@@ -10,6 +10,7 @@ patches:
     - patch_file: "patches/support-gcc-12.patch"
       patch_type: "portability"
       patch_description: "support gcc 12"
+      patch_source: "https://github.com/zaphoyd/websocketpp/issues/991"
   "0.8.1":
     - patch_file: "patches/websocket_boost_support_1_7_x.patch"
       patch_type: "conan"
@@ -17,3 +18,4 @@ patches:
     - patch_file: "patches/support-gcc-12.patch"
       patch_type: "portability"
       patch_description: "support gcc 12"
+      patch_source: "https://github.com/zaphoyd/websocketpp/issues/991"

--- a/recipes/websocketpp/all/conandata.yml
+++ b/recipes/websocketpp/all/conandata.yml
@@ -6,7 +6,14 @@ sources:
     url: "https://github.com/zaphoyd/websocketpp/archive/0.8.1.tar.gz"
     sha256: "178899de48c02853b55b1ea8681599641cedcdfce59e56beaff3dd0874bf0286"
 patches:
+  "0.8.2":
+    - patch_file: "patches/support-gcc-12.patch"
+      patch_type: "portability"
+      patch_description: "support gcc 12"
   "0.8.1":
     - patch_file: "patches/websocket_boost_support_1_7_x.patch"
       patch_type: "conan"
       patch_description: "Boost 1.70+ support: Mostly captures zaphoyd/websocketpp#814"
+    - patch_file: "patches/support-gcc-12.patch"
+      patch_type: "portability"
+      patch_description: "support gcc 12"

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -42,7 +42,7 @@ class WebsocketPPConan(ConanFile):
         if self.options.asio == "standalone":
             self.requires("asio/1.24.0", transitive_headers=True)
         elif self.options.asio == "boost":
-            self.requires("boost/1.80.0", transitive_headers=True)
+            self.requires("boost/1.81.0", transitive_headers=True)
 
     def package_id(self):
         self.info.clear()

--- a/recipes/websocketpp/all/patches/support-gcc-12.patch
+++ b/recipes/websocketpp/all/patches/support-gcc-12.patch
@@ -1,0 +1,93 @@
+diff --git a/websocketpp/endpoint.hpp b/websocketpp/endpoint.hpp
+index c124b1d..9ce8a62 100644
+--- a/websocketpp/endpoint.hpp
++++ b/websocketpp/endpoint.hpp
+@@ -109,7 +109,7 @@ public:
+ 
+ 
+     /// Destructor
+-    ~endpoint<connection,config>() {}
++    ~endpoint() {}
+ 
+     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+         // no copy constructor because endpoints are not copyable
+diff --git a/websocketpp/logger/basic.hpp b/websocketpp/logger/basic.hpp
+index 8451413..51efa94 100644
+--- a/websocketpp/logger/basic.hpp
++++ b/websocketpp/logger/basic.hpp
+@@ -58,33 +58,33 @@ namespace log {
+ template <typename concurrency, typename names>
+ class basic {
+ public:
+-    basic<concurrency,names>(channel_type_hint::value h =
++    basic(channel_type_hint::value h =
+         channel_type_hint::access)
+       : m_static_channels(0xffffffff)
+       , m_dynamic_channels(0)
+       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+ 
+-    basic<concurrency,names>(std::ostream * out)
++    basic(std::ostream * out)
+       : m_static_channels(0xffffffff)
+       , m_dynamic_channels(0)
+       , m_out(out) {}
+ 
+-    basic<concurrency,names>(level c, channel_type_hint::value h =
++    basic(level c, channel_type_hint::value h =
+         channel_type_hint::access)
+       : m_static_channels(c)
+       , m_dynamic_channels(0)
+       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+ 
+-    basic<concurrency,names>(level c, std::ostream * out)
++    basic(level c, std::ostream * out)
+       : m_static_channels(c)
+       , m_dynamic_channels(0)
+       , m_out(out) {}
+ 
+     /// Destructor
+-    ~basic<concurrency,names>() {}
++    ~basic() {}
+ 
+     /// Copy constructor
+-    basic<concurrency,names>(basic<concurrency,names> const & other)
++    basic(basic const & other)
+      : m_static_channels(other.m_static_channels)
+      , m_dynamic_channels(other.m_dynamic_channels)
+      , m_out(other.m_out)
+@@ -97,7 +97,7 @@ public:
+ 
+ #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+     /// Move constructor
+-    basic<concurrency,names>(basic<concurrency,names> && other)
++    basic(basic && other)
+      : m_static_channels(other.m_static_channels)
+      , m_dynamic_channels(other.m_dynamic_channels)
+      , m_out(other.m_out)
+diff --git a/websocketpp/roles/server_endpoint.hpp b/websocketpp/roles/server_endpoint.hpp
+index 9cc652f..ad8f403 100644
+--- a/websocketpp/roles/server_endpoint.hpp
++++ b/websocketpp/roles/server_endpoint.hpp
+@@ -72,11 +72,11 @@ public:
+     }
+ 
+     /// Destructor
+-    ~server<config>() {}
++    ~server() {}
+ 
+ #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+     // no copy constructor because endpoints are not copyable
+-    server<config>(server<config> &) = delete;
++    server(server&) = delete;
+ 
+     // no copy assignment operator because endpoints are not copyable
+     server<config> & operator=(server<config> const &) = delete;
+@@ -84,7 +84,7 @@ public:
+ 
+ #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+     /// Move constructor
+-    server<config>(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
++    server(server&& o) : endpoint<connection<config>,config>(std::move(o)) {}
+ 
+ #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+     // no move assignment operator because of const member variables


### PR DESCRIPTION
Specify library name and version:  **websocketpp/***

websocketpp failed to be compiled on gcc 12 by following constructor/destructor definitions.

```
    ~endpoint<connection,config>() {}
```



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
