### PR TITLE
android-ndk: add r25c

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,4 +1,17 @@
 sources:
+  "r25c":
+    "Windows":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r25c-windows.zip"
+        sha256: "f70093964f6cbbe19268f9876a20f92d3a593db3ad2037baadd25fd8d71e84e2"
+    "Linux":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r25c-linux.zip"
+        sha256: "769ee342ea75f80619d985c2da990c48b3d8eaf45f48783a2d48870d04b46108"
+    "Macos":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r25c-darwin.zip"
+        sha256: "b01bae969a5d0bfa0da18469f650a1628dc388672f30e0ba231da5c74245bc92"
   "r25b":
     "Windows":
       "x86_64":

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "r25c":
+    folder: all
   "r25b":
     folder: all
   "r25":


### PR DESCRIPTION
Specify library name and version:  **android-ndk/r25c**

This bumps android-ndk to r25c released two days ago.

Changelog: https://github.com/android/ndk/wiki/Changelog-r25

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
