### PR TITLE
bzip2: add package_type + fix check of custom CMake variables in test package

### DIFF
--- a/recipes/bzip2/all/conanfile.py
+++ b/recipes/bzip2/all/conanfile.py
@@ -72,21 +72,19 @@ class Bzip2Conan(ConanFile):
         )
 
     def _create_cmake_module_variables(self, module_file):
-        content = textwrap.dedent("""\
+        content = textwrap.dedent(f"""\
             set(BZIP2_NEED_PREFIX TRUE)
             set(BZIP2_FOUND TRUE)
             if(NOT DEFINED BZIP2_INCLUDE_DIRS AND DEFINED BZip2_INCLUDE_DIRS)
-                set(BZIP2_INCLUDE_DIRS ${BZip2_INCLUDE_DIRS})
+                set(BZIP2_INCLUDE_DIRS ${{BZip2_INCLUDE_DIRS}})
             endif()
             if(NOT DEFINED BZIP2_INCLUDE_DIR AND DEFINED BZip2_INCLUDE_DIR)
-                set(BZIP2_INCLUDE_DIR ${BZip2_INCLUDE_DIR})
+                set(BZIP2_INCLUDE_DIR ${{BZip2_INCLUDE_DIR}})
             endif()
             if(NOT DEFINED BZIP2_LIBRARIES AND DEFINED BZip2_LIBRARIES)
-                set(BZIP2_LIBRARIES ${BZip2_LIBRARIES})
+                set(BZIP2_LIBRARIES ${{BZip2_LIBRARIES}})
             endif()
-            if(NOT DEFINED BZIP2_VERSION_STRING AND DEFINED BZip2_VERSION)
-                set(BZIP2_VERSION_STRING ${BZip2_VERSION})
-            endif()
+            set(BZIP2_VERSION_STRING "{self.version}")
         """)
         save(self, module_file, content)
 

--- a/recipes/bzip2/all/conanfile.py
+++ b/recipes/bzip2/all/conanfile.py
@@ -15,6 +15,7 @@ class Bzip2Conan(ConanFile):
     license = "bzip2-1.0.8"
     description = "bzip2 is a free and open-source file compression program that uses the Burrows Wheeler algorithm."
     topics = ("data-compressor", "file-compression")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -46,8 +47,7 @@ class Bzip2Conan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/bzip2/all/test_package/CMakeLists.txt
+++ b/recipes/bzip2/all/test_package/CMakeLists.txt
@@ -16,7 +16,7 @@ set(_custom_vars
     BZIP2_VERSION_STRING
 )
 foreach(_custom_var ${_custom_vars})
-    if(DEFINED _custom_var)
+    if(DEFINED ${_custom_var})
         message(STATUS "${_custom_var}: ${${_custom_var}}")
     else()
         message(FATAL_ERROR "${_custom_var} not defined")


### PR DESCRIPTION
same fix than https://github.com/conan-io/conan-center-index/pull/16389#issue-1610015353, but for test package of bzip2.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
