### PR TITLE
Fix CMake variable check in OpenSSL test

### DIFF
--- a/recipes/openssl/1.x.x/test_package/CMakeLists.txt
+++ b/recipes/openssl/1.x.x/test_package/CMakeLists.txt
@@ -19,7 +19,7 @@ set(_custom_vars
     OPENSSL_VERSION
 )
 foreach(_custom_var ${_custom_vars})
-    if(DEFINED _custom_var)
+    if(DEFINED ${_custom_var})
         message(STATUS "${_custom_var}: ${${_custom_var}}")
     else()
         message(FATAL_ERROR "${_custom_var} not defined")


### PR DESCRIPTION
Previously, the logic was checking if `_custom_var` was defined, which is clearly always true. Instead, we want to see if the variable referenced by `_custom_var` is defined.