### PR TITLE
libwebp: add component for libsharpyuv

### DIFF
--- a/recipes/libwebp/all/conanfile.py
+++ b/recipes/libwebp/all/conanfile.py
@@ -105,20 +105,22 @@ class LibwebpConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["webpdecoder"].system_libs = ["m", "pthread"]
 
-        # sharpyuv
-        self.cpp_info.components["sharpyuv"].set_property("cmake_target_name", "WebP::sharpyuv")
-        self.cpp_info.components["sharpyuv"].set_property("pkg_config_name", "libsharpyuv")
-        self.cpp_info.components["sharpyuv"].libs = ["sharpyuv"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["sharpyuv"].system_libs = ["m", "pthread"]
-
         # webp
         self.cpp_info.components["webp"].set_property("cmake_target_name", "WebP::webp")
         self.cpp_info.components["webp"].set_property("pkg_config_name", "libwebp")
         self.cpp_info.components["webp"].libs = ["webp"]
-        self.cpp_info.components["webp"].requires = ["sharpyuv"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["webp"].system_libs = ["m", "pthread"]
+
+        if Version(self.version) >= "1.3.0":
+            # sharpyuv
+            self.cpp_info.components["sharpyuv"].set_property("cmake_target_name", "WebP::sharpyuv")
+            self.cpp_info.components["sharpyuv"].set_property("pkg_config_name", "libsharpyuv")
+            self.cpp_info.components["sharpyuv"].libs = ["sharpyuv"]
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.components["sharpyuv"].system_libs = ["m", "pthread"]
+            # note: webp now depends on sharpyuv
+            self.cpp_info.components["webp"].requires = ["sharpyuv"]
 
         # webpdemux
         self.cpp_info.components["webpdemux"].set_property("cmake_target_name", "WebP::webpdemux")

--- a/recipes/libwebp/all/conanfile.py
+++ b/recipes/libwebp/all/conanfile.py
@@ -103,12 +103,20 @@ class LibwebpConan(ConanFile):
         self.cpp_info.components["webpdecoder"].set_property("pkg_config_name", "libwebpdecoder")
         self.cpp_info.components["webpdecoder"].libs = ["webpdecoder"]
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["webpdecoder"].system_libs = ["pthread"]
+            self.cpp_info.components["webpdecoder"].system_libs = ["m", "pthread"]
+
+        # sharpyuv
+        self.cpp_info.components["sharpyuv"].set_property("cmake_target_name", "WebP::sharpyuv")
+        self.cpp_info.components["sharpyuv"].set_property("pkg_config_name", "libsharpyuv")
+        self.cpp_info.components["sharpyuv"].libs = ["sharpyuv"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["sharpyuv"].system_libs = ["m", "pthread"]
 
         # webp
         self.cpp_info.components["webp"].set_property("cmake_target_name", "WebP::webp")
         self.cpp_info.components["webp"].set_property("pkg_config_name", "libwebp")
         self.cpp_info.components["webp"].libs = ["webp"]
+        self.cpp_info.components["webp"].requires = ["sharpyuv"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["webp"].system_libs = ["m", "pthread"]
 


### PR DESCRIPTION
There was a problem with PR #15256 
1.3.0 split the SharpYuv* functions into a separate library: libsharpyuv.a
the webp libraries need the sharpyuv lib to link.

The new libwebp.pc file generated during the build (and then deleted by conan) looks like:
```
Name: libwebp
Description: Library for the WebP graphics format
Version: 1.3.0
Requires: libsharpyuv
Cflags: -I${includedir}
Libs: -L${libdir} -lwebp
Libs.private: -lm  -lpthread
```

This corrects the problem.  I also added syslib m to webpdecoder, as per the original .pc file specifications.