### PR TITLE
paho-mqtt-c: bump openssl + modernize more for conan v2

### DIFF
--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -14,6 +14,7 @@ class PahoMqttcConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/eclipse/paho.mqtt.c"
     topics = ("mqtt", "iot", "eclipse", "ssl", "tls", "paho")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -55,14 +56,11 @@ class PahoMqttcConan(ConanFile):
 
     def requirements(self):
         if self.options.ssl:
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/1.1.1t")
 
     def validate(self):
         if not self.options.shared and Version(self.version) < "1.3.4":
             raise ConanInvalidConfiguration(f"{self.ref} does not support static linking")
-
-    def package_id(self):
-        del self.info.options.samples
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/paho-mqtt-c/all/test_package/conanfile.py
+++ b/recipes/paho-mqtt-c/all/test_package/conanfile.py
@@ -16,8 +16,8 @@ class TestPackageConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["PAHO_MQTT_C_ASYNC"] = self.options["paho-mqtt-c"].asynchronous
-        tc.variables["PAHO_MQTT_C_WITH_SSL"] = self.options["paho-mqtt-c"].ssl
+        tc.variables["PAHO_MQTT_C_ASYNC"] = self.dependencies["paho-mqtt-c"].options.asynchronous
+        tc.variables["PAHO_MQTT_C_WITH_SSL"] = self.dependencies["paho-mqtt-c"].options.ssl
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
this recipe fails with conan v2 client because it tries to delete an option which doesn't exist anymore (deprecated `samples` option removed in https://github.com/conan-io/conan-center-index/pull/15434 but this PR forgot to remove logic in package id):

```
ERROR: paho-mqtt-c/1.3.12: Error in package_id() method, line 65
	del self.info.options.samples
	KeyError: 'samples'
```

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
