### PR TITLE
[vorbis] Export ogg as transitive library to avoid linkage error

### DIFF
--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -45,7 +45,7 @@ class VorbisConan(ConanFile):
             pass
 
     def requirements(self):
-        self.requires("ogg/1.3.5", transitive_headers=True)
+        self.requires("ogg/1.3.5", transitive_headers=True, transitive_libs=True)
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **vorbis/1.3.7**

When building Vorbis with the option `"*/*:shared=True"`, the `ogg` package is not linked correctly. This PR makes OGG be visible when linking.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
