### PR TITLE
libudev: conanv2 update

### DIFF
--- a/recipes/libudev/all/conanfile.py
+++ b/recipes/libudev/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.system import package_manager
-from conans import tools
+from conan.tools.gnu.pkgconfig import PkgConfig
 
 required_conan_version = ">=1.47"
 
@@ -21,27 +21,7 @@ class LibUDEVConan(ConanFile):
             raise ConanInvalidConfiguration("libudev is only supported on Linux.")
 
     def package_id(self):
-        self.info.header_only()
-
-    def _fill_cppinfo_from_pkgconfig(self, name):
-        pkg_config = tools.PkgConfig(name)
-        if not pkg_config.provides:
-            raise ConanException("libudev development files aren't available, give up")
-        libs = [lib[2:] for lib in pkg_config.libs_only_l]
-        lib_dirs = [lib[2:] for lib in pkg_config.libs_only_L]
-        ldflags = [flag for flag in pkg_config.libs_only_other]
-        include_dirs = [include[2:] for include in pkg_config.cflags_only_I]
-        cflags = [flag for flag in pkg_config.cflags_only_other if not flag.startswith("-D")]
-        defines = [flag[2:] for flag in pkg_config.cflags_only_other if flag.startswith("-D")]
-
-        self.cpp_info.system_libs = libs
-        self.cpp_info.libdirs = lib_dirs
-        self.cpp_info.sharedlinkflags = ldflags
-        self.cpp_info.exelinkflags = ldflags
-        self.cpp_info.defines = defines
-        self.cpp_info.includedirs = include_dirs
-        self.cpp_info.cflags = cflags
-        self.cpp_info.cxxflags = cflags
+        self.info.clear()
 
     def system_requirements(self):
         dnf = package_manager.Dnf(self)
@@ -62,4 +42,5 @@ class LibUDEVConan(ConanFile):
     def package_info(self):
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
-        self._fill_cppinfo_from_pkgconfig("libudev")
+        pkg_config = PkgConfig(self, "libudev")
+        pkg_config.fill_cpp_info(self.cpp_info)

--- a/recipes/libudev/all/conanfile.py
+++ b/recipes/libudev/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
-from conan.errors import ConanException, ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.system import package_manager
-from conan.tools.gnu.pkgconfig import PkgConfig
+from conan.tools.gnu import PkgConfig
 
 required_conan_version = ">=1.47"
 

--- a/recipes/libudev/all/test_package/CMakeLists.txt
+++ b/recipes/libudev/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package C)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 find_package(libudev REQUIRED CONFIG)
 

--- a/recipes/libudev/all/test_package/conanfile.py
+++ b/recipes/libudev/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.build import can_run
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libudev/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libudev/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/libudev/all/test_v1_package/conanfile.py
+++ b/recipes/libudev/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **libudev/system**

This PR resolves #16238. It is an update for the libudev conanfiles to be compatible with conan v2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
