### PR TITLE
grpc: use modern CMake integrations

### DIFF
--- a/recipes/grpc/all/conan_cmake_project_include.cmake
+++ b/recipes/grpc/all/conan_cmake_project_include.cmake
@@ -1,9 +1,3 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
 find_package(grpc-proto CONFIG REQUIRED)
 find_package(googleapis CONFIG REQUIRED)
 
@@ -17,8 +11,6 @@ set(grpc-proto_RES_DIRS
     $<$<CONFIG:RelWithDebInfo>:${grpc-proto_RES_DIRS_RELWITHDEBINFO}>
     $<$<CONFIG:MinSizeRel>:${grpc-proto_RES_DIRS_MINSIZEREL}>
     $<$<CONFIG:Debug>:${grpc-proto_RES_DIRS_DEBUG}>)
-
-add_subdirectory("source_subfolder")
 
 # TODO: move to a patch? It avoids link errors while resolving abseil symbols with gcc
 if (TARGET check_epollexclusive)

--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -17,26 +17,16 @@ sources:
 patches:
   "1.50.1":
     - patch_file: "patches/v1.50.x/001-disable-cppstd-override.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/v1.50.x/002-consume-protos-from-requirements.patch"
-      base_path: "source_subfolder"
   "1.50.0":
     - patch_file: "patches/v1.50.x/001-disable-cppstd-override.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/v1.50.x/002-consume-protos-from-requirements.patch"
-      base_path: "source_subfolder"
   "1.48.0":
     - patch_file: "patches/v1.48.x/001-disable-cppstd-override.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/v1.48.x/002-consume-protos-from-requirements.patch"
-      base_path: "source_subfolder"
   "1.47.1":
     - patch_file: "patches/v1.47.x/001-disable-cppstd-override.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/v1.47.x/002-consume-protos-from-requirements.patch"
-      base_path: "source_subfolder"
   "1.46.3":
     - patch_file: "patches/v1.46.x/001-disable-cppstd-override.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/v1.46.x/002-consume-protos-from-requirements.patch"
-      base_path: "source_subfolder"

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -100,6 +100,9 @@ class grpcConan(ConanFile):
         self.info.requires["protobuf"].full_package_mode()
 
     def validate(self):
+        if self.settings.os != "Macos":
+            raise ConanInvalidConfiguration(f"Do not merge - CI testing")
+            
         check_min_vs(self, "190")
         if is_msvc(self) and self.info.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} shared not supported by Visual Studio")

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
@@ -6,8 +9,6 @@ from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, replace_in_file, rmdir
 from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
-import os
-import shutil
 
 required_conan_version = ">=1.53.0"
 

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -2,10 +2,10 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.build import cross_building, valid_min_cppstd, check_min_cppstd
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, replace_in_file, rmdir
 from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
-from conans import CMake
 import os
 import shutil
 
@@ -14,6 +14,7 @@ required_conan_version = ">=1.52.0"
 
 class grpcConan(ConanFile):
     name = "grpc"
+    package_type = "library"
     description = "Google's RPC (remote procedure call) library and framework."
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
@@ -52,16 +53,9 @@ class grpcConan(ConanFile):
     }
 
     short_paths = True
-    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
-    _cmake = None
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     @property
     def _grpc_plugin_template(self):
@@ -72,8 +66,8 @@ class grpcConan(ConanFile):
         return 14 if Version(self.version) >= "1.47" else 11
 
     def export_sources(self):
