### PR TITLE
Expose more CMake options for opentelemetry-cpp

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -93,6 +93,11 @@ class OpenTelemetryCppConan(ConanFile):
             self.requires("abseil/20220623.0")
 
         if self.options.with_otlp:
+            if Version(self.version) <= "1.4.1":
+                self.requires("opentelemetry-proto/0.11.0")
+            else:
+                self.requires("opentelemetry-proto/0.19.0")
+
             if self.options.with_otlp_grpc:
                 self.requires("grpc/1.50.1")
                 self.requires("protobuf/3.21.4")
@@ -125,11 +130,6 @@ class OpenTelemetryCppConan(ConanFile):
         if self.options.with_etw:
             self.requires("nlohmann_json/3.11.2")
             self.requires("openssl/1.1.1s")
-
-        if Version(self.version) <= "1.4.1":
-            self.requires("opentelemetry-proto/0.11.0")
-        else:
-            self.requires("opentelemetry-proto/0.19.0")
 
     def validate(self):
         if self.info.settings.compiler.cppstd:
@@ -254,14 +254,16 @@ class OpenTelemetryCppConan(ConanFile):
             "opentelemetry_common",
             "opentelemetry_exporter_in_memory",
             "opentelemetry_exporter_ostream_span",
-            "opentelemetry_proto",
             "opentelemetry_resources",
             "opentelemetry_trace",
             "opentelemetry_version",
         ]
 
         if self.options.with_otlp:
-            libraries.append("opentelemetry_otlp_recordable")
+            libraries.extend([
+                "opentelemetry_proto",
+                "opentelemetry_otlp_recordable",
+                ])
 
             if self.options.with_otlp_grpc:
                 libraries.append("opentelemetry_exporter_otlp_grpc")
@@ -323,11 +325,6 @@ class OpenTelemetryCppConan(ConanFile):
             self.cpp_info.components[lib].build_modules["cmake_find_package"] = self._otel_build_modules
             self.cpp_info.components[lib].build_modules["cmake_find_package_multi"] = self._otel_build_modules
 
-        self.cpp_info.components["opentelemetry_proto"].requires.extend([
-            "opentelemetry-proto::opentelemetry-proto",
-            "protobuf::protobuf",
-        ])
-
         self.cpp_info.components["opentelemetry_resources"].requires.extend([
             "opentelemetry_common",
         ])
@@ -368,6 +365,11 @@ class OpenTelemetryCppConan(ConanFile):
             self.cpp_info.components["opentelemetry_common"].requires.append("abseil::abseil")
 
         if self.options.with_otlp:
