### PR TITLE
[readme] Add status page to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Conan Center Index is the source index of recipes of the [ConanCenter](https://c
 This repository includes a Continuous Integration system that will build automatically the Conan packages for the recipes submitted via
 [Pull Request](https://github.com/conan-io/conan-center-index/pulls).
 
+### Server Status
+
+The current Conan Center Index CI status can be found on https://status.conan.io/
+
+Any maintenance, outage or important event related to the CI will be informed there.
+
+
 ### Add ConanCenter remote
 
 ConanCenter remote is configured by default in any Conan client installation. If, for any reason, you need to add it manually, just execute:


### PR DESCRIPTION
Let's point the Status Page on README to give some centralized point.

Unfortunately, it does not generate a nice embed label, instead only javascript is provided, which can not be used. More info: https://support.atlassian.com/statuspage/docs/create-and-configure-the-recommended-status-embed/

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
