### PR TITLE
[Bug]Update sha256 signature in 0.8.2 package

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "0.8.2":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.8.2.tar.gz"
-    sha256: "36edc6e486c43bbb34059dde227e872c0d41ab54f0b3609d38f188cfbbc6d1f8"
+    sha256: "d4ace07b084b46aa30542948556326233f49d8a5a132bcde3035e7f58f7662e1"
   "0.7.5":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.7.5.tar.gz"
     sha256: "e34fd3d3d32e3597f572205aaabbe995e162f4015e14c7328987b596bd25812c"


### PR DESCRIPTION
Specify library name and version:  **aws-c-common/0.8.2**

The package updated but not its signature. Updating to the real computed hash

---

- [ x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ N/A] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
