### PR TITLE
ogg: Fix double delete, add a few minor improvements

### DIFF
--- a/recipes/ogg/all/conanfile.py
+++ b/recipes/ogg/all/conanfile.py
@@ -1,15 +1,15 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 import os
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.53.0"
 
 
 class OggConan(ConanFile):
     name = "ogg"
     description = "The OGG library"
-    topics = ("ogg", "codec", "audio", "lossless")
+    topics = ("codec", "audio", "lossless")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/xiph/ogg"
     license = "BSD-2-Clause"
@@ -25,8 +25,7 @@ class OggConan(ConanFile):
     }
 
     def export_sources(self):
-        for p in self.conan_data.get("patches", {}).get(self.version, []):
-            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -34,15 +33,9 @@ class OggConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        try:
-           del self.settings.compiler.libcxx
-        except Exception:
-           pass
-        try:
-           del self.settings.compiler.cppstd
-        except Exception:
-           pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/ogg/all/test_v1_package/conanfile.py
+++ b/recipes/ogg/all/test_v1_package/conanfile.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 from conans import ConanFile, CMake, tools
 import os
 


### PR DESCRIPTION
Specify library name and version:  **ogg/all**

While working for v2 migration, we found that ogg failed to compile in some instances. The reason was this double delete. I'll take a look around in the top 100 recipes and see if there are any more obvious problems