### PR TITLE
opencolorio: add version 2.2.1, support conan v2, support C++20 in 2.1.0

### DIFF
--- a/recipes/opencolorio/all/CMakeLists.txt
+++ b/recipes/opencolorio/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory("source_subfolder")

--- a/recipes/opencolorio/all/conandata.yml
+++ b/recipes/opencolorio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.1":
+    url: "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v2.2.1.tar.gz"
+    sha256: "36f27c5887fc4e5c241805c29b8b8e68725aa05520bcaa7c7ec84c0422b8580e"
   "2.1.0":
     url: "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v2.1.0.tar.gz"
     sha256: "81fc7853a490031632a69c73716bc6ac271b395e2ba0e2587af9995c2b0efb5f"
@@ -6,13 +9,31 @@ sources:
     url: "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v1.1.1.tar.gz"
     sha256: "c9b5b9def907e1dafb29e37336b702fff22cc6306d445a13b1621b8a754c14c8"
 patches:
+  "2.2.1":
+    - patch_file: "patches/2.2.1-0001-fix-cmake-source-dir-and-targets.patch"
+      patch_description: "use cci package, use PROJECT_BINARY_DIR/PROJECT_SOURCE_DIR"
+      patch_type: "conan"
+    - patch_file: "patches/2.2.1-0002-fix-pystring.patch"
+      patch_description: "fix include path for pystring"
+      patch_type: "conan"
+    - patch_file: "patches/2.2.1-0003-strlen.patch"
+      patch_description: "add std namespace for strlen"
+      patch_type: "portability"
   "2.1.0":
-    - patch_file: "patches/fix-cmake-source-dir-and-targets.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/pstring.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/strlen.patch"
-      base_path: "source_subfolder"
+    - patch_file: "patches/2.1.0-0001-fix-cmake-source-dir-and-targets.patch"
+      patch_description: "use cci package, use PROJECT_BINARY_DIR/PROJECT_SOURCE_DIR"
+      patch_type: "conan"
+    - patch_file: "patches/2.1.0-0002-fix-pystring.patch"
+      patch_description: "fix include path for pystring"
+      patch_type: "conan"
+    - patch_file: "patches/2.1.0-0003-strlen.patch"
+      patch_description: "include string.h for strlen"
+      patch_type: "portability"
+    - patch_file: "patches/2.1.0-0004-fix-cpp-version-check.patch"
+      patch_description: "fix C++20 compilation error"
+      patch_type: "portability"
+      patch_source: "https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1542"
   "1.1.1":
-    - patch_file: "patches/1.1.1.patch"
-      base_path: "source_subfolder"
+    - patch_file: "patches/1.1.1-fix-cmake.patch"
+      patch_description: "use cci package, use PROJECT_BINARY_DIR/PROJECT_SOURCE_DIR"
+      patch_type: "conan"

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -69,7 +69,8 @@ class OpenColorIOConan(ConanFile):
             check_min_cppstd(self, 11)
 
         # opencolorio>=2.2.0 requires minizip-ng with with_zlib
-        if Version(self.version) >= "2.2.0" and self.options["minizip-ng"].get_safe("with_zlib") == False:
+        if Version(self.version) >= "2.2.0" and \
+            not self.dependencies["minizip-ng"].options.get_safe("with_zlib", False):
             raise ConanInvalidConfiguration(f"{self.ref} requires minizip-ng with with_zlib = True.")
 
     def build_requirements(self):

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -56,9 +56,9 @@ class OpenColorIOConan(ConanFile):
             self.requires("tinyxml/2.6.2")
         else:
             self.requires("pystring/1.1.4")
-        self.requires("imath/3.1.6")
+        self.requires("imath/3.1.8")
         if Version(self.version) >= "2.2.0":
-            self.requires("minizip-ng/3.0.9")
+            self.requires("minizip-ng/4.0.0")
 
         # for tools only
         self.requires("lcms/2.14")
@@ -78,7 +78,7 @@ class OpenColorIOConan(ConanFile):
             self.tool_requires("cmake/[>=3.16 <4]")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -50,7 +50,7 @@ class OpenColorIOConan(ConanFile):
         if Version(self.version) < "2.2.0":
             self.requires("openexr/2.5.7")
         else:
-            self.requires("openexr/3.1.5")
+            self.requires("openexr/3.1.7")
         self.requires("yaml-cpp/0.7.0")
         if Version(self.version) < "2.0.0":
             self.requires("tinyxml/2.6.2")
@@ -58,7 +58,7 @@ class OpenColorIOConan(ConanFile):
             self.requires("pystring/1.1.4")
         self.requires("imath/3.1.6")
         if Version(self.version) >= "2.2.0":
-            self.requires("minizip-ng/3.0.8")
+            self.requires("minizip-ng/3.0.9")
 
         # for tools only
         self.requires("lcms/2.14")

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -44,8 +44,8 @@ class OpenColorIOConan(ConanFile):
         if Version(self.version) >= "2.2.0":
             # in Apple OS, minizip-ng/with_libcomp=True deletes minizip-ng/with_zlib options.
             if is_apple_os(self):
-                self.options["minizip-ng/*"].with_libcomp = False
-            self.options["minizip-ng/*"].with_zlib = True
+                self.options["minizip-ng"].with_libcomp = False
+            self.options["minizip-ng"].with_zlib = True
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.tools.microsoft import is_msvc
+from conan.tools.apple import is_apple_os
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
@@ -39,6 +40,12 @@ class OpenColorIOConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        # opencolorio>=2.2.0 requires minizip-ng with with_zlib
+        if Version(self.version) >= "2.2.0":
+            # in Apple OS, minizip-ng/with_libcomp=True deletes minizip-ng/with_zlib options.
+            if is_apple_os(self):
+                self.options["minizip-ng/*"].with_libcomp = False
+            self.options["minizip-ng/*"].with_zlib = True
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -75,6 +75,8 @@ class OpenColorIOConan(ConanFile):
 
         if Version(self.version) == "1.1.1" and self.options.shared and self.dependencies["yaml-cpp"].options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} requires static build yaml-cpp")
+        if Version(self.version) == "2.2.1" and self.options.shared and self.dependencies["minizip-ng"].options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} requires static build minizip-ng")
 
     def build_requirements(self):
         if Version(self.version) >= "2.2.0":

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -66,6 +66,10 @@ class OpenColorIOConan(ConanFile):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 11)
 
+    def build_requirements(self):
+        if Version(self.version) >= "2.2.0":
+            self.tool_requires("cmake/[>=3.16 <4]")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -73,6 +73,9 @@ class OpenColorIOConan(ConanFile):
             not self.dependencies["minizip-ng"].options.get_safe("with_zlib", False):
             raise ConanInvalidConfiguration(f"{self.ref} requires minizip-ng with with_zlib = True.")
 
