### PR TITLE
qhull: add option 'qhull:cpp' to build qhullcpp

### DIFF
--- a/recipes/qhull/all/patches/0003-fix-cmake-8.0.x.patch
+++ b/recipes/qhull/all/patches/0003-fix-cmake-8.0.x.patch
@@ -1,6 +1,8 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ace6d50..7c2a689 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -339,28 +339,28 @@ set(
+@@ -339,28 +339,35 @@ set(
  
  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
  
@@ -11,6 +13,15 @@
 -    set(qhull_SHAREDR qhull_rd)
 -    set(qhull_STATIC qhullstatic_d)
 -    set(qhull_STATICR qhullstatic_rd)
+-else()
+-    set(qhull_CPP qhullcpp)
+-    set(qhull_SHARED libqhull)  # Temporarily avoid name conflict with qhull executable
+-    set(qhull_SHAREDP qhull_p)
+-    set(qhull_SHAREDR qhull_r)
+-    set(qhull_STATIC qhullstatic)
+-    set(qhull_STATICR qhullstatic_r)
+-endif()
+-
 +set(qhull_CPP qhullcpp)
 +set(qhull_SHARED libqhull)  # Temporarily avoid name conflict with qhull executable
 +set(qhull_SHAREDP qhull_p)
@@ -19,33 +30,33 @@
 +set(qhull_STATICR qhullstatic_r)
 +
 +if(BUILD_SHARED_LIBS)
-+set(
-+    qhull_TARGETS_INSTALL
-+        ${qhull_SHAREDR}
-+        qhull rbox qconvex qdelaunay qvoronoi qhalf
-+        ${qhull_SHARED}
-+)
- else()
--    set(qhull_CPP qhullcpp)
--    set(qhull_SHARED libqhull)  # Temporarily avoid name conflict with qhull executable
--    set(qhull_SHAREDP qhull_p)
--    set(qhull_SHAREDR qhull_r)
--    set(qhull_STATIC qhullstatic)
--    set(qhull_STATICR qhullstatic_r)
--endif()
- 
  set(
      qhull_TARGETS_INSTALL
 -        ${qhull_CPP} ${qhull_STATIC} ${qhull_STATICR} ${qhull_SHAREDR}
-+        ${qhull_STATIC} ${qhull_STATICR}
++        ${qhull_SHAREDR}
          qhull rbox qconvex qdelaunay qvoronoi qhalf
 -        ${qhull_SHARED} ${qhull_SHAREDP}  # Deprecated, use qhull_r instead
++        ${qhull_SHARED}
  )
++else()
++    if(BUILD_QHULLCPP)
++    set(
++        qhull_TARGETS_INSTALL
++            ${qhull_CPP} ${qhull_STATIC} ${qhull_STATICR}
++            qhull rbox qconvex qdelaunay qvoronoi qhalf
++    )
++    else()
++    set(
++        qhull_TARGETS_INSTALL
++            ${qhull_STATIC} ${qhull_STATICR}
++            qhull rbox qconvex qdelaunay qvoronoi qhalf
++    )
++    endif()
 +endif()
  set(
      qhull_TARGETS_TEST   # Unused
          user_eg user_eg2 user_eg3 user_egp testqset testqset_r
-@@ -375,10 +375,12 @@ add_library(${qhull_SHAREDR} SHARED
+@@ -375,10 +382,12 @@ add_library(${qhull_SHAREDR} SHARED
          src/libqhull_r/qhull_r-exports.def)
  set_target_properties(${qhull_SHAREDR} PROPERTIES
      SOVERSION ${qhull_SOVERSION}
@@ -59,7 +70,7 @@
      if(APPLE)
          set_target_properties(${qhull_SHAREDR} PROPERTIES 
              INSTALL_NAME_DIR "${LIB_INSTALL_DIR}")
-@@ -388,6 +390,7 @@ if(UNIX)
+@@ -388,6 +397,7 @@ if(UNIX)
              INSTALL_RPATH_USE_LINK_PATH TRUE
              BUILD_WITH_INSTALL_RPATH FALSE)
      endif()
@@ -67,7 +78,7 @@
  endif(UNIX)
  
  # ---------------------------------------
-@@ -398,18 +401,15 @@ add_library(${qhull_SHARED} SHARED
+@@ -398,18 +408,15 @@ add_library(${qhull_SHARED} SHARED
          ${libqhull_SOURCES}
          src/libqhull/qhull-exports.def)
          
@@ -89,7 +100,7 @@
      if(APPLE)
          set_target_properties(${qhull_SHARED} PROPERTIES 
              INSTALL_NAME_DIR "${LIB_INSTALL_DIR}")
-@@ -419,6 +419,7 @@ if(UNIX)
+@@ -419,6 +426,7 @@ if(UNIX)
              INSTALL_RPATH_USE_LINK_PATH TRUE
              BUILD_WITH_INSTALL_RPATH FALSE)
      endif()
@@ -97,7 +108,7 @@
  endif(UNIX)
  
  # ---------------------------------------
-@@ -431,10 +432,12 @@ add_library(${qhull_SHAREDP} SHARED
+@@ -431,10 +439,12 @@ add_library(${qhull_SHAREDP} SHARED
  set_target_properties(${qhull_SHAREDP} PROPERTIES
      COMPILE_DEFINITIONS "qh_QHpointer"
      SOVERSION ${qhull_SOVERSION}
@@ -111,7 +122,7 @@
      if(APPLE)
          set_target_properties(${qhull_SHAREDP} PROPERTIES 
              INSTALL_NAME_DIR "${LIB_INSTALL_DIR}")
-@@ -444,6 +447,7 @@ if(UNIX)
+@@ -444,6 +454,7 @@ if(UNIX)
              INSTALL_RPATH_USE_LINK_PATH TRUE
              BUILD_WITH_INSTALL_RPATH FALSE)
      endif()
@@ -119,7 +130,7 @@
  endif(UNIX)
  
  # ---------------------------------------
-@@ -452,11 +456,13 @@ endif(UNIX)
+@@ -452,11 +463,13 @@ endif(UNIX)
  
  add_library(${qhull_STATIC} STATIC ${libqhull_SOURCES})
  set_target_properties(${qhull_STATIC} PROPERTIES
@@ -135,7 +146,7 @@
  
  if(UNIX)
      target_link_libraries(${qhull_STATIC} m)
-@@ -471,6 +477,7 @@ endif(UNIX)
+@@ -471,6 +484,7 @@ endif(UNIX)
  add_library(${qhull_CPP} STATIC ${libqhullcpp_SOURCES})
  set_target_properties(${qhull_CPP} PROPERTIES
      VERSION ${qhull_VERSION}
@@ -143,7 +154,7 @@
      POSITION_INDEPENDENT_CODE "TRUE")
  
  # ---------------------------------------
-@@ -561,10 +568,8 @@ target_link_libraries(user_eg2 ${qhull_STATICR})
+@@ -561,10 +575,8 @@ target_link_libraries(user_eg2 ${qhull_STATICR})
  
  set(user_eg3_SOURCES    src/user_eg3/user_eg3_r.cpp)
  
@@ -154,7 +165,7 @@
  
  # ---------------------------------------
  # qhullp is qhull/unix.c linked to deprecated qh_QHpointer libqhull_p
-@@ -615,8 +620,6 @@ add_test(NAME user_eg
+@@ -615,8 +627,6 @@ add_test(NAME user_eg
     COMMAND sh -c "./user_eg")
  add_test(NAME user_eg2
     COMMAND sh -c "./user_eg2")
@@ -163,7 +174,7 @@
  
  # ---------------------------------------
  # Define install
-@@ -624,6 +627,7 @@ add_test(NAME user_eg3
+@@ -624,6 +634,7 @@ add_test(NAME user_eg3
  
  install(TARGETS ${qhull_TARGETS_INSTALL} EXPORT QhullTargets
          RUNTIME DESTINATION ${BIN_INSTALL_DIR}
@@ -171,7 +182,7 @@
          LIBRARY DESTINATION ${LIB_INSTALL_DIR}
          ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
          INCLUDES DESTINATION include)
-@@ -681,10 +685,7 @@ foreach(pkgconfig IN ITEMS "${qhull_SHARED};Qhull shared library"
+@@ -681,10 +692,10 @@ foreach(pkgconfig IN ITEMS "${qhull_SHARED};Qhull shared library"
  endforeach()
  
  install(FILES ${libqhull_HEADERS}    DESTINATION ${INCLUDE_INSTALL_DIR}/libqhull)
@@ -179,6 +190,9 @@
  install(FILES ${libqhullr_HEADERS}    DESTINATION ${INCLUDE_INSTALL_DIR}/libqhull_r)
 -install(FILES ${libqhullr_DOC}        DESTINATION ${INCLUDE_INSTALL_DIR}/libqhull_r)
 -install(FILES ${libqhullcpp_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR}/libqhullcpp)
++if (BUILD_QHULLCPP)
++    install(FILES ${libqhullcpp_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR}/libqhullcpp)
++endif()
  install(FILES html/qhull.man         DESTINATION ${MAN_INSTALL_DIR} RENAME qhull.1)
  install(FILES html/rbox.man          DESTINATION ${MAN_INSTALL_DIR} RENAME rbox.1)
  install(FILES ${doc_FILES}           DESTINATION ${DOC_INSTALL_DIR})


### PR DESCRIPTION
Solves #16321 (~ "qhull doesn't include qhullcpp")

* Adds option 'cpp' to qhull, which defaults to False
* 'cpp' requires 'shared==False' and 'reentrant==True'. ConanInvalidConfiguration is raised otherwise
* new qhullcpp component in package_info()
* Modified patch 0003 to only install qhullcpp when cpp==True

Tested on MacOS, apple-clang 14, conan 1.59, cmake 3.25.2



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
