### PR TITLE
qcbor: add version 1.2

### DIFF
--- a/recipes/qcbor/all/conandata.yml
+++ b/recipes/qcbor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2":
+    url: "https://github.com/laurencelundblade/QCBOR/archive/refs/tags/v1.2.tar.gz"
+    sha256: "0f706ad90ada600bd1ddbdf8dc6f2f5910e11de355bb4454b9b4123f0e4ff525"
   "1.1":
     url: "https://github.com/laurencelundblade/QCBOR/archive/refs/tags/v1.1.tar.gz"
     sha256: "1e7e8986bf918eafb11f5373df9b80fd56811d2cd39c7630d8171130802199b6"
@@ -6,6 +9,10 @@ sources:
     url: "https://github.com/laurencelundblade/QCBOR/archive/refs/tags/v1.0.tar.gz"
     sha256: "961a46eb5a599cc040bfce4f4fade4427e046f1748f37ba4ebbc097fb9cdf1d3"
 patches:
+  "1.2":
+    - patch_file: "patches/1.2-0001-fix-cmake.patch"
+      patch_description: "disable fix fPIC and add installation"
+      patch_type: "conan"
   "1.1":
     - patch_file: "patches/1.1-0001-fix-cmake.patch"
       patch_description: "link mathlib and add installation"

--- a/recipes/qcbor/all/conanfile.py
+++ b/recipes/qcbor/all/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, rmdir, load, save
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.scm import Version
 
 import os
 import re
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 class QCBORConan(ConanFile):
     name = "qcbor"
@@ -18,10 +19,16 @@ class QCBORConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "disable_float_hw_use": [True, False],
+        "disable_float_preferred": [True, False],
+        "disable_float_all": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "disable_float_hw_use": False,
+        "disable_float_preferred": False,
+        "disable_float_all": False,
     }
 
     def export_sources(self):
@@ -31,20 +38,15 @@ class QCBORConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+        if Version(self.version) < "1.2":
+            del self.options.disable_float
+
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -54,6 +56,11 @@ class QCBORConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        if Version(self.version) >= "1.2":
+            tc.variables["QCBOR_OPT_DISABLE_FLOAT_HW_USE"] = self.options.disable_float in ["HW_USE", "PREFERRED", "ALL"]
+            tc.variables["QCBOR_OPT_DISABLE_FLOAT_PREFERRED"] = self.options.disable_float in ["PREFERRED", "ALL"]
+            tc.variables["QCBOR_OPT_DISABLE_FLOAT_ALL"] = self.options.disable_float == "ALL"
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
 
     def build(self):
@@ -74,5 +81,6 @@ class QCBORConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["qcbor"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
+        if self.settings.os in ["Linux", "FreeBSD"] and \
+            (Version(self.version) < "1.2" or self.options.disable_float == False):
             self.cpp_info.system_libs.append("m")

--- a/recipes/qcbor/all/conanfile.py
+++ b/recipes/qcbor/all/conanfile.py
@@ -19,16 +19,12 @@ class QCBORConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "disable_float_hw_use": [True, False],
-        "disable_float_preferred": [True, False],
-        "disable_float_all": [True, False],
+        "disable_float": [False, "HW_USE", "PREFERRED", "ALL"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "disable_float_hw_use": False,
-        "disable_float_preferred": False,
-        "disable_float_all": False,
+        "disable_float": False,
     }
 
     def export_sources(self):

--- a/recipes/qcbor/all/patches/1.2-0001-fix-cmake.patch
+++ b/recipes/qcbor/all/patches/1.2-0001-fix-cmake.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 486946c..4234a59 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,10 +58,14 @@ target_compile_definitions(qcbor
+         $<$<BOOL:${QCBOR_OPT_DISABLE_FLOAT_ALL}>:USEFULBUF_DISABLE_ALL_FLOAT>
+ )
+ 
+-if (BUILD_SHARED_LIBS)
++if (0)
+     target_compile_options(qcbor PRIVATE -Os -fPIC)
+ endif()
+ 
++set_target_properties(qcbor PROPERTIES
++    WINDOWS_EXPORT_ALL_SYMBOLS ON
++)
++
+ # The math library is needed for floating-point support.
+ # To avoid need for it #define QCBOR_DISABLE_FLOAT_HW_USE
+ if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+@@ -75,3 +79,12 @@ endif()
+ if (NOT BUILD_QCBOR_TEST STREQUAL "OFF")
+     add_subdirectory(test)
+ endif()
++
++include(GNUInstallDirs)
++install(TARGETS qcbor
++    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++
++install(DIRECTORY "inc/qcbor" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/recipes/qcbor/all/test_v1_package/CMakeLists.txt
+++ b/recipes/qcbor/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+project(test_packages)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(qcbor REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE qcbor::qcbor)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/qcbor/config.yml
+++ b/recipes/qcbor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2":
+    folder: all
   "1.1":
     folder: all
   "1.0":


### PR DESCRIPTION
Specify library name and version:  **qcbor/***

- add version 1.2
- use rm_safe
- use add_subdirectory
- add disable_float option for 1.2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
