### PR TITLE
cpuinfo: modernize more for conan v2

### DIFF
--- a/recipes/cpuinfo/all/CMakeLists.txt
+++ b/recipes/cpuinfo/all/CMakeLists.txt
@@ -1,8 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-if(NOT CMAKE_SYSTEM_PROCESSOR AND CONAN_CPUINFO_SYSTEM_PROCESSOR)
-    set(CMAKE_SYSTEM_PROCESSOR ${CONAN_CPUINFO_SYSTEM_PROCESSOR})
-endif()
-
-add_subdirectory(src)

--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -1,11 +1,10 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, replace_in_file, rmdir
 import os
 
-required_conan_version = ">=1.51.1"
+required_conan_version = ">=1.53.0"
 
 
 class CpuinfoConan(ConanFile):
@@ -29,45 +28,32 @@ class CpuinfoConan(ConanFile):
         "log_level": "default",
     }
 
-    exports_sources = "CMakeLists.txt"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.info.settings.os == "Windows" and self.info.options.shared:
+        if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("shared cpuinfo not supported on Windows")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
         # cpuinfo
         tc.cache_variables["CPUINFO_LIBRARY_TYPE"] = "default"
         tc.cache_variables["CPUINFO_RUNTIME_TYPE"] = "default"
-        # TODO: remove str cast in conan 1.53.0 (see https://github.com/conan-io/conan/pull/12086)
-        tc.cache_variables["CPUINFO_LOG_LEVEL"] = str(self.options.log_level)
+        tc.cache_variables["CPUINFO_LOG_LEVEL"] = self.options.log_level
         tc.variables["CPUINFO_BUILD_TOOLS"] = False
         tc.variables["CPUINFO_BUILD_UNIT_TESTS"] = False
         tc.variables["CPUINFO_BUILD_MOCK_TESTS"] = False
@@ -76,13 +62,6 @@ class CpuinfoConan(ConanFile):
         tc.cache_variables["CLOG_RUNTIME_TYPE"] = "default"
         tc.variables["CLOG_BUILD_TESTS"] = False
         tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
-        # CMAKE_SYSTEM_PROCESSOR must be manually set if cross-building
-        if cross_building(self):
-            cmake_system_processor = {
-                "armv8": "arm64",
-                "armv8.3": "arm64",
-            }.get(str(self.settings.arch), str(self.settings.arch))
-            tc.variables["CONAN_CPUINFO_SYSTEM_PROCESSOR"] = cmake_system_processor
         tc.generate()
 
     def _patch_sources(self):
@@ -93,7 +72,7 @@ class CpuinfoConan(ConanFile):
     def build(self):
         self._patch_sources()
         cmake = CMake(self)
-        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        cmake.configure()
         cmake.build()
 
     def package(self):

--- a/recipes/cpuinfo/all/test_v1_package/CMakeLists.txt
+++ b/recipes/cpuinfo/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES C)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(cpuinfo REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE cpuinfo::cpuinfo)
-target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
Manual handling of CMAKE_SYSTEM_PROCESSOR is not required anymore. CMakeToolchain injects correct values in case of cross-build.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
