### PR TITLE
xorg-cf-files: port to v2

### DIFF
--- a/recipes/xorg-cf-files/all/conandata.yml
+++ b/recipes/xorg-cf-files/all/conandata.yml
@@ -5,4 +5,3 @@ sources:
 patches:
   "1.0.7":
     - patch_file: "patches/1.0.7-0001-win-fixes.patch"
-      base_path: "source_subfolder"

--- a/recipes/xorg-cf-files/all/conanfile.py
+++ b/recipes/xorg-cf-files/all/conanfile.py
@@ -1,101 +1,95 @@
-from conans import ConanFile, tools, AutoToolsBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
-import contextlib
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.gnu import AutotoolsToolchain, Autotools, PkgConfigDeps
+from conan.tools.microsoft import is_msvc, unix_path
+from conan.tools.files import get, rmdir, copy, apply_conandata_patches, export_conandata_patches
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.apple import is_apple_os
+from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.53.0"
 
 
 class XorgCfFilesConan(ConanFile):
     name = "xorg-cf-files"
+    package_type = "build-scripts"
     description = "Imake configuration files & templates"
-    topics = ("conan", "imake", "xorg", "template", "configuration", "obsolete")
+    topics = ("imake", "xorg", "template", "configuration", "obsolete")
     license = "MIT"
     homepage = "https://gitlab.freedesktop.org/xorg/util/cf"
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "compiler"
 
-    exports_sources = "patches/*"
-    generators = "pkg_config"
-
-    _autotools = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
-    def requirements(self):
-        self.requires("xorg-macros/1.19.3")
-        self.requires("xorg-proto/2021.4")
-
-    def build_requirements(self):
-        self.build_requires("pkgconf/1.7.4")
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
-        if self.settings.compiler == "Visual Studio":
-            self.build_requires("automake/1.16.3")
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def configure(self):
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
-    def validate(self):
-        if tools.is_apple_os(self.settings.os):
-            raise ConanInvalidConfiguration("This recipe does not support Apple operating systems.")
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("xorg-macros/1.19.3")
+        self.requires("xorg-proto/2022.2")
 
     def package_id(self):
         del self.info.settings.compiler
         # self.info.settings.os  # FIXME: can be removed once c3i is able to test multiple os'es from one common package
 
+    def validate(self):
+        if is_apple_os(self):
+            raise ConanInvalidConfiguration(f"{self.ref} does not support Apple operating systems.")
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/1.9.3")
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
+        if is_msvc(self):
+            self.build_requires("automake/1.16.3")
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    @property
-    def _user_info_build(self):
-        return getattr(self, "user_info_build", self.deps_user_info)
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
 
-    @contextlib.contextmanager
-    def _build_context(self):
-        if self.settings.compiler == "Visual Studio":
-            with tools.vcvars(self):
-                env = {
-                    "CC": "{} cl -nologo".format(tools.unix_path(self._user_info_build["automake"].compile)),
-                    "CXX": "{} cl -nologo".format(tools.unix_path(self._user_info_build["automake"].compile)),
-                    "CPP": "{} cl -E".format(tools.unix_path(self._user_info_build["automake"].compile)),
-                }
-                with tools.environment_append(env):
-                    yield
-        else:
-            yield
+        tc = AutotoolsToolchain(self)
+        env = tc.environment()
+        if is_msvc(self):
+            compile_wrapper = unix_path(self, self.conf.get('user.automake:compile-wrapper'))
+            env.define("CC", f"{compile_wrapper} cl -nologo")
+            env.define("CXX", f"{compile_wrapper} cl -nologo")
+            env.define("CPP", f"{compile_wrapper} cl -E")
+        tc.generate()
 
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=self._settings_build.os == "Windows")
-        self._autotools.libs = []
-        self._autotools.configure(configure_dir=self._source_subfolder)
-        return self._autotools
+        deps = PkgConfigDeps(self)
+        deps.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        with self._build_context():
-            autotools = self._configure_autotools()
-            autotools.make()
+        apply_conandata_patches(self)
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
 
     def package(self):
-        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
-        with self._build_context():
-            autotools = self._configure_autotools()
-            autotools.install()
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
 
         self.user_info.CONFIG_PATH = os.path.join(self.package_folder, "lib", "X11", "config").replace("\\", "/")

--- a/recipes/xorg-cf-files/all/conanfile.py
+++ b/recipes/xorg-cf-files/all/conanfile.py
@@ -19,7 +19,7 @@ class XorgCfFilesConan(ConanFile):
     license = "MIT"
     homepage = "https://gitlab.freedesktop.org/xorg/util/cf"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "os", "compiler"
+    settings = "os", "arch", "compiler", "build_type"
 
     @property
     def _settings_build(self):
