### PR TITLE
simdutf: add version 3.2.0

### DIFF
--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.2.0":
+    url: "https://github.com/simdutf/simdutf/archive/v3.2.0.tar.gz"
+    sha256: "0d9f63e2f308b6b54f399ebbe3a02776b902a2670c88c28de2d75ea2197dc4e9"
   "3.1.0":
     url: "https://github.com/simdutf/simdutf/archive/v3.1.0.tar.gz"
     sha256: "9757a04085ad3ebab9fe933d9198ec6b84a857632a540418b6cfeb7b889a8017"
@@ -24,6 +27,10 @@ sources:
     url: "https://github.com/simdutf/simdutf/archive/v1.0.1.tar.gz"
     sha256: "e7832ba58fb95fe00de76dbbb2f17d844a7ad02a6f5e3e9e5ce9520e820049a0"
 patches:
+  "3.2.0":
+    - patch_file: "patches/2.0.3-0001-fix-cmake.patch"
+      patch_description: "remove static build, enable rpath on macOS"
+      patch_type: "conan"
   "3.1.0":
     - patch_file: "patches/2.0.3-0001-fix-cmake.patch"
       patch_description: "remove static build, enable rpath on macOS"

--- a/recipes/simdutf/config.yml
+++ b/recipes/simdutf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.2.0":
+    folder: all
   "3.1.0":
     folder: all
   "3.0.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **simdutf/3.2.0**




---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
