### PR TITLE
add pistache cci.20220902 (v0.0.5)

### DIFF
--- a/recipes/pistache/all/conandata.yml
+++ b/recipes/pistache/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "cci.20201127":
     url: https://github.com/pistacheio/pistache/archive/a3c5c68e0f08e19331d53d12846079ad761fe974.tar.gz
     sha256: f1abb9e43ff847ebff8edb72623c9942162df134bccfb571af9c7817d3261fae
+  "cci.20220902":
+    url: https://github.com/pistacheio/pistache/archive/769e4f458b85035f51c997e8a58d0dfeb8e5492e.tar.gz
+    sha256: c470559c25b7c89a5e964915fc4338893b969788a2a6222923dc92ac3fa6c998
 patches:
   "cci.20201127":
     - patch_file: "patches/0001-remove-fpic.patch"

--- a/recipes/pistache/all/conanfile.py
+++ b/recipes/pistache/all/conanfile.py
@@ -22,7 +22,7 @@ class PistacheConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_ssl": False,
+        "with_ssl": True,
     }
 
     generators = "cmake", "cmake_find_package"
@@ -48,7 +48,7 @@ class PistacheConan(ConanFile):
     def requirements(self):
         self.requires("rapidjson/1.1.0")
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1q")
+            self.requires("openssl/1.1.1s")
 
     def validate(self):
         compilers = {
@@ -93,8 +93,10 @@ class PistacheConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        cmake = self._configure_cmake()
-        cmake.install()
+        self.copy("*.h", src=os.path.join(self._source_subfolder, "include"), dst="include", keep_path=True)
+        self.copy("*.a", dst="lib/", keep_path=False)
+        self.copy("*.so", dst="lib/", keep_path=False)
+        self.copy("*.lib", dst="lib/", keep_path=False)
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         if self.options.shared:

--- a/recipes/pistache/config.yml
+++ b/recipes/pistache/config.yml
@@ -1,3 +1,5 @@
 versions:
   "cci.20201127":
     folder: all
+  "cci.20220902":
+    folder: all


### PR DESCRIPTION
The version "cci.20220902" points to the commit with a label "0.0.5".

Several changes since last version (cci.20201127):
1. set default option "with_ssl=True"
2. doesn't apply any patch in the patch folder, patch-0002 is already in upstream. For patch-0001 I don't know why it disables fPIC from cmake file, but most librarys support this version
3. update openssl to 1.1.1s

Specify library name and version:  **pistache/cci.20220902**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Pistache has switched to meson build, the cmake build is also supported, but the official repo no longer provides docs on how to build it as a library.
As a result, this Conan center index no longer updates pistache, the last version is still `cci.20201127`, which is significantly out of date. Hope this PR can bring a relatively up-to-date library.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
