### PR TITLE
add openal-soft recipe (copy of deprecated openal recipe)

### DIFF
--- a/recipes/openal-soft/all/conandata.yml
+++ b/recipes/openal-soft/all/conandata.yml
@@ -1,0 +1,37 @@
+sources:
+  "1.22.2":
+    url: "https://openal-soft.org/openal-releases/openal-soft-1.22.2.tar.bz2"
+    sha256: "ae94cc95cda76b7cc6e92e38c2531af82148e76d3d88ce996e2928a1ea7c3d20"
+  "1.21.1":
+    url: "https://openal-soft.org/openal-releases/openal-soft-1.21.1.tar.bz2"
+    sha256: "c8ad767e9a3230df66756a21cc8ebf218a9d47288f2514014832204e666af5d8"
+  "1.21.0":
+    url: "https://openal-soft.org/openal-releases/openal-soft-1.21.0.tar.bz2"
+    sha256: "2916b4fc24e23b0271ce0b3468832ad8b6d8441b1830215b28cc4fee6cc89297"
+  "1.20.1":
+    url: "https://openal-soft.org/openal-releases/openal-soft-1.20.1.tar.bz2"
+    sha256: "b6ceb051325732c23f5c8b6d37dbd89534517e6439a87e970882b447c3025d6d"
+  "1.19.1":
+    url: "https://openal-soft.org/openal-releases/openal-soft-1.19.1.tar.bz2"
+    sha256: "5c2f87ff5188b95e0dc4769719a9d89ce435b8322b4478b95dd4b427fe84b2e9"
+patches:
+  "1.22.2":
+    - patch_file: "patches/1.22.2-0001-fix-al-optional-in-if-compile-error.patch"
+  "1.21.0":
+    - patch_file: "patches/1.21.0-0001-c++14-does-not-have-std-aligned_alloc.patch"
+    - patch_file: "patches/1.21.0-0002-fix-windows-sdk.patch"
+      patch_description: "Avoid explicitly searching for the WindowsSDK"
+      patch_type: "portability"
+      patch_source: "https://github.com/kcat/openal-soft/commit/13698362f1726326ab60180b04a86df79b518614"
+  "1.20.1":
+    - patch_file: "patches/1.20.1-0001-fix-windows-sdk.patch"
+      patch_description: "Avoid explicitly searching for the WindowsSDK"
+      patch_type: "portability"
+      patch_source: "https://github.com/kcat/openal-soft/commit/13698362f1726326ab60180b04a86df79b518614"
+  "1.19.1":
+    - patch_file: "patches/1.19.1-0001-aligned-alloc.patch"
+    - patch_file: "patches/1.19.1-0002-gcc-10-fnocommon.patch"
+    - patch_file: "patches/1.19.1-0003-fix-windows-sdk.patch"
+      patch_description: "Avoid explicitly searching for the WindowsSDK"
+      patch_type: "portability"
+      patch_source: "https://github.com/kcat/openal-soft/commit/13698362f1726326ab60180b04a86df79b518614"

