### PR TITLE
libpq: fix with_openssl=True build

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -36,6 +36,7 @@ class LibpqConan(ConanFile):
         "with_openssl": False,
         "disable_rpath": False,
     }
+    generators = ["AutotoolsDeps"]
 
     _autotools = None
 


### PR DESCRIPTION
-lcrypto is not found during the configure phase since the paths from the openssl dependency didn't make it to the relevant environment variables.

Specify library name and version:  **libpq/14.5**

Ticket is #15343.


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
