### PR TITLE
log4cplus: add version 2.0.8, support conan v2

### DIFF
--- a/recipes/log4cplus/all/CMakeLists.txt
+++ b/recipes/log4cplus/all/CMakeLists.txt
@@ -1,8 +1,0 @@
-cmake_minimum_required(VERSION 2.8.11)
-
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/log4cplus/all/conandata.yml
+++ b/recipes/log4cplus/all/conandata.yml
@@ -19,20 +19,20 @@ patches:
   "2.0.8":
     - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
       patch_description: "disable fPIC, move cmake_minimum_version to front"
-      patch_type: "backport"
+      patch_type: "conan"
   "2.0.7":
     - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
       patch_description: "disable fPIC, move cmake_minimum_version to front"
-      patch_type: "backport"
+      patch_type: "conan"
   "2.0.6":
     - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
       patch_description: "disable fPIC, move cmake_minimum_version to front"
-      patch_type: "backport"
+      patch_type: "conan"
   "2.0.5":
     - patch_file: "patches/2.0.4-0001-fix-cmake.patch"
       patch_description: "disable fPIC, move cmake_minimum_version to front"
-      patch_type: "backport"
+      patch_type: "conan"
   "2.0.4":
     - patch_file: "patches/2.0.4-0001-fix-cmake.patch"
       patch_description: "disable fPIC, move cmake_minimum_version to front"
-      patch_type: "backport"
+      patch_type: "conan"

--- a/recipes/log4cplus/all/conandata.yml
+++ b/recipes/log4cplus/all/conandata.yml
@@ -1,13 +1,16 @@
 sources:
-  "2.0.4":
-    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_4/log4cplus-2.0.4.tar.bz2"
-    sha256: "0c8a7b4cabff07032385f0c6d1a078d2a79c69b1c43b06991ca774fb85880252"
-  "2.0.5":
-    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_5/log4cplus-2.0.5.tar.bz2"
-    sha256: "b38dbfc68ef6d771e4de7de0be3544bc51bd3f7d5b75c5f6500d10e23203eb15"
+  "2.0.8":
+    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_8/log4cplus-2.0.8.tar.bz2"
+    sha256: "ca36aa366036d1c61fc0366a9ffbcf32bad55d74878b2c36a9c34dcc00b8a0ca"
+  "2.0.7":
+    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_7/log4cplus-2.0.7.tar.bz2"
+    sha256: "8fadbafee2ba4e558a0f78842613c9fb239c775d83f23340d091084c0e1b12ab"
   "2.0.6":
     url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_6/log4cplus-2.0.6.tar.bz2"
     sha256: "1a963afd0f883d62de946b18927d238051fd47936e415eabeffe2b1397f16eca"
-  "2.0.7":
-    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_7/log4cplus-2.0.7.tar.bz2"
-    sha256: "8fadbafee2ba4e558a0f78842613c9fb239c775d83f23340d091084c0e1b12ab"        
+  "2.0.5":
+    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_5/log4cplus-2.0.5.tar.bz2"
+    sha256: "b38dbfc68ef6d771e4de7de0be3544bc51bd3f7d5b75c5f6500d10e23203eb15"
+  "2.0.4":
+    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_4/log4cplus-2.0.4.tar.bz2"
+    sha256: "0c8a7b4cabff07032385f0c6d1a078d2a79c69b1c43b06991ca774fb85880252"

--- a/recipes/log4cplus/all/conandata.yml
+++ b/recipes/log4cplus/all/conandata.yml
@@ -14,3 +14,25 @@ sources:
   "2.0.4":
     url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_4/log4cplus-2.0.4.tar.bz2"
     sha256: "0c8a7b4cabff07032385f0c6d1a078d2a79c69b1c43b06991ca774fb85880252"
+
+patches:
+  "2.0.8":
+    - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
+      patch_description: "disable fPIC, move cmake_minimum_version to front"
+      patch_type: "backport"
+  "2.0.7":
+    - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
+      patch_description: "disable fPIC, move cmake_minimum_version to front"
+      patch_type: "backport"
+  "2.0.6":
+    - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
+      patch_description: "disable fPIC, move cmake_minimum_version to front"
+      patch_type: "backport"
+  "2.0.5":
+    - patch_file: "patches/2.0.4-0001-fix-cmake.patch"
+      patch_description: "disable fPIC, move cmake_minimum_version to front"
+      patch_type: "backport"
+  "2.0.4":
+    - patch_file: "patches/2.0.4-0001-fix-cmake.patch"
+      patch_description: "disable fPIC, move cmake_minimum_version to front"
+      patch_type: "backport"

--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -1,11 +1,7 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file, collect_libs
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir, collect_libs
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.env import VirtualBuildEnv
 import os
 
 required_conan_version = ">=1.53.0"