--- a/recipes/openal-soft/all/conanfile.py
+++ b/recipes/openal-soft/all/conanfile.py
@@ -1,0 +1,165 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.build import check_min_cppstd, stdcpp_library
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, collect_libs, export_conandata_patches, copy, get, rmdir, save
+from conan.tools.scm import Version
+import os
+import textwrap
+
+required_conan_version = ">=1.54.0"
+
+
+class OpenALSoftConan(ConanFile):
+    name = "openal-soft"
+    description = "OpenAL Soft is a software implementation of the OpenAL 3D audio API."
+    topics = ("openal", "audio", "api")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://openal-soft.org/"
+    license = "LGPL-2.0-or-later"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _openal_cxx_backend(self):
+        return Version(self.version) >= "1.20"
+
+    @property
+    def _min_cppstd(self):
+        return "11" if Version(self.version) < "1.21" else "14"
+
+    @property
+    def _minimum_compilers_version(self):
+        return {
+            "Visual Studio": "13" if Version(self.version) < "1.21" else "15",
+            "msvc": "180" if Version(self.version) < "1.21" else "191",
+            "gcc": "5",
+            "clang": "5",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        # OpenAL's API is pure C, thus the c++ standard does not matter
+        # Because the backend is C++, the C++ STL matters
+        self.settings.rm_safe("compiler.cppstd")
+        if not self._openal_cxx_backend:
+            self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.settings.os == "Linux":
+            self.requires("libalsa/1.2.7.2")
+
+    def validate(self):
+        if self._openal_cxx_backend:
+            if self.settings.compiler.get_safe("cppstd"):
+                check_min_cppstd(self, self._min_cppstd)
+
+            compiler = self.settings.compiler
+
+            minimum_version = self._minimum_compilers_version.get(str(compiler), False)
+            if minimum_version and Version(compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
+                )
+
+            if compiler == "clang" and Version(compiler.version) < "9" and \
+               compiler.get_safe("libcxx") in ("libstdc++", "libstdc++11"):
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} cannot be built with {compiler} {compiler.version} and stdlibc++(11) c++ runtime",
+                )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["LIBTYPE"] = "SHARED" if self.options.shared else "STATIC"
+        tc.variables["ALSOFT_UTILS"] = False
+        tc.variables["ALSOFT_EXAMPLES"] = False
+        tc.variables["ALSOFT_TESTS"] = False
+        tc.variables["CMAKE_DISABLE_FIND_PACKAGE_SoundIO"] = True
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        self._create_cmake_module_variables(
+            os.path.join(self.package_folder, self._module_file_rel_path)
+        )
+
+    def _create_cmake_module_variables(self, module_file):
+        content = textwrap.dedent("""\
+            set(OPENAL_FOUND TRUE)
+            if(DEFINED OpenAL_INCLUDE_DIR)
+                set(OPENAL_INCLUDE_DIR ${OpenAL_INCLUDE_DIR})
+            endif()
+            if(DEFINED OpenAL_LIBRARIES)
+                set(OPENAL_LIBRARY ${OpenAL_LIBRARIES})
+            endif()
+            if(DEFINED OpenAL_VERSION)
+                set(OPENAL_VERSION_STRING ${OpenAL_VERSION})
+            endif()
+        """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.set_property("cmake_file_name", "OpenAL")
+        self.cpp_info.set_property("cmake_target_name", "OpenAL::OpenAL")
+        self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
+        self.cpp_info.set_property("pkg_config_name", "openal")
+
+        self.cpp_info.names["cmake_find_package"] = "OpenAL"
+        self.cpp_info.names["cmake_find_package_multi"] = "OpenAL"
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+
+        self.cpp_info.libs = collect_libs(self)
+        self.cpp_info.includedirs.append(os.path.join("include", "AL"))
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["dl", "m"])
+        elif is_apple_os(self):
+            self.cpp_info.frameworks.extend(["AudioToolbox", "AudioUnit", "CoreAudio", "CoreFoundation"])
+            if self.settings.os == "Macos":
+                self.cpp_info.frameworks.append("ApplicationServices")
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["winmm", "ole32", "shell32", "user32"])
+        if self._openal_cxx_backend and not self.options.shared:
+            libcxx = stdcpp_library(self)
+            if libcxx:
+                self.cpp_info.system_libs.append(libcxx)
+        if not self.options.shared:
+            self.cpp_info.defines.append("AL_LIBTYPE_STATIC")

--- a/recipes/openal-soft/all/patches/1.19.1-0001-aligned-alloc.patch
+++ b/recipes/openal-soft/all/patches/1.19.1-0001-aligned-alloc.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -546,7 +546,7 @@ IF(HAVE_INTRIN_H)
+ ENDIF()
+ 
+ CHECK_SYMBOL_EXISTS(sysconf          unistd.h HAVE_SYSCONF)
+-CHECK_SYMBOL_EXISTS(aligned_alloc    stdlib.h HAVE_ALIGNED_ALLOC)
++#CHECK_SYMBOL_EXISTS(aligned_alloc    stdlib.h HAVE_ALIGNED_ALLOC)
+ CHECK_SYMBOL_EXISTS(posix_memalign   stdlib.h HAVE_POSIX_MEMALIGN)
+ CHECK_SYMBOL_EXISTS(_aligned_malloc  malloc.h HAVE__ALIGNED_MALLOC)
+ CHECK_SYMBOL_EXISTS(proc_pidpath     libproc.h HAVE_PROC_PIDPATH)

