### PR TITLE
poco: add transitive_headers trait on OpenSSL dependency

### DIFF
--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -130,7 +130,7 @@ class PocoConan(ConanFile):
             self.requires("apr-util/1.6.1")
         if self.options.enable_netssl or self.options.enable_crypto or \
            self.options.get_safe("enable_jwt"):
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/1.1.1s", transitive_headers=True)
         if self.options.enable_data_odbc and self.settings.os != "Windows":
             self.requires("odbc/2.3.11")
         if self.options.get_safe("enable_data_postgresql"):


### PR DESCRIPTION
Specify library name and version:  **poco/all**

Add the `transitive_headers=True` trait on the OpenSSL dependency to reflect that poco headers transitively include OpenSSL headers