### PR TITLE
gnu-config: refactor invocation of config.sub in test_package

### DIFF
--- a/recipes/gnu-config/all/test_package/conanfile.py
+++ b/recipes/gnu-config/all/test_package/conanfile.py
@@ -1,6 +1,4 @@
 from conan import ConanFile
-from conan.errors import ConanException
-from conans import tools as tools_legacy
 
 
 class TestPackageConan(ConanFile):
@@ -20,8 +18,4 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         self.run("config.guess")
-        try:
-            triplet = tools_legacy.get_gnu_triplet(str(self.settings.os), str(self.settings.arch), str(self.settings.compiler))
-            self.run(f"config.sub {triplet}")
-        except ConanException:
-            self.output.info("Current configuration is not supported by GNU config.\nIgnoring...")
+        self.run("config.sub --version")


### PR DESCRIPTION
Specify library name and version:  **gnu-config/all - test package only**

Refactor test_package to remove call to legacy Conan tool. The purpose of the test_package is to test that the script is callable in a valid way - the previous logic was ignoring the output in case `get_gnu_triplet` returned something that `config.sub` doesn't support. Passing `--version` or an arbitrary triple is as good as any alternative.


