### PR TITLE
Document bumping version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ When pull requests are merged, the CI will upload the generated packages to the 
   + [Contributing to Conan Center Index](../CONTRIBUTING.md)
   + [Developing Recipes Locally](developing_recipes_locally.md)
   + [Adding Packages to ConanCenter](adding_packages/README.md) :point_left: Best place to learn how to contribute
+  + [Bumping versions to existing packages](bump_version.md)
   + [Errors from the conan-center hook (KB-Hxxx)](error_knowledge_base.md)
   + [Review Process](review_process.md)
   + [Labels](labels.md)

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -2,7 +2,7 @@
 
 Once a recipe is approved and merged to ConanCenterIndex, it may need to be updated with new versions released by the upstream.
 When someone needs a new package version that is not available in ConanCenterIndex, then open a new pull request adding, is what is
-called `bump version`.
+called a `bump version`.
 A bumping version process is when a PR only adds a new package version and nothing more. Removing older versions, or updating
 the recipe is not classified as a bump version action.
 

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -1,7 +1,7 @@
 # How to bump a package version for an existing recipe in ConanCenterIndex?
 
 Once a recipe is approved and merged to ConanCenterIndex, it may need to be updated with new versions released by the upstream.
-When someone needs a new package version that is not available in ConanCenterIndex, then open a new pull request adding, is what is
+When someone needs a new package version that is not available in ConanCenterIndex, then open a new pull request adding. This is
 called a `bump version`.
 A bumping version process is when a PR only adds a new package version and nothing more. Removing older versions, or updating
 the recipe is not classified as a bump version action.

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -4,7 +4,7 @@ Once a recipe is approved and merged to ConanCenterIndex, it may need to be upda
 When someone needs a new package version that is not available in ConanCenterIndex, then open a new pull request adding. This is
 called a `bump version`.
 A bumping version process is when a PR only adds a new package version and nothing more. Removing older versions, or updating
