### PR TITLE
[boost] Fix test package on macOS when *:shared=True

### DIFF
--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
+if(UNIX AND NOT APPLE)
+    # use RPATH instead of RUNPATH so that
+    # transitive dependencies can be located
+    add_link_options("LINKER:--disable-new-dtags")
+endif()
+
 include(CTest)
 enable_testing()
 

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
+include(CTest)
 enable_testing()
 
 if(BOOST_NAMESPACE)

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-include(CTest)
 enable_testing()
 
 if(BOOST_NAMESPACE)

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -58,5 +58,14 @@ class TestPackageConan(ConanFile):
         if not can_run(self):
             return
         with chdir(self, self.folders.build_folder):
+            # When boost and its dependencies are built as shared libraries,
+            # the test executables need to locate them. Typically the 
+            # `conanrun` env should be enough, but this may cause problems on macOS
+            # where the CMake installation has dependencies on Apple-provided
+            # system libraries that are incompatible with Conan-provided ones. 
+            # When `conanrun` is enabled, DYLD_LIBRARY_PATH will also apply
+            # to ctest itself. Given that CMake already embeds RPATHs by default, 
+            # we can bypass this by using the `conanbuild` environment on
+            # non-Windows platforms, while still retaining the correct behaviour.
             env = "conanrun" if self.settings.os == "Windows" else "conanbuild"
             self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env=env)

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import chdir
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualBuildEnv", "VirtualRunEnv"
     test_type = "explicit"
 
     def _boost_option(self, name, default):
@@ -58,4 +58,5 @@ class TestPackageConan(ConanFile):
         if not can_run(self):
             return
         with chdir(self, self.folders.build_folder):
-            self.run(f"ctest --output-on-failure -C {self.settings.build_type}")
+            env = "conanrun" if self.settings.os == "Windows" else "conanbuild"
+            self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env=env)

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -3,6 +3,8 @@ from conan.errors import ConanException
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import chdir
+from conan.tools.scm import Version
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
@@ -54,6 +56,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if can_run(self):
-            cmake = CMake(self)
-            cmake.test()
+        if not can_run(self):
+            return
+        with chdir(self, self.folders.build_folder):
+            self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env="conanrun")

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -3,7 +3,6 @@ from conan.errors import ConanException
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import chdir
-from conan.tools.scm import Version
 
 
 class TestPackageConan(ConanFile):
@@ -59,4 +58,4 @@ class TestPackageConan(ConanFile):
         if not can_run(self):
             return
         with chdir(self, self.folders.build_folder):
-            self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env="conanrun")
+            self.run(f"ctest --output-on-failure -C {self.settings.build_type}")

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -3,8 +3,6 @@ from conan.errors import ConanException
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import chdir
-from conan.tools.scm import Version
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
@@ -56,7 +54,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not can_run(self):
-            return
-        with chdir(self, self.folders.build_folder):
-            self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env="conanrun")
+        if can_run(self):
+            cmake = CMake(self)
+            cmake.test()


### PR DESCRIPTION
Specify library name and version:  **boost/1.79.0**

Some runtime error occurred when trying to run Boost test package on the CI:

https://c3i.jfrog.io/c3i/misc-v2/logs/prod-v2/TapaholesRepo/106-configs/macos-clang/boost/1.79.0//ff15167be75d82eb8c4445406fa2bff3f15f4cdb-test.txt

However, I can't reproduce that error, instead, it works for me, but I only have Clang Apple 14 installed. So my intention here is trying to use cmake build --target test, instead of invoking ctest directly, my guess is something related to DYLIB missing path. 

My build log:

