### PR TITLE
benchmark: bump required cmake version

### DIFF
--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -48,20 +48,11 @@ class BenchmarkConan(ConanFile):
         if Version(self.version) < "1.7.0" and is_msvc(self) and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support msvc shared builds")
 
-    def _cmake_new_enough(self, required_version):
-        try:
-            import re
-            from io import StringIO
-            output = StringIO()
-            self.run("cmake --version", output=output)
-            m = re.search(r'cmake version (\d+\.\d+\.\d+)', output.getvalue())
-            return Version(m.group(1)) >= required_version
-        except:
-            return False
-
     def build_requirements(self):
-        if Version(self.version) >= "1.7.1" and not self._cmake_new_enough("3.16.3"):
-            self.tool_requires("cmake/3.25.0")
+        # https://github.com/conan-io/conan-center-index/pull/14306#discussion_r1032157448
+        # Benchmark increased it's required CMake version
+        if Version(self.version) >= "1.7.1": 
+            self.tool_requires("cmake/3.25.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
This is for one of my tools tracking the v2 progress, it does not react well to "newer" versions being dropped from CMake

The graph should not be dependent on user's system, so i've removed the "new enough" logic. In the long term we'll invest is a solution the produces less conflicts or less building for the users cross compiling

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
