### PR TITLE
[highs] Fix typo in topic

### DIFF
--- a/recipes/highs/all/conanfile.py
+++ b/recipes/highs/all/conanfile.py
@@ -15,7 +15,7 @@ class HiGHSConan(ConanFile):
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.highs.dev/"
-    topics = ("simplex", "interior point", "solver", "linear", "programming")
+    topics = ("simplex", "interior-point", "solver", "linear", "programming")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],


### PR DESCRIPTION
conan center splits topics by spaces, but "interior point" belongs together

Specify library name and version:  **highs/1.4.2**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
