### PR TITLE
fix layout for editable mode

### DIFF
--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -61,7 +61,9 @@ class FmtConan(ConanFile):
             basic_layout(self, src_folder="src")
         else:
             cmake_layout(self, src_folder="src")
-
+            self.cpp.source.components["_fmt"].includedirs = self.cpp.source.includedirs
+            self.cpp.build.components["_fmt"].bindirs = self.cpp.build.bindirs
+            self.cpp.build.components["_fmt"].libdirs = self.cpp.build.libdirs
     def package_id(self):
         if self.info.options.header_only:
             self.info.clear()


### PR DESCRIPTION
**fmt/9.1.0**

This pull request will fix the fmt layout. With this fix the package can be consumed in the editable mode,


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
