### PR TITLE
[qxlsx/1.4.5] Use Qt 6.4.2

### DIFF
--- a/recipes/qxlsx/all/conanfile.py
+++ b/recipes/qxlsx/all/conanfile.py
@@ -43,7 +43,7 @@ class QXlsxConan(ConanFile):
 
     def requirements(self):
         if Version(self.version) <= "1.4.4":
-            self.requires("qt/5.15.2")
+            self.requires("qt/5.15.8")
         else:
             self.requires("qt/6.4.2")
 

--- a/recipes/qxlsx/all/conanfile.py
+++ b/recipes/qxlsx/all/conanfile.py
@@ -42,7 +42,10 @@ class QXlsxConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("qt/5.15.7")
+        if Version(self.version) <= "1.4.4":
+            self.requires("qt/5.15.2")
+        else:
+            self.requires("qt/6.4.2")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
I'm not sure if QXlsx is compatible with Qt 6 yet but let's give it a try

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
