### PR TITLE
mgs: modernize more for conan v2

### DIFF
--- a/recipes/mgs/all/conandata.yml
+++ b/recipes/mgs/all/conandata.yml
@@ -1,16 +1,16 @@
 sources:
-  0.2.1:
+  "0.2.1":
     url: "https://github.com/theodelrieu/mgs/releases/download/v0.2.1/mgs.zip"
     sha256: "da4a74d1cdaeb6c32c2097bcbebe21ba912ad84176a89014ac8232885d76bcc7"
-  0.2.0:
+  "0.2.0":
     url: "https://github.com/theodelrieu/mgs/releases/download/v0.2.0/mgs.zip"
     sha256: "aa057a4096da9451bef1950a3e784350df590f09f6bad0c0ca59ed1874df4a36"
-  0.1.5:
+  "0.1.5":
     url: "https://github.com/theodelrieu/mgs/releases/download/v0.1.5/mgs.zip"
     sha256: "ca00e5d26be18beac9874270c17bddbc4f96cad6d92aab685c9eb4be0e6d7fc7"
-  0.1.4:
+  "0.1.4":
     url: "https://github.com/theodelrieu/mgs/releases/download/v0.1.4/mgs.zip"
     sha256: "e247976860a0c8d237caaf62a918627f59d4f8a5b5bb811ab01e7cbecf31d4ce"
-  0.1.2:
+  "0.1.2":
     url: "https://github.com/theodelrieu/mgs/releases/download/v0.1.2/mgs.zip"
     sha256: "aba95870eafad95147c969c167a0e7c09b2c749ccafadbdd477de815e3e5bfd3"

--- a/recipes/mgs/all/conanfile.py
+++ b/recipes/mgs/all/conanfile.py
@@ -6,7 +6,8 @@ from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
+
 
 class MgsConan(ConanFile):
     name = "mgs"
@@ -15,6 +16,7 @@ class MgsConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://theodelrieu.github.io/mgs-docs"
     topics = ("codec", "base64", "base32", "base16", "header-only")
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -39,20 +41,19 @@ class MgsConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.cppstd:
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version:
-            if Version(self.settings.compiler.version) < minimum_version:
-                raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not fully support.")
-        else:
-            self.output.warn(f"{self.ref} requires C++{self._min_cppstd}. Your compiler is unknown. Assuming it supports C++{self._min_cppstd}.")
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not fully support."
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
-        self.copy("*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+        copy(self, "*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
 
     def package_info(self):

--- a/recipes/mgs/all/test_v1_package/conanfile.py
+++ b/recipes/mgs/all/test_v1_package/conanfile.py
@@ -1,5 +1,4 @@
-from conans import ConanFile, CMake
-from conan.tools.build import cross_building
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -13,6 +12,6 @@ class TestPackageV1Conan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
this recipe is not really v2 compatible (self.copy & self.output.warn usage)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
