### PR TITLE
benchmark: bump version of cmake tool requirement

### DIFF
--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -61,7 +61,7 @@ class BenchmarkConan(ConanFile):
 
     def build_requirements(self):
         if Version(self.version) >= "1.7.1" and not self._cmake_new_enough("3.16.3"):
-            self.tool_requires("cmake/3.25.0")
+            self.tool_requires("cmake/3.25.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **benchmark/all**

Bump the required version of CMake to 3.25.2 - this is not strictly necessary given that `3.25.0` recipe and binaries exist, but 3.25.0 is no longer a version of CMake that we build or maintain (useful for Conan 2.0).



