### PR TITLE
[tz] Add tz recipe

### DIFF
--- a/recipes/tz/all/conandata.yml
+++ b/recipes/tz/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2022g":
+    url: "https://data.iana.org/time-zones/releases/tzdata2022g.tar.gz"
+    sha256: "4491db8281ae94a84d939e427bdd83dc389f26764d27d9a5c52d782c16764478"

--- a/recipes/tz/all/conandata.yml
+++ b/recipes/tz/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2022g":
-    url: "https://data.iana.org/time-zones/releases/tzdata2022g.tar.gz"
-    sha256: "4491db8281ae94a84d939e427bdd83dc389f26764d27d9a5c52d782c16764478"
+    url: "https://github.com/eggert/tz/archive/refs/tags/2022g.tar.gz"
+    sha256: "cc1169a43591201964ba6977ce8a63bb9cbe2d6e6bdcde34cd609f50e9866039"

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -1,10 +1,12 @@
 import os
 
 from conan import ConanFile
+from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.files import get, copy
 from conan.tools.layout import basic_layout
 
-class TzdataConan(ConanFile):
+
+class TzConan(ConanFile):
     name = "tz"
     license = "Public Domain"
     url = "https://github.com/conan-io/conan-center-index"
@@ -13,20 +15,80 @@ class TzdataConan(ConanFile):
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
+    options = {"fPIC": [True, False], "data_only": [True, False]}
+    default_options = {"fPIC": True, "data_only": False}
 
     def package_id(self):
-        self.info.clear()
+        if self.options.data_only:
+            self.info.clear()
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=False)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.generate()
 
     def package(self):
-        copy(self, "*", dst=os.path.join(self.package_folder, "res"), src=self.source_folder)
+        if not self.options.data_only:
+            autotools = Autotools(self)
+            autotools.install(args=["-C", self.source_folder])
+        tzdata = [
+            "africa",
+            "antarctica",
+            "asia",
+            "australasia",
+            "backward",
+            "backzone",
+            "calendars",
+            "checklinks.awk",
+            "checktab.awk",
+            "etcetera",
+            "europe",
+            "factory",
+            "iso3166.tab",
+            "leap-seconds.list",
+            "leapseconds",
+            "leapseconds.awk",
+            "NEWS",
+            "northamerica",
+            "southamerica",
+            "version",
+            "ziguard.awk",
+            "zishrink.awk",
+            "zone.tab",
+            "zone1970.tab",
+        ]
+        for data in tzdata:
+            copy(self, data, dst=os.path.join(self.package_folder, "res", "tzdata"), src=self.source_folder)
+        copy(self, "theory.html", dst=os.path.join(self.package_folder, "res", "docs"), src=self.source_folder)
+        copy(self, "tz-*.html", dst=os.path.join(self.package_folder, "res", "docs"), src=self.source_folder)
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        copy(self, "NOTICE.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
 
     def package_info(self):
-        self.cpp_info.resdirs = ['res']
+        self.cpp_info.resdirs = ["res"]
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.includedirs = []
+        if not self.options.data_only:
+            self.cpp_info.resdirs.append(os.path.join("usr", "share"))
+            self.cpp_info.libdirs = [os.path.join("usr", "lib")]
+            self.cpp_info.bindirs = [
+                os.path.join("usr", "bin"),
+                os.path.join("usr", "sbin"),
+            ]
+            self.cpp_info.libs = ["tz"]
+
+        self.buildenv_info.define("TZDATA", os.path.join(self.package_folder, "res", "tzdata"))
+        self.runenv_info.define("TZDATA", os.path.join(self.package_folder, "res", "tzdata"))

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -1,0 +1,32 @@
+import os
+
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+
+class TzdataConan(ConanFile):
+    name = "tz"
+    license = "Public Domain"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "The Time Zone Database contains data that represent the history of local time for many representative locations around the globe."
+    topics = ("tz", "tzdb", "time", "zone", "date")
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+
+    def package_id(self):
+        self.info.clear()
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=False)
+
+    def package(self):
+        copy(self, "*", dst=os.path.join(self.package_folder, "res"), src=self.source_folder)
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "NOTICE.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+
+    def package_info(self):
+        self.cpp_info.resdirs = ['res']

--- a/recipes/tz/all/test_package/conanfile.py
+++ b/recipes/tz/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import cross_building
+
+class TzTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "VirtualBuildEnv", "VirtualRunEnv"
+    apply_env = False
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def test(self):
+        if not cross_building(self):
+            if not self.options["tz"].data_only:
+                which = "where" if self.settings.os == "Windows" else "which"
+                cmd = f"{which} zdump"
+                self.output.info(f"Executing '{cmd}'")
+                self.run(cmd, env="conanrun")
+
+                cmd = "zdump -v America/Los_Angeles"
+                self.output.info(f"Executing '{cmd}'")
+                self.run(cmd, env="conanrun")
+
+            self.output.info("Test that tzdata is readable")
+            cmd = "python -c 'import os; tzdata = os.environ[\"TZDATA\"]; f=open(os.path.join(tzdata, \"factory\"), \"r\"); s = f.read(); f.close(); print(s)'"
+            self.run(cmd, env="conanrun")

--- a/recipes/tz/config.yml
+++ b/recipes/tz/config.yml
@@ -1,0 +1,4 @@
+---
+versions:
+  "2022g":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **tz/2022g**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This is a recipe for [tz](https://github.com/eggert/tz).

The Time Zone Database (often called tz or zoneinfo) contains code and data that represent the history of local time for many representative locations around the globe. It is updated periodically to reflect changes made by political bodies to time zone boundaries, UTC offsets, and daylight-saving rules. Its management procedure is documented in [BCP 175: Procedures for Maintaining the Time Zone Database](https://www.iana.org/go/rfc6557).

This recipe packages the time zone database, as well as executables and libraries distributed along with it.

My primary motivation for packaging this is to add it as a dependency to the date library. date currently brings in libcurl to initiate its own download of this database. This is not ideal for offline environments, and has failed for me in the past on Windows systems. This presents an alternative default to date managing its own data dependency, where this database can be attained using a conan package. This data is well versioned and lends itself well to being packaged.

Relates to #16204 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
