### PR TITLE
libwebsockets: add support for LWS_MAX_SMP and bump OpenSSL version

### DIFF
--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -230,7 +230,7 @@ class LibwebsocketsConan(ConanFile):
             self.requires("sqlite3/3.37.2")
 
         if self.options.with_ssl == "openssl":
-            self.requires("openssl/1.1.1o")
+            self.requires("openssl/1.1.1t")
         elif self.options.with_ssl == "mbedtls":
             self.requires("mbedtls/2.25.0")
         elif self.options.with_ssl == "wolfssl":

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -25,6 +25,7 @@ class LibwebsocketsConan(ConanFile):
         "with_sqlite3": [True, False],
         "with_libmount": [True, False],
         "with_hubbub": [True, False],
+        "with_max_smp": [1, 16, 32],                                            # Set DLWS_MAX_SMP > 1 for multithreading support
         "ssl_client_use_os_ca_certs": [True, False],                            # SSL support should make use of the OS-installed CA root certs
         "ssl_server_with_ecdh_cert": [True, False],                             # Include SSL server use ECDH certificate
 
@@ -109,6 +110,7 @@ class LibwebsocketsConan(ConanFile):
         "with_sqlite3": False,
         "with_libmount": False,
         "with_hubbub": False,
+        "with_max_smp": 1,
 
         "ssl_client_use_os_ca_certs": True,
         "ssl_server_with_ecdh_cert": False,
@@ -355,6 +357,7 @@ class LibwebsocketsConan(ConanFile):
             self._cmake.definitions["LWS_LIBMOUNT_INCLUDE_DIRS"] = self._cmakify_path_list(self.deps_cpp_info["libmount"].include_paths)
 
         self._cmake.definitions["LWS_WITH_HUBBUB"] = self.options.with_hubbub
+        self._cmake.definitions["LWS_MAX_SMP"] = self.options.with_max_smp
 
         self._cmake.definitions["LWS_SSL_CLIENT_USE_OS_CA_CERTS"] = self.options.ssl_client_use_os_ca_certs
         self._cmake.definitions["LWS_SSL_SERVER_WITH_ECDH_CERT"] = self.options.ssl_server_with_ecdh_cert


### PR DESCRIPTION
Specify library name and version:  **libwebsockets/4.x.x**

Bumps OpenSSL version to 1.1.1t, and adds support to specify `LWS_MAX_SMP`. Recipe is still pre-2.0.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
