### PR TITLE
imgui: add version cci.20230105+1.89.2.docking

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -21,6 +21,9 @@ sources:
   # These versions belong to the docking branch in ImGUI repository. This branch is declared stable and production ready, and
   # it is synced with `master` regularly. These versions are taken from that branch using the commit where `master` was synced
   # after a regular release
+  "cci.20230105+1.89.2.docking":
+    url: "https://github.com/ocornut/imgui/archive/d822c65317ba881798bed8fce9ffba267d27dada.zip"
+    sha256: "0d2c09ae4c450d4c74f62e66667809752c9d11438354fc331ed9da5d5e850071"
   "cci.20220621+1.88.docking":
     url: "https://github.com/ocornut/imgui/archive/9cd9c2eff99877a3f10a7f9c2a3a5b9c15ea36c6.tar.gz"
     sha256: "61fb1ce5d48089bce1b4f92e9320fd234b2ce960f35f965b313c4842b3c8e440"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -15,6 +15,8 @@ versions:
   # These versions belong to the docking branch in ImGUI repository. This branch is declared stable and production ready, and
   # it is synced with `master` regularly. These versions are taken from that branch using the commit where `master` was synced
   # after a regular release
+  "cci.20230105+1.89.2.docking":
+    folder: all
   "cci.20220621+1.88.docking":
     folder: all
   "cci.20220207+1.87.docking":


### PR DESCRIPTION
Specify library name and version:  imgui/cci.20230105+1.89.2.docking

There has been a new release.

---

- [ x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
