### PR TITLE
expat: add package_type + fix check of custom CMake variables in test package

### DIFF
--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -14,6 +14,7 @@ class ExpatConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libexpat/libexpat"
     topics = ("xml", "parsing")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -43,7 +44,7 @@ class ExpatConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/expat/all/test_package_module/CMakeLists.txt
+++ b/recipes/expat/all/test_package_module/CMakeLists.txt
@@ -14,7 +14,7 @@ set(_custom_vars
     EXPAT_FOUND
 )
 foreach(_custom_var ${_custom_vars})
-    if(DEFINED _custom_var)
+    if(DEFINED ${_custom_var})
         message(STATUS "${_custom_var}: ${${_custom_var}}")
     else()
         message(FATAL_ERROR "${_custom_var} not defined")


### PR DESCRIPTION
same fix than https://github.com/conan-io/conan-center-index/pull/16389#issue-1610015353, but for test package of expat.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
