### PR TITLE
exprtk: add version 0.0.2, support conan v2

### DIFF
--- a/recipes/exprtk/all/conandata.yml
+++ b/recipes/exprtk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.0.2":
+    url: "https://github.com/ArashPartow/exprtk/archive/refs/tags/0.0.2.tar.gz"
+    sha256: "7e8de4a0bfc9855c1316d8b8bc422061aef9a307c2f42d2e66298980463195c1"
   "0.0.1":
     url: "https://github.com/ArashPartow/exprtk/archive/refs/tags/0.0.1.tar.gz"
     sha256: "fb72791c88ae3b3426e14fdad630027715682584daf56b973569718c56e33f28"

--- a/recipes/exprtk/all/conanfile.py
+++ b/recipes/exprtk/all/conanfile.py
@@ -1,42 +1,52 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, load, save
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
-from conans import ConanFile, tools
 
-required_conan_version = ">=1.33.0"
-
+required_conan_version = ">=1.52.0"
 
 class ExprTkConan(ConanFile):
     name = "exprtk"
     description = "C++ Mathematical Expression Parsing And Evaluation Library ExprTk"
     license = ("MIT")
-    topics = ("exprtk", "cpp", "math", "mathematics", "parser", "lexer", "numerical")
-    homepage = "https://www.partow.net/programming/exprtk/index.html"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "compiler"
+    homepage = "https://www.partow.net/programming/exprtk/index.html"
+    topics = ("math", "mathematics", "parser", "lexer", "numerical", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
-
-    def package_id(self):
-        self.info.header_only()
+            check_min_cppstd(self, 11)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def _extract_license(self):
-        exprtk_header_file = "exprtk.hpp"
-        file = os.path.join(self.source_folder, self._source_subfolder, exprtk_header_file)
-        file_content = tools.load(file)
+        source_file = os.path.join(self.source_folder, self.source_folder, "exprtk.hpp")
+        file_content = load(self, source_file)
         license_end = "/MIT                        *"
         license_contents = file_content[2:file_content.find(license_end) + len(license_end)]
-        tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), license_contents)
+        save(self, os.path.join(self.package_folder, "licenses", "LICENSE"), license_contents)
 
     def package(self):
         self._extract_license()
-        self.copy("exprtk.hpp", dst="include" , src=self._source_subfolder)
+        copy(
+            self,
+            pattern="exprtk.hpp",
+            dst=os.path.join(self.package_folder, "include"),
+            src=self.source_folder,
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/exprtk/all/test_package/CMakeLists.txt
+++ b/recipes/exprtk/all/test_package/CMakeLists.txt
@@ -1,17 +1,13 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
-project(test_package)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-
-conan_basic_setup()
+find_package(exprtk REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-
+target_link_libraries(${PROJECT_NAME} PRIVATE exprtk::exprtk)
 if (MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE "/bigobj")
 endif (MSVC)
 
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_compile_definitions(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/exprtk/all/test_package/conanfile.py
+++ b/recipes/exprtk/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/exprtk/all/test_v1_package/CMakeLists.txt
+++ b/recipes/exprtk/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/exprtk/all/test_v1_package/conanfile.py
+++ b/recipes/exprtk/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/exprtk/config.yml
+++ b/recipes/exprtk/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.0.2":
+    folder: "all"
   "0.0.1":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **exprtk/***

- add version 0.0.2
- support conan v2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
