### PR TITLE
Autoconf Archive Conan 2.0 compatibility

### DIFF
--- a/recipes/autoconf-archive/all/conandata.yml
+++ b/recipes/autoconf-archive/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "2021.02.19":
     url: "https://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2021.02.19.tar.xz"
     sha256: "e8a6eb9d28ddcba8ffef3fa211653239e9bf239aba6a01a6b7cfc7ceaec69cbd"
+  "2022.09.03":
+    url: "https://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2022.09.03.tar.xz"
+    sha256: "e07454f00d8cae7907bed42d0747798927809947684d94c37207a4d63a32f423"

--- a/recipes/autoconf-archive/all/conanfile.py
+++ b/recipes/autoconf-archive/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.microsoft import unix_path
 from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=1.57.0"
+required_conan_version = ">=1.56.0"
 
 
 class AutoconfArchiveConan(ConanFile):
@@ -71,7 +71,7 @@ class AutoconfArchiveConan(ConanFile):
         self.buildenv_info.append_path("ACLOCAL_PATH", aclocal_path)
 
         # Remove for Conan 2.0
-        aclocal_path = unix_path(self, aclocal_path) # Conan 1.x needs and allows unix_path() in package_info()
+        aclocal_path = aclocal_path.replace("\\", "/") # Can't use unix_path with Conan 2.0
         self.output.info(f'Appending ACLOCAL_PATH env: {aclocal_path}')
         self.env_info.ACLOCAL_PATH.append(aclocal_path)
         self.output.info("Appending AUTOMAKE_CONAN_INCLUDES environment var: {}".format(aclocal_path))

--- a/recipes/autoconf-archive/all/conanfile.py
+++ b/recipes/autoconf-archive/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.files import get, copy, mkdir, rename, rmdir, export_conandata_patches
 from conan.tools.gnu import AutotoolsToolchain, Autotools
-from conan.tools.microsoft import unix_path
 from conan.tools.layout import basic_layout
 import os
 

--- a/recipes/autoconf-archive/all/conanfile.py
+++ b/recipes/autoconf-archive/all/conanfile.py
@@ -61,7 +61,7 @@ class AutoconfArchiveConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.includedirs = [];
+        self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = ["res/aclocal"]
 

--- a/recipes/autoconf-archive/all/conanfile.py
+++ b/recipes/autoconf-archive/all/conanfile.py
@@ -1,11 +1,15 @@
-from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conan import ConanFile
+from conan.tools.files import get, copy, mkdir, rename, rmdir, export_conandata_patches
+from conan.tools.gnu import AutotoolsToolchain, Autotools
+from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.56.0"
 
 
 class AutoconfArchiveConan(ConanFile):
     name = "autoconf-archive"
+    package_type = "build-scripts"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.gnu.org/software/autoconf-archive/"
     license = "GPL-2.0-or-later"
@@ -13,47 +17,58 @@ class AutoconfArchiveConan(ConanFile):
     topics = ("conan", "GNU", "autoconf", "autoconf-archive", "macro")
     settings = "os"
 
-    _autotools = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
 
-    def _configure_autotools(self):
-        if not self._autotools:
-            self._autotools = AutoToolsBuildEnvironment(self, win_bash=self._settings_build.os == "Windows")
-            self._autotools.configure()
-        return self._autotools
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.generate()
 
     def build(self):
-        with tools.chdir(os.path.join(self._source_subfolder)):
-            self._autotools = self._configure_autotools()
-            self._autotools.make()
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
 
     def package(self):
-        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
-        with tools.chdir(os.path.join(self._source_subfolder)):
-            self._autotools = self._configure_autotools()
-            self._autotools.install()
+        autotools = Autotools(self)
+        autotools.install()
 
