### PR TITLE
hdrhistogram-c: add version 0.11.6

### DIFF
--- a/recipes/hdrhistogram-c/all/conandata.yml
+++ b/recipes/hdrhistogram-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.6":
+    url: "https://github.com/HdrHistogram/HdrHistogram_c/archive/0.11.6.tar.gz"
+    sha256: "b9bb6425d9b0ac5424f6d2286a1295900edab0170d1f50767decb00196785de3"
   "0.11.1":
     url: "https://github.com/HdrHistogram/HdrHistogram_c/archive/0.11.1.tar.gz"
     sha256: "8550071d4ae5c8229448f9b68469d6d42c620cd25111b49c696d00185e5f8329"

--- a/recipes/hdrhistogram-c/all/conanfile.py
+++ b/recipes/hdrhistogram-c/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, rmdir
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class HdrhistogramcConan(ConanFile):
@@ -33,18 +33,9 @@ class HdrhistogramcConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/hdrhistogram-c/all/conanfile.py
+++ b/recipes/hdrhistogram-c/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -71,18 +72,21 @@ class HdrhistogramcConan(ConanFile):
         copy(self, "LICENSE.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "COPYING.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         target = "hdr_histogram" if self.options.shared else "hdr_histogram_static"
         self.cpp_info.set_property("cmake_file_name", "hdr_histogram")
         self.cpp_info.set_property("cmake_target_name", f"hdr_histogram::{target}")
+        if Version(self.version) >= "0.11.6":
+            self.cpp_info.set_property("pkg_config_name", "hdr_histogram")
 
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["hdr_histrogram"].libs = collect_libs(self)
         self.cpp_info.components["hdr_histrogram"].includedirs.append(os.path.join("include", "hdr"))
         if not self.options.shared:
             if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.components["hdr_histrogram"].system_libs = ["m", "rt"]
+                self.cpp_info.components["hdr_histrogram"].system_libs = ["m", "rt", "pthread"]
             elif self.settings.os == "Windows":
                 self.cpp_info.components["hdr_histrogram"].system_libs = ["ws2_32"]
 

--- a/recipes/hdrhistogram-c/all/test_v1_package/CMakeLists.txt
+++ b/recipes/hdrhistogram-c/all/test_v1_package/CMakeLists.txt
@@ -1,14 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(hdr_histogram REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-if(TARGET hdr_histogram::hdr_histogram_static)
-    target_link_libraries(${PROJECT_NAME} PRIVATE hdr_histogram::hdr_histogram_static)
-else()
-    target_link_libraries(${PROJECT_NAME} PRIVATE hdr_histogram::hdr_histogram)
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/hdrhistogram-c/config.yml
+++ b/recipes/hdrhistogram-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.6":
+    folder: all
   "0.11.1":
     folder: all
   "0.11.0":


### PR DESCRIPTION
Specify library name and version:  **hdrhistogram-c/***

- add version 0.11.6
- use `add_subdirectory` in test_v1_package
- use `rm_safe`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
