### PR TITLE
[doxygen] Add support for Doxygen version 1.9.6

### DIFF
--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.6":
+    url: "https://sourceforge.net/projects/doxygen/files/doxygen-1.9.6.src.tar.gz"
+    sha256: "297f8ba484265ed3ebd3ff3fe7734eb349a77e4f95c8be52ed9977f51dea49df"
   "1.9.4":
     url: "https://sourceforge.net/projects/doxygen/files/doxygen-1.9.4.src.tar.gz"
     sha256: "a15e9cd8c0d02b7888bc8356eac200222ecff1defd32f3fe05257d81227b1f37"

--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -21,6 +21,11 @@ sources:
     url: "https://sourceforge.net/projects/doxygen/files/doxygen-1.8.17.src.tar.gz"
     sha256: "2cba988af2d495541cbbe5541b3bee0ee11144dcb23a81eada19f5501fd8b599"
 patches:
+  "1.9.6":
+    - patch_file: "patches/1.9.4-0001-enable-modern-compilers.patch"
+      patch_description: "Enable moxdern compilers"
+      patch_type: "portability"
+      patch_source: "https://github.com/doxygen/doxygen/commit/5198966c8d5fec89116d025c74934ac03ea511fa"
   "1.9.4":
     - patch_file: "patches/1.9.4-0001-enable-modern-compilers.patch"
       patch_description: "Enable modern compilers"

--- a/recipes/doxygen/config.yml
+++ b/recipes/doxygen/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.6":
+    folder: "all"
   "1.9.4":
     folder: "all"
   "1.9.2":


### PR DESCRIPTION
 **doxygen/1.9.6**

Add support for the latest Doxygen version 1.9.6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
