### PR TITLE
rtmidi: do not use pkgconf + modernize more for conan v2

### DIFF
--- a/recipes/rtmidi/all/conandata.yml
+++ b/recipes/rtmidi/all/conandata.yml
@@ -9,3 +9,6 @@ patches:
   "4.0.0":
     - patch_file: "patches/4.0.0-0001-add-a-separate-licence-file-0b5d67c.patch"
     - patch_file: "patches/4.0.0-0002-rtmidiconfig-install-location-da51f21.patch"
+    - patch_file: "patches/4.0.0-0003-relocatable-macos.patch"
+      patch_description: "Relocatable shared lib on macOS"
+      patch_type: "conan"

--- a/recipes/rtmidi/all/conanfile.py
+++ b/recipes/rtmidi/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file, rmdir
+from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file, rmdir
 from conan.tools.scm import Version
 import os
 
@@ -87,11 +88,11 @@ class RtMidiConan(ConanFile):
         # TODO: back to global scope in conan v2
         self.cpp_info.components["librtmidi"].includedirs = [os.path.join("include", "rtmidi")]
         self.cpp_info.components["librtmidi"].libs = ["rtmidi"]
-        if self.settings.os == "Macos":
+        if is_apple_os(self):
             self.cpp_info.components["librtmidi"].frameworks.extend(
-                ["CoreFoundation", "CoreAudio", "CoreMidi"]
+                ["CoreFoundation", "CoreAudio", "CoreMidi", "CoreServices"]
             )
-        if self.settings.os == "Windows":
+        elif self.settings.os == "Windows":
             self.cpp_info.components["librtmidi"].system_libs.append("winmm")
         elif self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["librtmidi"].system_libs.append("pthread")

--- a/recipes/rtmidi/all/conanfile.py
+++ b/recipes/rtmidi/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file, rmdir
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.scm import Version
 import os
@@ -57,8 +57,12 @@ class RtMidiConan(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
 
-    def build(self):
+    def _patch_sources(self):
         apply_conandata_patches(self)
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "${ALSA_LIBRARY}", "ALSA::ALSA")
+
+    def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/rtmidi/all/conanfile.py
+++ b/recipes/rtmidi/all/conanfile.py
@@ -2,10 +2,9 @@ from conan import ConanFile
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.scm import Version
-from conan.tools.env import VirtualBuildEnv
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
 
 
 class RtMidiConan(ConanFile):
@@ -13,23 +12,18 @@ class RtMidiConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://www.music.mcgill.ca/~gary/rtmidi/"
     description = "Realtime MIDI input/output"
-    topics = ("midi")
+    topics = ("midi",)
     license = "MIT+send-patches-upstream"
-    settings = "os", "compiler", "build_type", "arch"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        }
+    }
     default_options = {
         "shared": False,
         "fPIC": True,
-        }
-
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    }
 
     @property
     def _with_alsa(self):
@@ -44,7 +38,7 @@ class RtMidiConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -53,10 +47,6 @@ class RtMidiConan(ConanFile):
         if self._with_alsa:
             self.requires("libalsa/1.2.4")
 
-    def build_requirements(self):
-        if self._with_alsa and not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/1.9.3")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
@@ -64,12 +54,8 @@ class RtMidiConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["RTMIDI_BUILD_TESTING"] = False
         tc.generate()
-        if self._with_alsa:
-            tc = CMakeDeps(self)
-            tc.generate()
-            tc = VirtualBuildEnv(self)
-            tc.generate(scope="build")
-
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         apply_conandata_patches(self)
@@ -91,22 +77,12 @@ class RtMidiConan(ConanFile):
             )
 
     def package_info(self):
-        self.cpp_info.components["librtmidi"].includedirs = [os.path.join("include", "rtmidi")]
-
-        self.cpp_info.set_property("cmake_module_file_name", "RtMidi")
-        self.cpp_info.set_property("cmake_module_target_name", "RtMidi::rtmidi")
         self.cpp_info.set_property("cmake_file_name", "RtMidi")
         self.cpp_info.set_property("cmake_target_name", "RtMidi::rtmidi")
