### PR TITLE
antlr4-cppruntime: Upgrade to 4.12.0

### DIFF
--- a/recipes/antlr4-cppruntime/all/conanfile.py
+++ b/recipes/antlr4-cppruntime/all/conanfile.py
@@ -60,11 +60,16 @@ class Antlr4CppRuntimeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # As of 4.11, antlr4-cppruntime no longer requires libuuid.
-        # Reference: [C++] Remove libuuid dependency (https://github.com/antlr/antlr4/pull/3787)
+        # 1. As of 4.10, antlr4-cppruntime no longer requires `utfcpp`.
+        # Reference: [C++] Implement standalone Unicode encoding and decoding handling
+        #      Link: https://github.com/antlr/antlr4/pull/3398
+        # 2. As of 4.11, antlr4-cppruntime no longer requires `libuuid`.
+        # Reference: [C++] Remove libuuid dependency
+        #      Link: https://github.com/antlr/antlr4/pull/3787
         # Note that the above PR points that libuuid can be removed from 4.9.3, 4.10 and 4.10.1 as well.
         # We have patched the CMakeLists.txt to drop the dependency on libuuid from aforementioned antlr versions.
-        self.requires("utfcpp/3.2.3")
+        if Version(self.version) < "4.10":
+            self.requires("utfcpp/3.2.3")
 
     def validate(self):
         # Compilation of this library on version 15 claims C2668 Error.

--- a/recipes/antlr4-cppruntime/all/conanfile.py
+++ b/recipes/antlr4-cppruntime/all/conanfile.py
@@ -95,7 +95,7 @@ class Antlr4CppRuntimeConan(ConanFile):
         # As of ANTLR 4.12.0, one can choose to build the shared/static library only instead of both of them
         # Related Issue: https://github.com/antlr/antlr4/issues/3993
         # Related PR: https://github.com/antlr/antlr4/pull/3996
-        if Version(self.version) > "4.12":
+        if Version(self.version) >= "4.12":
             tc.variables["ANTLR_BUILD_SHARED"] = self.options.shared
             tc.variables["ANTLR_BUILD_STATIC"] = not self.options.shared
         tc.generate()

--- a/recipes/antlr4-cppruntime/all/conanfile.py
+++ b/recipes/antlr4-cppruntime/all/conanfile.py
@@ -92,6 +92,12 @@ class Antlr4CppRuntimeConan(ConanFile):
         if is_msvc(self):
             tc.cache_variables["WITH_STATIC_CRT"] = is_msvc_static_runtime(self)
         tc.variables["WITH_DEMO"] = False
+        # As of ANTLR 4.12.0, one can choose to build the shared/static library only instead of both of them
+        # Related Issue: https://github.com/antlr/antlr4/issues/3993
+        # Related PR: https://github.com/antlr/antlr4/pull/3996
+        if Version(self.version) > "4.12":
+            tc.variables["ANTLR_BUILD_SHARED"] = self.options.shared
+            tc.variables["ANTLR_BUILD_STATIC"] = not self.options.shared
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()

--- a/recipes/antlr4-cppruntime/all/conanfile.py
+++ b/recipes/antlr4-cppruntime/all/conanfile.py
@@ -64,7 +64,7 @@ class Antlr4CppRuntimeConan(ConanFile):
         # Reference: [C++] Remove libuuid dependency (https://github.com/antlr/antlr4/pull/3787)
         # Note that the above PR points that libuuid can be removed from 4.9.3, 4.10 and 4.10.1 as well.
         # We have patched the CMakeLists.txt to drop the dependency on libuuid from aforementioned antlr versions.
-        self.requires("utfcpp/3.2.1")
+        self.requires("utfcpp/3.2.3")
 
     def validate(self):
         # Compilation of this library on version 15 claims C2668 Error.


### PR DESCRIPTION
Specify library name and version:  **antlr4-cppruntime/4.12.0**

This PR contains the following changes:
- Upgrade the runtime library to 4.12.0.
- Upgrade the receipt to build the shared/static library only instead of both of them as of 4.12.0.
    - Related Issue: https://github.com/antlr/antlr4/issues/3993
    - Related PR: https://github.com/antlr/antlr4/pull/3996
    - Related CMake Options: `ANTLR_BUILD_SHARED` and `ANTLR_BUILD_STATIC`
- Drop the dependency `utfcpp` as of 4.10.0.
    - Related PR: https://github.com/antlr/antlr4/pull/3398
- Bump the dependency `utfcpp` to 3.2.3. 

Thank you.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
