### PR TITLE
ffmpeg: don't pass --as when assembler is disabled

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -536,10 +536,10 @@ class FFMpegConan(ConanFile):
             ])
         if not self.options.with_programs:
             args.append("--disable-programs")
-        # since ffmpeg"s build system ignores toolchain variables 
+        # since ffmpeg's build system ignores toolchain variables 
         if tools.get_env("AR"):
             args.append("--ar={}".format(tools.get_env("AR")))
-        if tools.get_env("AS"):
+        if tools.get_env("AS") and self.options.with_asm:
             args.append("--as={}".format(tools.get_env("AS")))
         if tools.get_env("CC"):
             args.append("--cc={}".format(tools.get_env("CC")))


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
fixes #15537

I haven't seen related bug report on ffmpeg tracker and not even sure that it should be considered as bug. Still not entirely sure what's going on inside ffmpeg's configure script, but with this change I was finally able to build it with NDK 25 (see the issue). Passing path to assembler when you request building without it doesn't make much sense anyway.

I tried debugging that script but couldn't find any difference between AS output from NDK 22 and 25 (apart from LLVM version of course) and manual checks of version output from AS duplicating script behavior (see `probe_cc()` function, it's identical in FFmpeg 4.4 and 5.1 branches) stuck in the same place, but somehow with NDK 22 it actually builds fine... Grep gets stuck on the line with `grep -q 'Microsoft.*ARM.*Assembler'`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