--- a/recipes/openal-soft/all/patches/1.19.1-0002-gcc-10-fnocommon.patch
+++ b/recipes/openal-soft/all/patches/1.19.1-0002-gcc-10-fnocommon.patch
@@ -1,0 +1,15 @@
+--- a/Alc/bformatdec.h	2018-10-11 18:05:31.000000000 -0400
++++ b/Alc/bformatdec.h	2020-10-10 21:01:08.842986977 -0400
+@@ -24,9 +24,9 @@
+ /* NOTE: These are scale factors as applied to Ambisonics content. Decoder
+  * coefficients should be divided by these values to get proper N3D scalings.
+  */
+-const ALfloat N3D2N3DScale[MAX_AMBI_COEFFS];
+-const ALfloat SN3D2N3DScale[MAX_AMBI_COEFFS];
+-const ALfloat FuMa2N3DScale[MAX_AMBI_COEFFS];
++extern const ALfloat N3D2N3DScale[MAX_AMBI_COEFFS];
++extern const ALfloat SN3D2N3DScale[MAX_AMBI_COEFFS];
++extern const ALfloat FuMa2N3DScale[MAX_AMBI_COEFFS];
+ 
+ 
+ struct AmbDecConf;

--- a/recipes/openal-soft/all/patches/1.19.1-0003-fix-windows-sdk.patch
+++ b/recipes/openal-soft/all/patches/1.19.1-0003-fix-windows-sdk.patch
@@ -1,0 +1,38 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1092,17 +1092,24 @@ IF(HAVE_WINDOWS_H)
+     ENDIF()
+ 
+     # Check DSound backend
+-    FIND_PACKAGE(DSound)
+-    IF(DSOUND_FOUND)
+-        OPTION(ALSOFT_BACKEND_DSOUND "Enable DirectSound backend" ON)
+-        IF(ALSOFT_BACKEND_DSOUND)
+-            SET(HAVE_DSOUND 1)
+-            SET(BACKENDS  "${BACKENDS} DirectSound${IS_LINKED},")
+-            SET(ALC_OBJS  ${ALC_OBJS} Alc/backends/dsound.c)
+-            ADD_BACKEND_LIBS(${DSOUND_LIBRARIES})
+-            SET(INC_PATHS ${INC_PATHS} ${DSOUND_INCLUDE_DIRS})
+-        ENDIF()
+-    ENDIF()
++    check_include_file(dsound.h HAVE_DSOUND_H)
++    if(DXSDK_DIR)
++        find_path(DSOUND_INCLUDE_DIR NAMES "dsound.h"
++            PATHS "${DXSDK_DIR}" PATH_SUFFIXES include
++            DOC "The DirectSound include directory")
++    endif()
++    if(HAVE_DSOUND_H OR DSOUND_INCLUDE_DIR)
++        option(ALSOFT_BACKEND_DSOUND "Enable DirectSound backend" ON)
++        if(ALSOFT_BACKEND_DSOUND)
++            set(HAVE_DSOUND 1)
++            set(BACKENDS "${BACKENDS} DirectSound,")
++            set(ALC_OBJS ${ALC_OBJS} Alc/backends/dsound.c)
++
++            if(NOT HAVE_DSOUND_H)
++                set(INC_PATHS ${INC_PATHS} ${DSOUND_INCLUDE_DIR})
++            endif()
++        endif()
++    endif()
+ 
+     # Check for WASAPI backend
+     CHECK_INCLUDE_FILE(mmdeviceapi.h HAVE_MMDEVICEAPI_H)

