### PR TITLE
[catch2] fix sha256 sum

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "3.3.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.3.0.tar.gz"
-    sha256: "fe2f29a54ca775c2dd04bb97ffb79d398e6210e3caa174348b5cd3b7e4ca887d"
+    sha256: "48f06c98e685ac809db092364a7ef5604ed51f3e9edacca1b4beb84cdd147038"
   "3.2.1":
     url: "https://github.com/catchorg/Catch2/archive/v3.2.1.tar.gz"
     sha256: "4613d3e8142b672159fcae252a4860d72c8cf8e2df5043b1ae3541db9ef5d73c"


### PR DESCRIPTION
**catch2/3.3.0**

Fix sha256 sum

```
ERROR: catch2/3.3.0: Error in source() method, line 92
	get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
	ConanException: sha256 signature failed for 'v3.3.0.tar.gz' file.
 Provided signature: fe2f29a54ca775c2dd04bb97ffb79d398e6210e3caa174348b5cd3b7e4ca887d
 Computed signature: 48f06c98e685ac809db092364a7ef5604ed51f3e9edacca1b4beb84cdd147038
```

```
sha256sum Catch2-3.3.0.tar.gz
48f06c98e685ac809db092364a7ef5604ed51f3e9edacca1b4beb84cdd147038  Catch2-3.3.0.tar.gz
```

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
