### PR TITLE
[linter] Allow failing community alert service

### DIFF
--- a/.github/actions/alert-community/action.yml
+++ b/.github/actions/alert-community/action.yml
@@ -16,10 +16,12 @@ runs:
   steps:
     # Assume the repo checked out the code since this is running
     - uses: ./.github/actions/pr_changed_files
+      continue-on-error: true
       id: changed_files
       with:
         files: ${{ inputs.files }}
     - if: always() && steps.changed_files.outputs.any_changed == 'true'
+      continue-on-error: true
       uses: actions/github-script@v6
       with:
         script: |

--- a/.github/actions/pr_changed_files/action.yml
+++ b/.github/actions/pr_changed_files/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "Check for changes using only this list of files (Defaults to the entire repo)"
     required: false
     default: ""
-    
+
 outputs:
   all_changed_files:
     description: List of all copied, modified, and added files.
@@ -34,7 +34,13 @@ runs:
 
         patterns = [Path(p).parts for p in '''${{ inputs.files }}'''.splitlines()]
 
-        res = subprocess.run(["gh", "api", "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files", "--paginate"], capture_output=True, check=True)
+        for i in range(0, 5):
+          while True:
+            try:
+              res = subprocess.run(["gh", "api", "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files", "--paginate"], capture_output=True, check=True)
+            except CalledProcessError:
+              continue
+            break
         files = []
         for f in json.loads(res.stdout):
           if f["status"] == "removed":

--- a/.github/actions/pr_changed_files/action.yml
+++ b/.github/actions/pr_changed_files/action.yml
@@ -35,12 +35,11 @@ runs:
         patterns = [Path(p).parts for p in '''${{ inputs.files }}'''.splitlines()]
 
         for i in range(0, 5):
-          while True:
-            try:
-              res = subprocess.run(["gh", "api", "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files", "--paginate"], capture_output=True, check=True)
-            except CalledProcessError:
-              continue
+          try:
+            res = subprocess.run(["gh", "api", "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files", "--paginate"], capture_output=True, check=True)
             break
+          except CalledProcessError:
+            continue
         files = []
         for f in json.loads(res.stdout):
           if f["status"] == "removed":

--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened]
 
+env:
+  PYVER: "3.10"
+
 jobs:
   comment:
     if: github.repository == 'conan-io/conan-center-index'


### PR DESCRIPTION
- Retry gh api command for 5 times in case of failure
- Community alert uses `continue-on-error` to avoid blocking PRs 

fixes #16104

/cc @ericLemanissier 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
