### PR TITLE
libxls: relocatable shared lib on macOS + allow to build on Windows without msvc

### DIFF
--- a/recipes/libxls/all/conanfile.py
+++ b/recipes/libxls/all/conanfile.py
@@ -1,14 +1,17 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
+from conan.tools.build import cross_building
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, save
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
 from conan.tools.layout import basic_layout
-from conan.tools.files import export_conandata_patches, apply_conandata_patches, rmdir, copy, save, get, rm
-from conan.tools.apple import is_apple_os
-from conan.tools.build import cross_building
+from conan.tools.microsoft import is_msvc
 
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
+
 
 class LibxlsConan(ConanFile):
     name = "libxls"
@@ -17,6 +20,7 @@ class LibxlsConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libxls/libxls/"
     topics = ("excel", "xls")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -28,6 +32,10 @@ class LibxlsConan(ConanFile):
         "fPIC": True,
         "with_cli": False,
     }
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -43,34 +51,41 @@ class LibxlsConan(ConanFile):
         self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
-        basic_layout(self, src_folder='src')
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         if not is_apple_os(self):
             self.requires("libiconv/1.17")
 
     def validate(self):
-        if self.settings.os == "Windows":
-            raise ConanInvalidConfiguration(f"{self.ref} doesn't support Windows (yet). Contributions are always welcomed")
+        if is_msvc(self):
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support Visual Studio (yet). Contributions are always welcomed")
 
     def build_requirements(self):
-        if self.settings.os == "Windows":
-            self.tool_requires("msys2/cci.latest")
+        if self._settings_build.os == "Windows":
             self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def generate(self):
-        toolchain = AutotoolsToolchain(self)
+        env = VirtualBuildEnv(self)
+        env.generate()
+        if not cross_building(self):
+            env = VirtualRunEnv(self)
+            env.generate(scope="build")
+        tc = AutotoolsToolchain(self)
         if cross_building(self):
-            toolchain.configure_args.append("ac_cv_func_malloc_0_nonnull=yes")
-            toolchain.configure_args.append("ac_cv_func_realloc_0_nonnull=yes")
-        toolchain.generate()
+            tc.configure_args.append("ac_cv_func_malloc_0_nonnull=yes")
+            tc.configure_args.append("ac_cv_func_realloc_0_nonnull=yes")
+        tc.generate()
         deps = AutotoolsDeps(self)
         deps.generate()
 
     def _patch_sources(self):
+        apply_conandata_patches(self)
         config_h_content = """
 #define HAVE_ICONV 1
 #define ICONV_CONST
@@ -79,7 +94,6 @@ class LibxlsConan(ConanFile):
         if self.settings.os == "Macos":
             config_h_content += "#define HAVE_XLOCALE_H 1\n"
         save(self, os.path.join(self.source_folder, "include", "config.h"), config_h_content)
-        apply_conandata_patches(self)
 
     def build(self):
         self._patch_sources()
@@ -94,20 +108,10 @@ class LibxlsConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "libxls")
         self.cpp_info.libs = ["xlsreader"]
-
         if is_apple_os(self):
             self.cpp_info.system_libs.append("iconv")
-
-        self.cpp_info.set_property("cmake_file_name", "libxls")
-        self.cpp_info.set_property("cmake_target_name", "libxls::libxls")
-        self.cpp_info.set_property("pkg_config_name", "libxls")
-
-        if not is_apple_os(self):
-            self.cpp_info.requires.append("libiconv::libiconv")
-
-        # TODO: Remove in Conan 2.0
-        self.cpp_info.names["cmake_find_package"] = "libxls"
-        self.cpp_info.names["cmake_find_package_multi"] = "libxls"


### PR DESCRIPTION
- relocatable shared lib on macOS
- allow to build with non-msvc compilers on Windows
- robust "all shared" build
- remove hardcoded cmake names since there is no CMake config file upstream

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
