### PR TITLE
websocketpp/0.8.2: Add patch to fix build with C++20 compilers

### DIFF
--- a/recipes/websocketpp/all/conandata.yml
+++ b/recipes/websocketpp/all/conandata.yml
@@ -10,3 +10,7 @@ patches:
     - patch_file: "patches/websocket_boost_support_1_7_x.patch"
       patch_type: "conan"
       patch_description: "Boost 1.70+ support: Mostly captures zaphoyd/websocketpp#814"
+  "0.8.2":
+    - patch_file: "patches/websocket_cxx20_compatability.patch"
+      patch_type: "portability"
+      patch_description: "Needed to build with C++20 compilers"

--- a/recipes/websocketpp/all/patches/websocket_cxx20_compatability.patch
+++ b/recipes/websocketpp/all/patches/websocket_cxx20_compatability.patch
@@ -1,0 +1,125 @@
+From 0823cfea38acb9827b9d5a742b0f394ed5b30d68 Mon Sep 17 00:00:00 2001
+From: Andre Azevedo <andre.azevedo@gmail.com>
+Date: Sun, 28 Aug 2022 15:18:08 -0700
+Subject: [PATCH 1/2] Fix build for cpp 20
+
+---
+ websocketpp/endpoint.hpp              |  2 +-
+ websocketpp/logger/basic.hpp          | 12 ++++++------
+ websocketpp/roles/server_endpoint.hpp |  6 +++---
+ 3 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/websocketpp/endpoint.hpp b/websocketpp/endpoint.hpp
+index c124b1d9a..9ce8a6261 100644
+--- a/websocketpp/endpoint.hpp
++++ b/websocketpp/endpoint.hpp
+@@ -109,7 +109,7 @@ class endpoint : public config::transport_type, public config::endpoint_base {
+ 
+ 
+     /// Destructor
+-    ~endpoint<connection,config>() {}
++    ~endpoint() {}
+ 
+     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+         // no copy constructor because endpoints are not copyable
+diff --git a/websocketpp/logger/basic.hpp b/websocketpp/logger/basic.hpp
+index 84514130e..35351a5f5 100644
+--- a/websocketpp/logger/basic.hpp
++++ b/websocketpp/logger/basic.hpp
+@@ -58,24 +58,24 @@ namespace log {
+ template <typename concurrency, typename names>
+ class basic {
+ public:
+-    basic<concurrency,names>(channel_type_hint::value h =
++    basic(channel_type_hint::value h =
+         channel_type_hint::access)
+       : m_static_channels(0xffffffff)
+       , m_dynamic_channels(0)
+       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+ 
+-    basic<concurrency,names>(std::ostream * out)
++    basic(std::ostream * out)
+       : m_static_channels(0xffffffff)
+       , m_dynamic_channels(0)
+       , m_out(out) {}
+ 
+-    basic<concurrency,names>(level c, channel_type_hint::value h =
++    basic(level c, channel_type_hint::value h =
+         channel_type_hint::access)
+       : m_static_channels(c)
+       , m_dynamic_channels(0)
+       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+ 
+-    basic<concurrency,names>(level c, std::ostream * out)
++    basic(level c, std::ostream * out)
+       : m_static_channels(c)
+       , m_dynamic_channels(0)
+       , m_out(out) {}
+@@ -84,7 +84,7 @@ class basic {
+     ~basic<concurrency,names>() {}
+ 
+     /// Copy constructor
+-    basic<concurrency,names>(basic<concurrency,names> const & other)
++    basic(basic<concurrency,names> const & other)
+      : m_static_channels(other.m_static_channels)
+      , m_dynamic_channels(other.m_dynamic_channels)
+      , m_out(other.m_out)
+@@ -97,7 +97,7 @@ class basic {
+ 
+ #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+     /// Move constructor
+-    basic<concurrency,names>(basic<concurrency,names> && other)
++    basic(basic<concurrency,names> && other)
+      : m_static_channels(other.m_static_channels)
+      , m_dynamic_channels(other.m_dynamic_channels)
+      , m_out(other.m_out)
+diff --git a/websocketpp/roles/server_endpoint.hpp b/websocketpp/roles/server_endpoint.hpp
+index 9cc652f75..63b200a54 100644
+--- a/websocketpp/roles/server_endpoint.hpp
++++ b/websocketpp/roles/server_endpoint.hpp
+@@ -72,11 +72,11 @@ class server : public endpoint<connection<config>,config> {
+     }
+ 
+     /// Destructor
+-    ~server<config>() {}
++    ~server() {}
+ 
+ #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+     // no copy constructor because endpoints are not copyable
+-    server<config>(server<config> &) = delete;
++    server(server<config> &) = delete;
+ 
+     // no copy assignment operator because endpoints are not copyable
+     server<config> & operator=(server<config> const &) = delete;
+@@ -84,7 +84,7 @@ class server : public endpoint<connection<config>,config> {
+ 
+ #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+     /// Move constructor
+-    server<config>(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
++    server(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
+ 
+ #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+     // no move assignment operator because of const member variables
+
+From 9b7fdd5b988b3b443fda60a5852173d0268d309e Mon Sep 17 00:00:00 2001
+From: Andre Azevedo <andre.azevedo@gmail.com>
+Date: Sun, 28 Aug 2022 15:19:53 -0700
+Subject: [PATCH 2/2] Fix build for cpp 20
+
+---
+ websocketpp/logger/basic.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/websocketpp/logger/basic.hpp b/websocketpp/logger/basic.hpp
+index 35351a5f5..4c9d83649 100644
+--- a/websocketpp/logger/basic.hpp
++++ b/websocketpp/logger/basic.hpp
+@@ -81,7 +81,7 @@ class basic {
+       , m_out(out) {}
+ 
+     /// Destructor
+-    ~basic<concurrency,names>() {}
++    ~basic() {}
+ 
+     /// Copy constructor
+     basic(basic<concurrency,names> const & other)


### PR DESCRIPTION
Specify library name and version:  **websocketpp/0.8.2**

Hi. I found this patch in issue: https://github.com/zaphoyd/websocketpp/issues/1068#issuecomment-1364647094

Tested with both C++17 and C++20 compilers and everything works good. With this patch I'm able to build project in any cases. I think this change will be beneficial for others too.