### PR TITLE
sigslot: add version 1.2.2

### DIFF
--- a/recipes/sigslot/all/conandata.yml
+++ b/recipes/sigslot/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.2":
+    url: "https://github.com/palacaze/sigslot/archive/v1.2.2.tar.gz"
+    sha256: "d2dd0f91c13dbec1026aa5f393e511db863a8c32146c68c10888a9c193458437"
   "1.2.1":
     url: "https://github.com/palacaze/sigslot/archive/v1.2.1.tar.gz"
     sha256: "180b45e41676a730220e3a9af6ee71b761f23b8f6ade73c8f2aa20b677504934"

--- a/recipes/sigslot/config.yml
+++ b/recipes/sigslot/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.2":
+    folder: all
   "1.2.1":
     folder: all
   "1.2.0":


### PR DESCRIPTION
Specify library name and version:  **sigslot/1.2.2**

Add new version 1.2.2 with bugfixes.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
