### PR TITLE
plf_list: add version 2.57, support apple-clang 14

### DIFF
--- a/recipes/plf_list/all/conandata.yml
+++ b/recipes/plf_list/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.57":
+    url: "https://github.com/mattreecebentley/plf_list/archive/d7a06d7497dc01261dd2c2fe675a8b605acb7a56.tar.gz"
+    sha256: "4297c7578fe5ea2c6346541b28a57d87ec311522fa55bc8a5ab069921fc073e9"
   "2.52":
     url: "https://github.com/mattreecebentley/plf_list/archive/76115adac11a5f362b7a8eea8362314d547284df.tar.gz"
     sha256: "897ff5309c399ec0f7c875b398c7eb07ebe3cd80a75ce337a0bd70456668116b"

--- a/recipes/plf_list/all/conandata.yml
+++ b/recipes/plf_list/all/conandata.yml
@@ -11,3 +11,16 @@ sources:
   "2.03":
     url: "https://github.com/mattreecebentley/plf_list/archive/cc579a5cc828d8a0da6715ef075d560e4de89901.tar.gz"
     sha256: "4ab3f7ca41e3567710a64ede3a9f708b388f3ae52e09b3ee1a45d6b4fd89dd09"
+patches:
+  "2.57":
+    - patch_file: "patches/2.57-0001-disable-cxx20-from-apple-clang14.patch"
+      patch_description: "apple-clang 14 defaults C++ 20, but it doesn't support C++20 features little"
+      patch_type: "portability"
+  "2.52":
+    - patch_file: "patches/2.50-0001-disable-cxx20-from-apple-clang14.patch"
+      patch_description: "apple-clang 14 defaults C++ 20, but it doesn't support C++20 features little"
+      patch_type: "portability"
+  "2.50":
+    - patch_file: "patches/2.50-0001-disable-cxx20-from-apple-clang14.patch"
+      patch_description: "apple-clang 14 defaults C++ 20, but it doesn't support C++20 features little"
+      patch_type: "portability"

--- a/recipes/plf_list/all/conanfile.py
+++ b/recipes/plf_list/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
-from conan.tools.files import copy, get, replace_in_file
+from conan.tools.files import copy, get, apply_conandata_patches, export_conandata_patches
 from conan.tools.layout import basic_layout
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.50.0"
@@ -16,6 +15,9 @@ class PlflistConan(ConanFile):
     homepage = "https://github.com/mattreecebentley/plf_list"
     settings = "os", "arch", "compiler", "build_type"
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def package_id(self):
         self.info.clear()
 
@@ -27,13 +29,7 @@ class PlflistConan(ConanFile):
             destination=self.source_folder, strip_root=True)
 
     def build(self):
-        # apple-clang 14 defaults C++ 20, but it doesn't support C++20 features little
-        # https://www.reddit.com/r/cpp/comments/v6ydea/xcode_now_defaults_to_c20/
-        if Version(self.version) >= "2.50":
-            replace_in_file(self, os.path.join(self.source_folder, "plf_list.h"),
-            "if __cplusplus > 201704L && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 13) || !defined(_LIBCPP_VERSION)) && ((defined(__clang__) && (__clang_major__ >= 13)) || (defined(__GNUC__) && __GNUC__ >= 10) || (!defined(__clang__) && !defined(__GNUC__)))",
-            "if __cplusplus > 201704L && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 13) || !defined(_LIBCPP_VERSION)) && (!defined(__APPLE_CC__) && (defined(__clang__) && (__clang_major__ >= 13)) || (defined(__GNUC__) && __GNUC__ >= 10) || (!defined(__clang__) && !defined(__GNUC__)))"
-            )
+        apply_conandata_patches(self)
 
     def package(self):
         copy(self, "LICENSE.md", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/plf_list/all/conanfile.py
+++ b/recipes/plf_list/all/conanfile.py
@@ -15,7 +15,6 @@ class PlflistConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/mattreecebentley/plf_list"
     settings = "os", "arch", "compiler", "build_type"
-    no_copy_source = True
 
     def package_id(self):
         self.info.clear()

--- a/recipes/plf_list/all/conanfile.py
+++ b/recipes/plf_list/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, replace_in_file
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.50.0"
@@ -10,9 +11,9 @@ class PlflistConan(ConanFile):
     name = "plf_list"
     description = "plf::list is a drop-in higher-performance replacement for std::list"
     license = "Zlib"
-    topics = ("plf_list", "container", "linked-list", "list")
-    homepage = "https://github.com/mattreecebentley/plf_list"
+    topics = ("container", "linked-list", "list", "header-only")
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/mattreecebentley/plf_list"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -27,7 +28,13 @@ class PlflistConan(ConanFile):
             destination=self.source_folder, strip_root=True)
 
     def build(self):
