### PR TITLE
ffmpeg: use ar / nm / ranlib / strip from toolchain

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -537,12 +537,20 @@ class FFMpegConan(ConanFile):
         if not self.options.with_programs:
             args.append("--disable-programs")
         # since ffmpeg"s build system ignores CC and CXX
+        if tools.get_env("AR"):
+            args.append("--ar={}".format(tools.get_env("AR")))
         if tools.get_env("AS"):
             args.append("--as={}".format(tools.get_env("AS")))
         if tools.get_env("CC"):
             args.append("--cc={}".format(tools.get_env("CC")))
         if tools.get_env("CXX"):
             args.append("--cxx={}".format(tools.get_env("CXX")))
+        if tools.get_env("NM"):
+            args.append("--nm={}".format(tools.get_env("NM")))
+        if tools.get_env("RANLIB"):
+            args.append("--ranlib={}".format(tools.get_env("RANLIB")))
+        if tools.get_env("STRIP"):
+            args.append("--strip={}".format(tools.get_env("STRIP")))
         extra_cflags = []
         extra_ldflags = []
         if is_apple_os(self) and self.settings.os.version:


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
Consuming static library on Android resulted in missing FFmpeg symbols at link step like

> ld: error: undefined symbol: avcodec_alloc_context3

During static FFmpeg build on macOS host there were warnings like:

> warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive library: libavformat/libavformat.a the table of contents is empty (no object file members in the library define global symbols)
>
> warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive library: /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/ffmpeg/4.4.3/_/_/package/e278c1bb85139d14996f9927c53fb33f16135eea/lib/libswscale.a the table of contents is empty (no object file members in the library define global symbols)

and during shared build:

> /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: warning: can't process non-object and non-archive file: /Users/kambala/dev/vcmi/conan-deps-android-32/.conan/data/ffmpeg/4.4.3/_/_/package/482031e64ba053214bda580dcc61306842009f95/lib/libavcodec.so

Only `ranlib` and `strip` adjustments are required, but I guess it wouldn't hurt to pass toolchain's `ar` and `nm` as well.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
