### PR TITLE
Add STLink v1.7.0 library

### DIFF
--- a/recipes/stlink/all/conandata.yml
+++ b/recipes/stlink/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "1.7.0":
+    url: "https://github.com/stlink-org/stlink/archive/refs/tags/v1.7.0.tar.gz"
+    sha256: "57ec1214905aedf59bee7f70ddff02316f64fa9ba5a9b6a3a64952edc5b65855"
+patches:
+  "1.7.0":
+    - patch_file: "patches/fix-v1.7.0.patch"
+      patch_description: "Fix v1.7.0"
+      patch_type: "fix"

--- a/recipes/stlink/all/conanfile.py
+++ b/recipes/stlink/all/conanfile.py
@@ -1,0 +1,101 @@
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.build import cross_building
+from conan.tools.files import collect_libs, copy, rename, get, apply_conandata_patches, export_conandata_patches, replace_in_file, rmdir, rm
+from conan.tools.microsoft import check_min_vs, msvc_runtime_flag, is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
+
+from conan.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.apple import is_apple_os
+
+import os
+import textwrap
+
+required_conan_version = ">=1.53"
+
+
+class STLinkConan(ConanFile):
+    name = "stlink"
+    description = "Open source STM32 MCU programming toolset"
+    topics = ("stm32", "mcu", "usb")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/stlink-org/stlink"
+    license = "BSD-3-Clause"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    short_paths = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+        if self.settings.os in ["Linux", "Android"]:
+            self.options["libusb"].enable_udev = False
+
+    def requirements(self):
+        self.requires("libusb/1.0.26")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    @property
+    def _cmake_install_base_path(self):
+        return os.path.join("lib", "cmake", "stlink")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE.md", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "bin"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+        if self.options.shared:
+            for ext in [".lib", ".a"]:
+                rm(self, "*"+ext, os.path.join(self.package_folder, "lib"))
+        else:
+            for ext in [".dll", ".so*", ".dylib"]:
+                rm(self, "*"+ext, os.path.join(self.package_folder, "lib"))
+
+
+    def package_info(self):
+        #self.cpp_info.libs = ["stlink"]
+        self.cpp_info.libs = collect_libs(self)
+        self.cpp_info.includedirs = ["include/stlink"]

