### PR TITLE
duckdb: add version 0.7.1, fix wrong url of 0.6.1

### DIFF
--- a/recipes/duckdb/all/conandata.yml
+++ b/recipes/duckdb/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "0.7.0":
+    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.7.0.tar.gz"
+    sha256: "40254006a84c7e1c86611a883fc7cf801cc9837712cd0ec49e17e19e06b3d3da"
   "0.6.1":
-    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.6.0.tar.gz"
-    sha256: "700b09114f8b99892a9d19ba21ca962ae65d1ea8085622418a2fa50ff915b244"
+    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.6.1.tar.gz"
+    sha256: "ea9bba89ae3e461f3fc9f83911b2f3b6c386c23463bcf7b1ed6bb4cc13e822a4"
   "0.6.0":
     url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.6.0.tar.gz"
     sha256: "700b09114f8b99892a9d19ba21ca962ae65d1ea8085622418a2fa50ff915b244"
@@ -10,6 +13,13 @@ sources:
     sha256: "3dab7ba0d0f8d024d3c73fd3d4fb8834203c31d7b0ddb1e8539ee266e11b0e9b"
 
 patches:
+  "0.7.0":
+    - patch_file: "patches/0.7.0-0001-fix-cmake.patch"
+      patch_description: "install static of shared library, add installation for odbc extention"
+      patch_type: "portability"
+    - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
+      patch_description: "include stdlib for abort function"
+      patch_type: "portability"
   "0.6.1":
     - patch_file: "patches/0.6.0-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"

--- a/recipes/duckdb/all/conandata.yml
+++ b/recipes/duckdb/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.7.0":
-    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.7.0.tar.gz"
-    sha256: "40254006a84c7e1c86611a883fc7cf801cc9837712cd0ec49e17e19e06b3d3da"
+  "0.7.1":
+    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.7.1.tar.gz"
+    sha256: "67f840f861e5ffbe137d65a8543642d016f900b89dd035492d562ad11acf0e1e"
   "0.6.1":
     url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.6.1.tar.gz"
     sha256: "ea9bba89ae3e461f3fc9f83911b2f3b6c386c23463bcf7b1ed6bb4cc13e822a4"
@@ -11,9 +11,8 @@ sources:
   "0.5.1":
     url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.5.1.tar.gz"
     sha256: "3dab7ba0d0f8d024d3c73fd3d4fb8834203c31d7b0ddb1e8539ee266e11b0e9b"
-
 patches:
-  "0.7.0":
+  "0.7.1":
     - patch_file: "patches/0.7.0-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"
       patch_type: "portability"

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -16,6 +16,7 @@ class DuckdbConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/cwida/duckdb"
     topics = ("sql", "database", "olap", "embedded-database")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -76,7 +77,7 @@ class DuckdbConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # FIXME: duckdb vendors a bunch of deps by modify the source code to have their own namespace 
+        # FIXME: duckdb vendors a bunch of deps by modify the source code to have their own namespace
         if self.options.with_odbc:
             self.requires("odbc/2.3.11")
         if self.options.with_httpfs:

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -58,7 +58,7 @@ class DuckdbConan(ConanFile):
     short_paths = True
 
     @property
-    def _minimum_cpp_standard(self):
+    def _min_cppstd(self):
         return 11
 
     def export_sources(self):
@@ -83,8 +83,8 @@ class DuckdbConan(ConanFile):
             self.requires("openssl/3.0.7")
 
     def validate(self):
-        if self.info.settings.compiler.cppstd:
-            check_min_cppstd(self, self._minimum_cpp_standard)
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
@@ -191,9 +191,7 @@ class DuckdbConan(ConanFile):
                 self.cpp_info.libs.append("sqlsmith_extension")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("pthread")
-            self.cpp_info.system_libs.append("dl")
-            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.extend(["pthread", "dl", "m"])
 
         if self.settings.os == "Windows":
             self.cpp_info.system_libs.append("ws2_32")

--- a/recipes/duckdb/all/patches/0.7.0-0001-fix-cmake.patch
+++ b/recipes/duckdb/all/patches/0.7.0-0001-fix-cmake.patch
@@ -1,0 +1,61 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 99cd46c..3f3d039 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -182,9 +182,18 @@ if(BUILD_PYTHON
+   endif()
+ endif()
+ 
+-install(
+-  TARGETS duckdb duckdb_static
+-  EXPORT "${DUCKDB_EXPORT_SET}"
+-  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+-  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+-  RUNTIME DESTINATION "${INSTALL_BIN_DIR}")
++if(BUILD_SHARED_LIBS)
++  install(
++    TARGETS duckdb
++    EXPORT "${DUCKDB_EXPORT_SET}"
++    LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
++    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
++    RUNTIME DESTINATION "${INSTALL_BIN_DIR}")
++else()
++  install(
++    TARGETS duckdb_static
++    EXPORT "${DUCKDB_EXPORT_SET}"
++    LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
++    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
++    RUNTIME DESTINATION "${INSTALL_BIN_DIR}")
++endif()
+diff --git a/tools/odbc/CMakeLists.txt b/tools/odbc/CMakeLists.txt
+index 8f13cfe..6755894 100644
+--- a/tools/odbc/CMakeLists.txt
++++ b/tools/odbc/CMakeLists.txt
+@@ -53,6 +53,14 @@ add_library(
+ set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")
+ target_link_libraries(duckdb_odbc ${LINK_LIB_LIST} duckdb_static)
+ 
++install(
++    TARGETS duckdb_odbc
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)
++
+ if(NOT WIN32 AND NOT CLANG_TIDY)
+   add_subdirectory(test)
+ endif()
+diff --git a/tools/sqlite3_api_wrapper/CMakeLists.txt b/tools/sqlite3_api_wrapper/CMakeLists.txt
+index e785d4f..922746f 100644
+--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
++++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
+@@ -17,7 +17,7 @@ add_library(sqlite3_api_wrapper_static STATIC ${SQLITE_API_WRAPPER_FILES})
+ target_link_libraries(sqlite3_api_wrapper_static duckdb_static duckdb_utf8proc)
+ link_threads(sqlite3_api_wrapper_static)
+ 
+-if(NOT WIN32)
++if(BUILD_SHARED_LIBS AND NOT WIN32)
+   add_library(sqlite3_api_wrapper SHARED ${SQLITE_API_WRAPPER_FILES})
+   target_link_libraries(sqlite3_api_wrapper duckdb ${DUCKDB_EXTRA_LINK_FLAGS})
+   link_threads(sqlite3_api_wrapper)

--- a/recipes/duckdb/config.yml
+++ b/recipes/duckdb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.7.0":
+    folder: "all"
   "0.6.1":
     folder: "all"
   "0.6.0":

--- a/recipes/duckdb/config.yml
+++ b/recipes/duckdb/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.7.0":
+  "0.7.1":
     folder: "all"
   "0.6.1":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **duckdb/***


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
