### PR TITLE
matchit: modernize more for conan v2

### DIFF
--- a/recipes/matchit/all/test_package/CMakeLists.txt
+++ b/recipes/matchit/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
 find_package(matchit REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE matchit::matchit)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/matchit/all/test_package/conanfile.py
+++ b/recipes/matchit/all/test_package/conanfile.py
@@ -7,12 +7,13 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-
-    def requirements(self):
-        self.requires(self.tested_reference_str)
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/matchit/all/test_v1_package/CMakeLists.txt
+++ b/recipes/matchit/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(matchit REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE matchit::matchit)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/matchit/all/test_v1_package/conanfile.py
+++ b/recipes/matchit/all/test_v1_package/conanfile.py
@@ -1,9 +1,7 @@
-from conans import ConanFile, CMake
-from conan.tools.build import cross_building
+from conans import ConanFile, CMake, tools
 import os
 
 
-# legacy validation with Conan 1.x
 class TestPackageV1Conan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
@@ -14,6 +12,6 @@ class TestPackageV1Conan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
This recipe is not v2 compatible for `compiler=msvc` because in this case it goes in a (useless) branch relying on legacy `self.warn`

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
