### PR TITLE
[doc] use `self.output.warning` in documentation instead of `self.output.warn` (invalid with conan v2 client)

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -181,7 +181,7 @@ default_options = {"foobar": "deprecated"}
 
 def configure(self):
     if self.options.foobar != "deprecated":
-        self.output.warn("foobar option is deprecated, do not use anymore.")
+        self.output.warning("foobar option is deprecated, do not use anymore.")
 
 def package_id(self):
     del self.info.options.foobar


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
