### PR TITLE
(#15564) C-Ares bump version to 1.19.0

### DIFF
--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.19.0":
+    url: "https://github.com/c-ares/c-ares/releases/download/cares-1_19_0/c-ares-1.19.0.tar.gz"
+    sha256: "bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3"
   "1.18.1":
     url: "https://github.com/c-ares/c-ares/releases/download/cares-1_18_1/c-ares-1.18.1.tar.gz"
     sha256: "1a7d52a8a84a9fbffb1be9133c0f6e17217d91ea5a6fa61f6b4729cda78ebbcf"

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.19.0":
+    folder: all
   "1.18.1":
     folder: all
   "1.17.2":


### PR DESCRIPTION
Specify library name and version:  **c-ares/1.19.0**

closes #15564 

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
