### PR TITLE
[service] fix alert community workflow

### DIFF
--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   comment:
-    if: github.repository == "conan-io/conan-center-index"
+    if: github.repository == 'conan-io/conan-center-index'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
single quotes must be used, cf https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository and https://docs.github.com/en/actions/learn-github-actions/expressions#literals

all the workflows fail since [last modification](https://github.com/conan-io/conan-center-index/commit/566d7433c8403b336602f9cff86ce4d9f1ac23a1): https://github.com/conan-io/conan-center-index/actions/workflows/alert-community.yml:
```
The workflow is not valid. .github/workflows/alert-community.yml (Line: 9, Col: 9): Unexpected symbol: '"conan-io/conan-center-index"'. Located at position 22 within expression: github.repository == "conan-io/conan-center-index"
```


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
