### PR TITLE
arsenalgear: add version 2.1.0

### DIFF
--- a/recipes/arsenalgear/all/conandata.yml
+++ b/recipes/arsenalgear/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.0":
+    url: "https://github.com/JustWhit3/arsenalgear-cpp/archive/refs/tags/v2.1.0.tar.gz"
+    sha256: "2548a0452f3c290f4912ccc3511ae70be62ef4cd8e5d372e27423184d72785f9"
   "2.0.1":
     url: "https://github.com/JustWhit3/arsenalgear-cpp/archive/refs/tags/v2.0.1.tar.gz"
     sha256: "d0fa1639abb3c41aa60e596b9d70966281a1206c5527b34a4526f6577c3bac6f"

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -17,14 +17,12 @@ class ArsenalgearConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/JustWhit3/arsenalgear-cpp"
     topics = ("constants", "math", "operators", "stream")
-    package_type = "library"
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
-        "shared": [True, False],
         "fPIC": [True, False],
     }
     default_options = {
-        "shared": False,
         "fPIC": True,
     }
 
@@ -49,8 +47,6 @@ class ArsenalgearConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if Version(self.version) >= "2.1.0":
-            del self.options.shared
 
     def configure(self):
         if self.options.get_safe("shared"):

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
@@ -17,6 +17,7 @@ class ArsenalgearConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/JustWhit3/arsenalgear-cpp"
     topics = ("constants", "math", "operators", "stream")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -28,7 +29,7 @@ class ArsenalgearConan(ConanFile):
     }
 
     @property
-    def _minimum_cpp_standard(self):
+    def _min_cppstd(self):
         return 17
 
     @property
@@ -42,14 +43,17 @@ class ArsenalgearConan(ConanFile):
         }
 
     def export_sources(self):
-        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+        if Version(self.version) < "2.1.0":
+            copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) >= "2.1.0":
+            del self.options.shared
 
     def configure(self):
-        if self.options.shared:
+        if self.options.get_safe("shared"):
             self.options.rm_safe("fPIC")
 
     def layout(self):
@@ -59,40 +63,47 @@ class ArsenalgearConan(ConanFile):
         if Version(self.version) < "2.0.0":
             self.requires("boost/1.81.0")
             if self.settings.os in ["Linux", "Macos"]:
-                self.requires("exprtk/0.0.1")
+                self.requires("exprtk/0.0.2")
 
     def validate(self):
         # arsenalgear doesn't support Visual Studio(yet).
         if is_msvc(self):
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support Visual Studio(yet)")
 
-        if self.info.settings.compiler.cppstd:
-            check_min_cppstd(self, self._minimum_cpp_standard)
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support.")
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-                  destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["ARSENALGEAR_VERSION"] = str(self.version)
-        tc.variables["ARSENALGEAR_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        if Version(self.version) < "2.1.0":
+            tc.variables["ARSENALGEAR_VERSION"] = str(self.version)
+            tc.variables["ARSENALGEAR_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        else:
+            tc.variables["ARSENALGEAR_TESTS"] = False
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        if Version(self.version) < "2.1.0":
+            cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        else:
+            cmake.configure()
         cmake.build()
 
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = ["arsenalgear"]

--- a/recipes/arsenalgear/config.yml
+++ b/recipes/arsenalgear/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.0":
+    folder: all
   "2.0.1":
     folder: all
   "1.2.2":


### PR DESCRIPTION
Specify library name and version:  **arsenalgear/2.1.0**

- add version 2.1.0
  - 2.1.0 provides official CMakeLists.txt

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
