### PR TITLE
harfbuzz: modernize more for conan v2

### DIFF
--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -1,33 +1,33 @@
 sources:
-  "3.2.0":
-    url: "https://github.com/harfbuzz/harfbuzz/releases/download/3.2.0/harfbuzz-3.2.0.tar.xz"
-    sha256: "0ada50a1c199bb6f70843ab893c55867743a443b84d087d54df08ad883ebc2cd"
-  "4.4.1":
-    url: "https://github.com/harfbuzz/harfbuzz/releases/download/4.4.1/harfbuzz-4.4.1.tar.xz"
-    sha256: "c5bc33ac099b2e52f01d27cde21cee4281b9d5bfec7684135e268512478bc9ee"
-  "5.1.0":
-    url: "https://github.com/harfbuzz/harfbuzz/releases/download/5.1.0/harfbuzz-5.1.0.tar.xz"
-    sha256: "2edb95db668781aaa8d60959d21be2ff80085f31b12053cdd660d9a50ce84f05"
-  "5.2.0":
-    url: "https://github.com/harfbuzz/harfbuzz/releases/download/5.2.0/harfbuzz-5.2.0.tar.xz"
-    sha256: "735a94917b47936575acb4d4fa7e7986522f8a89527e4635721474dee2bc942c"
-  "5.3.0":
-    url: "https://github.com/harfbuzz/harfbuzz/archive/5.3.0.tar.gz"
-    sha256: "94712b8cdae68f0b585ec8e3cd8c5160fdc241218119572236497a62dae770de"
-  "5.3.1":
-    url: "https://github.com/harfbuzz/harfbuzz/archive/5.3.1.tar.gz"
-    sha256: "77c8c903f4539b050a6d3a5be79705c7ccf7b1cb66d68152a651486e261edbd2"
   "6.0.0":
     url: "https://github.com/harfbuzz/harfbuzz/archive/6.0.0.tar.gz"
     sha256: "6d753948587db3c7c3ba8cc4f8e6bf83f5c448d2591a9f7ec306467f3a4fe4fa"
-patches:
+  "5.3.1":
+    url: "https://github.com/harfbuzz/harfbuzz/archive/5.3.1.tar.gz"
+    sha256: "77c8c903f4539b050a6d3a5be79705c7ccf7b1cb66d68152a651486e261edbd2"
+  "5.3.0":
+    url: "https://github.com/harfbuzz/harfbuzz/archive/5.3.0.tar.gz"
+    sha256: "94712b8cdae68f0b585ec8e3cd8c5160fdc241218119572236497a62dae770de"
+  "5.2.0":
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/5.2.0/harfbuzz-5.2.0.tar.xz"
+    sha256: "735a94917b47936575acb4d4fa7e7986522f8a89527e4635721474dee2bc942c"
+  "5.1.0":
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/5.1.0/harfbuzz-5.1.0.tar.xz"
+    sha256: "2edb95db668781aaa8d60959d21be2ff80085f31b12053cdd660d9a50ce84f05"
   "4.4.1":
-    - patch_file: "patches/0000-fix-freetype-lookup-4.4.1.patch"
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/4.4.1/harfbuzz-4.4.1.tar.xz"
+    sha256: "c5bc33ac099b2e52f01d27cde21cee4281b9d5bfec7684135e268512478bc9ee"
+  "3.2.0":
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/3.2.0/harfbuzz-3.2.0.tar.xz"
+    sha256: "0ada50a1c199bb6f70843ab893c55867743a443b84d087d54df08ad883ebc2cd"
+patches:
+  "5.1.0":
+    - patch_file: "patches/0000-fix-freetype-lookup-5.1.0.patch"
       patch_type: "portability"
       patch_description: "fix fretype and icu dependency lookup"
       patch_source: "https://github.com/harfbuzz/harfbuzz/pull/3811"
-  "5.1.0":
-    - patch_file: "patches/0000-fix-freetype-lookup-5.1.0.patch"
+  "4.4.1":
+    - patch_file: "patches/0000-fix-freetype-lookup-4.4.1.patch"
       patch_type: "portability"
       patch_description: "fix fretype and icu dependency lookup"
       patch_source: "https://github.com/harfbuzz/harfbuzz/pull/3811"

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -1,24 +1,15 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
-from conan.tools.build import can_run, stdcpp_library
-from conan.tools.env import VirtualBuildEnv
+from conan.tools.build import can_run, cross_building, stdcpp_library
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
-from conan.tools.files import (
-    copy,
-    apply_conandata_patches,
-    export_conandata_patches,
-    get,
-    rename,
-    rm,
-    rmdir
-)
 from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
 from conan.tools.scm import Version
 
-import glob
 import os
 
 required_conan_version = ">=1.54.0"
