### PR TITLE
Fix json_dto missing headers

### DIFF
--- a/recipes/json_dto/all/conanfile.py
+++ b/recipes/json_dto/all/conanfile.py
@@ -59,7 +59,7 @@ class PackageConan(ConanFile):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(
             self,
-            pattern="pub.hpp",
+            pattern="*.hpp",
             dst=os.path.join(self.package_folder, "include", "json_dto"),
             src=os.path.join(self.source_folder, "dev", "json_dto"),
         )

--- a/recipes/json_dto/all/test_package/example.cpp
+++ b/recipes/json_dto/all/test_package/example.cpp
@@ -3,6 +3,7 @@
 #include <ctime>
 
 #include <json_dto/pub.hpp>
+#include <json_dto/validators.hpp>
 
 // Message.
 struct message_t


### PR DESCRIPTION
Specify library name and version:  **json_dto/0.3**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