-        self.cpp_info.components["librtmidi"].set_property("cmake_target_name", "RtMidi::rtmidi")
         self.cpp_info.set_property("pkg_config_name", "rtmidi")
-        self.cpp_info.components["librtmidi"].set_property("pkg_config_name", "rtmidi")
-        self.cpp_info.names["cmake_find_package"] = "RtMidi"
-        self.cpp_info.names["cmake_find_package_multi"] = "RtMidi"
-        self.cpp_info.components["librtmidi"].names["cmake_find_package"] = "rtmidi"
-        self.cpp_info.components["librtmidi"].names["cmake_find_package_multi"] = "rtmidi"
+        # TODO: back to global scope in conan v2
+        self.cpp_info.components["librtmidi"].includedirs = [os.path.join("include", "rtmidi")]
         self.cpp_info.components["librtmidi"].libs = ["rtmidi"]
-        if self._with_alsa:
-            self.cpp_info.components["librtmidi"].requires.append("libalsa::libalsa")
         if self.settings.os == "Macos":
             self.cpp_info.components["librtmidi"].frameworks.extend(
                 ["CoreFoundation", "CoreAudio", "CoreMidi"]
@@ -115,3 +91,13 @@ class RtMidiConan(ConanFile):
             self.cpp_info.components["librtmidi"].system_libs.append("winmm")
         elif self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["librtmidi"].system_libs.append("pthread")
+
+        # TODO: to remove in conan v2
+        self.cpp_info.names["cmake_find_package"] = "RtMidi"
+        self.cpp_info.names["cmake_find_package_multi"] = "RtMidi"
+        self.cpp_info.components["librtmidi"].names["cmake_find_package"] = "rtmidi"
+        self.cpp_info.components["librtmidi"].names["cmake_find_package_multi"] = "rtmidi"
+        self.cpp_info.components["librtmidi"].set_property("cmake_target_name", "RtMidi::rtmidi")
+        self.cpp_info.components["librtmidi"].set_property("pkg_config_name", "rtmidi")
+        if self._with_alsa:
+            self.cpp_info.components["librtmidi"].requires.append("libalsa::libalsa")

--- a/recipes/rtmidi/all/conanfile.py
+++ b/recipes/rtmidi/all/conanfile.py
@@ -90,7 +90,7 @@ class RtMidiConan(ConanFile):
         self.cpp_info.components["librtmidi"].libs = ["rtmidi"]
         if is_apple_os(self):
             self.cpp_info.components["librtmidi"].frameworks.extend(
-                ["CoreFoundation", "CoreAudio", "CoreMidi", "CoreServices"]
+                ["CoreFoundation", "CoreAudio", "CoreMIDI", "CoreServices"]
             )
         elif self.settings.os == "Windows":
             self.cpp_info.components["librtmidi"].system_libs.append("winmm")

--- a/recipes/rtmidi/all/conanfile.py
+++ b/recipes/rtmidi/all/conanfile.py
@@ -46,7 +46,7 @@ class RtMidiConan(ConanFile):
 
     def requirements(self):
         if self._with_alsa:
-            self.requires("libalsa/1.2.4")
+            self.requires("libalsa/1.2.7.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/rtmidi/all/patches/4.0.0-0003-relocatable-macos.patch
+++ b/recipes/rtmidi/all/patches/4.0.0-0003-relocatable-macos.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -151,7 +151,6 @@ if (NEED_PTHREAD)
+ endif()
+ 
+ # Create library targets.
+-cmake_policy(SET CMP0042 OLD)
+ set(LIB_TARGETS)
+ 
+ # Use RTMIDI_BUILD_SHARED_LIBS / RTMIDI_BUILD_STATIC_LIBS if they


### PR DESCRIPTION
- don't use pkgconf, libalsa is discovered through find_package(): https://github.com/thestk/rtmidi/blob/5.0.0/CMakeLists.txt#L123
- cleanup package_info()
- final polishing to make this recipe v2 compatible:
  - fix topics (must be a valid tuple in conan v2)
  - fix double delete of fPIC option
  - add package_type (not strictly required, but it's better)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
