### PR TITLE
catch2 2.x: fix package_type

### DIFF
--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -16,7 +16,6 @@ class Catch2Conan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     license = "BSL-1.0"
 
-    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],

--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -41,7 +41,6 @@ class Catch2Conan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        self.package_type = "static-library" if self.options.with_main else "header-library"
         if not self.options.with_main:
             self.options.rm_safe("fPIC")
             self.options.rm_safe("with_benchmark")

--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -41,6 +41,7 @@ class Catch2Conan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        self.package_type = "static-library" if self.options.with_main else "header-library"
         if not self.options.with_main:
             self.options.rm_safe("fPIC")
             self.options.rm_safe("with_benchmark")


### PR DESCRIPTION
catch2 2.x is header only, or static if with_main=True, there is no shared option.
`package_type = "library"` fails with conan v2 client when there is no shared option.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
