### PR TITLE
glad: modernize for Conan 2.0

### DIFF
--- a/recipes/glad/all/CMakeLists.txt
+++ b/recipes/glad/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper)
-
-include("${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake")
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/glad/all/conandata.yml
+++ b/recipes/glad/all/conandata.yml
@@ -14,13 +14,9 @@ sources:
 patches:
   "0.1.36":
     - patch_file: "patches/0003-CMake-handle-all-specs.patch"
-      base_path: "source_subfolder"
   "0.1.35":
     - patch_file: "patches/0003-CMake-handle-all-specs.patch"
-      base_path: "source_subfolder"
   "0.1.34":
     - patch_file: "patches/0002-CMake-handle-all-specs.patch"
-      base_path: "source_subfolder"
   "0.1.33":
     - patch_file: "patches/0001-CMake-handle-all-specs.patch"
-      base_path: "source_subfolder"

--- a/recipes/glad/all/conanfile.py
+++ b/recipes/glad/all/conanfile.py
@@ -1,17 +1,17 @@
 import os
 
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, rmdir
+from conan.errors import ConanInvalidConfiguration
 
 class GladConan(ConanFile):
     name = "glad"
     description = "Multi-Language GL/GLES/EGL/GLX/WGL Loader-Generator based on the official specs."
-    topics = ("conan", "glad", "opengl")
+    topics = ("glad", "opengl")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Dav1dde/glad"
     license = "MIT"
-    exports_sources = ["CMakeLists.txt", "patches/*.patch"]
-    generators = "cmake"
     settings = "os", "compiler", "build_type", "arch"
 
     options = {
@@ -19,7 +19,7 @@ class GladConan(ConanFile):
         "fPIC": [True, False],
         "no_loader": [True, False],
         "spec": ["gl", "egl", "glx", "wgl"], # Name of the spec
-        "extensions": "ANY", # Path to extensions file or comma separated list of extensions, if missing all extensions are included
+        "extensions": ["ANY"], # Path to extensions file or comma separated list of extensions, if missing all extensions are included
         # if specification is gl
         "gl_profile": ["compatibility", "core"],
         "gl_version": ["None", "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "2.0",
@@ -41,7 +41,7 @@ class GladConan(ConanFile):
         "fPIC": True,
         "no_loader": False,
         "spec": "gl",
-        "extensions": "''",
+        "extensions": "",
         "gl_profile": "compatibility",
         "gl_version": "3.3",
         "gles1_version": "None",
@@ -54,23 +54,16 @@ class GladConan(ConanFile):
 
     _cmake = None
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            self.options.rm_safe("fPIC")
+
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
         if self.options.spec != "gl":
             del self.options.gl_profile
@@ -89,35 +82,39 @@ class GladConan(ConanFile):
             del self.options.wgl_version
 
         if self.options.spec == "wgl" and self.settings.os != "Windows":
-            raise ConanInvalidConfiguration("{0} specification is not compatible with {1}".format(self.options.spec,
-                                                                                                  self.settings.os))
+            raise ConanInvalidConfiguration(f"{self.options.spec} specification is not compatible with {self.settings.os}")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+    
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if "gl_profile" in self.options:
+            tc.variables["GLAD_PROFILE"] = self.options.gl_profile
+        tc.variables["GLAD_API"] = self._get_api()
+        tc.variables["GLAD_EXTENSIONS"] = self.options.extensions
+        tc.variables["GLAD_SPEC"] = self.options.spec
+        tc.variables["GLAD_NO_LOADER"] = self.options.no_loader
+        tc.variables["GLAD_GENERATOR"] = "c" if self.settings.build_type == "Release" else "c-debug"
+        tc.variables["GLAD_EXPORT"] = True
+        tc.variables["GLAD_INSTALL"] = True
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
-        cmake.build()
+        apply_conandata_patches(self)
+        self._configure_cmake().build()
 
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        if "gl_profile" in self.options:
-            self._cmake.definitions["GLAD_PROFILE"] = self.options.gl_profile
-        self._cmake.definitions["GLAD_API"] = self._get_api()
-        self._cmake.definitions["GLAD_EXTENSIONS"] = self.options.extensions
-        self._cmake.definitions["GLAD_SPEC"] = self.options.spec
-        self._cmake.definitions["GLAD_NO_LOADER"] = self.options.no_loader
-        self._cmake.definitions["GLAD_GENERATOR"] = "c" if self.settings.build_type == "Release" else "c-debug"
-        self._cmake.definitions["GLAD_EXPORT"] = True
-        self._cmake.definitions["GLAD_INSTALL"] = True
-
-        self._cmake.configure(build_folder=self._build_subfolder)
+        self._cmake.configure()
         return self._cmake
 
     def _get_api(self):
@@ -141,14 +138,13 @@ class GladConan(ConanFile):
         return api_concat
 
     def package(self):
-        cmake = self._configure_cmake()
-        cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        self._configure_cmake().install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = collect_libs(self)
         if self.options.shared:
             self.cpp_info.defines = ["GLAD_GLAPI_EXPORT"]
         if self.settings.os == "Linux":

--- a/recipes/glad/all/test_package/CMakeLists.txt
+++ b/recipes/glad/all/test_package/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+project(test_package LANGUAGES C)
 
 find_package(glad REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} glad::glad)
+target_link_libraries(${PROJECT_NAME} PRIVATE glad::glad)

--- a/recipes/glad/all/test_package/conanfile.py
+++ b/recipes/glad/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 
 
-class GladTestPackage(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"

--- a/recipes/glad/all/test_package/conanfile.py
+++ b/recipes/glad/all/test_package/conanfile.py
@@ -1,17 +1,26 @@
 import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 
-from conans import ConanFile, CMake, tools
 
-class TestPackageConan(ConanFile):
+class GladTestPackage(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/glad/all/test_v1_package/CMakeLists.txt
+++ b/recipes/glad/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/glad/all/test_v1_package/conanfile.py
+++ b/recipes/glad/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/glad/all/test_v1_package/conanfile.py
+++ b/recipes/glad/all/test_v1_package/conanfile.py
@@ -1,6 +1,6 @@
 import os
-
 from conans import ConanFile, CMake, tools
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"


### PR DESCRIPTION
I introduced Conan 2.0 support to the recipe of the **glad** library. For some reason I couldn't get hooks to work with Conan 2.0, so I'd appreciate some help with those if running them locally was necessary.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
