### PR TITLE
chaiscript: fix yml format

### DIFF
--- a/recipes/chaiscript/config.yml
+++ b/recipes/chaiscript/config.yml
@@ -1,4 +1,3 @@
----
 versions:
   "6.1.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **chaiscript/***

this touches only config.yml, so it does not trigger any actual build


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