-        copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
-        copy(self, f"cmake/{self._grpc_plugin_template}", self.recipe_folder, self.export_sources_folder)
+        copy(self, "conan_cmake_project_include.cmake", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
+        copy(self, f"cmake/{self._grpc_plugin_template}", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
         export_conandata_patches(self)
 
     def config_options(self):
@@ -82,27 +76,21 @@ class grpcConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
+            self.options.rm_safe("fPIC")
             self.options["protobuf"].shared = True
             self.options["googleapis"].shared = True
             self.options["grpc-proto"].shared = True
 
-    def layout(self):
-        pass
-
     def requirements(self):
         if is_msvc(self) and Version(self.version) < "1.47":
-            self.requires("abseil/20211102.0")
+            self.requires("abseil/20211102.0", transitive_headers=True)
         else:
-            self.requires("abseil/20220623.0")
+            self.requires("abseil/20220623.0", transitive_headers=True)
         self.requires("c-ares/1.18.1")
         self.requires("openssl/1.1.1s")
         self.requires("re2/20220601")
         self.requires("zlib/1.2.13")
-        self.requires("protobuf/3.21.4")
+        self.requires("protobuf/3.21.4", transitive_headers=True)
         self.requires("googleapis/cci.20220711")
         self.requires("grpc-proto/cci.20220627")
 
@@ -137,11 +125,10 @@ class grpcConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+                  destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake is not None:
-            return self._cmake
+    def generate(self):
+
 
         # This doesn't work yet as one would expect, because the install target builds everything
         # and we need the install target because of the generated CMake files
@@ -149,79 +136,81 @@ class grpcConan(ConanFile):
         #   enable_mobile=False # Enables iOS and Android support
         #
         # cmake.definitions["CONAN_ENABLE_MOBILE"] = "ON" if self.options.csharp_ext else "OFF"
+        tc = CMakeToolchain(self)
 
-        self._cmake = CMake(self)
-        self._cmake.definitions["gRPC_BUILD_CODEGEN"] = self.options.codegen
-        self._cmake.definitions["gRPC_BUILD_CSHARP_EXT"] = self.options.csharp_ext
-        self._cmake.definitions["gRPC_BUILD_TESTS"] = False
+        tc.cache_variables["CMAKE_PROJECT_grpc_INCLUDE"] = os.path.join(self.source_folder, "conan_cmake_project_include.cmake")
+
+        tc.cache_variables["gRPC_BUILD_CODEGEN"] = self.options.codegen
+        tc.cache_variables["gRPC_BUILD_CSHARP_EXT"] = self.options.csharp_ext
+        tc.cache_variables["gRPC_BUILD_TESTS"] = False
 
         # We need the generated cmake/ files (bc they depend on the list of targets, which is dynamic)
-        self._cmake.definitions["gRPC_INSTALL"] = True
-        self._cmake.definitions["gRPC_INSTALL_SHAREDIR"] = "res/grpc"
+        tc.cache_variables["gRPC_INSTALL"] = True
+        tc.cache_variables["gRPC_INSTALL_SHAREDIR"] = "res/grpc"
 
         # tell grpc to use the find_package versions
-        self._cmake.definitions["gRPC_ZLIB_PROVIDER"] = "package"
-        self._cmake.definitions["gRPC_CARES_PROVIDER"] = "package"
-        self._cmake.definitions["gRPC_RE2_PROVIDER"] = "package"
-        self._cmake.definitions["gRPC_SSL_PROVIDER"] = "package"
-        self._cmake.definitions["gRPC_PROTOBUF_PROVIDER"] = "package"
-        self._cmake.definitions["gRPC_ABSL_PROVIDER"] = "package"
+        tc.cache_variables["gRPC_ZLIB_PROVIDER"] = "package"
+        tc.cache_variables["gRPC_CARES_PROVIDER"] = "package"
+        tc.cache_variables["gRPC_RE2_PROVIDER"] = "package"
+        tc.cache_variables["gRPC_SSL_PROVIDER"] = "package"
+        tc.cache_variables["gRPC_PROTOBUF_PROVIDER"] = "package"
+        tc.cache_variables["gRPC_ABSL_PROVIDER"] = "package"
 
-        self._cmake.definitions["gRPC_BUILD_GRPC_CPP_PLUGIN"] = self.options.cpp_plugin
-        self._cmake.definitions["gRPC_BUILD_GRPC_CSHARP_PLUGIN"] = self.options.csharp_plugin
-        self._cmake.definitions["gRPC_BUILD_GRPC_NODE_PLUGIN"] = self.options.node_plugin
-        self._cmake.definitions["gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN"] = self.options.objective_c_plugin
-        self._cmake.definitions["gRPC_BUILD_GRPC_PHP_PLUGIN"] = self.options.php_plugin
-        self._cmake.definitions["gRPC_BUILD_GRPC_PYTHON_PLUGIN"] = self.options.python_plugin
-        self._cmake.definitions["gRPC_BUILD_GRPC_RUBY_PLUGIN"] = self.options.ruby_plugin
+        tc.cache_variables["gRPC_BUILD_GRPC_CPP_PLUGIN"] = self.options.cpp_plugin
+        tc.cache_variables["gRPC_BUILD_GRPC_CSHARP_PLUGIN"] = self.options.csharp_plugin
+        tc.cache_variables["gRPC_BUILD_GRPC_NODE_PLUGIN"] = self.options.node_plugin
+        tc.cache_variables["gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN"] = self.options.objective_c_plugin
+        tc.cache_variables["gRPC_BUILD_GRPC_PHP_PLUGIN"] = self.options.php_plugin
+        tc.cache_variables["gRPC_BUILD_GRPC_PYTHON_PLUGIN"] = self.options.python_plugin
+        tc.cache_variables["gRPC_BUILD_GRPC_RUBY_PLUGIN"] = self.options.ruby_plugin
 
         # Consumed targets (abseil) via interface target_compiler_feature can propagate newer standards
         if not valid_min_cppstd(self, self._cxxstd_required):
-            self._cmake.definitions["CMAKE_CXX_STANDARD"] = self._cxxstd_required
-
-        if cross_building(self):
-            # otherwise find_package() can't find config files since
-            # conan doesn't populate CMAKE_FIND_ROOT_PATH
-            self._cmake.definitions["CMAKE_FIND_ROOT_PATH_MODE_PACKAGE"] = "BOTH"
+            tc.cache_variables["CMAKE_CXX_STANDARD"] = self._cxxstd_required
 
         if is_apple_os(self):
             # workaround for: install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
-            self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False
+            tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
 
         if is_msvc(self) and Version(self.version) >= "1.48":
-            self._cmake.definitions["CMAKE_SYSTEM_VERSION"] = "10.0.18362.0"
+            tc.cache_variables["CMAKE_SYSTEM_VERSION"] = "10.0.18362.0"
 
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        tc.generate()
+
+        cmake_deps = CMakeDeps(self)
+        cmake_deps.generate()
+
+
 
     def _patch_sources(self):
         apply_conandata_patches(self)
 
         # Clean existing proto files, they will be taken from requirements
-        shutil.rmtree(os.path.join(self._source_subfolder, "src", "proto", "grpc"))
+        shutil.rmtree(os.path.join(self.source_folder, "src", "proto", "grpc"))
 
         if Version(self.version) >= "1.47":
             # Take googleapis from requirement instead of vendored/hardcoded version
-            replace_in_file(self, os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                 "if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googleapis)",
                 "if (FALSE)  # Do not download, it is provided by Conan"
             )
 
         # We are fine with protobuf::protoc coming from conan generated Find/config file
         # TODO: to remove when moving to CMakeToolchain (see https://github.com/conan-io/conan/pull/10186)
-        replace_in_file(self, os.path.join(self._source_subfolder, "cmake", "protobuf.cmake"),
+        replace_in_file(self, os.path.join(self.source_folder, "cmake", "protobuf.cmake"),
             "find_program(_gRPC_PROTOBUF_PROTOC_EXECUTABLE protoc)",
             "set(_gRPC_PROTOBUF_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)"
         )
 
     def build(self):
         self._patch_sources()
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        copy(self, "LICENSE", src=os.path.join(self.source_folder, self._source_subfolder), dst=os.path.join(self.package_folder, "licenses"))
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
 
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.scm import Version
 import os
 import shutil
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class grpcConan(ConanFile):

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -100,9 +100,6 @@ class grpcConan(ConanFile):
         self.info.requires["protobuf"].full_package_mode()
 
     def validate(self):
-        if self.settings.os != "Macos":
-            raise ConanInvalidConfiguration(f"Do not merge - CI testing")
-            
         check_min_vs(self, "190")
         if is_msvc(self) and self.info.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} shared not supported by Visual Studio")

--- a/recipes/grpc/all/test_package/CMakeLists.txt
+++ b/recipes/grpc/all/test_package/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 3.12)
-project(test_package)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 find_package(protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)

--- a/recipes/grpc/all/test_package/CMakeLists.txt
+++ b/recipes/grpc/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 
-find_package(protobuf CONFIG REQUIRED)
-find_package(gRPC CONFIG REQUIRED)
+find_package(protobuf CONFIG REQUIRED QUIET)
+find_package(gRPC CONFIG REQUIRED QUIET)
+
+message("DYLD_LIBRARY_PATH from CMake: $ENV{DYLD_LIBRARY_PATH}")
 
 add_executable(${PROJECT_NAME} test_package.cpp helloworld.proto)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)  # grpc 1.47.0 requires c++14

