### PR TITLE
[grpc-proto] bump required googleapis version

### DIFF
--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -20,11 +20,11 @@ class GRPCProto(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps"
     options = {
-        "shared": [True, False], 
+        "shared": [True, False],
         "fPIC": [True, False]
         }
     default_options = {
-        "shared": False, 
+        "shared": False,
         "fPIC": True
         }
     exports = "helpers.py"
@@ -60,7 +60,7 @@ class GRPCProto(ConanFile):
 
     def requirements(self):
         self.requires('protobuf/3.21.4', transitive_headers=True)
-        self.requires('googleapis/cci.20220711')
+        self.requires('googleapis/cci.20221108')
 
     def build_requirements(self):
         self.build_requires('protobuf/3.21.4')
@@ -69,7 +69,7 @@ class GRPCProto(ConanFile):
     def _parse_proto_libraries(self):
         # Generate the libraries to build dynamically
         proto_libraries = parse_proto_libraries(os.path.join(self.source_folder, 'BUILD.bazel'), self.source_folder, self.output.error)
-        
+
         # Validate that all files exist and all dependencies are found
         all_deps = [it.cmake_target for it in proto_libraries]
         all_deps += ["googleapis::googleapis", "protobuf::libprotobuf"]


### PR DESCRIPTION
Specify library name and version:  **grpc-proto/cci.20211106**

My best guess is that I need to make this change to unblock #15817.
In summary: `google-cloud-cpp/2.5.0` requires a new version of `googleapis` and (to be best of my limited knowledge) that requires updating `grpc-proto` and `grpc`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
