### PR TITLE
opentdf-client: add version 1.3.9

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.9":
+    url: "https://github.com/opentdf/client-cpp/archive/1.3.9.tar.gz"
+    sha256: "8fdd88d90afe865ca86261c26abd1ca5e9895261490252199b7f9d4910ca0b49"
   "1.3.6":
     url: "https://github.com/opentdf/client-cpp/archive/1.3.6.tar.gz"
     sha256: "e0d4cf1d0b1824d903a2b0ec1da528acb42623e32f3ca36aa28b2e950c3cc7a0"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.9":
+    folder: all
   "1.3.6":
     folder: all
   "1.3.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opentdf-client/1.39**

Make TDF reader and writer interface public to support alternate document formats

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
