### PR TITLE
gtest: add version 1.13.0

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.13.0":
+    url: "https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz"
+    sha256: "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363"
   "1.12.1":
     url: "https://github.com/google/googletest/archive/release-1.12.1.tar.gz"
     sha256: "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2"

--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -15,5 +15,5 @@ patches:
       patch_type: "conan"
     - patch_file: "patches/gtest-1.10.0-override.patch"
       patch_description: "prevent compiler from complaining while compiling"
-      patch_type: "backport"
+      patch_type: "bugfix"
       patch_source: "https://github.com/google/googletest/pull/2507"

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -37,17 +37,26 @@ class GTestConan(ConanFile):
 
     @property
     def _minimum_cpp_standard(self):
-        return 11
+        return 11 if Version(self.version) < "1.13.0" else 14
 
     @property
     def _minimum_compilers_version(self):
-        return {
-            "Visual Studio": "14",
-            "msvc": "190",
-            "gcc": "4.8.1" if Version(self.version) < "1.11.0" else "5",
-            "clang": "3.3" if Version(self.version) < "1.11.0" else "5",
-            "apple-clang": "5.0" if Version(self.version) < "1.11.0" else "9.1",
-        }
+        if Version(self.version) < "1.13.0":
+            return {
+                "Visual Studio": "14",
+                "msvc": "190",
+                "gcc": "4.8.1" if Version(self.version) < "1.11.0" else "5",
+                "clang": "3.3" if Version(self.version) < "1.11.0" else "5",
+                "apple-clang": "5.0" if Version(self.version) < "1.11.0" else "9.1",
+            }
+        else:
+            return {
+                "Visual Studio": "15",
+                "msvc": "190",
+                "gcc": "5",
+                "clang": "5",
+                "apple-clang": "5.1",
+            }
 
     @property
     def _is_clang_cl(self):

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -50,12 +50,14 @@ class GTestConan(ConanFile):
                 "apple-clang": "5.0" if Version(self.version) < "1.11.0" else "9.1",
             }
         else:
+            # Sinse 1.13.0, gtest requires C++14 and Google's Foundational C++ Support Policy
+            # https://github.com/google/oss-policies-info/blob/603a042ce2ee8f165fac46721a651d796ce59cb6/foundational-cxx-support-matrix.md
             return {
                 "Visual Studio": "15",
                 "msvc": "190",
-                "gcc": "5",
-                "clang": "5",
-                "apple-clang": "5.1",
+                "gcc": "7.3.1",
+                "clang": "6",
+                "apple-clang": "12",
             }
 
     @property

--- a/recipes/gtest/all/test_package/CMakeLists.txt
+++ b/recipes/gtest/all/test_package/CMakeLists.txt
@@ -5,7 +5,11 @@ find_package(GTest REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+if(GTest_VERSION VERSION_LESS "1.13.0")
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+else()
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+endif()
 
 if(WITH_MAIN)
     target_link_libraries(${PROJECT_NAME} PRIVATE GTest::gtest_main)

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.13.0":
+    folder: all
   "1.12.1":
     folder: all
   "1.10.0":


### PR DESCRIPTION
Specify library name and version:  **gtest/1.13.0**

- add version 1.13.0
- Because gtest requires C++14 since 1.13.0, _minimum_compilers_version is updated.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