--- a/recipes/openal-soft/all/patches/1.20.1-0001-fix-windows-sdk.patch
+++ b/recipes/openal-soft/all/patches/1.20.1-0001-fix-windows-sdk.patch
@@ -1,0 +1,76 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -854,44 +854,38 @@ OPTION(ALSOFT_REQUIRE_WINMM "Require Windows Multimedia backend" OFF)
+ OPTION(ALSOFT_REQUIRE_DSOUND "Require DirectSound backend" OFF)
+ OPTION(ALSOFT_REQUIRE_WASAPI "Require WASAPI backend" OFF)
+ IF(WIN32)
+-    SET(WINSDK_LIB_DIRS )
+-    SET(WINSDK_INCLUDE_DIRS )
+-    FIND_PACKAGE(WindowsSDK)
+-    IF(WINDOWSSDK_FOUND)
+-        get_windowssdk_library_dirs(${WINDOWSSDK_PREFERRED_DIR} WINSDK_LIB_DIRS)
+-        get_windowssdk_include_dirs(${WINDOWSSDK_PREFERRED_DIR} WINSDK_INCLUDE_DIRS)
+-    ENDIF()
+-
+-    SET(OLD_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS})
+-    SET(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} -D_WIN32_WINNT=0x0502)
+-
+     # Check MMSystem backend
+-    CHECK_INCLUDE_FILES("windows.h;mmsystem.h" HAVE_MMSYSTEM_H)
+-    FIND_LIBRARY(WINMM_LIBRARY NAMES winmm
+-        PATHS ${WINSDK_LIB_DIRS}
+-        PATH_SUFFIXES lib lib/x86 lib/x64)
+-    IF(HAVE_MMSYSTEM_H AND WINMM_LIBRARY)
+-        OPTION(ALSOFT_BACKEND_WINMM "Enable Windows Multimedia backend" ON)
+-        IF(ALSOFT_BACKEND_WINMM)
+-            SET(HAVE_WINMM 1)
+-            SET(BACKENDS  "${BACKENDS} WinMM,")
+-            SET(ALC_OBJS  ${ALC_OBJS} alc/backends/winmm.cpp alc/backends/winmm.h)
+-            SET(EXTRA_LIBS ${WINMM_LIBRARY} ${EXTRA_LIBS})
+-        ENDIF()
+-    ENDIF()
++    option(ALSOFT_BACKEND_WINMM "Enable Windows Multimedia backend" ON)
++    if(ALSOFT_BACKEND_WINMM)
++        set(HAVE_WINMM 1)
++        set(BACKENDS "${BACKENDS} WinMM,")
++        set(ALC_OBJS ${ALC_OBJS} alc/backends/winmm.cpp alc/backends/winmm.h)
++        # There doesn't seem to be good way to search for winmm.lib for MSVC.
++        # find_library doesn't find it without being told to look in a specific
++        # place in the WindowsSDK, but it links anyway. If there ends up being
++        # Windows targets without this, another means to detect it is needed.
++        set(EXTRA_LIBS winmm ${EXTRA_LIBS})
++    endif()
+ 
+     # Check DSound backend
+-    FIND_PACKAGE(DSound)
+-    IF(DSOUND_FOUND)
+-        OPTION(ALSOFT_BACKEND_DSOUND "Enable DirectSound backend" ON)
+-        IF(ALSOFT_BACKEND_DSOUND)
+-            SET(HAVE_DSOUND 1)
+-            SET(BACKENDS  "${BACKENDS} DirectSound${IS_LINKED},")
+-            SET(ALC_OBJS  ${ALC_OBJS} alc/backends/dsound.cpp alc/backends/dsound.h)
+-            ADD_BACKEND_LIBS(${DSOUND_LIBRARIES})
+-            SET(INC_PATHS ${INC_PATHS} ${DSOUND_INCLUDE_DIRS})
+-        ENDIF()
+-    ENDIF()
++    check_include_file(dsound.h HAVE_DSOUND_H)
++    if(DXSDK_DIR)
++        find_path(DSOUND_INCLUDE_DIR NAMES "dsound.h"
++            PATHS "${DXSDK_DIR}" PATH_SUFFIXES include
++            DOC "The DirectSound include directory")
++    endif()
++    if(HAVE_DSOUND_H OR DSOUND_INCLUDE_DIR)
++        option(ALSOFT_BACKEND_DSOUND "Enable DirectSound backend" ON)
++        if(ALSOFT_BACKEND_DSOUND)
++            set(HAVE_DSOUND 1)
++            set(BACKENDS "${BACKENDS} DirectSound,")
++            set(ALC_OBJS ${ALC_OBJS} alc/backends/dsound.cpp alc/backends/dsound.h)
++
++            if(NOT HAVE_DSOUND_H)
++                set(INC_PATHS ${INC_PATHS} ${DSOUND_INCLUDE_DIR})
++            endif()
++        endif()
++    endif()
+ 
+     # Check for WASAPI backend
+     CHECK_INCLUDE_FILE(mmdeviceapi.h HAVE_MMDEVICEAPI_H)

