### PR TITLE
Add BUILD_TESTING OFF to CMake

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -99,6 +99,7 @@ class CMakeConan(ConanFile):
             save(self, "bootstrap_args", json.dumps({"bootstrap_cmake_options": ' '.join(arg for arg in bootstrap_cmake_options)}))
         else:
             tc = CMakeToolchain(self)
+            # Disabling testing because CMake tests build can fail in Windows in some cases
             tc.variables["BUILD_TESTING"] = False
             if not self.settings.compiler.cppstd:
                 tc.variables["CMAKE_CXX_STANDARD"] = 11

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -99,6 +99,7 @@ class CMakeConan(ConanFile):
             save(self, "bootstrap_args", json.dumps({"bootstrap_cmake_options": ' '.join(arg for arg in bootstrap_cmake_options)}))
         else:
             tc = CMakeToolchain(self)
+            tc.variables["BUILD_TESTING"] = False
             if not self.settings.compiler.cppstd:
                 tc.variables["CMAKE_CXX_STANDARD"] = 11
             tc.variables["CMAKE_BOOTSTRAP"] = False


### PR DESCRIPTION
We detected [some failures when building CMake](https://ci.conan.io/blue/organizations/jenkins/Examples2.0/detail/main/383/pipeline/38) in Windows. CMake tries to find the MFC's when there's a file association with _.vcproj_ files and will fail using the toolchain passed by Conan. Setting `BUILD_TESTING=OFF` seems to pass that test.