### PR TITLE
quill: QUILL_X86ARCH should be optional

### DIFF
--- a/recipes/quill/all/conanfile.py
+++ b/recipes/quill/all/conanfile.py
@@ -91,6 +91,8 @@ class QuillConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def is_quilll_x86_arch(self):
+        if not self.options.with_x86_arch:
+            return False
         if Version(self.version) < "2.7.0":
             return False
         if self.settings.arch not in ("x86", "x86_64"):
@@ -108,7 +110,7 @@ class QuillConan(ConanFile):
         tc.variables["QUILL_USE_BOUNDED_QUEUE"] = self.options.with_bounded_queue
         tc.variables["QUILL_NO_EXCEPTIONS"] = self.options.with_no_exceptions
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-        if self.options.with_x86_arch and self.is_quilll_x86_arch():
+        if self.is_quilll_x86_arch():
             tc.variables["QUILL_X86ARCH"] = True
             tc.variables["CMAKE_CXX_FLAGS"] = "-mclflushopt"
         tc.generate()
@@ -144,7 +146,7 @@ class QuillConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["quill"]
         self.cpp_info.defines.append("QUILL_FMT_EXTERNAL")
-        if self.options.with_x86_arch and self.is_quilll_x86_arch():
+        if self.is_quilll_x86_arch():
             self.cpp_info.defines.append("QUILL_X86ARCH")
             self.cpp_info.cxxflags.append("-mclflushopt")
 

--- a/recipes/quill/all/conanfile.py
+++ b/recipes/quill/all/conanfile.py
@@ -22,11 +22,13 @@ class QuillConan(ConanFile):
         "fPIC": [True, False],
         "with_bounded_queue": [True, False],
         "with_no_exceptions": [True, False],
+        "with_x86_arch": [True, False],
     }
     default_options = {
         "fPIC": True,
         "with_bounded_queue": False,
         "with_no_exceptions": False,
+        "with_x86_arch": False,
     }
 
     @property
@@ -106,7 +108,7 @@ class QuillConan(ConanFile):
         tc.variables["QUILL_USE_BOUNDED_QUEUE"] = self.options.with_bounded_queue
         tc.variables["QUILL_NO_EXCEPTIONS"] = self.options.with_no_exceptions
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-        if self.is_quilll_x86_arch():
+        if self.options.with_x86_arch and self.is_quilll_x86_arch():
             tc.variables["QUILL_X86ARCH"] = True
             tc.variables["CMAKE_CXX_FLAGS"] = "-mclflushopt"
         tc.generate()
@@ -142,7 +144,7 @@ class QuillConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["quill"]
         self.cpp_info.defines.append("QUILL_FMT_EXTERNAL")
-        if self.is_quilll_x86_arch():
+        if self.options.with_x86_arch and self.is_quilll_x86_arch():
             self.cpp_info.defines.append("QUILL_X86ARCH")
             self.cpp_info.cxxflags.append("-mclflushopt")
 


### PR DESCRIPTION
`QUILL_X86ARCH` uses some specific instructions for cache line optimisations (prefetch, clflushop) that are not available in each architecture. It also requires the user to compile their executable by passing specific flags (march). This option won't be needed by the majority of the users. It also should be possible to disable it. The default should be `False` and we should let the user explicitly enable it.

Specify library name and version:  **quill/2.7.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
