### PR TITLE
mpdecimal: support conan v2

### DIFF
--- a/recipes/mpdecimal/2.5.x/conandata.yml
+++ b/recipes/mpdecimal/2.5.x/conandata.yml
@@ -7,14 +7,14 @@ sources:
     url: "http://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.0.tar.gz"
 patches:
   "2.5.1":
-    - base_path: "."
+    - base_path: "./"
       patch_file: "patches/2.5.1-0001-msvc-fixes.patch"
-    - base_path: "."
+    - base_path: "./"
       patch_file: "patches/2.5.1-0002-add-mingw-to-configure-ac.patch"
-    - base_path: "."
+    - base_path: "./"
       patch_file: "patches/2.5.1-0003-use-MPDECIMAL_DLL.patch"
   "2.5.0":
-    - base_path: "."
+    - base_path: "./"
       patch_file: "patches/0001-2.5.0-msvc-fixes.patch"
-    - base_path: "."
+    - base_path: "./"
       patch_file: "patches/0002-add-mingw-to-configure-ac.patch"

--- a/recipes/mpdecimal/2.5.x/conandata.yml
+++ b/recipes/mpdecimal/2.5.x/conandata.yml
@@ -7,14 +7,9 @@ sources:
     url: "http://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.0.tar.gz"
 patches:
   "2.5.1":
-    - base_path: "./"
-      patch_file: "patches/2.5.1-0001-msvc-fixes.patch"
-    - base_path: "./"
-      patch_file: "patches/2.5.1-0002-add-mingw-to-configure-ac.patch"
-    - base_path: "./"
-      patch_file: "patches/2.5.1-0003-use-MPDECIMAL_DLL.patch"
+    - patch_file: "patches/2.5.1-0001-msvc-fixes.patch"
+    - patch_file: "patches/2.5.1-0002-add-mingw-to-configure-ac.patch"
+    - patch_file: "patches/2.5.1-0003-use-MPDECIMAL_DLL.patch"
   "2.5.0":
-    - base_path: "./"
-      patch_file: "patches/0001-2.5.0-msvc-fixes.patch"
-    - base_path: "./"
-      patch_file: "patches/0002-add-mingw-to-configure-ac.patch"
+    - patch_file: "patches/0001-2.5.0-msvc-fixes.patch"
+    - patch_file: "patches/0002-add-mingw-to-configure-ac.patch"

--- a/recipes/mpdecimal/2.5.x/conandata.yml
+++ b/recipes/mpdecimal/2.5.x/conandata.yml
@@ -7,14 +7,14 @@ sources:
     url: "http://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.0.tar.gz"
 patches:
   "2.5.1":
-    - base_path: "source_subfolder"
+    - base_path: "."
       patch_file: "patches/2.5.1-0001-msvc-fixes.patch"
-    - base_path: "source_subfolder"
+    - base_path: "."
       patch_file: "patches/2.5.1-0002-add-mingw-to-configure-ac.patch"
-    - base_path: "source_subfolder"
+    - base_path: "."
       patch_file: "patches/2.5.1-0003-use-MPDECIMAL_DLL.patch"
   "2.5.0":
-    - base_path: "source_subfolder"
+    - base_path: "."
       patch_file: "patches/0001-2.5.0-msvc-fixes.patch"
-    - base_path: "source_subfolder"
+    - base_path: "."
       patch_file: "patches/0002-add-mingw-to-configure-ac.patch"

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -10,7 +10,7 @@ from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 import pathlib
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.55.0"
 
 
 class MpdecimalConan(ConanFile):
@@ -47,7 +47,6 @@ class MpdecimalConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
         if not self.options.cxx:
-            # for plain C projects only
             self.settings.rm_safe("compiler.libcxx")
             self.settings.rm_safe("compiler.cppstd")
 
@@ -225,12 +224,11 @@ class MpdecimalConan(ConanFile):
                 lib_pre_suf = ("", ".dll")
 
         self.cpp_info.components["libmpdecimal"].libs = ["{}mpdec{}".format(*lib_pre_suf)]
