### PR TITLE
libvpx: several fixes like relocatable share lib on macOS & proper conan v2 support

### DIFF
--- a/recipes/libvpx/all/test_package/CMakeLists.txt
+++ b/recipes/libvpx/all/test_package/CMakeLists.txt
@@ -1,6 +1,5 @@
-cmake_minimum_required(VERSION 3.8)
-
-project(test_package C)
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
 
 find_package(libvpx REQUIRED CONFIG)
 

--- a/recipes/libvpx/all/test_package/conanfile.py
+++ b/recipes/libvpx/all/test_package/conanfile.py
@@ -4,17 +4,16 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
-    def requirements(self):
-        self.requires(self.tested_reference_str)
-
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- relocatable shared lib on macOS
- fix legacy Visual Studio test to be v2 compatible
- move back configure logic to generate() thanks to AutotoolsToolchain.update_configure_args()
- add package_type
- honor compile & linker flags from profile in case of non-msvc builds

conan v2 support of this recipe (as well as libx264 & libx265) is important for `ffmpeg` (and therefore `opencv`).

/cc @paulharris I know there is https://github.com/conan-io/conan-center-index/pull/15827, but more fixes are needed for conan v2

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
