### PR TITLE
icu: small fixes to support Conan 2.0

### DIFF
--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -14,15 +14,6 @@ sources:
   "68.2":
     url: "https://github.com/unicode-org/icu/releases/download/release-68-2/icu4c-68_2-src.tgz"
     sha256: "c79193dee3907a2199b8296a93b52c5cb74332c26f3d167269487680d479d625"
-  "67.1":
-    url: "https://github.com/unicode-org/icu/releases/download/release-67-1/icu4c-67_1-src.tgz"
-    sha256: "94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc"
-  "66.1":
-    url: "https://github.com/unicode-org/icu/releases/download/release-66-1/icu4c-66_1-src.tgz"
-    sha256: "52a3f2209ab95559c1cf0a14f24338001f389615bf00e2585ef3dbc43ecf0a2e"
-  "65.1":
-    url: "https://github.com/unicode-org/icu/releases/download/release-65-1/icu4c-65_1-src.tgz"
-    sha256: "53e37466b3d6d6d01ead029e3567d873a43a5d1c668ed2278e253b683136d948"
 patches:
   "72.1":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
@@ -38,7 +29,4 @@ patches:
   "69.1":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
   "68.2":
-    - patch_file: "patches/0001-67.1-fix-mingw.patch"
-  "67.1":
-    - patch_file: "patches/6aba9344a18f4f32e8070ee53b79495630901c26.patch"
     - patch_file: "patches/0001-67.1-fix-mingw.patch"

--- a/recipes/icu/config.yml
+++ b/recipes/icu/config.yml
@@ -9,9 +9,4 @@ versions:
     folder: all
   "68.2":
     folder: all
-  "67.1":
-    folder: all
-  "66.1":
-    folder: all
-  "65.1":
-    folder: all
+

--- a/recipes/icu/config.yml
+++ b/recipes/icu/config.yml
@@ -9,4 +9,3 @@ versions:
     folder: all
   "68.2":
     folder: all
-


### PR DESCRIPTION
Specify library name and version:  **icu/all**

### Summary of changes

* Use `str(self.ref)` to support cross-building in Conan 2
* Compose build and host triplets directly when cross-building for iOS/watchOS/tvOS, while fixing an issue cross-building from an Apple Silicon mac (the build/host triplets would be the same and the scripts were not correctly detecting cross compilation). 
* Remove logic for cross-building on Windows as the issue mentioned in the comments is now resolved in 1.57. This, however, still requires a small nudge to the build scripts, which is specific to the `icu` build system (telling the build scripts that the `mh-msys-msvc` config fragment is needed). 

### Other changes
* Clean-up logic to check that the version of Visual Studio/msvc is the minimum required to pass the `-FS` flag - this is now possible with `check_min_vs` when passing `raise_invalid=False`. 
* Remove older versions not referenced elsewhere in Conan Center

### Manual testing, both working correctly:
* Conan 2.0: native build on macOS and cross-build to iOS with arm64 and armv7s 
* Conan 1.x: Windows, native build and cross-build to ARM64
