### PR TITLE
openssl: add 1.1.1t + add GitHub mirror

### DIFF
--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -9,11 +9,6 @@ sources:
     url:
       - "https://www.openssl.org/source/openssl-1.1.0l.tar.gz"
       - "https://www.openssl.org/source/old/1.1.0/openssl-1.1.0l.tar.gz"
-  1.1.1p:
-    sha256: bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f
-    url:
-      - "https://www.openssl.org/source/openssl-1.1.1p.tar.gz"
-      - "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1p.tar.gz"
   1.1.1q:
     sha256: d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
     url:
@@ -24,20 +19,27 @@ sources:
     url:
       - "https://www.openssl.org/source/openssl-1.1.1s.tar.gz"
       - "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1s.tar.gz"
+      - "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1s/openssl-1.1.1s.tar.gz"
+  1.1.1t:
+    sha256: 8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b
+    url:
+      - "https://www.openssl.org/source/openssl-1.1.1t.tar.gz"
+      - "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1t.tar.gz"
+      - "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1t/openssl-1.1.1t.tar.gz"
 patches:
   1.0.2u:
     - patch_file: patches/1.0.2u-darwin-arm64.patch
       patch_description: "Darwin ARM64 support"
-      patch_type: "portability"
-  1.1.1p:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
-      patch_description: "TVOS and WatchOS don't like fork()"
       patch_type: "portability"
   1.1.1q:
     - patch_file: patches/1.1.1-tvos-watchos.patch
       patch_description: "TVOS and WatchOS don't like fork()"
       patch_type: "portability"
   1.1.1s:
+    - patch_file: patches/1.1.1-tvos-watchos.patch
+      patch_description: "TVOS and WatchOS don't like fork()"
+      patch_type: "portability"
+  1.1.1t:
     - patch_file: patches/1.1.1-tvos-watchos.patch
       patch_description: "TVOS and WatchOS don't like fork()"
       patch_type: "portability"

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -8,11 +8,11 @@ versions:
     folder: "3.x.x"
 
   # 1.1.1x releases
+  1.1.1t:
+    folder: "1.x.x"
   1.1.1s:
     folder: "1.x.x"
   1.1.1q:
-    folder: "1.x.x"
-  1.1.1p:
     folder: "1.x.x"
   # 1.1.0x releases
   1.1.0l:


### PR DESCRIPTION
https://www.openssl.org/news/openssl-1.1.1-notes.html

Fixes #15813

For 3.0.8 see #15802