### PR TITLE
thrift: add version 0.18.0, update openssl, use official tarballs

### DIFF
--- a/recipes/thrift/all/conandata.yml
+++ b/recipes/thrift/all/conandata.yml
@@ -1,29 +1,32 @@
 sources:
   "0.18.0":
-    url: "https://github.com/apache/thrift/archive/v0.18.0.tar.gz"
-    sha256: "b42a659ebe3711a78de4b14a117ea44558106223593c3f09c0d8dbe8a1b26848"
+    url: "http://archive.apache.org/dist/thrift/0.18.0/thrift-0.18.0.tar.gz"
+    sha256: "7c19389cb7910a20e58b8e46903c8c1a36353008f9fcc1b03f748accf9b5f3e1"
   "0.17.0":
-    url: "https://github.com/apache/thrift/archive/v0.17.0.tar.gz"
-    sha256: "f5888bcd3b8de40c2c2ab86896867ad9b18510deb412cba3e5da76fb4c604c29"
+    url: "http://archive.apache.org/dist/thrift/0.17.0/thrift-0.17.0.tar.gz"
+    sha256: "b272c1788bb165d99521a2599b31b97fa69e5931d099015d91ae107a0b0cc58f"
   "0.16.0":
-    url: "https://github.com/apache/thrift/archive/refs/tags/v0.16.0.tar.gz"
-    sha256: "df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b"
+    url: "http://archive.apache.org/dist/thrift/0.16.0/thrift-0.16.0.tar.gz"
+    sha256: "f460b5c1ca30d8918ff95ea3eb6291b3951cf518553566088f3f2be8981f6209"
   "0.15.0":
-    url: "https://github.com/apache/thrift/archive/refs/tags/v0.15.0.tar.gz"
-    sha256: "32d2f18aa9be114619ee54e1abc3bb497febb2a8aa917894c20bae21185fac15"
+    url: "http://archive.apache.org/dist/thrift/0.15.0/thrift-0.15.0.tar.gz"
+    sha256: "d5883566d161f8f6ddd4e21f3a9e3e6b8272799d054820f1c25b11e86718f86b"
   "0.14.2":
-    url: "https://github.com/apache/thrift/archive/v0.14.2.tar.gz"
-    sha256: "f966cdac6bb8d149a9950a761e6ee6f3b22d5a6073da43a333d3468f159ebeaa"
+    url: "http://archive.apache.org/dist/thrift/0.14.2/thrift-0.14.2.tar.gz"
+    sha256: "4191bfc0b7490e20cc69f9f4dc6e991fbb612d4551aa9eef1dbf7f4c47ce554d"
   "0.14.1":
-    url: "https://github.com/apache/thrift/archive/refs/tags/v0.14.1.tar.gz"
-    sha256: "5ae1c4d16452a22eaf9d802ba7489907147c2b316ff38c9758918552fae5132c"
+    url: "http://archive.apache.org/dist/thrift/0.14.1/thrift-0.14.1.tar.gz"
+    sha256: "13da5e1cd9c8a3bb89778c0337cc57eb0c29b08f3090b41cf6ab78594b410ca5"
   "0.13.0":
-    url: "https://github.com/apache/thrift/archive/0.13.0.tar.gz"
-    sha256: "8469c8d72c684c6de72ddf55fc65d1c10868a576e7dc4d1f4a21a59814b97110"
+    url: "http://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz"
+    sha256: "7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179"
 patches:
   "0.18.0":
     - patch_file: "patches/cmake-0.16.0.patch"
       patch_description: "use cci packages"
+      patch_type: "conan"
+    - patch_file: "patches/include-cstddef-0.18.0.patch"
+      patch_description: "include cstddef for ptrdiff_t"
       patch_type: "conan"
   "0.17.0":
     - patch_file: "patches/cmake-0.16.0.patch"

--- a/recipes/thrift/all/conandata.yml
+++ b/recipes/thrift/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.18.0":
+    url: "https://github.com/apache/thrift/archive/v0.18.0.tar.gz"
+    sha256: "b42a659ebe3711a78de4b14a117ea44558106223593c3f09c0d8dbe8a1b26848"
   "0.17.0":
     url: "https://github.com/apache/thrift/archive/v0.17.0.tar.gz"
     sha256: "f5888bcd3b8de40c2c2ab86896867ad9b18510deb412cba3e5da76fb4c604c29"
@@ -18,6 +21,10 @@ sources:
     url: "https://github.com/apache/thrift/archive/0.13.0.tar.gz"
     sha256: "8469c8d72c684c6de72ddf55fc65d1c10868a576e7dc4d1f4a21a59814b97110"
 patches:
+  "0.18.0":
+    - patch_file: "patches/cmake-0.16.0.patch"
+      patch_description: "use cci packages"
+      patch_type: "conan"
   "0.17.0":
     - patch_file: "patches/cmake-0.16.0.patch"
       patch_description: "use cci packages"

--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -66,7 +66,7 @@ class ThriftConan(ConanFile):
     def requirements(self):
         self.requires("boost/1.81.0")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/1.1.1t")
         if self.options.with_zlib:
             self.requires("zlib/1.2.13")
         if self.options.with_libevent:
@@ -86,8 +86,7 @@ class ThriftConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/thrift/all/patches/include-cstddef-0.18.0.patch
+++ b/recipes/thrift/all/patches/include-cstddef-0.18.0.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/cpp/src/thrift/transport/TBufferTransports.h b/lib/cpp/src/thrift/transport/TBufferTransports.h
+index f72d8f6..6df339f 100644
+--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
++++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
+@@ -20,6 +20,7 @@
+ #ifndef _THRIFT_TRANSPORT_TBUFFERTRANSPORTS_H_
+ #define _THRIFT_TRANSPORT_TBUFFERTRANSPORTS_H_ 1
+ 
++#include <cstddef>
+ #include <cstdlib>
+ #include <cstring>
+ #include <limits>
+diff --git a/lib/cpp/src/thrift/transport/THeaderTransport.cpp b/lib/cpp/src/thrift/transport/THeaderTransport.cpp
+index b3b8333..7078767 100644
+--- a/lib/cpp/src/thrift/transport/THeaderTransport.cpp
++++ b/lib/cpp/src/thrift/transport/THeaderTransport.cpp
+@@ -23,6 +23,7 @@
+ #include <thrift/protocol/TBinaryProtocol.h>
+ #include <thrift/protocol/TCompactProtocol.h>
+ 
++#include <cstddef>
+ #include <limits>
+ #include <utility>
+ #include <string>

--- a/recipes/thrift/config.yml
+++ b/recipes/thrift/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.18.0":
+    folder: all
   "0.17.0":
     folder: all
   "0.16.0":


### PR DESCRIPTION
Specify library name and version:  **thrift/***

- add version 0.18.0
- update openssl
- remove destination argument in `get()`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
