### PR TITLE
qt: don't use cmake 3.25.0, due to Ninja dependency cycle bug

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -435,7 +435,8 @@ class QtConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("cmake/3.25.2")
         self.tool_requires("ninja/1.11.1")
-        self.tool_requires("pkgconf/1.9.3")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/1.9.3")
         if self.settings.os == "Windows":
             self.tool_requires('strawberryperl/5.32.1.1')
 

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -433,7 +433,7 @@ class QtConan(ConanFile):
             self.requires("md4c/0.4.8")
 
     def build_requirements(self):
-        self.tool_requires("cmake/3.25.0")
+        self.tool_requires("cmake/3.25.2")
         self.tool_requires("ninja/1.11.1")
         self.tool_requires("pkgconf/1.9.3")
         if self.settings.os == "Windows":


### PR DESCRIPTION
Strangely, I started getting a "Ninja cycle dependency error" on Windows (QT 6.4.2).
The error looks something like this (different files for me):

```
ninja: error: dependency cycle: src/CMakeFiles/ossia.dir/cmake_pch.cxx.obj -> src/CMakeFiles/ossia.dir/CXX.dd -> src/CMakeFiles/ossia.dir/ossia/context.cpp.obj.ddi -> src/CMakeFiles/ossia.dir/cmake_pch.cxx.pch -> src/CMakeFiles/ossia.dir/cmake_pch.cxx.obj
```

After a bit of googling, it appears that it is caused by a change in cmake 3.25,
and was later patched (apparently).

example: https://gitlab.kitware.com/cmake/cmake/-/issues/19220
https://gitlab.kitware.com/cmake/cmake/-/issues/24209

Forcing qt to build with cmake 3.25.1 (with [tool_requires] in the profile) worked, so I'm bumping the build_requirements to 3.25.2.
