### PR TITLE
(#15271) qt/5.x.x: Add configure_verbose and build_silent options

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -94,7 +94,9 @@ class QtConan(ConanFile):
         "cross_compile": "ANY",
         "sysroot": "ANY",
         "config": "ANY",
-        "multiconfiguration": [True, False]
+        "multiconfiguration": [True, False],
+        "configure_verbose": [True, False],
+        "build_silent": [True, False]
     }
     options.update({module: [True, False] for module in _submodules})
 
@@ -136,7 +138,9 @@ class QtConan(ConanFile):
         "cross_compile": None,
         "sysroot": None,
         "config": None,
-        "multiconfiguration": False
+        "multiconfiguration": False,
+        "configure_verbose": True,
+        "build_silent": True
     }
     default_options.update({module: (module in ["qttools", "qttranslations"]) for module in _submodules})
 
@@ -560,11 +564,14 @@ class QtConan(ConanFile):
         return None
 
     def build(self):
-        args = ["-confirm-license", "-silent", "-nomake examples", "-nomake tests",
+        args = ["-confirm-license", "-nomake examples", "-nomake tests",
                 f"-prefix {self.package_folder}"]
+        if self.options.configure_verbose:
+            args.append("-verbose")
+        if self.options.build_silent:
+            args.append("-silent")
         if cross_building(self):
             args.append(f"-extprefix {self.package_folder}")
-        args.append("-v")
         args.append("-archdatadir  %s" % os.path.join(self.package_folder, "bin", "archdatadir"))
         args.append("-datadir  %s" % os.path.join(self.package_folder, "bin", "datadir"))
         args.append("-sysconfdir  %s" % os.path.join(self.package_folder, "bin", "sysconfdir"))
@@ -930,6 +937,8 @@ Examples = bin/datadir/examples""")
     def package_id(self):
         del self.info.options.cross_compile
         del self.info.options.sysroot
+        del self.info.options.configure_verbose
+        del self.info.options.build_silent
         if self.options.multiconfiguration and is_msvc(self):
             if self.settings.compiler == "Visual Studio":
                 if "MD" in self.settings.compiler.runtime:


### PR DESCRIPTION
Specify library name and version: qt/5.15.x

Fixes: https://github.com/conan-io/conan-center-index/issues/15271

Current qt/5.x.x recipe passes -silent and -v to the configure script.

According to the Qt5 documentation:
    - v (-verbose): Print verbose messages during configuration
    -silent: Reduce the build output so that warnings and errors can be seen more easily

It happens that the build fails, and some information is missing in the logs.

This Pull request adds 2 options to the recipe, so we can control the logs verbosity:

    configure_verbose: corresponds to -verbose
    build_silent: corresponds to -silent

The default values for those options correspond to the current behavior (-verbose and -silent).
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