```
% conan test test_package boost/1.79.0@ -o "*/*:shared=True" -o "boost/*:header_only=False" -s compiler.cppstd=gnu17

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=14
os=Macos
[options]
*/*:shared=True
boost/*:header_only=False

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=17
compiler.libcxx=libc++
compiler.version=14
os=Macos


======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    boost/1.79.0 (test package): /Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/conanfile.py
Requirements
    boost/1.79.0#7e3ccedb3882273b9467973efff282d6 - Cache
    bzip2/1.0.8#a7bd81ce9d6434d26023b12f71dd83e0 - Cache
    libbacktrace/cci.20210118#83410de09fe2b7785ee8953e2be8db33 - Cache
    libiconv/1.17#7f5704761b99aeddacadf5c7904ffbaa - Cache
    zlib/1.2.13#416618fa04d433c6bd94279ed2e93638 - Cache
Build requirements
    b2/4.9.3#5445210661950ce568cfd76158d9e117 - Cache

======== Computing necessary packages ========
Requirements
    boost/1.79.0#7e3ccedb3882273b9467973efff282d6:0a452add1a3fedea75d229e67bcb68d3412e6fc7#290cb9cab516649bfa4e27dfe517a828 - Cache
    bzip2/1.0.8#a7bd81ce9d6434d26023b12f71dd83e0:e1eb526de07d182617f89eeb6df0eac18d9515ca#c426fcb5d3ecd6a82a6344c2c5e86c70 - Cache
    libbacktrace/cci.20210118#83410de09fe2b7785ee8953e2be8db33:7f186b6c0245706607316853852bb7e3b56374d8#91104f9c6843618b1101e7a740c76689 - Cache
    libiconv/1.17#7f5704761b99aeddacadf5c7904ffbaa:7f186b6c0245706607316853852bb7e3b56374d8#282a75d69c1891b57885ec1d0eb7a4df - Cache
    zlib/1.2.13#416618fa04d433c6bd94279ed2e93638:7f186b6c0245706607316853852bb7e3b56374d8#5a9078faaa7856d836aaf522dbf7adcb - Cache
Build requirements
    b2/4.9.3#5445210661950ce568cfd76158d9e117:dcf68e932572755309a5f69f3cee1bede410e907#53765578593bcf82fcf9a348f7f47f88 - Skip
======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release
boost/1.79.0 (test package): Test package build: build/apple-clang-14-armv8-gnu17-release
boost/1.79.0 (test package): Test package build folder: /Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release
boost/1.79.0 (test package): Writing generators to /Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release/generators
boost/1.79.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
boost/1.79.0 (test package): Generator 'CMakeDeps' calling 'generate()'
boost/1.79.0 (test package): Calling generate()
boost/1.79.0 (test package): Generators folder: /Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release/generators
boost/1.79.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
boost/1.79.0 (test package): CMakeToolchain generated: CMakePresets.json
boost/1.79.0 (test package): CMakeToolchain generated: ../../../CMakeUserPresets.json
boost/1.79.0 (test package): Generating aggregated env files
boost/1.79.0 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
boost/1.79.0 (test package): Calling build()
boost/1.79.0 (test package): Running CMake.configure()
boost/1.79.0 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="/Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release/generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package" -DHEADER_ONLY="OFF" -DBoost_USE_STATIC_LIBS="OFF" -DWITH_PYTHON="OFF" -DWITH_RANDOM="ON" -DWITH_REGEX="ON" -DWITH_TEST="ON" -DWITH_COROUTINE="ON" -DWITH_CHRONO="ON" -DWITH_FIBER="ON" -DWITH_LOCALE="ON" -DWITH_NOWIDE="ON" -DWITH_JSON="ON" -DWITH_STACKTRACE="ON" -DWITH_STACKTRACE_ADDR2LINE="ON" -DWITH_STACKTRACE_BACKTRACE="ON" -DWITH_URL="OFF" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/."
-- Using Conan toolchain: /Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The CXX compiler identification is AppleClang 14.0.0.14000029
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'Boost::diagnostic_definitions'
-- Conan: Component target declared 'Boost::disable_autolinking'
-- Conan: Component target declared 'Boost::dynamic_linking'
-- Conan: Component target declared 'Boost::headers'
-- Conan: Component target declared 'Boost::boost'
-- Conan: Component target declared 'boost::_libboost'
-- Conan: Component target declared 'Boost::atomic'
-- Conan: Component target declared 'Boost::container'
-- Conan: Component target declared 'Boost::context'
-- Conan: Component target declared 'Boost::date_time'
-- Conan: Component target declared 'Boost::exception'
-- Conan: Component target declared 'Boost::math'
-- Conan: Component target declared 'Boost::math_c99'
-- Conan: Component target declared 'Boost::math_c99f'
-- Conan: Component target declared 'Boost::math_c99l'
-- Conan: Component target declared 'Boost::math_tr1'
-- Conan: Component target declared 'Boost::math_tr1f'
-- Conan: Component target declared 'Boost::math_tr1l'
-- Conan: Component target declared 'Boost::program_options'
-- Conan: Component target declared 'Boost::regex'
-- Conan: Component target declared 'Boost::serialization'
-- Conan: Component target declared 'Boost::stacktrace'
-- Conan: Component target declared 'Boost::stacktrace_addr2line'
-- Conan: Component target declared 'Boost::stacktrace_backtrace'
-- Conan: Component target declared 'Boost::stacktrace_basic'
-- Conan: Component target declared 'Boost::stacktrace_noop'
-- Conan: Component target declared 'Boost::system'
-- Conan: Component target declared 'Boost::test'
-- Conan: Component target declared 'Boost::test_exec_monitor'
-- Conan: Component target declared 'Boost::wserialization'
-- Conan: Component target declared 'Boost::chrono'
-- Conan: Component target declared 'Boost::coroutine'
-- Conan: Component target declared 'Boost::filesystem'
-- Conan: Component target declared 'Boost::json'
-- Conan: Component target declared 'Boost::nowide'
-- Conan: Component target declared 'Boost::prg_exec_monitor'
-- Conan: Component target declared 'Boost::random'
-- Conan: Component target declared 'Boost::thread'
-- Conan: Component target declared 'Boost::timer'
-- Conan: Component target declared 'Boost::type_erasure'
-- Conan: Component target declared 'Boost::unit_test_framework'
-- Conan: Component target declared 'Boost::wave'
-- Conan: Component target declared 'Boost::contract'
-- Conan: Component target declared 'Boost::fiber'
-- Conan: Component target declared 'Boost::fiber_numa'
-- Conan: Component target declared 'Boost::graph'
-- Conan: Component target declared 'Boost::iostreams'
-- Conan: Component target declared 'Boost::locale'
-- Conan: Component target declared 'Boost::log'
-- Conan: Component target declared 'Boost::log_setup'
-- Conan: Target declared 'boost::boost'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Target declared 'BZip2::BZip2'
-- Conan: Including build module from '/Users/uilian/.conan2/p/bzip28d2bd80a1b6f5/p/lib/cmake/conan-official-bzip2-variables.cmake'
-- Conan: Target declared 'libbacktrace::libbacktrace'
-- Conan: Target declared 'Iconv::Iconv'
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    Boost_USE_STATIC_LIBS
    CMAKE_POLICY_DEFAULT_CMP0091


-- Build files have been written to: /Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release

boost/1.79.0 (test package): Running CMake.build()
boost/1.79.0 (test package): RUN: cmake --build "/Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release" -- -j10
[  3%] Building CXX object CMakeFiles/random_exe.dir/random.cpp.o
[  7%] Building CXX object CMakeFiles/coroutine_exe.dir/coroutine.cpp.o
[ 10%] Building CXX object CMakeFiles/nowide_exe.dir/nowide.cpp.o
[ 14%] Building CXX object CMakeFiles/regex_exe.dir/regex.cpp.o
[ 17%] Building CXX object CMakeFiles/json_exe.dir/json.cpp.o
[ 21%] Building CXX object CMakeFiles/locale_exe.dir/locale.cpp.o
[ 25%] Building CXX object CMakeFiles/chrono_exe.dir/chrono.cpp.o
[ 28%] Building CXX object CMakeFiles/stacktrace_addr2line_exe.dir/stacktrace.cpp.o
[ 32%] Building CXX object CMakeFiles/test_exe.dir/test.cpp.o
[ 35%] Building CXX object CMakeFiles/fiber_exe.dir/fiber.cpp.o
[ 39%] Linking CXX executable random_exe
[ 42%] Linking CXX executable nowide_exe
[ 46%] Linking CXX executable chrono_exe
[ 50%] Linking CXX executable json_exe
[ 53%] Linking CXX executable stacktrace_addr2line_exe
[ 53%] Built target random_exe
[ 53%] Built target nowide_exe
[ 53%] Built target chrono_exe
[ 53%] Built target json_exe
[ 53%] Built target stacktrace_addr2line_exe
[ 57%] Building CXX object CMakeFiles/stacktrace_backtrace_exe.dir/stacktrace.cpp.o
[ 60%] Linking CXX executable locale_exe
[ 64%] Building CXX object CMakeFiles/stacktrace_noop_exe.dir/stacktrace.cpp.o
[ 67%] Building CXX object CMakeFiles/stacktrace_basic_exe.dir/stacktrace.cpp.o
[ 71%] Building CXX object CMakeFiles/lambda_exe.dir/lambda.cpp.o
[ 75%] Linking CXX executable fiber_exe
[ 78%] Linking CXX executable test_exe
[ 78%] Built target locale_exe
[ 78%] Built target fiber_exe
[ 78%] Built target test_exe
[ 82%] Linking CXX executable stacktrace_noop_exe
[ 85%] Linking CXX executable stacktrace_backtrace_exe
[ 89%] Linking CXX executable stacktrace_basic_exe
[ 89%] Built target stacktrace_noop_exe
[ 92%] Linking CXX executable lambda_exe
[ 92%] Built target stacktrace_backtrace_exe
[ 92%] Built target stacktrace_basic_exe
[ 92%] Built target lambda_exe
[ 96%] Linking CXX executable coroutine_exe
[ 96%] Built target coroutine_exe
[100%] Linking CXX executable regex_exe
[100%] Built target regex_exe


======== Testing the package: Executing test ========
boost/1.79.0 (test package): Running test()
boost/1.79.0 (test package): RUN: cmake --build "/Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release" --target test -- -j10
Running tests...
Test project /Users/uilian/Development/conan/conan-center-index/recipes/boost/all/test_package/build/apple-clang-14-armv8-gnu17-release
      Start  1: boost_random
 1/14 Test  #1: boost_random .....................   Passed    0.22 sec
      Start  2: boost_regex
 2/14 Test  #2: boost_regex ......................   Passed    0.05 sec
      Start  3: boost_test
 3/14 Test  #3: boost_test .......................   Passed    0.04 sec
      Start  4: coroutine_test
 4/14 Test  #4: coroutine_test ...................   Passed    0.05 sec
      Start  5: chrono_test
 5/14 Test  #5: chrono_test ......................   Passed    0.04 sec
      Start  6: boost_fiber
 6/14 Test  #6: boost_fiber ......................   Passed    0.06 sec
      Start  7: boost_json
 7/14 Test  #7: boost_json .......................   Passed    0.04 sec
      Start  8: boost_nowide
 8/14 Test  #8: boost_nowide .....................   Passed    0.05 sec
      Start  9: boost_locale
 9/14 Test  #9: boost_locale .....................   Passed    0.06 sec
      Start 10: boost_stacktrace_addr2line
10/14 Test #10: boost_stacktrace_addr2line .......   Passed    0.05 sec
      Start 11: boost_stacktrace_backtrace
11/14 Test #11: boost_stacktrace_backtrace .......   Passed    0.04 sec
      Start 12: boost_stacktrace_noop
12/14 Test #12: boost_stacktrace_noop ............   Passed    0.05 sec
      Start 13: boost_stacktrace_basic
13/14 Test #13: boost_stacktrace_basic ...........   Passed    0.05 sec
      Start 14: boost_boost
14/14 Test #14: boost_boost ......................   Passed    0.05 sec

100% tests passed, 0 tests failed out of 14

Total Test time (real) =   0.87 sec
```


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
