### PR TITLE
Update MDSpan to Conan 2.0

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -46,7 +46,7 @@ tasks:
 
 configurations:
   - id: linux-gcc
-    epochs: [0, 20220628]
+    epochs: [0, 20211221, 20220120, 20220628]
     hrname: "Linux, GCC"
     build_profile:
       os: "Linux"
@@ -59,7 +59,7 @@ configurations:
               compiler.version: ["11"]
               build_type: ["Release"]
   - id: configs/macos-clang
-    epochs: [0, 20220628]
+    epochs: [0, 20211221, 20220120, 20220628]
     hrname: "macOS, Clang"
     build_profile:
       os: "Macos"
@@ -72,7 +72,7 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
   - id: configs/macos-m1-clang
-    epochs: [0, 20220628]
+    epochs: [0, 20211221, 20220120, 20220628]
     hrname: "macOS M1, Clang"
     build_profile:
       os: "Macos"
@@ -86,7 +86,7 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
   - id: configs/windows-msvc
-    epochs: [0, 20220628]
+    epochs: [0, 20211221, 20220120, 20220628]
     hrname: "Windows, MSVC"
     build_profile:
       os: "Windows"

--- a/recipes/mdspan/all/conanfile.py
+++ b/recipes/mdspan/all/conanfile.py
@@ -34,26 +34,33 @@ class MDSpanConan(ConanFile):
             "apple-clang": "5.1"
         }
 
+    @property
+    def _full_compiler_version(self):
+        compiler = self.settings.compiler
+        if compiler == "msvc":
+            if compiler.update:
+                return int(f"{compiler.version}{compiler.update}")
+            else:
+                return int(f"{compiler.version}0")
+        else:
+            return compiler.version
+
     def configure(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(
             str(self.settings.compiler))
         if not min_version:
-            self.output.warn("{} recipe lacks information about the {} "
-                             "compiler support.".format(
-                                 self.name, self.settings.compiler))
+            self.output.warn(f"{self.name} recipe lacks information about the "
+                             f"{self.settings.compiler} compiler support.")
         else:
             if Version(self.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration(
-                    "{} requires C++{} support. "
-                    "The current compiler {} {} does not support it.".format(
-                        self.name, self._minimum_cpp_standard,
-                        self.settings.compiler,
-                        self.settings.compiler.version))
+                    f"{self.name} requires C++{self._minimum_cpp_standard} support. "
+                    f"The current compiler {self._full_compiler_version} does not support it.")
 
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/mdspan/all/conanfile.py
+++ b/recipes/mdspan/all/conanfile.py
@@ -1,9 +1,12 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
 import os
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
 
-required_conan_version = ">=1.33.0"
-
+required_conan_version = ">=2.0.0"
 
 class MDSpanConan(ConanFile):
     name = "mdspan"
@@ -12,12 +15,11 @@ class MDSpanConan(ConanFile):
     topics = ("multi-dimensional", "array", "span")
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "compiler"
+    settings = "os", "arch", "compiler", "build_type"
+    package_type = "header-library"
     no_copy_source = True
+    generators = "CMakeToolchain", "CMakeDeps"
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
 
     @property
     def _minimum_cpp_standard(self):
@@ -34,7 +36,7 @@ class MDSpanConan(ConanFile):
 
     def configure(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, self._minimum_cpp_standard)
+            check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(
             str(self.settings.compiler))
         if not min_version:
@@ -42,7 +44,7 @@ class MDSpanConan(ConanFile):
                              "compiler support.".format(
                                  self.name, self.settings.compiler))
         else:
-            if tools.Version(self.settings.compiler.version) < min_version:
+            if Version(self.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration(
                     "{} requires C++{} support. "
                     "The current compiler {} {} does not support it.".format(
@@ -50,20 +52,19 @@ class MDSpanConan(ConanFile):
                         self.settings.compiler,
                         self.settings.compiler.version))
 
+    def layout(self):
+        cmake_layout(self)
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def package(self):
-        self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
-        self.copy("*LICENSE", dst="licenses", keep_path=False)
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "mdspan"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "mdspan"
-        self.cpp_info.names["cmake_find_package"] = "std"
-        self.cpp_info.names["cmake_find_package_multi"] = "std"
-        self.cpp_info.components["_mdspan"].names["cmake_find_package"] = "mdspan"
-        self.cpp_info.components["_mdspan"].names["cmake_find_package_multi"] = "mdspan"
+        self.cpp_info.set_property("cmake_file_name", "mdspan")
+        self.cpp_info.set_property("cmake_target_name", "std::mdspan")

--- a/recipes/mdspan/all/conanfile.py
+++ b/recipes/mdspan/all/conanfile.py
@@ -2,8 +2,8 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.cmake import cmake_layout
+from conan.tools.files import copy, get
 from conan.tools.scm import Version
 
 required_conan_version = ">=2.0.0"

--- a/recipes/mdspan/all/test_package/CMakeLists.txt
+++ b/recipes/mdspan/all/test_package/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(test_package CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
 find_package(mdspan REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/mdspan/all/test_package/conanfile.py
+++ b/recipes/mdspan/all/test_package/conanfile.py
@@ -1,16 +1,24 @@
-from conans import ConanFile, CMake, tools
 import os
-
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            self.run(os.path.join("bin", "test_package"), run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")


### PR DESCRIPTION
Specify library name and version:  **mdspan/0.1.0**

I'm updating this package to Conan 2.0.  This is a dependency of wg21-linear_algebra package (of which I am a maintainer) which is also being updated to Conan 2.0.
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
