### PR TITLE
simdjson: add version 3.1.1

### DIFF
--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.1":
+    url: "https://github.com/simdjson/simdjson/archive/v3.1.1.tar.gz"
+    sha256: "4fcb1c9b1944e2eb8a4a4a22c979e2827165216f859e94d93c846c1261e0e432"
   "3.1.0":
     url: "https://github.com/simdjson/simdjson/archive/refs/tags/3.1.0.tar.gz"
     sha256: "14d17ba7139d27c1e1bf01e765f5c26e84cc9e9be6a316c977638e01c7de85fa"

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.1.1":
+    folder: all
   "3.1.0":
     folder: all
   "3.0.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **simdjson/3.1.1**




---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
