### PR TITLE
(#15657) Perfetto: Bump to v32.1

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "32.1":
+    url: "https://github.com/google/perfetto/archive/refs/tags/v32.1.tar.gz"
+    sha256: "0d1088b4758b3d5f3813178c6de22386329d42407d23aa1479f20dce96e49d78"
   "31.0":
     url: "https://github.com/google/perfetto/archive/refs/tags/v31.0.tar.gz"
     sha256: "544c68293590f53391ea4267d5a9b1a4594e1c8216fc5f5ce9d0f1227797922e"

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "32.1":
+    folder: all
   "31.0":
     folder: all
   "30.0":


### PR DESCRIPTION
Specify library name and version:  **perfetto/v32.1**

Closes #15657 

```
v32.1 - 2023-02-01:
  Trace Processor:
    * Fix build on windows.


v32.0 - 2023-02-01:
  Tracing service and probes:
    * Added an explicit TraceUuid packet. The tracing service now always
      generates a UUID, even if TraceConfig.trace_uuid_msb/lsb is empty.
  Trace Processor:
    *
  UI:
    *
  SDK:
    * Add perfetto::Tracing::ActivateTriggers() function.
    * Made it possible to declare track event categories in a C++ namespace
      with PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE, allowing multiple category
      sets to be used in one same translation unit. Correspondingly, the
      PERFETTO_COMPONENT_EXPORT and PERFETTO_TRACK_EVENT_NAMESPACE macros have
      been deprecated in favor of this new functionality.
    * Deprecated the PERFETTO_COMPONENT_EXPORT macro in favor of
      PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE_WITH_ATTRS.
    * Added TracingInitArgs::enable_system_consumer configuration option, that
      allows the linker to discard the consumer IPC, if not required.
```

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