@@ -31,6 +22,7 @@ class HarfbuzzConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://harfbuzz.org"
     license = "MIT"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -74,19 +66,8 @@ class HarfbuzzConan(ConanFile):
         if self.options.shared and self.options.with_glib:
             self.options["glib"].shared = True
 
-    def validate(self):
-        if self.info.options.shared and self.info.options.with_glib and not self.dependencies["glib"].options.shared:
-            raise ConanInvalidConfiguration(
-                "Linking a shared library against static glib can cause unexpected behaviour."
-            )
-        if Version(self.version) >= "4.4.0":
-            if self.info.settings.compiler == "gcc" and Version(self.info.settings.compiler.version) < "7":
-                raise ConanInvalidConfiguration("New versions of harfbuzz require at least gcc 7")
-
-        if self.info.options.with_glib and self.dependencies["glib"].options.shared and is_msvc_static_runtime(self):
-            raise ConanInvalidConfiguration(
-                "Linking shared glib with the MSVC static runtime is not supported"
-            )
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.with_freetype:
@@ -94,10 +75,31 @@ class HarfbuzzConan(ConanFile):
         if self.options.with_icu:
             self.requires("icu/72.1")
         if self.options.with_glib:
-            self.requires("glib/2.75.2")
+            self.requires("glib/2.75.3", run=not cross_building(self))
 
-    def layout(self):
-        basic_layout(self, src_folder="src")
+    def validate(self):
+        if self.options.shared and self.options.with_glib and not self.dependencies["glib"].options.shared:
+            raise ConanInvalidConfiguration(
+                "Linking a shared library against static glib can cause unexpected behaviour."
+            )
+        if Version(self.version) >= "4.4.0":
+            if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "7":
+                raise ConanInvalidConfiguration("New versions of harfbuzz require at least gcc 7")
+
+        if self.options.with_glib and self.dependencies["glib"].options.shared and is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration(
+                "Linking shared glib with the MSVC static runtime is not supported"
+            )
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.0.0")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/1.9.3")
+        if self.options.with_glib and cross_building(self):
+            self.tool_requires("glib/2.75.3")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         def is_enabled(value):
@@ -113,6 +115,9 @@ class HarfbuzzConan(ConanFile):
                 return "vs", ["/bigobj"]
             return "ninja", []
 
+        VirtualBuildEnv(self).generate()
+        if self.options.with_glib and not cross_building(self):
+            VirtualRunEnv(self).generate(scope="build")
         PkgConfigDeps(self).generate()
 
         backend, cxxflags = meson_backend_and_flags()
@@ -133,18 +138,6 @@ class HarfbuzzConan(ConanFile):
         tc.cpp_args += cxxflags
         tc.generate()
 
-        VirtualBuildEnv(self).generate()
-
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-                  destination=self.source_folder, strip_root=True)
-
-    def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
-        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/1.9.3")
-        self.tool_requires("glib/2.75.2")
-
     def build(self):
         apply_conandata_patches(self)
         meson = Meson(self)
@@ -152,32 +145,18 @@ class HarfbuzzConan(ConanFile):
         meson.build()
 
     def package(self):
-        def fix_msvc_libname(remove_lib_prefix=True):
-            """remove lib prefix & change extension to .lib"""
-            if not is_msvc(self):
-                return
-            libdirs = getattr(self.cpp.package, "libdirs")
-            for libdir in libdirs:
-                for ext in [".dll.a", ".dll.lib", ".a"]:
-                    full_folder = os.path.join(self.package_folder, libdir)
-                    for filepath in glob.glob(os.path.join(full_folder, f"*{ext}")):
-                        libname = os.path.basename(filepath)[0:-len(ext)]
-                        if remove_lib_prefix and libname[0:3] == "lib":
-                            libname = libname[3:]
-                        rename(self, filepath, os.path.join(os.path.dirname(filepath), f"{libname}.lib"))
-
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
         meson = Meson(self)
         meson.install()
-        fix_msvc_libname()
-        fix_apple_shared_install_name(self)
-        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        fix_apple_shared_install_name(self)
+        fix_msvc_libname(self)
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "harfbuzz"
-        self.cpp_info.names["cmake_find_package_multi"] = "harfbuzz"
+        self.cpp_info.set_property("cmake_file_name", "harfbuzz")
+        self.cpp_info.set_property("cmake_target_name", "harfbuzz::harfbuzz")
         self.cpp_info.set_property("pkg_config_name", "harfbuzz")
         if self.options.with_icu:
             self.cpp_info.libs.append("harfbuzz-icu")
@@ -185,7 +164,7 @@ class HarfbuzzConan(ConanFile):
             self.cpp_info.libs.append("harfbuzz-subset")
         self.cpp_info.libs.append("harfbuzz")
         self.cpp_info.includedirs.append(os.path.join("include", "harfbuzz"))
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.system_libs.append("user32")
@@ -204,6 +183,18 @@ class HarfbuzzConan(ConanFile):
             if libcxx:
                 self.cpp_info.system_libs.append(libcxx)
 
