### PR TITLE
minizip-ng: add frameworks for Apple

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -28,10 +28,6 @@ patches:
     - patch_file: "patches/3.0.8-0001-fix-cmake-project.patch"
       patch_description: "CMake: declare project() sooner"
       patch_type: "conan"
-    - patch_file: "patches/3.0.6-0002-fix-lzma-libdir.patch"
-      patch_description: "CMake: inject libdir of lzma"
-      patch_type: "conan"
-      patch_source: "https://github.com/zlib-ng/minizip-ng/pull/658"
   "3.0.7":
     - patch_file: "patches/3.0.7-0001-fix-cmake-project.patch"
       patch_description: "CMake: declare project() sooner"

--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -54,6 +54,8 @@ patches:
       patch_source: "https://github.com/zlib-ng/minizip-ng/pull/658"
   "3.0.4":
     - patch_file: "patches/3.0.4-0001-fix-cmake-project.patch"
+      patch_description: "CMake: declare project() sooner"
+      patch_type: "conan"
     - patch_file: "patches/3.0.1-0002-fix-lzma-libdir.patch"
       patch_description: "CMake: inject libdir of lzma"
       patch_type: "conan"

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -88,7 +88,7 @@ class MinizipNgConan(ConanFile):
         if self.options.with_lzma:
             self.requires("xz_utils/5.4.0")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.2")
+            self.requires("zstd/1.5.4")
         if self.options.with_openssl:
             self.requires("openssl/1.1.1t")
         if self.settings.os != "Windows":

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -89,7 +89,7 @@ class MinizipNgConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.2")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/1.1.1t")
         if self.settings.os != "Windows":
             if self.options.get_safe("with_iconv"):
                 self.requires("libiconv/1.17")

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -19,6 +19,7 @@ class MinizipNgConan(ConanFile):
     homepage = "https://github.com/zlib-ng/minizip-ng"
     license = "Zlib"
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -186,5 +186,7 @@ class MinizipNgConan(ConanFile):
             self.cpp_info.components["minizip"].requires.append("zstd::zstd")
         if self.options.with_openssl:
             self.cpp_info.components["minizip"].requires.append("openssl::openssl")
+        elif is_apple_os(self):
+            self.cpp_info.components["minizip"].frameworks.extend(["CoreFoundation", "Security"])
         if self.settings.os != "Windows" and self.options.with_iconv:
             self.cpp_info.components["minizip"].requires.append("libiconv::libiconv")

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -99,8 +99,7 @@ class MinizipNgConan(ConanFile):
             self.tool_requires("pkgconf/1.9.3")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         if self._needs_pkg_config:


### PR DESCRIPTION
Specify library name and version:  **minizip-ng/all**

Added missing frameworks
https://github.com/zlib-ng/minizip-ng/blob/cee6d8cbd4da70c48e9df1426607ff95b4f24fa6/CMakeLists.txt#L462

This allowed me to build minizip-ng for iOS (minizip-ng can't use OpenSSL that is built from recipe in CCI on iOS because of missing engine).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
