### PR TITLE
libjpeg-turbo: add version 2.1.90

### DIFF
--- a/recipes/libjpeg-turbo/all/conandata.yml
+++ b/recipes/libjpeg-turbo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.90":
+    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/2.1.90.tar.gz"
+    sha256: "426d097a29bd67ab7ef8584673ba2e0da5fe65dcddd0c8daa123bdcb7a5e871f"
   "2.1.4":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.4.tar.gz"
     sha256: "a78b05c0d8427a90eb5b4eb08af25309770c8379592bb0b8a863373128e6143f"

--- a/recipes/libjpeg-turbo/config.yml
+++ b/recipes/libjpeg-turbo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.90":
+    folder: all
   "2.1.4":
     folder: all
   "2.1.3":


### PR DESCRIPTION
Specify library name and version:  **libjpeg-turbo/2.1.90**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
