### PR TITLE
opentdf-client: add version 1.3.8

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.8":
+    url: "https://github.com/opentdf/client-cpp/archive/1.3.8.tar.gz"
+    sha256: "0d73bd17f6d211c04136239e1db630e1ab320a6e41bd5c18533c44381519842c"
   "1.3.6":
     url: "https://github.com/opentdf/client-cpp/archive/1.3.6.tar.gz"
     sha256: "e0d4cf1d0b1824d903a2b0ec1da528acb42623e32f3ca36aa28b2e950c3cc7a0"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.8":
+    folder: all
   "1.3.6":
     folder: all
   "1.3.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  opentdf-client/1.3.8

- Remote Content Architecture(RCA) support in C++ Open SDK

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
