### PR TITLE
Add library OGDF with graph algorithms and data structures

### DIFF
--- a/recipes/ogdf/all/conandata.yml
+++ b/recipes/ogdf/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2022.02":
+    url: "https://github.com/ogdf/ogdf/archive/refs/tags/dogwood-202202.tar.gz"
+    sha256: "308cc2749c6a63520f7979bac86a04066dfea2fb9d3a5e89831318db404bfbf5"

--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import collect_libs, copy, get, replace_in_file, rmdir
+from conan.tools.files import copy, get, replace_in_file, rmdir
 from conan.tools.microsoft import is_msvc
 from os.path import join
 
@@ -12,7 +12,7 @@ required_conan_version = ">=1.53.0"
 class OGDFConan(ConanFile):
     name = "ogdf"
     description = "Open Graph algorithms and Data structures Framework"
-    license = "GPL-2.0-or-later"
+    license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://ogdf.net"
     topics = ("graph", "algorithm", "data-structures")
@@ -50,7 +50,6 @@ class OGDFConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
         tc.variables["COIN_SOLVER"] = "CLP"
         tc.variables["COIN_SOLVER_IS_EXTERNAL"] = 0
         tc.generate()
@@ -83,7 +82,7 @@ class OGDFConan(ConanFile):
         cmake.build(target="OGDF")
 
     def package(self):
-        copy(self, pattern="LICENSE.txt", src=self.source_folder, dst=join(self.package_folder, "licenses"))
+        copy(self, pattern="LICENSE*.txt", src=self.source_folder, dst=join(self.package_folder, "licenses"))
         copy(self, pattern="*.h", src=join(self.source_folder, "include"), dst=join(self.package_folder, "include"))
         copy(self, pattern="*.h", src=join(self.build_folder, "include"), dst=join(self.package_folder, "include"))
         if self.options.shared:
@@ -95,7 +94,7 @@ class OGDFConan(ConanFile):
         fix_apple_shared_install_name(self)
 
     def package_info(self):
-        self.cpp_info.libs = collect_libs(self)
+        self.cpp_info.libs = ["OGDF"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
             self.cpp_info.system_libs.append("pthread")

--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import collect_libs, copy, get, replace_in_file, rmdir
-from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.microsoft import is_msvc
 from os.path import join
 
 required_conan_version = ">=1.53.0"
@@ -26,9 +26,9 @@ class OGDFConan(ConanFile):
         "fPIC": True,
     }
 
