### PR TITLE
automake: fix cpp_info.resdirs & more conan v2 stuff

### DIFF
--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -16,7 +16,7 @@ class AutomakeConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.gnu.org/software/automake/"
     description = "Automake is a tool for automatically generating Makefile.in files compliant with the GNU Coding Standards."
-    topics = ("configure", "build")
+    topics = ("autotools", "configure", "build")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     settings = "os", "arch", "compiler", "build_type"
 

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -31,12 +31,12 @@ class AutomakeConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
     def layout(self):
         basic_layout(self, src_folder="src")
-
-    def configure(self):
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
 
     def requirements(self):
         self.requires("autoconf/2.71")
@@ -44,10 +44,11 @@ class AutomakeConan(ConanFile):
 
     def build_requirements(self):
         if hasattr(self, "settings_build"):
-            self.build_requires("autoconf/2.71")
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
+            self.tool_requires("autoconf/2.71")
+        if self._settings_build.os == "Windows":
             self.win_bash = True
-            self.build_requires("msys2/cci.latest")
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
 
     def package_id(self):
         del self.info.settings.arch
@@ -55,8 +56,7 @@ class AutomakeConan(ConanFile):
         del self.info.settings.build_type
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     @property
     def _datarootdir(self):

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -88,7 +88,7 @@ class AutomakeConan(ConanFile):
                                 "          $file =~ s/^\\s+|\\s+$//g;\n"
                                 "          $map_traced_defs{$arg1} = $file;")
             # handle relative paths during aclocal.m4 creation
-            replace_in_file(self, ac_local_in, "$map{$m} eq $map_traced_defs{$m}", 
+            replace_in_file(self, ac_local_in, "$map{$m} eq $map_traced_defs{$m}",
                                 "abs_path($map{$m}) eq abs_path($map_traced_defs{$m})")
 
     def build(self):
@@ -118,6 +118,7 @@ class AutomakeConan(ConanFile):
     def package_info(self):
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
+        self.cpp_info.resdirs = ["res"]
 
         # For consumers with new integrations (Conan 1 and 2 compatible):
         compile_wrapper = os.path.join(self._automake_libdir, "compile")

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -15,14 +16,9 @@ class AutomakeConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.gnu.org/software/automake/"
     description = "Automake is a tool for automatically generating Makefile.in files compliant with the GNU Coding Standards."
-    topics = ("conan", "automake", "configure", "build")
+    topics = ("configure", "build")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     settings = "os", "arch", "compiler", "build_type"
-
-    @property
-    def _version_major_minor(self):
-        [major, minor, _] = self.version.split(".", 2)
-        return '{}.{}'.format(major, minor)
 
     @property
     def _settings_build(self):
@@ -42,6 +38,11 @@ class AutomakeConan(ConanFile):
         self.requires("autoconf/2.71")
         # automake requires perl-Thread-Queue package
 
+    def package_id(self):
+        del self.info.settings.arch
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
     def build_requirements(self):
         if hasattr(self, "settings_build"):
             self.tool_requires("autoconf/2.71")
@@ -50,21 +51,8 @@ class AutomakeConan(ConanFile):
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
 
-    def package_id(self):
-        del self.info.settings.arch
-        del self.info.settings.compiler
-        del self.info.settings.build_type
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
-    @property
-    def _datarootdir(self):
-        return os.path.join(self.package_folder, "res")
-
-    @property
-    def _automake_libdir(self):
-        return os.path.join(self._datarootdir, "automake-{}".format(self._version_major_minor))
 
     def generate(self):
         env = VirtualBuildEnv(self)
@@ -74,7 +62,6 @@ class AutomakeConan(ConanFile):
         tc.configure_args.extend([
             "--datarootdir=${prefix}/res",
         ])
-
         tc.generate()
 
     def _patch_sources(self):
@@ -97,6 +84,10 @@ class AutomakeConan(ConanFile):
         autotools.configure()
         autotools.make()
 
+    @property
+    def _datarootdir(self):
+        return os.path.join(self.package_folder, "res")
+
     def package(self):
         autotools = Autotools(self)
         autotools.install()
@@ -115,6 +106,11 @@ class AutomakeConan(ConanFile):
                     continue
                 os.rename(fullpath, fullpath + ".exe")
 
+    @property
+    def _automake_libdir(self):
+        ver = Version(self.version)
+        return os.path.join(self._datarootdir, f"automake-{ver.major}.{ver.minor}")
+
     def package_info(self):
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
@@ -129,6 +125,4 @@ class AutomakeConan(ConanFile):
         # For legacy Conan 1.x consumers only:
         self.user_info.compile = compile_wrapper
         self.user_info.ar_lib = lib_wrapper
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable:: {}".format(bin_path))
-        self.env_info.PATH.append(bin_path)
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
`cpp_info.resdirs` is empty by default with layout(), it has to be explicitly set if there is some res or share folder.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
