### PR TITLE
protobuf: do not build protoc for tvos

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -94,11 +94,11 @@ class ProtobufConan(ConanFile):
         tc.cache_variables["CMAKE_INSTALL_CMAKEDIR"] = self._cmake_install_base_path.replace("\\", "/")
         tc.cache_variables["protobuf_WITH_ZLIB"] = self.options.with_zlib
         tc.cache_variables["protobuf_BUILD_TESTS"] = False
-        tc.cache_variables["protobuf_BUILD_PROTOC_BINARIES"] = True
+        tc.cache_variables["protobuf_BUILD_PROTOC_BINARIES"] = self.settings.os != "tvOS"
         if not self.options.debug_suffix:
             tc.cache_variables["protobuf_DEBUG_POSTFIX"] = ""
         if Version(self.version) >= "3.14.0":
-            tc.cache_variables["protobuf_BUILD_LIBPROTOC"] = True
+            tc.cache_variables["protobuf_BUILD_LIBPROTOC"] = self.settings.os != "tvOS"
         if self._can_disable_rtti:
             tc.cache_variables["protobuf_DISABLE_RTTI"] = not self.options.with_rtti
         if is_msvc(self) or self._is_clang_cl:
@@ -229,9 +229,10 @@ class ProtobufConan(ConanFile):
                 self.cpp_info.components["libprotobuf"].defines = ["PROTOBUF_USE_DLLS"]
 
         # libprotoc
-        self.cpp_info.components["libprotoc"].set_property("cmake_target_name", "protobuf::libprotoc")
-        self.cpp_info.components["libprotoc"].libs = [lib_prefix + "protoc" + lib_suffix]
-        self.cpp_info.components["libprotoc"].requires = ["libprotobuf"]
+        if Version(self.version) >= "3.14.0" and self.settings.os != "tvOS":
+            self.cpp_info.components["libprotoc"].set_property("cmake_target_name", "protobuf::libprotoc")
+            self.cpp_info.components["libprotoc"].libs = [lib_prefix + "protoc" + lib_suffix]
+            self.cpp_info.components["libprotoc"].requires = ["libprotobuf"]
 
         # libprotobuf-lite
         if self.options.lite:

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -229,7 +229,7 @@ class ProtobufConan(ConanFile):
                 self.cpp_info.components["libprotobuf"].defines = ["PROTOBUF_USE_DLLS"]
 
         # libprotoc
-        if Version(self.version) >= "3.14.0" and self.settings.os != "tvOS":
+        if self.settings.os != "tvOS":
             self.cpp_info.components["libprotoc"].set_property("cmake_target_name", "protobuf::libprotoc")
             self.cpp_info.components["libprotoc"].libs = [lib_prefix + "protoc" + lib_suffix]
             self.cpp_info.components["libprotoc"].requires = ["libprotobuf"]

--- a/recipes/protobuf/all/test_package/CMakeLists.txt
+++ b/recipes/protobuf/all/test_package/CMakeLists.txt
@@ -13,7 +13,10 @@ else()
     target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::libprotobuf)
 endif()
 
-target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::libprotoc)
+string(FIND "${protobuf_COMPONENTS_RELEASE}" "protobuf::libprotoc" HAS_LIBPROTOC)
+if (${HAS_LIBPROTOC} GREATER_EQUAL 0)
+    target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::libprotoc)
+endif()
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS TARGET ${PROJECT_NAME})
 protobuf_generate(LANGUAGE cpp TARGET ${PROJECT_NAME} PROTOS addressbook.proto)

--- a/recipes/protobuf/all/test_package/CMakeLists.txt
+++ b/recipes/protobuf/all/test_package/CMakeLists.txt
@@ -13,8 +13,7 @@ else()
     target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::libprotobuf)
 endif()
 
-string(FIND "${protobuf_COMPONENTS_RELEASE}" "protobuf::libprotoc" HAS_LIBPROTOC)
-if (${HAS_LIBPROTOC} GREATER_EQUAL 0)
+if(TARGET protobuf::libprotoc)
     target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::libprotoc)
 endif()
 


### PR DESCRIPTION
Specify library name and version: **protobuf/***

`protoc` has `fork()` and `execv()`. These functions do not exist for tvOS.

It was opened as https://github.com/conan-io/conan-center-index/pull/14474, but protobuf still needs to be migrated to use CMakeToolchain at that time. Now, that protobuf was modernized in https://github.com/conan-io/conan-center-index/pull/14851, I'm opening this PR again to skip the build of `protoc` for tvOS.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