+        if Version(self.version) == "1.1.1" and self.options.shared and self.dependencies["yaml-cpp"].options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} requires static build yaml-cpp")
+
     def build_requirements(self):
         if Version(self.version) >= "2.2.0":
             self.tool_requires("cmake/[>=3.16 <4]")
@@ -82,6 +85,7 @@ class OpenColorIOConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["CMAKE_VERBOSE_MAKEFILE"] = True
         if Version(self.version) >= "2.1.0":
             tc.variables["OCIO_BUILD_PYTHON"] = False
         else:

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -56,9 +56,9 @@ class OpenColorIOConan(ConanFile):
             self.requires("tinyxml/2.6.2")
         else:
             self.requires("pystring/1.1.4")
-        self.requires("imath/3.1.8")
+        self.requires("imath/3.1.6")
         if Version(self.version) >= "2.2.0":
-            self.requires("minizip-ng/4.0.0")
+            self.requires("minizip-ng/3.0.7")
 
         # for tools only
         self.requires("lcms/2.14")

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -1,10 +1,12 @@
+from conan import ConanFile
 from conan.tools.microsoft import is_msvc
-from conans import ConanFile, CMake, tools
-import functools
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.45.0"
-
+required_conan_version = ">=1.53.0"
 
 class OpenColorIOConan(ConanFile):
     name = "opencolorio"
@@ -13,7 +15,6 @@ class OpenColorIOConan(ConanFile):
     homepage = "https://opencolorio.org/"
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("colors", "visual", "effects", "animation")
-
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -26,20 +27,8 @@ class OpenColorIOConan(ConanFile):
         "use_sse": True,
     }
 
-    generators = "cmake", "cmake_find_package"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -49,96 +38,109 @@ class OpenColorIOConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("expat/2.4.8")
-        self.requires("openexr/2.5.7")
+        self.requires("expat/2.5.0")
+        if Version(self.version) < "2.2.0":
+            self.requires("openexr/2.5.7")
+        else:
+            self.requires("openexr/3.1.5")
         self.requires("yaml-cpp/0.7.0")
-        if tools.Version(self.version) < "2.0.0":
+        if Version(self.version) < "2.0.0":
             self.requires("tinyxml/2.6.2")
         else:
-            self.requires("pystring/1.1.3")
+            self.requires("pystring/1.1.4")
+        self.requires("imath/3.1.6")
+        if Version(self.version) >= "2.2.0":
+            self.requires("minizip-ng/3.0.8")
+
         # for tools only
-        self.requires("lcms/2.13.1")
+        self.requires("lcms/2.14")
         # TODO: add GLUT (needed for ociodisplay tool)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
+            check_min_cppstd(self, 11)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-
-        if tools.Version(self.version) >= "2.1.0":
-            cmake.definitions["OCIO_BUILD_PYTHON"] = False
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if Version(self.version) >= "2.1.0":
+            tc.variables["OCIO_BUILD_PYTHON"] = False
         else:
-            cmake.definitions["OCIO_BUILD_SHARED"] = self.options.shared
-            cmake.definitions["OCIO_BUILD_STATIC"] = not self.options.shared
-            cmake.definitions["OCIO_BUILD_PYGLUE"] = False
+            tc.variables["OCIO_BUILD_SHARED"] = self.options.shared
+            tc.variables["OCIO_BUILD_STATIC"] = not self.options.shared
+            tc.variables["OCIO_BUILD_PYGLUE"] = False
 
-            cmake.definitions["USE_EXTERNAL_YAML"] = True
-            cmake.definitions["USE_EXTERNAL_TINYXML"] = True
-            cmake.definitions["USE_EXTERNAL_LCMS"] = True
+            tc.variables["USE_EXTERNAL_YAML"] = True
+            tc.variables["USE_EXTERNAL_TINYXML"] = True
+            tc.variables["TINYXML_OBJECT_LIB_EMBEDDED"] = False
+            tc.variables["USE_EXTERNAL_LCMS"] = True
 
-        cmake.definitions["OCIO_USE_SSE"] = self.options.get_safe("use_sse", False)
+        tc.variables["OCIO_USE_SSE"] = self.options.get_safe("use_sse", False)
 
         # openexr 2.x provides Half library
-        cmake.definitions["OCIO_USE_OPENEXR_HALF"] = True
+        tc.variables["OCIO_USE_OPENEXR_HALF"] = True
 
-        cmake.definitions["OCIO_BUILD_APPS"] = True
-        cmake.definitions["OCIO_BUILD_DOCS"] = False
-        cmake.definitions["OCIO_BUILD_TESTS"] = False
-        cmake.definitions["OCIO_BUILD_GPU_TESTS"] = False
-        cmake.definitions["OCIO_USE_BOOST_PTR"] = False
+        tc.variables["OCIO_BUILD_APPS"] = True
+        tc.variables["OCIO_BUILD_DOCS"] = False
+        tc.variables["OCIO_BUILD_TESTS"] = False
+        tc.variables["OCIO_BUILD_GPU_TESTS"] = False
+        tc.variables["OCIO_USE_BOOST_PTR"] = False
 
         # avoid downloading dependencies
-        cmake.definitions["OCIO_INSTALL_EXT_PACKAGE"] = "NONE"
+        tc.variables["OCIO_INSTALL_EXT_PACKAGE"] = "NONE"
 
         if is_msvc(self) and not self.options.shared:
             # define any value because ifndef is used
-            cmake.definitions["OpenColorIO_SKIP_IMPORTS"] = True
+            tc.variables["OpenColorIO_SKIP_IMPORTS"] = True
 
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        apply_conandata_patches(self)
 
-        for module in ("expat", "lcms2", "pystring", "yaml-cpp", "Imath"):
-            tools.remove_files_by_mask(os.path.join(self._source_subfolder, "share", "cmake", "modules"), "Find"+module+".cmake")
+        for module in ("expat", "lcms2", "pystring", "yaml-cpp", "Imath", "minizip-ng"):
+            rm(self, "Find"+module+".cmake", os.path.join(self.source_folder, "share", "cmake", "modules"))
 
     def build(self):
         self._patch_sources()
 
-        cm = self._configure_cmake()
+        cm = CMake(self)
+        cm.configure()
         cm.build()
 
     def package(self):
-        cm = self._configure_cmake()
+        cm = CMake(self)
         cm.install()
 
         if not self.options.shared:
-            self.copy("*", src=os.path.join(self.package_folder,
-                      "lib", "static"), dst="lib")
-            tools.rmdir(os.path.join(self.package_folder, "lib", "static"))
+            copy(self, "*",
+                src=os.path.join(self.package_folder, "lib", "static"),
+                dst=os.path.join(self.package_folder, "lib"))
+            rmdir(self, os.path.join(self.package_folder, "lib", "static"))
 