-the recipe is not classified as a bump version action.
+the recipe will disqualify a pull request from the `Bump version` [review process](#)
 
 ## Choosing which version should be updated
 

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -13,6 +13,9 @@ need. Adding a new version will increase the building time and storage for each 
 
 Once you detect which version should be updated, please, first check if the project `license` keeps the same.
 
+> In case needing to update attributes, dependencies versions, patches, or anything besides the package version in `conandata.yml` and `config.yml`,
+  then your pull request will not be classified as bump version.
+
 ## What should be modified when bumping a version?
 
 Only the `config.yml` and `conandata.yml` should be updated with that new version:

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -41,5 +41,5 @@ In case a patch should be re-used, it should be present in `conandata.yml` to th
 
 ## Reviewing and merginging
 
-Bumping version PRs follow the same regular review [process](review_process.md#automatic-merges), with the excetion of being merged automatically
+Bumping version PRs follow the same regular review [process](review_process.md), with the excetion of being merged automatically
 as listed on [Labels](labels.md#bump-version) section.

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -1,0 +1,45 @@
+# How to bump a package version for an existing recipe in ConanCenterIndex?
+
+Once a recipe is approved and merged to ConanCenterIndex, it may need to be updated with new versions released by the upstream.
+When someone needs a new package version which is not available in ConanCenterIndex, then open a new pull request adding, is what is
+called `bump version`.
+A bumping version process is when a PR only adds a new package version and nothing more. Removing older versions, or updating
+the recipe are not classified as a bump version action.
+
+## Choosing which version should be updated
+
+The first step is checking the version which should be added from the uptream. Please, avoid adding multiple versions which you really do not
+need. Adding a new version will increase the building time and storage for each new package configuration.
+
+Once you dectect which version should be update, please, first check if the project `license` keeps the same.
+
+## What should be modified when bumping a version?
+
+Only the `config.yml` and `conandata.yml` should be updated with that new version:
+
+```yaml
+# config.yml
+versions:
+  "1.1.0":       <-- New version added. It should be protected by quotes
+    folder: all  <-- Folder name where conandata.yml is installed
+  "1.0.0":
+    folder: all
+```
+
+```yaml
+# all/conandata.yml
+sources:
+  "1.1.0":       <-- New version added
+    url: "https://example.com/repo/exameple-1.1.0.tar.gz"
+    sha256: "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
+  "1.0.0":
+    url: "https://example.com/repo/exameple-1.0.0.tar.gz"
+    sha256: "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
+```
+
+In case a patch should be re-used, it should be present in `conandata.yml` to the specfic version as well.
+
+## Reviewing and merginging
+
+Bumping version PRs follow the same regular review [process](review_process.yml), with the excetion of being merged automatically
+as listed on [Labels](labels.md) section.

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -3,7 +3,7 @@
 Once a recipe is approved and merged to ConanCenterIndex, it may need to be updated with new versions released by the upstream.
 When someone needs a new package version that is not available in ConanCenterIndex, then open a new pull request adding. This is
 called a `bump version`.
-A bumping version process is when a PR only adds a new package version and nothing more. Removing older versions, or updating
+The [build service](#) bumping process is limited to pull requests which **only** adds a new package version and nothing more. Removing older versions, or updating
 the recipe will disqualify a pull request from the `Bump version` [review process](#)
 
 ## Choosing which version should be updated

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -13,7 +13,7 @@ need. Adding a new version will increase the building time and storage for each 
 
 Once you detect which version should be updated, please, first check if the project `license` keeps the same.
 
-> In case needing to update attributes, dependencies versions, patches, or anything besides the package version in `conandata.yml` and `config.yml`,
+> In case you need to update attributes, dependencies versions, patches, or anything besides the package version in `conandata.yml` and `config.yml`,
   then your pull request will not be classified as bump version.
 
 ## What should be modified when bumping a version?

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -1,10 +1,10 @@
 # How to bump a package version for an existing recipe in ConanCenterIndex?
 
 Once a recipe is approved and merged to ConanCenterIndex, it may need to be updated with new versions released by the upstream.
-When someone needs a new package version that is not available in ConanCenterIndex, then open a new pull request adding. This is
-called a `bump version`.
-The [build service](#) bumping process is limited to pull requests which **only** adds a new package version and nothing more. Removing older versions, or updating
-the recipe will disqualify a pull request from the `Bump version` [review process](#)
+When someone needs a new package version that is not available in ConanCenterIndex, that person can open an issue [resquesting a new version](https://github.com/conan-io/conan-center-index/issues/new?assignees=&labels=upstream+update&template=package_upstream_update.yml&title=%5Brequest%5D+%3CLIBRARY-NAME%3E%2F%3CLIBRARY-VERSION%3E).
+Or, by opening a pull request changing and adding that needed version, this is called a `bump version`.
+The [build service](adding_packages/README.md#the-build-service) bumping process is limited to pull requests which **only** adds a new package version and nothing more. Removing older versions, or updating
+the recipe will disqualify a pull request from the `Bump version` [review process](review_process.md)
 
 ## Choosing which version should be updated
 
@@ -41,5 +41,5 @@ In case a patch should be re-used, it should be present in `conandata.yml` to th
 
 ## Reviewing and merging
 
-Bumping version PRs follow the same regular review [process](review_process.md), except for being merged automatically
+Bumping version PRs follow the same regular [review process](review_process.md), except for being merged automatically
 as listed on [Labels](labels.md#bump-version) section.

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -41,5 +41,5 @@ In case a patch should be re-used, it should be present in `conandata.yml` to th
 
 ## Reviewing and merginging
 
-Bumping version PRs follow the same regular review [process](review_process.yml), with the excetion of being merged automatically
-as listed on [Labels](labels.md) section.
+Bumping version PRs follow the same regular review [process](review_process.md#automatic-merges), with the excetion of being merged automatically
+as listed on [Labels](labels.md#bump-version) section.

--- a/docs/bump_version.md
+++ b/docs/bump_version.md
@@ -1,17 +1,17 @@
 # How to bump a package version for an existing recipe in ConanCenterIndex?
 
 Once a recipe is approved and merged to ConanCenterIndex, it may need to be updated with new versions released by the upstream.
-When someone needs a new package version which is not available in ConanCenterIndex, then open a new pull request adding, is what is
+When someone needs a new package version that is not available in ConanCenterIndex, then open a new pull request adding, is what is
 called `bump version`.
 A bumping version process is when a PR only adds a new package version and nothing more. Removing older versions, or updating
-the recipe are not classified as a bump version action.
+the recipe is not classified as a bump version action.
 
 ## Choosing which version should be updated
 
-The first step is checking the version which should be added from the uptream. Please, avoid adding multiple versions which you really do not
+The first step is checking the version which should be added from the upstream. Please, avoid adding multiple versions which you do not
 need. Adding a new version will increase the building time and storage for each new package configuration.
 
-Once you dectect which version should be update, please, first check if the project `license` keeps the same.
+Once you detect which version should be updated, please, first check if the project `license` keeps the same.
 
 ## What should be modified when bumping a version?
 
@@ -37,9 +37,9 @@ sources:
     sha256: "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
 ```
 
-In case a patch should be re-used, it should be present in `conandata.yml` to the specfic version as well.
+In case a patch should be re-used, it should be present in `conandata.yml` to the specific version as well.
 
-## Reviewing and merginging
+## Reviewing and merging
 
-Bumping version PRs follow the same regular review [process](review_process.md), with the excetion of being merged automatically
+Bumping version PRs follow the same regular review [process](review_process.md), except for being merged automatically
 as listed on [Labels](labels.md#bump-version) section.


### PR DESCRIPTION
New contributors are not totally aware how to update a package with new version, and the documentation is not specific with it, only adding new packages.

This new section is focused on how to bump a conan recipe with a new upstream release. 


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