@@ -41,6 +41,8 @@ class XorgCfFilesConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
+        del self.info.settings.arch
+        del self.info.settings.build_type
         # self.info.settings.os  # FIXME: can be removed once c3i is able to test multiple os'es from one common package
 
     def validate(self):

--- a/recipes/xorg-cf-files/all/conanfile.py
+++ b/recipes/xorg-cf-files/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.apple import is_apple_os
 from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.57.0"
 
 
 class XorgCfFilesConan(ConanFile):
@@ -41,6 +41,7 @@ class XorgCfFilesConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
+        del self.info.settings.arch
         # self.info.settings.os  # FIXME: can be removed once c3i is able to test multiple os'es from one common package
 
     def validate(self):
@@ -55,7 +56,7 @@ class XorgCfFilesConan(ConanFile):
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
         if is_msvc(self):
-            self.build_requires("automake/1.16.3")
+            self.build_requires("automake/1.16.5")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -92,4 +93,7 @@ class XorgCfFilesConan(ConanFile):
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
 
-        self.user_info.CONFIG_PATH = os.path.join(self.package_folder, "lib", "X11", "config").replace("\\", "/")
+        x11_config_files = os.path.join(self.package_folder, "lib", "X11", "config")
+        self.conf_info.define("user.xorg-cf-files:config-path", x11_config_files)
+
+        self.user_info.CONFIG_PATH = x11_config_files.replace("\\", "/")

--- a/recipes/xorg-cf-files/all/conanfile.py
+++ b/recipes/xorg-cf-files/all/conanfile.py
@@ -41,7 +41,6 @@ class XorgCfFilesConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
-        del self.info.settings.arch
         # self.info.settings.os  # FIXME: can be removed once c3i is able to test multiple os'es from one common package
 
     def validate(self):

--- a/recipes/xorg-cf-files/all/conanfile.py
+++ b/recipes/xorg-cf-files/all/conanfile.py
@@ -73,7 +73,7 @@ class XorgCfFilesConan(ConanFile):
             env.define("CC", f"{compile_wrapper} cl -nologo")
             env.define("CXX", f"{compile_wrapper} cl -nologo")
             env.define("CPP", f"{compile_wrapper} cl -E")
-        tc.generate()
+        tc.generate(env)
 
         deps = PkgConfigDeps(self)
         deps.generate()

--- a/recipes/xorg-cf-files/all/test_package/conanfile.py
+++ b/recipes/xorg-cf-files/all/test_package/conanfile.py
@@ -1,3 +1,5 @@
+import os
+
 from conan import ConanFile
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
@@ -5,17 +7,18 @@ from conan.tools.files import copy
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.microsoft import is_msvc
 from conan.tools.build import can_run
-import os
-import shutil
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "Imakefile", "test_package.c"
     test_type = "explicit"
 
-    def export_sources(self):
-        copy(self, "Imakefile", self.recipe_folder, self.export_folder)
-        copy(self, "test_package.c", self.recipe_folder, self.export_folder)
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+        self.tool_requires("imake/1.0.8")
+        if not self.conf_info.get("tools.gnu:make_program", check_type=str):
+            self.tool_requires("make/4.3")
 
     @property
     def _settings_build(self):
@@ -24,28 +27,25 @@ class TestPackageConan(ConanFile):
     def layout(self):
         basic_layout(self)
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
-        self.tool_requires("imake/1.0.8")
-        if not self.conf_info.get("tools.gnu:make_program", check_type=str):
-            self.tool_requires("make/4.3")
-
     def generate(self):
-        env = VirtualBuildEnv(self)
-        env.generate()
-
         tc = AutotoolsToolchain(self)
         env = tc.environment()
         if is_msvc(self):
             env.define("CC", "cl -nologo")
         tc.generate()
 
+        buildenv = VirtualBuildEnv(self)
+        buildenv.generate()
+
     def build(self):
-        self.run("imake -DUseInstalled -I{}".format(self.deps_user_info["xorg-cf-files"].CONFIG_PATH), env="conanbuild")
+        for src in self.exports_sources:
+            copy(self, src, self.source_folder, self.build_folder)
+
+        config_path = self.conf.get("user.xorg-cf-files:config-path")
+        self.run(f"imake -DUseInstalled -I{config_path}", env="conanbuild")
         autotools = Autotools(self)
         autotools.make(target="test_package")
 
     def test(self):
         if can_run(self):
-            bindir = self.cpp_info.bindirs[0]
-            self.run(os.path.join(bindir, "test_package"), env="conanrun")
+            self.run(os.path.join(".", "test_package"), env="conanrun")