-    def package_id(self):
-        if self.options.with_glib and not self.options["glib"].shared:
-            self.info.requires["glib"].full_package_mode()
+def fix_msvc_libname(conanfile, remove_lib_prefix=True):
+    """remove lib prefix & change extension to .lib in case of cl like compiler"""
+    from conan.tools.files import rename
+    import glob
+    if not conanfile.settings.get_safe("compiler.runtime"):
+        return
+    libdirs = getattr(conanfile.cpp.package, "libdirs")
+    for libdir in libdirs:
+        for ext in [".dll.a", ".dll.lib", ".a"]:
+            full_folder = os.path.join(conanfile.package_folder, libdir)
+            for filepath in glob.glob(os.path.join(full_folder, f"*{ext}")):
+                libname = os.path.basename(filepath)[0:-len(ext)]
+                if remove_lib_prefix and libname[0:3] == "lib":
+                    libname = libname[3:]
+                rename(conanfile, filepath, os.path.join(os.path.dirname(filepath), f"{libname}.lib"))

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
-from conan.tools.build import can_run, cross_building, stdcpp_library
+from conan.tools.build import can_run, stdcpp_library
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
@@ -75,7 +75,7 @@ class HarfbuzzConan(ConanFile):
         if self.options.with_icu:
             self.requires("icu/72.1")
         if self.options.with_glib:
-            self.requires("glib/2.75.3", run=not cross_building(self))
+            self.requires("glib/2.75.3", run=can_run(self))
 
     def validate(self):
         if self.options.shared and self.options.with_glib and not self.dependencies["glib"].options.shared:
@@ -95,7 +95,7 @@ class HarfbuzzConan(ConanFile):
         self.tool_requires("meson/1.0.0")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/1.9.3")
-        if self.options.with_glib and cross_building(self):
+        if self.options.with_glib and not can_run(self):
             self.tool_requires("glib/2.75.3")
 
     def source(self):
@@ -116,7 +116,7 @@ class HarfbuzzConan(ConanFile):
             return "ninja", []
 
         VirtualBuildEnv(self).generate()
-        if self.options.with_glib and not cross_building(self):
+        if self.options.with_glib and can_run(self):
             VirtualRunEnv(self).generate(scope="build")
         PkgConfigDeps(self).generate()
 

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -71,7 +71,7 @@ class HarfbuzzConan(ConanFile):
 
     def requirements(self):
         if self.options.with_freetype:
-            self.requires("freetype/2.12.1")
+            self.requires("freetype/2.13.0")
         if self.options.with_icu:
             self.requires("icu/72.1")
         if self.options.with_glib:

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import can_run, stdcpp_library
@@ -64,7 +64,8 @@ class HarfbuzzConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
         if self.options.shared and self.options.with_glib:
-            self.options["glib"].shared = True
+            wildcard = "" if Version(conan_version) < "2.0.0" else "/*"
+            self.options[f"glib{wildcard}"].shared = True
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -76,7 +76,7 @@ class HarfbuzzConan(ConanFile):
         if self.options.with_icu:
             self.requires("icu/72.1")
         if self.options.with_glib:
-            self.requires("glib/2.75.3", run=can_run(self))
+            self.requires("glib/2.76.0", run=can_run(self))
 
     def validate(self):
         if self.options.shared and self.options.with_glib and not self.dependencies["glib"].options.shared:
@@ -97,7 +97,7 @@ class HarfbuzzConan(ConanFile):
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/1.9.3")
         if self.options.with_glib and not can_run(self):
-            self.tool_requires("glib/2.75.3")
+            self.tool_requires("glib/2.76.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/harfbuzz/all/test_package/CMakeLists.txt
+++ b/recipes/harfbuzz/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES C)
 
 find_package(harfbuzz REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE harfbuzz::harfbuzz)
-set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -1,15 +1,15 @@
 versions:
-  "3.2.0":
-    folder: all
-  "4.4.1":
-    folder: all
-  "5.1.0":
-    folder: all
-  "5.2.0":
-    folder: all
-  "5.3.0":
+  "6.0.0":
     folder: all
   "5.3.1":
     folder: all
-  "6.0.0":
+  "5.3.0":
+    folder: all
+  "5.2.0":
+    folder: all
+  "5.1.0":
+    folder: all
+  "4.4.1":
+    folder: all
+  "3.2.0":
     folder: all


### PR DESCRIPTION
- fix access to self.options in package_id() (forbidden in conan v2). Actually logic in package_id() is removed to follow recommendations of https://github.com/conan-io/conan-center-index/pull/16018
- add package_type
- avoid glib in build requirements in case of native build or if with_glib=False (having the same dependency in requirements & build requirements can significantly increase build time because they may be built with different shared option (including transitive dependencies, and glib is not a tiny library...))
- sort methods by order of execution
- bump freetype & glib

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
