### PR TITLE
protobuf: restore 3.17.1 + improve robustness of test_v1_package conanfile.py

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -17,6 +17,9 @@ sources:
   "3.18.1":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.18.1.tar.gz"
     sha256: "9111bf0b542b631165fadbd80aa60e7fb25b25311c532139ed2089d76ddf6dd7"
+  "3.17.1":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.17.1.tar.gz"
+    sha256: "036d66d6eec216160dd898cfb162e9d82c1904627642667cc32b104d407bb411"
 patches:
   "3.19.6":
     - patch_file: "patches/upstream-pr-9437-msvc-runtime.patch"

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "3.21.9":
-    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.9.tar.gz"
-    sha256: "0aa7df8289c957a4c54cbe694fbabe99b180e64ca0f8fdb5e2f76dcf56ff2422"
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.21.9.tar.gz"
+    sha256: "1add10f9bd92775b91f326da259f243881e904dd509367d5031d4c782ba82810"
   "3.21.4":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.21.4.tar.gz"
     sha256: "85d42d4485f36f8cec3e475a3b9e841d7d78523cd775de3a86dba77081f4ca25"

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -24,8 +24,10 @@ patches:
   "3.19.6":
     - patch_file: "patches/upstream-pr-9437-msvc-runtime.patch"
       patch_description: "Properly handle CMAKE_MSVC_RUNTIME_LIBRARY when using CMake >= 3.15"
-      patch_type: "backport"
+      patch_type: "portability"
+      patch_source: "https://github.com/protocolbuffers/protobuf/pull/9437"
   "3.19.4":
     - patch_file: "patches/upstream-pr-9437-msvc-runtime.patch"
       patch_description: "Properly handle CMAKE_MSVC_RUNTIME_LIBRARY when using CMake >= 3.15"
-      patch_type: "backport"
+      patch_type: "portability"
+      patch_source: "https://github.com/protocolbuffers/protobuf/pull/9437"

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -80,7 +80,7 @@ class ProtobufConan(ConanFile):
 
         if self.settings.compiler == "clang":
             if Version(self.version) >= "3.15.4" and Version(self.settings.compiler.version) < "4":
-                raise ConanInvalidConfiguration("protobuf {} doesn't support clang < 4".format(self.version))
+                raise ConanInvalidConfiguration(f"{self.ref} doesn't support clang < 4")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -250,10 +250,6 @@ class ProtobufConan(ConanFile):
             if self.settings.os == "Android":
                 self.cpp_info.components["libprotobuf-lite"].system_libs.append("log")
 
-        bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bindir))
-        self.env_info.PATH.append(bindir)
-
         # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
         self.cpp_info.filenames["cmake_find_package"] = "Protobuf"
         self.cpp_info.filenames["cmake_find_package_multi"] = "protobuf"
@@ -263,3 +259,4 @@ class ProtobufConan(ConanFile):
         if self.options.lite:
             for generator in ["cmake_find_package", "cmake_find_package_multi"]:
                 self.cpp_info.components["libprotobuf-lite"].build_modules[generator] = build_modules
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -192,8 +192,8 @@ class ProtobufConan(ConanFile):
                      os.path.join(self.package_folder, self._cmake_install_base_path, "protobuf-generate.cmake"))
 
         if not self.options.lite:
-            rm(self, "libprotobuf-lite.*", os.path.join(self.package_folder, "lib"))
-            rm(self, "libprotobuf-lite.*", os.path.join(self.package_folder, "bin"))
+            rm(self, "libprotobuf-lite*", os.path.join(self.package_folder, "lib"))
+            rm(self, "libprotobuf-lite*", os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -219,7 +219,7 @@ class ProtobufConan(ConanFile):
         if self.options.with_zlib:
             self.cpp_info.components["libprotobuf"].requires = ["zlib::zlib"]
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["libprotobuf"].system_libs.append("pthread")
+            self.cpp_info.components["libprotobuf"].system_libs.extend(["m", "pthread"])
             if self._is_clang_x86 or "arm" in str(self.settings.arch):
                 self.cpp_info.components["libprotobuf"].system_libs.append("atomic")
         if self.settings.os == "Android":
@@ -241,7 +241,7 @@ class ProtobufConan(ConanFile):
             self.cpp_info.components["libprotobuf-lite"].builddirs.append(self._cmake_install_base_path)
             self.cpp_info.components["libprotobuf-lite"].libs = [lib_prefix + "protobuf-lite" + lib_suffix]
             if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.components["libprotobuf-lite"].system_libs.append("pthread")
+                self.cpp_info.components["libprotobuf-lite"].system_libs.extend(["m", "pthread"])
                 if self._is_clang_x86 or "arm" in str(self.settings.arch):
                     self.cpp_info.components["libprotobuf-lite"].system_libs.append("atomic")
             if self.settings.os == "Windows":

--- a/recipes/protobuf/all/test_v1_package/conanfile.py
+++ b/recipes/protobuf/all/test_v1_package/conanfile.py
@@ -1,24 +1,27 @@
-from conan import ConanFile
-from conan.tools.build import cross_building
-from conans import CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        if hasattr(self, "settings_build") and cross_building(self):
-            self.build_requires(str(self.requires["protobuf"]))
+        if hasattr(self, "settings_build"):
+            self.build_requires(self.tested_reference_str)
 
     def build(self):
-        cmake = CMake(self)
-        cmake.definitions["protobuf_LITE"] = self.options["protobuf"].lite
-        cmake.configure()
-        cmake.build()
+        with tools.no_op() if hasattr(self, "settings_build") else tools.run_environment(self):
+            cmake = CMake(self)
+            cmake.definitions["protobuf_LITE"] = self.options["protobuf"].lite
+            cmake.configure()
+            cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if not tools.cross_building(self):
             self.run("protoc --version", run_environment=True)
             self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "3.18.1":
     folder: all
+  "3.17.1":
+    folder: all


### PR DESCRIPTION
- restore 3.17.1: Address review in https://github.com/conan-io/conan-center-index/pull/14851#issuecomment-1380869366. Maintenance of this version has been removed during conan v2 migration, but it's still widely used in other CCI recipes (like OpenCV), which can't depend on newer versions than this one, therefore it's not a good thing to not have migrated this version to conan v2 helpers nor to drop its maintenance.

- test_v1_pacage: Inspired from test_v1_package conanfile of capnproto. I've experimented a lot both 1 & 2 profiles while migrating capnproto.
  The idea is to avoid a patch in https://github.com/conan-io/conan-center-index/pull/15202 due to this error in test v1 package: https://github.com/conan-io/conan-center-index/pull/15202#issuecomment-1384025392, which comes from a lack of robustness in test v1 package.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
