### PR TITLE
wasmtime-cpp: add version 5.0.0

### DIFF
--- a/recipes/wasmtime-cpp/all/conandata.yml
+++ b/recipes/wasmtime-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.0.0":
+    url: "https://github.com/bytecodealliance/wasmtime-cpp/archive/v5.0.0.tar.gz"
+    sha256: "071ab8f01eb52760e584b711c76630b491e7516672188bb51f696ae45c08e0cc"
   "3.0.0":
     url: "https://github.com/bytecodealliance/wasmtime-cpp/archive/v3.0.0.tar.gz"
     sha256: "9840637cc3040f924db1caf957b883efcfa4ad9d92a86245cc0fd3967ea3db09"

--- a/recipes/wasmtime-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/wasmtime-cpp/all/test_package/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(wasmtime-cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE wasmtime-cpp::wasmtime-cpp)
-target_compile_definitions(${PROJECT_NAME} PRIVATE WASMTIME_EXAMPLES_PATH="${CMAKE_SOURCE_DIR}")
+target_compile_definitions(${PROJECT_NAME} PRIVATE WASMTIME_EXAMPLES_PATH="${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_EXTENSIONS OFF

--- a/recipes/wasmtime-cpp/all/test_v1_package/CMakeLists.txt
+++ b/recipes/wasmtime-cpp/all/test_v1_package/CMakeLists.txt
@@ -1,13 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(test_package CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(wasmtime-cpp REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE wasmtime-cpp::wasmtime-cpp)
-target_compile_definitions(${PROJECT_NAME} PRIVATE WASMTIME_EXAMPLES_PATH="${CMAKE_SOURCE_DIR}/../test_package")
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/wasmtime-cpp/all/test_v1_package/conanfile.py
+++ b/recipes/wasmtime-cpp/all/test_v1_package/conanfile.py
@@ -3,7 +3,6 @@ from conan.tools.build import cross_building
 import os
 
 
-# legacy validation with Conan 1.x
 class TestPackageV1Conan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"

--- a/recipes/wasmtime-cpp/config.yml
+++ b/recipes/wasmtime-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.0.0":
+    folder: all
   "3.0.0":
     folder: all
   "2.0.0":


### PR DESCRIPTION
Specify library name and version:  **wasmtime-cpp/***

- add version 5.0.0
- use `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
