### PR TITLE
civetweb: modernize more for conan v2

### DIFF
--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -1,11 +1,11 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import export_conandata_patches, apply_conandata_patches, copy, get, rmdir
 from conan.tools.scm import Version
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class CivetwebConan(ConanFile):
@@ -16,6 +16,7 @@ class CivetwebConan(ConanFile):
     description = "Embedded C/C++ web server"
     topics = ("web-server", "embedded")
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
@@ -69,37 +70,28 @@ class CivetwebConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
+            self.options.rm_safe("fPIC")
         if not self.options.with_cxx:
-            try:
-                del self.settings.compiler.libcxx
-            except Exception:
-                pass
-            try:
-                del self.settings.compiler.cppstd
-            except Exception:
-                pass
+            self.settings.rm_safe("compiler.cppstd")
+            self.settings.rm_safe("compiler.libcxx")
         if not self.options.with_ssl:
             del self.options.ssl_dynamic_loading
 
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
     def requirements(self):
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/1.1.1t")
         if self.options.get_safe("with_zlib"):
             self.requires("zlib/1.2.13")
 
     def validate(self):
-        if self.options.get_safe("ssl_dynamic_loading") and not self.options["openssl"].shared:
+        if self.options.get_safe("ssl_dynamic_loading") and not self.dependencies["openssl"].options.shared:
             raise ConanInvalidConfiguration("ssl_dynamic_loading requires shared openssl")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
-
-    def layout(self):
-        cmake_layout(self, src_folder="src")
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -152,15 +144,12 @@ class CivetwebConan(ConanFile):
                 os.remove(os.path.join(bin_folder, bin_file))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "civetweb"
-        self.cpp_info.names["cmake_find_package_multi"] = "civetweb"
         self.cpp_info.set_property("cmake_file_name", "civetweb")
-        self.cpp_info.set_property("cmake_target_name", "civetweb::civetweb")
-        self.cpp_info.components["_civetweb"].names["cmake_find_package"] = "civetweb"
-        self.cpp_info.components["_civetweb"].names["cmake_find_package_multi"] = "civetweb"
+        self.cpp_info.set_property("cmake_target_name", "civetweb::civetweb-cpp" if self.options.with_cxx else "civetweb::civetweb")
+
         self.cpp_info.components["_civetweb"].set_property("cmake_target_name", "civetweb::civetweb")
         self.cpp_info.components["_civetweb"].libs = ["civetweb"]
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["_civetweb"].system_libs.extend(["rt", "pthread"])
             if self.options.get_safe("ssl_dynamic_loading"):
                 self.cpp_info.components["_civetweb"].system_libs.append("dl")
@@ -170,24 +159,25 @@ class CivetwebConan(ConanFile):
             self.cpp_info.components["_civetweb"].system_libs.append("ws2_32")
             if self.options.shared:
                 self.cpp_info.components["_civetweb"].defines.append("CIVETWEB_DLL_IMPORTS")
-
         if self.options.with_ssl:
             self.cpp_info.components["_civetweb"].requires.append("openssl::openssl")
         if self.options.get_safe("with_zlib"):
             self.cpp_info.components["_civetweb"].requires.append("zlib::zlib")
 
         if self.options.with_cxx:
-            self.cpp_info.components["civetweb-cpp"].names["cmake_find_package"] = "civetweb-cpp"
-            self.cpp_info.components["civetweb-cpp"].names["cmake_find_package_multi"] = "civetweb-cpp"
             self.cpp_info.components["civetweb-cpp"].set_property("cmake_target_name", "civetweb::civetweb-cpp")
             self.cpp_info.components["civetweb-cpp"].libs = ["civetweb-cpp"]
             self.cpp_info.components["civetweb-cpp"].requires = ["_civetweb"]
-            if self.settings.os == "Linux":
+            if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["civetweb-cpp"].system_libs.append("m")
             elif self.settings.os == "Windows":
                 if self.options.shared:
                     self.cpp_info.components["civetweb-cpp"].defines.append("CIVETWEB_CXX_DLL_IMPORTS")
 
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bin_path))
-        self.env_info.PATH.append(bin_path)
+        # TODO: to remove once conan v1 support dropped
+        self.cpp_info.components["_civetweb"].names["cmake_find_package"] = "civetweb"
+        self.cpp_info.components["_civetweb"].names["cmake_find_package_multi"] = "civetweb"
+        if self.options.with_cxx:
+            self.cpp_info.components["civetweb-cpp"].names["cmake_find_package"] = "civetweb-cpp"
+            self.cpp_info.components["civetweb-cpp"].names["cmake_find_package_multi"] = "civetweb-cpp"
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/civetweb/all/test_package/conanfile.py
+++ b/recipes/civetweb/all/test_package/conanfile.py
@@ -1,17 +1,18 @@
 from conan import ConanFile
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 import os
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-
-    def requirements(self):
-        self.requires(self.tested_reference_str)
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -19,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/civetweb/all/test_v1_package/CMakeLists.txt
+++ b/recipes/civetweb/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(civetweb CONFIG REQUIRED)
-
-add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} civetweb::civetweb)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/civetweb/all/test_v1_package/test_package.cpp
+++ b/recipes/civetweb/all/test_v1_package/test_package.cpp
@@ -1,7 +1,0 @@
-#include "civetweb.h"
-
-int main(int argc, char *argv[])
-{
-	mg_init_library(0);
-	return 0;
-}


### PR DESCRIPTION
`ssl_dynamic_loading=True` is broken for conan v2 due to illegal usage of `self.options["openssl"]`.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
