### PR TITLE
fix: use correct OS check for settings_build when calling b2 or bcp exe

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -774,12 +774,12 @@ class BoostConan(ConanFile):
 
     @property
     def _b2_exe(self):
-        return "b2.exe" if self._settings_build == "Windows" else "b2"
+        return "b2.exe" if self._settings_build.os == "Windows" else "b2"
 
     @property
     def _bcp_exe(self):
         folder = os.path.join(self.source_folder, "dist", "bin")
-        return os.path.join(folder, "bcp.exe" if self._settings_build == "Windows" else "bcp")
+        return os.path.join(folder, "bcp.exe" if self._settings_build.os == "Windows" else "bcp")
 
     @property
     def _use_bcp(self):
@@ -869,7 +869,7 @@ class BoostConan(ConanFile):
         with chdir(self, sources):
             # To show the libraries *1
             # self.run("%s --show-libraries" % b2_exe)
-            self.run(full_command)
+            self.run(full_command, run_environment=True)
 
     @property
     def _b2_os(self):

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -774,12 +774,12 @@ class BoostConan(ConanFile):
 
     @property
     def _b2_exe(self):
-        return "b2.exe" if self._settings_build.os == "Windows" else "b2"
+        return "b2"
 
     @property
     def _bcp_exe(self):
         folder = os.path.join(self.source_folder, "dist", "bin")
-        return os.path.join(folder, "bcp.exe" if self._settings_build.os == "Windows" else "bcp")
+        return os.path.join(folder, "bcp")
 
     @property
     def _use_bcp(self):
@@ -869,7 +869,7 @@ class BoostConan(ConanFile):
         with chdir(self, sources):
             # To show the libraries *1
             # self.run("%s --show-libraries" % b2_exe)
-            self.run(full_command, run_environment=True)
+            self.run(full_command)
 
     @property
     def _b2_os(self):


### PR DESCRIPTION
Specify library name and version:  **boost/1.81.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The check `self._settings_build == "Windows"` will always return `False`, since it is the settings object.

Correct check is `self._settings_build.os == "Windows"`.



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
