### PR TITLE
[openssl] Update test_package for Conan v2

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -763,7 +763,7 @@ class OpenSSLConan(ConanFile):
             old_str = '-install_name $(INSTALLTOP)/$(LIBDIR)/'
             new_str = '-install_name @rpath/'
             makefile = "Makefile" if self._full_version >= "1.1.1" else "Makefile.shared"
-            replace_in_file(self, makefile, old_str, new_str, strict=self.in_local_cache)
+            replace_in_file(self, makefile, old_str, new_str)
         if self._use_nmake:
             # NMAKE interprets trailing backslash as line continuation
             if self._full_version >= "1.1.0":

--- a/recipes/openssl/1.x.x/test_package/CMakeLists.txt
+++ b/recipes/openssl/1.x.x/test_package/CMakeLists.txt
@@ -4,7 +4,7 @@ project(test_package C)
 option(OPENSSL_WITH_ZLIB "OpenSSL with zlib support" ON)
 
 set(OpenSSL_DEBUG 1)
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL REQUIRED CONFIG)
 
 # Test whether variables from https://cmake.org/cmake/help/latest/module/FindOpenSSL.html
 # are properly defined in conan generators
@@ -26,8 +26,6 @@ foreach(_custom_var ${_custom_vars})
     endif()
 endforeach()
 
-add_executable(digest digest.c)
-target_link_libraries(digest OpenSSL::SSL)
-if(OPENSSL_WITH_ZLIB)
-    target_compile_definitions(digest PRIVATE WITH_ZLIB)
-endif()
+add_executable(${PROJECT_NAME} digest.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::SSL)
+target_compile_definitions(${PROJECT_NAME} PRIVATE $<$<BOOL:${OPENSSL_WITH_ZLIB}>:WITH_ZLIB>)

--- a/recipes/openssl/1.x.x/test_package/CMakeLists.txt
+++ b/recipes/openssl/1.x.x/test_package/CMakeLists.txt
@@ -4,7 +4,7 @@ project(test_package C)
 option(OPENSSL_WITH_ZLIB "OpenSSL with zlib support" ON)
 
 set(OpenSSL_DEBUG 1)
-find_package(OpenSSL REQUIRED CONFIG)
+find_package(OpenSSL REQUIRED)
 
 # Test whether variables from https://cmake.org/cmake/help/latest/module/FindOpenSSL.html
 # are properly defined in conan generators

--- a/recipes/openssl/1.x.x/test_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_package/conanfile.py
@@ -6,8 +6,6 @@ from conan.tools.files import save, load
 import os
 import json
 
-required_conan_version = ">=1.50.2 <1.51.0 || >=1.51.2"
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
@@ -28,7 +26,7 @@ class TestPackageConan(ConanFile):
         # see https://github.com/conan-io/conan/pull/9839
         dict_test = {"skip_test": self.settings.os == "Macos" and \
                                   self.settings.arch == "armv8" and \
-                                  bool(self.dependencies["openssl"].options.shared)}
+                                  bool(self.dependencies[self.tested_reference_str].options.shared)}
         save(self, self._skip_test_filename, json.dumps(dict_test))
 
     @property
@@ -45,7 +43,7 @@ class TestPackageConan(ConanFile):
         tc = CMakeToolchain(self)
         if self.settings.os == "Android":
             tc.cache_variables["CONAN_LIBCXX"] = ""
-        openssl = self.dependencies["openssl"]
+        openssl = self.dependencies[self.tested_reference_str]
         openssl_version = Version(openssl.ref.version)
         if openssl_version.major == "1" and openssl_version.minor == "1":
             tc.cache_variables["OPENSSL_WITH_ZLIB"] = False
@@ -63,5 +61,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not self._skip_test and can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "digest")
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/openssl/1.x.x/test_v1_package/CMakeLists.txt
+++ b/recipes/openssl/1.x.x/test_v1_package/CMakeLists.txt
@@ -4,33 +4,5 @@ project(test_package C)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-option(OPENSSL_WITH_ZLIB "OpenSSL with zlib support" ON)
-
-set(OpenSSL_DEBUG 1)
-find_package(OpenSSL REQUIRED)
-
-# Test whether variables from https://cmake.org/cmake/help/latest/module/FindOpenSSL.html
-# are properly defined in conan generators
-set(_custom_vars
-    OPENSSL_FOUND
-    OPENSSL_INCLUDE_DIR
-    OPENSSL_CRYPTO_LIBRARY
-    OPENSSL_CRYPTO_LIBRARIES
-    OPENSSL_SSL_LIBRARY
-    OPENSSL_SSL_LIBRARIES
-    OPENSSL_LIBRARIES
-    OPENSSL_VERSION
-)
-foreach(_custom_var ${_custom_vars})
-    if(DEFINED _custom_var)
-        message(STATUS "${_custom_var}: ${${_custom_var}}")
-    else()
-        message(FATAL_ERROR "${_custom_var} not defined")
-    endif()
-endforeach()
-
-add_executable(digest ../test_package/digest.c)
-target_link_libraries(digest OpenSSL::SSL)
-if(OPENSSL_WITH_ZLIB)
-    target_compile_definitions(digest PRIVATE WITH_ZLIB)
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/openssl/1.x.x/test_v1_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_v1_package/conanfile.py
@@ -3,12 +3,10 @@ from conan.tools.scm import Version
 from conan.tools.build import cross_building
 import os
 
-required_conan_version = ">=1.50.2 <1.51.0 || >=1.51.2"
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     @property
     def _skip_test(self):
@@ -37,6 +35,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not self._skip_test and not cross_building(self):
-            bin_path = os.path.join("bin", "digest")
+            bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)
-        assert os.path.exists(os.path.join(self.deps_cpp_info["openssl"].rootpath, "licenses", "LICENSE"))

--- a/recipes/openssl/1.x.x/test_v1_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_v1_package/conanfile.py
@@ -6,7 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "cmake", "cmake_find_package"
 
     @property
     def _skip_test(self):


### PR DESCRIPTION
- The `self.in_local_cache` is not available on Conan v2 and should be used only for "Conan Development Flow" which does not fit regular CCI recipes
- Test package needs a dependency option value which should be cached for Conan v1


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
