### PR TITLE
qpdf: bump dependencies + modernize more for conan v2

### DIFF
--- a/recipes/qpdf/all/conanfile.py
+++ b/recipes/qpdf/all/conanfile.py
@@ -1,22 +1,23 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
-from conan.tools.files import replace_in_file, apply_conandata_patches, export_conandata_patches, get, copy, rmdir
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.microsoft import check_min_vs
 from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rmdir
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
 
-class PackageConan(ConanFile):
+
+class QpdfConan(ConanFile):
     name = "qpdf"
     description = "QPDF is a command-line tool and C++ library that performs content-preserving transformations on PDF files."
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/qpdf/qpdf"
-    topics = ("pdf")
+    topics = ("pdf",)
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -32,8 +33,8 @@ class PackageConan(ConanFile):
     }
 
     @property
-    def _minimum_cpp_standard(self):
-        return 14
+    def _min_cppstd(self):
+        return "14"
 
     @property
     def _compilers_minimum_version(self):
@@ -41,6 +42,8 @@ class PackageConan(ConanFile):
             "gcc": "5",
             "clang": "3.4",
             "apple-clang": "10",
+            "Visual Studio": "14",
+            "msvc": "190",
         }
 
     def export_sources(self):
@@ -61,33 +64,49 @@ class PackageConan(ConanFile):
         # https://qpdf.readthedocs.io/en/stable/installation.html#basic-dependencies
         self.requires("zlib/1.2.13")
         if self.options.with_ssl == "openssl":
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/1.1.1t")
         elif self.options.with_ssl == "gnutls":
             raise ConanInvalidConfiguration("GnuTLS is not available in Conan Center yet.")
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.1.4")
+            self.requires("libjpeg-turbo/2.1.5")
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.1")
 
-
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._minimum_cpp_standard)
-        check_min_vs(self, "150")
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support.")
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def _cmake_new_enough(self, required_version):
+        try:
+            import re
+            from io import StringIO
+            output = StringIO()
+            self.run("cmake --version", output)
+            m = re.search(r"cmake version (\d+\.\d+\.\d+)", output.getvalue())
+            return Version(m.group(1)) >= required_version
+        except:
+            return False
 
     def build_requirements(self):
-        self.tool_requires("cmake/3.24.1")
-        self.tool_requires("pkgconf/1.9.3")
+        if not self._cmake_new_enough("3.16"):
+            self.tool_requires("cmake/3.25.2")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/1.9.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        tc = VirtualBuildEnv(self)
+        tc.generate()
         tc = CMakeToolchain(self)
         tc.variables["BUILD_STATIC_LIBS"] = not self.options.shared
         # https://qpdf.readthedocs.io/en/latest/installation.html#build-time-crypto-selection
@@ -112,8 +131,6 @@ class PackageConan(ConanFile):
         # At the moment, even with the linked work-around, the linkage is mixed-up
         tc = CMakeDeps(self)
         tc.generate()
-        tc = VirtualBuildEnv(self)
-        tc.generate(scope="build")
 
     def _patch_sources(self):
         apply_conandata_patches(self)
@@ -153,13 +170,17 @@ class PackageConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "qpdf")
-
+        self.cpp_info.set_property("cmake_target_name", "qpdf::libqpdf")
+        self.cpp_info.set_property("pkg_config_name", "libqpdf")
+        # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["libqpdf"].libs = ["qpdf"]
-        self.cpp_info.components["libqpdf"].set_property("pkg_config_name", "libqpdf")
-        self.cpp_info.components["libqpdf"].set_property("cmake_target_name", "qpdf::libqpdf")
         self.cpp_info.components["libqpdf"].requires.append("zlib::zlib")
-        self.cpp_info.components["libqpdf"].requires.append(f"{self.options.with_jpeg}::{self.options.with_jpeg}")
-
+        if self.options.with_jpeg == "libjpeg":
+            self.cpp_info.components["libqpdf"].requires.append("libjpeg::libjpeg")
+        elif self.options.with_jpeg == "libjpeg-turbo":
+            self.cpp_info.components["libqpdf"].requires.append("libjpeg-turbo::jpeg")
+        elif self.options.with_jpeg == "mozjpeg":
+            self.cpp_info.components["libqpdf"].requires.append("mozjpeg::libjpeg")
         if self.options.with_ssl == "openssl":
             self.cpp_info.components["libqpdf"].requires.append("openssl::openssl")
 
@@ -167,9 +188,9 @@ class PackageConan(ConanFile):
             self.cpp_info.components["libqpdf"].system_libs.append("m")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "qpdf"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "qpdf"
         self.cpp_info.names["cmake_find_package"] = "qpdf"
         self.cpp_info.names["cmake_find_package_multi"] = "qpdf"
         self.cpp_info.components["libqpdf"].names["cmake_find_package"] = "libqpdf"
         self.cpp_info.components["libqpdf"].names["cmake_find_package_multi"] = "libqpdf"
+        self.cpp_info.components["libqpdf"].set_property("pkg_config_name", "libqpdf")
+        self.cpp_info.components["libqpdf"].set_property("cmake_target_name", "qpdf::libqpdf")

--- a/recipes/qpdf/all/conanfile.py
+++ b/recipes/qpdf/all/conanfile.py
@@ -97,7 +97,7 @@ class QpdfConan(ConanFile):
 
     def build_requirements(self):
         if not self._cmake_new_enough("3.16"):
-            self.tool_requires("cmake/3.25.2")
+            self.tool_requires("cmake/3.25.3")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/1.9.3")
 

--- a/recipes/qpdf/all/test_v1_package/CMakeLists.txt
+++ b/recipes/qpdf/all/test_v1_package/CMakeLists.txt
@@ -1,15 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-
-project(test_package CXX) 
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(qpdf REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE qpdf::libqpdf)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
-# msvc has problems consuming #warning macro
-# therefore we need a code-path in the include avoiding this warning https://github.com/qpdf/qpdf/issues/804
-target_compile_definitions(${PROJECT_NAME} PUBLIC POINTERHOLDER_TRANSITION=4)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/qpdf/all/test_v1_package/conanfile.py
+++ b/recipes/qpdf/all/test_v1_package/conanfile.py
@@ -1,9 +1,7 @@
-from conans import ConanFile, CMake
-from conan.tools.build import cross_building
+from conans import ConanFile, CMake, tools
 import os
 
 
-# legacy validation with Conan 1.x
 class TestPackageV1Conan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
@@ -14,6 +12,6 @@ class TestPackageV1Conan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- bump openssl
- add package_type
- Fix few issues:
  - build requirements to cmake 3.24.1 prevents build with conan v2 since the specific version has not been migrated
  - topics was not a tuple
  - there was an unwanted qpdf::qpdf target declared in CMakeDeps

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