@@ -43,6 +39,9 @@ class Log4cplusConan(ConanFile):
         "thread_pool": True,
     }
     short_paths = True
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -85,16 +84,8 @@ class Log4cplusConan(ConanFile):
         dpes = CMakeDeps(self)
         dpes.generate()
 
-    def _patch_sources(self):
-        # don't force PIC
-        replace_in_file(self,
-            os.path.join(self.source_folder, "CMakeLists.txt"),
-            "set (CMAKE_POSITION_INDEPENDENT_CODE ON)",
-            ""
-        )
-
     def build(self):
-        self._patch_sources()
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -97,6 +97,8 @@ class Log4cplusConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "log4cplus")
+        self.cpp_info.set_property("cmake_target_name", "log4cplus::log4cplus")
         self.cpp_info.libs = collect_libs(self)
         if self.options.unicode:
             self.cpp_info.defines = ["UNICODE", "_UNICODE"]

--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -101,7 +101,7 @@ class Log4cplusConan(ConanFile):
         if self.options.unicode:
             self.cpp_info.defines = ["UNICODE", "_UNICODE"]
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs = ["dl", "m", "rt"]
+            self.cpp_info.system_libs = ["dl", "m", "rt", "nsl"]
             if not self.options.single_threaded:
                 self.cpp_info.system_libs.append("pthread")
         elif self.settings.os == "Windows":

--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -1,51 +1,48 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file, collect_libs
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
 import os
-from conan.tools import files
-from conans import ConanFile, CMake, tools
 
-required_conan_version = ">=1.35.0"
-
+required_conan_version = ">=1.53.0"
 
 class Log4cplusConan(ConanFile):
     name = "log4cplus"
     description = "simple to use C++ logging API, modelled after the Java log4j API"
+    license = ("BSD-2-Clause, Apache-2.0")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/log4cplus/log4cplus"
-    topics = ("log4cplus", "logging", "log", "logging-library")
-    license = ("BSD-2-Clause, Apache-2.0")
-    exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
-    settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False],
-               "fPIC": [True, False],
-               "single_threaded": [True, False],
-               "build_logging_server": [True, False],
-               "with_iconv": [True, False],
-               "working_locale": [True, False],
-               "working_c_locale": [True, False],
-               "decorated_name": [True, False],
-               "unicode": [True, False],
-               "thread_pool": [True, False]}
-    default_options = {"shared": False,
-                       "fPIC": True,
-                       "single_threaded": False,
-                       "build_logging_server": False,
-                       "with_iconv": False,
-                       "working_locale": False,
-                       "working_c_locale": False,
-                       "decorated_name": False,
-                       "unicode": True,
-                       "thread_pool": True}
+    topics = ("logging", "log", "logging-library")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "single_threaded": [True, False],
+        "build_logging_server": [True, False],
+        "with_iconv": [True, False],
+        "working_locale": [True, False],
+        "working_c_locale": [True, False],
+        "decorated_name": [True, False],
+        "unicode": [True, False],
+        "thread_pool": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "single_threaded": False,
+        "build_logging_server": False,
+        "with_iconv": False,
+        "working_locale": False,
+        "working_c_locale": False,
+        "decorated_name": False,
+        "unicode": True,
+        "thread_pool": True,
+    }
     short_paths = True
-
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -53,59 +50,67 @@ class Log4cplusConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 11)
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.with_iconv:
-            self.requires("libiconv/1.16")
+            self.requires("libiconv/1.17")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
 
     def source(self):
-        files.get(self, **self.conan_data["sources"][self.version], strip_root=True,
-                destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["LOG4CPLUS_ENABLE_THREAD_POOL"] = self.options.thread_pool
-        self._cmake.definitions["UNICODE"] = self.options.unicode
-        self._cmake.definitions["LOG4CPLUS_BUILD_TESTING"] = False
-        self._cmake.definitions["WITH_UNIT_TESTS"] = False
-        self._cmake.definitions["LOG4CPLUS_ENABLE_DECORATED_LIBRARY_NAME"] = self.options.decorated_name
-        self._cmake.definitions["LOG4CPLUS_QT4"] = False
-        self._cmake.definitions["LOG4CPLUS_QT5"] = False
-        self._cmake.definitions["LOG4CPLUS_SINGLE_THREADED"] = self.options.single_threaded
-        self._cmake.definitions["LOG4CPLUS_BUILD_LOGGINGSERVER"] = self.options.build_logging_server
-        self._cmake.definitions["WITH_ICONV"] = self.options.with_iconv
-        self._cmake.definitions["LOG4CPLUS_WORKING_LOCALE"] = self.options.working_locale
-        self._cmake.definitions["LOG4CPLUS_WORKING_C_LOCALE"] = self.options.working_c_locale
-        self._cmake.configure(build_dir=self._build_subfolder)
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["LOG4CPLUS_ENABLE_THREAD_POOL"] = self.options.thread_pool
+        tc.variables["UNICODE"] = self.options.unicode
+        tc.variables["LOG4CPLUS_BUILD_TESTING"] = False
+        tc.variables["WITH_UNIT_TESTS"] = False
+        tc.variables["LOG4CPLUS_ENABLE_DECORATED_LIBRARY_NAME"] = self.options.decorated_name
+        tc.variables["LOG4CPLUS_QT4"] = False
+        tc.variables["LOG4CPLUS_QT5"] = False
+        tc.variables["LOG4CPLUS_SINGLE_THREADED"] = self.options.single_threaded
+        tc.variables["LOG4CPLUS_BUILD_LOGGINGSERVER"] = self.options.build_logging_server
+        tc.variables["WITH_ICONV"] = self.options.with_iconv
+        tc.variables["LOG4CPLUS_WORKING_LOCALE"] = self.options.working_locale
+        tc.variables["LOG4CPLUS_WORKING_C_LOCALE"] = self.options.working_c_locale
+        tc.generate()
+
+        dpes = CMakeDeps(self)
+        dpes.generate()
 
     def _patch_sources(self):
         # don't force PIC
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "set (CMAKE_POSITION_INDEPENDENT_CODE ON)", "")
+        replace_in_file(self,
+            os.path.join(self.source_folder, "CMakeLists.txt"),
+            "set (CMAKE_POSITION_INDEPENDENT_CODE ON)",
+            ""
+        )
 
     def build(self):
         self._patch_sources()
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = collect_libs(self)
         if self.options.unicode:
             self.cpp_info.defines = ["UNICODE", "_UNICODE"]
