### PR TITLE
googleapis: use modern CMake integrations

### DIFF
--- a/recipes/googleapis/all/CMakeLists.txt
+++ b/recipes/googleapis/all/CMakeLists.txt
@@ -3,9 +3,6 @@ cmake_minimum_required(VERSION 3.20)
 
 project(googleapis)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup(TARGETS)
-
 find_package(Protobuf REQUIRED CONFIG)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -18,6 +18,7 @@ required_conan_version = ">=1.50.0"
 
 class GoogleAPIS(ConanFile):
     name = "googleapis"
+    package_type = "library"
     description = "Public interface definitions of Google APIs"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -3,10 +3,10 @@ import functools
 import glob
 from io import StringIO
 
-from conans import CMake, tools
-
 from conan import ConanFile
-from conan.tools.files import get, copy
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.files import copy, get, export_conandata_patches, copy
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
@@ -14,8 +14,7 @@ from conan.errors import ConanInvalidConfiguration
 
 from helpers import parse_proto_libraries
 
-required_conan_version = ">=1.45.0"
-
+required_conan_version = ">=1.50.0"
 
 class GoogleAPIS(ConanFile):
     name = "googleapis"
@@ -25,7 +24,7 @@ class GoogleAPIS(ConanFile):
     homepage = "https://github.com/googleapis/googleapis"
     topics = "google", "protos", "api"
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain"
     options = {
         "shared": [True, False],
         "fPIC": [True, False]
@@ -38,9 +37,8 @@ class GoogleAPIS(ConanFile):
     short_paths = True
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=os.path.join(self.export_sources_folder, "src"))
+        export_conandata_patches(self)
 
     def source(self):
         get(self, **self.conan_data["sources"][str(self.version)], destination=self.source_folder, strip_root=True)
@@ -50,6 +48,9 @@ class GoogleAPIS(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
@@ -57,7 +58,7 @@ class GoogleAPIS(ConanFile):
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 11)
+            check_min_cppstd(self, 11)
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) <= "5":
             raise ConanInvalidConfiguration("Build with GCC 5 fails")
 
@@ -81,19 +82,13 @@ class GoogleAPIS(ConanFile):
             return True
 
     def requirements(self):
-        self.requires('protobuf/3.21.4')
+        self.requires('protobuf/3.21.4', transitive_headers=True)
 
     def build_requirements(self):
         self.build_requires('protobuf/3.21.4')
         # CMake >= 3.20 is required. There is a proto with dots in the name 'k8s.min.proto' and CMake fails to generate project files
         if not self._cmake_new_enough:
-            self.build_requires('cmake/3.23.2')
-
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.configure()
-        return cmake
+            self.build_requires('cmake/3.23.5')
 
     @functools.lru_cache(1)
     def _parse_proto_libraries(self):
@@ -131,13 +126,13 @@ class GoogleAPIS(ConanFile):
         #  - Inconvenient macro names from usr/include/sys/syslimits.h in some macOS SDKs: GID_MAX
         #    Patched here: https://github.com/protocolbuffers/protobuf/commit/f138d5de2535eb7dd7c8d0ad5eb16d128ab221fd
         #    as of 3.21.4 issue still exist
-        if Version(self.deps_cpp_info["protobuf"].version) <= "3.21.5" and self.settings.os == "Macos" or \
+        if Version(self.dependencies["protobuf"].ref.version) <= "3.21.5" and self.settings.os == "Macos" or \
             self.settings.os == "Android":
             deactivate_library("//google/storagetransfer/v1:storagetransfer_proto")
             deactivate_library("//google/storagetransfer/v1:storagetransfer_cc_proto")
         #  - Inconvenient macro names from /usr/include/math.h : DOMAIN
         if (self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++") or \
-            self.settings.compiler in ["Visual Studio", "msvc"]:
+            is_msvc(self):
             deactivate_library("//google/cloud/channel/v1:channel_proto")
             deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
         #  - Inconvenient names for android
@@ -169,7 +164,8 @@ class GoogleAPIS(ConanFile):
             f.write("# DO NOT EDIT - change the generation code in conanfile.py instead\n")
             for it in filter(lambda u: u.is_used, proto_libraries):
                 f.write(it.cmake_content)
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def _patch_sources(self):
@@ -199,6 +195,7 @@ class GoogleAPIS(ConanFile):
         self.info.requires["protobuf"].full_package_mode()
 
     def package_info(self):
+        self.cpp_info.resdirs = ["res"]
         with open(os.path.join(self.package_folder, self._DEPS_FILE), "r", encoding="utf-8") as f:
             for line in f.read().splitlines():
                 (name, libtype, deps) = line.rstrip('\n').split(' ')

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -43,7 +43,6 @@ class GoogleAPIS(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][str(self.version)], destination=self.source_folder, strip_root=True)
-        apply_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -156,6 +155,7 @@ class GoogleAPIS(ConanFile):
         return proto_libraries
 
     def build(self):