--- a/recipes/grpc/all/test_package/conanfile.py
+++ b/recipes/grpc/all/test_package/conanfile.py
@@ -33,6 +33,7 @@ class TestPackageConan(ConanFile):
             VirtualBuildEnv(self).generate()
         else:
             # Cover case in Conan 1.x when only one profile is provided
+            self.output.info("Generating VirtualRunEnv in build environment - using two profiles is advised.")
             VirtualRunEnv(self).generate(scope="build")
 
         # Environment so that the compiled test executable can load shared libraries

--- a/recipes/grpc/all/test_package/conanfile.py
+++ b/recipes/grpc/all/test_package/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
+from conan.tools.cmake import cmake_layout, CMake, CMakeDeps, CMakeToolchain
 from conan.tools.env import VirtualRunEnv, VirtualBuildEnv
 from conan.tools.microsoft import is_msvc
 import os
@@ -8,7 +8,6 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps"
     test_type = "explicit"
 
     def layout(self):
@@ -44,6 +43,9 @@ class TestPackageConan(ConanFile):
         # Environment so that the compiled test executable can load shared libraries
         runenv = VirtualRunEnv(self)
         runenv.generate(scope="run")
+
+        deps = CMakeDeps(self)
+        deps.generate()
         
     def build(self):
         cmake = CMake(self)

