### PR TITLE
[changelog] Release 2023-03-03

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,14 @@
 # Changelog
 
+### 10-March-2023 - 19:55 CET
+
+- [feature] Add priority to pull requests
+- [hotfix] Avoid extra http requests to run automatic merge faster
+
 ### 10-March-2023 - 13:15 CET
 
 - [hotfix] No longer update conan_v2_ready_references.yml automatically
 - [bugfix] Validate Green and clean PRs first when executing automatic merge CI job
-
 
 ### 07-March-2023 - 17:05 CET
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 07-March-2023 - 17:05 CET
+
+- [hotfix] Automatic merge skips git conflicts
+- [hotfix] Conan V2 ready label depends on PR author
+
 ### 03-March-2023 - 11:05 CET
 
 - [feature] Update ready_v2_references.yml file automatically

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 03-March-2023 - 11:05 CET
+
+- [feature] Update ready_v2_references.yml file automatically
+- [fix] Do not reuse the same build folder to avoid busy files
+
 ### 21-February-2023 - 17:22 CET
 
 - [fix] Fix bug with cppstd entry in configuration files.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 ### 07-March-2023 - 17:05 CET
 
 - [hotfix] Automatic merge skips git conflicts
-- [hotfix] Conan V2 ready label depends on PR author
+- [hotfix] config label for "v2 ready" depends on PR author
 
 ### 03-March-2023 - 11:05 CET
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 10-March-2023 - 13:15 CET
+
+- [hotfix] No longer update conan_v2_ready_references.yml automatically
+- [bugfix] Validate Green and clean PRs first when executing automatic merge CI job
+
+
 ### 07-March-2023 - 17:05 CET
 
 - [hotfix] Automatic merge skips git conflicts


### PR DESCRIPTION
- Once a package passes by Conan v2 build, it will be computed in `.c3i/conan_v2_ready_references.yml`, then it will mandatory to pass by Conan v2 for every new PR opened.
- Windows builds may fail for busy file handle, because they are re-using the same folder when building. Using unique temporary folder for each build should fix it.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
