### PR TITLE
spdlog: add transitive_libs trait on fmt dependency (Conan 2.0)

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -12,6 +12,7 @@ required_conan_version = ">=1.53.0"
 
 class SpdlogConan(ConanFile):
     name = "spdlog"
+    package_type = "library"
     description = "Fast C++ logging library"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/gabime/spdlog"
@@ -49,18 +50,19 @@ class SpdlogConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "1.11.0":
-            self.requires("fmt/9.1.0", transitive_headers=True)
-        elif Version(self.version) >= "1.10.0":
-            self.requires("fmt/8.1.1", transitive_headers=True)
-        elif Version(self.version) >= "1.9.0":
-            self.requires("fmt/8.0.1", transitive_headers=True)
-        elif Version(self.version) >= "1.7.0":
-            self.requires("fmt/7.1.3", transitive_headers=True)
-        elif Version(self.version) >= "1.5.0":
-            self.requires("fmt/6.2.1", transitive_headers=True)
-        else:
-            self.requires("fmt/6.0.0", transitive_headers=True)
+        self_version = Version(self.version)
+        fmt_version = "7.1.3"
+
+        if self_version >= "1.11.0":
+            fmt_version = "9.1.0"
+        elif self_version >= "1.10.0":
+            fmt_version = "8.1.1"
+        elif self_version >= "1.9.0":
+            fmt_version = "8.0.1"
+        elif self_version >= "1.7.0":
+            fmt_version = "7.1.3"
+
+        self.requires(f"fmt/{fmt_version}", transitive_headers=True, transitive_libs=True)
 
     def package_id(self):
         if self.info.options.header_only:


### PR DESCRIPTION
Specify library name and version:  **spdlog/all**

### Summary of changes
Add `transitive_libs=True` dependency trait on `fmt` dependency, as public use of public `spdlog` headers cause downstream consumers to directly reference symbols from `fmt` and these need to be seen by the linker.

This fixes an error when `spdlog` and `fmt` are both shared libraries (`-o "*:shared=True"` in Conan 2.0), and the test package of `spdlog` fails to build correctly. This would also be experienced by any downstream consumer of this configuration.

The public `spdlog` headers cause the consumers to _directly_ reference symbols from `fmt` themselves (at least as far as the C++ and linker are concerned). Thus, this is not a case where `spdlog` uses `fmt` privately but rather it's a public dependency. In Conan 2 this implies we need to make `transitive_libs=True` so that consumers also link against `fmt`.


Additional change: add `package_type` attribute.