--- a/recipes/openal-soft/all/patches/1.21.0-0001-c++14-does-not-have-std-aligned_alloc.patch
+++ b/recipes/openal-soft/all/patches/1.21.0-0001-c++14-does-not-have-std-aligned_alloc.patch
@@ -1,0 +1,16 @@
+gcc-11 triggers an error. std::aligned_alloc needs c++17.
+This patch ports openal 1.21.1 behavior back to 1.21.0.
+--- common/almalloc.cpp
++++ common/almalloc.cpp
+@@ -21,4 +21,4 @@
+-#if defined(HAVE_STD_ALIGNED_ALLOC)
+-    size = (size+(alignment-1))&~(alignment-1);
+-    return std::aligned_alloc(alignment, size);
++//#if defined(HAVE_STD_ALIGNED_ALLOC)
++//    size = (size+(alignment-1))&~(alignment-1);
++//    return std::aligned_alloc(alignment, size);
+-#elif defined(HAVE_POSIX_MEMALIGN)
++#if defined(HAVE_POSIX_MEMALIGN)
+@@ -56,1 +56,1 @@
+-#if defined(HAVE_STD_ALIGNED_ALLOC) || defined(HAVE_POSIX_MEMALIGN)
++#if defined(HAVE_POSIX_MEMALIGN)

--- a/recipes/openal-soft/all/patches/1.21.0-0002-fix-windows-sdk.patch
+++ b/recipes/openal-soft/all/patches/1.21.0-0002-fix-windows-sdk.patch
@@ -1,0 +1,74 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -880,49 +880,36 @@ option(ALSOFT_REQUIRE_WINMM "Require Windows Multimedia backend" OFF)
+ option(ALSOFT_REQUIRE_DSOUND "Require DirectSound backend" OFF)
+ option(ALSOFT_REQUIRE_WASAPI "Require WASAPI backend" OFF)
+ if(WIN32)
+-    set(WINSDK_LIB_DIRS )
+-    set(WINSDK_INCLUDE_DIRS )
+-    find_package(WindowsSDK)
+-    if(WINDOWSSDK_FOUND)
+-        get_windowssdk_library_dirs(${WINDOWSSDK_PREFERRED_DIR} WINSDK_LIB_DIRS)
+-        get_windowssdk_include_dirs(${WINDOWSSDK_PREFERRED_DIR} WINSDK_INCLUDE_DIRS)
+-    endif()
+-
+     # Check MMSystem backend
+-    check_include_files("windows.h;mmsystem.h" HAVE_MMSYSTEM_H)
+-    find_library(WINMM_LIBRARY NAMES winmm
+-        PATHS ${WINSDK_LIB_DIRS})
+-    if(HAVE_MMSYSTEM_H AND WINMM_LIBRARY)
+-        option(ALSOFT_BACKEND_WINMM "Enable Windows Multimedia backend" ON)
+-        if(ALSOFT_BACKEND_WINMM)
+-            set(HAVE_WINMM 1)
+-            set(BACKENDS  "${BACKENDS} WinMM,")
+-            set(ALC_OBJS  ${ALC_OBJS} alc/backends/winmm.cpp alc/backends/winmm.h)
+-            set(EXTRA_LIBS ${WINMM_LIBRARY} ${EXTRA_LIBS})
+-        endif()
++    option(ALSOFT_BACKEND_WINMM "Enable Windows Multimedia backend" ON)
++    if(ALSOFT_BACKEND_WINMM)
++        set(HAVE_WINMM 1)
++        set(BACKENDS "${BACKENDS} WinMM,")
++        set(ALC_OBJS ${ALC_OBJS} alc/backends/winmm.cpp alc/backends/winmm.h)
++        # There doesn't seem to be good way to search for winmm.lib for MSVC.
++        # find_library doesn't find it without being told to look in a specific
++        # place in the WindowsSDK, but it links anyway. If there ends up being
++        # Windows targets without this, another means to detect it is needed.
++        set(EXTRA_LIBS winmm ${EXTRA_LIBS})
+     endif()
+ 
+     # Check DSound backend
+-    find_package(DSound)
+-    if(DSOUND_FOUND)
++    check_include_file(dsound.h HAVE_DSOUND_H)
++    if(DXSDK_DIR)
++        find_path(DSOUND_INCLUDE_DIR NAMES "dsound.h"
++            PATHS "${DXSDK_DIR}" PATH_SUFFIXES include
++            DOC "The DirectSound include directory")
++    endif()
++    if(HAVE_DSOUND_H OR DSOUND_INCLUDE_DIR)
+         option(ALSOFT_BACKEND_DSOUND "Enable DirectSound backend" ON)
+         if(ALSOFT_BACKEND_DSOUND)
+             set(HAVE_DSOUND 1)
+-            set(BACKENDS  "${BACKENDS} DirectSound${IS_LINKED},")
+-            set(ALC_OBJS  ${ALC_OBJS} alc/backends/dsound.cpp alc/backends/dsound.h)
+-            add_backend_libs(${DSOUND_LIBRARIES})
+-            set(INC_PATHS ${INC_PATHS} ${DSOUND_INCLUDE_DIRS})
+-        endif()
+-    endif()
++            set(BACKENDS "${BACKENDS} DirectSound,")
++            set(ALC_OBJS ${ALC_OBJS} alc/backends/dsound.cpp alc/backends/dsound.h)
+ 
+-    # Check for WASAPI backend
+-    check_include_file(mmdeviceapi.h HAVE_MMDEVICEAPI_H)
+-    if(HAVE_MMDEVICEAPI_H)
+-        option(ALSOFT_BACKEND_WASAPI "Enable WASAPI backend" ON)
+-        if(ALSOFT_BACKEND_WASAPI)
+-            set(HAVE_WASAPI 1)
+-            set(BACKENDS  "${BACKENDS} WASAPI,")
+-            set(ALC_OBJS  ${ALC_OBJS} alc/backends/wasapi.cpp alc/backends/wasapi.h)
++            if(NOT HAVE_DSOUND_H)
++                set(INC_PATHS ${INC_PATHS} ${DSOUND_INCLUDE_DIR})
++            endif()
+         endif()
+     endif()
+ endif()

