### PR TITLE
work around path length when compiling qtwebengine on windows

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -358,6 +358,8 @@ class QtConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+        if self.settings.os == "Windows" and self.options.get_safe("qtwebengine", False):
+            self.folders.build = "build"
 
     def requirements(self):
         self.requires("zlib/1.2.13")


### PR DESCRIPTION
Specify library name and version:  **qt/6.4.x**

Fixes #15488

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
