### PR TITLE
xorg-proto: remove misplaced call to autotools helper

### DIFF
--- a/recipes/xorg-proto/all/conanfile.py
+++ b/recipes/xorg-proto/all/conanfile.py
@@ -64,9 +64,6 @@ class XorgProtoConan(ConanFile):
             env.define("CC", f"{compile_wrapper} cl -nologo")
         tc.generate(env)
 
-        autotools = Autotools(self)
-        autotools.configure()
-
     def build(self):
         apply_conandata_patches(self)
 


### PR DESCRIPTION
Specify library name and version:  **xorg-proto/all**

* remove redundant call to the Autotools helper in the `generate()` method