### PR TITLE
[cairo] add 1.17.6

### DIFF
--- a/recipes/cairo/all/conandata.yml
+++ b/recipes/cairo/all/conandata.yml
@@ -1,22 +1,19 @@
 sources:
   "1.17.4":
     sha256: "74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705"
-    url: [
-      "https://www.cairographics.org/snapshots/cairo-1.17.4.tar.xz",
-      "https://mirror.koddos.net/blfs/conglomeration/cairo/cairo-1.17.4.tar.xz"
-    ]
+    url:
+      - "https://www.cairographics.org/snapshots/cairo-1.17.4.tar.xz"
+      - "https://mirror.koddos.net/blfs/conglomeration/cairo/cairo-1.17.4.tar.xz"
   "1.17.2":
     sha256: "6b70d4655e2a47a22b101c666f4b29ba746eda4aa8a0f7255b32b2e9408801df"
-    url: [
-      "https://www.cairographics.org/snapshots/cairo-1.17.2.tar.xz",
-      "https://www.mirrorservice.org/sites/tinycorelinux.net/11.x/x86_64/tcz/src/cairo/cairo-1.17.2.tar.xz"
-    ]
+    url:
+      - "https://www.cairographics.org/snapshots/cairo-1.17.2.tar.xz"
+      - "https://www.mirrorservice.org/sites/tinycorelinux.net/11.x/x86_64/tcz/src/cairo/cairo-1.17.2.tar.xz"
   "1.16.0":
     sha256: "5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331"
-    url: [
-      "https://www.cairographics.org/releases/cairo-1.16.0.tar.xz",
-      "https://mirror.koddos.net/blfs/conglomeration/cairo/cairo-1.16.0.tar.xz"
-    ]
+    url:
+      - "https://www.cairographics.org/releases/cairo-1.16.0.tar.xz"
+      - "https://mirror.koddos.net/blfs/conglomeration/cairo/cairo-1.16.0.tar.xz"
 patches:
   "1.17.4":
     - patch_file: "patches/0001-msvc-update-build-scripts-to-compile-with-more-featu.patch"

--- a/recipes/cairo/config.yml
+++ b/recipes/cairo/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "1.17.4":
     folder: meson
+  "1.17.6":
+    folder: meson

--- a/recipes/cairo/meson/conandata.yml
+++ b/recipes/cairo/meson/conandata.yml
@@ -1,10 +1,10 @@
 sources:
   "1.17.4":
     sha256: "74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705"
-    url: [
-      "https://www.cairographics.org/snapshots/cairo-1.17.4.tar.xz",
-      "https://mirror.koddos.net/blfs/conglomeration/cairo/cairo-1.17.4.tar.xz"
-    ]
+    url:
+      - "https://www.cairographics.org/snapshots/cairo-1.17.4.tar.xz"
+      - "https://mirror.koddos.net/blfs/conglomeration/cairo/cairo-1.17.4.tar.xz"
+
   "1.17.6":
     sha256: "90496d135c9ef7612c98f8ee358390cdec0825534573778a896ea021155599d2"
     url: "https://gitlab.freedesktop.org/cairo/cairo/-/archive/1.17.6/cairo-1.17.6.tar.bz2"

--- a/recipes/cairo/meson/conandata.yml
+++ b/recipes/cairo/meson/conandata.yml
@@ -5,6 +5,9 @@ sources:
       "https://www.cairographics.org/snapshots/cairo-1.17.4.tar.xz",
       "https://mirror.koddos.net/blfs/conglomeration/cairo/cairo-1.17.4.tar.xz"
     ]
+  "1.17.6":
+    sha256: "90496d135c9ef7612c98f8ee358390cdec0825534573778a896ea021155599d2"
+    url: "https://gitlab.freedesktop.org/cairo/cairo/-/archive/1.17.6/cairo-1.17.6.tar.bz2"
 patches:
   "1.17.4":
     - patch_file: "patches/binutils-2.34-libbfd-fix.patch"

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -61,7 +61,7 @@ class CairoConan(ConanFile):
         "with_png": True,
         "with_opengl": "desktop",
         "with_symbol_lookup": False,
-        "tee": True,
+        "tee": False,
     }
     short_paths = True
 
@@ -158,7 +158,6 @@ class CairoConan(ConanFile):
         if self.settings.os == "Linux":
             options["xcb"] = is_enabled(self.options.with_xcb)
             options["xlib"] = is_enabled(self.options.with_xlib)
-            options["xlib-xrender"] = is_enabled(self.options.with_xlib_xrender)
         else:
             options["xcb"] = "disabled"
             options["xlib"] = "disabled"
@@ -177,11 +176,17 @@ class CairoConan(ConanFile):
 
         # future options to add, see meson_options.txt.
         # for now, disabling explicitly, to avoid non-reproducible auto-detection of system libs
-        options["cogl"] = "disabled"  # https://gitlab.gnome.org/GNOME/cogl
-        options["directfb"] = "disabled"
-        options["drm"] = "disabled"  # not yet compilable in cairo 1.17.4
-        options["openvg"] = "disabled"  # https://www.khronos.org/openvg/
-        options["qt"] = "disabled"  # not yet compilable in cairo 1.17.4
+
+        version = Version(self.version)
+        if version < "1.17.6":
+            options["cogl"] = "disabled"  # https://gitlab.gnome.org/GNOME/cogl
+            options["directfb"] = "disabled"
+            options["drm"] = "disabled"  # not yet compilable in cairo 1.17.4
+            options["openvg"] = "disabled"  # https://www.khronos.org/openvg/
+            options["qt"] = "disabled"  # not yet compilable in cairo 1.17.4
+            if self.settings.os == "Linux":
+                options["xlib-xrender"] = is_enabled(self.options.with_xlib_xrender)
+
         options["gtk2-utils"] = "disabled"
         options["spectre"] = "disabled"  # https://www.freedesktop.org/wiki/Software/libspectre/
 


### PR DESCRIPTION
Specify library name and version:  **cairo/1.17.6**

* Add latest version of cairo.
* Flip `options.tee` to False as this is the default in the meson build. Otherwise the build fails and would require a patch.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
