### PR TITLE
[config] Use Conan 2.0.0 in v2 pipeline and add new conditional status check

### DIFF
--- a/.c3i/conan_v2_ready_references.yml
+++ b/.c3i/conan_v2_ready_references.yml
@@ -5,8 +5,10 @@ required_for_references:
   - boost
   - catch2
   - cmake
+  - eigen
   - flex
   - fmt
+  - gtest
   - jsoncpp
   - libbacktrace
   - libelf
@@ -16,6 +18,9 @@ required_for_references:
 #  - openssl ? 3.0.0 version still not working
   - ogg
   - pcre2
+  - rapidjson
+  - sqlite3
   - yaml-cpp
   - xz_utils
   - zlib
+  - zstd

--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -40,6 +40,8 @@ tasks:
     status_checks:
       - name: "license/cla"
       - name: "continuous-integration/jenkins/pr-merge"
+      - name: "c3i/conan-v2/pr-merge"
+        required_for_references: "conan_v2_ready_references.yml"
   cci:
     conan_v2_run_export: false
     write_comments: true

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -3,7 +3,7 @@
 id: 'conan-io/conan-center-index'
 
 conan:
-  version: 2.0.0-beta10
+  version: 2.0.0
 
 artifactory:
   url: "https://c3i.jfrog.io/c3i"


### PR DESCRIPTION

- Conan v2 pipeline now runs with 2.0.0 version
- AutomaticMerge will take into account the new "c3i/conan-v2" status check (the one from pipeline v2) for those recipes included in the list. This means that PRs that modify recipes included in the list should have this status check green in order to get merged.