+        apply_conandata_patches(self)
         proto_libraries = self._parse_proto_libraries()
         # Use a separate file to host the generated code, which is generated in full each time.
         # This is safe to call multiple times, for example, if you need to invoke `conan build` more than

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -4,13 +4,13 @@ import glob
 from io import StringIO
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import cmake_layout, CMake
-from conan.tools.files import copy, get, export_conandata_patches, copy
+from conan.tools.files import apply_conandata_patches, copy, get, export_conandata_patches, copy
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
-from conan.errors import ConanInvalidConfiguration
 
 from helpers import parse_proto_libraries
 
@@ -43,7 +43,7 @@ class GoogleAPIS(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][str(self.version)], destination=self.source_folder, strip_root=True)
-        self._patch_sources()
+        apply_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -168,11 +168,6 @@ class GoogleAPIS(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
-
-    def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            # Using **patch here results in an error with the required `patch_description` field.
-            tools.patch(patch_file=patch['patch_file'])
 
     _DEPS_FILE = "res/generated_targets.deps"
 

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -191,11 +191,11 @@ class GoogleAPIS(ConanFile):
         self.info.requires["protobuf"].full_package_mode()
 
     def package_info(self):
-        self.cpp_info.resdirs = ["res"]
         with open(os.path.join(self.package_folder, self._DEPS_FILE), "r", encoding="utf-8") as f:
             for line in f.read().splitlines():
                 (name, libtype, deps) = line.rstrip('\n').split(' ')
                 self.cpp_info.components[name].requires = deps.split(',')
+                self.cpp_info.components[name].resdirs = ["res"]
                 if libtype == 'LIB':
                     self.cpp_info.components[name].libs = [name]
                 self.cpp_info.components[name].names["pkg_config"] = name

--- a/recipes/googleapis/all/test_package/conanfile.py
+++ b/recipes/googleapis/all/test_package/conanfile.py
@@ -1,8 +1,7 @@
 import os
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain
-from conan.tools.build import cross_building as tools_cross_building
-from conan.tools.layout import cmake_layout
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
+from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
@@ -25,5 +24,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools_cross_building(self):
+        if can_run(self):
             self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/googleapis/all/test_package/conanfile.py
+++ b/recipes/googleapis/all/test_package/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.build import can_run
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake_find_package", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
Specify library name and version:  **googleapis/all**

### Summary of changes

This PR updates the `googleapis` recipe to use functionality that is compatible with both Conan 1.x and Conan 2.0

* Use `CMakeDeps` and `CMakeToolchain` instead of legacy integrations
* Add transitive headers trait to the protobuf dependency - this is for Conan 2.0. `.pb.h` headers inside this package have transitive public header dependencies on Protobuf
* Minor changes to use new functions from `conan.tools`
* Add `resdirs` cpp_info attribute - it needs to be explicitly set in Conan 2.0 as there is no default.
* Add `package_type` attribute

### Shorten build paths in CMake-generated files:
* Modify the logic in the CMake code generation such that the target names _do not_ start with `google_` or end with `_proto` - this is in an attempt to get cmake to generate shorter vcxproj files, such that the path to the build-time-only `.dir` directory and all temporary files generated by MSBuild have shorter names, to work around the following error:
```
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets\Microsoft.CppBuild.targets(321,5): error MSB3491: Could not write lines to file "google_cloud_beyondcorp_clientconnectorservices_v1_clientconnectorservices_proto.dir\Release\google_c.96C68757.tlog\google_cloud_beyondcorp_clientconnectorservices_v1_clientconnectorservices_proto.lastbuildstate". The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters. [C:\J\w\prod\BuildSingleReference@5\s\495e34\1\build\google_cloud_beyondcorp_clientconnectorservices_v1_clientconnectorservices_proto.vcxproj]
```

The _file_ names of the built libraries are preserved, as well as the target names that we are parsing in `package_info`.


















































































































































