### PR TITLE
[service] fix community alerts

### DIFF
--- a/.github/actions/alert-community/action.yml
+++ b/.github/actions/alert-community/action.yml
@@ -1,4 +1,4 @@
-name: "Alter Community"
+name: "Alert Community"
 description: "Comment on pull request if certain files changes"
 author: "prince-chrismc"
 inputs:
@@ -15,6 +15,8 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3
+      with:
+        ref: master
     - uses: ./.github/actions/pr_changed_files
       id: changed_files
       with:

--- a/.github/actions/alert-community/action.yml
+++ b/.github/actions/alert-community/action.yml
@@ -14,9 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: master
+    # Assume the repo checked out the code since this is running
     - uses: ./.github/actions/pr_changed_files
       id: changed_files
       with:

--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: master
       - uses: ./.github/actions/alert-community
         with:
           files: "docs/*/*"

--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -1,7 +1,7 @@
 name: "[service] Alert Community"
 
 on:
-  pull_request:
+  pull_request_target:
    types: [opened] 
 
 jobs:

--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: master
       - uses: ./.github/actions/alert-community
         with:
           files: "docs/*/*"


### PR DESCRIPTION
use pull_request_target event as documented in https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target `This event allows your workflow to do things like label or comment on pull requests from forks`

see also https://github.com/conan-io/conan-center-index/pull/15333#issuecomment-1408336044

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