-        pass
+        # apple-clang 14 defaults C++ 20, but it doesn't support C++20 features little
+        # https://www.reddit.com/r/cpp/comments/v6ydea/xcode_now_defaults_to_c20/
+        if Version(self.version) >= "2.50":
+            replace_in_file(self, os.path.join(self.source_folder, "plf_list.h"),
+            "if __cplusplus > 201704L && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 13) || !defined(_LIBCPP_VERSION)) && ((defined(__clang__) && (__clang_major__ >= 13)) || (defined(__GNUC__) && __GNUC__ >= 10) || (!defined(__clang__) && !defined(__GNUC__)))",
+            "if __cplusplus > 201704L && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 13) || !defined(_LIBCPP_VERSION)) && (!defined(__APPLE_CC__) && (defined(__clang__) && (__clang_major__ >= 13)) || (defined(__GNUC__) && __GNUC__ >= 10) || (!defined(__clang__) && !defined(__GNUC__)))"
+            )
 
     def package(self):
         copy(self, "LICENSE.md", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/plf_list/all/patches/2.50-0001-disable-cxx20-from-apple-clang14.patch
+++ b/recipes/plf_list/all/patches/2.50-0001-disable-cxx20-from-apple-clang14.patch
@@ -1,0 +1,13 @@
+diff --git a/plf_list.h b/plf_list.h
+index a9e3711..8357582 100644
+--- a/plf_list.h
++++ b/plf_list.h
+@@ -168,7 +168,7 @@
+ 		#define PLF_CONSTEXPR constexpr
+ 	#endif
+ 
+-	#if __cplusplus > 201704L && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 13) || !defined(_LIBCPP_VERSION)) && ((defined(__clang__) && (__clang_major__ >= 13)) || (defined(__GNUC__) && __GNUC__ >= 10) || (!defined(__clang__) && !defined(__GNUC__)))
++	#if __cplusplus > 201704L && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 13) || !defined(_LIBCPP_VERSION)) && (!defined(__APPLE_CC__) && (defined(__clang__) && (__clang_major__ >= 13)) || (defined(__GNUC__) && __GNUC__ >= 10) || (!defined(__clang__) && !defined(__GNUC__)))
+ 		#define PLF_CPP20_SUPPORT
+ 		#undef PLF_CONSTFUNC
+ 		#define PLF_CONSTFUNC constexpr

--- a/recipes/plf_list/all/patches/2.57-0001-disable-cxx20-from-apple-clang14.patch
+++ b/recipes/plf_list/all/patches/2.57-0001-disable-cxx20-from-apple-clang14.patch
@@ -1,0 +1,13 @@
+diff --git a/plf_list.h b/plf_list.h
+index c729efe..1d0eb67 100644
+--- a/plf_list.h
++++ b/plf_list.h
+@@ -176,7 +176,7 @@
+ 		#define PLF_CONSTEXPR constexpr
+ 	#endif
+ 
+-	#if __cplusplus > 201704L && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 13) || !defined(_LIBCPP_VERSION)) && ((defined(__clang__) && (__clang_major__ >= 13)) || (defined(__GNUC__) && __GNUC__ >= 10) || (!defined(__clang__) && !defined(__GNUC__)))
++	#if __cplusplus > 201704L && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 13) || !defined(_LIBCPP_VERSION)) && (!defined(__APPLE_CC__) && (defined(__clang__) && (__clang_major__ >= 13)) || (defined(__GNUC__) && __GNUC__ >= 10) || (!defined(__clang__) && !defined(__GNUC__)))
+ 		#define PLF_CPP20_SUPPORT
+ 		#undef PLF_CONSTFUNC
+ 		#define PLF_CONSTFUNC constexpr

--- a/recipes/plf_list/all/test_v1_package/CMakeLists.txt
+++ b/recipes/plf_list/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(plf_list REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE plf_list::plf_list)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/plf_list/config.yml
+++ b/recipes/plf_list/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.57":
+    folder: all
   "2.52":
     folder: all
   "2.50":


### PR DESCRIPTION
Specify library name and version:  **plf_list/***

- add version 2.57
- plf_list >= 2.50 doesn't support apple-clang 14 because apple-clang 14 defaults C++20
- use `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
