### PR TITLE
qt5: fix some Android and iOS errors

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -45,6 +45,8 @@ patches:
       base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/337f28c9ab-5.15.8.patch"
       base_path: "qt5/qtbase"
+    - patch_file: "patches/android-backtrace.diff"
+      base_path: "qt5/qtbase"
   "5.15.7":
     - patch_file: "patches/337f28c9ab.patch"
       base_path: "qt5/qtbase"
@@ -70,6 +72,8 @@ patches:
       base_path: "qt5/qtwebengine/src/3rdparty/chromium/third_party/skia"
     - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
+    - patch_file: "patches/android-backtrace.diff"
+      base_path: "qt5/qtbase"
   "5.15.6":
     - patch_file: "patches/337f28c9ab.patch"
       base_path: "qt5/qtbase"
@@ -95,6 +99,8 @@ patches:
       base_path: "qt5/qtwebengine/src/3rdparty/chromium/third_party/skia"
     - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
+    - patch_file: "patches/android-backtrace.diff"
+      base_path: "qt5/qtbase"
   "5.15.5":
     - patch_file: "patches/337f28c9ab-5.15.5.patch"
       base_path: "qt5/qtbase"
@@ -120,3 +126,5 @@ patches:
       base_path: "qt5/qtwebengine/src/3rdparty/chromium/third_party/skia"
     - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
+    - patch_file: "patches/android-backtrace.diff"
+      base_path: "qt5/qtbase"

--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -47,6 +47,8 @@ patches:
       base_path: "qt5/qtbase"
     - patch_file: "patches/android-backtrace.diff"
       base_path: "qt5/qtbase"
+    - patch_file: "patches/android-openssl.diff"
+      base_path: "qt5/qtbase"
   "5.15.7":
     - patch_file: "patches/337f28c9ab.patch"
       base_path: "qt5/qtbase"
@@ -73,6 +75,8 @@ patches:
     - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/android-backtrace.diff"
+      base_path: "qt5/qtbase"
+    - patch_file: "patches/android-openssl.diff"
       base_path: "qt5/qtbase"
   "5.15.6":
     - patch_file: "patches/337f28c9ab.patch"
@@ -101,6 +105,8 @@ patches:
       base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/android-backtrace.diff"
       base_path: "qt5/qtbase"
+    - patch_file: "patches/android-openssl.diff"
+      base_path: "qt5/qtbase"
   "5.15.5":
     - patch_file: "patches/337f28c9ab-5.15.5.patch"
       base_path: "qt5/qtbase"
@@ -127,4 +133,6 @@ patches:
     - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
       base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/android-backtrace.diff"
+      base_path: "qt5/qtbase"
+    - patch_file: "patches/android-openssl.diff"
       base_path: "qt5/qtbase"

--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -49,6 +49,8 @@ patches:
       base_path: "qt5/qtbase"
     - patch_file: "patches/android-openssl.diff"
       base_path: "qt5/qtbase"
+    - patch_file: "patches/android-new-ndk.diff"
+      base_path: "qt5/qtbase"
   "5.15.7":
     - patch_file: "patches/337f28c9ab.patch"
       base_path: "qt5/qtbase"
@@ -77,6 +79,8 @@ patches:
     - patch_file: "patches/android-backtrace.diff"
       base_path: "qt5/qtbase"
     - patch_file: "patches/android-openssl.diff"
+      base_path: "qt5/qtbase"
+    - patch_file: "patches/android-new-ndk.diff"
       base_path: "qt5/qtbase"
   "5.15.6":
     - patch_file: "patches/337f28c9ab.patch"
@@ -107,6 +111,8 @@ patches:
       base_path: "qt5/qtbase"
     - patch_file: "patches/android-openssl.diff"
       base_path: "qt5/qtbase"
+    - patch_file: "patches/android-new-ndk.diff"
+      base_path: "qt5/qtbase"
   "5.15.5":
     - patch_file: "patches/337f28c9ab-5.15.5.patch"
       base_path: "qt5/qtbase"
