### PR TITLE
daw_header_libraries: modernize more for conan v2

### DIFF
--- a/recipes/daw_header_libraries/all/conanfile.py
+++ b/recipes/daw_header_libraries/all/conanfile.py
@@ -1,13 +1,14 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import get, copy
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
+from conan.tools.files import get, copy
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 
 import os
 
 required_conan_version = ">=1.50.0"
+
 
 class DawHeaderLibrariesConan(ConanFile):
     name = "daw_header_libraries"
@@ -16,11 +17,16 @@ class DawHeaderLibrariesConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/beached/header_libraries"
     topics = ("algorithms", "helpers", "data-structures")
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
-    def _compiler_required_cpp17(self):
+    def _min_cppstd(self):
+        return "17"
+
+    @property
+    def _compilers_minimum_version(self):
         return {
             "Visual Studio": "16",
             "msvc": "192",
@@ -37,17 +43,16 @@ class DawHeaderLibrariesConan(ConanFile):
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
-            check_min_cppstd(self, "17")
+            check_min_cppstd(self, self._min_cppstd)
 
-        minimum_version = self._compiler_required_cpp17.get(str(self.settings.compiler), False)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.get_safe("compiler.version")) < minimum_version:
-            raise ConanInvalidConfiguration(f"{self.ref} requires C++17, which your compiler does not support.")
-        else:
-            self.output.warn(f"{self.ref} requires C++17. Your compiler is unknown. Assuming it supports C++17.")
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         pass
@@ -62,7 +67,6 @@ class DawHeaderLibrariesConan(ConanFile):
 
         self.cpp_info.set_property("cmake_file_name", "daw-header-libraries")
         self.cpp_info.set_property("cmake_target_name", "daw::daw-header-libraries")
-        self.cpp_info.components["daw"].set_property("cmake_target_name", "daw::daw-header-libraries")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "daw-header-libraries"
@@ -71,3 +75,4 @@ class DawHeaderLibrariesConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "daw"
         self.cpp_info.components["daw"].names["cmake_find_package"] = "daw-header-libraries"
         self.cpp_info.components["daw"].names["cmake_find_package_multi"] = "daw-header-libraries"
+        self.cpp_info.components["daw"].set_property("cmake_target_name", "daw::daw-header-libraries")


### PR DESCRIPTION
remove self.warn which is not conan v2 compatible. Moreover the logic was wrong.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
