### PR TITLE
libmp3lame: modernize more

### DIFF
--- a/recipes/libmp3lame/all/test_package/conanfile.py
+++ b/recipes/libmp3lame/all/test_package/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"


### PR DESCRIPTION
- use `NMakeToolchain` (conan 1.55.0)
- for clang-cl, get compilers paths from `tools.build:compiler_executables` then `VirtualBuildEnv` then fallback to default values.
- remove autotools install workaround for MinGW (fixed in conan 1.54.0)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
