### PR TITLE
boost: fix build-time checks against libbacktrace

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -821,6 +821,15 @@ class BoostConan(ConanFile):
             replace_in_file(self, os.path.join(self.source_folder, "libs", "stacktrace", "build", "Jamfile.v2"),
                                   "$(>) > $(<)",
                                   "echo \"\" > $(<)", strict=False)
+        if self._with_stacktrace_backtrace and self.settings.os in ["Linux", "Macos"] and not cross_building(self):
+            # When libbacktrace is shared, give extra help to the test-executable
+            linker_var = "LD_LIBRARY_PATH" if self.settings.os == "Linux" else "DYLD_LIBRARY_PATH"
+            libbacktrace_libdir = self.dependencies["libbacktrace"].cpp_info.libdirs[0]
+            patched_run_rule = f"{linker_var}={libbacktrace_libdir} $(>) > $(<)"
+            replace_in_file(self, os.path.join(self.source_folder, "libs", "stacktrace", "build", "Jamfile.v2"),
+                                  "$(>) > $(<)",
+                                  patched_run_rule, strict=False)
+
         # Older clang releases require a thread_local variable to be initialized by a constant value
         replace_in_file(self, os.path.join(self.source_folder, "boost", "stacktrace", "detail", "libbacktrace_impls.hpp"),
                               "/* thread_local */", "thread_local", strict=False)

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -820,10 +820,10 @@ class BoostConan(ConanFile):
         if cross_building(self, skip_x64_x86=True):
             # When cross building, do not attempt to run the test-executable (assume they work)
             replace_in_file(self, stacktrace_jamfile, "$(>) > $(<)", "echo \"\" > $(<)", strict=False)
-        if self._with_stacktrace_backtrace and self.settings.os in ["Linux", "Macos"] and not cross_building(self):
+        if self._with_stacktrace_backtrace and self.settings.os != "Windows" and not cross_building(self):
             # When libbacktrace is shared, give extra help to the test-executable
-            linker_var = "LD_LIBRARY_PATH" if self.settings.os == "Linux" else "DYLD_LIBRARY_PATH"
-            libbacktrace_libdir = self.dependencies["libbacktrace"].cpp_info.libdirs[0]
+            linker_var = "DYLD_LIBRARY_PATH" if self.settings.os == "Macos" else "LD_LIBRARY_PATH"
+            libbacktrace_libdir = self.dependencies["libbacktrace"].cpp_info.aggregated_components().libdirs[0]
             patched_run_rule = f"{linker_var}={libbacktrace_libdir} $(>) > $(<)"
             replace_in_file(self, stacktrace_jamfile, "$(>) > $(<)", patched_run_rule, strict=False)
             if self.dependencies["libbacktrace"].options.shared:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -539,7 +539,7 @@ class BoostConan(ConanFile):
         if self._with_zstd:
             self.requires("zstd/1.5.2")
         if self._with_stacktrace_backtrace:
-            self.requires("libbacktrace/cci.20210118", transitive_headers=True)
+            self.requires("libbacktrace/cci.20210118", transitive_headers=True, transitive_libs=True)
 
         if self._with_icu:
             self.requires("icu/72.1")


### PR DESCRIPTION
Specify library name and version:  **boost/all**

### Problem

* When building boost when `libbacktrace` is shared, the build may be misconfigured in a way that it doesn't build the stacktrace library when expected. 
```ERROR: boost/1.80.0: Error in package_info() method, line 1681
        raise ConanException(f"These libraries were expected to be built, but were not built: {non_built}")
        ConanException: These libraries were expected to be built, but were not built: {'boost_stacktrace_backtrace'}
```

This correlates with the following in the configuration checks:
```
    - libbacktrace builds      : no [2]
    - libbacktrace builds      : no [3]
```

### Causes
On platforms where Boost is built against `libbacktrace` by default, the build scripts compile a test executable and then run it during configuration time. 
There are two problems with this, in particular when the `libbacktrace` dependency is built with `shared=True`:
* on macOS, the executable (which is run at build time) cannot run as it cannot find `@rpath/libbacktrace.dylib`. This can be fixed with `DYLD_LIBRARY_PATH`, and while it could be fixed by exposing the `ConanRunEnv` at build time, `/bin/sh` will clear all `DYLD_*` environment variables due to the System integrity protection and won't work. 
* on Linux, the test executable tries to link to `libbacktrace` statically, _regardless_ of whether this is what we want, by telling the linker to prefer the static version (possibly with `-Wl,-Bstatic`, which would explain why this is not observed on macOS, as the linker does not have an equivalent flag). This may well be a defect of the upstream build scripts and may need more investigation. This can have two side effects:
    - the check passes, but the executable is linked against a static `libbacktrace` that is found on the system (very likely on Ubuntu)
    - the check fails, reporting that `-lbacktrace` doesn't work, despite the fact that the Conan recipe does pass the right flags - this will happen when the `libbacktrace` dependency has `shared=True`. 

If the check fails, this will cause the stacktrace library to not be built (leading to the errors described above), _even_ if it could be built without issues.
  
    
### Solution
* Expose `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` with the directory that contains `libbacktrace.[so|dylib]` by patching the relevant jam file
* Make sure the test executable is linked against the shared library when we know `libbacktrace` is shared

## Verifying this:
When building with `-o *:shared=True`, the resulting `libboost_stacktrace_backtrace.so` (or dylib) _must_ have a runtime dependency on the shared `libbacktrace.so` (or dylib).

Close https://github.com/conan-io/conan-center-index/issues/13448
Close https://github.com/conan-io/conan-center-index/issues/7346
