### PR TITLE
zstd: don't require CMake 3.18 or later

### DIFF
--- a/recipes/zstd/all/conandata.yml
+++ b/recipes/zstd/all/conandata.yml
@@ -40,6 +40,10 @@ patches:
     - patch_file: "patches/1.5.2-cmake-remove-asm-except-x86_64.patch"
       patch_description: "use assembler codes only on x86_64"
       patch_type: "portability"
+    - patch_file: "patches/1.5.4-decrease-min-cmake-version.patch"
+      patch_description: "Don't require CMake 3.18 or later"
+      patch_type: "portability"
+      patch_source: "https://github.com/facebook/zstd/pull/3510"
   "1.5.2":
     - patch_file: "patches/1.5.2-cmake-remove-asm-except-x86_64.patch"
       patch_description: "use assembler codes only on x86_64"

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -43,22 +43,6 @@ class ZstdConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
-    def _cmake_new_enough(self, required_version):
-        try:
-            import re
-            from io import StringIO
-            output = StringIO()
-            self.run("cmake --version", output=output)
-            m = re.search(r'cmake version (\d+\.\d+\.\d+)', output.getvalue())
-            return Version(m.group(1)) >= required_version
-        except:
-            return False
-
-    def build_requirements(self):
-        # zstd/>=1.5.4 uses `check_linker_flag` which is introduced since cmake 3.1.8.
-        if Version(self.version) >= "1.5.4" and not self._cmake_new_enough("3.18"):
-            self.tool_requires("cmake/3.25.2")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -15,6 +15,7 @@ class ZstdConan(ConanFile):
     topics = ("zstandard", "compression", "algorithm", "decoder")
     license = "BSD-3-Clause"
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/zstd/all/patches/1.5.4-decrease-min-cmake-version.patch
+++ b/recipes/zstd/all/patches/1.5.4-decrease-min-cmake-version.patch
@@ -1,0 +1,36 @@
+--- a/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
++++ b/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake
+@@ -1,6 +1,15 @@
+ include(CheckCXXCompilerFlag)
+ include(CheckCCompilerFlag)
+-include(CheckLinkerFlag)
++# VERSION_GREATER_EQUAL requires CMake 3.7 or later.
++# https://cmake.org/cmake/help/latest/command/if.html#version-greater-equal
++if (CMAKE_VERSION VERSION_LESS 3.18)
++    set(ZSTD_HAVE_CHECK_LINKER_FLAG false)
++else ()
++    set(ZSTD_HAVE_CHECK_LINKER_FLAG true)
++endif ()
++if (ZSTD_HAVE_CHECK_LINKER_FLAG)
++    include(CheckLinkerFlag)
++endif()
+ 
+ function(EnableCompilerFlag _flag _C _CXX _LD)
+     string(REGEX REPLACE "\\+" "PLUS" varname "${_flag}")
+@@ -20,7 +29,15 @@ function(EnableCompilerFlag _flag _C _CXX _LD)
+         endif ()
+     endif ()
+     if (_LD)
+-        CHECK_LINKER_FLAG(C ${_flag} LD_FLAG_${varname})
++        # We never add a linker flag with CMake < 3.18. We will
++        # implement CHECK_LINKER_FLAG() like feature for CMake < 3.18
++        # or require CMake >= 3.18 when we need to add a required
++        # linker flag in future.
++        if (ZSTD_HAVE_CHECK_LINKER_FLAG)
++            CHECK_LINKER_FLAG(C ${_flag} LD_FLAG_${varname})
++        else ()
++            set(LD_FLAG_${varname} false)
++        endif ()
+         if (LD_FLAG_${varname})
+             set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${_flag}" PARENT_SCOPE)
+             set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${_flag}" PARENT_SCOPE)


### PR DESCRIPTION
backport https://github.com/facebook/zstd/pull/3510

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
