### PR TITLE
[googleapis]: add version matching google-cloud-cpp-2.5.0

### DIFF
--- a/recipes/googleapis/all/conandata.yml
+++ b/recipes/googleapis/all/conandata.yml
@@ -7,6 +7,9 @@
 #     (master branch) https://github.com/grpc/grpc/blob/master/CMakeLists.txt#L347
 
 sources:
+  "cci.20221108":
+    url: "https://github.com/googleapis/googleapis/archive/67b2d7c2fb11188776bc398f02c67fccd8187502.zip"
+    sha256: "cca450c34e3a8adc03364686d44748f362e4a9af6d3ef32b918f2d5483a3025e"
   "cci.20220711":
     url: "https://github.com/googleapis/googleapis/archive/220b13e335ea8e0153c84c56a135a19d15384621.zip"
     sha256: "0a8aac018f49f8595fc0fbfe53f46d73b2fb42661a425746be802302928e6ac2"
@@ -20,6 +23,11 @@ sources:
     url: "https://github.com/googleapis/googleapis/archive/2f9af297c84c55c8b871ba4495e01ade42476c92.zip"
     sha256: "c53ef0768e07bd4e2334cdacba8c6672d2252bef307a889f94893652e8e7f3a4"
 patches:
+  "cci.20221108":
+    - patch_file: "patches/cci.20220711/001-fix-google-api-deps.patch"
+      patch_description: "Fix incorrect dependency name in BUILD.bazel file"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/googleapis/googleapis/commit/5fd35b6a1316570df7f117426ed35af9086e9bda"
   "cci.20220711":
     - patch_file: "patches/cci.20220711/001-fix-google-api-deps.patch"
       patch_description: "Fix incorrect dependency name in BUILD.bazel file"

--- a/recipes/googleapis/config.yml
+++ b/recipes/googleapis/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20221108":
+    folder: all
   "cci.20220711":
     folder: all
   "cci.20220531":


### PR DESCRIPTION
Specify library name and version:  **googleapis/cci.20221108**

I am planning to send a PR updating  `google-cloud-cpp` to (1) use `googleapis`, and (2) get it upgraded to `v2.5.0`. Before I do so, I need to update `googleapis`.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