-        if self.options.shared:
-            if is_msvc(self):
-                if Version(self.version) >= "2.5.1":
-                    self.cpp_info.components["libmpdecimal"].defines = ["MPDECIMAL_DLL"]
-                else:
-                    self.cpp_info.components["libmpdecimal"].defines = ["USE_DLL"]
+        if self.options.shared and is_msvc(self):
+            if Version(self.version) >= "2.5.1":
+                self.cpp_info.components["libmpdecimal"].defines = ["MPDECIMAL_DLL"]
+            else:
+                self.cpp_info.components["libmpdecimal"].defines = ["USE_DLL"]
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libmpdecimal"].system_libs = ["m"]
@@ -240,6 +238,5 @@ class MpdecimalConan(ConanFile):
             self.cpp_info.components["libmpdecimal++"].requires = ["libmpdecimal"]
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["libmpdecimal++"].system_libs = ["pthread"]
-            if self.options.shared:
-                if Version(self.version) >= "2.5.1":
-                    self.cpp_info.components["libmpdecimal"].defines = ["MPDECIMALXX_DLL"]
+            if self.options.shared and Version(self.version) >= "2.5.1":
+                self.cpp_info.components["libmpdecimal"].defines = ["MPDECIMALXX_DLL"]

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.gnu import AutotoolsToolchain, AutotoolsDeps, Autotools
-from conan.tools.files import get, chdir, load, copy, export_conandata_patches, apply_conandata_patches, mkdir, rename
+from conan.tools.files import get, chdir, copy, export_conandata_patches, apply_conandata_patches, mkdir, rename
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import VCVars, is_msvc, NMakeDeps, NMakeToolchain
 from conan.tools.apple import is_apple_os

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -56,7 +56,8 @@ class MpdecimalConan(ConanFile):
 
     def validate(self):
         if is_msvc(self) and self.settings.arch not in ("x86", "x86_64"):