--- a/recipes/grpc/all/test_package/conanfile.py
+++ b/recipes/grpc/all/test_package/conanfile.py
@@ -26,6 +26,11 @@ class TestPackageConan(ConanFile):
         tc.cache_variables["TEST_ACTUAL_SERVER"] = not (is_msvc(self)
                                                         and str(self.settings.compiler.version) in ("15", "191")
                                                         and self.settings.build_type == "Release")
+
+        # Additional logic to override the make program on MacOS if /usr/bin/make is found by CMake
+        # which otherwise prevents the propagation of DYLD_LIBRARY_PATH as set by the VirtualBuildEnv
+        project_include = os.path.join(self.source_folder, "macos_make_override.cmake")
+        tc.cache_variables["CMAKE_PROJECT_test_package_INCLUDE"] = project_include
         tc.generate()
         
         # Set up environment so that we can run grpc-cpp-plugin at build time

--- a/recipes/grpc/all/test_package/conanfile.py
+++ b/recipes/grpc/all/test_package/conanfile.py
@@ -30,7 +30,12 @@ class TestPackageConan(ConanFile):
         
         # Set up environment so that we can run grpc-cpp-plugin at build time
         if not cross_building(self):
-            VirtualRunEnv(self).generate(scope="build")
+            buildenv = VirtualRunEnv(self)
+            buildenv.generate(scope="build")
+
+        # Environment so that the compiled test executable can load shared libraries
+        runenv = VirtualRunEnv(self)
+        runenv.generate(scope="run")
         
     def build(self):
         cmake = CMake(self)

--- a/recipes/grpc/all/test_package/conanfile.py
+++ b/recipes/grpc/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
-from conan.tools.build import can_run, cross_building
+from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
-from conan.tools.env import VirtualRunEnv
+from conan.tools.env import VirtualRunEnv, VirtualBuildEnv
 from conan.tools.microsoft import is_msvc
 import os
 
@@ -29,9 +29,11 @@ class TestPackageConan(ConanFile):
         tc.generate()
         
         # Set up environment so that we can run grpc-cpp-plugin at build time
-        if not cross_building(self):
-            buildenv = VirtualRunEnv(self)
-            buildenv.generate(scope="build")
+        if hasattr(self, "settings_build"):
+            VirtualBuildEnv(self).generate()
+        else:
+            # Cover case in Conan 1.x when only one profile is provided
+            VirtualRunEnv(self).generate(scope="build")
 
         # Environment so that the compiled test executable can load shared libraries
         runenv = VirtualRunEnv(self)

--- a/recipes/grpc/all/test_package/macos_make_override.cmake
+++ b/recipes/grpc/all/test_package/macos_make_override.cmake
@@ -1,0 +1,13 @@
+if (CMAKE_GENERATOR MATCHES "Unix Makefiles" AND CMAKE_HOST_APPLE AND CMAKE_MAKE_PROGRAM MATCHES "/usr/bin/make")
+    execute_process(
+        COMMAND xcrun --find make
+        OUTPUT_VARIABLE xcode_make OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_VARIABLE xcrun_error)
+    if(xcode_make)
+        #Override the value of `CMAKE_MAKE_PROGRAM`
+        set_property(CACHE CMAKE_MAKE_PROGRAM PROPERTY VALUE "${xcode_make}")
+    else()
+        message(WARNING "Using /usr/bin/make may prevent execution of Conan tool_requires that require DYLD_LIBRARY_PATH"
+                        " to be set at build time.")
+    endif()
+endif()

