### PR TITLE
trantor: add version 1.5.10

### DIFF
--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.9":
+    url: "https://github.com/an-tao/trantor/archive/v1.5.9.tar.gz"
+    sha256: "989ac09aa211fe8b04577c596524052faa91fabb084edc1072e550d8bd3e21a8"
   "1.5.8":
     url: "https://github.com/an-tao/trantor/archive/v1.5.8.tar.gz"
     sha256: "705ec0176681be5c99fcc7af37416ece9d65ff4d907bca764cb11471b104fbf8"

--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.5.9":
-    url: "https://github.com/an-tao/trantor/archive/v1.5.9.tar.gz"
-    sha256: "989ac09aa211fe8b04577c596524052faa91fabb084edc1072e550d8bd3e21a8"
+  "1.5.10":
+    url: "https://github.com/an-tao/trantor/archive/v1.5.10.tar.gz"
+    sha256: "2d47775b3091a1a103bea46f5da017dc03c39883f8d717cf6ba24bdcdf01a15d"
   "1.5.8":
     url: "https://github.com/an-tao/trantor/archive/v1.5.8.tar.gz"
     sha256: "705ec0176681be5c99fcc7af37416ece9d65ff4d907bca764cb11471b104fbf8"

--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -4,7 +4,7 @@ sources:
     sha256: "2d47775b3091a1a103bea46f5da017dc03c39883f8d717cf6ba24bdcdf01a15d"
   "1.5.8":
     url: "https://github.com/an-tao/trantor/archive/v1.5.8.tar.gz"
-    sha256: "37943ecad541d9a3751ec761dc65a23f9c904eebaaa51bb7b738b815cfd7ff05"
+    sha256: "705ec0176681be5c99fcc7af37416ece9d65ff4d907bca764cb11471b104fbf8"
   "1.5.7":
     url: "https://github.com/an-tao/trantor/archive/v1.5.7.tar.gz"
     sha256: "42576563afbf1e58c7d68f758cf3fca4d193496d4e3f82c80069d8389a7839d5"

--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -4,7 +4,7 @@ sources:
     sha256: "2d47775b3091a1a103bea46f5da017dc03c39883f8d717cf6ba24bdcdf01a15d"
   "1.5.8":
     url: "https://github.com/an-tao/trantor/archive/v1.5.8.tar.gz"
-    sha256: "705ec0176681be5c99fcc7af37416ece9d65ff4d907bca764cb11471b104fbf8"
+    sha256: "37943ecad541d9a3751ec761dc65a23f9c904eebaaa51bb7b738b815cfd7ff05"
   "1.5.7":
     url: "https://github.com/an-tao/trantor/archive/v1.5.7.tar.gz"
     sha256: "42576563afbf1e58c7d68f758cf3fca4d193496d4e3f82c80069d8389a7839d5"

--- a/recipes/trantor/all/conanfile.py
+++ b/recipes/trantor/all/conanfile.py
@@ -38,6 +38,7 @@ class TrantorConan(ConanFile):
         return {
             "gcc": "5",
             "Visual Studio": "15.0",
+            "msvc": "191",
             "clang": "5",
             "apple-clang": "10",
         }
@@ -48,10 +49,7 @@ class TrantorConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/trantor/all/conanfile.py
+++ b/recipes/trantor/all/conanfile.py
@@ -57,7 +57,7 @@ class TrantorConan(ConanFile):
     def requirements(self):
         self.requires("openssl/1.1.1s")
         if self.options.with_c_ares:
-            self.requires("c-ares/1.18.1")
+            self.requires("c-ares/1.19.0")
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/trantor/all/conanfile.py
+++ b/recipes/trantor/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 class TrantorConan(ConanFile):
     name = "trantor"

--- a/recipes/trantor/all/test_package/CMakeLists.txt
+++ b/recipes/trantor/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(Trantor CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} Trantor::Trantor)
+target_link_libraries(${PROJECT_NAME} PRIVATE Trantor::Trantor)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/trantor/all/test_v1_package/CMakeLists.txt
+++ b/recipes/trantor/all/test_v1_package/CMakeLists.txt
@@ -1,12 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(test_package CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(Trantor REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE Trantor::Trantor)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/trantor/config.yml
+++ b/recipes/trantor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.9":
+    folder: "all"
   "1.5.8":
     folder: "all"
   "1.5.7":

--- a/recipes/trantor/config.yml
+++ b/recipes/trantor/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.5.9":
+  "1.5.10":
     folder: "all"
   "1.5.8":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **trantor/***

- add version 1.5.10
- use `rm_safe`
- use `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
