### PR TITLE
cpr: add version 1.10.0, update libcurl

### DIFF
--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -24,9 +24,16 @@ sources:
     url: "https://github.com/libcpr/cpr/archive/1.4.0.tar.gz"
     sha256: "13baffba95445e02291684e31906b04df41d8c6a3020a1a55253047c6756a004"
 patches:
+  "1.10.0":
+    - patch_file: "patches/008-1.10.0-remove-warning-flags.patch"
+      patch_description: "disable warning flags"
+      patch_type: "conan"
   "1.9.3":
     - patch_file: "patches/005-1.9.3-fix-curl-components.patch"
       patch_description: "use cci package"
+      patch_type: "conan"
+    - patch_file: "patches/008-1.9.3-remove-warning-flags.patch"
+      patch_description: "disable warning flags"
       patch_type: "conan"
   "1.9.0":
     - patch_file: "patches/005-1.9.0-fix-curl-components.patch"
@@ -51,6 +58,9 @@ patches:
       patch_type: "conan"
     - patch_file: "patches/007-fix-dll-install.patch"
       patch_description: "fix install path for dll"
+      patch_type: "conan"
+    - patch_file: "patches/008-1.7.2-remove-warning-flags.patch"
+      patch_description: "disable warning flags"
       patch_type: "conan"
   "1.6.2":
     - patch_file: "patches/005-1.6.2-fix-curl-components.patch"

--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -39,6 +39,9 @@ patches:
     - patch_file: "patches/007-fix-dll-install.patch"
       patch_description: "fix install path for dll"
       patch_type: "conan"
+    - patch_file: "patches/008-1.8.1-remove-warning-flags.patch"
+      patch_description: "disable warning flags"
+      patch_type: "conan"
   "1.7.2":
     - patch_file: "patches/005-1.7.2-fix-curl-components.patch"
       patch_description: "use cci package"

--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -32,6 +32,9 @@ patches:
     - patch_file: "patches/005-1.9.0-fix-curl-components.patch"
       patch_description: "use cci package"
       patch_type: "conan"
+    - patch_file: "patches/008-1.8.1-remove-warning-flags.patch"
+      patch_description: "disable warning flags"
+      patch_type: "conan"
   "1.8.1":
     - patch_file: "patches/005-1.8.1-fix-curl-components.patch"
       patch_description: "use cci package"

--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.10.0":
+    url: "https://github.com/libcpr/cpr/archive/refs/tags/1.10.0.tar.gz"
+    sha256: "d669c028bd63a1c8827c32b348ecc85e46747bb33be3b00ce59b77717b91aee8"
   "1.9.3":
     url: "https://github.com/libcpr/cpr/archive/refs/tags/1.9.3.tar.gz"
     sha256: "df53e7213d80fdc24583528521f7d3349099f5bb4ed05ab05206091a678cc53c"

--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -47,7 +47,7 @@ class CprConan(ConanFile):
         if self._min_cppstd == 11:
             return {}
         return {
-            "gcc": "7",
+            "gcc": "9",
             "clang": "7",
             "apple-clang": "10",
             "Visual Studio": "15",

--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -82,7 +82,7 @@ class CprConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
-    def config_options(self):   
+    def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 

--- a/recipes/cpr/all/patches/008-1.10.0-remove-warning-flags.patch
+++ b/recipes/cpr/all/patches/008-1.10.0-remove-warning-flags.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d0e8854..807377f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -103,11 +103,6 @@ if(CPR_ENABLE_CPPCHECK)
+     include(cmake/cppcheck.cmake)
+ endif()
+ 
+-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+-else()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
+-endif()
+-
+ # SSL
+ if(CPR_ENABLE_SSL)
+     if(CPR_FORCE_OPENSSL_BACKEND OR CPR_FORCE_WINSSL_BACKEND OR CPR_FORCE_DARWINSSL_BACKEND OR CPR_FORCE_MBEDTLS_BACKEND)

--- a/recipes/cpr/all/patches/008-1.7.2-remove-warning-flags.patch
+++ b/recipes/cpr/all/patches/008-1.7.2-remove-warning-flags.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fef2d28..6dcbf0d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -67,11 +67,6 @@ if(CPR_ENABLE_CPPCHECK)
+     include(cmake/cppcheck.cmake)
+ endif()
+ 
+-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+-else()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
+-endif()
+-
+ # SSL
+ if(CPR_ENABLE_SSL)
+     if(CPR_FORCE_OPENSSL_BACKEND OR CPR_FORCE_WINSSL_BACKEND OR CPR_FORCE_DARWINSSL_BACKEND)

--- a/recipes/cpr/all/patches/008-1.8.1-remove-warning-flags.patch
+++ b/recipes/cpr/all/patches/008-1.8.1-remove-warning-flags.patch
@@ -1,0 +1,16 @@
+diff --git a/a/CMakeLists.txt b/b/CMakeLists.txt
+index 9317f97..c17a97f 100644
+--- a/a/CMakeLists.txt
++++ b/b/CMakeLists.txt
+@@ -71,11 +71,6 @@ if(CPR_ENABLE_CPPCHECK)
+     include(cmake/cppcheck.cmake)
+ endif()
+ 
+-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+-else()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
+-endif()
+-
+ # SSL
+ if(CPR_ENABLE_SSL)
+     if(CPR_FORCE_OPENSSL_BACKEND OR CPR_FORCE_WINSSL_BACKEND OR CPR_FORCE_DARWINSSL_BACKEND OR CPR_FORCE_MBEDTLS_BACKEND)

--- a/recipes/cpr/all/patches/008-1.9.3-remove-warning-flags.patch
+++ b/recipes/cpr/all/patches/008-1.9.3-remove-warning-flags.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9627982..481b9a0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -76,11 +76,6 @@ if(CPR_ENABLE_CPPCHECK)
+     include(cmake/cppcheck.cmake)
+ endif()
+ 
+-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+-else()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
+-endif()
+-
+ # SSL
+ if(CPR_ENABLE_SSL)
+     if(CPR_FORCE_OPENSSL_BACKEND OR CPR_FORCE_WINSSL_BACKEND OR CPR_FORCE_DARWINSSL_BACKEND OR CPR_FORCE_MBEDTLS_BACKEND)

--- a/recipes/cpr/config.yml
+++ b/recipes/cpr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.10.0":
+    folder: all
   "1.9.3":
     folder: all
   "1.9.0":


### PR DESCRIPTION
Specify library name and version:  **cpr/***

- add version 1.10.0
    - rename CPR_FORCE_USE_SYSTEM_CURL to CPR_USE_SYSTEM_CURL
    - add CURL_VERBOSE_LOGGING
- update libcurl

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
