### PR TITLE
grpc-proto: fix injection of googleapis resdirs in CMake build

### DIFF
--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -7,6 +7,8 @@ from conans import CMake, tools
 
 from helpers import parse_proto_libraries
 
+required_conan_version = ">=1.47.0"
+
 
 class GRPCProto(ConanFile):
     name = "grpc-proto"

--- a/recipes/grpc-proto/all/test_package/CMakeLists.txt
+++ b/recipes/grpc-proto/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.15)
-project(test_package CXX)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(grpc-proto REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE grpc-proto::grpc-proto)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/grpc-proto/all/test_package/conanfile.py
+++ b/recipes/grpc-proto/all/test_package/conanfile.py
@@ -1,23 +1,19 @@
-import os
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain
-from conan.tools.build import cross_building as tools_cross_building
-from conan.tools.layout import cmake_layout
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "VirtualRunEnv"
-
-    def requirements(self):
-        self.requires(self.tested_reference_str)
-
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.generate()
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -25,5 +21,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools_cross_building(self):
+        if can_run(self):
             self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/grpc-proto/all/test_v1_package/CMakeLists.txt
+++ b/recipes/grpc-proto/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/grpc-proto/all/test_v1_package/conanfile.py
+++ b/recipes/grpc-proto/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/15599

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
