### PR TITLE
(#15330) hiredis: use self.settings instead of self.info.settings

### DIFF
--- a/recipes/hiredis/all/conanfile.py
+++ b/recipes/hiredis/all/conanfile.py
@@ -92,7 +92,7 @@ class HiredisConan(ConanFile):
         if Version(self.version) >= "1.1.0":
             if is_msvc(self) and not self.options.shared:
                 suffix += "_static"
-            if self.info.settings.build_type == "Debug":
+            if self.settings.build_type == "Debug":
                 suffix += "d"
 
         # hiredis


### PR DESCRIPTION
Specify library name and version:  **hiredis/1.1.0**

Trying to make it works for conan2.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

fixes #15330 