### PR TITLE
grpc-proto: use modern CMake integrations

### DIFF
--- a/recipes/grpc-proto/all/CMakeLists.txt
+++ b/recipes/grpc-proto/all/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.4)
 
 project(grpc-proto)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup(TARGETS)
-
 find_package(Protobuf REQUIRED CONFIG)
 find_package(googleapis REQUIRED CONFIG)
 

--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -1,22 +1,24 @@
 import os
 import functools
 from conan import ConanFile
-from conans import CMake, tools
-from conan.tools.files import get, copy
-from conans.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.files import get, collect_libs, copy
 
 from helpers import parse_proto_libraries
 
 
 class GRPCProto(ConanFile):
     name = "grpc-proto"
+    package_type = "library"
     description = "gRPC-defined protobufs for peripheral services such as health checking, load balancing, etc"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/grpc/grpc-proto"
     topics = "google", "protos", "api"
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps"
     options = {
         "shared": [True, False], 
         "fPIC": [True, False]
@@ -28,7 +30,7 @@ class GRPCProto(ConanFile):
     exports = "helpers.py"
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
 
     def source(self):
         get(self, **self.conan_data["sources"][str(self.version)], destination=self.source_folder, strip_root=True)
@@ -45,24 +47,22 @@ class GRPCProto(ConanFile):
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 11)
+            check_min_cppstd(self, 11)
 
         if self.options.shared and (not self.options["protobuf"].shared or not self.options["googleapis"].shared):
             raise ConanInvalidConfiguration("If built as shared, protobuf and googleapis must be shared as well. Please, use `protobuf:shared=True` and `googleapis:shared=True`")
 
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["GOOGLEAPIS_PROTO_DIRS"] = self.dependencies["googleapis"].cpp_info.resdirs[0].replace("\\", "/")
+        tc.generate()
+
     def requirements(self):
-        self.requires('protobuf/3.21.4')
+        self.requires('protobuf/3.21.4', transitive_headers=True)
         self.requires('googleapis/cci.20220711')
 
     def build_requirements(self):
         self.build_requires('protobuf/3.21.4')
-
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["GOOGLEAPIS_PROTO_DIRS"] = self.dependencies["googleapis"].cpp_info.resdirs[0].replace("\\", "/")
-        cmake.configure()
-        return cmake
 
     @functools.lru_cache(1)
     def _parse_proto_libraries(self):
@@ -94,7 +94,8 @@ class GRPCProto(ConanFile):
         with open(os.path.join(self.source_folder, "CMakeLists.txt"), "a", encoding="utf-8") as f:
             for it in filter(lambda u: u.is_used, proto_libraries):
                 f.write(it.cmake_content)
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
@@ -113,6 +114,7 @@ class GRPCProto(ConanFile):
 
     def package_info(self):
         # We are not creating components, we can just collect the libraries
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = collect_libs(self)
+        self.cpp_info.resdirs = ["res"]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.extend(["m"])

--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -54,7 +54,8 @@ class GRPCProto(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["GOOGLEAPIS_PROTO_DIRS"] = self.dependencies["googleapis"].cpp_info.resdirs[0].replace("\\", "/")
+        googleapis_resdirs = self.dependencies["googleapis"].cpp_info.aggregated_components().resdirs
+        tc.cache_variables["GOOGLEAPIS_PROTO_DIRS"] = ";".join([p.replace("\\", "/") for p in googleapis_resdirs])
         tc.generate()
 
     def requirements(self):

--- a/recipes/grpc-proto/all/test_package/conanfile.py
+++ b/recipes/grpc-proto/all/test_package/conanfile.py
@@ -1,8 +1,7 @@
 import os
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain
-from conan.tools.build import cross_building as tools_cross_building
-from conan.tools.layout import cmake_layout
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
 
 
 class TestPackageConan(ConanFile):
@@ -25,5 +24,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools_cross_building(self):
+        if can_run(self):
             self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/grpc-proto/all/test_v1_package/CMakeLists.txt
+++ b/recipes/grpc-proto/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_v1_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/grpc-proto/all/test_v1_package/conanfile.py
+++ b/recipes/grpc-proto/all/test_v1_package/conanfile.py
@@ -1,0 +1,20 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **grpc-proto/all**

### Summary of changes

This PR makes the recipe use syntax that is compatible with both Conan 1.x and Conan 2.0.

* Use newer `CMakeDeps` and `CMakeToolchain` instead of legacy integrations
* Add `transitive_headers=True` to dependency on protobuf (needed for 2.0 - public headers in this package transitively include protobuf headers)
* Explicitly define `cpp_info.resdirs` - needed for Conan 2.0 since it no longer has a default value
* Minor fixes to use tools from `conan.tools` instead of legacy tools.

Close https://github.com/conan-io/conan-center-index/issues/15599 - caused by `googleapis` introducing components and moving the `resdirs` definition to the component. 