### PR TITLE
libxml2: add transitive traits to libiconv dependency

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -97,7 +97,7 @@ class Libxml2Conan(ConanFile):
         if self.options.lzma:
             self.requires("xz_utils/5.2.5")
         if self.options.iconv:
-            self.requires("libiconv/1.17")
+            self.requires("libiconv/1.17", transitive_headers=True, transitive_libs=True)
         if self.options.icu:
             self.requires("icu/72.1")
 


### PR DESCRIPTION
Specify library name and version:  **libxml2/all**

The public `libxml2` headers include `<iconv.h>`. Conan 2.0 does not propagate the include directories of the libiconv dependency unless specified in the traits. This causes a downstream failure on Windows as the iconv header cannot be found. On Linux and Mac it could also result in the system version being picked up instead. 

I can see **no** evidence that any other the other dependencies are publicly transitive. 
