### PR TITLE
wildmidi: add new recipe, version 0.4.5

### DIFF
--- a/recipes/wildmidi/all/conandata.yml
+++ b/recipes/wildmidi/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.4.5":
+    url: "https://github.com/Mindwerks/wildmidi/releases/download/wildmidi-0.4.5/wildmidi-0.4.5.tar.gz"
+    sha256: "d5e7bef00a7aa47534a53d43b1265f8d3d27f6a28e7f563c1cdf02ff4fa35b99"

--- a/recipes/wildmidi/all/conanfile.py
+++ b/recipes/wildmidi/all/conanfile.py
@@ -1,0 +1,94 @@
+from conan import ConanFile
+from conan.tools.microsoft import is_msvc
+from conan.tools.files import export_conandata_patches, get, copy, rmdir
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class WildmidiConan(ConanFile):
+    name = "wildmidi"
+    description = "WildMIDI is a simple software midi player which has a core softsynth library that can be used in other applications."
+    license = "LGPL-3.0-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.mindwerks.net/projects/wildmidi"
+    topics = ("audio", "midi", "multimedia", "music", "softsynth", "sound", "synth")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if self.settings.os == "Windows":
+            tc.variables["CMAKE_BUILD_TYPE"] = self.settings.build_type
+        tc.variables["WANT_PLAYER"] = False
+        if not self.options.shared:
+            tc.variables["WANT_STATIC"] = True
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="docs/license/LGPLv3.txt", dst=os.path.join(
+            self.package_folder, "licenses"), src=self.source_folder, keep_path=False)
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        if is_msvc(self):
+            libname = "libWildMidi"
+            if not self.options.shared:
+                libname += "-static" 
+        else:
+            libname = "WildMidi"
+            
+        self.cpp_info.set_property("cmake_file_name", "WildMidi")
+        self.cpp_info.set_property("cmake_target_name", "WildMidi::libwildmidi")
+        self.cpp_info.set_property("pkg_config_name", "wildmidi")
+
+        # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.components["libwildmidi"].libs = [libname]
+        if not self.options.shared:
+            self.cpp_info.components["libwildmidi"].defines = ["WILDMIDI_STATIC"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["libwildmidi"].system_libs.append("m")
+
+        # TODO: remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.names["cmake_find_package"] = "WildMidi"
+        self.cpp_info.names["cmake_find_package_multi"] = "WildMidi"
+        self.cpp_info.components["libwildmidi"].names["cmake_find_package"] = "libwildmidi"
+        self.cpp_info.components["libwildmidi"].names["cmake_find_package_multi"] = "libwildmidi"

--- a/recipes/wildmidi/all/test_package/CMakeLists.txt
+++ b/recipes/wildmidi/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package C)
+
+find_package(WildMidi REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE WildMidi::libwildmidi)

--- a/recipes/wildmidi/all/test_package/conanfile.py
+++ b/recipes/wildmidi/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/wildmidi/all/test_package/test_package.c
+++ b/recipes/wildmidi/all/test_package/test_package.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <wildmidi_lib.h> 
+
+
+int main(void) {
+    printf("WildMidi version %d\n", WildMidi_GetVersion());
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/wildmidi/all/test_v1_package/CMakeLists.txt
+++ b/recipes/wildmidi/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/wildmidi/all/test_v1_package/conanfile.py
+++ b/recipes/wildmidi/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/wildmidi/config.yml
+++ b/recipes/wildmidi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.4.5":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **wildmidi/0.4.5**

WildMIDI is a simple software midi player which has a core softsynth library that can be used with other applications.

Unlike other MIDI libraries here, it supports Redbook's extended MIDI files (XMI) that are used by many old games.

There are few issues that I'd like to resolve, I don't know where else I can ask for help.

- On Windows, CMAKE_BUILD_TYPE is not set automatically from build_type, so I had to set it explicitly. Why is this happening?
- CMake's find_library can't find "libWildMidi" without ".a"/."so" extension on Linux, so I had to add it in conanfile.py. Why? Why is it working for other recipes?
- Sometimes I get this error
`[HOOK - conan-center.py] post_package_info(): ERROR: [LIBRARY DOES NOT EXIST (KB-H054)] Component wildmidi::wildmidi library 'libwildmidi' is listed in the recipe, but not found installed at self.cpp_info.libdirs. Make sure you compiled the library correctly. If so, then the library name should probably be fixed. Otherwise, then the component should be removed. (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H054)`
Even though the library is in correct location, test_package and my app works well. Is it ok?
- There are files in lib/cmake describing WildMidi::libwildmidi target but this lines produce vague errors
`self.cpp_info.set_property("cmake_file_name", "wildmidi")`
`self.cpp_info.set_property("cmake_target_name", "libwildmidi")`
How to debug this issue?

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