-        tools.mkdir(os.path.join(self.package_folder, "res"))
-        tools.rename(os.path.join(self.package_folder, "share", "aclocal"),
+        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+
+        mkdir(self, os.path.join(self.package_folder, "res"))
+        rename(self, os.path.join(self.package_folder, "share", "aclocal"),
                      os.path.join(self.package_folder, "res", "aclocal"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        aclocal_path = tools.unix_path(os.path.join(self.package_folder, "res", "aclocal"))
+        self.cpp_info.includedirs = [];
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = ["res/aclocal"]
+
+        # Use ACLOCAL_PATH to access the .m4 files provided with autoconf-archive
+        aclocal_path = os.path.join(self.package_folder, "res", "aclocal")
+        self.buildenv_info.append_path("ACLOCAL_PATH", aclocal_path)
+
+        # Remove for Conan 2.0
         self.output.info("Appending AUTOMAKE_CONAN_INCLUDES environment var: {}".format(aclocal_path))
         self.env_info.AUTOMAKE_CONAN_INCLUDES.append(aclocal_path)

--- a/recipes/autoconf-archive/all/conanfile.py
+++ b/recipes/autoconf-archive/all/conanfile.py
@@ -70,7 +70,7 @@ class AutoconfArchiveConan(ConanFile):
         self.buildenv_info.append_path("ACLOCAL_PATH", aclocal_path)
 
         # Remove for Conan 2.0
-        aclocal_path = aclocal_path.replace("\\", "/") # Can't use unix_path with Conan 2.0
+        aclocal_path = "/" + aclocal_path.replace("\\", "/").replace(":", "") # Can't use unix_path with Conan 2.0
         self.output.info(f'Appending ACLOCAL_PATH env: {aclocal_path}')
         self.env_info.ACLOCAL_PATH.append(aclocal_path)
         self.output.info("Appending AUTOMAKE_CONAN_INCLUDES environment var: {}".format(aclocal_path))

--- a/recipes/autoconf-archive/all/conanfile.py
+++ b/recipes/autoconf-archive/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.files import get, copy, mkdir, rename, rmdir, export_conandata_patches
 from conan.tools.gnu import AutotoolsToolchain, Autotools
+from conan.tools.microsoft import unix_path
 from conan.tools.layout import basic_layout
 import os
 

--- a/recipes/autoconf-archive/all/conanfile.py
+++ b/recipes/autoconf-archive/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.microsoft import unix_path
 from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=1.56.0"
+required_conan_version = ">=1.57.0"
 
 
 class AutoconfArchiveConan(ConanFile):

--- a/recipes/autoconf-archive/all/conanfile.py
+++ b/recipes/autoconf-archive/all/conanfile.py
@@ -70,5 +70,8 @@ class AutoconfArchiveConan(ConanFile):
         self.buildenv_info.append_path("ACLOCAL_PATH", aclocal_path)
 
         # Remove for Conan 2.0
+        aclocal_path = unix_path(self, aclocal_path) # Conan 1.x needs and allows unix_path() in package_info()
+        self.output.info(f'Appending ACLOCAL_PATH env: {aclocal_path}')
+        self.env_info.ACLOCAL_PATH.append(aclocal_path)
         self.output.info("Appending AUTOMAKE_CONAN_INCLUDES environment var: {}".format(aclocal_path))
         self.env_info.AUTOMAKE_CONAN_INCLUDES.append(aclocal_path)

--- a/recipes/autoconf-archive/all/test_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_package/conanfile.py
@@ -2,7 +2,6 @@ from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 from conan.tools.microsoft import is_msvc, unix_path
-from conan.tools.layout import basic_layout
 import os
 import shutil
 
@@ -17,9 +16,6 @@ class TestPackageConan(ConanFile):
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
-
-    def layout(self):
-        basic_layout(self, src_folder="src")
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)

--- a/recipes/autoconf-archive/all/test_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_package/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.build import cross_building, can_run
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 from conan.tools.microsoft import is_msvc, unix_path
+from conan.tools.layout import basic_layout
 import os
 import shutil
 
@@ -16,6 +17,9 @@ class TestPackageConan(ConanFile):
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
+
+    def layout(self):
+        basic_layout(self)
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)

--- a/recipes/autoconf-archive/all/test_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_package/conanfile.py
@@ -3,7 +3,6 @@ from conan.tools.build import cross_building, can_run
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 from conan.tools.microsoft import is_msvc, unix_path
 from conan.tools.layout import basic_layout
-from conan.tools.env import VirtualBuildEnv
 import os
 import shutil
 
@@ -14,6 +13,7 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = "configure.ac", "Makefile.am", "test_package.c"
     test_type = "explicit"
+    generators = "VirtualBuildEnv"  # Need VirtualBuildEnv for Conan 1.x env_info support
     win_bash = True # This assignment must be *here* to avoid "Cannot wrap command with different envs." in Conan 1.x
 
     @property
@@ -39,9 +39,6 @@ class TestPackageConan(ConanFile):
             env.define("CC", "cl -nologo")
             env.define("CXX", "cl -nologo")
         tc.generate(env)
-        # Need VirtualBuildEnv for Conan 1.x env_info support
-        env = VirtualBuildEnv(self)
-        env.generate()
 
     def build(self):
         if not cross_building(self):

--- a/recipes/autoconf-archive/all/test_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_package/conanfile.py
@@ -3,6 +3,7 @@ from conan.tools.build import cross_building, can_run
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 from conan.tools.microsoft import is_msvc, unix_path
 from conan.tools.layout import basic_layout
+from conan.tools.env import VirtualBuildEnv
 import os
 import shutil
 
@@ -13,6 +14,7 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = "configure.ac", "Makefile.am", "test_package.c"
     test_type = "explicit"
+    win_bash = True # This assignment must be *here* to avoid "Cannot wrap command with different envs." in Conan 1.x
 
     @property
     def _settings_build(self):
@@ -37,6 +39,9 @@ class TestPackageConan(ConanFile):
             env.define("CC", "cl -nologo")
             env.define("CXX", "cl -nologo")
         tc.generate(env)
+        # Need VirtualBuildEnv for Conan 1.x env_info support
+        env = VirtualBuildEnv(self)
+        env.generate()
 
     def build(self):
         if not cross_building(self):

--- a/recipes/autoconf-archive/all/test_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.build import can_run
+from conan.tools.build import cross_building, can_run
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 from conan.tools.microsoft import is_msvc, unix_path
 import os
@@ -35,12 +35,13 @@ class TestPackageConan(ConanFile):
         tc.generate(env)
 
     def build(self):
-        for src in self.exports_sources:
-            shutil.copy(os.path.join(self.source_folder, src), self.build_folder)
-        self.run("autoreconf -fiv")
-        autotools = Autotools(self)
-        autotools.configure(build_script_folder=self.build_folder)
-        autotools.make()
+        if not cross_building(self):
+            for src in self.exports_sources:
+                shutil.copy(os.path.join(self.source_folder, src), self.build_folder)
+            self.run("autoreconf -fiv")
+            autotools = Autotools(self)
+            autotools.configure(build_script_folder=self.build_folder)
+            autotools.make()
 
     def test(self):
         if can_run(self):

--- a/recipes/autoconf-archive/all/test_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_package/conanfile.py
@@ -1,6 +1,5 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.files import get, copy, mkdir, rename, rmdir, export_conandata_patches
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 from conan.tools.microsoft import is_msvc, unix_path
 from conan.tools.layout import basic_layout
@@ -18,6 +17,9 @@ class TestPackageConan(ConanFile):
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
@@ -39,7 +41,7 @@ class TestPackageConan(ConanFile):
     def build(self):
         for src in self.exports_sources:
             shutil.copy(os.path.join(self.source_folder, src), self.build_folder)
-        self.run(f'autoreconf -fiv')
+        self.run("autoreconf -fiv")
         autotools = Autotools(self)
         autotools.configure(build_script_folder=self.build_folder)
         autotools.make()

--- a/recipes/autoconf-archive/all/test_v1_package/Makefile.am
+++ b/recipes/autoconf-archive/all/test_v1_package/Makefile.am
@@ -1,0 +1,2 @@
+bin_PROGRAMS = test_package
+test_package_sources = test_package.c

--- a/recipes/autoconf-archive/all/test_v1_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_v1_package/conanfile.py
@@ -1,0 +1,49 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
+import contextlib
+import os
+import shutil
+
+required_conan_version = ">=1.36.0"
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "configure.ac", "Makefile.am", "test_package.c"
+    test_type = "explicit"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def build_requirements(self):
+        self.build_requires(self.tested_reference_str)
+        self.build_requires("automake/1.16.3")
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+
+    @contextlib.contextmanager
+    def _build_context(self):
+        if self.settings.compiler == "Visual Studio":
+            with tools.vcvars(self):
+                env = {
+                    "CC": "cl -nologo",
+                    "CXX": "cl -nologo",
+                }
+                with tools.environment_append(env):
+                    yield
+        else:
+            yield
+
+    def build(self):
+        for src in self.exports_sources:
+            shutil.copy(os.path.join(self.source_folder, src), self.build_folder)
+        self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, win_bash=self._settings_build.os == "Windows")
+        with self._build_context():
+            autotools = AutoToolsBuildEnvironment(self, win_bash=self._settings_build.os == "Windows")
+            autotools.libs = []
+            autotools.configure()
+            autotools.make()
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run(os.path.join(".", "test_package"))

