### PR TITLE
autoconf: add package_type attribute

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -11,6 +11,7 @@ required_conan_version = ">=1.54.0"
 
 class AutoconfConan(ConanFile):
     name = "autoconf"
+    package_type = "application"
     description = (
         "Autoconf is an extensible package of M4 macros that produce shell "
         "scripts to automatically configure software source code packages"


### PR DESCRIPTION
Specify library name and version:  **autoconf/all**

Add package_type attribute needed in Conan 2 for runtime to correctly propagate transitively (e.g. when automake is a tool_requirement, autoconf comes transitively).


