### PR TITLE
openh264: fix check for visual studio on Windows (conan 2.0)

### DIFF
--- a/recipes/openh264/all/conanfile.py
+++ b/recipes/openh264/all/conanfile.py
@@ -5,13 +5,12 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.layout import basic_layout
-from conan.tools.scm import Version
-from conan.tools.microsoft import is_msvc, unix_path, msvc_runtime_flag
+from conan.tools.microsoft import check_min_vs, is_msvc, unix_path, msvc_runtime_flag
 
 import os
 
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=1.57.0"
 
 
 class OpenH264Conan(ConanFile):
@@ -150,7 +149,8 @@ class OpenH264Conan(ConanFile):
 
         if is_msvc(self):
             tc.extra_cxxflags.append("-nologo")
-            if not (self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) < "12"):
+            if check_min_vs(self, "180", raise_invalid=False):
+                # https://github.com/conan-io/conan/issues/6514
                 tc.extra_cxxflags.append("-FS")
         # not needed during and after 2.3.1
         elif self.settings.compiler in ("apple-clang",):


### PR DESCRIPTION
Specify library name and version:  **openh264/all**

* Fix evaluation of "Visual Studio" as compiler by using newer `check_min_vs` which works with both old and new - fixes building recipe on Windows with Conan 2.0
