### PR TITLE
cn-cbor: fix yml format

### DIFF
--- a/recipes/cn-cbor/config.yml
+++ b/recipes/cn-cbor/config.yml
@@ -1,4 +1,3 @@
----
 versions:
   "1.0.0":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **cn-cbor/***

this touches only config.yml, so it does not trigger any actual build


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
