### PR TITLE
fix OSI recipe: missing patches files from recipe

### DIFF
--- a/recipes/open-simulation-interface/config.yml
+++ b/recipes/open-simulation-interface/config.yml
@@ -5,3 +5,10 @@ versions:
     folder: "all"
   "3.1.2":
     folder: "all"
+patches:
+  "3.4.0":
+    - patch_file: "patches/3.4.0_single_lib.patch"
+  "3.3.1":
+    - patch_file: "patches/3.3.x_single_lib.patch"
+  "3.1.2":
+    - patch_file: "patches/3.1.2_single_lib.patch"


### PR DESCRIPTION
Specify library name and version:  **open-simulation-interface/***

This is a fix for missing patches file from config.yml.
<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
