### PR TITLE
gnutls: several fixes & improvements (CMake variables, libs ordering, MinGW)

### DIFF
--- a/recipes/gnutls/all/conanfile.py
+++ b/recipes/gnutls/all/conanfile.py
@@ -157,20 +157,22 @@ class GnuTLSConan(ConanFile):
         )
 
     def _create_cmake_module_variables(self, module_file):
-        content = textwrap.dedent("""\
+        content = textwrap.dedent(f"""\
             set(GNUTLS_FOUND TRUE)
             if(NOT DEFINED GNUTLS_INCLUDE_DIR AND DEFINED GnuTLS_INCLUDE_DIRS)
-                set(GNUTLS_INCLUDE_DIR ${GnuTLS_INCLUDE_DIRS})
+                set(GNUTLS_INCLUDE_DIR ${{GnuTLS_INCLUDE_DIRS}})
             endif()
             if(NOT DEFINED GNUTLS_LIBRARIES AND DEFINED GnuTLS_LIBRARIES)
-                set(GNUTLS_LIBRARIES ${GnuTLS_LIBRARIES})
+                set(GNUTLS_LIBRARIES ${{GnuTLS_LIBRARIES}})
             endif()
-            if(NOT DEFINED GNUTLS_DEFINITIONS AND DEFINED GnuTLS_DEFINITIONS)
-                set(GNUTLS_DEFINITIONS ${GnuTLS_DEFINITIONS})
+            if(NOT DEFINED GNUTLS_DEFINITIONS)
+                if(DEFINED GnuTLS_DEFINITIONS)
+                    set(GNUTLS_DEFINITIONS ${{GnuTLS_DEFINITIONS}})
+                else()
+                    set(GNUTLS_DEFINITIONS "")
+                endif()
             endif()
-            if(NOT DEFINED GNUTLS_VERSION AND DEFINED GnuTLS_VERSION)
-                set(GNUTLS_VERSION ${GnuTLS_VERSION})
-            endif()
+            set(GNUTLS_VERSION {self.version})
         """)
         save(self, module_file, content)
 

--- a/recipes/gnutls/all/conanfile.py
+++ b/recipes/gnutls/all/conanfile.py
@@ -127,6 +127,10 @@ class GnuTLSConan(ConanFile):
             "--enable-tools={}".format(yes_no(self.options.enable_tools)),
             "--enable-openssl-compatibility={}".format(yes_no(self.options.enable_openssl_compatibility)),
         ])
+        if is_apple_os(self):
+            # fix_apple_shared_install_name() may fail without -headerpad_max_install_names
+            # (see https://github.com/conan-io/conan-center-index/pull/15946#issuecomment-1464321305)
+            tc.extra_ldflags.append("-headerpad_max_install_names")
         env = tc.environment()
         if cross_building(self):
             # INFO: Undefined symbols for architecture Mac arm64 rpl_malloc and rpl_realloc

--- a/recipes/gnutls/all/conanfile.py
+++ b/recipes/gnutls/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import is_apple_os
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, save
@@ -151,6 +151,7 @@ class GnuTLSConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        fix_apple_shared_install_name(self)
         self._create_cmake_module_variables(
             os.path.join(self.package_folder, self._module_file_rel_path)
         )

--- a/recipes/gnutls/all/conanfile.py
+++ b/recipes/gnutls/all/conanfile.py
@@ -71,7 +71,7 @@ class GnuTLSConan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/1.2.13")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.2")
+            self.requires("zstd/1.5.4")
         if self.options.with_brotli:
             self.requires("brotli/1.0.9")
 

--- a/recipes/gnutls/all/conanfile.py
+++ b/recipes/gnutls/all/conanfile.py
@@ -1,16 +1,16 @@
 from conan import ConanFile
-from conan.tools.microsoft import is_msvc
-from conan.tools.files import get, rmdir, rm, copy, export_conandata_patches, apply_conandata_patches
-from conan.tools.layout import basic_layout
-from conan.tools.gnu import AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps, Autotools
-from conan.tools.build import cross_building
-from conan.tools.env import VirtualRunEnv
-from conan.tools.apple import is_apple_os
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.build import cross_building
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, save
+from conan.tools.gnu import AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps, Autotools
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc
 import os
+import textwrap
 
-
-required_conan_version = ">=1.55.0"
+required_conan_version = ">=1.54.0"
 
 
 class GnuTLSConan(ConanFile):
@@ -20,30 +20,43 @@ class GnuTLSConan(ConanFile):
     description = "GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols"
     topics = ("tls", "ssl", "secure communications")
     license = ("LGPL-2.1-or-later", "GPL-3-or-later")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False],
-               "fPIC": [True, False],
-               "enable_cxx": [True, False],
-               "enable_tools": [True, False],
-               "enable_openssl_compatibility": [True, False],
-               "with_zlib": [True, False],
-               "with_zstd": [True, False],
-               "with_brotli": [True, False],}
-    default_options = {"shared": False,
-                       "fPIC": True,
-                       "enable_cxx": True,
-                       "enable_tools": True,
-                       "enable_openssl_compatibility": False,
-                       "with_zlib": True,
-                       "with_zstd": True,
-                       "with_brotli": True,}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "enable_cxx": [True, False],
+        "enable_tools": [True, False],
+        "enable_openssl_compatibility": [True, False],
+        "with_zlib": [True, False],
+        "with_zstd": [True, False],
+        "with_brotli": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "enable_cxx": True,
+        "enable_tools": True,
+        "enable_openssl_compatibility": False,
+        "with_zlib": True,
+        "with_zstd": True,
+        "with_brotli": True,
+    }
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
     def export_sources(self):
         export_conandata_patches(self)
 
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
         if not self.options.enable_cxx:
             self.settings.rm_safe("compiler.libcxx")
             self.settings.rm_safe("compiler.cppstd")
@@ -66,50 +79,60 @@ class GnuTLSConan(ConanFile):
         if is_msvc(self):
             raise ConanInvalidConfiguration(f"{self.ref} cannot be deployed by Visual Studio.")
 
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/1.9.3")
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
+
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self.source_folder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
         if not cross_building(self):
             env = VirtualRunEnv(self)
             env.generate(scope="build")
 
         yes_no = lambda v: "yes" if v else "no"
-        autotoolstc = AutotoolsToolchain(self)
-        autotoolstc.configure_args.extend([
-                          "--disable-tests",
-                          "--disable-doc",
-                          "--disable-guile",
-                          "--disable-libdane",
-                          "--disable-manpages",
-                          "--disable-silent-rules",
-                          "--disable-full-test-suite",
-                          "--disable-maintainer-mode",
-                          "--disable-option-checking",
-                          "--disable-dependency-tracking",
-                          "--disable-heartbeat-support",
-                          "--disable-gtk-doc-html",
-                          "--without-p11-kit",
-                          "--disable-rpath",
-                          "--without-idn",
-                          "--with-included-unistring",
-                          "--with-included-libtasn1",
-                          "--with-libiconv-prefix={}".format(self.dependencies["libiconv"].package_folder),
-                          "--enable-shared={}".format(yes_no(self.options.shared)),
-                          "--enable-static={}".format(yes_no(not self.options.shared)),
-                          "--with-cxx={}".format(yes_no(self.options.enable_cxx)),
-                          "--with-zlib={}".format(yes_no(self.options.with_zlib)),
-                          "--with-brotli={}".format(yes_no(self.options.with_brotli)),
-                          "--with-zstd={}".format(yes_no(self.options.with_zstd)),
-                          "--enable-tools={}".format(yes_no(self.options.enable_tools)),
-                          "--enable-openssl-compatibility={}".format(yes_no(self.options.enable_openssl_compatibility)),
-                          ])
-        env = autotoolstc.environment()
+        tc = AutotoolsToolchain(self)
+        tc.configure_args.extend([
+            "--disable-tests",
+            "--disable-doc",
+            "--disable-guile",
+            "--disable-libdane",
+            "--disable-manpages",
+            "--disable-silent-rules",
+            "--disable-full-test-suite",
+            "--disable-maintainer-mode",
+            "--disable-option-checking",
+            "--disable-dependency-tracking",
+            "--disable-heartbeat-support",
+            "--disable-gtk-doc-html",
+            "--without-p11-kit",
+            "--disable-rpath",
+            "--without-idn",
+            "--with-included-unistring",
+            "--with-included-libtasn1",
+            "--with-libiconv-prefix={}".format(self.dependencies["libiconv"].package_folder),
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
+            "--with-cxx={}".format(yes_no(self.options.enable_cxx)),
+            "--with-zlib={}".format(yes_no(self.options.with_zlib)),
+            "--with-brotli={}".format(yes_no(self.options.with_brotli)),
+            "--with-zstd={}".format(yes_no(self.options.with_zstd)),
+            "--enable-tools={}".format(yes_no(self.options.enable_tools)),
+            "--enable-openssl-compatibility={}".format(yes_no(self.options.enable_openssl_compatibility)),
+        ])
+        env = tc.environment()
         if cross_building(self):
             # INFO: Undefined symbols for architecture Mac arm64 rpl_malloc and rpl_realloc
             env.define("ac_cv_func_malloc_0_nonnull", "yes")
             env.define("ac_cv_func_realloc_0_nonnull", "yes")
-        autotoolstc.generate(env)
+        tc.generate(env)
         autodeps = AutotoolsDeps(self)
         autodeps.generate()
         pkgdeps = PkgConfigDeps(self)
@@ -128,12 +151,38 @@ class GnuTLSConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        self._create_cmake_module_variables(
+            os.path.join(self.package_folder, self._module_file_rel_path)
+        )
+
+    def _create_cmake_module_variables(self, module_file):
+        content = textwrap.dedent("""\
+            set(GNUTLS_FOUND TRUE)
+            if(NOT DEFINED GNUTLS_INCLUDE_DIR AND DEFINED GnuTLS_INCLUDE_DIRS)
+                set(GNUTLS_INCLUDE_DIR ${GnuTLS_INCLUDE_DIRS})
+            endif()
+            if(NOT DEFINED GNUTLS_LIBRARIES AND DEFINED GnuTLS_LIBRARIES)
+                set(GNUTLS_LIBRARIES ${GnuTLS_LIBRARIES})
+            endif()
+            if(NOT DEFINED GNUTLS_DEFINITIONS AND DEFINED GnuTLS_DEFINITIONS)
+                set(GNUTLS_DEFINITIONS ${GnuTLS_DEFINITIONS})
+            endif()
+            if(NOT DEFINED GNUTLS_VERSION AND DEFINED GnuTLS_VERSION)
+                set(GNUTLS_VERSION ${GnuTLS_VERSION})
+            endif()
+        """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")
 
     def package_info(self):
-        self.cpp_info.libs = ["gnutls", "gnutlsxx"] if self.options.enable_cxx else ["gnutls"]
+        self.cpp_info.libs = ["gnutlsxx", "gnutls"] if self.options.enable_cxx else ["gnutls"]
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "GnuTLS")
         self.cpp_info.set_property("cmake_target_name", "GnuTLS::GnuTLS")
+        self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
         self.cpp_info.set_property("pkg_config_name", "gnutls")
 
         if is_apple_os(self):
@@ -144,7 +193,6 @@ class GnuTLSConan(ConanFile):
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "GnuTLS"
         self.cpp_info.names["cmake_find_package_multi"] = "GnuTLS"
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
         if self.options.enable_tools:
-            bin_path = os.path.join(self.package_folder, "bin")
-            self.output.info("Appending PATH env var with : {}".format(bin_path))
-            self.env_info.PATH.append(bin_path)
+            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/gnutls/all/test_package/CMakeLists.txt
+++ b/recipes/gnutls/all/test_package/CMakeLists.txt
@@ -5,3 +5,19 @@ find_package(GnuTLS REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE GnuTLS::GnuTLS)
+
+# Test whether variables from https://cmake.org/cmake/help/latest/module/FindGnuTLS.html are properly defined
+set(_custom_vars
+    GNUTLS_FOUND
+    GNUTLS_INCLUDE_DIR
+    GNUTLS_LIBRARIES
+    GNUTLS_DEFINITIONS
+    GNUTLS_VERSION
+)
+foreach(_custom_var ${_custom_vars})
+    if(DEFINED _custom_var)
+        message(STATUS "${_custom_var}: ${${_custom_var}}")
+    else()
+        message(FATAL_ERROR "${_custom_var} not defined")
+    endif()
+endforeach()

--- a/recipes/gnutls/all/test_package/CMakeLists.txt
+++ b/recipes/gnutls/all/test_package/CMakeLists.txt
@@ -15,7 +15,7 @@ set(_custom_vars
     GNUTLS_VERSION
 )
 foreach(_custom_var ${_custom_vars})
-    if(DEFINED _custom_var)
+    if(DEFINED ${_custom_var})
         message(STATUS "${_custom_var}: ${${_custom_var}}")
     else()
         message(FATAL_ERROR "${_custom_var} not defined")

--- a/recipes/gnutls/all/test_package/CMakeLists.txt
+++ b/recipes/gnutls/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES C)
 
-find_package(GnuTLS REQUIRED CONFIG)
+find_package(GnuTLS REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE GnuTLS::GnuTLS)

--- a/recipes/gnutls/all/test_package/conanfile.py
+++ b/recipes/gnutls/all/test_package/conanfile.py
@@ -1,4 +1,3 @@
-
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake

--- a/recipes/gnutls/all/test_v1_package/conanfile.py
+++ b/recipes/gnutls/all/test_v1_package/conanfile.py
@@ -3,8 +3,8 @@ from conans import ConanFile, CMake, tools
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- fix libs ordering in package_info() (gnutlsxx depends on gnutls)
- allow to build with MinGW
- add pkgconf in build requirements since recipe relies on pkgconf files
- expose official CMake variabes from https://cmake.org/cmake/help/latest/module/FindGnuTLS.html in CMakeDeps & cmake_find_package generators
- add package_type

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
