### PR TITLE
libbacktrace: retrieve automake wrapper scripts using newer user conf

### DIFF
--- a/recipes/libbacktrace/all/conanfile.py
+++ b/recipes/libbacktrace/all/conanfile.py
@@ -32,10 +32,6 @@ class LibbacktraceConan(ConanFile):
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
-    @property
-    def _user_info_build(self):
-        return getattr(self, "user_info_build", self.deps_user_info)
-
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -81,8 +77,8 @@ class LibbacktraceConan(ConanFile):
 
         if is_msvc(self):
             env = Environment()
-            compile_wrapper = unix_path(self, self._user_info_build["automake"].compile)
-            ar_wrapper = unix_path(self, self._user_info_build["automake"].ar_lib)
+            compile_wrapper = unix_path(self, self.conf.get("user.automake:compile-wrapper"))
+            ar_wrapper = unix_path(self, self.conf.get("user.automake:lib-wrapper"))
             env.define("CC", f"{compile_wrapper} cl -nologo")
             env.define("CXX", f"{compile_wrapper} cl -nologo")
             env.define("LD", "link -nologo")


### PR DESCRIPTION
Specify library name and version:  **libbacktrace/all**

This fixes issue building this with Conan 2.0 on Windows:
* `self.deps_user_info` is removed from Conan 2 (it is now `self.dependencies`) - however for propagating custom variables, this is now done with a conf that can be retrieved via `self.conf` - the automake recipe was updated with this a few weeks ago.