+            self.cpp_info.components["opentelemetry_proto"].requires.extend([
+                "opentelemetry-proto::opentelemetry-proto",
+                "protobuf::protobuf",
+            ])
+
             self.cpp_info.components["opentelemetry_otlp_recordable"].requires.extend([
                 "opentelemetry_proto",
                 "opentelemetry_resources",

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -86,50 +86,54 @@ class OpenTelemetryCppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
+        requires = set()
+
         if self.options.with_gsl:
-            self.requires("ms-gsl/4.0.0")
+            requires.add("ms-gsl/4.0.0")
 
         if self.options.with_abseil:
-            self.requires("abseil/20220623.0")
+            requires.add("abseil/20220623.0")
 
         if self.options.with_otlp:
+            requires.add("protobuf/3.21.4")
             if Version(self.version) <= "1.4.1":
-                self.requires("opentelemetry-proto/0.11.0")
+                requires.add("opentelemetry-proto/0.11.0")
             else:
-                self.requires("opentelemetry-proto/0.19.0")
+                requires.add("opentelemetry-proto/0.19.0")
 
             if self.options.with_otlp_grpc:
-                self.requires("grpc/1.50.1")
-                self.requires("protobuf/3.21.4")
+                requires.add("grpc/1.50.1")
 
             if self.options.with_otlp_http:
-                self.requires("protobuf/3.21.4")
-                self.requires("libcurl/7.86.0")
-                self.requires("nlohmann_json/3.11.2")
-                self.requires("openssl/1.1.1s")
+                requires.add("libcurl/7.87.0")
+                requires.add("nlohmann_json/3.11.2")
+                requires.add("openssl/1.1.1s")
 
         if self.options.with_zipkin:
-            self.requires("nlohmann_json/3.11.2")
-            self.requires("libcurl/7.86.0")
-            self.requires("openssl/1.1.1s")
+            requires.add("nlohmann_json/3.11.2")
+            requires.add("libcurl/7.87.0")
+            requires.add("openssl/1.1.1s")
 
         if self.options.with_prometheus:
-            self.requires("prometheus-cpp/1.1.0")
+            requires.add("prometheus-cpp/1.1.0")
 
         if self.options.with_elasticsearch:
-            self.requires("nlohmann_json/3.11.2")
-            self.requires("libcurl/7.86.0")
-            self.requires("openssl/1.1.1s")
+            requires.add("nlohmann_json/3.11.2")
+            requires.add("libcurl/7.87.0")
+            requires.add("openssl/1.1.1s")
 
         if self.options.with_jaeger:
-            self.requires("thrift/0.17.0")
+            requires.add("thrift/0.17.0")
 
             if Version(self.version) >= "1.3.0":
-                self.requires("boost/1.80.0")
+                requires.add("boost/1.81.0")
 
         if self.options.with_etw:
-            self.requires("nlohmann_json/3.11.2")
-            self.requires("openssl/1.1.1s")
+            requires.add("nlohmann_json/3.11.2")
+            requires.add("openssl/1.1.1s")
+
+        for r in requires:
+            self.requires(r)
 
     def validate(self):
         if self.info.settings.compiler.cppstd:

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -126,7 +126,10 @@ class OpenTelemetryCppConan(ConanFile):
             requires.add("thrift/0.17.0")
 
             if Version(self.version) >= "1.3.0":
-                requires.add("boost/1.81.0")
+                if self.settings.compiler == "apple-clang":
+                    requires.add("boost/1.80.0")
+                else:
+                    requires.add("boost/1.81.0")
 
         if self.options.with_etw:
             requires.add("nlohmann_json/3.11.2")

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -155,11 +155,12 @@ class OpenTelemetryCppConan(ConanFile):
         if not self.dependencies["grpc"].options.cpp_plugin:
             raise ConanInvalidConfiguration(f"{self.ref} requires grpc with cpp_plugin=True")
 
-        miss_boost_required_comp = any(self.dependencies["boost"].options.get_safe(f"without_{boost_comp}", True)
+        boost_required_comp = any(self.dependencies["boost"].options.get_safe(f"without_{boost_comp}", True)
                                        for boost_comp in self._required_boost_components)
-        if self.dependencies["boost"].options.header_only or miss_boost_required_comp:
+
+        if boost_required_comp:
             raise ConanInvalidConfiguration(
-                f"{self.ref} requires non header-only boost with these components: "
+                f"{self.ref} requires boost with these components: "
                 f"{', '.join(self._required_boost_components)}"
             )
 

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -109,7 +109,7 @@ class OpenTelemetryCppConan(ConanFile):
            self.options.with_etw
         ):
            self.requires("nlohmann_json/3.11.2")
-           self.requires("openssl/1.1.1s")
+           self.requires("openssl/1.1.1t")
 
         if (self.options.with_zipkin or
            self.options.with_elasticsearch or

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -22,12 +22,45 @@ class OpenTelemetryCppConan(ConanFile):
     options = {
         "fPIC": [True, False],
         "shared": [True, False],
+        "with_no_deprecated_code": [True, False],
+        "with_stl": [True, False],
+        "with_gsl": [True, False],
+        "with_abseil": [True, False],
+        "with_otlp": [True, False],
+        "with_otlp_grpc": [True, False],
+        "with_otlp_http": [True, False],
+        "with_zipkin": [True, False],
+        "with_prometheus": [True, False],
+        "with_elasticsearch": [True, False],
+        "with_zpages": [True, False],
+        "with_jaeger": [True, False],
+        "with_no_getenv": [True, False],
+        "with_etw": [True, False],
         "with_logs_preview": [True, False],
+        "with_async_export_preview": [True, False],
+        "with_metrics_exemplar_preview": [True, False],
     }
     default_options = {
         "fPIC": True,
         "shared": False,
+
+        "with_no_deprecated_code": False,
+        "with_stl": False,
+        "with_gsl": False,
+        "with_abseil": True,
+        "with_otlp": True,
+        "with_otlp_grpc": True,
+        "with_otlp_http": True,
+        "with_zipkin": True,
+        "with_prometheus": False,
+        "with_elasticsearch": False,
+        "with_zpages": False,
+        "with_jaeger": True,
+        "with_no_getenv": False,
+        "with_etw": False,
         "with_logs_preview": False,
+        "with_async_export_preview": False,
+        "with_metrics_exemplar_preview": False,
     }
     short_paths = True
 
@@ -53,19 +86,50 @@ class OpenTelemetryCppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("abseil/20220623.0")
-        self.requires("grpc/1.50.1")
-        self.requires("libcurl/7.86.0")
-        self.requires("nlohmann_json/3.11.2")
-        self.requires("openssl/1.1.1s")
+        if self.options.with_gsl:
+            self.requires("ms-gsl/4.0.0")
+
+        if self.options.with_abseil:
+            self.requires("abseil/20220623.0")
+
+        if self.options.with_otlp:
+            if self.options.with_otlp_grpc:
+                self.requires("grpc/1.50.1")
+                self.requires("protobuf/3.21.4")
+
+            if self.options.with_otlp_http:
+                self.requires("protobuf/3.21.4")
+                self.requires("libcurl/7.86.0")
+                self.requires("nlohmann_json/3.11.2")
+                self.requires("openssl/1.1.1s")
+
+        if self.options.with_zipkin:
+            self.requires("nlohmann_json/3.11.2")
+            self.requires("libcurl/7.86.0")
+            self.requires("openssl/1.1.1s")
+
+        if self.options.with_prometheus:
+            self.requires("prometheus-cpp/1.1.0")
+
+        if self.options.with_elasticsearch:
+            self.requires("nlohmann_json/3.11.2")
+            self.requires("libcurl/7.86.0")
+            self.requires("openssl/1.1.1s")
+
+        if self.options.with_jaeger:
+            self.requires("thrift/0.17.0")
+
+            if Version(self.version) >= "1.3.0":
+                self.requires("boost/1.80.0")
+
+        if self.options.with_etw:
+            self.requires("nlohmann_json/3.11.2")
+            self.requires("openssl/1.1.1s")
+
         if Version(self.version) <= "1.4.1":
             self.requires("opentelemetry-proto/0.11.0")
         else:
             self.requires("opentelemetry-proto/0.19.0")
-        self.requires("protobuf/3.21.4")
-        self.requires("thrift/0.17.0")
-        if Version(self.version) >= "1.3.0":
-            self.requires("boost/1.80.0")
 
     def validate(self):
         if self.info.settings.compiler.cppstd:
@@ -74,6 +138,12 @@ class OpenTelemetryCppConan(ConanFile):
 
         if self.settings.os != "Linux" and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} supports building shared libraries only on Linux")
+
+        if self.options.with_otlp_grpc and not self.options.with_otlp:
+            raise ConanInvalidConfiguration("Option 'with_otlp_grpc' requires 'with_otlp'")
+
+        if self.options.with_otlp_http and not self.options.with_otlp:
+            raise ConanInvalidConfiguration("Option 'with_otlp_http' requires 'with otlp'")
 
         if not self.dependencies["grpc"].options.cpp_plugin:
             raise ConanInvalidConfiguration(f"{self.ref} requires grpc with cpp_plugin=True")
@@ -99,15 +169,28 @@ class OpenTelemetryCppConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+
         tc.variables["BUILD_TESTING"] = False
-        tc.variables["WITH_ABSEIL"] = True
-        tc.variables["WITH_ETW"] = True
-        tc.variables["WITH_EXAMPLES"] = False
-        tc.variables["WITH_JAEGER"] = True
-        tc.variables["WITH_OTLP"] = True
-        tc.variables["WITH_ZIPKIN"] = True
-        if self.options.with_logs_preview:
-            tc.variables["WITH_LOGS_PREVIEW"] = True
+        tc.variables["BUILD_BENCHMARK"] = False
+
+        tc.variables["WITH_NO_DEPRECATED_CODE"] = self.options.with_no_deprecated_code
+        tc.variables["WITH_STL"] = self.options.with_stl
+        tc.variables["WITH_GSL"] = self.options.with_gsl
+        tc.variables["WITH_ABSEIL"] = self.options.with_abseil
+        tc.variables["WITH_OTLP"] = self.options.with_otlp
+        tc.variables["WITH_OTLP_GRPC"] = self.options.with_otlp_grpc
+        tc.variables["WITH_OTLP_HTTP"] = self.options.with_otlp_http
+        tc.variables["WITH_ZIPKIN"] = self.options.with_zipkin
+        tc.variables["WITH_PROMETHEUS"] = self.options.with_prometheus
+        tc.variables["WITH_ELASTICSEARCH"] = self.options.with_elasticsearch
+        tc.variables["WITH_ZPAGES"] = self.options.with_zpages
+        tc.variables["WITH_JAEGER"] = self.options.with_jaeger
+        tc.variables["WITH_NO_GETENV"] = self.options.with_no_getenv
+        tc.variables["WITH_ETW"] = self.options.with_etw
+        tc.variables["WITH_LOGS_PREVIEW"] = self.options.with_logs_preview
+        tc.variables["WITH_ASYNC_EXPORT_PREVIEW"] = self.options.with_async_export_preview
+        tc.variables["WITH_METRICS_EXEMPLAR_PREVIEW"] = self.options.with_metrics_exemplar_preview
+
         tc.generate()
 
         tc = CMakeDeps(self)
@@ -170,20 +253,51 @@ class OpenTelemetryCppConan(ConanFile):
             self._http_client_name,
             "opentelemetry_common",
             "opentelemetry_exporter_in_memory",
-            "opentelemetry_exporter_jaeger_trace",
             "opentelemetry_exporter_ostream_span",
-            "opentelemetry_exporter_otlp_grpc",
-            "opentelemetry_exporter_otlp_http",
-            "opentelemetry_exporter_zipkin_trace",
-            "opentelemetry_otlp_recordable",
             "opentelemetry_proto",
             "opentelemetry_resources",
             "opentelemetry_trace",
             "opentelemetry_version",
         ]
 
-        if Version(self.version) >= "1.1.0":
-            libraries.append("opentelemetry_exporter_otlp_http_client")
+        if self.options.with_otlp:
+            libraries.append("opentelemetry_otlp_recordable")
+
+            if self.options.with_otlp_grpc:
+                libraries.append("opentelemetry_exporter_otlp_grpc")
+
+                if Version(self.version) >= "1.5.0":
+                    libraries.append("opentelemetry_exporter_otlp_grpc_metrics")
+
+                if Version(self.version) >= "1.7.0":
+                    libraries.append("opentelemetry_exporter_otlp_grpc_client")
+
+                if self.options.with_logs_preview:
+                    libraries.append("opentelemetry_exporter_otlp_grpc_log")
+
+            if self.options.with_otlp_http:
+                libraries.append("opentelemetry_exporter_otlp_http")
+
+                if Version(self.version) >= "1.1.0":
+                    libraries.append("opentelemetry_exporter_otlp_http_client")
+
+                if Version(self.version) >= "1.5.0":
+                    libraries.append("opentelemetry_exporter_otlp_http_metric")
+
+                if self.options.with_logs_preview:
+                    libraries.append("opentelemetry_exporter_otlp_http_log")
+
+        if self.options.with_prometheus:
+            libraries.append("opentelemetry_exporter_prometheus")
+
+        if self.options.with_elasticsearch and self.options.with_logs_preview:
+            libraries.append("opentelemetry_exporter_elasticsearch_logs")
+
+        if self.options.with_zipkin:
+            libraries.append("opentelemetry_exporter_zipkin_trace")
+
+        if self.options.with_jaeger:
+            libraries.append("opentelemetry_exporter_jaeger_trace")
 
         if Version(self.version) >= "1.2.0":
             libraries.append("opentelemetry_metrics")
@@ -191,25 +305,15 @@ class OpenTelemetryCppConan(ConanFile):
         if Version(self.version) >= "1.4.0":
             libraries.append("opentelemetry_exporter_ostream_metrics")
 
-        if Version(self.version) >= "1.5.0":
-            libraries.append("opentelemetry_exporter_otlp_grpc_metrics")
-            libraries.append("opentelemetry_exporter_otlp_http_metric")
-
-        if Version(self.version) >= "1.7.0":
-            libraries.append("opentelemetry_exporter_otlp_grpc_client")
-
         if self.options.with_logs_preview:
             libraries.extend([
                 "opentelemetry_logs",
                 "opentelemetry_exporter_ostream_logs",
-                "opentelemetry_exporter_otlp_grpc_log",
-                "opentelemetry_exporter_otlp_http_log",
             ])
 
-        if self.settings.os == "Windows":
-            libraries.extend([
-                "opentelemetry_exporter_etw",
-            ])
+        if self.settings.os == "Windows" and self.options.with_etw:
+            libraries.append("opentelemetry_exporter_etw")
+
         return libraries
 
     def package_info(self):
@@ -218,93 +322,6 @@ class OpenTelemetryCppConan(ConanFile):
             self.cpp_info.components[lib].builddirs.append(self._module_subfolder)
             self.cpp_info.components[lib].build_modules["cmake_find_package"] = self._otel_build_modules
             self.cpp_info.components[lib].build_modules["cmake_find_package_multi"] = self._otel_build_modules
-
-        self.cpp_info.components[self._http_client_name].requires.extend(["libcurl::libcurl"])
-
-        self.cpp_info.components["opentelemetry_common"].defines.append("HAVE_ABSEIL")
-        self.cpp_info.components["opentelemetry_common"].requires.extend([
-            "abseil::abseil",
-        ])
-
-        if self.settings.os == "Windows":
-            self.cpp_info.components["opentelemetry_exporter_etw"].libs = []
-            self.cpp_info.components["opentelemetry_exporter_etw"].requires.extend([
-                "nlohmann_json::nlohmann_json",
-            ])
-
-        self.cpp_info.components["opentelemetry_exporter_in_memory"].libs = []
-
-        self.cpp_info.components["opentelemetry_exporter_jaeger_trace"].requires.extend([
-            self._http_client_name,
-            "openssl::openssl",
-            "opentelemetry_resources",
-            "thrift::thrift",
-        ])
-        if Version(self.version) >= "1.3.0":
-            self.cpp_info.components["opentelemetry_exporter_jaeger_trace"].requires.extend([
-                "boost::locale",
-            ])
-
-        self.cpp_info.components["opentelemetry_exporter_ostream_span"].requires.extend([
-            "opentelemetry_trace",
-        ])
-
-        self.cpp_info.components["opentelemetry_exporter_otlp_http_client"].requires.extend([
-            self._http_client_name,
-            "nlohmann_json::nlohmann_json",
-            "opentelemetry_proto",
-        ])
-
-        self.cpp_info.components["opentelemetry_exporter_otlp_http"].requires.extend([
-            "opentelemetry_otlp_recordable",
-            "opentelemetry_exporter_otlp_http_client",
-        ])
-
-        if Version(self.version) >= "1.5.0":
-            self.cpp_info.components["opentelemetry_exporter_otlp_http_metric"].requires.extend([
-                "opentelemetry_otlp_recordable",
-                "opentelemetry_exporter_otlp_http_client"
-            ])
-
-        if Version(self.version) >= "1.5.0" and Version(self.version) < "1.7.0":
-            self.cpp_info.components["opentelemetry_exporter_otlp_grpc_metrics"].requires.extend([
-                "grpc::grpc++",
-                "opentelemetry_otlp_recordable",
-            ])
-
-        if Version(self.version) <= "1.7.0":
-            self.cpp_info.components["opentelemetry_exporter_otlp_grpc"].requires.extend([
-                "grpc::grpc++",
-                "opentelemetry_otlp_recordable",
-            ])
-
-        if Version(self.version) >= "1.7.0":
-            self.cpp_info.components["opentelemetry_exporter_otlp_grpc_client"].requires.extend([
-                "grpc::grpc++",
-                "opentelemetry_proto",
-            ])
-
-            self.cpp_info.components["opentelemetry_exporter_otlp_grpc"].requires.extend([
-                "opentelemetry_otlp_recordable",
-                "opentelemetry_exporter_otlp_grpc_client"
-            ])
-
-            self.cpp_info.components["opentelemetry_exporter_otlp_grpc_metrics"].requires.extend([
-                "opentelemetry_otlp_recordable",
-                "opentelemetry_exporter_otlp_grpc_client"
-            ])
-
-        self.cpp_info.components["opentelemetry_exporter_zipkin_trace"].requires.extend([
-            self._http_client_name,
-            "nlohmann_json::nlohmann_json",
-            "opentelemetry_trace",
-        ])
-
-        self.cpp_info.components["opentelemetry_otlp_recordable"].requires.extend([
-            "opentelemetry_proto",
-            "opentelemetry_resources",
-            "opentelemetry_trace",
-        ])
 
         self.cpp_info.components["opentelemetry_proto"].requires.extend([
             "opentelemetry-proto::opentelemetry-proto",
@@ -320,25 +337,131 @@ class OpenTelemetryCppConan(ConanFile):
             "opentelemetry_resources",
         ])
 
+        self.cpp_info.components["opentelemetry_exporter_ostream_span"].requires.append(
+            "opentelemetry_trace",
+        )
+
+        self.cpp_info.components["opentelemetry_exporter_in_memory"].libs = []
+
         if self.options.with_logs_preview:
             self.cpp_info.components["opentelemetry_logs"].requires.extend([
                 "opentelemetry_resources",
                 "opentelemetry_common",
             ])
 
-            self.cpp_info.components["opentelemetry_exporter_ostream_logs"].requires.extend([
+            self.cpp_info.components["opentelemetry_exporter_ostream_logs"].requires.append(
                 "opentelemetry_logs",
+            )
+
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.components["opentelemetry_common"].system_libs.extend(["pthread"])
+
+        if self.options.with_stl:
+            self.cpp_info.components["opentelemetry_common"].defines.append("HAVE_CPP_STDLIB")
+
+        if self.options.with_gsl:
+            self.cpp_info.components["opentelemetry_common"].defines.append("HAVE_GSL")
+            self.cpp_info.components["opentelemetry_common"].requires.append("ms-gsl::_ms-gsl")
+
+        if self.options.with_abseil:
+            self.cpp_info.components["opentelemetry_common"].defines.append("HAVE_ABSEIL")
+            self.cpp_info.components["opentelemetry_common"].requires.append("abseil::abseil")
+
+        if self.options.with_otlp:
+            self.cpp_info.components["opentelemetry_otlp_recordable"].requires.extend([
+                "opentelemetry_proto",
+                "opentelemetry_resources",
+                "opentelemetry_trace",
             ])
 
-            self.cpp_info.components["opentelemetry_exporter_otlp_grpc_log"].requires.extend([
-                "opentelemetry_otlp_recordable",
-                "opentelemetry_exporter_otlp_grpc_client",
+        if self.options.with_otlp_grpc:
+            if Version(self.version) >= "1.5.0" and Version(self.version) < "1.7.0":
+                self.cpp_info.components["opentelemetry_exporter_otlp_grpc_metrics"].requires.extend([
+                    "grpc::grpc++",
+                    "opentelemetry_otlp_recordable",
+                ])
+
+            if Version(self.version) <= "1.7.0":
+                self.cpp_info.components["opentelemetry_exporter_otlp_grpc"].requires.extend([
+                    "grpc::grpc++",
+                    "opentelemetry_otlp_recordable",
+                ])
+
+            if Version(self.version) >= "1.7.0":
+                self.cpp_info.components["opentelemetry_exporter_otlp_grpc_client"].requires.extend([
+                    "grpc::grpc++",
+                    "opentelemetry_proto",
+                ])
+
+                self.cpp_info.components["opentelemetry_exporter_otlp_grpc"].requires.extend([
+                    "opentelemetry_otlp_recordable",
+                    "opentelemetry_exporter_otlp_grpc_client"
+                ])
+
+                self.cpp_info.components["opentelemetry_exporter_otlp_grpc_metrics"].requires.extend([
+                    "opentelemetry_otlp_recordable",
+                    "opentelemetry_exporter_otlp_grpc_client"
+                ])
+
+            if self.options.with_logs_preview:
+                self.cpp_info.components["opentelemetry_exporter_otlp_grpc_log"].requires.extend([
+                    "opentelemetry_otlp_recordable",
+                    "opentelemetry_exporter_otlp_grpc_client",
+                ])
+
+        if (self.options.with_otlp_http or
+            self.options.with_zipkin or
+            self.options.with_elasticsearch
+        ):
+            self.cpp_info.components[self._http_client_name].requires.append("libcurl::libcurl")
+
+        if self.options.with_otlp_http:
+            self.cpp_info.components["opentelemetry_exporter_otlp_http_client"].requires.extend([
+                self._http_client_name,
+                "nlohmann_json::nlohmann_json",
+                "opentelemetry_proto",
             ])
 
-            self.cpp_info.components["opentelemetry_exporter_otlp_http_log"].requires.extend([
+            self.cpp_info.components["opentelemetry_exporter_otlp_http"].requires.extend([
                 "opentelemetry_otlp_recordable",
                 "opentelemetry_exporter_otlp_http_client",
             ])
 
-        if self.settings.os in ("Linux", "FreeBSD"):
-            self.cpp_info.components["opentelemetry_common"].system_libs.extend(["pthread"])
+            if Version(self.version) >= "1.5.0":
+                self.cpp_info.components["opentelemetry_exporter_otlp_http_metric"].requires.extend([
+                    "opentelemetry_otlp_recordable",
+                    "opentelemetry_exporter_otlp_http_client"
+                ])
+
+            if self.options.with_logs_preview:
+                self.cpp_info.components["opentelemetry_exporter_otlp_http_log"].requires.extend([
+                    "opentelemetry_otlp_recordable",
+                    "opentelemetry_exporter_otlp_http_client",
+                ])
+
+        if self.options.with_zipkin:
+            self.cpp_info.components["opentelemetry_exporter_zipkin_trace"].requires.extend([
+                self._http_client_name,
+                "nlohmann_json::nlohmann_json",
+                "opentelemetry_trace",
+            ])
+
+        if self.options.with_jaeger:
+            self.cpp_info.components["opentelemetry_exporter_jaeger_trace"].requires.extend([
+                self._http_client_name,
+                "openssl::openssl",
+                "opentelemetry_resources",
+                "thrift::thrift",
+            ])
+
+            if Version(self.version) >= "1.3.0":
+                self.cpp_info.components["opentelemetry_exporter_jaeger_trace"].requires.append(
+                    "boost::locale"
+                )
+
+        if self.settings.os == "Windows" and self.options.with_etw:
+            self.cpp_info.components["opentelemetry_exporter_etw"].libs = []
+            self.cpp_info.components["opentelemetry_exporter_etw"].requires.append(
+                "nlohmann_json::nlohmann_json",
+            )
+


### PR DESCRIPTION
Specify library name and version:  **opentelemetry-cpp**

I was looking for some of these extra features that are hidden behind cmake options, and noticed that the recipe didn't expose them. So I've had a crack at exposing all the rest that are available in opentelemetry-cpp's CMakeLists.txt.

I've tried to keep the conan option defaults matching what the package was previously being built with, and for the new ones defaulting to what opentelemetry-cpp defaults them to. 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
