### PR TITLE
hdf5: specify the cmake_build_modules file correctly

### DIFF
--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -276,8 +276,8 @@ class Hdf5Conan(ConanFile):
             # TODO: to remove in conan v2 once cmake_find_package_* generators removed
             self.cpp_info.components[component_name].names["cmake_find_package"] = component
             self.cpp_info.components[component_name].names["cmake_find_package_multi"] = component
-            self.cpp_info.components[component_name].build_modules["cmake_find_package"] = [self._module_targets_file_rel_path]
-            self.cpp_info.components[component_name].build_modules["cmake_find_package_multi"] = [self._module_targets_file_rel_path]
+            self.cpp_info.components[component_name].build_modules["cmake_find_package"] = [self._module_targets_file_rel_path, self._module_variables_file_rel_path]
+            self.cpp_info.components[component_name].build_modules["cmake_find_package_multi"] = [self._module_targets_file_rel_path, self._module_variables_file_rel_path]
 
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "HDF5")

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -277,7 +277,6 @@ class Hdf5Conan(ConanFile):
             self.cpp_info.components[component_name].libs = [_config_libname(alias_target)]
             self.cpp_info.components[component_name].requires = requirements
             self.cpp_info.components[component_name].includedirs.append(os.path.join("include", "hdf5"))
-            self.cpp_info.components[component_name].builddirs.append(os.path.join("lib", "cmake"))
 
             # TODO: to remove in conan v2 once cmake_find_package_* generators removed
             self.cpp_info.components[component_name].names["cmake_find_package"] = component

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -271,6 +271,7 @@ class Hdf5Conan(ConanFile):
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "HDF5")
         self.cpp_info.set_property("cmake_target_name", "HDF5::HDF5")
+        self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
         self.cpp_info.set_property("pkg_config_name", "hdf5-all-do-not-use") # to avoid conflict with hdf5_c component
 
         components = self._components()

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -277,6 +277,7 @@ class Hdf5Conan(ConanFile):
             self.cpp_info.components[component_name].libs = [_config_libname(alias_target)]
             self.cpp_info.components[component_name].requires = requirements
             self.cpp_info.components[component_name].includedirs.append(os.path.join("include", "hdf5"))
+            self.cpp_info.components[component_name].builddirs.append(os.path.join("lib", "cmake"))
 
             # TODO: to remove in conan v2 once cmake_find_package_* generators removed
             self.cpp_info.components[component_name].names["cmake_find_package"] = component
@@ -288,6 +289,7 @@ class Hdf5Conan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "HDF5")
         self.cpp_info.set_property("cmake_target_name", "HDF5::HDF5")
         self.cpp_info.set_property("cmake_build_modules", [self._module_variables_file_rel_path])
+        self.cpp_info.builddirs.append(os.path.join("lib", "cmake"))
         self.cpp_info.set_property("pkg_config_name", "hdf5-all-do-not-use") # to avoid conflict with hdf5_c component
 
         components = self._components()

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -274,6 +274,7 @@ class Hdf5Conan(ConanFile):
 
             self.cpp_info.components[component_name].set_property("cmake_target_name", f"hdf5::{alias_target}")
             self.cpp_info.components[component_name].set_property("pkg_config_name", alias_target)
+            self.cpp_info.components[component_name].set_property("cmake_build_modules", [self._module_variables_file_rel_path])
             self.cpp_info.components[component_name].libs = [_config_libname(alias_target)]
             self.cpp_info.components[component_name].requires = requirements
             self.cpp_info.components[component_name].includedirs.append(os.path.join("include", "hdf5"))
@@ -287,7 +288,6 @@ class Hdf5Conan(ConanFile):
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "HDF5")
         self.cpp_info.set_property("cmake_target_name", "HDF5::HDF5")
-        self.cpp_info.set_property("cmake_build_modules", [self._module_variables_file_rel_path])
         self.cpp_info.set_property("pkg_config_name", "hdf5-all-do-not-use") # to avoid conflict with hdf5_c component
 
         components = self._components()

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -288,7 +288,6 @@ class Hdf5Conan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "HDF5")
         self.cpp_info.set_property("cmake_target_name", "HDF5::HDF5")
         self.cpp_info.set_property("cmake_build_modules", [self._module_variables_file_rel_path])
-        self.cpp_info.builddirs.append(os.path.join("lib", "cmake"))
         self.cpp_info.set_property("pkg_config_name", "hdf5-all-do-not-use") # to avoid conflict with hdf5_c component
 
         components = self._components()

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -244,6 +244,11 @@ class Hdf5Conan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rm(self, "libhdf5.settings", os.path.join(self.package_folder, "lib"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+        # remove extra libs... building 1.8.21 as shared also outputs static libs on Linux.
+        if self.options.shared:
+            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
+
         # Mimic the official CMake FindHDF5 targets. HDF5::HDF5 refers to the global target as per conan,
         # but component targets have a lower case namespace prefix. hdf5::hdf5 refers to the C library only
         components = self._components()

--- a/recipes/hdf5/all/test_package/conanfile.py
+++ b/recipes/hdf5/all/test_package/conanfile.py
@@ -19,10 +19,10 @@ class TestPackageConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables.update({
-            "HDF5_CXX": self.options["hdf5"].enable_cxx,
-            "HDF5_HL": self.options["hdf5"].hl,
+            "HDF5_CXX": self.dependencies["hdf5"].options.enable_cxx,
+            "HDF5_HL": self.dependencies["hdf5"].options.hl,
         })
-        if self.options["hdf5"].enable_cxx:
+        if self.dependencies["hdf5"].options.enable_cxx:
             tc.variables.update({"CMAKE_CXX_STANDARD": 11})
         tc.generate()
 


### PR DESCRIPTION
Needed to add the line:
```
self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
```

Otherwise the consumer doesn't see the generated cmake file.