### PR TITLE
[cmake] Use FindOpenSSL generated by CMakeDeps

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -115,7 +115,7 @@ class CMakeConan(ConanFile):
                 tc.variables["HAVE_POLL_FINE_EXITCODE__TRYRUN_OUTPUT"] = ''
             tc.generate()
             tc = CMakeDeps(self)
-            # CMake tries to consume openssl::openssl target by default but it fails when checking
+            # CMake try_compile failure: https://github.com/conan-io/conan-center-index/pull/16073#discussion_r1110037534
             tc.set_property("openssl", "cmake_find_mode", "module")
             tc.generate()
 

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
 from conan.tools.files import chdir, copy, rmdir, get, save, load
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
 from conan.tools.layout import basic_layout
 from conan.tools.build import build_jobs, cross_building, check_min_cppstd
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
+
 import os
 import json
 
@@ -113,6 +114,11 @@ class CMakeConan(ConanFile):
                 tc.variables["HAVE_POLL_FINE_EXITCODE"] = ''
                 tc.variables["HAVE_POLL_FINE_EXITCODE__TRYRUN_OUTPUT"] = ''
             tc.generate()
+            tc = CMakeDeps(self)
+            # CMake tries to consume openssl::openssl target by default but it fails when checking
+            tc.set_property("openssl", "cmake_find_mode", "module")
+            tc.generate()
+
 
     def build(self):
         if self.options.bootstrap:

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
 from conan.tools.layout import basic_layout
 from conan.tools.build import build_jobs, cross_building, check_min_cppstd
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 from conan.errors import ConanInvalidConfiguration
 
 import os
@@ -113,6 +114,11 @@ class CMakeConan(ConanFile):
             if cross_building(self):
                 tc.variables["HAVE_POLL_FINE_EXITCODE"] = ''
                 tc.variables["HAVE_POLL_FINE_EXITCODE__TRYRUN_OUTPUT"] = ''
+            # TODO: Remove after fixing https://github.com/conan-io/conan-center-index/issues/13159
+            # C3I workaround to force CMake to choose the highest version of
+            # the windows SDK available in the system
+            if is_msvc(self) and not self.conf.get("tools.cmake.cmaketoolchain:system_version"):
+                tc.variables["CMAKE_SYSTEM_VERSION"] = "10.0"
             tc.generate()
             tc = CMakeDeps(self)
             # CMake try_compile failure: https://github.com/conan-io/conan-center-index/pull/16073#discussion_r1110037534


### PR DESCRIPTION
Specify library name and version:  **cmake/3.x**

When building CMake by using system CMake, it will find OpenSSL library through FindOpenSSL from native cmake modules folder (e.g. /usr/cmake/cmake-3.15/Modules). As result, building Cmake package with Conan 2.0 will result on a linkage error between static openssl libraries and pthread. 

The error is caused because FindOpenssl finds openssl libraries associated to Conan, but the linkage order does not work and fails. However, Cmake fixed it on version 3.16: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4235. But due Conan Tribe decision, we should use 3.15.

On the other hand, we can use CMakeDeps to generate FindOpenSSL.cmake and consume our targets and variables, which is much safer.

Other changes: set the `CMAKE_SYSTEM_VERSION` to `10.0` on Windows so that CMake uses the most recent version of the Windows SDK it can use. 

/cc @jcar87 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
