### PR TITLE
mcap: add version 0.9.0, support conan v2 more

### DIFF
--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -1,19 +1,22 @@
 sources:
-  0.1.0:
-    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.0/main.tar.gz
-    sha256: a936abb1493b0d189d7909a79c45bdc6703b6016801e10b5cd129ba39642d2b2
-  0.1.1:
-    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.1/main.tar.gz
-    sha256: a9ea899315851bfacdb234b7acc917b1a9c67593f0d68e1920321a8f6fa2cfbf
-  0.1.2:
-    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.2/main.tar.gz
-    sha256: 0f456d6c53730445c3dbf57afd285493cf748c66a02f77d6e48c075128fd0896
-  0.3.0:
-    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.3.0/main.tar.gz
-    sha256: ef29ea4c09520b8aaa2d78ce5e79cbbcd87511ed14d6abf3c4b249ae67a4153b
-  0.4.0:
-    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.4.0/main.tar.gz
-    sha256: c0ab99e51005fa8b74fe9ca1ed23b205cf532b8b0723eedd243f35a28d7b466b
+  0.9.0:
+    url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.9.0/main.tar.gz"
+    sha256: "e17702fcc0259bf72eab0d84d3fa6e02c051256357ab7ba4421462f2c02b434f"
   0.5.0:
-    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.5.0/main.tar.gz
-    sha256: 408e255a6c6419b16de38a9ecbdd9729d60adc657767b2d52a234d1da1185349
+    url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.5.0/main.tar.gz"
+    sha256: "408e255a6c6419b16de38a9ecbdd9729d60adc657767b2d52a234d1da1185349"
+  0.4.0:
+    url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.4.0/main.tar.gz"
+    sha256: "c0ab99e51005fa8b74fe9ca1ed23b205cf532b8b0723eedd243f35a28d7b466b"
+  0.3.0:
+    url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.3.0/main.tar.gz"
+    sha256: "ef29ea4c09520b8aaa2d78ce5e79cbbcd87511ed14d6abf3c4b249ae67a4153b"
+  0.1.2:
+    url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.2/main.tar.gz"
+    sha256: "0f456d6c53730445c3dbf57afd285493cf748c66a02f77d6e48c075128fd0896"
+  0.1.1:
+    url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.1/main.tar.gz"
+    sha256: "a9ea899315851bfacdb234b7acc917b1a9c67593f0d68e1920321a8f6fa2cfbf"
+  0.1.0:
+    url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.0/main.tar.gz"
+    sha256: "a936abb1493b0d189d7909a79c45bdc6703b6016801e10b5cd129ba39642d2b2"

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -1,60 +1,79 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools import files
 from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 import os
 
-required_conan_version = ">=1.47.0"
-
+required_conan_version = ">=1.52.0"
 
 class McapConan(ConanFile):
     name = "mcap"
+    description = (
+        "MCAP is a modular, performant, and serialization-agnostic container file format for pub/sub messages, "
+        "primarily intended for use in robotics applications."
+    )
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/foxglove/mcap"
-    description = "A C++ implementation of the MCAP file format"
-    license = "MIT"
-    topics = ("mcap", "serialization", "deserialization", "recording")
-
-    settings = ("os", "compiler", "build_type", "arch")
-    generators = ("cmake", "cmake_find_package")
+    topics = ("serialization", "deserialization", "recording", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "16",
+            "msvc": "191",
+            "gcc": "9",
+            "clang": "9",
+            "apple-clang": "12",
+        }
 
     @property
     def _source_package_path(self):
-        return os.path.join(self._source_subfolder, "cpp", "mcap")
-
-    def source(self):
-        files.get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
-
-    def requirements(self):
-        self.requires("lz4/1.9.3")
-        self.requires("zstd/1.5.2")
-        if Version(self.version) < "0.1.1":
-            self.requires("fmt/8.1.1")
-
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, "17")
-        if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) <= "11":
-            raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
-        if (self.settings.compiler in ("gcc", "clang")) and Version(self.settings.compiler.version) <= "8":
-            raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
-        if Version(self.version) < "0.1.1" and self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("Visual Studio compiler support is added in 0.1.1")
-        if self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) < "16":
-            raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
+        return os.path.join(self.source_folder, "cpp", "mcap")
 
     def configure(self):
         if Version(self.version) < "0.3.0":
             self.license = "Apache-2.0"
 
-    def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_package_path)
-        self.copy("include/*", src=self._source_package_path)
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("lz4/1.9.4")
+        self.requires("zstd/1.5.2")
+        if Version(self.version) < "0.1.1":
+            self.requires("fmt/9.1.0")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
+
+    def validate(self):
+        if Version(self.version) < "0.1.1" and is_msvc(self):
+            raise ConanInvalidConfiguration("Visual Studio compiler has been supported since 0.1.1")
+
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self._source_package_path)
+        copy(self, "*", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self._source_package_path, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/mcap/all/test_package/CMakeLists.txt
+++ b/recipes/mcap/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(mcap REQUIRED CONFIG)
 

--- a/recipes/mcap/all/test_v1_package/CMakeLists.txt
+++ b/recipes/mcap/all/test_v1_package/CMakeLists.txt
@@ -1,12 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-
-project(test_package CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(mcap REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE mcap::mcap)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/mcap/all/test_v1_package/conanfile.py
+++ b/recipes/mcap/all/test_v1_package/conanfile.py
@@ -2,8 +2,6 @@ from conans import ConanFile, CMake
 from conan.tools.build import cross_building
 import os
 
-
-# legacy validation with Conan 1.x
 class TestPackageV1Conan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -1,13 +1,15 @@
 versions:
-  0.1.0:
+  0.9.0:
     folder: all
-  0.1.1:
-    folder: all
-  0.1.2:
-    folder: all
-  0.3.0:
+  0.5.0:
     folder: all
   0.4.0:
     folder: all
-  0.5.0:
+  0.3.0:
+    folder: all
+  0.1.2:
+    folder: all
+  0.1.1:
+    folder: all
+  0.1.0:
     folder: all


### PR DESCRIPTION
Specify library name and version:  **mcap/***

- add version 0.9.0
- support conan v2 more
- sort by version in config.yml, conandata.yml
- use `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
