### PR TITLE
cmake: make openssl requirement invisible

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -38,7 +38,7 @@ class CMakeConan(ConanFile):
 
     def requirements(self):
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1t")
+            self.requires("openssl/1.1.1t", visible=False)
 
     def validate_build(self):
         if self.settings.os == "Windows" and self.options.bootstrap:


### PR DESCRIPTION
Specify library name and version:  **cmake/***

currently, openssl is in the dependency graph, so it can conflict. also it prevents re-use of a cmake executable with a different compiler:
`conan install --tool-requires cmake/3.25.2@ -g VirtualBuildEnv`
```
======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=12
os=Linux

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=12
os=Linux


======== Computing dependency graph ========
cmake/3.25.2: Not found in local cache, looking in remotes...
cmake/3.25.2: Checking remote: conancenter
Decompressing conan_export.tgz
cmake/3.25.2: Downloaded recipe revision 1e43a83edba41c63a6d14e02baf20134
openssl/1.1.1t: Not found in local cache, looking in remotes...
openssl/1.1.1t: Checking remote: conancenter
Decompressing conan_export.tgz
openssl/1.1.1t: Downloaded recipe revision 1e58dd56a2a930f23160558c572a62fd
Graph root
    cli
Build requirements
    cmake/3.25.2#1e43a83edba41c63a6d14e02baf20134 - Downloaded (conancenter)
    openssl/1.1.1t#1e58dd56a2a930f23160558c572a62fd - Downloaded (conancenter)

======== Computing necessary packages ========
cmake/3.25.2: Compatible package ID 1484131419ae0ff38fff53ce472b1c7579509be3 equal to the default package ID
Build requirements
    cmake/3.25.2#1e43a83edba41c63a6d14e02baf20134:1484131419ae0ff38fff53ce472b1c7579509be3 - Missing
    openssl/1.1.1t#1e58dd56a2a930f23160558c572a62fd:3dbf44d5043a2124b7b7670dedfd65ce721f96a2 - Skip

======== Installing packages ========
ERROR: Missing binary: cmake/3.25.2:1484131419ae0ff38fff53ce472b1c7579509be3

cmake/3.25.2: WARN: Can't find a 'cmake/3.25.2' package binary '1484131419ae0ff38fff53ce472b1c7579509be3' for the configuration:
[settings]
arch=x86_64
build_type=Release
os=Linux
[options]
with_openssl=True
[requires]
openssl/1.1.1t#1e58dd56a2a930f23160558c572a62fd:3dbf44d5043a2124b7b7670dedfd65ce721f96a2

ERROR: Missing prebuilt package for 'cmake/3.25.2'
Check the available packages using 'conan list cmake/3.25.2:* -r=remote'
or try to build locally from sources using the '--build=cmake/3.25.2' argument

More Info at 'https://docs.conan.io/2/knowledge/faq.html#error-missing-prebuilt-package'
```


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
