### PR TITLE
Update conanfile.py

### DIFF
--- a/recipes/openscenegraph/all/conanfile.py
+++ b/recipes/openscenegraph/all/conanfile.py
@@ -138,7 +138,7 @@ class OpenSceneGraphConanFile(ConanFile):
         if self.options.with_jasper:
             self.requires("jasper/2.0.33")
         if self.options.get_safe("with_jpeg"):
-            self.requires("libjpeg/9d")
+            self.requires("libjpeg/9e")
         if self.options.get_safe("with_openexr"):
             self.requires("openexr/3.1.5")
         if self.options.get_safe("with_png"):

--- a/recipes/openscenegraph/all/conanfile.py
+++ b/recipes/openscenegraph/all/conanfile.py
@@ -1,5 +1,5 @@
-from conans import CMake, ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import CMake, ConanFile, tools
+from conan.errors import ConanInvalidConfiguration
 import os
 import functools
 


### PR DESCRIPTION
(#15221) update libjpeg dependency to libjpeg/9e to be compatible with existing libtiff/4.3.0 dependency which itself depends on libjpeg/9e (and not libjpeg/9d)

Specify library name and version:  **openscenegraph/3.6.5**

I am submitting this PR as current recipe version of openscenegraph/3.6.5 is broken due to mismatch between openscenegraph and libtiff package on libjpeg version 

fixes #15221
---

- [X ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