--- a/recipes/openal-soft/all/patches/1.22.2-0001-fix-al-optional-in-if-compile-error.patch
+++ b/recipes/openal-soft/all/patches/1.22.2-0001-fix-al-optional-in-if-compile-error.patch
@@ -1,0 +1,47 @@
+From 650a6d49e9a511d005171940761f6dd6b440ee66 Mon Sep 17 00:00:00 2001
+From: Chris Robinson <chris.kcat@gmail.com>
+Date: Mon, 18 Jul 2022 11:10:27 -0700
+Subject: [PATCH] Declare variables closer to where they're used
+
+---
+ alc/backends/alsa.cpp | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/alc/backends/alsa.cpp b/alc/backends/alsa.cpp
+index 9c78b6c6a..b6efeaba1 100644
+--- a/alc/backends/alsa.cpp
++++ b/alc/backends/alsa.cpp
+@@ -623,7 +623,6 @@ int AlsaPlayback::mixerNoMMapProc()
+ 
+ void AlsaPlayback::open(const char *name)
+ {
+-    al::optional<std::string> driveropt;
+     const char *driver{"default"};
+     if(name)
+     {
+@@ -640,7 +639,7 @@ void AlsaPlayback::open(const char *name)
+     else
+     {
+         name = alsaDevice;
+-        if(bool{driveropt = ConfigValueStr(nullptr, "alsa", "device")})
++        if(auto driveropt = ConfigValueStr(nullptr, "alsa", "device"))
+             driver = driveropt->c_str();
+     }
+     TRACE("Opening device \"%s\"\n", driver);
+@@ -896,7 +895,6 @@ AlsaCapture::~AlsaCapture()
+ 
+ void AlsaCapture::open(const char *name)
+ {
+-    al::optional<std::string> driveropt;
+     const char *driver{"default"};
+     if(name)
+     {
+@@ -913,7 +911,7 @@ void AlsaCapture::open(const char *name)
+     else
+     {
+         name = alsaDevice;
+-        if(bool{driveropt = ConfigValueStr(nullptr, "alsa", "capture")})
++        if(auto driveropt = ConfigValueStr(nullptr, "alsa", "capture"))
+             driver = driveropt->c_str();
+     }
+ 

--- a/recipes/openal-soft/all/test_package/CMakeLists.txt
+++ b/recipes/openal-soft/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+find_package(OpenAL REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE OpenAL::OpenAL)

--- a/recipes/openal-soft/all/test_package/conanfile.py
+++ b/recipes/openal-soft/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/openal-soft/all/test_package/test_package.c
+++ b/recipes/openal-soft/all/test_package/test_package.c
@@ -1,0 +1,134 @@
+#include "alc.h"
+#include "al.h"
+#include "alext.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static ALenum checkALErrors(int linenum)
+{
+    ALenum err = alGetError();
+    if(err != AL_NO_ERROR)
+        printf("OpenAL Error: %s (0x%x), @ %d\n", alGetString(err), err, linenum);
+    return err;
+}
+#define checkALErrors() checkALErrors(__LINE__)
+
+static ALCenum checkALCErrors(ALCdevice *device, int linenum)
+{
+    ALCenum err = alcGetError(device);
+    if(err != ALC_NO_ERROR)
+        printf("ALC Error: %s (0x%x), @ %d\n", alcGetString(device, err), err, linenum);
+    return err;
+}
+#define checkALCErrors(x) checkALCErrors((x),__LINE__)
+
+#define MAX_WIDTH  80
+
+static void printList(const char *list, char separator)
+{
+    size_t col = MAX_WIDTH, len;
+    const char *indent = "    ";
+    const char *next;
+
+    if(!list || *list == '\0')
+    {
+        fprintf(stdout, "\n%s!!! none !!!\n", indent);
+        return;
+    }
+
+    do {
+        next = strchr(list, separator);
+        if(next)
+        {
+            len = next-list;
+            do {
+                next++;
+            } while(*next == separator);
+        }
+        else
+            len = strlen(list);
+
+        if(len + col + 2 >= MAX_WIDTH)
+        {
+            fprintf(stdout, "\n%s", indent);
+            col = strlen(indent);
+        }
+        else
+        {
+            fputc(' ', stdout);
+            col++;
+        }
+
+        len = fwrite(list, 1, len, stdout);
+        col += len;
+
+        if(!next || *next == '\0')
+            break;
+        fputc(',', stdout);
+        col++;
+
+        list = next;
+    } while(1);
+    fputc('\n', stdout);
+}
+
+static void printALCInfo(ALCdevice *device)
+{
+    ALCint major, minor;
+
+    if(device)
+    {
+        const ALCchar *devname = NULL;
+        printf("\n");
+        if(alcIsExtensionPresent(device, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
+            devname = alcGetString(device, ALC_ALL_DEVICES_SPECIFIER);
+        if(checkALCErrors(device) != ALC_NO_ERROR || !devname)
+            devname = alcGetString(device, ALC_DEVICE_SPECIFIER);
+        printf("** Info for device \"%s\" **\n", devname);
+    }
+    alcGetIntegerv(device, ALC_MAJOR_VERSION, 1, &major);
+    alcGetIntegerv(device, ALC_MINOR_VERSION, 1, &minor);
+    if(checkALCErrors(device) == ALC_NO_ERROR)
+        printf("ALC version: %d.%d\n", major, minor);
+    if(device)
+    {
+        printf("ALC extensions:");
+        printList(alcGetString(device, ALC_EXTENSIONS), ' ');
+        checkALCErrors(device);
+    }
+}
+
+static void printDeviceList(const char *list)
+{
+    if(!list || *list == '\0')
+        printf("    !!! none !!!\n");
+    else do {
+        printf("    %s\n", list);
+        list += strlen(list) + 1;
+    } while(*list != '\0');
+}
+
+int main(int argc, char **argv)
+{
+    printf("Available playback devices:\n");
+    if(alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
+        printDeviceList(alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER));
+    else
+        printDeviceList(alcGetString(NULL, ALC_DEVICE_SPECIFIER));
+    printf("Available capture devices:\n");
+    printDeviceList(alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER));
+
+    if(alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
+        printf("Default playback device: %s\n",
+               alcGetString(NULL, ALC_DEFAULT_ALL_DEVICES_SPECIFIER));
+    else
+        printf("Default playback device: %s\n",
+               alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER));
+    printf("Default capture device: %s\n",
+           alcGetString(NULL, ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER));
+
+    printALCInfo(NULL);
+
+    return 0;
+}

--- a/recipes/openal-soft/all/test_v1_package/CMakeLists.txt
+++ b/recipes/openal-soft/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/openal-soft/all/test_v1_package/conanfile.py
+++ b/recipes/openal-soft/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/openal-soft/config.yml
+++ b/recipes/openal-soft/config.yml
@@ -1,0 +1,11 @@
+versions:
+  "1.22.2":
+    folder: all
+  "1.21.1":
+    folder: all
+  "1.21.0":
+    folder: all
+  "1.20.1":
+    folder: all
+  "1.19.1":
+    folder: all


### PR DESCRIPTION
`openal` recipe refers actually to OpenAL Soft (https://openal-soft.org), so `openal` recipe is deprecated in https://github.com/conan-io/conan-center-index/pull/15590 in favor of this new `openal-soft` recipe.

see also https://github.com/conan-io/conan-center-index/issues/9181

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
