### PR TITLE
libcurl: add `with_libgsasl` option (disabled by default)

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -47,6 +47,7 @@ class LibcurlConan(ConanFile):
         "with_libssh2": [True, False],
         "with_libidn": [True, False],
         "with_librtmp": [True, False],
+        "with_libgsasl": [True, False],
         "with_libmetalink": [True, False],
         "with_libpsl": [True, False],
         "with_largemaxwritesize": [True, False],
@@ -91,6 +92,7 @@ class LibcurlConan(ConanFile):
         "with_libssh2": False,
         "with_libidn": False,
         "with_librtmp": False,
+        "with_libgsasl": False,
         "with_libmetalink": False,
         "with_libpsl": False,
         "with_largemaxwritesize": False,
@@ -173,6 +175,7 @@ class LibcurlConan(ConanFile):
             if Version(self.version) < "7.75.0":
                 del self.options.with_libidn
             del self.options.with_libpsl
+            del self.options.with_libgsasl
 
     def requirements(self):
         if self.options.with_ssl == "openssl":
@@ -365,6 +368,7 @@ class LibcurlConan(ConanFile):
             f"--with-libidn2={self._yes_no(self.options.with_libidn)}",
             f"--with-librtmp={self._yes_no(self.options.with_librtmp)}",
             f"--with-libpsl={self._yes_no(self.options.with_libpsl)}",
+            f"--with-libgsasl={self._yes_no(self.options.with_libgsasl)}",
             f"--with-schannel={self._yes_no(self.options.with_ssl == 'schannel')}",
             f"--with-secure-transport={self._yes_no(self.options.with_ssl == 'darwinssl')}",
             f"--with-brotli={self._yes_no(self.options.with_brotli)}",


### PR DESCRIPTION
This option has been added in libcurl 7.76.0  (https://github.com/curl/curl/commit/3eebbfe8f34d37c4d68d08277a44ec7aa6bd0889), which is also the oldest version maintained in CCI. It's not properly controlled by libcurl recipe, leading to non-reproducible builds.

closes https://github.com/conan-io/conan-center-index/issues/15370

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
