### PR TITLE
libpng: download official tarballs + remove manual injection of CMAKE_SYSTEM_PROCESSOR when cross-building

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,16 +1,16 @@
 sources:
   "1.6.39":
-    url: "https://github.com/glennrp/libpng/archive/v1.6.39.tar.gz"
-    sha256: "a00e9d2f2f664186e4202db9299397f851aea71b36a35e74910b8820e380d441"
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.39/libpng-1.6.39.tar.xz"
+    sha256: "1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937"
   "1.6.38":
-    url: "https://github.com/glennrp/libpng/archive/v1.6.38.tar.gz"
-    sha256: "d4160037fa5d09fa7cff555037f2a7f2fefc99ca01e21723b19bfcda33015234"
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.38/libpng-1.6.38.tar.xz"
+    sha256: "b3683e8b8111ebf6f1ac004ebb6b0c975cd310ec469d98364388e9cedbfa68be"
   "1.6.37":
-    url: "https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz"
-    sha256: "ca74a0dace179a8422187671aee97dd3892b53e168627145271cad5b5ac81307"
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.37/libpng-1.6.37.tar.xz"
+    sha256: "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca"
   "1.5.30":
-    url: "https://github.com/glennrp/libpng/archive/v1.5.30.tar.gz"
-    sha256: "738e2eb31abc1140f2d6c914f0f69748b49f2ae7ffc05e7a073abafc08f37441"
+    url: "https://sourceforge.net/projects/libpng/files/libpng15/1.5.30/libpng-1.5.30.tar.xz"
+    sha256: "7d76275fad2ede4b7d87c5fd46e6f488d2a16b5a69dc968ffa840ab39ba756ed"
 patches:
   "1.6.37":
     - patch_file: "patches/0001-1.6.37-cmakefile-zlib.patch"

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
-from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.microsoft import is_msvc
@@ -97,16 +96,6 @@ class LibpngConan(ConanFile):
             "check": "check",
         }
 
-    @property
-    def _libpng_cmake_system_processor(self):
-        # FIXME: too specific and error prone, should be delegated to a conan helper function
-        # It should satisfy libpng CMakeLists specifically, do not use it naively in an other recipe
-        if "mips" in self.settings.arch:
-            return "mipsel"
-        if "ppc" in self.settings.arch:
-            return "powerpc"
-        return str(self.settings.arch)
-
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["PNG_TESTS"] = False
@@ -114,10 +103,6 @@ class LibpngConan(ConanFile):
         tc.variables["PNG_STATIC"] = not self.options.shared
         tc.variables["PNG_DEBUG"] = self.settings.build_type == "Debug"
         tc.variables["PNG_PREFIX"] = self.options.api_prefix
-        if cross_building(self):
-            system_processor = self.conf.get("tools.cmake.cmaketoolchain:system_processor",
-                                                  self._libpng_cmake_system_processor, check_type=str)
-            tc.cache_variables["CMAKE_SYSTEM_PROCESSOR"] = system_processor
         if self._has_neon_support:
             tc.variables["PNG_ARM_NEON"] = self._neon_msa_sse_vsx_mapping[str(self.options.neon)]
         if self._has_msa_support:

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -81,12 +81,11 @@ class LibpngConan(ConanFile):
         self.requires("zlib/1.2.13")
 
     def validate(self):
-        if Version(self.version) < "1.6" and self.info.settings.arch == "armv8" and is_apple_os(self):
-            raise ConanInvalidConfiguration(f"{self.ref} currently does not building for {self.info.settings.os} {self.info.settings.arch}. Contributions are welcomed")
+        if Version(self.version) < "1.6" and self.settings.arch == "armv8" and is_apple_os(self):
+            raise ConanInvalidConfiguration(f"{self.ref} currently does not building for {self.settings.os} {self.settings.arch}. Contributions are welcomed")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-                  destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     @property
     def _neon_msa_sse_vsx_mapping(self):


### PR DESCRIPTION
It's not necessary with CMakeToolchain, since a default `CMAKE_SYSTEM_PROCESSOR` value is always injected by CMakeToolchain in case of cross-build (either deduced from host profile or from `tools.cmake.cmaketoolchain:system_processor` conf).
Moreover `CMAKE_SYSTEM_PROCESSOR` coming from user toolchains (or Android NDK toolchain, first class citizen in CMakeToolchain) must not be overridden.

closes https://github.com/conan-io/conan-center-index/issues/8003

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
