### PR TITLE
libsamplerate: fix `_cmake_new_enough()` for conan v2

### DIFF
--- a/recipes/libsamplerate/all/conanfile.py
+++ b/recipes/libsamplerate/all/conanfile.py
@@ -16,10 +16,11 @@ class LibsamplerateConan(ConanFile):
         "performing sample rate conversion of audio data."
     )
     license = "BSD-2-Clause"
-    topics = ("libsamplerate", "audio", "resample-audio-files")
+    topics = ("audio", "resample-audio-files")
     homepage = "https://github.com/libsndfile/libsamplerate"
     url = "https://github.com/conan-io/conan-center-index"
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -48,7 +49,7 @@ class LibsamplerateConan(ConanFile):
             import re
             from io import StringIO
             output = StringIO()
-            self.run("cmake --version", output=output)
+            self.run("cmake --version", output)
             m = re.search(r"cmake version (\d+\.\d+\.\d+)", output.getvalue())
             return Version(m.group(1)) >= required_version
         except:
@@ -58,7 +59,7 @@ class LibsamplerateConan(ConanFile):
         if is_apple_os(self) and self.options.shared and Version(self.version) >= "0.2.2":
             # see https://github.com/libsndfile/libsamplerate/blob/0.2.2/src/CMakeLists.txt#L110-L119
             if not self._cmake_new_enough("3.17"):
-                self.tool_requires("cmake/3.25.1")
+                self.tool_requires("cmake/3.25.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
