### PR TITLE
opentelemetry-cpp: add version 1.8.2, update dependencies

### DIFF
--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.2":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.2.tar.gz"
+    sha256: "20fa97e507d067e9e2ab0c1accfc334f5a4b10d01312e55455dc3733748585f4"
   "1.8.1":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.1.tar.gz"
     sha256: "3d640201594b07f08dade9cd1017bd0b59674daca26223b560b9bb6bf56264c2"
@@ -25,6 +28,10 @@ sources:
     sha256: "32f12ff15ec257e3462883f84bc291c2d5dc30055604c12ec4b46a36dfa3f189"
 
 patches:
+  "1.8.2":
+    - patch_file: "patches/1.8.2-0001-fix-cmake.patch"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"
   "1.8.1":
     - patch_file: "patches/1.8.1-0001-fix-cmake.patch"
       patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -53,7 +53,7 @@ class OpenTelemetryCppConan(ConanFile):
     def requirements(self):
         self.requires("abseil/20220623.0")
         self.requires("grpc/1.50.1")
-        self.requires("libcurl/7.86.0")
+        self.requires("libcurl/7.87.0")
         self.requires("nlohmann_json/3.11.2")
         self.requires("openssl/1.1.1s")
         if Version(self.version) <= "1.4.1":
@@ -63,7 +63,7 @@ class OpenTelemetryCppConan(ConanFile):
         self.requires("protobuf/3.21.4")
         self.requires("thrift/0.17.0")
         if Version(self.version) >= "1.3.0":
-            self.requires("boost/1.80.0")
+            self.requires("boost/1.81.0")
 
     def validate(self):
         if self.info.settings.compiler.cppstd:
@@ -103,6 +103,8 @@ class OpenTelemetryCppConan(ConanFile):
         tc.variables["WITH_EXAMPLES"] = False
         tc.variables["WITH_JAEGER"] = True
         tc.variables["WITH_OTLP"] = True
+        if Version(self.version) >= "1.8.2":
+            tc.variables["WITH_OTLP_HTTP"] = True
         tc.variables["WITH_ZIPKIN"] = True
         tc.generate()
 

--- a/recipes/opentelemetry-cpp/all/patches/1.8.2-0001-fix-cmake.patch
+++ b/recipes/opentelemetry-cpp/all/patches/1.8.2-0001-fix-cmake.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9df8f5c..43b9d82 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -251,7 +251,6 @@ if(WITH_JAEGER)
+   find_package(Thrift QUIET)
+   if(Thrift_FOUND)
+     find_package(Boost REQUIRED)
+-    include_directories(${Boost_INCLUDE_DIR})
+   else()
+     # Install Thrift and propagate via vcpkg toolchain file
+     if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))
+diff --git a/cmake/opentelemetry-proto.cmake b/cmake/opentelemetry-proto.cmake
+index a21c0f1..a467ffd 100644
+--- a/cmake/opentelemetry-proto.cmake
++++ b/cmake/opentelemetry-proto.cmake
+@@ -280,6 +280,10 @@ else() # cmake 3.8 or lower
+   target_link_libraries(opentelemetry_proto INTERFACE ${Protobuf_LIBRARIES})
+ endif()
+ 
++if(TARGET gRPC::grpc++)
++  target_link_libraries(opentelemetry_proto PUBLIC gRPC::grpc++)
++endif()
++
+ if(BUILD_SHARED_LIBS)
+   set_property(TARGET opentelemetry_proto PROPERTY POSITION_INDEPENDENT_CODE ON)
+ endif()

--- a/recipes/opentelemetry-cpp/all/test_v1_package/CMakeLists.txt
+++ b/recipes/opentelemetry-cpp/all/test_v1_package/CMakeLists.txt
@@ -1,12 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(test_package CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(opentelemetry-cpp REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE opentelemetry-cpp::opentelemetry-cpp)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/opentelemetry-cpp/config.yml
+++ b/recipes/opentelemetry-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.2":
+    folder: all
   "1.8.1":
     folder: all
   "1.7.0":


### PR DESCRIPTION
Specify library name and version:  **opentelemetry-cpp/***

- add version 1.8.2
  - set WITH_OTLP_HTTP explicitly since 1.8.2 
     (https://github.com/open-telemetry/opentelemetry-cpp/pull/1916)
- update depedencies
- add `add_subdirectory` in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