--- a/recipes/xorg-cf-files/all/test_package/conanfile.py
+++ b/recipes/xorg-cf-files/all/test_package/conanfile.py
@@ -1,45 +1,51 @@
-from conans import AutoToolsBuildEnvironment, ConanFile, tools
-import contextlib
+from conan import ConanFile
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+from conan.tools.files import copy
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.microsoft import is_msvc
+from conan.tools.build import can_run
 import os
 import shutil
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    exports_sources = "Imakefile", "test_package.c"
+    test_type = "explicit"
 
-    def build_requirements(self):
-        self.build_requires("imake/1.0.8")
-        if not tools.get_env("CONAN_MAKE_PROGRAM"):
-            self.build_requires("make/4.3")
+    def export_sources(self):
+        copy(self, "Imakefile", self.recipe_folder, self.export_folder)
+        copy(self, "test_package.c", self.recipe_folder, self.export_folder)
 
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
-    @contextlib.contextmanager
-    def _build_context(self):
-        if self.settings.compiler == "Visual Studio":
-            with tools.vcvars(self):
-                env = {
-                    "CC": "cl -nologo",
-                }
-                with tools.environment_append(env):
-                    yield
-        else:
-            yield
+    def layout(self):
+        basic_layout(self)
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+        self.tool_requires("imake/1.0.8")
+        if not self.conf_info.get("tools.gnu:make_program", check_type=str):
+            self.tool_requires("make/4.3")
+
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
+        tc = AutotoolsToolchain(self)
+        env = tc.environment()
+        if is_msvc(self):
+            env.define("CC", "cl -nologo")
+        tc.generate()
 
     def build(self):
-        for src in self.exports_sources:
-            shutil.copy(os.path.join(self.source_folder, src), os.path.join(self.build_folder, src))
-        if not tools.cross_building(self):
-            with self._build_context():
-                self.run("imake -DUseInstalled -I{}".format(self.deps_user_info["xorg-cf-files"].CONFIG_PATH), run_environment=True)
-        with self._build_context():
-            autotools = AutoToolsBuildEnvironment(self)
-            with tools.environment_append(autotools.vars):
-                autotools.make(target="test_package")
+        self.run("imake -DUseInstalled -I{}".format(self.deps_user_info["xorg-cf-files"].CONFIG_PATH), env="conanbuild")
+        autotools = Autotools(self)
+        autotools.make(target="test_package")
 
     def test(self):
-        if not tools.cross_building(self):
-            self.run(os.path.join(".", "test_package"), run_environment=True)
+        if can_run(self):
+            bindir = self.cpp_info.bindirs[0]
+            self.run(os.path.join(bindir, "test_package"), env="conanrun")

--- a/recipes/xorg-cf-files/all/test_v1_package/Imakefile
+++ b/recipes/xorg-cf-files/all/test_v1_package/Imakefile
@@ -1,0 +1,4 @@
+PROGRAMS = ProgramTargetName(test_package)
+AllTarget($(PROGRAMS))
+
+NormalProgramTarget(test_package,test_package.o,,,)

--- a/recipes/xorg-cf-files/all/test_v1_package/conanfile.py
+++ b/recipes/xorg-cf-files/all/test_v1_package/conanfile.py
@@ -1,0 +1,45 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
+import contextlib
+import os
+import shutil
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "Imakefile", "test_package.c"
+
+    def build_requirements(self):
+        self.build_requires("imake/1.0.8")
+        if not tools.get_env("CONAN_MAKE_PROGRAM"):
+            self.build_requires("make/4.3")
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    @contextlib.contextmanager
+    def _build_context(self):
+        if self.settings.compiler == "Visual Studio":
+            with tools.vcvars(self):
+                env = {
+                    "CC": "cl -nologo",
+                }
+                with tools.environment_append(env):
+                    yield
+        else:
+            yield
+
+    def build(self):
+        for src in self.exports_sources:
+            shutil.copy(os.path.join(self.source_folder, src), os.path.join(self.build_folder, src))
+        if not tools.cross_building(self):
+            with self._build_context():
+                self.run("imake -DUseInstalled -I{}".format(self.deps_user_info["xorg-cf-files"].CONFIG_PATH), run_environment=True)
+        with self._build_context():
+            autotools = AutoToolsBuildEnvironment(self)
+            with tools.environment_append(autotools.vars):
+                autotools.make(target="test_package")
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run(os.path.join(".", "test_package"), run_environment=True)

--- a/recipes/xorg-cf-files/all/test_v1_package/test_package.c
+++ b/recipes/xorg-cf-files/all/test_v1_package/test_package.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("hello world!\n");
+    return 0;
+}


### PR DESCRIPTION
Specify library name and version:  **xorg-cf-files/all**

Ports xorg-cf-files to v2. Based on the work of @StellaSmith from https://github.com/conan-io/conan-center-index/pull/16128. Sorry that we have to open a new PR for this, but due to the maintenance mode only PRs from core team members will be built, I've tried to properly credit your work :)