### PR TITLE
Update sqlcipher

### DIFF
--- a/recipes/sqlcipher/all/conandata.yml
+++ b/recipes/sqlcipher/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "4.5.3":
+    url: "https://github.com/sqlcipher/sqlcipher/archive/v4.5.3.zip"
+    sha256: "e3509338717cd75366ddbd25f6fb1e467fe6a37ec33fda54a6b24f05ce5ac179"
+  "4.5.2":
+    url: "https://github.com/sqlcipher/sqlcipher/archive/v4.5.2.zip"
+    sha256: "b7281269fa4005a2c516932f260ca1333449acd93a8347efaf8dd6844b5ed223"
   "4.5.1":
     url: "https://github.com/sqlcipher/sqlcipher/archive/v4.5.1.zip"
     sha256: "08a1024b299b5527d5b5ed79f67957938b516567f68662e973c4bec1b843b28e"

--- a/recipes/sqlcipher/config.yml
+++ b/recipes/sqlcipher/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "4.5.3":
+    folder: all
+  "4.5.2":
+    folder: all
   "4.5.1":
     folder: all
   "4.5.0":


### PR DESCRIPTION
Specify library name and version:  **sqlcipher/4.5.3**

This adds new versions without patching the Windows NMake file or any other build file, since that is a nightmare to maintain.

I have not tested old versions, and the transition to conan2 style is missing, but maybe with a PR here, I can get some progress on that topic. Either through feedback, or someone whats to step in and help

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