-    # def validate(self):
-    #     if is_msvc(self) and self.options.shared:
-    #         raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
+    def validate(self):
+        if is_msvc(self) and self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -91,5 +91,6 @@ class OGDFConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = collect_libs(self)
-        #if self.settings.os in ["Linux", "FreeBSD"]:
-        #    self.cpp_info.system_libs.append("m")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -1,0 +1,95 @@
+from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import collect_libs, copy, get, replace_in_file, rmdir
+from conan.tools.microsoft import check_min_vs, is_msvc
+from os.path import join
+
+required_conan_version = ">=1.53.0"
+
+
+class OGDFConan(ConanFile):
+    name = "ogdf"
+    description = "Open Graph algorithms and Data structures Framework"
+    license = "GPL-2.0-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://ogdf.net"
+    topics = ("graph", "algorithm", "data-structures")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    # def validate(self):
+    #     if is_msvc(self) and self.options.shared:
+    #         raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        rmdir(self, join(self.source_folder, "src", "coin"))
+        rmdir(self, join(self.source_folder, "include", "coin"))
+        rmdir(self, join(self.source_folder, "include", "ogdf", "lib", "backward"))
+        rmdir(self, join(self.source_folder, "src", "ogdf", "lib", "pugixml"))
+        rmdir(self, join(self.source_folder, "include", "ogdf", "lib", "pugixml"))
+        replace_in_file(self, join(self.source_folder, "CMakeLists.txt"), "include(coin)", "find_package(coin-clp REQUIRED CONFIG)\nfind_package(pugixml REQUIRED CONFIG)")
+        replace_in_file(self, join(self.source_folder, "cmake", "ogdf.cmake"), "target_link_libraries(OGDF PUBLIC COIN)", "target_link_libraries(OGDF PUBLIC coin-clp::coin-clp pugixml::pugixml)")
+        # replace pugixml copy in repo by conan dependency
+        for dir_name, file_name in [("include", "GexfParser.h"),
+                                    ("include", "GraphMLParser.h"),
+                                    ("include", "SvgPrinter.h"),
+                                    ("include", "TsplibXmlParser.h"),
+                                    ("src", "GraphIO_graphml.cpp"),
+                                    ("src", "GraphIO_gexf.cpp")]:
+            replace_in_file(self, join(self.source_folder, dir_name, "ogdf", "fileformats", file_name), "ogdf/lib/pugixml/pugixml.h", "pugixml.hpp")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def requirements(self):
+        self.requires("coin-clp/1.17.7")
+        self.requires("pugixml/1.13")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.variables["COIN_SOLVER"] = "CLP"
+        tc.variables["COIN_SOLVER_IS_EXTERNAL"] = 0
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build(target="OGDF")
+
+    def package(self):
+        copy(self, pattern="LICENSE.txt", src=self.source_folder, dst=join(self.package_folder, "licenses"))
+        copy(self, pattern="*.h", src=join(self.source_folder, "include"), dst=join(self.package_folder, "include"))
+        copy(self, pattern="*.h", src=join(self.build_folder, "include"), dst=join(self.package_folder, "include"))
+        if self.options.shared:
+            copy(self, pattern="*.so*", src=self.build_folder, dst=join(self.package_folder, "lib"))
+            copy(self, pattern="*.dylib*", src=self.build_folder, dst=join(self.package_folder, "lib"))
+        else:
+            copy(self, pattern="*.a", src=self.build_folder, dst=join(self.package_folder, "lib"))
+            copy(self, pattern="*.lib", src=self.build_folder, dst=join(self.package_folder, "lib"), keep_path=False)
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.libs = collect_libs(self)
+        #if self.settings.os in ["Linux", "FreeBSD"]:
+        #    self.cpp_info.system_libs.append("m")