--- a/recipes/autoconf-archive/all/test_v1_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_v1_package/conanfile.py
@@ -3,7 +3,7 @@ import contextlib
 import os
 import shutil
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.56.0"
 
 
 class TestPackageConan(ConanFile):
@@ -37,7 +37,10 @@ class TestPackageConan(ConanFile):
     def build(self):
         for src in self.exports_sources:
             shutil.copy(os.path.join(self.source_folder, src), self.build_folder)
-        self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, win_bash=self._settings_build.os == "Windows")
+
+        # Work around the fact that "used_special_vars" in conans/client/tools/win.py doesn't handle ACLOCAL_PATH
+        aclocal_path = "$ACLOCAL_PATH:" + self.deps_env_info.vars["ACLOCAL_PATH"][0].lower()
+        self.run("ACLOCAL_PATH={} autoreconf -fiv".format(aclocal_path), win_bash=self._settings_build.os == "Windows")
         with self._build_context():
             autotools = AutoToolsBuildEnvironment(self, win_bash=self._settings_build.os == "Windows")
             autotools.libs = []

--- a/recipes/autoconf-archive/all/test_v1_package/conanfile.py
+++ b/recipes/autoconf-archive/all/test_v1_package/conanfile.py
@@ -17,7 +17,7 @@ class TestPackageConan(ConanFile):
 
     def build_requirements(self):
         self.build_requires(self.tested_reference_str)
