### PR TITLE
modern-cpp-kafka: add version 2023.01.05

### DIFF
--- a/recipes/modern-cpp-kafka/all/conandata.yml
+++ b/recipes/modern-cpp-kafka/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2023.01.05":
+    url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2023.01.05.tar.gz"
+    sha256: "3ac5256b7b16bab020b32ac048cf53fddc3353682068bb727eb7c95550598b9b"
   "2022.12.07":
     url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2022.12.07.tar.gz"
     sha256: "980533fe5e0f5630d7deab6567ed051cf51d61ac341e4a75810f68d58cbff439"

--- a/recipes/modern-cpp-kafka/config.yml
+++ b/recipes/modern-cpp-kafka/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2023.01.05":
+    folder: all
   "2022.12.07":
     folder: all
   "2022.10.12":


### PR DESCRIPTION
Specify library name and version:  **modern-cpp-kafka/2023.01.05**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
