### PR TITLE
cxxopts: lowered minimum required version of gcc to 4.9

### DIFF
--- a/recipes/cxxopts/all/conanfile.py
+++ b/recipes/cxxopts/all/conanfile.py
@@ -34,7 +34,7 @@ class CxxOptsConan(ConanFile):
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "14",
-            "gcc": "5",
+            "gcc": "4.9",
             "clang": "3.9",
             "apple-clang": "8",
         }


### PR DESCRIPTION
Since gcc 4.9 is still in use, and it supports c++11

Specify library name and version:  **cxxopts/2.2.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [+] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [+] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [+] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
