### PR TITLE
hazelcast-cpp-client: add cmake to build_requirements

### DIFF
--- a/recipes/hazelcast-cpp-client/all/conanfile.py
+++ b/recipes/hazelcast-cpp-client/all/conanfile.py
@@ -69,6 +69,9 @@ class HazelcastCppClient(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
 
+    def build_requirements(self):
+        self.tool_requires("cmake/3.19.7")
+
     def build(self):
         files.apply_conandata_patches(self)
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **hazelcast-cpp-client**

`cmake` is added to `build_requirements`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
