### PR TITLE
yamllinter: disable empty-lines and colons

### DIFF
--- a/linter/yamllint_rules.yml
+++ b/linter/yamllint_rules.yml
@@ -24,3 +24,5 @@ rules:
     type: unix
   key-duplicates:
     level: error
+  empty-lines: disable
+  colons: disable


### PR DESCRIPTION
these are stylistic only

I'd argue we should also disable trailing-spaces, but it was explicitly enabled and raised to an error as part of https://github.com/conan-io/conan-center-index/commit/e437f8c3d29f5f8d0318b7484675ee045463dd0a#diff-07f78d11ff1e3d892a9288086eeec841dcc0f5cda411589c60b248dabe2d3963R9-R10, so there may be a reason I don't know about ?

@prince-chrismc 

My end objective with this change is to reduce the noise in the `Test linter changes` job: https://github.com/conan-io/conan-center-index/actions/runs/4079603049/jobs/7031148255#step:6:1 and https://github.com/conan-io/conan-center-index/actions/runs/4079603049/jobs/7031148255#step:8:1, Currently, these jobs are close to useless because of these 57 errors which are not related to the actual change being tested.

This PR improves the situation by lowering this number to 39. Disabling trailing-spaces would lower it to 26 (12 document-start and 14 indentation)


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
