### PR TITLE
freetype: add package_type + fix check of custom CMake variables in test package

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -19,7 +19,7 @@ class FreetypeConan(ConanFile):
     homepage = "https://www.freetype.org"
     license = "FTL"
     topics = ("freetype", "fonts")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -37,7 +37,7 @@ class FreetypeConan(ConanFile):
         "with_zlib": True,
         "with_bzip2": True,
         "with_brotli": True,
-        "subpixel": False
+        "subpixel": False,
     }
 
     @property

--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -203,17 +203,15 @@ class FreetypeConan(ConanFile):
         )
 
     def _create_cmake_module_variables(self, module_file):
-        content = textwrap.dedent("""\
+        content = textwrap.dedent(f"""\
             set(FREETYPE_FOUND TRUE)
             if(DEFINED Freetype_INCLUDE_DIRS)
-                set(FREETYPE_INCLUDE_DIRS ${Freetype_INCLUDE_DIRS})
+                set(FREETYPE_INCLUDE_DIRS ${{Freetype_INCLUDE_DIRS}})
             endif()
             if(DEFINED Freetype_LIBRARIES)
-                set(FREETYPE_LIBRARIES ${Freetype_LIBRARIES})
+                set(FREETYPE_LIBRARIES ${{Freetype_LIBRARIES}})
             endif()
-            if(DEFINED Freetype_VERSION)
-                set(FREETYPE_VERSION_STRING ${Freetype_VERSION})
-            endif()
+            set(FREETYPE_VERSION_STRING "{self.version}")
         """)
         save(self, module_file, content)
 

--- a/recipes/freetype/all/test_package_module/CMakeLists.txt
+++ b/recipes/freetype/all/test_package_module/CMakeLists.txt
@@ -15,7 +15,7 @@ set(_custom_vars
     FREETYPE_VERSION_STRING
 )
 foreach(_custom_var ${_custom_vars})
-    if(DEFINED _custom_var)
+    if(DEFINED ${_custom_var})
         message(STATUS "${_custom_var}: ${${_custom_var}}")
     else()
         message(FATAL_ERROR "${_custom_var} not defined")


### PR DESCRIPTION
same fix than https://github.com/conan-io/conan-center-index/pull/16389#issue-1610015353, but for test package of freetype.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
