### PR TITLE
libsvtav1: fix static build on macos llvm-clang

### DIFF
--- a/recipes/libsvtav1/all/conandata.yml
+++ b/recipes/libsvtav1/all/conandata.yml
@@ -8,3 +8,20 @@ sources:
   "1.2.1":
     url: https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v1.2.1/SVT-AV1-v1.2.1.tar.bz2
     sha256: 805827daa8aedec4f1362b959f377075e2a811680bfc76b6f4fbf2ef4e7101d4
+
+patches:
+  "1.4.1":
+    - patch_file: "patches/llvm-clang-macos.patch"
+      patch_type: "portability"
+      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2070
+      patch_description: "Allow statically compiling on macos with llvm-clang"
+  "1.3.0":
+    - patch_file: "patches/llvm-clang-macos.patch"
+      patch_type: "portability"
+      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2070
+      patch_description: "Allow statically compiling on macos with llvm-clang"
+  "1.2.1":
+    - patch_file: "patches/llvm-clang-macos.patch"
+      patch_type: "portability"
+      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2070
+      patch_description: "Allow statically compiling on macos with llvm-clang"

--- a/recipes/libsvtav1/all/conanfile.py
+++ b/recipes/libsvtav1/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMakeToolchain, CMakeDeps, CMake
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get, rmdir, apply_conandata_patches, export_conandata_patches
 from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
@@ -43,6 +43,9 @@ class SVTAV1Conan(ConanFile):
         if self.settings.arch in ("x86", "x86_64"):
             self.tool_requires("nasm/2.15.05")
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -61,6 +64,7 @@ class SVTAV1Conan(ConanFile):
         deps.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/libsvtav1/all/patches/llvm-clang-macos.patch
+++ b/recipes/libsvtav1/all/patches/llvm-clang-macos.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d2dd735..7cabadd0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -205,8 +205,11 @@ if(UNIX)
+         set(CMAKE_MACOSX_RPATH 1)
+         set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+         set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+-        set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+-        set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
++        if(NOT CMAKE_RANLIB MATCHES "llvm-ranlib$")
++            # we are using apple-clang
++            set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
++            set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
++        endif()
+     else()
+         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -z noexecstack -z relro -z now")
+     endif()


### PR DESCRIPTION
Specify library name and version:  **libsvtav1/all**

Honestly, I don't know if its the right way to handle that but I already submitted a patch upstream.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
