### PR TITLE
flex: Avoid CMakeDeps messing with Conan targets

### DIFF
--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -82,6 +82,8 @@ class FlexConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["fl"]
         self.cpp_info.system_libs = ["m"]
+        # Avoid CMakeDeps messing with Conan targets
+        self.cpp_info.set_property("cmake_find_mode", "none")
 
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -34,6 +34,11 @@ class FlexConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
+    def requirements(self):
+        # Flex requires M4 to be compiled. If consumer does not have M4
+        # installed, Conan will need to know that Flex requires it.
+        self.requires("m4/1.4.19")
+
     def build_requirements(self):
         self.tool_requires("m4/1.4.19")
         if hasattr(self, "settings_build") and cross_building(self):

--- a/recipes/flex/all/test_package/conanfile.py
+++ b/recipes/flex/all/test_package/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.cmake import CMake, cmake_layout
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
+    generators = "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv", "CMakeDeps"
     test_type = "explicit"
 
     def requirements(self):


### PR DESCRIPTION
Specify library name and version:  **flex/2.6.4**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
