### PR TITLE
libgettext: refactor logic for default value of threads option

### DIFF
--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -32,12 +32,12 @@ class GetTextConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "threads": ["posix", "solaris", "pth", "windows", "disabled", "auto"],
+        "threads": ["posix", "solaris", "pth", "windows", "disabled"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "threads": "auto",
+        # Handle default value for `threads` in `config_options` method
     }
 
     @property
@@ -56,14 +56,13 @@ class GetTextConan(ConanFile):
         if self.settings.os == "Windows":
             self.options.rm_safe("fPIC")
 
+        self.options.threads = {"Solaris": "solaris", "Windows": "windows"}.get(str(self.settings.os), "posix")
+
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
-
-        if (self.options.threads == "auto"):
-            self.options.threads = {"Solaris": "solaris", "Windows": "windows"}.get(str(self.settings.os), "posix")
 
     def layout(self):
         basic_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **libgettext/all**

in Conan 2.0, the value of the option cannot be reassigned in the `configure()` method. This PR replaces the logic such that the value of the `threads` option is conditionally derived depending on the platform _when the user does not provide an option explicitly_. This achieves the same intended goal as the auto option, and keeps the same package_ids. The key is to not give the option a default value statically, and do it in `config_options()` instead as per documentation. 
