### PR TITLE
config: limit alerts to on CCI

### DIFF
--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   comment:
+    if: github.repository == "conan-io/conan-center-index"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
