### PR TITLE
backward-cpp: expose transitive dependencies

### DIFF
--- a/recipes/backward-cpp/all/conanfile.py
+++ b/recipes/backward-cpp/all/conanfile.py
@@ -66,11 +66,11 @@ class BackwardCppConan(ConanFile):
     def requirements(self):
         if self.settings.os in ["Linux", "Android"]:
             if self._has_stack_details("dwarf"):
-                self.requires("libdwarf/20191104")
+                self.requires("libdwarf/20191104", transitive_headers=True, transitive_libs=True)
             if self._has_stack_details("dw"):
-                self.requires("elfutils/0.186")
+                self.requires("elfutils/0.186", transitive_headers=True, transitive_libs=True)
             if self._has_stack_details("bfd"):
-                self.requires("binutils/2.38")
+                self.requires("binutils/2.38", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.os not in self._supported_os:


### PR DESCRIPTION
Specify library name and version:  **backward-cpp/1.6**

These are transitive dependencies needed to build this package. If you include the header without this change, you get errors about it not finding the libraries this links to. Also, even if you don't have the header you want to expose the libraries as transitive dependencies because they are essential for how this library creates backtraces.

I've tested this locally using conan 2. There is still a remaining issue I'm experiencing when trying to use this package: I can't get it to print with debug info. I will continue to dig into that, but that it is unrelated to this fix.

@prince-chrismc thank you for the help over on cppslack. Let me know if there is anything I need to change about this PR.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
