### PR TITLE
zpp_bits: add 4.4.13, remove wrong version

### DIFF
--- a/recipes/zpp_bits/all/conandata.yml
+++ b/recipes/zpp_bits/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
+  "4.4.13":
+    url: "https://github.com/eyalz800/zpp_bits/archive/v4.4.13.tar.gz"
+    sha256: "817be8218f1ef6ad66f2c18154d16a9577d0f939a29c76cb95c71f7f24c53fe1"
   "4.4.12":
     url: "https://github.com/eyalz800/zpp_bits/archive/v4.4.12.tar.gz"
-    sha256: "0060c36d394ab1fb340120a7d14e45657a72419fd1745426e75d820980fa095a"
-  "4.1.2":
-    url: "https://github.com/eyalz800/zpp_bits/archive/refs/tags/v4.4.12.tar.gz"
     sha256: "0060c36d394ab1fb340120a7d14e45657a72419fd1745426e75d820980fa095a"

--- a/recipes/zpp_bits/all/conanfile.py
+++ b/recipes/zpp_bits/all/conanfile.py
@@ -3,7 +3,6 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.files import get, copy
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, check_min_vs
 import os
 
 
@@ -30,6 +29,8 @@ class ZppBitsConan(ConanFile):
             "gcc": "11",
             "clang": "12",
             "apple-clang": "13.1",
+            "Visual Studio": "17",
+            "msvc": "193",
         }
 
     def layout(self):
@@ -41,19 +42,17 @@ class ZppBitsConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-        check_min_vs(self, 193)
-        if not is_msvc(self):
-            def loose_lt_semver(v1, v2):
-                lv1 = [int(v) for v in v1.split(".")]
-                lv2 = [int(v) for v in v2.split(".")]
-                min_length = min(len(lv1), len(lv2))
-                return lv1[:min_length] < lv2[:min_length]
+        def loose_lt_semver(v1, v2):
+            lv1 = [int(v) for v in v1.split(".")]
+            lv2 = [int(v) for v in v2.split(".")]
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
 
-            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-            if minimum_version and loose_lt_semver(str(self.settings.compiler.version), minimum_version):
-                raise ConanInvalidConfiguration(
-                    f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler does not support.",
-                )
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and loose_lt_semver(str(self.settings.compiler.version), minimum_version):
+            raise ConanInvalidConfiguration(
+                f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler does not support.",
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/zpp_bits/config.yml
+++ b/recipes/zpp_bits/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.4.12":
+  "4.4.13":
     folder: all
-  "4.1.2":
+  "4.4.12":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- add version 4.4.13
- remove version 4.1.2 (it is wrong version which I added)
- modify validate logic

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