-        if self.settings.os == "Linux":
-            self.cpp_info.system_libs = ["dl", "m", "rt", "nsl"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["dl", "m", "rt"]
             if not self.options.single_threaded:
                 self.cpp_info.system_libs.append("pthread")
         elif self.settings.os == "Windows":

--- a/recipes/log4cplus/all/patches/2.0.4-0001-fix-cmake.patch
+++ b/recipes/log4cplus/all/patches/2.0.4-0001-fix-cmake.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index abe12e0..73d443f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,3 +1,5 @@
++cmake_minimum_required (VERSION 3.1)
++
+ # This block needs to stay before the project (log4cplus) line so that
+ #  the output files placed into Android's libs directory.
+ if (CMAKE_TOOLCHAIN_FILE)
+@@ -12,10 +14,6 @@ endif ()
+ set (CMAKE_LEGACY_CYGWIN_WIN32 0)
+ 
+ project (log4cplus)
+-cmake_minimum_required (VERSION 3.1)
+-
+-# Use "-fPIC" / "-fPIE" for all targets by default, including static libs.
+-set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+ enable_language (CXX)
+ if (MSVC)

--- a/recipes/log4cplus/all/patches/2.0.6-0001-fix-cmake.patch
+++ b/recipes/log4cplus/all/patches/2.0.6-0001-fix-cmake.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5fa96f7..4209098 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,3 +1,5 @@
++cmake_minimum_required (VERSION 3.12)
++
+ # This block needs to stay before the project (log4cplus) line so that
+ #  the output files placed into Android's libs directory.
+ if (CMAKE_TOOLCHAIN_FILE)
+@@ -12,10 +14,6 @@ endif ()
+ set (CMAKE_LEGACY_CYGWIN_WIN32 0)
+ 
+ project (log4cplus)
+-cmake_minimum_required (VERSION 3.12)
+-
+-# Use "-fPIC" / "-fPIE" for all targets by default, including static libs.
+-set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+ enable_language (CXX)
+ if (MSVC)

--- a/recipes/log4cplus/all/test_package/CMakeLists.txt
+++ b/recipes/log4cplus/all/test_package/CMakeLists.txt
@@ -1,11 +1,9 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
+set(CMAKE_VERBOSE_MAKEFILE ON)
 find_package(log4cplus REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} log4cplus::log4cplus)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE log4cplus::log4cplus)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/log4cplus/all/test_package/CMakeLists.txt
+++ b/recipes/log4cplus/all/test_package/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
-set(CMAKE_VERBOSE_MAKEFILE ON)
 find_package(log4cplus REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/log4cplus/all/test_package/conanfile.py
+++ b/recipes/log4cplus/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-from conans import ConanFile, CMake, tools
-
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/log4cplus/all/test_v1_package/CMakeLists.txt
+++ b/recipes/log4cplus/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/log4cplus/all/test_v1_package/conanfile.py
+++ b/recipes/log4cplus/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/log4cplus/config.yml
+++ b/recipes/log4cplus/config.yml
@@ -1,9 +1,11 @@
 versions:
-  "2.0.4":
+  "2.0.8":
     folder: all
-  "2.0.5":
+  "2.0.7":
     folder: all
   "2.0.6":
     folder: all
-  "2.0.7":
+  "2.0.5":
+    folder: all
+  "2.0.4":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **log4cplus/***

- add version 2.0.8
- support conan v2
- update libiconv

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
