### PR TITLE
Migrate RapidFuzz to conan 2.0 and add 1.10.4 version

### DIFF
--- a/recipes/rapidfuzz/all/conandata.yml
+++ b/recipes/rapidfuzz/all/conandata.yml
@@ -2,3 +2,5 @@ sources:
   "cci.20210513":
     url: "https://github.com/maxbachmann/rapidfuzz-cpp/archive/d1e82379395cafc6d439c1c1e2cbe7512eaf2518.tar.gz"
     sha256: "e5c306aae2fb4b34a381fbffaa97399114f20de14d83914ac2c9013b0226ce57"
+  "1.10.4":
+    url: "https://github.com/maxbachmann/rapidfuzz-cpp/archive/refs/tags/v1.10.4.tar.gz"

--- a/recipes/rapidfuzz/all/conanfile.py
+++ b/recipes/rapidfuzz/all/conanfile.py
@@ -1,6 +1,8 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.tools.files import get, copy
+from os.path import join
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class RapidFuzzConan(ConanFile):
@@ -12,17 +14,13 @@ class RapidFuzzConan(ConanFile):
     license = "MIT"
     no_copy_source = True
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="rapidfuzz/*.hpp", dst="include", src=self._source_subfolder)
+        copy(self, "LICENSE", self.source_folder, join(self.package_folder, "licenses"))
+        copy(self, "rapidfuzz/*.hpp", self.source_folder, join(self.package_folder, "include"))
+        copy(self, "rapidfuzz/*.impl", self.source_folder, join(self.package_folder, "include"))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/rapidfuzz/all/test_package/CMakeLists.txt
+++ b/recipes/rapidfuzz/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/rapidfuzz/config.yml
+++ b/recipes/rapidfuzz/config.yml
@@ -1,3 +1,5 @@
 versions:
   "cci.20210513":
     folder: "all"
+  "1.10.4":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **rapidfuzz/1.10.4**

Proposal to migrate RapidFuzz to conan 2.0 and add upstream version