### PR TITLE
xorg: on Suse systems libXScrnSaver-devel is called libXss-devel.

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -54,7 +54,7 @@ class XorgConan(ConanFile):
         zypper = package_manager.Zypper(self)
         zypper.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                               "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                              "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel", "libXvMC-devel",
+                              "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXss-devel", "libXvMC-devel",
                               "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                               "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                               "xcb-util-devel", "libuuid-devel"], update=True, check=True)


### PR DESCRIPTION
Specify library name and version:  **xorg/system**

On Suse Linux distributions libXScrnSaver is called libXss. 

```
wdobbe@linux-wdobbe:~> zypper se libXss
Loading repository data...
Reading installed packages...

S  | Name               | Summary                                                      | Type
---+--------------------+--------------------------------------------------------------+--------
i+ | libXss-devel       | Development files for the X11 Screen Saver extension library | package
   | libXss-devel-32bit | Development files for the X11 Screen Saver extension library | package
i  | libXss1            | X11 Screen Saver extension client library                    | package
   | libXss1-32bit      | X11 Screen Saver extension client library                    | package
```


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
