### PR TITLE
readd self version check for macOS armv8 compatibility

### DIFF
--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -125,7 +125,7 @@ class SentryNativeConan(ConanFile):
             raise ConanInvalidConfiguration("The winhttp transport is only supported on Windows")
         if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "10.0":
             raise ConanInvalidConfiguration("apple-clang < 10.0 not supported")
-        if self.options.backend == "crashpad" and self.settings.os == "Macos" and self.settings.arch == "armv8":
+        if self.options.backend == "crashpad" and Version(self.version) < "0.4.7" and self.settings.os == "Macos" and self.settings.arch == "armv8":
             raise ConanInvalidConfiguration("This version doesn't support ARM compilation")
 
         if self.options.performance:


### PR DESCRIPTION
Specify library name and version:  **sentry-native/>=5.0**

This fixes [#16352](https://github.com/conan-io/conan-center-index/issues/16352) by bringing back this [version check](https://github.com/conan-io/conan-center-index/commit/f191454ab3068da508ef64dad8aa55c4e0a303c3#diff-95df6adf18543155d3f51239ff9678848b33c8922e0e652daa20175d2d2fc816L129).

With conan 1.59.0 this makes the recipe work again on macOS armv8.
With conan 2.0 I still this error at the end (on `sentry-crashpad`, which is a requirement of `sentry-native`:
<img width="767" alt="image" src="https://user-images.githubusercontent.com/25109902/222629321-b9f2dc88-3f84-4220-ac0a-f0a246da3989.png">
which seems to be the same as [issue #13187](https://github.com/conan-io/conan/issues/13187).

Both conan versions were tested with `sentry-native` versions `0.5.0` and `0.5.4`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.