### PR TITLE
[lightgbm] Update version to 3.3.5 (#16409)

### DIFF
--- a/recipes/lightgbm/all/conandata.yml
+++ b/recipes/lightgbm/all/conandata.yml
@@ -2,9 +2,17 @@ sources:
   "3.3.2":
     url: "https://github.com/microsoft/LightGBM/archive/refs/tags/v3.3.2.tar.gz"
     sha256: "d7c0f842e94165578d5a0c046ca942838d1574149f98c84400ce511239d17b9f"
+  "3.3.5":
+    url: "https://github.com/microsoft/LightGBM/archive/refs/tags/v3.3.5.tar.gz"
+    sha256: "16fb9e299ced37be5ac69dd510e7323337e623019c9c578628c43b285f764be7"
 patches:
   "3.3.2":
     - patch_file: "patches/0001-fix-includes.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-fix-openmp-clang.patch"
+      base_path: "source_subfolder"
+  "3.3.5":
+    - patch_file: "patches/0001-fix-includes.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-fix-openmp-clang.patch"
       base_path: "source_subfolder"

--- a/recipes/lightgbm/all/patches/0003-fix-openmp-clang.patch
+++ b/recipes/lightgbm/all/patches/0003-fix-openmp-clang.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 95610d55..2b48507d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -444,7 +444,7 @@ if(USE_MPI)
+ endif(USE_MPI)
+ 
+ if(USE_OPENMP)
+-    if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
++    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+         TARGET_LINK_LIBRARIES(lightgbm OpenMP::OpenMP_CXX)
+         TARGET_LINK_LIBRARIES(_lightgbm OpenMP::OpenMP_CXX)
+     endif()

--- a/recipes/lightgbm/config.yml
+++ b/recipes/lightgbm/config.yml
@@ -1,3 +1,5 @@
 versions:
   "3.3.2":
     folder: all
+  "3.3.5":
+    folder: all


### PR DESCRIPTION
lightgbm/3.3.5

Updated to version 3.3.5, fixed patch 0002-fix-openmp-clang.patch

Closes #16409
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