-        tools.rmdir(os.path.join(self.package_folder, "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
         # nop for 2.x
-        tools.remove_files_by_mask(self.package_folder, "OpenColorIOConfig*.cmake")
+        rm(self, "OpenColorIOConfig*.cmake", self.package_folder)
 
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
 
-        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "OpenColorIO")
@@ -147,7 +149,7 @@ class OpenColorIOConan(ConanFile):
 
         self.cpp_info.libs = ["OpenColorIO"]
 
-        if tools.Version(self.version) < "2.1.0":
+        if Version(self.version) < "2.1.0":
             if not self.options.shared:
                 self.cpp_info.defines.append("OpenColorIO_STATIC")
 

--- a/recipes/opencolorio/all/patches/1.1.1-fix-cmake.patch
+++ b/recipes/opencolorio/all/patches/1.1.1-fix-cmake.patch
@@ -1,0 +1,287 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e4f3119..9eb6d07 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,14 +1,16 @@
++cmake_minimum_required(VERSION 2.8)
+ project(OpenColorIO)
+ set(OCIO_VERSION_MAJOR 1)
+ set(OCIO_VERSION_MINOR 1)
+ set(OCIO_VERSION_PATCH 1)
+ 
+-cmake_minimum_required(VERSION 2.8)
+-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/share/cmake)
++list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/share/cmake)
+ if(NOT DEFINED CMAKE_FIRST_RUN)
+     SET(CMAKE_FIRST_RUN 1 CACHE INTERNAL "")
+ endif()
+ 
++set(CMAKE_CXX_STANDARD 11)
++
+ ###############################################################################
+ ### GLOBAL ###
+ 
+@@ -142,11 +144,11 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
+ ###############################################################################
+ ### Python ###
+ 
+-OCIOFindPython()
++#OCIOFindPython()
+ 
+ # Find Python, used for (possibly) building pyglue, and now to
+ # construct the external project path
+-set(EXTDIST_ROOT ${CMAKE_BINARY_DIR}/ext/dist)
++set(EXTDIST_ROOT ${PROJECT_BINARY_DIR}/ext/dist)
+ set(EXTDIST_BINPATH ${EXTDIST_ROOT}/bin)
+ if(PYTHON_OK)
+     set(EXTDIST_PYTHONPATH ${EXTDIST_ROOT}/${PYTHON_VARIANT_PATH})
+@@ -170,7 +172,12 @@ messageonce("Setting EXTDIST_PYTHONPATH: ${EXTDIST_PYTHONPATH}")
+ 
+ if(USE_EXTERNAL_TINYXML)
+     set(TINYXML_VERSION_MIN "2.6.1")
+-    find_package(TinyXML)
++    find_package(TinyXML REQUIRED)
++    set(TINYXML_FOUND ${TinyXML_FOUND})
++    set(TINYXML_LIBRARIES tinyxml::tinyxml)
++    set(TINYXML_VERSION "${TinyXML_VERSION}")
++    list(APPEND EXTERNAL_LIBRARIES ${TINYXML_LIBRARIES})
++
+     if(TINYXML_FOUND)
+         if(TINYXML_VERSION VERSION_EQUAL ${TINYXML_VERSION_MIN} OR
+            TINYXML_VERSION VERSION_GREATER ${TINYXML_VERSION_MIN})
+@@ -251,6 +258,13 @@ endif(USE_EXTERNAL_TINYXML)
+ if(USE_EXTERNAL_YAML)
+     # Set minimum yaml version for non-patched sources.
+     set(YAML_VERSION_MIN "0.3.0")
++    find_package(yaml-cpp REQUIRED)
++    set(YAML_CPP_INCLUDE_DIRS "${CONAN_INCLUDE_DIRS_YAML-CPP}")
++    set(YAML_CPP_LIBRARIES yaml-cpp)
++    set(YAML_CPP_VERSION "${yaml-cpp_VERSION}")
++    list(APPEND EXTERNAL_LIBRARIES ${YAML_CPP_LIBRARIES})
++
++    if(0)
+     include(FindPkgConfig)
+     pkg_check_modules(PC_YAML_CPP REQUIRED QUIET yaml-cpp)
+     find_path(YAML_CPP_INCLUDE_DIR yaml-cpp/yaml.h
+@@ -293,6 +307,7 @@ if(USE_EXTERNAL_YAML)
+     else(YAML_CPP_FOUND)
+         message(FATAL_ERROR "ERROR: System yaml-cpp library was not found. Make sure the library is installed and the pkg-config file exists.")
+     endif(YAML_CPP_FOUND)
++    endif()
+ else(USE_EXTERNAL_YAML) ## provide 2 ways to build this dependency
+     set(YAML_CPP_VERSION 0.3.0)
+     set(YAML_CPP_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/ext/dist -DYAML_CPP_BUILD_TOOLS:BOOL=FALSE -DOCIO_INLINES_HIDDEN:BOOL=${OCIO_INLINES_HIDDEN})
+@@ -384,7 +399,7 @@ else()
+     set(OCIO_INLINES_HIDDEN OFF)
+ endif()
+ 
+-set(EXTERNAL_COMPILE_FLAGS "-DTIXML_USE_STL ${YAML_CPP_COMPILE_FLAGS} ${GCC_COMPILE_FLAGS}")
++set(EXTERNAL_COMPILE_FLAGS "${YAML_CPP_COMPILE_FLAGS} ${GCC_COMPILE_FLAGS}")
+ 
+ set(EXTERNAL_LINK_FLAGS "")
+ set(EXTERNAL_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)
+@@ -460,7 +475,7 @@ endif()
+ if(OCIO_BUILD_APPS AND (OCIO_BUILD_STATIC OR OCIO_BUILD_SHARED) )
+ 
+     # Try to find OpenImageIO (OIIO) and OpenGL stuff
+-    OCIOFindOpenImageIO()
++    #OCIOFindOpenImageIO()
+     
+     if(OIIO_FOUND)
+         add_subdirectory(src/apps/ocioconvert)
+@@ -528,7 +543,7 @@ endif()
+ 
+ ###############################################################################
+ ### Configure env script ###
+-configure_file(${CMAKE_SOURCE_DIR}/share/ocio/setup_ocio.sh.in
++configure_file(${PROJECT_SOURCE_DIR}/share/ocio/setup_ocio.sh.in
+     ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh @ONLY)
+ 
+ INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh DESTINATION share/ocio/)
+@@ -597,7 +612,7 @@ if(TARGET OpenColorIO_STATIC)
+     endif()
+ endif()
+ install(EXPORT OpenColorIO DESTINATION cmake)
+-file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
++file(WRITE "${PROJECT_BINARY_DIR}/OpenColorIOConfig.cmake"
+     "
+     get_filename_component(OpenColorIO_DIR \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)
+     
+@@ -646,4 +661,4 @@ file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
+     message(STATUS OPENCOLORIO_FOUND=\${OPENCOLORIO_FOUND})
+     "
+ )
+-install(FILES "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake" DESTINATION .)
++install(FILES "${PROJECT_BINARY_DIR}/OpenColorIOConfig.cmake" DESTINATION .)
+diff --git a/share/cmake/OCIOMacros.cmake b/share/cmake/OCIOMacros.cmake
+index b9fb239..b1a206e 100644
+--- a/share/cmake/OCIOMacros.cmake
++++ b/share/cmake/OCIOMacros.cmake
+@@ -356,9 +356,9 @@ ENDMACRO()
+ 
+ MACRO(ExtractRstCPP INFILE OUTFILE)
+    add_custom_command(
+-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
++      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+       OUTPUT ${OUTFILE}
+-      COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceCPP.py ${INFILE} ${OUTFILE}
++      COMMAND ${PYTHON} ${PROJECT_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceCPP.py ${INFILE} ${OUTFILE}
+       DEPENDS ${INFILE}
+       COMMENT "Extracting reStructuredText from ${INFILE} (using old process)"
+    )
+@@ -366,9 +366,9 @@ ENDMACRO()
+ 
+ MACRO(ExtractRstSimple INFILE OUTFILE)
+    add_custom_command(
+-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
++      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+       OUTPUT ${OUTFILE}
+-      COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceSimple.py ${INFILE} ${OUTFILE}
++      COMMAND ${PYTHON} ${PROJECT_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceSimple.py ${INFILE} ${OUTFILE}
+       DEPENDS ${INFILE}
+       COMMENT "Extracting reStructuredText from ${INFILE}"
+    )
+diff --git a/src/apps/ociobakelut/CMakeLists.txt b/src/apps/ociobakelut/CMakeLists.txt
+index d31b4e3..4aa1efb 100644
+--- a/src/apps/ociobakelut/CMakeLists.txt
++++ b/src/apps/ociobakelut/CMakeLists.txt
+@@ -1,6 +1,10 @@
+ # LCMS
+-include(FindPkgConfig FindPackageMessage)
+-pkg_check_modules(LCMS QUIET lcms2)
++find_package(lcms REQUIRED)
++set(LCMS_FOUND ${lcms_FOUND})
++set(LCMS_VERSION ${lcms_VERSION})
++set(LCMS_LIBRARIES ${lcms_LIBRARIES})
++set(LCMS_INCLUDE_DIR ${lcms_INCLUDE_DIR})
++
+ if(LCMS_FOUND AND (LCMS_VERSION VERSION_EQUAL 2.1 OR LCMS_VERSION VERSION_GREATER 2.1))
+     FIND_PACKAGE_MESSAGE(LCMS "Found lcms: ${LCMS_LIBRARIES}"
+         "${LCMS_INCLUDE_DIR}")
+@@ -29,12 +33,12 @@ else()
+     set(LCMS_LIBRARIES 		${PROJECT_BINARY_DIR}/ext/dist/lib/${CMAKE_STATIC_LIBRARY_PREFIX}lcms2${CMAKE_STATIC_LIBRARY_SUFFIX})
+ endif()
+ 
+-file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")
++file(GLOB_RECURSE share_src_files "${PROJECT_SOURCE_DIR}/src/apps/share/*.cpp")
+ 
+ include_directories(
+-    ${CMAKE_SOURCE_DIR}/export/
+-    ${CMAKE_BINARY_DIR}/export/
+-    ${CMAKE_SOURCE_DIR}/src/apps/share/
++    ${PROJECT_SOURCE_DIR}/export/
++    ${PROJECT_BINARY_DIR}/export/
++    ${PROJECT_SOURCE_DIR}/src/apps/share/
+     ${LCMS_INCLUDE_DIRS}
+     ${Boost_INCLUDE_DIR}
+ )
+diff --git a/src/apps/ociocheck/CMakeLists.txt b/src/apps/ociocheck/CMakeLists.txt
+index 4955f4d..14b5017 100644
+--- a/src/apps/ociocheck/CMakeLists.txt
++++ b/src/apps/ociocheck/CMakeLists.txt
+@@ -1,9 +1,9 @@
+-file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")
++file(GLOB_RECURSE share_src_files "${PROJECT_SOURCE_DIR}/src/apps/share/*.cpp")
+ 
+ include_directories(
+-    ${CMAKE_SOURCE_DIR}/export/
+-    ${CMAKE_BINARY_DIR}/export/
+-    ${CMAKE_SOURCE_DIR}/src/apps/share/
++    ${PROJECT_SOURCE_DIR}/export/
++    ${PROJECT_BINARY_DIR}/export/
++    ${PROJECT_SOURCE_DIR}/src/apps/share/
+     ${Boost_INCLUDE_DIR}
+     )
+ 
+diff --git a/src/core/CDLTransform.cpp b/src/core/CDLTransform.cpp
+index 8b05deb..a7d6031 100644
+--- a/src/core/CDLTransform.cpp
++++ b/src/core/CDLTransform.cpp
+@@ -126,7 +126,11 @@ OCIO_NAMESPACE_ENTER
+             TiXmlPrinter printer;
+             printer.SetStreamPrinting();
+             doc.Accept( &printer );
+-            return printer.Str();
++            #ifdef TIXML_USE_STL
++                return printer.Str();
++            #else
++                return printer.CStr();
++            #endif
+         }
+     }
+     
+diff --git a/src/core/CMakeLists.txt b/src/core/CMakeLists.txt
+index 1eb691b..a2f099a 100644
+--- a/src/core/CMakeLists.txt
++++ b/src/core/CMakeLists.txt
+@@ -2,29 +2,29 @@
+ ### OCIO CORE ###
+ 
+ include_directories(
+-    ${CMAKE_SOURCE_DIR}/export/
+-    ${CMAKE_BINARY_DIR}/export/
+-    ${CMAKE_SOURCE_DIR}/ext/oiio/src/include
++    ${PROJECT_SOURCE_DIR}/export/
++    ${PROJECT_BINARY_DIR}/export/
++    ${PROJECT_SOURCE_DIR}/ext/oiio/src/include
+     ${EXTERNAL_INCLUDE_DIRS}
+ )
+ 
+-file(GLOB_RECURSE core_src_files "${CMAKE_SOURCE_DIR}/src/core/*.cpp")
+-file(GLOB_RECURSE core_export_headers "${CMAKE_SOURCE_DIR}/export/OpenColorIO/*.h")
++file(GLOB_RECURSE core_src_files "${PROJECT_SOURCE_DIR}/src/core/*.cpp")
++file(GLOB_RECURSE core_export_headers "${PROJECT_SOURCE_DIR}/export/OpenColorIO/*.h")
+ 
+ message(STATUS "Create OpenColorABI.h from OpenColorABI.h.in")
+-configure_file(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorABI.h.in
+-    ${CMAKE_BINARY_DIR}/export/OpenColorABI.h @ONLY)
+-list(APPEND core_export_headers ${CMAKE_BINARY_DIR}/export/OpenColorABI.h)
++configure_file(${PROJECT_SOURCE_DIR}/export/OpenColorIO/OpenColorABI.h.in
++    ${PROJECT_BINARY_DIR}/export/OpenColorABI.h @ONLY)
++list(APPEND core_export_headers ${PROJECT_BINARY_DIR}/export/OpenColorABI.h)
+ 
+ # Process all warnings as errors
+ 
+ if(WIN32)
+     # On debug mode there are other kinds of warning...
+     if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+-        set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} /WX")
++        # set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} /WX")
+     endif()
+ else()
+-    set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} -Werror")
++    # set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} -Werror")
+ endif()
+ 
+ # SHARED
+@@ -75,7 +75,7 @@ endif()
+ # STATIC
+ 
+ if(OCIO_BUILD_STATIC)
+-    list(REMOVE_ITEM core_src_files ${CMAKE_SOURCE_DIR}/src/core/UnitTest.cpp)
++    list(REMOVE_ITEM core_src_files ${PROJECT_SOURCE_DIR}/src/core/UnitTest.cpp)
+     add_library(OpenColorIO_STATIC STATIC ${EXTERNAL_OBJECTS} ${core_src_files})
+     add_dependencies(OpenColorIO_STATIC TINYXML_LIB YAML_CPP_LIB)
+     if(EXTERNAL_LIBRARIES)
+@@ -113,7 +113,7 @@ install(FILES ${core_export_headers}
+ 
+ # pkg-config
+ message(STATUS "Create OpenColorIO.pc from OpenColorIO.pc.in")
+-configure_file(${CMAKE_SOURCE_DIR}/export/pkgconfig/OpenColorIO.pc.in
++configure_file(${PROJECT_SOURCE_DIR}/export/pkgconfig/OpenColorIO.pc.in
+     ${CMAKE_CURRENT_BINARY_DIR}/OpenColorIO.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenColorIO.pc
+     DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib${LIB_SUFFIX}/pkgconfig/)
+diff --git a/src/core/OCIOYaml.cpp b/src/core/OCIOYaml.cpp
+index 68fcef6..a1c1c1d 100644
+--- a/src/core/OCIOYaml.cpp
++++ b/src/core/OCIOYaml.cpp
+@@ -1442,7 +1442,7 @@ OCIO_NAMESPACE_ENTER
+ #ifdef OLDYAML
+             if(node.FindValue("ocio_profile_version") == NULL)
+ #else
+-            if(node["ocio_profile_version"] == NULL)
++            if(node["ocio_profile_version"].IsNull())
+ #endif
+             {
+                 std::ostringstream os;

--- a/recipes/opencolorio/all/patches/2.1.0-0001-fix-cmake-source-dir-and-targets.patch
+++ b/recipes/opencolorio/all/patches/2.1.0-0001-fix-cmake-source-dir-and-targets.patch
@@ -1,0 +1,61 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b0840ac..e4875ab 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,9 +9,9 @@ cmake_minimum_required(VERSION 3.12)
+ 
+ set(CMAKE_MODULE_PATH
+     ${CMAKE_MODULE_PATH}
+-    ${CMAKE_SOURCE_DIR}/share/cmake/utils
+-    ${CMAKE_SOURCE_DIR}/share/cmake/macros
+-    ${CMAKE_SOURCE_DIR}/share/cmake/modules
++    ${CMAKE_CURRENT_SOURCE_DIR}/share/cmake/utils
++    ${CMAKE_CURRENT_SOURCE_DIR}/share/cmake/macros
++    ${CMAKE_CURRENT_SOURCE_DIR}/share/cmake/modules
+ )
+ 
+ set(CMAKE_WARN_DEPRECATED ON)
+@@ -272,7 +272,7 @@ else()
+     set(OCIO_SETUP_NAME setup_ocio.sh)
+ endif()
+ 
+-configure_file(${CMAKE_SOURCE_DIR}/share/ocio/${OCIO_SETUP_NAME}.in
++configure_file(${PROJECT_SOURCE_DIR}/share/ocio/${OCIO_SETUP_NAME}.in
+     ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/${OCIO_SETUP_NAME} @ONLY)
+ 
+ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/${OCIO_SETUP_NAME} DESTINATION share/ocio/)
+diff --git a/share/cmake/modules/FindExtPackages.cmake b/share/cmake/modules/FindExtPackages.cmake
+index 86a0225..73d8599 100644
+--- a/share/cmake/modules/FindExtPackages.cmake
++++ b/share/cmake/modules/FindExtPackages.cmake
+@@ -50,7 +50,7 @@ else()
+ 
+     # OpenEXR/IlmBase (<=2.5)
+     # https://github.com/AcademySoftwareFoundation/openexr
+-    find_package(Half 2.4.0 REQUIRED)
++    find_package(OpenEXR 2.4.0 REQUIRED)
+ 
+     set(OCIO_HALF_LIB IlmBase::Half CACHE STRING "Half library target" FORCE)
+     set(OCIO_USE_IMATH_HALF "0" CACHE STRING "Whether 'half' type will be sourced from the Imath library (>=v3.0)" FORCE)
+@@ -65,7 +65,7 @@ if(OCIO_BUILD_APPS)
+ 
+     # lcms2
+     # https://github.com/mm2/Little-CMS
+-    find_package(lcms2 2.2 REQUIRED)
++    find_package(lcms 2.2 REQUIRED)
+ endif()
+ 
+ if(OCIO_BUILD_OPENFX)
+diff --git a/src/apps/ociobakelut/CMakeLists.txt b/src/apps/ociobakelut/CMakeLists.txt
+index 7eb1cd8..de13607 100755
+--- a/src/apps/ociobakelut/CMakeLists.txt
++++ b/src/apps/ociobakelut/CMakeLists.txt
+@@ -35,7 +35,7 @@ set_target_properties(ociobakelut
+ target_link_libraries(ociobakelut 
+     PRIVATE 
+         apputils
+-        lcms2::lcms2
++        lcms::lcms
+         OpenColorIO
+ )
+ 

--- a/recipes/opencolorio/all/patches/2.1.0-0002-fix-pystring.patch
+++ b/recipes/opencolorio/all/patches/2.1.0-0002-fix-pystring.patch
@@ -1,0 +1,117 @@
+diff --git a/src/OpenColorIO/Context.cpp b/src/OpenColorIO/Context.cpp
+index 26fdcbee..9ddb4522 100644
+--- a/src/OpenColorIO/Context.cpp
++++ b/src/OpenColorIO/Context.cpp
+@@ -14,7 +14,7 @@
+ #include "Mutex.h"
+ #include "PathUtils.h"
+ #include "PrivateTypes.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ 
+ 
+diff --git a/src/OpenColorIO/OCIOYaml.cpp b/src/OpenColorIO/OCIOYaml.cpp
+index 67cafdf1..744fb817 100644
+--- a/src/OpenColorIO/OCIOYaml.cpp
++++ b/src/OpenColorIO/OCIOYaml.cpp
+@@ -19,7 +19,7 @@
+ #include "ParseUtils.h"
+ #include "PathUtils.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ #include "ViewingRules.h"
+ #include "yaml-cpp/yaml.h"
+diff --git a/src/OpenColorIO/Op.cpp b/src/OpenColorIO/Op.cpp
+index ebbba040..08db0f68 100755
+--- a/src/OpenColorIO/Op.cpp
++++ b/src/OpenColorIO/Op.cpp
+@@ -20,7 +20,7 @@
+ #include "ops/lut1d/Lut1DOp.h"
+ #include "ops/lut3d/Lut3DOp.h"
+ #include "ops/range/RangeOp.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ 
+ namespace OCIO_NAMESPACE
+ {
+diff --git a/src/OpenColorIO/PathUtils.cpp b/src/OpenColorIO/PathUtils.cpp
+index 7ed5e9e8..e71d03d9 100644
+--- a/src/OpenColorIO/PathUtils.cpp
++++ b/src/OpenColorIO/PathUtils.cpp
+@@ -10,7 +10,7 @@
+ 
+ #include "Mutex.h"
+ #include "PathUtils.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ 
+ #if !defined(_WIN32)
+diff --git a/src/OpenColorIO/fileformats/FileFormatCTF.cpp b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+index 89c13066..648aabc0 100644
+--- a/src/OpenColorIO/fileformats/FileFormatCTF.cpp
++++ b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+@@ -22,7 +22,7 @@
+ #include "OpBuilders.h"
+ #include "ops/noop/NoOps.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "TransformBuilder.h"
+ #include "transforms/FileTransform.h"
+ #include "utils/StringUtils.h"
+diff --git a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+index a52bc728..bd827f06 100755
+--- a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
++++ b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+@@ -16,7 +16,7 @@
+ #include "ops/lut1d/Lut1DOp.h"
+ #include "ops/lut3d/Lut3DOp.h"
+ #include "ParseUtils.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "Platform.h"
+ #include "transforms/FileTransform.h"
+ #include "utils/StringUtils.h"
+diff --git a/src/OpenColorIO/fileformats/FileFormatICC.cpp b/src/OpenColorIO/fileformats/FileFormatICC.cpp
+index df86206e..b6983cf6 100755
+--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
++++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
+@@ -12,7 +12,7 @@
+ #include "ops/gamma/GammaOp.h"
+ #include "ops/lut1d/Lut1DOp.h"
+ #include "ops/matrix/MatrixOp.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "transforms/FileTransform.h"
+ 
+ 
+diff --git a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+index 0f83f5b3..d6ee59de 100755
+--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
++++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+@@ -13,7 +13,7 @@
+ #include "ops/lut3d/Lut3DOp.h"
+ #include "ParseUtils.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "transforms/FileTransform.h"
+ #include "utils/StringUtils.h"
+ 
+diff --git a/src/OpenColorIO/transforms/FileTransform.cpp b/src/OpenColorIO/transforms/FileTransform.cpp
+index 4f6ea887..97621959 100755
+--- a/src/OpenColorIO/transforms/FileTransform.cpp
++++ b/src/OpenColorIO/transforms/FileTransform.cpp
+@@ -17,7 +17,7 @@
+ #include "ops/noop/NoOps.h"
+ #include "PathUtils.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ 
+ 

--- a/recipes/opencolorio/all/patches/2.1.0-0003-strlen.patch
+++ b/recipes/opencolorio/all/patches/2.1.0-0003-strlen.patch
@@ -1,0 +1,12 @@
+diff --git a/src/OpenColorIO/FileRules.cpp b/src/OpenColorIO/FileRules.cpp
+index 794dfdbe..94729459 100644
+--- a/src/OpenColorIO/FileRules.cpp
++++ b/src/OpenColorIO/FileRules.cpp
+@@ -6,6 +6,7 @@
+ #include <map>
+ #include <regex>
+ #include <sstream>
++#include <string.h>
+ 
+ #include <OpenColorIO/OpenColorIO.h>
+ 

--- a/recipes/opencolorio/all/patches/2.1.0-0004-fix-cpp-version-check.patch
+++ b/recipes/opencolorio/all/patches/2.1.0-0004-fix-cpp-version-check.patch
@@ -1,0 +1,18 @@
+diff --git a/share/cmake/utils/CppVersion.cmake b/share/cmake/utils/CppVersion.cmake
+index aeca6c0..6b4dc4e 100644
+--- a/share/cmake/utils/CppVersion.cmake
++++ b/share/cmake/utils/CppVersion.cmake
+@@ -12,11 +12,11 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
+     message(STATUS "Setting C++ version to '11' as none was specified.")
+     set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard to compile against")
+ elseif(NOT CMAKE_CXX_STANDARD IN_LIST SUPPORTED_CXX_STANDARDS)
+-    message(FATAL_ERROR 
++    message(WARNING
+             "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is unsupported. Supported standards are: ${SUPPORTED_CXX_STANDARDS_STR}.")
+ endif()
+ 
+-set_property(CACHE CMAKE_CXX_STANDARD PROPERTY STRINGS "${SUPPORTED_CXX_STANDARDS}")
++#set_property(CACHE CMAKE_CXX_STANDARD PROPERTY STRINGS "${SUPPORTED_CXX_STANDARDS}")
+ 
+ include(CheckCXXCompilerFlag)
+ 

--- a/recipes/opencolorio/all/patches/2.2.1-0001-fix-cmake-source-dir-and-targets.patch
+++ b/recipes/opencolorio/all/patches/2.2.1-0001-fix-cmake-source-dir-and-targets.patch
@@ -1,0 +1,87 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 17e188d..4cf9fb6 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -332,7 +332,7 @@ install(
+     FILE ${OCIO_TARGETS_EXPORT_NAME}
+ )
+ 
+-if (NOT BUILD_SHARED_LIBS)
++if (0)
+     # Install custom macros used in the find modules.
+     install(FILES
+         ${CMAKE_CURRENT_LIST_DIR}/share/cmake/macros/VersionUtils.cmake
+diff --git a/share/cmake/modules/FindExtPackages.cmake b/share/cmake/modules/FindExtPackages.cmake
+index 5455a08..5b6bfec 100644
+--- a/share/cmake/modules/FindExtPackages.cmake
++++ b/share/cmake/modules/FindExtPackages.cmake
+@@ -138,7 +138,7 @@ endif()
+ 
+ # minizip-ng
+ # https://github.com/zlib-ng/minizip-ng
+-find_package(minizip-ng 3.0.7 REQUIRED)
++find_package(minizip 3.0.7 REQUIRED)
+ 
+ if(OCIO_BUILD_APPS)
+ 
+@@ -149,7 +149,7 @@ if(OCIO_BUILD_APPS)
+ 
+     # lcms2
+     # https://github.com/mm2/Little-CMS
+-    find_package(lcms2 2.2 REQUIRED)
++    find_package(lcms 2.2 REQUIRED)
+ endif()
+ 
+ if(OCIO_BUILD_OPENFX)
+diff --git a/share/cmake/utils/CppVersion.cmake b/share/cmake/utils/CppVersion.cmake
+index 175d89c..2d34a65 100644
+--- a/share/cmake/utils/CppVersion.cmake
++++ b/share/cmake/utils/CppVersion.cmake
+@@ -16,8 +16,6 @@ elseif(NOT CMAKE_CXX_STANDARD IN_LIST SUPPORTED_CXX_STANDARDS)
+             "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is unsupported. Supported standards are: ${SUPPORTED_CXX_STANDARDS_STR}.")
+ endif()
+ 
+-set_property(CACHE CMAKE_CXX_STANDARD PROPERTY STRINGS "${SUPPORTED_CXX_STANDARDS}")
+-
+ include(CheckCXXCompilerFlag)
+ 
+ # As CheckCXXCompilerFlag implicitly uses CMAKE_CXX_FLAGS some custom flags could trigger unrelated
+diff --git a/src/OpenColorIO/CMakeLists.txt b/src/OpenColorIO/CMakeLists.txt
+index 1c4d774..da70227 100755
+--- a/src/OpenColorIO/CMakeLists.txt
++++ b/src/OpenColorIO/CMakeLists.txt
+@@ -289,7 +289,7 @@ target_link_libraries(OpenColorIO
+         "$<BUILD_INTERFACE:utils::strings>"
+         "$<BUILD_INTERFACE:xxHash>"
+         yaml-cpp
+-        MINIZIP::minizip-ng
++        MINIZIP::minizip
+ )
+ 
+ if(APPLE)
+diff --git a/src/apps/ocioarchive/CMakeLists.txt b/src/apps/ocioarchive/CMakeLists.txt
+index 6b868d1..820e36c 100644
+--- a/src/apps/ocioarchive/CMakeLists.txt
++++ b/src/apps/ocioarchive/CMakeLists.txt
+@@ -19,7 +19,7 @@ target_link_libraries(ocioarchive
+     PRIVATE
+         apputils
+         OpenColorIO
+-        MINIZIP::minizip-ng
++        MINIZIP::minizip
+ )
+ 
+ install(TARGETS ocioarchive
+diff --git a/src/apps/ociobakelut/CMakeLists.txt b/src/apps/ociobakelut/CMakeLists.txt
+index a50e87e..37174ea 100755
+--- a/src/apps/ociobakelut/CMakeLists.txt
++++ b/src/apps/ociobakelut/CMakeLists.txt
+@@ -28,7 +28,7 @@ set_target_properties(ociobakelut
+ target_link_libraries(ociobakelut 
+     PRIVATE 
+         apputils
+-        lcms2::lcms2
++        lcms::lcms
+         OpenColorIO
+ )
+ 

--- a/recipes/opencolorio/all/patches/2.2.1-0001-fix-cmake-source-dir-and-targets.patch
+++ b/recipes/opencolorio/all/patches/2.2.1-0001-fix-cmake-source-dir-and-targets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 17e188d..4cf9fb6 100755
+index 17e188d..91af0ec 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -332,7 +332,7 @@ install(
@@ -12,7 +12,7 @@ index 17e188d..4cf9fb6 100755
      install(FILES
          ${CMAKE_CURRENT_LIST_DIR}/share/cmake/macros/VersionUtils.cmake
 diff --git a/share/cmake/modules/FindExtPackages.cmake b/share/cmake/modules/FindExtPackages.cmake
-index 5455a08..5b6bfec 100644
+index 5455a08..eb91a37 100644
 --- a/share/cmake/modules/FindExtPackages.cmake
 +++ b/share/cmake/modules/FindExtPackages.cmake
 @@ -138,7 +138,7 @@ endif()
@@ -33,6 +33,15 @@ index 5455a08..5b6bfec 100644
  endif()
  
  if(OCIO_BUILD_OPENFX)
+@@ -214,7 +214,7 @@ if(OCIO_BUILD_APPS)
+         # OpenEXR
+         # https://github.com/AcademySoftwareFoundation/openexr
+         set(_OpenEXR_ExternalProject_VERSION "3.1.5")
+-        find_package(OpenEXR 3.0)
++        find_package(OpenEXR CONFIG)
+ 
+         if(OpenEXR_FOUND AND TARGET OpenEXR::OpenEXR)
+             add_library(OpenColorIO::ImageIOBackend ALIAS OpenEXR::OpenEXR)
 diff --git a/share/cmake/utils/CppVersion.cmake b/share/cmake/utils/CppVersion.cmake
 index 175d89c..2d34a65 100644
 --- a/share/cmake/utils/CppVersion.cmake

--- a/recipes/opencolorio/all/patches/2.2.1-0002-fix-pystring.patch
+++ b/recipes/opencolorio/all/patches/2.2.1-0002-fix-pystring.patch
@@ -1,0 +1,163 @@
+diff --git a/src/OpenColorIO/Config.cpp b/src/OpenColorIO/Config.cpp
+index 665d522..6abc149 100644
+--- a/src/OpenColorIO/Config.cpp
++++ b/src/OpenColorIO/Config.cpp
+@@ -33,7 +33,7 @@
+ #include "Platform.h"
+ #include "PrivateTypes.h"
+ #include "Processor.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "transforms/FileTransform.h"
+ #include "utils/StringUtils.h"
+ #include "ViewingRules.h"
+diff --git a/src/OpenColorIO/Context.cpp b/src/OpenColorIO/Context.cpp
+index bb6fb07..a8890ed 100644
+--- a/src/OpenColorIO/Context.cpp
++++ b/src/OpenColorIO/Context.cpp
+@@ -15,7 +15,7 @@
+ #include "OCIOZArchive.h"
+ #include "PathUtils.h"
+ #include "PrivateTypes.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ 
+ namespace OCIO_NAMESPACE
+diff --git a/src/OpenColorIO/OCIOYaml.cpp b/src/OpenColorIO/OCIOYaml.cpp
+index 62cbb0d..59c1564 100644
+--- a/src/OpenColorIO/OCIOYaml.cpp
++++ b/src/OpenColorIO/OCIOYaml.cpp
+@@ -19,7 +19,7 @@
+ #include "ParseUtils.h"
+ #include "PathUtils.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ #include "ViewingRules.h"
+ #include "yaml-cpp/yaml.h"
+diff --git a/src/OpenColorIO/OCIOZArchive.cpp b/src/OpenColorIO/OCIOZArchive.cpp
+index 85fc7bb..4cd1448 100644
+--- a/src/OpenColorIO/OCIOZArchive.cpp
++++ b/src/OpenColorIO/OCIOZArchive.cpp
+@@ -11,7 +11,7 @@
+ #include <OpenColorIO/OpenColorIO.h>
+ #include "Mutex.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ #include "transforms/FileTransform.h"
+ 
+@@ -630,4 +630,4 @@ void CIOPOciozArchive::buildEntries()
+     getEntriesMappingFromArchiveFile(m_archiveAbsPath, m_entries);
+ }
+ 
+-} // namespace OCIO_NAMESPACE
+\ No newline at end of file
++} // namespace OCIO_NAMESPACE
+diff --git a/src/OpenColorIO/Op.cpp b/src/OpenColorIO/Op.cpp
+index 1ae607a..bb5406f 100755
+--- a/src/OpenColorIO/Op.cpp
++++ b/src/OpenColorIO/Op.cpp
+@@ -20,7 +20,7 @@
+ #include "ops/lut1d/Lut1DOp.h"
+ #include "ops/lut3d/Lut3DOp.h"
+ #include "ops/range/RangeOp.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ 
+ namespace OCIO_NAMESPACE
+ {
+diff --git a/src/OpenColorIO/PathUtils.cpp b/src/OpenColorIO/PathUtils.cpp
+index 9dc8c6b..4a1096d 100644
+--- a/src/OpenColorIO/PathUtils.cpp
++++ b/src/OpenColorIO/PathUtils.cpp
+@@ -10,7 +10,7 @@
+ #include "Mutex.h"
+ #include "PathUtils.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ #include "OCIOZArchive.h"
+ 
+diff --git a/src/OpenColorIO/fileformats/FileFormatCTF.cpp b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+index ebed326..9f70ff8 100644
+--- a/src/OpenColorIO/fileformats/FileFormatCTF.cpp
++++ b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+@@ -23,7 +23,7 @@
+ #include "OpBuilders.h"
+ #include "ops/noop/NoOps.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "TransformBuilder.h"
+ #include "transforms/FileTransform.h"
+ #include "utils/StringUtils.h"
+diff --git a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+index a52bc72..bd827f0 100755
+--- a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
++++ b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+@@ -16,7 +16,7 @@
+ #include "ops/lut1d/Lut1DOp.h"
+ #include "ops/lut3d/Lut3DOp.h"
+ #include "ParseUtils.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "Platform.h"
+ #include "transforms/FileTransform.h"
+ #include "utils/StringUtils.h"
+diff --git a/src/OpenColorIO/fileformats/FileFormatICC.cpp b/src/OpenColorIO/fileformats/FileFormatICC.cpp
+index 786c8a5..4953103 100755
+--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
++++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
+@@ -14,7 +14,7 @@
+ #include "ops/lut1d/Lut1DOp.h"
+ #include "ops/matrix/MatrixOp.h"
+ #include "ops/range/RangeOp.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "transforms/FileTransform.h"
+ 
+ 
+diff --git a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+index 7402efd..cc3acb4 100755
+--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
++++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+@@ -13,7 +13,7 @@
+ #include "ops/lut3d/Lut3DOp.h"
+ #include "ParseUtils.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "transforms/FileTransform.h"
+ #include "utils/StringUtils.h"
+ #include "utils/NumberUtils.h"
+diff --git a/src/OpenColorIO/transforms/FileTransform.cpp b/src/OpenColorIO/transforms/FileTransform.cpp
+index 4fd4d5d..dc5eb3c 100755
+--- a/src/OpenColorIO/transforms/FileTransform.cpp
++++ b/src/OpenColorIO/transforms/FileTransform.cpp
+@@ -19,7 +19,7 @@
+ #include "ops/noop/NoOps.h"
+ #include "PathUtils.h"
+ #include "Platform.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ #include "utils/StringUtils.h"
+ 
+ namespace OCIO_NAMESPACE
+diff --git a/vendor/openfx/OCIOUtils.cpp b/vendor/openfx/OCIOUtils.cpp
+index ca44905..469ed35 100644
+--- a/vendor/openfx/OCIOUtils.cpp
++++ b/vendor/openfx/OCIOUtils.cpp
+@@ -9,7 +9,7 @@ namespace OCIO = OCIO_NAMESPACE;
+ #include <vector>
+ 
+ #include "ofxsLog.h"
+-#include "pystring/pystring.h"
++#include "pystring.h"
+ 
+ namespace
+ {

--- a/recipes/opencolorio/all/patches/2.2.1-0003-strlen.patch
+++ b/recipes/opencolorio/all/patches/2.2.1-0003-strlen.patch
@@ -1,0 +1,13 @@
+diff --git a/src/OpenColorIO/FileRules.cpp b/src/OpenColorIO/FileRules.cpp
+index 61a5e0f..e0df0d0 100644
+--- a/src/OpenColorIO/FileRules.cpp
++++ b/src/OpenColorIO/FileRules.cpp
+@@ -62,7 +62,7 @@ std::string ConvertToRegularExpression(const char * globPattern, bool ignoreCase
+ 
+     if (ignoreCase)
+     {
+-        const size_t length = strlen(globPattern);
++        const size_t length = std::strlen(globPattern);
+         bool respectCase = false;
+         for (size_t i = 0; i < length; ++i)
+         {

--- a/recipes/opencolorio/all/test_package/CMakeLists.txt
+++ b/recipes/opencolorio/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(OpenColorIO REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} OpenColorIO::OpenColorIO)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE OpenColorIO::OpenColorIO)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/opencolorio/all/test_package/conanfile.py
+++ b/recipes/opencolorio/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/opencolorio/all/test_v1_package/CMakeLists.txt
+++ b/recipes/opencolorio/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/opencolorio/all/test_v1_package/conanfile.py
+++ b/recipes/opencolorio/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/opencolorio/config.yml
+++ b/recipes/opencolorio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.1":
+    folder: "all"
   "2.1.0":
     folder: "all"
   "1.1.1":


### PR DESCRIPTION
Specify library name and version:  **opencolorio/***

- add version 2.2.1
- support conan v2
- update dependencies
- fix C++20 compilation errors in 2.1.0
- add version prefix to patch files

Retry https://github.com/conan-io/conan-center-index/pull/14683.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
