### PR TITLE
aws-c-auth: fix dependencies traits + modernize more

### DIFF
--- a/recipes/aws-c-auth/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-auth/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_v1_package)
+
+enable_testing()
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(aws-c-auth REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-auth)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
`aws-c-common`, `aws-c-io`, `aws-c-http` & `aws-c-sdkutils` are public dependencies of `aws-c-auth` (for sure headers, but when headers are public I assume by default that symbols of these libs must also be visible).

`aws-c-s3` recipe can't be built with conan v2 without this fix in `aws-c-auth`:

```
[1/19] Building C object CMakeFiles/aws-c-s3.dir/source/s3_checksum_stream.c.o
FAILED: CMakeFiles/aws-c-s3.dir/source/s3_checksum_stream.c.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DAWS_S3_EXPORTS -DAWS_S3_USE_IMPORT_EXPORT -DCJSON_HIDE_SYMBOLS -DHAVE_SYSCONF -Daws_c_s3_EXPORTS -I/Users/spaceim/.conan2/p/t/aws-c70872509acb17/b/src/include -isystem /Users/spaceim/.conan2/p/aws-cd1aa2d9c17c7a/p/include -isystem /Users/spaceim/.conan2/p/aws-c5383876dfd65b/p/include -isystem /Users/spaceim/.conan2/p/aws-cecf31dd5a9016/p/include -isystem /Users/spaceim/.conan2/p/aws-c2387d14f6acd5/p/include -isystem /Users/spaceim/.conan2/p/aws-c7c74557c01326/p/include -m64 -O3 -DNDEBUG -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -fPIC -Wall -Wstrict-prototypes -Wextra -pedantic -Wno-long-long -fPIC -Wgnu -Wno-gnu-zero-variadic-macro-arguments -fvisibility=hidden -std=gnu99 -MD -MT CMakeFiles/aws-c-s3.dir/source/s3_checksum_stream.c.o -MF CMakeFiles/aws-c-s3.dir/source/s3_checksum_stream.c.o.d -o CMakeFiles/aws-c-s3.dir/source/s3_checksum_stream.c.o -c /Users/spaceim/.conan2/p/t/aws-c70872509acb17/b/src/source/s3_checksum_stream.c
In file included from /Users/spaceim/.conan2/p/t/aws-c70872509acb17/b/src/source/s3_checksum_stream.c:6:
In file included from /Users/spaceim/.conan2/p/t/aws-c70872509acb17/b/src/include/aws/s3/private/s3_checksums.h:7:
In file included from /Users/spaceim/.conan2/p/t/aws-c70872509acb17/b/src/include/aws/s3/s3_client.h:9:
In file included from /Users/spaceim/.conan2/p/aws-cd1aa2d9c17c7a/p/include/aws/auth/signing_config.h:9:
/Users/spaceim/.conan2/p/aws-cd1aa2d9c17c7a/p/include/aws/auth/auth.h:12:10: fatal error: 'aws/sdkutils/sdkutils.h' file not found
#include <aws/sdkutils/sdkutils.h>
```

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
