### PR TITLE
cpp-lazy: add version 7.0.2

### DIFF
--- a/recipes/cpp-lazy/all/conandata.yml
+++ b/recipes/cpp-lazy/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.0.2":
+    url: "https://github.com/MarcDirven/cpp-lazy/releases/download/v7.0.2/cpp-lazy-src.zip"
+    sha256: "fb6dd0870e07050f9e0bba3ddb5f53ee35d8d9a05987f73cb0d667ca1f8348aa"
   "6.0.0":
     url: "https://github.com/MarcDirven/cpp-lazy/releases/download/v6.0.0/cpp-lazy-src.zip"
     sha256: "424973eabaab8c756dae5e1795febeface65bb1dc42f474e5e2e1e4ab3effc5e"

--- a/recipes/cpp-lazy/all/conanfile.py
+++ b/recipes/cpp-lazy/all/conanfile.py
@@ -40,7 +40,7 @@ class CpplazyConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support apple-clang < 14.0.")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder)
+        get(self, **self.conan_data["sources"][self.version])
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/cpp-lazy/config.yml
+++ b/recipes/cpp-lazy/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "7.0.2":
+    folder: all
   "6.0.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **cpp-lazy/7.0.2**

The patch for 6.0.0 is already merged to upstream.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
