### PR TITLE
spirv-tools: fix `_cmake_new_enough()` for conan v2

### DIFF
--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -115,7 +115,7 @@ class SpirvtoolsConan(ConanFile):
         if (Version(self.version) >= "1.3.239" and Version(self.version) < "2016.6") or \
            Version(self.version) >= "2023.1":
             if not self._cmake_new_enough("3.17.2"):
-                self.tool_requires("cmake/3.25.2")
+                self.tool_requires("cmake/3.25.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -21,6 +21,7 @@ class SpirvtoolsConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     license = "Apache-2.0"
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -104,7 +105,7 @@ class SpirvtoolsConan(ConanFile):
             import re
             from io import StringIO
             output = StringIO()
-            self.run("cmake --version", output=output)
+            self.run("cmake --version", output)
             m = re.search(r"cmake version (\d+\.\d+\.\d+)", output.getvalue())
             return Version(m.group(1)) >= required_version
         except:
@@ -114,7 +115,7 @@ class SpirvtoolsConan(ConanFile):
         if (Version(self.version) >= "1.3.239" and Version(self.version) < "2016.6") or \
            Version(self.version) >= "2023.1":
             if not self._cmake_new_enough("3.17.2"):
-                self.tool_requires("cmake/3.25.1")
+                self.tool_requires("cmake/3.25.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
