### PR TITLE
minizip: fix building for Android API level < 24

### DIFF
--- a/recipes/minizip/all/conanfile.py
+++ b/recipes/minizip/all/conanfile.py
@@ -68,6 +68,11 @@ class MinizipConan(ConanFile):
         tc.variables["MINIZIP_SRC_DIR"] = os.path.join(self.source_folder, "contrib", "minizip").replace("\\", "/")
         tc.variables["MINIZIP_ENABLE_BZIP2"] = self.options.bzip2
         tc.variables["MINIZIP_BUILD_TOOLS"] = self.options.tools
+
+        # fopen64 and similar are unavailable before API level 24: https://github.com/madler/zlib/pull/436
+        if self.settings.os == "Android" and int(str(self.settings.os.api_level)) < 24:
+            tc.preprocessor_definitions["IOAPI_NO_64"] = "1"
+
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
Specify library name and version:  **minizip/1.2.13**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

function names ending with 64 are unavailable before Android 24. Pending upstream PR: https://github.com/madler/zlib/pull/436

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
