### PR TITLE
apr: fix url of source code tarball + modernize more

### DIFF
--- a/recipes/apr/all/conandata.yml
+++ b/recipes/apr/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.7.0":
-    url: "https://downloads.apache.org/apr/apr-1.7.0.tar.gz"
-    sha256: "48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2"
+    url: "https://archive.apache.org/dist/apr/apr-1.7.0.tar.bz2"
+    sha256: "e2e148f0b2e99b8e5c6caa09f6d4fb4dd3e83f744aa72a952f94f5a14436f7ea"
 patches:
   "1.7.0":
     - patch_file: "patches/0001-cmake-build-only-shared-static.patch"

--- a/recipes/apr/all/conanfile.py
+++ b/recipes/apr/all/conanfile.py
@@ -7,12 +7,12 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, unix_path
+from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 import re
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
 
 
 class AprConan(ConanFile):
@@ -81,8 +81,7 @@ class AprConan(ConanFile):
                     self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         if is_msvc(self):
@@ -125,8 +124,7 @@ class AprConan(ConanFile):
             cmake.install()
         else:
             autotools = Autotools(self)
-            # TODO: replace by autotools.install() once https://github.com/conan-io/conan/issues/12153 fixed
-            autotools.install(args=[f"DESTDIR={unix_path(self, self.package_folder)}"])
+            autotools.install()
             rm(self, "*.la", os.path.join(self.package_folder, "lib"))
             rmdir(self, os.path.join(self.package_folder, "build-1"))
             rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))


### PR DESCRIPTION
https://downloads.apache.org/apr/apr-1.7.0.tar.gz is a dead link now.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
