### PR TITLE
luau: add version 0.563, remove older versions

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.562":
+    url: "https://github.com/Roblox/luau/archive/0.562.tar.gz"
+    sha256: "fa5d10356b287a8290ecdc066874870aa07bb1e5039e09bf1cddba0f8ff4d743"
   "0.558":
     url: "https://github.com/Roblox/luau/archive/0.558.tar.gz"
     sha256: "3484adddb18872700e033f5917af44d90c266f9e0fff2fac21aec1061f472a06"
@@ -20,17 +23,15 @@ sources:
   "0.540":
     url: "https://github.com/Roblox/luau/archive/0.540.tar.gz"
     sha256: "84b3e52b3b0ccf4d5bc0e0c04055f3a9b2f045c1281e203a858335a6fe76b0ff"
-  "0.539":
-    url: "https://github.com/Roblox/luau/archive/0.539.tar.gz"
-    sha256: "d0a33bbafc88d6d89f23e43229e523b117cd761f1fdbd86977800b5725cc647f"
-  "0.538":
-    url: "https://github.com/Roblox/luau/archive/0.538.tar.gz"
-    sha256: "8a1240e02a7daacf1e5cff249040a3298c013157fc496c66adce6dcb21cc30be"
-  "0.537":
-    url: "https://github.com/Roblox/luau/archive/0.537.tar.gz"
-    sha256: "24122d3192083b2133de47d8039fb744b8007c6667fc1b6f254a2a8d72e15d53"
 
 patches:
+  "0.562":
+    - patch_file: "patches/0.552-0001-fix-cmake.patch"
+      patch_description: "enable shared build"
+      patch_type: "portability"
+    - patch_file: "patches/0.536-0002-rename-lerp.patch"
+      patch_description: "rename lerp function to avoid name conflict"
+      patch_type: "portability"
   "0.558":
     - patch_file: "patches/0.552-0001-fix-cmake.patch"
       patch_description: "enable shared build"
@@ -74,27 +75,6 @@ patches:
       patch_description: "rename lerp function to avoid name conflict"
       patch_type: "portability"
   "0.540":
-    - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      patch_description: "enable shared build"
-      patch_type: "portability"
-    - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      patch_description: "rename lerp function to avoid name conflict"
-      patch_type: "portability"
-  "0.539":
-    - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      patch_description: "enable shared build"
-      patch_type: "portability"
-    - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      patch_description: "rename lerp function to avoid name conflict"
-      patch_type: "portability"
-  "0.538":
-    - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      patch_description: "enable shared build"
-      patch_type: "portability"
-    - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      patch_description: "rename lerp function to avoid name conflict"
-      patch_type: "portability"
-  "0.537":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
       patch_description: "enable shared build"
       patch_type: "portability"

--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.562":
-    url: "https://github.com/Roblox/luau/archive/0.562.tar.gz"
-    sha256: "fa5d10356b287a8290ecdc066874870aa07bb1e5039e09bf1cddba0f8ff4d743"
+  "0.563":
+    url: "https://github.com/Roblox/luau/archive/0.563.tar.gz"
+    sha256: "717c1b3e03d20829d75eb484e0699fc824b651b8f394164bc4ab8194482890b2"
   "0.558":
     url: "https://github.com/Roblox/luau/archive/0.558.tar.gz"
     sha256: "3484adddb18872700e033f5917af44d90c266f9e0fff2fac21aec1061f472a06"
@@ -25,7 +25,7 @@ sources:
     sha256: "84b3e52b3b0ccf4d5bc0e0c04055f3a9b2f045c1281e203a858335a6fe76b0ff"
 
 patches:
-  "0.562":
+  "0.563":
     - patch_file: "patches/0.552-0001-fix-cmake.patch"
       patch_description: "enable shared build"
       patch_type: "portability"

--- a/recipes/luau/all/conanfile.py
+++ b/recipes/luau/all/conanfile.py
@@ -65,10 +65,10 @@ class LuauConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.info.settings.compiler.cppstd:
+        if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._minimum_cpp_standard)
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support."
             )

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.562":
+    folder: all
   "0.558":
     folder: all
   "0.556":
@@ -12,10 +14,4 @@ versions:
   "0.541":
     folder: all
   "0.540":
-    folder: all
-  "0.539":
-    folder: all
-  "0.538":
-    folder: all
-  "0.537":
     folder: all

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.562":
+  "0.563":
     folder: all
   "0.558":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **luau/0.563**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
