### PR TITLE
log4cplus: add version 2.1.0

### DIFF
--- a/recipes/log4cplus/all/conandata.yml
+++ b/recipes/log4cplus/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.0":
+    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_1_0/log4cplus-2.1.0.tar.bz2"
+    sha256: "a04945aca5fbc0487503c852befb9cdefbc3ae3fe614b08a905333f6df754387"
   "2.0.8":
     url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_8/log4cplus-2.0.8.tar.bz2"
     sha256: "ca36aa366036d1c61fc0366a9ffbcf32bad55d74878b2c36a9c34dcc00b8a0ca"
@@ -16,6 +19,10 @@ sources:
     sha256: "0c8a7b4cabff07032385f0c6d1a078d2a79c69b1c43b06991ca774fb85880252"
 
 patches:
+  "2.1.0":
+    - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
+      patch_description: "disable fPIC, move cmake_minimum_version to front"
+      patch_type: "conan"
   "2.0.8":
     - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
       patch_description: "disable fPIC, move cmake_minimum_version to front"

--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir, collect_libs
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -95,10 +96,16 @@ class Log4cplusConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        if Version(self.version) >= "2.1.0":
+            rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+            rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "log4cplus")
         self.cpp_info.set_property("cmake_target_name", "log4cplus::log4cplus")
+        if Version(self.version) >= "2.1.0":
+            self.cpp_info.set_property("pkg_config_name", "log4cplus")
+
         self.cpp_info.libs = collect_libs(self)
         if self.options.unicode:
             self.cpp_info.defines = ["UNICODE", "_UNICODE"]

--- a/recipes/log4cplus/config.yml
+++ b/recipes/log4cplus/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.0":
+    folder: all
   "2.0.8":
     folder: all
   "2.0.7":


### PR DESCRIPTION
Specify library name and version:  **log4cplus/2.1.0**

- 2.1.0 starts to define pkgconfig
- 2.1.0 starts to install share folder with some documentation (conan recipe removes all)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
