### PR TITLE
[sentry-native/0.6.0] + remove old versions

### DIFF
--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -1,22 +1,10 @@
 sources:
+  "0.6.0":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.6.0/sentry-native.zip"
+    sha256: "ae03c9c8487794cd0f6d7fb7bb9b3c13e1a253190b290eaf752e2b4f007fd089"
   "0.5.4":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.5.4/sentry-native.zip"
     sha256: "e151bdc76894eb964ba4637361b2a96b7447fb04212053cf695fd7f72b636e4d"
-  "0.5.3":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.5.3/sentry-native.zip"
-    sha256: "d9a2434783e558bc9e074518ce155bda129bfa12d376dde939e6a732c92f9757"
-  "0.5.0":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.5.0/sentry-native.zip"
-    sha256: "1a65767a7c6c368a6dea44125eb268ed8374100f33168829f21df78cbfa8632b"
   "0.4.18":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.18/sentry-native.zip"
     sha256: "41fdf6499cd8576142beb03104badcc9e0b80b8ef27080ca71cd4408cc1d7ece"
-  "0.4.17":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.17/sentry-native.zip"
-    sha256: "38c9e180c29b6561c5f91ada154e191eabe9d7c270734cff81e55532878ec273"
-  "0.4.15":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.15/sentry-native.zip"
-    sha256: "ae3ac4efa76d431d8734d7b0b1bf9bbedaf2cbdb18dfc5c95e2411a67808cf29"
-  "0.4.13":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.13/sentry-native.zip"
-    sha256: "85e0e15d7fb51388d967ab09e7ee1b95f82330a469a93c65d964ea1afd5e6127"

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -34,7 +34,6 @@ class SentryNativeConan(ConanFile):
         "qt": [True, False],
         "with_crashpad": ["google", "sentry"],
         "with_breakpad": ["google", "sentry"],
-        "performance": [True, False],
     }
     default_options = {
         "shared": False,
@@ -44,7 +43,6 @@ class SentryNativeConan(ConanFile):
         "qt": False,
         "with_crashpad": "sentry",
         "with_breakpad": "sentry",
-        "performance": False,
     }
 
     @property
@@ -125,12 +123,6 @@ class SentryNativeConan(ConanFile):
             raise ConanInvalidConfiguration("The winhttp transport is only supported on Windows")
         if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "10.0":
             raise ConanInvalidConfiguration("apple-clang < 10.0 not supported")
-        if self.options.backend == "crashpad" and self.settings.os == "Macos" and self.settings.arch == "armv8":
-            raise ConanInvalidConfiguration("This version doesn't support ARM compilation")
-
-        if self.options.performance:
-            if Version(self.version) < "0.4.14" or Version(self.version) > "0.4.15":
-                raise ConanInvalidConfiguration("Performance monitoring is only valid in 0.4.14 and 0.4.15")
 
     def _cmake_new_enough(self, required_version):
         try:
@@ -163,7 +155,6 @@ class SentryNativeConan(ConanFile):
         tc.variables["SENTRY_TRANSPORT"] = self.options.transport
         tc.variables["SENTRY_PIC"] = self.options.get_safe("fPIC", True)
         tc.variables["SENTRY_INTEGRATION_QT"] = self.options.qt
-        tc.variables["SENTRY_PERFORMANCE_MONITORING"] = self.options.performance
         tc.generate()
         CMakeDeps(self).generate()
         if self.options.backend == "breakpad":

--- a/recipes/sentry-native/config.yml
+++ b/recipes/sentry-native/config.yml
@@ -1,15 +1,7 @@
 versions:
+  "0.6.0":
+    folder: all
   "0.5.4":
     folder: all
-  "0.5.3":
-    folder: all
-  "0.5.0":
-    folder: all
   "0.4.18":
-    folder: all
-  "0.4.17":
-    folder: all
-  "0.4.15":
-    folder: all
-  "0.4.13":
     folder: all


### PR DESCRIPTION
- [sentry-native/0.6.0] + remove old versions
- Remove performance option


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
