### PR TITLE
cppcheck: put all resources back in bin folder

### DIFF
--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -44,7 +44,7 @@ class CppcheckConan(ConanFile):
         tc.variables["HAVE_RULES"] = self.options.have_rules
         tc.variables["USE_MATCHCOMPILER"] = "Auto"
         tc.variables["ENABLE_OSS_FUZZ"] = False
-        tc.variables["FILESDIR"] = os.path.join(self.package_folder, "res").replace('\\', '/')
+        tc.variables["FILESDIR"] = os.path.join(self.package_folder, "bin").replace('\\', '/')
         tc.generate()
 
         deps = CMakeDeps(self)


### PR DESCRIPTION
otherwise cppcheck does not find them
fixes conan-io/conan-center-index#15421

Specify library name and version:  **cppcheck/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
