### PR TITLE
[linter] Do not accept version attribute on regular recipes

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -23,7 +23,8 @@ to configure plugins, warnings and errors which should be enabled or disabled.
     * [E9008 - conan-import-errors: Deprecated imports should be replaced by new imports](#e9008---conan-import-errors-deprecated-imports-should-be-replaced-by-new-imports)
     * [E9009 - conan-import-error-conanexception: conans.errors is deprecated and conan.errors should be used instead](#e9009---conan-import-error-conanexception-conanserrors-is-deprecated-and-conanerrors-should-be-used-instead)
     * [E9010 - conan-import-error-conaninvalidconfiguration: conans.errors is deprecated and conan.errors should be used instead](#e9010---conan-import-error-conaninvalidconfiguration-conanserrors-is-deprecated-and-conanerrors-should-be-used-instead)
-    * [E9011 - conan-import-tools: Importing conan.tools or conan.tools.xxx.zzz.yyy should be considered as private](#e9011---conan-import-tools-importing-conantools-or-conantoolsxxxzzzyyy-should-be-considered-as-private)<!-- endToc -->
+    * [E9011 - conan-import-tools: Importing conan.tools or conan.tools.xxx.zzz.yyy should be considered as private](#e9011---conan-import-tools-importing-conantools-or-conantoolsxxxzzzyyy-should-be-considered-as-private)
+    * [E9012 - conan-attr-version: Recipe should not contain version attribute](#e9012---conan-attr-version-recipe-should-not-contain-version-attribute)<!-- endToc -->
 
 ## Understanding the different linters
 
@@ -157,4 +158,26 @@ Only modules under `conan.tools` and `conan.tools.xxx` are allowed:
 ```python
 from conan.tools.files import rmdir
 from conan.tools import scm
+```
+
+### E9012 - conan-attr-version: Recipe should not contain version attribute
+
+All recipes on CCI should be generic enough to support as many versions as possible, so enforcing a specific
+version as attribute will not allow to re-use the same recipe for multiple release versions.
+
+```python
+from conan import ConanFile
+
+class FooConanFile(ConanFile):
+    version = "1.0.0"  # Wrong!
 ````
+
+The package version should be passed as command argument, e.g:
+
+    conan create all/ 1.0.0@ -pr:h=default -pr:b=default
+
+Or, if you are running Conan 2.0:
+
+    conan create all/ --version=1.0.0 -pr:h=default -pr:b=default
+
+The only exception is when providing ``system`` packages, which are allowed.

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -170,7 +170,7 @@ from conan import ConanFile
 
 class FooConanFile(ConanFile):
     version = "1.0.0"  # Wrong!
-````
+```
 
 The package version should be passed as command argument, e.g:
 
@@ -181,3 +181,10 @@ Or, if you are running Conan 2.0:
     conan create all/ --version=1.0.0 -pr:h=default -pr:b=default
 
 The only exception is when providing ``system`` packages, which are allowed.
+
+```python
+from conan import ConanFile
+
+class FooConanFile(ConanFile):
+    version = "system"  # Okay!
+```

--- a/linter/check_version_attribute.py
+++ b/linter/check_version_attribute.py
@@ -10,11 +10,11 @@ class VersionAttribute(BaseChecker):
 
     __implements__ = IAstroidChecker
 
-    name = "conan-package-name"
+    name = "conan-attr-version"
     msgs = {
-        "E9012": (
+        "E9014": (
             "Recipe should not contain version attribute",
-            "conan-attr-version",
+            "conan-forced-version",
             "Do not enforce a specific version in your recipe. Keep it generic for any version."
         ),
     }
@@ -29,5 +29,5 @@ class VersionAttribute(BaseChecker):
                    isinstance(children[1], Const):
                     value = children[1].as_string()
                     if not value and value != "system":
-                        self.add_message("conan-attr-version", node=attr, line=attr.lineno)
+                        self.add_message("conan-forced-version", node=attr, line=attr.lineno)
                     return

--- a/linter/check_version_attribute.py
+++ b/linter/check_version_attribute.py
@@ -1,0 +1,33 @@
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+from astroid import nodes, Const, AssignName
+
+
+class VersionAttribute(BaseChecker):
+    """
+       All packages should not enforce a specific version in the recipe
+    """
+
+    __implements__ = IAstroidChecker
+
+    name = "conan-package-name"
+    msgs = {
+        "E9012": (
+            "Recipe should not contain version attribute",
+            "conan-attr-version",
+            "Do not enforce a specific version in your recipe. Keep it generic for any version."
+        ),
+    }
+
+    def visit_classdef(self, node: nodes) -> None:
+        if node.basenames == ['ConanFile']:
+            for attr in node.body:
+                children = list(attr.get_children())
+                if len(children) == 2 and \
+                   isinstance(children[0], AssignName) and \
+                   children[0].name == "version" and \
+                   isinstance(children[1], Const):
+                    value = children[1].as_string()
+                    if not value and value != "system":
+                        self.add_message("conan-attr-version", node=attr, line=attr.lineno)
+                    return

--- a/linter/check_version_attribute.py
+++ b/linter/check_version_attribute.py
@@ -27,7 +27,7 @@ class VersionAttribute(BaseChecker):
                    isinstance(children[0], AssignName) and \
                    children[0].name == "version" and \
                    isinstance(children[1], Const):
-                    value = children[1].as_string()
-                    if not value and value != "system":
+                    value = children[1].as_string().replace('"', "").replace("'", "")
+                    if value and value != "system":
                         self.add_message("conan-forced-version", node=attr, line=attr.lineno)
                     return

--- a/linter/conanv2_transition.py
+++ b/linter/conanv2_transition.py
@@ -10,6 +10,7 @@ from linter.check_import_conanfile import ImportConanFile
 from linter.check_import_errors import ImportErrorsConanException, ImportErrorsConanInvalidConfiguration, ImportErrors
 from linter.check_import_tools import ImportTools
 from linter.check_layout_src_folder import LayoutSrcFolder
+from linter.check_version_attribute import VersionAttribute
 
 
 def register(linter: PyLinter) -> None:
@@ -20,3 +21,4 @@ def register(linter: PyLinter) -> None:
     linter.register_checker(ImportErrorsConanInvalidConfiguration(linter))
     linter.register_checker(ImportTools(linter))
     linter.register_checker(LayoutSrcFolder(linter))
+    linter.register_checker(VersionAttribute(linter))

--- a/linter/pylintrc_recipe
+++ b/linter/pylintrc_recipe
@@ -20,7 +20,8 @@ disable=fixme,
 
 enable=conan-bad-name,
        conan-missing-name,
-       conan-import-conanfile
+       conan-import-conanfile,
+       conan-attr-version
 
 [REPORTS]
 evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error) / statement) * 10))

--- a/linter/pylintrc_recipe
+++ b/linter/pylintrc_recipe
@@ -21,7 +21,7 @@ disable=fixme,
 enable=conan-bad-name,
        conan-missing-name,
        conan-import-conanfile,
-       conan-enforced-version
+       conan-forced-version
 
 [REPORTS]
 evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error) / statement) * 10))

--- a/linter/pylintrc_recipe
+++ b/linter/pylintrc_recipe
@@ -21,11 +21,10 @@ disable=fixme,
 enable=conan-bad-name,
        conan-missing-name,
        conan-import-conanfile,
-       conan-attr-version
+       conan-enforced-version
 
 [REPORTS]
 evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error) / statement) * 10))
 output-format=text
 reports=no
 score=no
-


### PR DESCRIPTION
Enforcing a specific package version by the `version` attribute is no a good idea, as the same recipe should support multiple versions. 

There is an exception for `system` packages, which does not require a generic recipe version.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
