### PR TITLE
sentry-breakpad: conan v2 support & fix PkgConfigDeps

### DIFF
--- a/recipes/sentry-breakpad/all/CMakeLists.txt
+++ b/recipes/sentry-breakpad/all/CMakeLists.txt
@@ -1,14 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(cmake_wrapper)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    set(LINUX ON)
-endif()
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_C_STANDARD 11)
-
-add_subdirectory(source_subfolder/external)
+add_subdirectory(src/external)

--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -1,9 +1,13 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
-import functools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, replace_in_file, save
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.45.0"
+required_conan_version = ">=1.51.3"
 
 
 class SentryBreakpadConan(ConanFile):
@@ -12,7 +16,7 @@ class SentryBreakpadConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/getsentry/breakpad"
     license = "Apache-2.0"
-    topics = ("conan", "breakpad", "error-reporting", "crash-reporting")
+    topics = ("breakpad", "error-reporting", "crash-reporting")
     provides = "breakpad"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -21,45 +25,42 @@ class SentryBreakpadConan(ConanFile):
     default_options = {
         "fPIC": True,
     }
-    exports_sources = "CMakeLists.txt", "patches/*"
-    generators = "cmake"
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def export_sources(self):
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.settings.os in ("FreeBSD", "Linux"):
             self.requires("linux-syscall-support/cci.20200813")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 11)
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
 
-        if tools.Version(self.version) <= "0.4.1":
-            if self.settings.os == "Android" or tools.is_apple_os(self.settings.os):
+        if Version(self.version) <= "0.4.1":
+            if self.settings.os == "Android" or is_apple_os(self):
                 raise ConanInvalidConfiguration("Versions <=0.4.1 do not support Apple or Android")
-        if tools.Version(self.version) <= "0.2.6":
+        if Version(self.version) <= "0.2.6":
             if self.settings.os == "Windows":
                 raise ConanInvalidConfiguration("Versions <=0.2.6 do not support Windows")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version])
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.configure()
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            tc.variables["LINUX"] = True
+        tc.generate()
 
     def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
         # FIXME: convert to patches
         import textwrap
 
@@ -86,14 +87,19 @@ class SentryBreakpadConan(ConanFile):
         ]
 
         for file in files_to_patch:
-            tools.replace_in_file(
-                os.path.join(self._source_subfolder, "external", "breakpad", file),
+            replace_in_file(self,
+                os.path.join(self.source_folder, "external", "breakpad", file),
                 "#include \"third_party/lss/linux_syscall_support.h\"",
                 "#include <linux_syscall_support.h>"
             )
 
-        tools.save(os.path.join(self._source_subfolder, "external", "CMakeLists.txt"),
+        save(self, os.path.join(self.source_folder, "external", "CMakeLists.txt"),
                    textwrap.dedent("""\
+                    target_compile_features(breakpad_client PUBLIC cxx_std_11)
+                    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+                        find_path(LINUX_SYSCALL_INCLUDE_DIR NAMES linux_syscall_support.h)
+                        target_include_directories(breakpad_client PRIVATE ${LINUX_SYSCALL_INCLUDE_DIR})
+                    endif()
                     install(TARGETS breakpad_client
                         ARCHIVE DESTINATION lib
                         LIBRARY DESTINATION lib
@@ -132,19 +138,21 @@ class SentryBreakpadConan(ConanFile):
 
     def build(self):
         self._patch_sources()
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=os.path.join(self._source_subfolder, "external", "breakpad"))
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE", src=os.path.join(self.source_folder, "external", "breakpad"),
+                              dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.names["pkg_config"] = "breakpad-client"
+        self.cpp_info.set_property("pkg_config_name", "breakpad-client")
         self.cpp_info.libs = ["breakpad_client"]
         self.cpp_info.includedirs.append(os.path.join("include", "breakpad"))
-        if tools.is_apple_os(self.settings.os):
+        if is_apple_os(self):
             self.cpp_info.frameworks.append("CoreFoundation")
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("pthread")

--- a/recipes/sentry-breakpad/all/test_package/CMakeLists.txt
+++ b/recipes/sentry-breakpad/all/test_package/CMakeLists.txt
@@ -1,12 +1,9 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(BREAKPAD REQUIRED IMPORTED_TARGET breakpad-client)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::BREAKPAD)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/sentry-breakpad/all/test_package/conanfile.py
+++ b/recipes/sentry-breakpad/all/test_package/conanfile.py
@@ -1,13 +1,23 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "pkg_config"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "PkgConfigDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.build_requires("pkgconf/1.7.3")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/1.9.3")
 
     def build(self):
         cmake = CMake(self)
@@ -15,6 +25,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sentry-breakpad/all/test_v1_package/CMakeLists.txt
+++ b/recipes/sentry-breakpad/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/sentry-breakpad/all/test_v1_package/conanfile.py
+++ b/recipes/sentry-breakpad/all/test_v1_package/conanfile.py
@@ -1,0 +1,20 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "pkg_config"
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.9.3")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Fix of `pkg_config_name` is required for https://github.com/conan-io/conan-center-index/pull/15512

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
