### PR TITLE
(#14180) Add SoPlex linear programming solver 

### DIFF
--- a/recipes/soplex/all/conandata.yml
+++ b/recipes/soplex/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "6.0.3":
+    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-603.tar.gz"
+    sha256: "2bdf9adc9ac6ad48f98056679b7b852e626ac4aaaf277e7d4ce17794ed1097be"

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -1,0 +1,123 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import collect_libs, get, replace_in_file
+from conan.tools.microsoft import check_min_vs, is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
+
+
+class SoPlexConan(ConanFile):
+    name = "soplex"
+    description = "SoPlex linear programming solver"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://soplex.zib.de"
+    topics = ("soplex", "simplex", "solver", "linear", "programming")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "BOOST": [True, False],
+        "GMP": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "BOOST": False,
+        "GMP": False
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "5",
+            "clang": "4",
+            "apple-clang": "7",
+        }
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        replace_in_file(self, "CMakeLists.txt", "GMP_INCLUDE_DIRS", "gmp_INCLUDE_DIRS")
+        replace_in_file(self, "CMakeLists.txt", "GMP_LIBRARIES", "gmp_LIBRARIES")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def requirements(self):
+        self.requires("zlib/1.2.13")
+        if self.options.GMP:
+            self.requires("gmp/6.2.1")
+        if self.options.BOOST:
+            self.requires("boost/1.81.0")  # also update Boost_VERSION_MACRO below!
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["GMP"] = self.options.GMP
+        tc.variables["BOOST"] = self.options.BOOST
+        tc.variables["Boost_VERSION_MACRO"] = "108100"
+        if is_msvc(self):
+            tc.variables["MT"] = is_msvc_static_runtime(self)
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def _determine_lib_name(self):
+        if self.options.shared:
+            return "soplexshared"
+        elif self.options.get_safe("fPIC"):
+            return "soplex-pic"
+        else:
+            return "soplex"
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        check_min_vs(self, 191)
+        if not is_msvc(self):
+            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+            if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+                )
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build(target=f"lib{self._determine_lib_name()}")
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses")
+        self.copy(pattern="src/soplex.h", dst="include", keep_path=False)
+        self.copy(pattern="src/soplex.hpp", dst="include", keep_path=False)
+        self.copy(pattern="src/soplex_interface.h", dst="include", keep_path=False)
+        self.copy(pattern="src/soplex/*.h", dst="include/soplex", keep_path=False)
+        self.copy(pattern="src/soplex/*.hpp", dst="include/soplex", keep_path=False)
+        self.copy(pattern="soplex/*.h", dst="include/soplex", keep_path=False)
+        # unix
+        self.copy(pattern="lib/*.a")
+        self.copy(pattern="lib/*.so*", symlinks=True)
+        # mac
+        self.copy(pattern="lib/*.dylib*", symlinks=True)
+        # win
+        self.copy(pattern="bin/*.dll", dst="lib", keep_path=False)
+        self.copy(pattern="lib/*.lib", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = collect_libs(self)
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -119,6 +119,7 @@ class SoPlexConan(ConanFile):
         fix_apple_shared_install_name(self)
 
     def package_info(self):
-        self.cpp_info.libs = [self._determine_lib_name()]
+        prefix = "lib" if is_msvc(self) else ""
+        self.cpp_info.libs = [prefix + self._determine_lib_name()]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/soplex/all/test_package/CMakeLists.txt
+++ b/recipes/soplex/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(soplex REQUIRED CONFIG)
+add_executable(${PROJECT_NAME} main.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE soplex::soplex)

--- a/recipes/soplex/all/test_package/conanfile.py
+++ b/recipes/soplex/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/soplex/all/test_package/main.cpp
+++ b/recipes/soplex/all/test_package/main.cpp
@@ -1,0 +1,26 @@
+#include <cstdlib>
+#include <soplex.h>
+
+using namespace soplex;
+using namespace std;
+
+int main() {
+    SoPlex mysoplex;
+    mysoplex.setIntParam(SoPlex::OBJSENSE, SoPlex::OBJSENSE_MAXIMIZE);
+
+    DSVector dummycol(0); // obj: max x + 3y
+    mysoplex.addColReal(LPCol(1.0, dummycol, 1.0, 0.0));
+    mysoplex.addColReal(LPCol(3.0, dummycol, 1.0, 0.0));
+
+    DSVector row1(2);
+    row1.add(0, 1.0);
+    row1.add(1, 1.0);
+    mysoplex.addRowReal(LPRow(0.0, row1, 2.0)); // x + y <= 2
+    mysoplex.addRowReal(LPRow(1.0, row1, infinity)); // 1 <= x + y
+
+    mysoplex.optimize();
+
+    auto objective = mysoplex.objValueReal();
+    bool objectiveValueIsFour = objective > 3.9 && objective < 4.1;
+    return objectiveValueIsFour ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/recipes/soplex/all/test_v1_package/CMakeLists.txt
+++ b/recipes/soplex/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+set(CMAKE_CXX_STANDARD 14)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/soplex/all/test_v1_package/conanfile.py
+++ b/recipes/soplex/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/soplex/config.yml
+++ b/recipes/soplex/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "6.0.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version: 
* **soplex/6.0.3**

SoPlex is the linear programming solver used within SCIP. This PR adds a required dependency to add SCIP later, see #14180

I am not the author of SCIP nor SoPlex, but my company uses MIP solvers in many projects.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
