### PR TITLE
fix b2 to work for conan2 in windows

### DIFF
--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.layout import basic_layout
 
 from contextlib import contextmanager
 import os
-from six import StringIO
+from io import StringIO
 
 required_conan_version = ">=1.47.0"
 
@@ -126,7 +126,7 @@ class B2Conan(ConanFile):
                 with chdir(self, self._b2_engine_dir):
                     with self._bootstrap_env():
                         buf = StringIO()
-                        self.run('guess_toolset && set', output=buf)
+                        self.run('guess_toolset && set', buf)
                         guess_vars = map(
                             lambda x: x.strip(), buf.getvalue().split("\n"))
                         if "B2_TOOLSET=vcunk" in guess_vars:


### PR DESCRIPTION
Specify library name and version:  **b2/all**

Recipe broken for b2 in Windows

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
