### PR TITLE
etl: add version 20.35.11

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.35.11":
+    url: "https://github.com/ETLCPP/etl/archive/20.35.11.tar.gz"
+    sha256: "64a9eed9b9ac8a278349aac8e5888320fda0e090ba24373651767b7a8b8793fc"
   "20.35.8":
     url: "https://github.com/ETLCPP/etl/archive/20.35.8.tar.gz"
     sha256: "7d0a6402b24fc91cf66328b95391a38c52d20f582f42497fb9b0a99d71ab8879"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.35.11":
+    folder: all
   "20.35.8":
     folder: all
   "20.35.7":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **etl/20.35.11**




---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
