### PR TITLE
fix compiling opencascade/7.6.2 with c++17

### DIFF
--- a/recipes/opencascade/all/conandata.yml
+++ b/recipes/opencascade/all/conandata.yml
@@ -9,6 +9,11 @@ sources:
     url: "https://github.com/Open-Cascade-SAS/OCCT/archive/V7_5_0.tar.gz"
     sha256: "dbe1d62a9317ad1516bd4575293d9aab2dc20206ca7a60a7705c9a3b77dc59c9"
 patches:
+  "7.6.2":
+    - patch_file: "patches/0002-fix-for-cpp17.patch"
+      base_path: "source_subfolder"
+      cppstd: "17"
+
   "7.5.0":
     - patch_file: "patches/0001-undefined-ref-ncollection-lerp.patch"
       base_path: "source_subfolder"

--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -126,8 +126,14 @@ class OpenCascadeConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
+        requested_cppstd = self.settings.compiler.get_safe("cppstd")
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+            applicapble_cppstd = patch.pop("cppstd", None)
+            if applicapble_cppstd and requested_cppstd:
+                if requested_cppstd >= applicapble_cppstd:
+                    tools.patch(**patch)
+            else:
+                tools.patch(**patch)
 
         cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
         cmakelists_tools = os.path.join(self._source_subfolder, "tools", "CMakeLists.txt")

--- a/recipes/opencascade/all/patches/0002-fix-for-cpp17.patch
+++ b/recipes/opencascade/all/patches/0002-fix-for-cpp17.patch
@@ -1,0 +1,37 @@
+--- src/QANCollection/QANCollection_Stl.cxx	2023-01-20 08:13:06.606228500 -0800
++++ src/QANCollection/QANCollection_Stl.cxx.patch	2023-01-20 08:12:48.081585800 -0800
+@@ -43,10 +43,14 @@
+ const int THE_TEST_SIZE = 5000;
+ 
+ namespace {
+-  // Auxiliary class to use in std::random_shuffle()
++  // Auxiliary class to use in std::shuffle()
+   struct RandomGenerator {
++	using result_type = int;
++	using type = int;
++	static constexpr int min() { return 0; }
++	static constexpr int max() { return RAND_MAX; }
+     RandomGenerator () { srand(1); }
+-    ptrdiff_t operator () (ptrdiff_t upper) const { return rand() % upper; }
++ 	int operator () () { return rand(); }
+   };
+ }
+ 
+@@ -955,7 +959,7 @@
+       for (Standard_Integer anIdx = 0; anIdx < 10; ++anIdx)
+       {
+         std::sort           (aVector->begin(), aVector->end());
+-        std::random_shuffle (aVector->begin(), aVector->end(), aRandomGen);
++        std::shuffle (aVector->begin(), aVector->end(), aRandomGen);
+       }
+     }
+     aTimer.Stop();
+@@ -969,7 +973,7 @@
+       for (Standard_Integer anIdx = 0; anIdx < 10; ++anIdx)
+       {
+         std::sort           (aCollec->begin(), aCollec->end());
+-        std::random_shuffle (aCollec->begin(), aCollec->end(), aRandomGen);
++        std::shuffle (aCollec->begin(), aCollec->end(), aRandomGen);
+       }
+     }
+     aTimer.Stop();


### PR DESCRIPTION
I'm trying to compile opencascade with c++17 and I was getting some errors due to `random_shuffle` being removed. See [cppreference](https://en.cppreference.com/w/cpp/algorithm/random_shuffle).

There's a better fix upstream, but I didn't want to change the logic for this current version:
https://github.com/Open-Cascade-SAS/OCCT/blob/d404757de01e2cd8704349daf5030ac2a8905a8e/src/QANCollection/QANCollection_Stl.cxx#L951

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
