### PR TITLE
Add René/grafikrobot to some recipes.

### DIFF
--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -33,6 +33,11 @@ jobs:
 
       - uses: ./.github/actions/alert-community
         with:
+          files: "recipes/b2/*/*"
+          reviewers: "@grafikrobot"
+
+      - uses: ./.github/actions/alert-community
+        with:
           files: "recipes/bandit/*/*"
           reviewers: "@MartinDelille"
 
@@ -60,6 +65,11 @@ jobs:
         with:
           files: "recipes/libltc/*/*"
           reviewers: "@MartinDelille"
+
+      - uses: ./.github/actions/alert-community
+        with:
+          files: "recipes/lyra/*/*"
+          reviewers: "@grafikrobot"
 
       - uses: ./.github/actions/alert-community
         with:


### PR DESCRIPTION
Adding grafikrobot, aka René, to notify for b2 and lyra recipes.

Specify library name and version:  **lib/1.0**

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
