### PR TITLE
Revise modular boost policy and clarify options which do no impact `package_id`

### DIFF
--- a/docs/adding_packages/conanfile_attributes.md
+++ b/docs/adding_packages/conanfile_attributes.md
@@ -177,3 +177,17 @@ Usage of each option should follow the rules:
    ```
 
    The `skip_test` configuration is supported by [CMake](https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#test) and [Meson](https://docs.conan.io/en/latest/reference/build_helpers/meson.html#test).
+ 
+ ### Removing from `package_id`
+ 
+ By default, option are include in the calculation for the `package_id` ([docs](https://docs.conan.io/en/latest/reference/conanfile/methods.html#package-id)).
+ For options which do not impact the generated packages, for instance adding a `#define` for a package should be deleted.
+ 
+ ```python
+def package_id(self):
+   del self.info.options.enable_feature
+ 
+def package_info(self):
+   if self.options.enable_feature:
+      self.cpp_info.defines.append("FOBAR_FEATURE=1")
+```

--- a/docs/adding_packages/conanfile_attributes.md
+++ b/docs/adding_packages/conanfile_attributes.md
@@ -180,8 +180,8 @@ Usage of each option should follow the rules:
  
  ### Removing from `package_id`
  
- By default, option are include in the calculation for the `package_id` ([docs](https://docs.conan.io/en/latest/reference/conanfile/methods.html#package-id)).
- For options which do not impact the generated packages, for instance adding a `#define` for a package should be deleted.
+ By default, options are included in the calculation for the `package_id` ([docs](https://docs.conan.io/en/latest/reference/conanfile/methods.html#package-id)).
+ Options which do not impact the generated packages should be deleted, for instance adding a `#define` for a package.
  
  ```python
 def package_id(self):

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -420,12 +420,20 @@ Please, read [Inactivity and user removal section](adding_packages/README.md#ina
 
 ## Can we add package which are parts of bigger projects like Boost?
 
-Sadly no. There have been many efforts in the past and we feel it's not sustainable given the number of combinations of libraries and version. See #14660 for recent discussions.
+Sadly no. There have been many efforts in the past and we feel it's not sustainable given the number of combinations of libraries and version.
+See #14660 for recent discussions. There is one main "boost" recipe with many versions maintained. Adding boost libraries with no dependencies
+just opens the does to graph resolution problems and once available allows for depedant libraries to be added.
 
-There is one main "boost" recipe with many versions maintained.
-
-There are good arguments for permitting some boost libraries but we feel doing so is not fair to the rest.
+In order to avoid this the sole permuation which permissible is when the project does not package any headers under the `boost/` folder, does not use the boost namespace
+and does not install libraries with the boost prefix.
 
 ### Can I add my project which I will submit to Boost?
 
-Yes, but make sure it does not have Boost in the name. Use the [`author-name` convention](https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-is-the-policy-on-recipe-name-collisions) so there are no conflicts.
+Yes, but make sure it does not have Boost in the name. Use the [`author-name` convention](https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-is-the-policy-on-recipe-name-collisions) so there are no conflicts. In addition to follow the rules outlined above.
+
+## Can I add options that do not affect `package_id` or the package contents
+
+Generally no, these shorts of options can most likely be set from a profile or downstream recipes. However if the project supports this option from its build script
+and would otherwise dynamically embeed this into the CMake config files or generated pkg-config files then it should be allowed.
+
+Doing so requires [deleting the option from the `package_id`](adding_packages/conanfile_attributes.md#removing-from-package_id)

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -422,9 +422,9 @@ Please, read [Inactivity and user removal section](adding_packages/README.md#ina
 
 Sadly no. There have been many efforts in the past and we feel it's not sustainable given the number of combinations of libraries and version.
 See #14660 for recent discussions. There is one main "boost" recipe with many versions maintained. Adding boost libraries with no dependencies
-just opens the does to graph resolution problems and once available allows for depedant libraries to be added.
+just opens the door to graph resolution problems and once available allows for dependent libraries to be added.
 
-In order to avoid this the sole permuation which permissible is when the project does not package any headers under the `boost/` folder, does not use the boost namespace
+In order to avoid this the sole permutation which is permissible is when the project does not package any headers under the `boost/` folder, does not use the boost namespace
 and does not install libraries with the boost prefix.
 
 ### Can I add my project which I will submit to Boost?
@@ -433,7 +433,7 @@ Yes, but make sure it does not have Boost in the name. Use the [`author-name` co
 
 ## Can I add options that do not affect `package_id` or the package contents
 
-Generally no, these shorts of options can most likely be set from a profile or downstream recipes. However if the project supports this option from its build script
-and would otherwise dynamically embeed this into the CMake config files or generated pkg-config files then it should be allowed.
+Generally no, these sorts of options can most likely be set from a profile or downstream recipes. However if the project supports this option from its build script
+and would otherwise dynamically embed this into the CMake config files or generated pkg-config files then it should be allowed.
 
-Doing so requires [deleting the option from the `package_id`](adding_packages/conanfile_attributes.md#removing-from-package_id)
+Doing so requires [deleting the option from the `package_id`](adding_packages/conanfile_attributes.md#removing-from-package_id).


### PR DESCRIPTION
Docs!

- No modular boost (unless is completely not boost, take asio for example of "independent")
- Generally options must impact pgk_id unless supported by upstream

closes #14625

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
