### PR TITLE
Fix mikelankamp-fpm test_package code

### DIFF
--- a/recipes/mikelankamp-fpm/all/test_package/test_package.cpp
+++ b/recipes/mikelankamp-fpm/all/test_package/test_package.cpp
@@ -5,9 +5,7 @@
 #include <iostream>
 
 int main() {
-    std::cout << "Please input a number: ";
-    fpm::fixed_16_16 x;
-    std::cin >> x;
+    fpm::fixed_16_16 x {0.0};
     std::cout << "The cosine of " << x << " radians is: " << cos(x) << std::endl;
 
     return 0;


### PR DESCRIPTION
Specify library name and version:  **mikelankamp-fpm/all**

The quick start code from this library uses cin to ask for user input, and it was used as the code from the test package in #15054
