### PR TITLE
remove MesonDeps from template

### DIFF
--- a/docs/package_templates/meson_package/all/conanfile.py
+++ b/docs/package_templates/meson_package/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
-from conan.tools.meson import Meson, MesonToolchain, MesonDeps
+from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
 import os
@@ -113,9 +113,6 @@ class PackageConan(ConanFile):
         tc.generate()
         # In case there are dependencies listed on requirements, PkgConfigDeps should be used
         tc = PkgConfigDeps(self)
-        tc.generate()
-        # Sometimes, when PkgConfigDeps is not enough to find requirements, MesonDeps should solve it
-        tc = MesonDeps(self)
         tc.generate()
         # In case there are dependencies listed on build_requirements, VirtualBuildEnv should be used
         tc = VirtualBuildEnv(self)


### PR DESCRIPTION
- Conan 2.0 is removing MesonDeps, as it is broken, not being capable of managing transitive dependencies: https://github.com/conan-io/conan/pull/13134
- No ConanCenter uses it, only Pistache, and it is not needed: https://github.com/conan-io/conan-center-index/pull/16014
- Conan 1.X will mark MesonDeps as deprecated and not-recommended in the docs

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
