### PR TITLE
[atk] Do not use full-package-id mode for glib

### DIFF
--- a/recipes/atk/all/conanfile.py
+++ b/recipes/atk/all/conanfile.py
@@ -52,9 +52,6 @@ class AtkConan(ConanFile):
     def requirements(self):
         self.requires("glib/2.75.2")
 
-    def package_id(self):
-        self.info.requires["glib"].full_package_mode()
-
     def validate(self):
         if self.options.shared and not self.dependencies["glib"].options.shared:
             raise ConanInvalidConfiguration(


### PR DESCRIPTION
Using glib on full package id mode is a solution to avoid multiple instances of glib. However, for CCI it's painful as it result on missing packages for any minimal change, we need to rebuild everything.

Specify library name and version:  **atk/2.38.0**

Related to #15756

/cc @SpaceIm

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
