### PR TITLE
sqlite_orm: add version 1.8.1

### DIFF
--- a/recipes/sqlite_orm/all/conandata.yml
+++ b/recipes/sqlite_orm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.1":
+    url: "https://github.com/fnc12/sqlite_orm/archive/v1.8.1.tar.gz"
+    sha256: "3fbe40d4bb7884a29a9a5764baa27e150ef53940895eb097014202bee3f06644"
   "1.8":
     url: "https://github.com/fnc12/sqlite_orm/archive/v1.8.tar.gz"
     sha256: "90893bb0035daf9803ad9e6d45b3e67f48b5515e69ed3a7577feffed7a9f3309"
@@ -14,3 +17,6 @@ sources:
 patches:
   "1.7":
     - patch_file: "patches/0001-declare-is-upsert-clause.patch"
+      patch_description: "declare is_upsert_clause declaration"
+      patch_type: "portability"
+      patch_source: "https://github.com/fnc12/sqlite_orm/pull/821"

--- a/recipes/sqlite_orm/all/test_v1_package/CMakeLists.txt
+++ b/recipes/sqlite_orm/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(SqliteOrm REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE sqlite_orm::sqlite_orm)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/sqlite_orm/config.yml
+++ b/recipes/sqlite_orm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.1":
+    folder: all
   "1.8":
     folder: all
   "1.7.1":


### PR DESCRIPTION
Specify library name and version:  **sqlite_orm/1.8.1**

- add version 1.8.1
- use `add_subdirectory` in test_v1_package
- add patch description

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
