### PR TITLE
libspatialindex: fix package_type

### DIFF
--- a/recipes/libspatialindex/all/conanfile.py
+++ b/recipes/libspatialindex/all/conanfile.py
@@ -16,7 +16,7 @@ class LibspatialindexConan(ConanFile):
     homepage = "https://github.com/libspatialindex/libspatialindex"
     url = "https://github.com/conan-io/conan-center-index"
 
-    package_type = "explicit"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
