### PR TITLE
msdfgen: add version 1.10

### DIFF
--- a/recipes/msdfgen/all/conandata.yml
+++ b/recipes/msdfgen/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.10":
+    url: "https://github.com/Chlumsky/msdfgen/archive/refs/tags/v1.10.tar.gz"
+    sha256: "2754d1687bfb80968d9c682e0c4c04c8fcf72df1421d076baf44ea0d87aa3662"
   "1.9.1":
     url: "https://github.com/Chlumsky/msdfgen/archive/refs/tags/v1.9.1.tar.gz"
     sha256: "0d2cf3113eea97776731888c711ff836b2be7ff35966a2aa86f3dc57103d0740"
@@ -6,6 +9,10 @@ sources:
     url: "https://github.com/Chlumsky/msdfgen/archive/refs/tags/v1.9.tar.gz"
     sha256: "909eb88c71268dc00cdda244a1fa40a0feefae45f68a779fbfddd5463559fa40"
 patches:
+  "1.10":
+    - patch_file: "patches/1.10-0001-fix-cmake.patch"
+      patch_description: "move project position to top"
+      patch_type: "conan"
   "1.9.1":
     - patch_file: "patches/1.9-0001-unvendor-external-libs.patch"
       patch_description: "Use external libs from conan instead of vendored ones"

--- a/recipes/msdfgen/all/conanfile.py
+++ b/recipes/msdfgen/all/conanfile.py
@@ -88,7 +88,7 @@ class MsdfgenConan(ConanFile):
         rmdir(self, os.path.join(self.source_folder, "lib"))
         rmdir(self, os.path.join(self.source_folder, "include"))
         # very weird but required for Visual Studio when libs are unvendored (at least for Ninja generator)
-        if is_msvc(self):
+        if is_msvc(self) and Version(self.version) < "1.10":
             replace_in_file(
                 self,
                 cmakelists,

--- a/recipes/msdfgen/all/patches/1.10-0001-fix-cmake.patch
+++ b/recipes/msdfgen/all/patches/1.10-0001-fix-cmake.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6dec916..432f218 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,6 +2,9 @@
+ cmake_minimum_required(VERSION 3.15)
+ include(cmake/version.cmake)
+ 
++# Version is specified in vcpkg.json
++project(msdfgen VERSION ${MSDFGEN_VERSION} LANGUAGES CXX)
++
+ option(MSDFGEN_CORE_ONLY "Only build the core library with no dependencies" OFF)
+ option(MSDFGEN_BUILD_STANDALONE "Build the msdfgen standalone executable" ON)
+ option(MSDFGEN_USE_VCPKG "Use vcpkg package manager to link project dependencies" ON)
+@@ -67,9 +70,6 @@ if(MSDFGEN_USE_VCPKG)
+     endif()
+ endif()
+ 
+-# Version is specified in vcpkg.json
+-project(msdfgen VERSION ${MSDFGEN_VERSION} LANGUAGES CXX)
+-
+ file(GLOB_RECURSE MSDFGEN_CORE_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "core/*.h" "core/*.hpp")
+ file(GLOB_RECURSE MSDFGEN_CORE_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "core/*.cpp")
+ file(GLOB_RECURSE MSDFGEN_EXT_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "ext/*.h" "ext/*.hpp")

--- a/recipes/msdfgen/config.yml
+++ b/recipes/msdfgen/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.10":
+    folder: all
   "1.9.1":
     folder: all
   "1.9":


### PR DESCRIPTION
Specify library name and version:  **msdfgen/1.10**

- 1.10 introduces MSDFGEN_PUBLIC macro
- 1.10 begins to require libpng instead of lodepng 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
