### PR TITLE
[faqs] Can use full_package_mode over my dependencies

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -438,3 +438,23 @@ Generally no, these sorts of options can most likely be set from a profile or do
 and would otherwise dynamically embed this into the CMake config files or generated pkg-config files then it should be allowed.
 
 Doing so requires [deleting the option from the `package_id`](adding_packages/conanfile_attributes.md#removing-from-package_id).
+
+## Can I use full_package_mode for a requirement in my recipe?
+
+For some unusual projects, they need to be aligned and beign used as requirement, using the very same version, options and settings.
+Those projects usually break between patch versions and are very sentsitive, so we can't use different versions throught Conan graph dependencies,
+otherwise it may result on unexpected behavior, or even runtime errors.
+
+A very kwnon project is [glib](https://conan.io/center/glib), which requires the very same configuration to prevent multiple instances and using static link. As solution, we could consume glib on full package id mode, like:
+
+```python
+def package_id(self):
+    self.info.requires["glib"].full_package_mode()
+```
+
+However, there is a painful side-effect: CCI will not re-generate all involved packages for any change in the dependencies graph which glib is associated, which means, users will start to see **MISSING_PACKAGES** error during their pull requests. As workaround, it would be necessary updating
+all recipes involved, by opening new PRs, then it should generate new packages, but it takes many days and still is a fragile process.
+
+To have more context about it, please, visit the issues #11684 and #11022
+
+In summary, we do not recommend `full_package_mode` usage on CCI. Instead, prefer using `shared=True` by default, when is really needed.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -441,20 +441,24 @@ Doing so requires [deleting the option from the `package_id`](adding_packages/co
 
 ## Can I use full_package_mode for a requirement in my recipe?
 
-For some unusual projects, they need to be aligned and being used as requirement, using the very same version, options and settings.
-Those projects usually break between patch versions and are very sentsitive, so we can not use different versions throught Conan graph dependencies,
-otherwise, it may result on unexpected behavior, or even runtime errors.
+For some not regular projects, they may need to be aligned when being used as a requirement, using the very same version, options, and settings and maybe not mixing shared with static linkage.
+Those projects usually break between patch versions and are very sensitive, so we can not use different versions through Conan graph dependencies,
+otherwise, it may result in unexpected behavior or even runtime errors.
 
-A very kwnon project is [glib](https://conan.io/center/glib), which requires the very same configuration to prevent multiple instances when using static link. As solution, we could consume glib on full package id mode, like:
+A very known project is GLib, which requires the very same configuration to prevent multiple instances when using static linkage.
+As a solution, we could consume glib on full package id mode, like:
 
 ```python
 def package_id(self):
     self.info.requires["glib"].full_package_mode()
 ```
 
-Perfect solution on consumer side, but there is a painful side-effect: CCI will not re-generate all involved packages for any change in the dependencies graph which glib is associated, which means, users will start to see **MISSING_PACKAGES** error during their pull requests.
-As workaround, it would be necessary updating all recipes involved, by opening new PRs, then it should generate new packages, but it takes many days and still is a fragile process.
+Perfect solution on the consumer side, but there is a painful side-effect: CCI will not re-generate all involved packages for any change in the dependencies graph with which glib is associated, which means, users will start to see **MISSING_PACKAGES** error during their pull requests.
+As a trade-off, it would be necessary to update all recipes involved, by opening new PRs,
+then it should generate new packages, but it takes many days and still is a process that is not supported by CCI internally.
 
-To have more context about it, please, visit the issues #11684 and #11022
+To have more context about it, please, visit issues #11684 and #11022
 
-In summary, we do recommend `full_package_mode` usage on CCI. Instead, prefer using `shared=True` by default, when is really needed.
+In summary, we do not recommend `full_package_mode` or any other custom package id mode for requirements on CCI, it will break other PRs soon or later.
+Instead, prefer using `shared=True` by default, when needed.
+Also, when having a similar situation, do not hesitate in opening an issue explaining your case, and ask for support from the community.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -441,7 +441,7 @@ Doing so requires [deleting the option from the `package_id`](adding_packages/co
 
 ## Can I use full_package_mode for a requirement in my recipe?
 
-For some not regular projects, they may need to be aligned when being used as a requirement, using the very same version, options, and settings and maybe not mixing shared with static linkage.
+For some irregular projects, they may need to be aligned when being used as a requirement, using the very same version, options, and settings and maybe not mixing shared with static linkage.
 Those projects usually break between patch versions and are very sensitive, so we can not use different versions through Conan graph dependencies,
 otherwise, it may result in unexpected behavior or even runtime errors.
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -441,19 +441,19 @@ Doing so requires [deleting the option from the `package_id`](adding_packages/co
 
 ## Can I use full_package_mode for a requirement in my recipe?
 
-For some unusual projects, they need to be aligned and beign used as requirement, using the very same version, options and settings.
-Those projects usually break between patch versions and are very sentsitive, so we can't use different versions throught Conan graph dependencies,
-otherwise it may result on unexpected behavior, or even runtime errors.
+For some unusual projects, they need to be aligned and being used as requirement, using the very same version, options and settings.
+Those projects usually break between patch versions and are very sentsitive, so we can not use different versions throught Conan graph dependencies,
+otherwise, it may result on unexpected behavior, or even runtime errors.
 
-A very kwnon project is [glib](https://conan.io/center/glib), which requires the very same configuration to prevent multiple instances and using static link. As solution, we could consume glib on full package id mode, like:
+A very kwnon project is [glib](https://conan.io/center/glib), which requires the very same configuration to prevent multiple instances when using static link. As solution, we could consume glib on full package id mode, like:
 
 ```python
 def package_id(self):
     self.info.requires["glib"].full_package_mode()
 ```
 
-However, there is a painful side-effect: CCI will not re-generate all involved packages for any change in the dependencies graph which glib is associated, which means, users will start to see **MISSING_PACKAGES** error during their pull requests. As workaround, it would be necessary updating
-all recipes involved, by opening new PRs, then it should generate new packages, but it takes many days and still is a fragile process.
+Perfect solution on consumer side, but there is a painful side-effect: CCI will not re-generate all involved packages for any change in the dependencies graph which glib is associated, which means, users will start to see **MISSING_PACKAGES** error during their pull requests.
+As workaround, it would be necessary updating all recipes involved, by opening new PRs, then it should generate new packages, but it takes many days and still is a fragile process.
 
 To have more context about it, please, visit the issues #11684 and #11022
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -446,7 +446,7 @@ Those projects usually break between patch versions and are very sensitive, so w
 otherwise, it may result in unexpected behavior or even runtime errors.
 
 A very known project is GLib, which requires the very same configuration to prevent multiple instances when using static linkage.
-As a solution, we could consume glib on full package id mode, like:
+As a solution, we could consume GLib on full package id mode, like:
 
 ```python
 def package_id(self):

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -453,7 +453,7 @@ def package_id(self):
     self.info.requires["glib"].full_package_mode()
 ```
 
-Perfect solution on the consumer side, but there is a painful side-effect: CCI will not re-generate all involved packages for any change in the dependencies graph with which glib is associated, which means, users will start to see **MISSING_PACKAGES** error during their pull requests.
+Perfect solution on the consumer side, but there is a side-effect: CCI will not re-generate all involved packages for any change in the dependencies graph with which glib is associated, which means, users will start to see **MISSING_PACKAGES** error during their pull requests.
 As a trade-off, it would be necessary to update all recipes involved, by opening new PRs,
 then it should generate new packages, but it takes many days and still is a process that is not supported by CCI internally.
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -457,4 +457,4 @@ As workaround, it would be necessary updating all recipes involved, by opening n
 
 To have more context about it, please, visit the issues #11684 and #11022
 
-In summary, we do not recommend `full_package_mode` usage on CCI. Instead, prefer using `shared=True` by default, when is really needed.
+In summary, we do recommend `full_package_mode` usage on CCI. Instead, prefer using `shared=True` by default, when is really needed.


### PR DESCRIPTION
Spoiler: No.

Using `full_package_mode` will result on **missing package** errors on CCI, so it's not recommended. When really needed, I would recommend by using `shared=True` instead and maybe, not allowing static link. 

/cc @SpaceIm 

Related to https://github.com/conan-io/conan-center-index/pull/15756#discussion_r1106041531


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
