### PR TITLE
libsvtav1: fix static build on macos llvm-clang

### DIFF
--- a/recipes/libsvtav1/all/conandata.yml
+++ b/recipes/libsvtav1/all/conandata.yml
@@ -13,15 +13,15 @@ patches:
   "1.4.1":
     - patch_file: "patches/llvm-clang-macos.patch"
       patch_type: "portability"
-      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2070
+      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2087
       patch_description: "Allow statically compiling on macos with llvm-clang"
   "1.3.0":
     - patch_file: "patches/llvm-clang-macos.patch"
       patch_type: "portability"
-      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2070
+      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2087
       patch_description: "Allow statically compiling on macos with llvm-clang"
   "1.2.1":
     - patch_file: "patches/llvm-clang-macos.patch"
       patch_type: "portability"
-      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2070
+      patch_source: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2087
       patch_description: "Allow statically compiling on macos with llvm-clang"

--- a/recipes/libsvtav1/all/patches/llvm-clang-macos.patch
+++ b/recipes/libsvtav1/all/patches/llvm-clang-macos.patch
@@ -1,15 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4d2dd735..7cabadd0 100644
+index 25a40f09..9c861554 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -205,8 +205,11 @@ if(UNIX)
+@@ -203,10 +203,12 @@ endif()
+ if(UNIX)
+     if(APPLE)
          set(CMAKE_MACOSX_RPATH 1)
-         set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
-         set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+-        set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+-        set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
 -        set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 -        set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
-+        if(NOT CMAKE_RANLIB MATCHES "llvm-ranlib$")
-+            # we are using apple-clang
++        if(CMAKE_C_COMPILER_ID MATCHES "AppleClang")
++            set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
++            set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
 +            set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 +            set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 +        endif()


### PR DESCRIPTION
Specify library name and version:  **libsvtav1/all**

I am sorry, the last patch wasn't good enough.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
