### PR TITLE
service: set python version for alert-community action

### DIFF
--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened]
 
+env:
+  PYVER: "3.10"
+
 jobs:
   comment:
     if: github.repository == 'conan-io/conan-center-index'


### PR DESCRIPTION
this silences a bunch of warnings

cf https://github.com/conan-io/conan-center-index/actions/runs/4202405009


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
