### PR TITLE
- reduce number of v1 configurations being built on CI

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -56,17 +56,6 @@ tasks:
 # Profile configurations to build packages
 configurations:
   - id: linux-gcc
-    epochs: [0]
-    hrname: "Linux, GCC"
-    content:
-      - os: [ "Linux" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "gcc":
-              compiler.libcxx: [ "libstdc++11", "libstdc++" ]
-              compiler.version: [ "5", "7", "8", "9", "10" ]
-              build_type: [ "Release", "Debug" ]
-  - id: linux-gcc
     epochs: [20211221, 20220120]
     hrname: "Linux, GCC"
     content:
@@ -75,94 +64,8 @@ configurations:
         compiler:
           - "gcc":
               compiler.libcxx: ["libstdc++11", "libstdc++"]
-              compiler.version: ["5", "7", "8", "9", "10", "11"]
+              compiler.version: ["11"]
               build_type: ["Release", "Debug"]
-  - id: linux-clang
-    epochs: [0]
-    hrname: "Linux, Clang"
-    content:
-      - os: [ "Linux" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "clang":
-              compiler.libcxx: [ "libstdc++", "libc++" ]
-              compiler.version: [ "11" ]
-              build_type: [ "Release", "Debug" ]
-  - id: linux-clang
-    epochs: [20211221, 20220120]
-    hrname: "Linux, Clang"
-    content:
-      - os: ["Linux"]
-        arch: ["x86_64"]
-        compiler:
-          - "clang":
-              compiler.libcxx: ["libstdc++", "libc++"]
-              compiler.version: ["11", "12", "13"]
-              build_type: ["Release", "Debug"]
-  - id: configs/macos-clang
-    epochs: [0, 20211221]
-    hrname: "macOS, Clang"
-    content:
-      - os: [ "Macos" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "apple-clang":
-              compiler.version: [ "11.0", "12.0" ]
-              compiler.libcxx: [ "libc++" ]
-              build_type: [ "Release", "Debug" ]
-  - id: configs/macos-clang
-    epochs: [20220120]
-    hrname: "macOS, Clang"
-    content:
-      - os: [ "Macos" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "apple-clang":
-              compiler.version: [ "11.0", "12.0", "13.0"]
-              compiler.libcxx: [ "libc++" ]
-              build_type: [ "Release", "Debug" ]
-  - id: configs/macos-m1-clang
-    epochs: [0, 20211221]
-    hrname: "macOS, Clang (M1/arm64)"
-    build_profile:
-      os: "Macos"
-      arch: "x86_64"
-    content:
-      - os: [ "Macos" ]
-        arch: [ "armv8" ]
-        compiler:
-          - "apple-clang":
-              compiler.version: [ "12.0" ]
-              compiler.libcxx: [ "libc++" ]
-              build_type: [ "Release", "Debug" ]
-  - id: configs/macos-m1-clang
-    epochs: [20220120]
-    hrname: "macOS, Clang (M1/arm64)"
-    build_profile:
-      os: "Macos"
-      arch: "x86_64"
-    content:
-      - os: [ "Macos" ]
-        arch: [ "armv8" ]
-        compiler:
-          - "apple-clang":
-              compiler.version: [ "12.0", "13.0" ]
-              compiler.libcxx: [ "libc++" ]
-              build_type: [ "Release", "Debug" ]
-  - id: configs/windows-visual_studio
-    epochs: [0, 20211221, 20220120]
-    hrname: "Windows, Visual Studio"
-    content:
-      - os: [ "Windows" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "Visual Studio":
-              compiler.version: [ "15", "16" ]
-              build_type:
-                - "Release":
-                    compiler.runtime: [ "MT", "MD" ]
-                - "Debug":
-                    compiler.runtime: [ "MTd", "MDd" ]
 
 jenkins:
   url: "http://mb-jenkins-my-bloody-jenkins:8080"


### PR DESCRIPTION
as conan 2.0 is already [released](https://github.com/conan-io/conan/releases/tag/2.0.0), ConanCenterIndex, according to its [policy](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) to support only latest conan client releases, should gradually start switching to 2.0 as a main configuration.
therefore, it makes sense to start with reducing an amount of v1 configurations being built, e.g. just to GCC 11 for now, to reduce CI load and build times.
after some grace transition period (e.g. a month), ConanCenterIndex may drop generating new v1 packages altogether.
please note, it doesn't break any existing v1 users, consumers, enterprise customers, etc. existing v1 recipes and packages are going to be never deleted, and they will stay on remote forever, always available for consumption.
going forward, new PRs will be no longer required to pass v1 builds, but only to pass v2 builds.
in other words, if v1 build fails, but v2 build passes, PR will be safely merged by the bot. it will not hurt anyone, as previous recipe revision still exists and available for download.
since now, many people will start to use and rely on v2-only features in their recipes, and v1 clients will be unable to execute that recipe code (because feature doesn't exist in v1 at all, or because there are bugs in v1 that aren't going to be fixed any more).