@@ -135,4 +141,6 @@ patches:
     - patch_file: "patches/android-backtrace.diff"
       base_path: "qt5/qtbase"
     - patch_file: "patches/android-openssl.diff"
+      base_path: "qt5/qtbase"
+    - patch_file: "patches/android-new-ndk.diff"
       base_path: "qt5/qtbase"

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -312,7 +312,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("qtwayland", False) and not self.dependencies.direct_host["xkbcommon"].options.with_wayland:
             raise ConanInvalidConfiguration("The 'with_wayland' option for the 'xkbcommon' package must be enabled when the 'qtwayland' option is enabled")
 
-        if cross_building(self) and self.options.cross_compile == "None" and not is_apple_os(self):
+        if cross_building(self) and self.options.cross_compile == "None" and not is_apple_os(self) and self.settings.os != "Android":
             raise ConanInvalidConfiguration("option cross_compile must be set for cross compilation "
                                             "cf https://doc.qt.io/qt-5/configure-options.html#cross-compilation-options")
 

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1429,8 +1429,9 @@ Examples = bin/datadir/examples""")
                     self.cpp_info.components["qtNetwork"].frameworks.append("GSS")
                 if not self.options.openssl: # with SecureTransport
                     self.cpp_info.components["qtNetwork"].frameworks.append("Security")
-            if self.settings.os == "Macos":
+            if self.settings.os == "Macos" or (self.settings.os == "iOS" and Version(self.settings.compiler.version) >= "14.0"):
                 self.cpp_info.components["qtCore"].frameworks.append("IOKit")     # qtcore requires "_IORegistryEntryCreateCFProperty", "_IOServiceGetMatchingService" and much more which are in "IOKit" framework
+            if self.settings.os == "Macos":
                 self.cpp_info.components["qtCore"].frameworks.append("Cocoa")     # qtcore requires "_OBJC_CLASS_$_NSApplication" and more, which are in "Cocoa" framework
                 self.cpp_info.components["qtCore"].frameworks.append("Security")  # qtcore requires "_SecRequirementCreateWithString" and more, which are in "Security" framework
 

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.android import android_abi
 from conan.tools.apple import is_apple_os
 from conan.tools.build import build_jobs, check_min_cppstd, cross_building
 from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
@@ -14,7 +15,7 @@ import os
 import textwrap
 import shutil
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.59.0"
 
 
 class QtConan(ConanFile):
@@ -969,6 +970,8 @@ Examples = bin/datadir/examples""")
             self.cpp_info.components[component].build_modules["cmake_find_package_multi"].append(module)
 
         libsuffix = ""
+        if self.settings.os == "Android":
+            libsuffix = f"_{android_abi(self)}"
         if not self.options.multiconfiguration:
             if self.settings.build_type == "Debug":
                 if self.settings.os == "Windows" and is_msvc(self):

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -735,10 +735,7 @@ class QtConan(ConanFile):
                 args.append('QMAKE_APPLE_DEVICE_ARCHS="arm64"')
         elif self.settings.os == "Android":
             args += [f"-android-ndk-platform android-{self.settings.os.api_level}"]
-            args += ["-android-abis %s" % {"armv7": "armeabi-v7a",
-                                           "armv8": "arm64-v8a",
-                                           "x86": "x86",
-                                           "x86_64": "x86_64"}.get(str(self.settings.arch))]
+            args += [f"-android-abis {android_abi(self)}"]
 
         if self.settings.get_safe("compiler.libcxx") == "libstdc++":
             args += ["-D_GLIBCXX_USE_CXX11_ABI=0"]

