### PR TITLE
[config v2] Add default epoch to all profile configurations

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -57,7 +57,7 @@ tasks:
 
 configurations:
   - id: linux-gcc
-    epochs: [20220628]
+    epochs: [0, 20220628]
     hrname: "Linux, GCC"
     build_profile:
       os: "Linux"
@@ -70,7 +70,7 @@ configurations:
               compiler.version: ["11"]
               build_type: ["Release"]
   - id: configs/macos-clang
-    epochs: [20220628]
+    epochs: [0, 20220628]
     hrname: "macOS, Clang"
     build_profile:
       os: "Macos"
@@ -83,7 +83,7 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
   - id: configs/windows-msvc
-    epochs: [20220628]
+    epochs: [0, 20220628]
     hrname: "Windows, MSVC"
     build_profile:
       os: "Windows"


### PR DESCRIPTION
All initial configurations should have the default (`0`) epoch
