### PR TITLE
fontconfig: use self.dependencies instead of deps_cpp_info

### DIFF
--- a/recipes/fontconfig/meson/conanfile.py
+++ b/recipes/fontconfig/meson/conanfile.py
@@ -89,7 +89,7 @@ class FontconfigConan(ConanFile):
         apply_conandata_patches(self)
         replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
                         "freetype_req = '>= 21.0.15'",
-                        f"freetype_req = '{Version(self.deps_cpp_info['freetype'].version)}'")
+                        f"freetype_req = '{Version(self.dependencies['freetype'].ref.version)}'")
 
     def build(self):
         self._patch_files()


### PR DESCRIPTION
Specify library name and version:  **fontconfig/all** (meson-based recipe)

Use newer `self.dependencies` interface to retrieve the version of a dependency, rather than the legacy `deps_cpp_info` (Conan 2 compatibility)