### PR TITLE
Add protobuf-python package

### DIFF
--- a/recipes/protobuf-python/all/conandata.yml
+++ b/recipes/protobuf-python/all/conandata.yml
@@ -1,0 +1,19 @@
+sources:
+  "3.21.9":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.9.tar.gz"
+    sha256: "0aa7df8289c957a4c54cbe694fbabe99b180e64ca0f8fdb5e2f76dcf56ff2422"
+  "3.21.4":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.21.4.tar.gz"
+    sha256: "85d42d4485f36f8cec3e475a3b9e841d7d78523cd775de3a86dba77081f4ca25"
+  "3.20.0":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.20.0.tar.gz"
+    sha256: "b07772d38ab07e55eca4d50f4b53da2d998bb221575c60a4f81100242d4b4889"
+  "3.19.6":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.19.6.tar.gz"
+    sha256: "9a301cf94a8ddcb380b901e7aac852780b826595075577bb967004050c835056"
+  "3.19.4":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.19.4.tar.gz"
+    sha256: "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568"
+  "3.18.1":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.18.1.tar.gz"
+    sha256: "9111bf0b542b631165fadbd80aa60e7fb25b25311c532139ed2089d76ddf6dd7"

--- a/recipes/protobuf-python/all/conanfile.py
+++ b/recipes/protobuf-python/all/conanfile.py
@@ -14,6 +14,8 @@ class ProtobufPythonPkg(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/protocolbuffers/protobuf"
     license = "BSD-3-Clause"
+    no_copy_source = True
+    settings = "os", "arch", "compiler", "build_type"
 
     def layout(self):
         basic_layout(self,src_folder="src")

--- a/recipes/protobuf-python/all/conanfile.py
+++ b/recipes/protobuf-python/all/conanfile.py
@@ -1,0 +1,45 @@
+from conan import ConanFile
+from conan.tools.layout import basic_layout
+from conan.tools.files import copy, get
+
+import os
+import sys
+
+required_conan_version = ">=1.53"
+
+class ProtobufPythonPkg(ConanFile):
+    name = "protobuf-python"
+    description = "Protocol Buffers - Google's data interchange format - Python Module"
+    topics = ("protocol-buffers", "protocol-compiler", "serialization", "rpc", "protocol-compiler", "python")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/protocolbuffers/protobuf"
+    license = "BSD-3-Clause"
+
+    def layout(self):
+        basic_layout(self,src_folder="src")
+
+    def requirements(self):
+        self.requires(f"protobuf/{self.version}", run=True, build=True)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        self.run(f"{sys.executable} setup.py build",
+                 cwd=os.path.join(self.source_folder, "python"))
+
+    @property
+    def _python_instdir(self):
+        return "lib/python/site-packages"
+
+    def package(self):
+        copy(self, "*",
+             os.path.join(self.source_folder, "python", "build", "lib"),
+             os.path.join(self.package_folder, self._python_instdir))
+
+    def package_info(self):
+        self.buildenv_info.append_path("PYTHONPATH", os.path.join(self.package_folder, self._python_instdir))
+        self.runenv_info.append_path("PYTHONPATH", os.path.join(self.package_folder, self._python_instdir))
+
+    def package_id(self):
+        self.info.clear()

--- a/recipes/protobuf-python/all/test_package/conanfile.py
+++ b/recipes/protobuf-python/all/test_package/conanfile.py
@@ -1,0 +1,20 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+
+import os
+import sys
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.source_folder, "test_package.py")
+            self.run(f"{sys.executable} {bin_path}", env="conanrun")

--- a/recipes/protobuf-python/all/test_package/test_package.py
+++ b/recipes/protobuf-python/all/test_package/test_package.py
@@ -1,0 +1,1 @@
+import google.protobuf

--- a/recipes/protobuf-python/all/test_v1_package/conanfile.py
+++ b/recipes/protobuf-python/all/test_v1_package/conanfile.py
@@ -1,0 +1,22 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+
+import os
+import sys
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualRunEnv"
+    test_type = "explicit" 
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.source_folder, "test_package.py")
+            self.run(f"{sys.executable} {bin_path}", env="conanrun")

--- a/recipes/protobuf-python/all/test_v1_package/test_package.py
+++ b/recipes/protobuf-python/all/test_v1_package/test_package.py
@@ -1,0 +1,1 @@
+import google.protobuf

--- a/recipes/protobuf-python/config.yml
+++ b/recipes/protobuf-python/config.yml
@@ -1,0 +1,13 @@
+versions:
+  "3.21.9":
+    folder: all
+  "3.21.4":
+    folder: all
+  "3.20.0":
+    folder: all
+  "3.19.6":
+    folder: all
+  "3.19.4":
+    folder: all
+  "3.18.1":
+    folder: all


### PR DESCRIPTION
# Protobuf-python

Protobuf provides a python library that can be used by clients. This is built by entering the `python` folder provided in the repo and running `setup.py`. Unfortunately, this step requires `protoc` to already be properly installed and available in the environment. I found that this is a bit awkward to express in the `protobuf` recipe and instead opted to make a separate package that uses the `protobuf` package as a `tool` in order to run `setup.py` and make the python library available using the `PYTHONPATH` env variable. 

The reason I care about the python support is that it is used by some `protobuf` plugins, including [nanopb](https://github.com/nanopb/nanopb) (an embedded-friendly C generator) in particular.

Another option is to make a `protobuf-ext` package that provides support for all extensions that already require `protoc`. In any case, I am creating this PR to facilitate discussion and provide to the repo if deemed useful.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
