### PR TITLE
openjdk: Remove x86_64 architecture restriction

### DIFF
--- a/recipes/openjdk/all/conandata.yml
+++ b/recipes/openjdk/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
   "19.0.2":
     Windows:
-      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/9/GPL/openjdk-19.0.2_windows-x64_bin.zip"
+      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_windows-x64_bin.zip"
       sha256: "9f70eba3f2631674a2d7d3aa01150d697f68be16ad76662ff948d7fe1b4985d8"
     Linux:
-      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/9/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz"
+      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz"
       sha256: "34cf8d095cc071e9e10165f5c45023f96ec68397fdaabf6c64bfec1ffeee6198"
     Macos_x86_64:
       url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-aarch64_bin.tar.gz"

--- a/recipes/openjdk/all/conandata.yml
+++ b/recipes/openjdk/all/conandata.yml
@@ -1,4 +1,17 @@
 sources:
+  "19.0.2":
+    Windows:
+      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/9/GPL/openjdk-19.0.2_windows-x64_bin.zip"
+      sha256: "9f70eba3f2631674a2d7d3aa01150d697f68be16ad76662ff948d7fe1b4985d8"
+    Linux:
+      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/9/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz"
+      sha256: "34cf8d095cc071e9e10165f5c45023f96ec68397fdaabf6c64bfec1ffeee6198"
+    Macos_x86_64:
+      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-aarch64_bin.tar.gz"
+      sha256: "4317442e14c5c2f4f698db0e41347df99d050a32137b2a02dfec28ed856577cc"
+    Macos_armv8:
+      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-aarch64_bin.tar.gz"
+      sha256: "4317442e14c5c2f4f698db0e41347df99d050a32137b2a02dfec28ed856577cc"
   "16.0.1":
     Windows:
       url: "https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_windows-x64_bin.zip"
@@ -6,6 +19,6 @@ sources:
     Linux:
       url: "https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz"
       sha256: "b1198ffffb7d26a3fdedc0fa599f60a0d12aa60da1714b56c1defbce95d8b235"
-    Macos:
+    Macos_x86_64:
       url: "https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_osx-x64_bin.tar.gz"
       sha256: "6098f839954439d4916444757c542c1b8778a32461706812d41cc8bbefce7f2f"

--- a/recipes/openjdk/all/conandata.yml
+++ b/recipes/openjdk/all/conandata.yml
@@ -7,8 +7,8 @@ sources:
       url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz"
       sha256: "34cf8d095cc071e9e10165f5c45023f96ec68397fdaabf6c64bfec1ffeee6198"
     Macos_x86_64:
-      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-aarch64_bin.tar.gz"
-      sha256: "4317442e14c5c2f4f698db0e41347df99d050a32137b2a02dfec28ed856577cc"
+      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-x64_bin.tar.gz"
+      sha256: "c57c7c511706738fff6540945e0159e97b8b328777e6460977dd64e00f4c2c0b"
     Macos_armv8:
       url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-aarch64_bin.tar.gz"
       sha256: "4317442e14c5c2f4f698db0e41347df99d050a32137b2a02dfec28ed856577cc"

--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.tools.files import copy, get, symlinks
+from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 import os
 
@@ -21,11 +22,16 @@ class OpenJDK(ConanFile):
         del self.info.settings.build_type
 
     def validate(self):
+        if Version(self.version) < "19.0.2" and self.settings.arch != "x86_64":
+            raise ConanInvalidConfiguration("Unsupported Architecture.  This package currently only supports x86_64.")
         if self.settings.os not in ["Windows", "Macos", "Linux"]:
             raise ConanInvalidConfiguration("Unsupported os. This package currently only support Linux/Macos/Windows")
 
     def build(self):
-        get(self, **self.conan_data["sources"][self.version][str(self.settings.os)],
+        key = self.settings.os
+        if self.settings.os == "Macos":
+            key = f"{self.settings.os}_{self.settings.arch}"
+        get(self, **self.conan_data["sources"][self.version][str(key)],
                   destination=self.source_folder, strip_root=True)
 
     def package(self):

--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -21,8 +21,6 @@ class OpenJDK(ConanFile):
         del self.info.settings.build_type
 
     def validate(self):
-        if self.settings.arch != "x86_64":
-            raise ConanInvalidConfiguration("Unsupported Architecture.  This package currently only supports x86_64.")
         if self.settings.os not in ["Windows", "Macos", "Linux"]:
             raise ConanInvalidConfiguration("Unsupported os. This package currently only support Linux/Macos/Windows")
 

--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -9,6 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class OpenJDK(ConanFile):
     name = "openjdk"
+    package_type = "application"
     url = "https://github.com/conan-io/conan-center-index/"
     description = "Java Development Kit builds, from Oracle"
     homepage = "https://jdk.java.net"
@@ -65,6 +66,10 @@ class OpenJDK(ConanFile):
 
     def package_info(self):
         self.output.info(f"Creating JAVA_HOME environment variable with : {self.package_folder}")
-        self.env_info.JAVA_HOME = self.package_folder
+
+        self.runenv_info.append("JAVA_HOME", self.package_folder)
         self.buildenv_info.append("JAVA_HOME", self.package_folder)
+
+        # TODO: remove `env_info` once the recipe is only compatible with Conan >= 2.0
+        self.env_info.JAVA_HOME = self.package_folder
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/openjdk/all/test_package/conanfile.py
+++ b/recipes/openjdk/all/test_package/conanfile.py
@@ -8,9 +8,11 @@ required_conan_version = ">=1.47.0"
 
 class TestPackage(ConanFile):
     test_type = "explicit"
+    settings = "os", "arch"
+    generators = "VirtualRunEnv"
 
-    def build_requirements(self):
-        self.build_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         pass  # nothing to build, but tests should not warn
@@ -18,8 +20,8 @@ class TestPackage(ConanFile):
     def test(self):
         if can_run(self):
             output = StringIO()
-            self.run("java --version", output=output, run_environment=True)
-            print(output.getvalue)
+            self.run("java --version", output, env="conanrun")
+            self.output.info(f"Java version output: {output.getvalue()}")
             version_info = output.getvalue()
             if "openjdk" in version_info:
                 pass

--- a/recipes/openjdk/config.yml
+++ b/recipes/openjdk/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "19.0.2":
+    folder: all
   "16.0.1":
     folder: all


### PR DESCRIPTION
I tried removing this restriction on my Mac M1 and it worked so I wonder if we can delete it.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