--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -58,7 +58,13 @@ class OGDFConan(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
-        # use cci packages where available 
+        # delete code from other cci packages
+        rmdir(self, join(self.source_folder, "src", "coin"))
+        rmdir(self, join(self.source_folder, "include", "coin"))
+        rmdir(self, join(self.source_folder, "include", "ogdf", "lib", "backward"))
+        rmdir(self, join(self.source_folder, "src", "ogdf", "lib", "pugixml"))
+        rmdir(self, join(self.source_folder, "include", "ogdf", "lib", "pugixml"))
+        # use cci packages where available
         replace_in_file(self, join(self.source_folder, "CMakeLists.txt"), "include(coin)", "find_package(coin-clp REQUIRED CONFIG)\nfind_package(pugixml REQUIRED CONFIG)")
         replace_in_file(self, join(self.source_folder, "cmake", "ogdf.cmake"), "target_link_libraries(OGDF PUBLIC COIN)", "target_link_libraries(OGDF PUBLIC coin-clp::coin-clp pugixml::pugixml)")
         # replace pugixml copy in repo by conan dependency

--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -32,21 +32,6 @@ class OGDFConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        rmdir(self, join(self.source_folder, "src", "coin"))
-        rmdir(self, join(self.source_folder, "include", "coin"))
-        rmdir(self, join(self.source_folder, "include", "ogdf", "lib", "backward"))
-        rmdir(self, join(self.source_folder, "src", "ogdf", "lib", "pugixml"))
-        rmdir(self, join(self.source_folder, "include", "ogdf", "lib", "pugixml"))
-        replace_in_file(self, join(self.source_folder, "CMakeLists.txt"), "include(coin)", "find_package(coin-clp REQUIRED CONFIG)\nfind_package(pugixml REQUIRED CONFIG)")
-        replace_in_file(self, join(self.source_folder, "cmake", "ogdf.cmake"), "target_link_libraries(OGDF PUBLIC COIN)", "target_link_libraries(OGDF PUBLIC coin-clp::coin-clp pugixml::pugixml)")
-        # replace pugixml copy in repo by conan dependency
-        for dir_name, file_name in [("include", "GexfParser.h"),
-                                    ("include", "GraphMLParser.h"),
-                                    ("include", "SvgPrinter.h"),
-                                    ("include", "TsplibXmlParser.h"),
-                                    ("src", "GraphIO_graphml.cpp"),
-                                    ("src", "GraphIO_gexf.cpp")]:
-            replace_in_file(self, join(self.source_folder, dir_name, "ogdf", "fileformats", file_name), "ogdf/lib/pugixml/pugixml.h", "pugixml.hpp")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -72,7 +72,21 @@ class OGDFConan(ConanFile):
         tc = CMakeDeps(self)
         tc.generate()
 
+    def _patch_sources(self):
+        # use cci packages where available 
+        replace_in_file(self, join(self.source_folder, "CMakeLists.txt"), "include(coin)", "find_package(coin-clp REQUIRED CONFIG)\nfind_package(pugixml REQUIRED CONFIG)")
+        replace_in_file(self, join(self.source_folder, "cmake", "ogdf.cmake"), "target_link_libraries(OGDF PUBLIC COIN)", "target_link_libraries(OGDF PUBLIC coin-clp::coin-clp pugixml::pugixml)")
+        # replace pugixml copy in repo by conan dependency
+        for dir_name, file_name in [("include", "GexfParser.h"),
+                                    ("include", "GraphMLParser.h"),
+                                    ("include", "SvgPrinter.h"),
+                                    ("include", "TsplibXmlParser.h"),
+                                    ("src", "GraphIO_graphml.cpp"),
+                                    ("src", "GraphIO_gexf.cpp")]:
+            replace_in_file(self, join(self.source_folder, dir_name, "ogdf", "fileformats", file_name), "ogdf/lib/pugixml/pugixml.h", "pugixml.hpp")
+
     def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build(target="OGDF")

--- a/recipes/ogdf/all/test_package/CMakeLists.txt
+++ b/recipes/ogdf/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(ogdf REQUIRED CONFIG)
+add_executable(${PROJECT_NAME} main.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE ogdf::ogdf)

--- a/recipes/ogdf/all/test_package/conanfile.py
+++ b/recipes/ogdf/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/ogdf/all/test_package/main.cpp
+++ b/recipes/ogdf/all/test_package/main.cpp
@@ -1,0 +1,18 @@
+#include <ogdf/basic/graph_generators.h>
+#include <ogdf/layered/DfsAcyclicSubgraph.h>
+#include <ogdf/fileformats/GraphIO.h>
+
+using namespace ogdf;
+
+int main()
+{
+	Graph G;
+	randomSimpleGraph(G, 10, 20);
+
+	DfsAcyclicSubgraph DAS;
+	DAS.callAndReverse(G);
+
+	GraphIO::write(G, "output-acyclic-graph.graphml", GraphIO::writeGraphML);
+
+	return 0;
+}

--- a/recipes/ogdf/all/test_v1_package/CMakeLists.txt
+++ b/recipes/ogdf/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+set(CMAKE_CXX_STANDARD 11)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/ogdf/all/test_v1_package/conanfile.py
+++ b/recipes/ogdf/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/ogdf/config.yml
+++ b/recipes/ogdf/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2022.02":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ogdf/2022.02**

I am one of the OGDF developers.

Remark: The recipe deletes lots of content from the sources as they contain many libs via copy&paste. Everything that is provided by conan was dropped and replaced by conan dependencies. Other libs remain in the sources, for example coin-abacus and minisat, for which no conan packages exist. Here is the complete list:

Dropped:

* pugixml: was contained in `(src|include)/ogdf/lib/pugixml`, replaced by the dependency on pugixml/1.13 from conan center
* coin-clp: was contained in `(src|include)/coin`, replaced by the dependency on coin-clp/1.17.7 from conan-center
* backward-cpp: was contained in `include/ogdf/lib/backward`, dropped as only required for a special parameter settings not supported in the recipe

Remaining:

* coin-abacus: contained in `(src|include)/ogdf/lib/abacus` is a deprecated library (https://github.com/coin-or/ABACUS)
* minisat: a SAT solver (http://minisat.se/) in `(src|include)/ogdf/lib/minisat` for which no conan package exists yet

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