-            raise ConanInvalidConfiguration("Arch is unsupported")
+            raise ConanInvalidConfiguration(
+                f"{self.ref} currently does not supported {self.settings.arch}. Contributions are welcomed")
         if self.options.cxx:
             if self.options.shared and self.settings.os == "Windows":
                 raise ConanInvalidConfiguration(

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -186,8 +186,8 @@ class MpdecimalConan(ConanFile):
             copy(self, "*.h", src=distfolder, dst= pkg_dir/ "include")
             if self.options.cxx:
                 copy(self, "*.hh", src=distfolder, dst=pkg_dir / "include")
-            self.copy(self, "*.lib", src=distfolder, dst=pkg_dir / "lib")
-            self.copy(self, "*.dll", src=distfolder, dst=pkg_dir / "bin")
+            copy(self, "*.lib", src=distfolder, dst=pkg_dir / "lib")
+            copy(self, "*.dll", src=distfolder, dst=pkg_dir / "bin")
         else:
             src_dir = pathlib.Path(self._source_subfolder)
             mpdecdir = src_dir /  "libmpdec"

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -160,7 +160,6 @@ class MpdecimalConan(ConanFile):
             self._build_msvc()
         else:
             with tools.chdir(self._source_subfolder):
-                self.run("autoreconf -fiv", win_bash=tools.os_info.is_windows)
                 autotools = self._configure_autotools()
                 self.output.info(tools.load(os.path.join("libmpdec", "Makefile")))
                 libmpdec, libmpdecpp = self._target_names

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -231,13 +231,15 @@ class MpdecimalConan(ConanFile):
                     self.cpp_info.components["libmpdecimal"].defines = ["MPDECIMAL_DLL"]
                 else:
                     self.cpp_info.components["libmpdecimal"].defines = ["USE_DLL"]
-        else:
-            if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.components["libmpdecimal"].system_libs = ["m"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["libmpdecimal"].system_libs = ["m"]
 
         if self.options.cxx:
             self.cpp_info.components["libmpdecimal++"].libs = ["{}mpdec++{}".format(*lib_pre_suf)]
             self.cpp_info.components["libmpdecimal++"].requires = ["libmpdecimal"]
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.components["libmpdecimal++"].system_libs = ["pthread"]
             if self.options.shared:
                 if Version(self.version) >= "2.5.1":
                     self.cpp_info.components["libmpdecimal"].defines = ["MPDECIMALXX_DLL"]

--- a/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
+++ b/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
@@ -1,19 +1,18 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package)
 
-# Workaround for -rpath on arm64: https://cmake.org/cmake/help/latest/release/3.20.html#id2
-if(CMAKE_VERSION VERSION_LESS "3.20.1" AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
-    set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
-endif()
+enable_testing()
 
 # This is a non-official mpdecimal module!
 find_package(mpdecimal REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE mpdecimal::libmpdecimal)
+add_test(NAME test_package COMMAND test_package 10 13)
 
 if(MPDECIMAL_CXX)
     add_executable(${PROJECT_NAME}_cpp test_package.cpp)
     set_propertY(TARGET ${PROJECT_NAME}_cpp PROPERTY CXX_STANDARD 11)
     target_link_libraries(${PROJECT_NAME}_cpp PRIVATE mpdecimal::libmpdecimal++)
+    add_test(NAME test_package_cpp COMMAND test_package_cpp 10 13)
 endif()

--- a/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
+++ b/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup(TARGETS)
-
 # Workaround for -rpath on arm64: https://cmake.org/cmake/help/latest/release/3.20.html#id2
 if(CMAKE_VERSION VERSION_LESS "3.20.1" AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
     set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")

--- a/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
+++ b/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(mpdecimal REQUIRED)
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE mpdecimal::libmpdecimal)
 
-if(MPDECIMAL_CXX    )
+if(MPDECIMAL_CXX)
     add_executable(${PROJECT_NAME}_cpp test_package.cpp)
     set_propertY(TARGET ${PROJECT_NAME}_cpp PROPERTY CXX_STANDARD 11)
     target_link_libraries(${PROJECT_NAME}_cpp PRIVATE mpdecimal::libmpdecimal++)

--- a/recipes/mpdecimal/2.5.x/test_package/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/test_package/conanfile.py
@@ -1,8 +1,6 @@
-import os
-import pathlib
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
-from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.build import can_run, build_jobs
 
 
 class TestPackageConan(ConanFile):
@@ -17,7 +15,6 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def generate(self):
-
         tc = CMakeToolchain(self)
         tc.variables["MPDECIMAL_CXX"] = self.dependencies["mpdecimal"].options.cxx
         tc.generate()
@@ -29,5 +26,4 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            with chdir(self, self.build_folder):
-                self.run(f"ctest --output-on-failure -C {self.settings.build_type} -j {build_jobs(self)}", env="conanrun")
+            self.run(f"ctest --output-on-failure -C {self.settings.build_type} -j {build_jobs(self)}", env="conanrun")

--- a/recipes/mpdecimal/2.5.x/test_package/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/test_package/conanfile.py
@@ -17,10 +17,8 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def generate(self):
-        build_type = self.settings.build_type.value
         tc = CMakeToolchain(self)
         tc.variables["MPDECIMAL_CXX"] = self.dependencies["mpdecimal"].options.cxx
-        tc.variables[f"CMAKE_RUNTIME_OUTPUT_DIRECTORY_{build_type.upper()}"] = "bin"
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -33,8 +31,10 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = pathlib.Path(self.cpp.build.bindirs[0], "bin", "test_package")
+            bin_ext = ".exe" if self.settings.os == "Windows" else ""
+            bin_path = pathlib.Path(self.cpp.build.bindirs[0], f"test_package{bin_ext}")
             self.run("{} 13 100".format(bin_path), env="conanrun")
-            if self.options["mpdecimal"].cxx:
-                bin_path = pathlib.Path(self.cpp.build.bindirs[0], "bin", "test_package_cpp")
+            if self.dependencies["mpdecimal"].options.cxx:
+                bin_ext = ".exe" if self.settings.os == "Windows" else ""
+                bin_path = pathlib.Path(self.cpp.build.bindirs[0], f"test_package_cpp{bin_ext}")
                 self.run("{} 13 100".format(bin_path), env="conanrun")

--- a/recipes/mpdecimal/2.5.x/test_package/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/test_package/conanfile.py
@@ -1,19 +1,27 @@
-import os
-from conans import ConanFile, CMake, tools
+import pathlib
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.build import cross_building
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "CMakeDeps"
+
+    def generate(self):
+        build_type = self.settings.build_type.value
+        tc = CMakeToolchain(self)
+        tc.variables["MPDECIMAL_CXX"] = self.options["mpdecimal"].cxx
+        tc.variables[f"CMAKE_RUNTIME_OUTPUT_DIRECTORY_{build_type.upper()}"] = "bin"
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["MPDECIMAL_CXX"] = self.options["mpdecimal"].cxx
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            self.run("{} 13 100".format(os.path.join("bin", "test_package")), run_environment=True)
+        if not cross_building(self):
+            self.run("{} 13 100".format(pathlib.Path("bin", "test_package")), run_environment=True)
             if self.options["mpdecimal"].cxx:
-                self.run("{} 13 100".format(os.path.join("bin", "test_package_cpp")), run_environment=True)
+                self.run("{} 13 100".format(pathlib.Path("bin", "test_package_cpp")), run_environment=True)

--- a/recipes/mpdecimal/2.5.x/test_v1_package/CMakeLists.txt
+++ b/recipes/mpdecimal/2.5.x/test_v1_package/CMakeLists.txt
@@ -1,22 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_v1_package)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+enable_testing()
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-# Workaround for -rpath on arm64: https://cmake.org/cmake/help/latest/release/3.20.html#id2
-if(CMAKE_VERSION VERSION_LESS "3.20.1" AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
-    set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
-endif()
-
-# This is a non-official mpdecimal module!
-find_package(mpdecimal REQUIRED)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE mpdecimal::libmpdecimal)
-
-if(MPDECIMAL_CXX    )
-    add_executable(${PROJECT_NAME}_cpp ../test_package/test_package.cpp)
-    set_propertY(TARGET ${PROJECT_NAME}_cpp PROPERTY CXX_STANDARD 11)
-    target_link_libraries(${PROJECT_NAME}_cpp PRIVATE mpdecimal::libmpdecimal++)
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/mpdecimal/2.5.x/test_v1_package/CMakeLists.txt
+++ b/recipes/mpdecimal/2.5.x/test_v1_package/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup(TARGETS)
+
+# Workaround for -rpath on arm64: https://cmake.org/cmake/help/latest/release/3.20.html#id2
+if(CMAKE_VERSION VERSION_LESS "3.20.1" AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+    set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
+endif()
+
+# This is a non-official mpdecimal module!
+find_package(mpdecimal REQUIRED)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE mpdecimal::libmpdecimal)
+
+if(MPDECIMAL_CXX    )
+    add_executable(${PROJECT_NAME}_cpp ../test_package/test_package.cpp)
+    set_propertY(TARGET ${PROJECT_NAME}_cpp PROPERTY CXX_STANDARD 11)
+    target_link_libraries(${PROJECT_NAME}_cpp PRIVATE mpdecimal::libmpdecimal++)
+endif()

--- a/recipes/mpdecimal/2.5.x/test_v1_package/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/test_v1_package/conanfile.py
@@ -14,6 +14,4 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            self.run("{} 13 100".format(os.path.join("bin", "test_package")), run_environment=True)
-            if self.options["mpdecimal"].cxx:
-                self.run("{} 13 100".format(os.path.join("bin", "test_package_cpp")), run_environment=True)
+            self.run(f"ctest --output-on-failure -C {self.settings.build_type} -j {tools.cpu_count()}", run_environment=True)

--- a/recipes/mpdecimal/2.5.x/test_v1_package/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/test_v1_package/conanfile.py
@@ -14,4 +14,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            self.run(f"ctest --output-on-failure -C {self.settings.build_type} -j {tools.cpu_count()}", run_environment=True)
+            self.run(f"ctest --output-on-failure -C {self.settings.build_type} -j {tools.cpu_count()}",
+                     run_environment=True)

--- a/recipes/mpdecimal/2.5.x/test_v1_package/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.definitions["MPDECIMAL_CXX"] = self.options["mpdecimal"].cxx
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run("{} 13 100".format(os.path.join("bin", "test_package")), run_environment=True)
+            if self.options["mpdecimal"].cxx:
+                self.run("{} 13 100".format(os.path.join("bin", "test_package_cpp")), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **mpdecimal/2.5.x**

The recipe required system autconf for a single invocation of autoreconf. I could reason out that so I removed that line, and the recipe seems to work without any problems. It could be remnants of past but on the other hand it could be for a specific corner case which I am not aware of.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
