### PR TITLE
update doctest recipe to conan 2

### DIFF
--- a/recipes/doctest/2.x.x/conanfile.py
+++ b/recipes/doctest/2.x.x/conanfile.py
@@ -1,6 +1,6 @@
 import os
 from conan import ConanFile
-from conan.tools import files
+from conan.tools.files import copy, get
 
 
 class DoctestConan(ConanFile):
@@ -17,19 +17,19 @@ class DoctestConan(ConanFile):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"
 
     def source(self):
-        files.get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         pass
 
     def package(self):
-        files.copy(
+        copy(
             self,
             pattern="LICENSE.txt",
             src=self.source_folder,
             dst=os.path.join(self.package_folder, "licenses"),
         )
-        files.copy(
+        copy(
             self,
             pattern="*doctest.h",
             src=self.source_folder,
@@ -41,8 +41,8 @@ class DoctestConan(ConanFile):
             "dst": os.path.join(self.package_folder, "lib/cmake"),
         }
 
-        files.copy(self, pattern="doctest.cmake", **cmake_script_dirs)
-        files.copy(self, pattern="doctestAddTests.cmake", **cmake_script_dirs)
+        copy(self, pattern="doctest.cmake", **cmake_script_dirs)
+        copy(self, pattern="doctestAddTests.cmake", **cmake_script_dirs)
 
     def package_info(self):
         if self._is_mingw:

--- a/recipes/doctest/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/doctest/2.x.x/test_package/CMakeLists.txt
@@ -1,14 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(doctest REQUIRED)
 
-file(GLOB SOURCE_FILES *.cpp)
-
-add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+add_executable(${PROJECT_NAME} test_package.cpp)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} doctest::doctest)
 
 enable_testing()
 

--- a/recipes/doctest/2.x.x/test_package/conanfile.py
+++ b/recipes/doctest/2.x.x/test_package/conanfile.py
@@ -1,5 +1,6 @@
-from conan import ConanFile, tools
+from conan import ConanFile
 from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
@@ -22,6 +23,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if tools.build.can_run(self):
+        if can_run(self):
             cmake = self._configure_cmake()
             cmake.test()

--- a/recipes/doctest/2.x.x/test_package/conanfile.py
+++ b/recipes/doctest/2.x.x/test_package/conanfile.py
@@ -1,10 +1,16 @@
-from conans import ConanFile, CMake, tools
-import os
+from conan import ConanFile, tools
+from conan.tools.cmake import CMake, cmake_layout
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def _configure_cmake(self):
         cmake = CMake(self)
@@ -16,6 +22,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings) or tools.os_info.is_windows:
+        if tools.build.can_run(self):
             cmake = self._configure_cmake()
             cmake.test()


### PR DESCRIPTION
Specify library name and version:  **doctest/2.4.9**

The doctest recipe is broken when using conan 2.
This PR fixes it and makes the recipe a bit more consistent with other ones.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