--- a/recipes/qt/5.x.x/patches/android-backtrace.diff
+++ b/recipes/qt/5.x.x/patches/android-backtrace.diff
@@ -1,0 +1,19 @@
+diff --git a/src/corelib/global/qlogging.cpp b/src/corelib/global/qlogging.cpp
+index 89f49324c..dedf78fe5 100644
+--- a/src/corelib/global/qlogging.cpp
++++ b/src/corelib/global/qlogging.cpp
+@@ -107,7 +107,13 @@
+ #      define QLOGGING_HAVE_BACKTRACE
+ #    endif
+ #  elif (defined(__GLIBC__) && defined(__GLIBCXX__)) || (__has_include(<cxxabi.h>) && __has_include(<execinfo.h>))
+-#    define QLOGGING_HAVE_BACKTRACE
++#    ifdef __ANDROID_API__
++#      if __ANDROID_API__ >= 33
++#        define QLOGGING_HAVE_BACKTRACE
++#      endif
++#    else
++#      define QLOGGING_HAVE_BACKTRACE
++#    endif
+ #  endif
+ #endif
+ 

--- a/recipes/qt/5.x.x/patches/android-new-ndk.diff
+++ b/recipes/qt/5.x.x/patches/android-new-ndk.diff
@@ -1,0 +1,27 @@
+From 49f62e8c5a8aef4c0b7fd6867a30e653d2f5dd98 Mon Sep 17 00:00:00 2001
+From: Alexey Edelev <alexey.edelev@qt.io>
+Date: Mon, 21 Nov 2022 15:03:17 +0100
+Subject: [PATCH] Remove QMAKE_RANLIB and QMAKE_LINK_SHLIB from android/default_pre.prf
+
+The values should come from android-clang mkspecs. The hardcoded
+values don't work correctly with recent Android NDKs.
+
+Pick-to: 6.4 6.2 5.15
+Fixes: QTBUG-108662
+Change-Id: Ie153a50ee0c49bd4f0704b588a4e2c87a05c1063
+Reviewed-by: Assam Boudjelthia <assam.boudjelthia@qt.io>
+---
+
+diff --git a/mkspecs/features/android/default_pre.prf b/mkspecs/features/android/default_pre.prf
+index 9f90dcb..2328b72 100644
+--- a/mkspecs/features/android/default_pre.prf
++++ b/mkspecs/features/android/default_pre.prf
+@@ -76,8 +76,6 @@
+ else: equals(QT_ARCH, arm64-v8a): CROSS_COMPILE = $$NDK_LLVM_PATH/bin/aarch64-linux-android-
+ else: CROSS_COMPILE = $$NDK_LLVM_PATH/bin/arm-linux-androideabi-
+ 
+-QMAKE_RANLIB            = $${CROSS_COMPILE}ranlib
+-QMAKE_LINK_SHLIB        = $$QMAKE_LINK
+ QMAKE_LFLAGS            =
+ 
+ QMAKE_LIBS_PRIVATE      = -llog -lz -lm -ldl -lc

--- a/recipes/qt/5.x.x/patches/android-openssl.diff
+++ b/recipes/qt/5.x.x/patches/android-openssl.diff
@@ -1,0 +1,13 @@
+diff --git a/src/network/ssl/ssl.pri b/src/network/ssl/ssl.pri
+index 230c45c26..d7527949e 100644
+--- a/src/network/ssl/ssl.pri
++++ b/src/network/ssl/ssl.pri
+@@ -117,7 +117,7 @@ qtConfig(ssl) {
+ 
+         qtConfig(openssl-linked): {
+             android {
+-                build_pass|single_android_abi: LIBS_PRIVATE += -lssl_$${QT_ARCH} -lcrypto_$${QT_ARCH}
++                build_pass|single_android_abi: LIBS_PRIVATE += -lssl -lcrypto
+             } else: QMAKE_USE_FOR_PRIVATE += openssl
+         } else: \
+             QMAKE_USE_FOR_PRIVATE += openssl/nolink


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.x**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
- `CROSS_COMPILE` option isn't required for Android according to https://doc.qt.io/qt-5/android-building.html
- With NDK 24 it's not buildable because of backtrace functions which are available only since API level 33 according to `execinfo.h`.
- fixes #15536 - linking to OpenSSL libs built by Conan
- iOS fix from #15471
- adds option to pass path to Android SDK which is required to build Qt
- fixes #15552 - backported patch for NDK >= 23

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
