### PR TITLE
proposal: bump to 7.5.0

### DIFF
--- a/recipes/proposal/all/conandata.yml
+++ b/recipes/proposal/all/conandata.yml
@@ -35,3 +35,6 @@ sources:
   "7.4.2":
     url: "https://github.com/tudo-astroparticlephysics/PROPOSAL/archive/refs/tags/7.4.2.tar.gz"
     sha256: "f0db44c96a80a6ce3dda02c598574f5f0209376bd2c6c176797710da8eb3e108"
+  "7.5.0":
+    url: "https://github.com/tudo-astroparticlephysics/PROPOSAL/archive/refs/tags/7.5.0.tar.gz"
+    sha256: "ba31bd0a2337f3717a1ad88a3b3f7fefa3f1e4dae4fc922e72144cfecffe5e94"

--- a/recipes/proposal/config.yml
+++ b/recipes/proposal/config.yml
@@ -23,3 +23,5 @@ versions:
     folder: all
   "7.4.2":
     folder: all
+  "7.5.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **proposal/7.5.0**

We have released version 7.5.0 of PROPOSAL 🥳 
This also means that there is a new version for conan.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