-        self.build_requires("automake/1.16.3")
+        self.build_requires("automake/1.16.5")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 

--- a/recipes/autoconf-archive/all/test_v1_package/configure.ac
+++ b/recipes/autoconf-archive/all/test_v1_package/configure.ac
@@ -1,0 +1,15 @@
+AC_INIT([test_package], [1.0])
+AC_CONFIG_SRCDIR([test_package.c])
+AC_CONFIG_AUX_DIR([autostuff])
+AM_INIT_AUTOMAKE([foreign])
+AC_PROG_CC
+m4_pattern_forbid([^AX_],
+        [Unexpanded AX_ macro found. Please install GNU autoconf-archive.])
+AX_CXX_BOOL()
+AX_CXX_HAVE_VECTOR_AT()
+AX_CXX_HAVE_BIND()
+AX_PRINTF_SIZE_T()
+AX_CHECK_AWK_INDEX()
+AX_BERKELEY_DB()
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/recipes/autoconf-archive/all/test_v1_package/test_package.c
+++ b/recipes/autoconf-archive/all/test_v1_package/test_package.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello world from test_package.c\n");
+	return 0;
+}

--- a/recipes/autoconf-archive/config.yml
+++ b/recipes/autoconf-archive/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2021.02.19":
     folder: all
+  "2022.09.03":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **autoconf-archive/2021.02.19**

Didn't find existing effort to port this to Conan 2.0, so did so in support of building MPFR from Git source.


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