--- a/recipes/stlink/all/patches/fix-include.patch
+++ b/recipes/stlink/all/patches/fix-include.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 064aa06..3edb747 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,11 +19,11 @@ set(PROJECT_DESCRIPTION "Open source version of the STMicroelectronics ST-LINK T
+ include(GNUInstallDirs) # Define GNU standard installation directories
+ 
+ ## Determine project version
+-include(${CMAKE_MODULE_PATH}/get_version.cmake)
++include(${CMAKE_SOURCE_DIR}/cmake/modules/get_version.cmake)
+ 
+ ## Set C build flags
+ if (NOT MSVC)
+-    include(${CMAKE_MODULE_PATH}/c_flags.cmake)
++    include(${CMAKE_SOURCE_DIR}/cmake/modules/c_flags.cmake)
+ else ()
+     message(STATUS "MSVC C Flags override to /MT")
+     set(CMAKE_C_FLAGS_DEBUG_INIT          "/D_DEBUG /MTd /Zi /Ob0 /Od /RTC1")

--- a/recipes/stlink/all/patches/fix-v1.7.0.patch
+++ b/recipes/stlink/all/patches/fix-v1.7.0.patch
@@ -1,0 +1,82 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 064aa06..9e34108 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,11 +19,11 @@ set(PROJECT_DESCRIPTION "Open source version of the STMicroelectronics ST-LINK T
+ include(GNUInstallDirs) # Define GNU standard installation directories
+ 
+ ## Determine project version
+-include(${CMAKE_MODULE_PATH}/get_version.cmake)
++include(${CMAKE_SOURCE_DIR}/cmake/modules/get_version.cmake)
+ 
+ ## Set C build flags
+ if (NOT MSVC)
+-    include(${CMAKE_MODULE_PATH}/c_flags.cmake)
++    include(${CMAKE_SOURCE_DIR}/cmake/modules/c_flags.cmake)
+ else ()
+     message(STATUS "MSVC C Flags override to /MT")
+     set(CMAKE_C_FLAGS_DEBUG_INIT          "/D_DEBUG /MTd /Zi /Ob0 /Od /RTC1")
+@@ -80,9 +80,6 @@ endif ()
+ # Main build process
+ ###
+ 
+-## Define include directories to avoid absolute paths for header defines
+-include_directories(${LIBUSB_INCLUDE_DIR})
+-
+ include_directories(${PROJECT_SOURCE_DIR}/inc) # contains top-level header files
+ include_directories(${PROJECT_BINARY_DIR}/inc) # contains version.h
+ 
+@@ -187,11 +184,11 @@ if (APPLE)     # ... with Apple macOS libraries
+     find_library(ObjC objc)
+     find_library(CoreFoundation CoreFoundation)
+     find_library(IOKit IOKit)
+-    target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB} ${ObjC} ${CoreFoundation} ${IOKit})
++    target_link_libraries(${STLINK_LIB_SHARED} libusb::libusb ${SSP_LIB} ${ObjC} ${CoreFoundation} ${IOKit})
+ elseif (WIN32) # ... with Windows libraries
+-    target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB} wsock32 ws2_32)
++    target_link_libraries(${STLINK_LIB_SHARED} libusb::libusb ${SSP_LIB} wsock32 ws2_32)
+ else ()
+-    target_link_libraries(${STLINK_LIB_SHARED} ${LIBUSB_LIBRARY} ${SSP_LIB})
++    target_link_libraries(${STLINK_LIB_SHARED} libusb::libusb ${SSP_LIB})
+ endif ()
+ 
+ install(TARGETS ${STLINK_LIB_SHARED} DESTINATION ${STLINK_LIBRARY_PATH})
+@@ -226,11 +223,11 @@ if (APPLE)     # ... with Apple macOS libraries
+     find_library(ObjC objc)
+     find_library(CoreFoundation CoreFoundation)
+     find_library(IOKit IOKit)
+-    target_link_libraries(${STLINK_LIB_STATIC} ${LIBUSB_LIBRARY} ${SSP_LIB} ${ObjC} ${CoreFoundation} ${IOKit})
++    target_link_libraries(${STLINK_LIB_STATIC} libusb::libusb ${SSP_LIB} ${ObjC} ${CoreFoundation} ${IOKit})
+ elseif (WIN32) # ... with Windows libraries
+-    target_link_libraries(${STLINK_LIB_STATIC} ${LIBUSB_LIBRARY} ${SSP_LIB} wsock32 ws2_32)
++    target_link_libraries(${STLINK_LIB_STATIC} libusb::libusb ${SSP_LIB} wsock32 ws2_32)
+ else ()
+-    target_link_libraries(${STLINK_LIB_STATIC} ${LIBUSB_LIBRARY} ${SSP_LIB})
++    target_link_libraries(${STLINK_LIB_STATIC} libusb::libusb ${SSP_LIB})
+ endif ()
+ 
+ install(TARGETS ${STLINK_LIB_STATIC} ARCHIVE DESTINATION ${STLINK_LIBRARY_PATH})
+@@ -274,23 +271,6 @@ install(TARGETS st-info DESTINATION ${CMAKE_INSTALL_BINDIR})
+ install(TARGETS st-util DESTINATION ${CMAKE_INSTALL_BINDIR})
+ install(TARGETS st-trace DESTINATION ${CMAKE_INSTALL_BINDIR})
+ 
+-
+-###
+-# Device configuration (Linux only)
+-###
+-
+-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-    ## Install modprobe.d conf files to /etc/modprobe.d/ (explicitly hardcoded)
+-    set(STLINK_MODPROBED_DIR "/etc/modprobe.d" CACHE PATH "modprobe.d directory")
+-    install(FILES ${CMAKE_SOURCE_DIR}/config/modprobe.d/stlink_v1.conf DESTINATION ${STLINK_MODPROBED_DIR})
+-
+-    ## Install udev rules files to /lib/udev/rules.d/ (explicitly hardcoded)
+-    set(STLINK_UDEV_RULES_DIR "/lib/udev/rules.d" CACHE PATH "udev rules directory")
+-    file(GLOB RULES_FILES ${CMAKE_SOURCE_DIR}/config/udev/rules.d/*.rules)
+-    install(FILES ${RULES_FILES} DESTINATION ${STLINK_UDEV_RULES_DIR})
+-endif ()
+-
+-
+ ###
+ # Additional build tasks
+ ###

--- a/recipes/stlink/all/test_package/CMakeLists.txt
+++ b/recipes/stlink/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(stlink REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE stlink::stlink)

--- a/recipes/stlink/all/test_package/conanfile.py
+++ b/recipes/stlink/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/stlink/all/test_package/test_package.c
+++ b/recipes/stlink/all/test_package/test_package.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <stlink.h>
+
+int main(void) {
+  stlink_t* sl;
+  sl = stlink_open_usb(UERROR, CONNECT_NORMAL, NULL, 0);
+
+  if (sl != NULL) {
+    printf("-- version\n");
+    stlink_version(sl);
+
+    stlink_close(sl);
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/recipes/stlink/all/test_v1_package/CMakeLists.txt
+++ b/recipes/stlink/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(stlink REQUIRED)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE stlink::stlink)

--- a/recipes/stlink/all/test_v1_package/conanfile.py
+++ b/recipes/stlink/all/test_v1_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/stlink/config.yml
+++ b/recipes/stlink/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.7.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **STLink/1.7.0**

The STLink library is an open source STM32 MCU programming toolset and can be found at the follwing address: [stlink](https://github.com/stlink-org/stlink)

We are using it to trigger hardware reset for STM32 micro-controllers and programmatically operate the STM32 debugger.
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
