### PR TITLE
[docs] Document label c3i-conan2-ready

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -39,6 +39,14 @@ For now, only [SEMVER](https://semver.org/#semantic-versioning-200) and `<MAJOR.
 
 If the pull request modifies anything else, the label won't be assigned, we need to be very careful about false positives.
 
+## C3I Conan2 Ready
+
+Label [`c3i-conan2-ready`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22c3i-conan2-ready%22)
+is assigned by the bot to pull-requests that are just adding a new package references which passed by Conan v2 and are not listed in `.c3i/conan_v2_ready_references.yml`.
+This is a regression test, in case package is working with Conan v2, it can not be merged in a future pull request in case of failure.
+
+> These pull-requests will be merged right away without requiring any approval (CI and CLA checks must have passed).
+
 ## Infrastructure
 
 Label [`infrastructure`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3Ainfrastructure) is

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -47,6 +47,8 @@ This is a regression test, in case package is working with Conan v2, it can not 
 
 > These pull-requests will be merged right away without requiring any approval (CI and CLA checks must have passed).
 
+Only team members can open a pull request with these changes.
+
 ## Infrastructure
 
 Label [`infrastructure`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3Ainfrastructure) is


### PR DESCRIPTION
This new label will be used by C3I to automerge changes in `.c3i/conan_v2_ready_references.yml` without reviewers.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
