### PR TITLE
pkgconf: Cross-building is now supported with the new Meson configuration

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -1,7 +1,6 @@
 import os
 
 from conan import ConanFile
-from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, rm, rmdir, replace_in_file
 from conan.tools.layout import basic_layout
@@ -52,10 +51,6 @@ class PkgConfConan(ConanFile):
        
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
-
-    def validate(self):
-        if cross_building(self):
-            raise ConanInvalidConfiguration("Cross-building is not implemented in the recipe, contributions welcome.")
 
     def build_requirements(self):
         self.tool_requires("meson/1.0.0")


### PR DESCRIPTION
Specify library name and version:  **pkgconf/1.9.3**

After https://github.com/conan-io/conan-center-index/pull/15990, pkgconf can support cross-building. Removed the validate() message, and confirmed on MacOS that builds work for both x86_64 and arm64.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.