### PR TITLE
[aaf/1.2.0] Handle Apple Silicon

### DIFF
--- a/recipes/aaf/all/conanfile.py
+++ b/recipes/aaf/all/conanfile.py
@@ -47,7 +47,7 @@ class AafConan(ConanFile):
         arch = "x86_64"
         if tools.is_apple_os(self.settings.os):
             cmake.definitions["PLATFORM"] = "apple-clang"
-            if self.setting.arch == "armv8":
+            if self.settings.arch == "armv8":
                 arch = "arm64"
         elif self.settings.compiler == "Visual Studio":
             cmake.definitions["PLATFORM"] = "vc"


### PR DESCRIPTION
Specify library name and version:  **aaf/1.2.0**

The apple silicon architecture was fixed in the 1.2.0 RC1. This recipe already link to the code, but I fixed it so that it doesn't fail.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
