### PR TITLE
Boost: use versionless soname on Android

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -852,7 +852,8 @@ class BoostConan(ConanFile):
                               "    <link>shared:<library>.//boost_fiber : <conditional>@numa",
                               strict=False)
         if self.settings.os == "Android":
-            # force versionless soname
+            # force versionless soname from boostorg/boost#206 
+            # this can be applied to all versions and it's easier with a replace
             replace_in_file(self, os.path.join(self.source_folder, "boostcpp.jam"),
                             "! [ $(property-set).get <target-os> ] in windows cygwin darwin aix &&",
                             "! [ $(property-set).get <target-os> ] in windows cygwin darwin aix android &&",

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -851,6 +851,12 @@ class BoostConan(ConanFile):
                               "    <conditional>@numa",
                               "    <link>shared:<library>.//boost_fiber : <conditional>@numa",
                               strict=False)
+        if self.settings.os == "Android":
+            # force versionless soname
+            replace_in_file(self, os.path.join(self.source_folder, "boostcpp.jam"),
+                            "! [ $(property-set).get <target-os> ] in windows cygwin darwin aix &&",
+                            "! [ $(property-set).get <target-os> ] in windows cygwin darwin aix android &&",
+                            strict=False)
 
         if self.options.header_only:
             self.output.warning("Header only package, skipping build")


### PR DESCRIPTION
Specify library name and version:  **boost/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
Issue that I faced as written on Slack:

> I have boost built for android, each lib has a symlink (libboost_atomic.so) and real file (libboost_atomic.so.1.81.0). I consume the libs in a cmake project, project’s libs get linked to the real file (libboost_atomic.so.1.81.0). Now when gradle builds apk, it resolves all symlinks (i.e. libboost_atomic.so  becomes a real file in the apk) but completely ignores all files that don’t end with .so . (before running gradle I copy all libs with conan imports if it matters) Of course, app doesn’t work because it can’t find libboost_atomic.so.1.81.0 , sample error:
>
>…caused by could not load library “libboost_atomic.so.1.81.0” needed by “libvcmi.so”; caused by library “libboost_atomic.so.1.81.0” not found

The proper solution is to tell Boost to use versionless soname, but unfortunately there's no such option. There's a pending PR in upstream https://github.com/boostorg/boost/pull/206 for some years already, hopefully it'd be merged one day.

Using string replace should be safe as that line wasn't touched for many years:

![Screenshot 2023-02-18 at 14 22 07](https://user-images.githubusercontent.com/1557784/219864860-e07f8b03-c54d-42eb-97a7-6f0cbd119890.png)

and it can be used for any Boost version as that change was a part of v1.51 according to https://github.com/boostorg/boost/commit/4ba4e16f8e7290f0f0811d1e0cc0372581248c98

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
