### PR TITLE
gperf: fix check for msvc version for conan 2 compatibility

### DIFF
--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -3,11 +3,11 @@ from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, unix_path
+from conan.tools.microsoft import is_msvc, check_min_vs, unix_path
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.57.0"
 
 
 class GperfConan(ConanFile):
@@ -49,8 +49,7 @@ class GperfConan(ConanFile):
         env.generate()
 
         tc = AutotoolsToolchain(self)
-        if (self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) >= "12") or \
-           (self.settings.compiler == "msvc" and Version(self.settings.compiler.version) >= "180"):
+        if is_msvc(self) and check_min_vs(self, "180", raise_invalid=False):
             tc.extra_cflags.append("-FS")
             tc.extra_cxxflags.append("-FS")
         tc.generate()

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.files import apply_conandata_patches, chdir, copy, export_conan
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, check_min_vs, unix_path
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.57.0"


### PR DESCRIPTION
Specify library name and version:  **gperf/all**

Fix issue where compiler `Visual Studio` does not exist in `settings.yml` in Conan 2.0, and clean-up logic with functionality available in Conan 1.57.