### PR TITLE
sdl: link to required Android system libs in static variant

### DIFF
--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -488,6 +488,12 @@ class SDLConan(ConanFile):
             self.cpp_info.components["libsdl2"].system_libs = ["user32", "gdi32", "winmm", "imm32", "ole32", "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32"]
             if self.settings.compiler == "gcc":
                 self.cpp_info.components["libsdl2"].system_libs.append("mingw32")
+        elif self.settings.os == "Android" and not self.options.shared:
+            self.cpp_info.components["libsdl2"].system_libs.extend(["android", "dl", "log"])
+            if self.options.opengles:
+                self.cpp_info.components["libsdl2"].system_libs.extend(["GLESv1_CM", "GLESv2"])
+            if Version(self.version) >= "2.0.16":
+                self.cpp_info.components["libsdl2"].system_libs.append("OpenSLES")
 
         # SDL2main
         if self.options.sdl2main:


### PR DESCRIPTION
Specify library name and version:  **sdl/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
Fixes consuming static library on Android. Almost like #6105 but without HID stuff. OpenSLES was added only in 2.0.16 according to the tags of https://github.com/libsdl-org/SDL/commit/d4e96e1153906c458a53c38ccc11a3b64b0dc06a

The shared variant already has all the dependencies inside:

```
> .../llvm-objdump -p .../libSDL2.so | fgrep NEEDED
  NEEDED       libm.so
  NEEDED       libOpenSLES.so
  NEEDED       libdl.so
  NEEDED       liblog.so
  NEEDED       libandroid.so
  NEEDED       libGLESv1_CM.so
  NEEDED       libGLESv2.so
  NEEDED       libc.so
```

There's however a link error for `test_package`, but I think it can be ignored:

<details><summary>Click to expand log</summary>

```
> conan create . sdl/2.26.1@ --build=missing --profile:host=android-32 -o 'sdl/*:vulkan=False'
Exporting package recipe
sdl/2.26.1 exports: File 'conandata.yml' found. Exporting it...
sdl/2.26.1 exports: Copied 1 '.yml' file: conandata.yml
sdl/2.26.1: Calling export_sources()
sdl/2.26.1: A new conanfile.py version was exported
sdl/2.26.1: Folder: /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/sdl/2.26.1/_/_/export
sdl/2.26.1: Using the exported files summary hash as the recipe revision: 65506f09f0f5aca67b78a4104ae852aa 
sdl/2.26.1: Package recipe modified in export, forcing source folder removal
sdl/2.26.1: Use the --keep-source, -k option to skip it
sdl/2.26.1: Removing the local binary packages from different recipe revisions
sdl/2.26.1: Exported revision: 65506f09f0f5aca67b78a4104ae852aa
Configuration (profile_host):
[settings]
arch=armv7
build_type=Release
compiler=clang
compiler.libcxx=c++_shared
compiler.version=11
os=Android
os.api_level=19
[options]
sdl:vulkan=False
[build_requires]
*: android-ndk/r22b
[env]
[conf]
tools.cmake.cmaketoolchain:generator=Ninja

Configuration (profile_build):
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=apple-clang
compiler.libcxx=libc++
compiler.version=14
os=Macos
os_build=Macos
[options]
[build_requires]
[env]
[conf]
tools.cmake.cmaketoolchain:generator=Ninja
...
sdl/2.26.1 (test package): CMake command: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="/Users/kambala/dev/other/conan-center-index/recipes/sdl/all/test_package/build/Release/generators/conan_toolchain.cmake" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/kambala/dev/other/conan-center-index/recipes/sdl/all/test_package/."
-- Using Conan toolchain: /Users/kambala/dev/other/conan-center-index/recipes/sdl/all/test_package/build/Release/generators/conan_toolchain.cmake
-- The C compiler identification is Clang 11.0.5
-- The CXX compiler identification is Clang 11.0.5
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/android-ndk/r22b/_/_/package/46f53f156846659bf39ad6675fa0ee8156e859fe/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/android-ndk/r22b/_/_/package/46f53f156846659bf39ad6675fa0ee8156e859fe/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'SDL2::SDL2'
-- Conan: Component target declared 'SDL2::SDL2main'
-- Conan: Target declared 'Iconv::Iconv'
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/kambala/dev/other/conan-center-index/recipes/sdl/all/test_package/build/Release
sdl/2.26.1 (test package): CMake command: cmake --build "/Users/kambala/dev/other/conan-center-index/recipes/sdl/all/test_package/build/Release" '--' '-j6'
[2/2] Linking CXX executable test_package
FAILED: test_package 
: && /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/android-ndk/r22b/_/_/package/46f53f156846659bf39ad6675fa0ee8156e859fe/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=armv7-none-linux-androideabi19 --gcc-toolchain=/Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/android-ndk/r22b/_/_/package/46f53f156846659bf39ad6675fa0ee8156e859fe/bin/toolchains/llvm/prebuilt/darwin-x86_64 --sysroot=/Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/android-ndk/r22b/_/_/package/46f53f156846659bf39ad6675fa0ee8156e859fe/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security   -Oz -DNDEBUG -Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libgcc_real.a -Wl,--exclude-libs,libatomic.a -Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,--fatal-warnings -Wl,--exclude-libs,libunwind.a -Wl,--no-undefined -Qunused-arguments -Wl,--gc-sections CMakeFiles/test_package.dir/test_package.cpp.o -o test_package  /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/sdl/2.26.1/_/_/package/8296b846cbb2159159046bc52b00f4d4969245af/lib/libSDL2main.a  /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/sdl/2.26.1/_/_/package/8296b846cbb2159159046bc52b00f4d4969245af/lib/libSDL2.a  -landroid  -ldl  -llog  -lGLESv1_CM  -lGLESv2  -lOpenSLES  /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/libiconv/1.17/_/_/package/a8e8bba9f9e7e3976ec971ca7b4f3c735d9d5a61/lib/libiconv.a  /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/libiconv/1.17/_/_/package/a8e8bba9f9e7e3976ec971ca7b4f3c735d9d5a61/lib/libcharset.a  -latomic -lm && :
ld: error: undefined symbol: main
>>> referenced by crtbegin.c
>>>               /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/android-ndk/r22b/_/_/package/46f53f156846659bf39ad6675fa0ee8156e859fe/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/arm-linux-androideabi/19/crtbegin_dynamic.o:(_start_main)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
ERROR: sdl/2.26.1 (test package): Error in build() method, line 27
	cmake.build()
	ConanException: Error 1 while executing cmake --build "/Users/kambala/dev/other/conan-center-index/recipes/sdl/all/test_package/build/Release" '--' '-j6'
```

</details>

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