--- a/recipes/grpc/all/test_v1_package/CMakeLists.txt
+++ b/recipes/grpc/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_v1_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/grpc/all/test_v1_package/conanfile.py
+++ b/recipes/grpc/all/test_v1_package/conanfile.py
@@ -1,0 +1,44 @@
+from conans import ConanFile, CMake, tools
+import contextlib
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build_requirements(self):
+        if hasattr(self, "settings_build"):
+            self.build_requires(str(self.requires["grpc"]))
+
+    @contextlib.contextmanager
+    def _buildenv(self):
+        # TODO: conan v2: replace by VirtualBuildEnv and always add grpc to build requirements
+        if tools.cross_building(self):
+            yield
+        else:
+            with tools.run_environment(self):
+                yield
+
+    def build(self):
+        # TODO: always build in conan v2
+        # this is a limitation of conan v1:
+        # at build time we want to inject PATH/LD_LIBRARY/DYLD_LIBRARY_PATH
+        # of build requirements so that gprc_cpp_plugin can find its
+        # shared dependencies (in build context as well)
+        # should be fixed by using: CMakeToolchain + VirtualBuildEnv
+        if tools.cross_building(self) and self.options["grpc"].shared:
+            return
+        with self._buildenv():
+            cmake = CMake(self)
+            # FIXME: This combination of settings randomly fails in CI
+            cmake.definitions["TEST_ACTUAL_SERVER"] = not (self.settings.compiler == "Visual Studio"
+                                                           and self.settings.compiler.version == "15"
+                                                           and self.settings.build_type == "Release")
+            cmake.configure()
+            cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/grpc/all/test_v1_package/conanfile.py
+++ b/recipes/grpc/all/test_v1_package/conanfile.py
@@ -37,7 +37,6 @@ class TestPackageConan(ConanFile):
         if (tools.cross_building(self) and self.options["grpc"].shared) or self.macos_grpc_shared:
             self.output.warning("Skipping build of test_package due to limitation propagating "
                                 "runtime environment when invoking protoc and grpc_cpp_plugin. "
-                                "This is fixed in Conan 2.0 - please use new integrations. "
                                 "For a working example, please see the newer Conan 2.0 compatible "
                                 "test package.")
             return


### PR DESCRIPTION
Specify library name and version:  **grpc/all**

### Summary of changes

This PR makes the grpc compatible with both Conan 1.x and Conan 2.0

* Use `CMakeDeps` and `CMakeToolchain` instead of legacy integrations
* Use CMake `project()` code injection instead of enclosing the project in a superproject (docs [here](https://cmake.org/cmake/help/latest/command/project.html#code-injection)) - this preserves the logic that was previously in the recipe's `CMakeLists.txt` that acted as the top-level. The variable used ensures that this is processed _after_ the CMake toolchain file has been processed.
* Express the `transitive_headers` trait for both abseil and protobuf (public headers from grpc reference headers from these).
* Remove definition of `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE` as that is already handled by `CMakeToolchain`

#### Handle test_package when `grpc:shared=True`
During the build of a consumer project (in this case, the `test_package`), the protobuf compiler (`protoc`) and the `grpc_cpp_plugin` executables need to run. If any of the executables are built with shared libraries (in this case `grpc:shared=True`), the Conan generated `VirtualBuildEnv` will correctly define the environment variables needed for those executables to locate their runtime dependencies. 
A limitation of recent versions of macOS prevents the propagation of all `DYLD_*` environment variables. We have observed that when CMake finds the `make` program at `/usr/bin/make`, the variables will be erased in following chain of execution:
```
cmake --build -> make -> protoc -> grpc_cpp_plugin`
                  ^ `/usr/bin/make` will not inherit `DYLD_LIBRARY_PATH`
```
This PR introduces logic in the `test_package` such that if after the initial configuration pass (during the `project()` call), `make` is found at that location, that this is overridden to invoking `make` directly from within the `xcode` installation - which does not have the `DYLD*` restriction from the System Integrity Protection.
We have observed that this is not an issue if the `gmake` executable from homebrew is installed on the system, as CMake will automatically prefer that one over the Apple-provided one at `/usr/bin`. 
