### PR TITLE
CMake: Refactor recipe to download official binaries

### DIFF
--- a/recipes/cmake/binary/conandata.yml
+++ b/recipes/cmake/binary/conandata.yml
@@ -1,0 +1,121 @@
+sources:
+  "3.20.6":
+    Linux:
+      armv8:
+        "sha256": 9ac2035174d3c62827c85fb052372d70cf35fb565e8d47b8241fbe451c29b2f2
+        "url": https://cmake.org/files/v3.20/cmake-3.20.6-linux-aarch64.tar.gz
+      x86_64:
+        "sha256": 458777097903b0f35a0452266b923f0a2f5b62fe331e636e2dcc4b636b768e36
+        "url": https://cmake.org/files/v3.20/cmake-3.20.6-linux-x86_64.tar.gz
+    Macos:
+      armv8:
+        "sha256": bc75cfbcbd95851d2e712c884de80814d7a7939441612af0ae6c5ccc2d94929f
+        "url": https://cmake.org/files/v3.20/cmake-3.20.6-macos-universal.tar.gz
+      x86_64:
+        "sha256": bc75cfbcbd95851d2e712c884de80814d7a7939441612af0ae6c5ccc2d94929f
+        "url": https://cmake.org/files/v3.20/cmake-3.20.6-macos-universal.tar.gz
+    Windows:
+      x86_64:
+        "sha256": f240a38c964712aac474644b3ba21bdc2b4e8d5e31179f67bd2e6f45fa349419
+        "url": https://cmake.org/files/v3.20/cmake-3.20.6-windows-x86_64.zip
+  "3.21.7":
+    Linux:
+      armv8:
+        "sha256": fa7e82170391c71dcc958ff57a63e9d6be9742a8b85a8b1386da9e571980474a
+        "url": https://cmake.org/files/v3.21/cmake-3.21.7-linux-aarch64.tar.gz
+      x86_64:
+        "sha256": f84e209d903a96e54f398bb8760693969b13fc50bce2f8278a9ee9dca01406b2
+        "url": https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz
+    Macos:
+      armv8:
+        "sha256": 3c968c5877a99a801ea30ff3edd3f5a42e10fb715bef295ba611e62c50a2e87c
+        "url": https://cmake.org/files/v3.21/cmake-3.21.7-macos-universal.tar.gz
+      x86_64:
+        "sha256": 3c968c5877a99a801ea30ff3edd3f5a42e10fb715bef295ba611e62c50a2e87c
+        "url": https://cmake.org/files/v3.21/cmake-3.21.7-macos-universal.tar.gz
+    Windows:
+      x86_64:
+        "sha256": 4c4840e2dc2bf82e8a16081ff506bba54f3a228b91ce36317129fed4035ef2e3
+        "url": https://cmake.org/files/v3.21/cmake-3.21.7-windows-x86_64.zip
+  "3.22.6":
+    Linux:
+      armv8:
+        "sha256": 79be85d3e76565faacd60695cee11d030f7e7dd8691476144fa25eb93dbd0397
+        "url": https://cmake.org/files/v3.22/cmake-3.22.6-linux-aarch64.tar.gz
+      x86_64:
+        "sha256": 09e1b34026c406c5bf4d1b053eadb3a8519cb360e37547ebf4b70ab766d94fbc
+        "url": https://cmake.org/files/v3.22/cmake-3.22.6-linux-x86_64.tar.gz
+    Macos:
+      armv8:
+        "sha256": b4569e10b0f86ed4fad23aae879a197de6fb14aca057bfc2e3baf236c3e876c5
+        "url": https://cmake.org/files/v3.22/cmake-3.22.6-macos-universal.tar.gz
+      x86_64:
+        "sha256": b4569e10b0f86ed4fad23aae879a197de6fb14aca057bfc2e3baf236c3e876c5
+        "url": https://cmake.org/files/v3.22/cmake-3.22.6-macos-universal.tar.gz
+    Windows:
+      x86_64:
+        "sha256": 48bcc3e71e918b72e2682f9ca9d44dd6c416379071c1ecb530d0633374f91f15
+        "url": https://cmake.org/files/v3.22/cmake-3.22.6-windows-x86_64.zip
+  "3.23.5":
+    Linux:
+      armv8:
+        "sha256": dcf25a81de6bd4e646389a0635b050ed04d0f27e4f07ae22d975391f38f3c4b8
+        "url": https://cmake.org/files/v3.23/cmake-3.23.5-linux-aarch64.tar.gz
+      x86_64:
+        "sha256": bbd7ad93d2a14ed3608021a9466ae63db76a24efd1fae7a5f7798c1de7ab9344
+        "url": https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.tar.gz
+    Macos:
+      armv8:
+        "sha256": 245f07d6e346d2b3fdda600b3705579cf956fdd82ac4f4326b96e7d2c43a9312
+        "url": https://cmake.org/files/v3.23/cmake-3.23.5-macos-universal.tar.gz
+      x86_64:
+        "sha256": 245f07d6e346d2b3fdda600b3705579cf956fdd82ac4f4326b96e7d2c43a9312
+        "url": https://cmake.org/files/v3.23/cmake-3.23.5-macos-universal.tar.gz
+    Windows:
+      x86_64:
+        "sha256": 51c75f93ebfe295701df205e5e78808b1e707996b26b5c26c3f680ab7b543881
+        "url": https://cmake.org/files/v3.23/cmake-3.23.5-windows-x86_64.zip
+  "3.24.4":
+    Linux:
+      armv8:
+        "sha256": 86f823f2636bf715af89da10e04daa476755a799d451baee66247846e95d7bee
+        "url": https://cmake.org/files/v3.24/cmake-3.24.4-linux-aarch64.tar.gz
+      x86_64:
+        "sha256": cac77d28fb8668c179ac02c283b058aeb846fe2133a57d40b503711281ed9f19
+        "url": https://cmake.org/files/v3.24/cmake-3.24.4-linux-x86_64.tar.gz
+    Macos:
+      armv8:
+        "sha256": 16f68724ccd6c2e63e803d3d1dbc2961e5c84d3e123a7bf91825515d750eeac6
+        "url": https://cmake.org/files/v3.24/cmake-3.24.4-macos-universal.tar.gz
+      x86_64:
+        "sha256": 16f68724ccd6c2e63e803d3d1dbc2961e5c84d3e123a7bf91825515d750eeac6
+        "url": https://cmake.org/files/v3.24/cmake-3.24.4-macos-universal.tar.gz
+    Windows:
+      armv8:
+        "sha256": 55e81f0c95b06a4435b708cdee7d5739e38cc29c909d3d3134c1a3117e09b965
+        "url": https://cmake.org/files/v3.24/cmake-3.24.4-windows-arm64.zip
+      x86_64:
+        "sha256": c135c7ab78143c46e6686b1e9652bc1dd07e0cf71fd4decee777cdca77019c39
+        "url": https://cmake.org/files/v3.24/cmake-3.24.4-windows-x86_64.zip
+  "3.25.3":
+    Linux:
+      armv8:
+        "sha256": cd6e853639f858569e22e6298f009eb24b4702c51c0d5bc1cb36c688f7ce246d
+        "url": https://cmake.org/files/v3.25/cmake-3.25.3-linux-aarch64.tar.gz
+      x86_64:
+        "sha256": d4d2ba83301b215857d3b6590cd4434a414fa151c5807693abe587bd6c03581e
+        "url": https://cmake.org/files/v3.25/cmake-3.25.3-linux-x86_64.tar.gz
+    Macos:
+      armv8:
+        "sha256": 771548ed2abae17f3fd28dcfa572ba3fe9f970652a72c36c2e1aafdee93a234e
+        "url": https://cmake.org/files/v3.25/cmake-3.25.3-macos-universal.tar.gz
+      x86_64:
+        "sha256": 771548ed2abae17f3fd28dcfa572ba3fe9f970652a72c36c2e1aafdee93a234e
+        "url": https://cmake.org/files/v3.25/cmake-3.25.3-macos-universal.tar.gz
+    Windows:
+      armv8:
+        "sha256": 3498fea26257eebfbfc89ed17963f3d8d83c19362b90fb23517842de777a522a
+        "url": https://cmake.org/files/v3.25/cmake-3.25.3-windows-arm64.zip
+      x86_64:
+        "sha256": d129425d569140b729210f3383c246dec19c4183f7d0afae1837044942da3b4b
+        "url": https://cmake.org/files/v3.25/cmake-3.25.3-windows-x86_64.zip

--- a/recipes/cmake/binary/conandata.yml
+++ b/recipes/cmake/binary/conandata.yml
@@ -12,7 +12,6 @@ sources:
         url: "https://cmake.org/files/v3.20/cmake-3.20.6-macos10.10-universal.tar.gz"
         sha256: "e75e95c10089b54fe0a7dfb369a87214e8a0ffb46d0fcf6a9678b38140dba983"
     Windows:
-      armv8: {}
       x86_64:
         url: "https://cmake.org/files/v3.20/cmake-3.20.6-windows-x86_64.zip"
         sha256: "f240a38c964712aac474644b3ba21bdc2b4e8d5e31179f67bd2e6f45fa349419"
@@ -29,7 +28,6 @@ sources:
         url: "https://cmake.org/files/v3.21/cmake-3.21.7-macos10.10-universal.tar.gz"
         sha256: "d79775e35efca40ff1d213155c2d5e2e028d0ce376c5089c97f2fe3c6133af1d"
     Windows:
-      armv8: {}
       x86_64:
         url: "https://cmake.org/files/v3.21/cmake-3.21.7-windows-x86_64.zip"
         sha256: "4c4840e2dc2bf82e8a16081ff506bba54f3a228b91ce36317129fed4035ef2e3"
@@ -46,7 +44,6 @@ sources:
         url: "https://cmake.org/files/v3.22/cmake-3.22.6-macos10.10-universal.tar.gz"
         sha256: "873d296000b2fbd5cd306a3455fddc254b485cad988c67bf4ee0ba4fd7a1e057"
     Windows:
-      armv8: {}
       x86_64:
         url: "https://cmake.org/files/v3.22/cmake-3.22.6-windows-x86_64.zip"
         sha256: "48bcc3e71e918b72e2682f9ca9d44dd6c416379071c1ecb530d0633374f91f15"
@@ -63,7 +60,6 @@ sources:
         url: "https://cmake.org/files/v3.23/cmake-3.23.5-macos10.10-universal.tar.gz"
         sha256: "d3b44c59e72ef9cc13f7a4642de56e69b1b33fc3a6bb003b59b7f2036ace7e03"
     Windows:
-      armv8: {}
       x86_64:
         url: "https://cmake.org/files/v3.23/cmake-3.23.5-windows-x86_64.zip"
         sha256: "51c75f93ebfe295701df205e5e78808b1e707996b26b5c26c3f680ab7b543881"

--- a/recipes/cmake/binary/conandata.yml
+++ b/recipes/cmake/binary/conandata.yml
@@ -1,87 +1,4 @@
 sources:
-  "3.20.6":
-    Linux:
-      armv8:
-        url: "https://cmake.org/files/v3.20/cmake-3.20.6-linux-aarch64.tar.gz"
-        sha256: "9ac2035174d3c62827c85fb052372d70cf35fb565e8d47b8241fbe451c29b2f2"
-      x86_64:
-        url: "https://cmake.org/files/v3.20/cmake-3.20.6-linux-x86_64.tar.gz"
-        sha256: "458777097903b0f35a0452266b923f0a2f5b62fe331e636e2dcc4b636b768e36"
-    Macos:
-      universal:
-        url: "https://cmake.org/files/v3.20/cmake-3.20.6-macos10.10-universal.tar.gz"
-        sha256: "e75e95c10089b54fe0a7dfb369a87214e8a0ffb46d0fcf6a9678b38140dba983"
-    Windows:
-      x86_64:
-        url: "https://cmake.org/files/v3.20/cmake-3.20.6-windows-x86_64.zip"
-        sha256: "f240a38c964712aac474644b3ba21bdc2b4e8d5e31179f67bd2e6f45fa349419"
-  "3.21.7":
-    Linux:
-      armv8:
-        url: "https://cmake.org/files/v3.21/cmake-3.21.7-linux-aarch64.tar.gz"
-        sha256: "fa7e82170391c71dcc958ff57a63e9d6be9742a8b85a8b1386da9e571980474a"
-      x86_64:
-        url: "https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz"
-        sha256: "f84e209d903a96e54f398bb8760693969b13fc50bce2f8278a9ee9dca01406b2"
-    Macos:
-      universal:
-        url: "https://cmake.org/files/v3.21/cmake-3.21.7-macos10.10-universal.tar.gz"
-        sha256: "d79775e35efca40ff1d213155c2d5e2e028d0ce376c5089c97f2fe3c6133af1d"
-    Windows:
-      x86_64:
-        url: "https://cmake.org/files/v3.21/cmake-3.21.7-windows-x86_64.zip"
-        sha256: "4c4840e2dc2bf82e8a16081ff506bba54f3a228b91ce36317129fed4035ef2e3"
-  "3.22.6":
-    Linux:
-      armv8:
-        url: "https://cmake.org/files/v3.22/cmake-3.22.6-linux-aarch64.tar.gz"
-        sha256: "79be85d3e76565faacd60695cee11d030f7e7dd8691476144fa25eb93dbd0397"
-      x86_64:
-        url: "https://cmake.org/files/v3.22/cmake-3.22.6-linux-x86_64.tar.gz"
-        sha256: "09e1b34026c406c5bf4d1b053eadb3a8519cb360e37547ebf4b70ab766d94fbc"
-    Macos:
-      universal:
-        url: "https://cmake.org/files/v3.22/cmake-3.22.6-macos10.10-universal.tar.gz"
-        sha256: "873d296000b2fbd5cd306a3455fddc254b485cad988c67bf4ee0ba4fd7a1e057"
-    Windows:
-      x86_64:
-        url: "https://cmake.org/files/v3.22/cmake-3.22.6-windows-x86_64.zip"
-        sha256: "48bcc3e71e918b72e2682f9ca9d44dd6c416379071c1ecb530d0633374f91f15"
-  "3.23.5":
-    Linux:
-      armv8:
-        url: "https://cmake.org/files/v3.23/cmake-3.23.5-linux-aarch64.tar.gz"
-        sha256: "dcf25a81de6bd4e646389a0635b050ed04d0f27e4f07ae22d975391f38f3c4b8"
-      x86_64:
-        url: "https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.tar.gz"
-        sha256: "bbd7ad93d2a14ed3608021a9466ae63db76a24efd1fae7a5f7798c1de7ab9344"
-    Macos:
-      universal:
-        url: "https://cmake.org/files/v3.23/cmake-3.23.5-macos10.10-universal.tar.gz"
-        sha256: "d3b44c59e72ef9cc13f7a4642de56e69b1b33fc3a6bb003b59b7f2036ace7e03"
-    Windows:
-      x86_64:
-        url: "https://cmake.org/files/v3.23/cmake-3.23.5-windows-x86_64.zip"
-        sha256: "51c75f93ebfe295701df205e5e78808b1e707996b26b5c26c3f680ab7b543881"
-  "3.24.4":
-    Linux:
-      armv8:
-        url: "https://cmake.org/files/v3.24/cmake-3.24.4-linux-aarch64.tar.gz"
-        sha256: "86f823f2636bf715af89da10e04daa476755a799d451baee66247846e95d7bee"
-      x86_64:
-        url: "https://cmake.org/files/v3.24/cmake-3.24.4-linux-x86_64.tar.gz"
-        sha256: "cac77d28fb8668c179ac02c283b058aeb846fe2133a57d40b503711281ed9f19"
-    Macos:
-      universal:
-        url: "https://cmake.org/files/v3.24/cmake-3.24.4-macos10.10-universal.tar.gz"
-        sha256: "3cda3995d6ea06a9d05dfaac633006754d6df5d80cd3d08bf4c284507a550496"
-    Windows:
-      armv8:
-        url: "https://cmake.org/files/v3.24/cmake-3.24.4-windows-arm64.zip"
-        sha256: "55e81f0c95b06a4435b708cdee7d5739e38cc29c909d3d3134c1a3117e09b965"
-      x86_64:
-        url: "https://cmake.org/files/v3.24/cmake-3.24.4-windows-x86_64.zip"
-        sha256: "c135c7ab78143c46e6686b1e9652bc1dd07e0cf71fd4decee777cdca77019c39"
   "3.25.3":
     Linux:
       armv8:
@@ -101,3 +18,86 @@ sources:
       x86_64:
         url: "https://cmake.org/files/v3.25/cmake-3.25.3-windows-x86_64.zip"
         sha256: "d129425d569140b729210f3383c246dec19c4183f7d0afae1837044942da3b4b"
+  "3.24.4":
+    Linux:
+      armv8:
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-linux-aarch64.tar.gz"
+        sha256: "86f823f2636bf715af89da10e04daa476755a799d451baee66247846e95d7bee"
+      x86_64:
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-linux-x86_64.tar.gz"
+        sha256: "cac77d28fb8668c179ac02c283b058aeb846fe2133a57d40b503711281ed9f19"
+    Macos:
+      universal:
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-macos10.10-universal.tar.gz"
+        sha256: "3cda3995d6ea06a9d05dfaac633006754d6df5d80cd3d08bf4c284507a550496"
+    Windows:
+      armv8:
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-windows-arm64.zip"
+        sha256: "55e81f0c95b06a4435b708cdee7d5739e38cc29c909d3d3134c1a3117e09b965"
+      x86_64:
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-windows-x86_64.zip"
+        sha256: "c135c7ab78143c46e6686b1e9652bc1dd07e0cf71fd4decee777cdca77019c39"
+  "3.23.5":
+    Linux:
+      armv8:
+        url: "https://cmake.org/files/v3.23/cmake-3.23.5-linux-aarch64.tar.gz"
+        sha256: "dcf25a81de6bd4e646389a0635b050ed04d0f27e4f07ae22d975391f38f3c4b8"
+      x86_64:
+        url: "https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.tar.gz"
+        sha256: "bbd7ad93d2a14ed3608021a9466ae63db76a24efd1fae7a5f7798c1de7ab9344"
+    Macos:
+      universal:
+        url: "https://cmake.org/files/v3.23/cmake-3.23.5-macos10.10-universal.tar.gz"
+        sha256: "d3b44c59e72ef9cc13f7a4642de56e69b1b33fc3a6bb003b59b7f2036ace7e03"
+    Windows:
+      x86_64:
+        url: "https://cmake.org/files/v3.23/cmake-3.23.5-windows-x86_64.zip"
+        sha256: "51c75f93ebfe295701df205e5e78808b1e707996b26b5c26c3f680ab7b543881"
+  "3.22.6":
+    Linux:
+      armv8:
+        url: "https://cmake.org/files/v3.22/cmake-3.22.6-linux-aarch64.tar.gz"
+        sha256: "79be85d3e76565faacd60695cee11d030f7e7dd8691476144fa25eb93dbd0397"
+      x86_64:
+        url: "https://cmake.org/files/v3.22/cmake-3.22.6-linux-x86_64.tar.gz"
+        sha256: "09e1b34026c406c5bf4d1b053eadb3a8519cb360e37547ebf4b70ab766d94fbc"
+    Macos:
+      universal:
+        url: "https://cmake.org/files/v3.22/cmake-3.22.6-macos10.10-universal.tar.gz"
+        sha256: "873d296000b2fbd5cd306a3455fddc254b485cad988c67bf4ee0ba4fd7a1e057"
+    Windows:
+      x86_64:
+        url: "https://cmake.org/files/v3.22/cmake-3.22.6-windows-x86_64.zip"
+        sha256: "48bcc3e71e918b72e2682f9ca9d44dd6c416379071c1ecb530d0633374f91f15"
+  "3.21.7":
+    Linux:
+      armv8:
+        url: "https://cmake.org/files/v3.21/cmake-3.21.7-linux-aarch64.tar.gz"
+        sha256: "fa7e82170391c71dcc958ff57a63e9d6be9742a8b85a8b1386da9e571980474a"
+      x86_64:
+        url: "https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz"
+        sha256: "f84e209d903a96e54f398bb8760693969b13fc50bce2f8278a9ee9dca01406b2"
+    Macos:
+      universal:
+        url: "https://cmake.org/files/v3.21/cmake-3.21.7-macos10.10-universal.tar.gz"
+        sha256: "d79775e35efca40ff1d213155c2d5e2e028d0ce376c5089c97f2fe3c6133af1d"
+    Windows:
+      x86_64:
+        url: "https://cmake.org/files/v3.21/cmake-3.21.7-windows-x86_64.zip"
+        sha256: "4c4840e2dc2bf82e8a16081ff506bba54f3a228b91ce36317129fed4035ef2e3"
+  "3.20.6":
+    Linux:
+      armv8:
+        url: "https://cmake.org/files/v3.20/cmake-3.20.6-linux-aarch64.tar.gz"
+        sha256: "9ac2035174d3c62827c85fb052372d70cf35fb565e8d47b8241fbe451c29b2f2"
+      x86_64:
+        url: "https://cmake.org/files/v3.20/cmake-3.20.6-linux-x86_64.tar.gz"
+        sha256: "458777097903b0f35a0452266b923f0a2f5b62fe331e636e2dcc4b636b768e36"
+    Macos:
+      universal:
+        url: "https://cmake.org/files/v3.20/cmake-3.20.6-macos10.10-universal.tar.gz"
+        sha256: "e75e95c10089b54fe0a7dfb369a87214e8a0ffb46d0fcf6a9678b38140dba983"
+    Windows:
+      x86_64:
+        url: "https://cmake.org/files/v3.20/cmake-3.20.6-windows-x86_64.zip"
+        sha256: "f240a38c964712aac474644b3ba21bdc2b4e8d5e31179f67bd2e6f45fa349419"

--- a/recipes/cmake/binary/conandata.yml
+++ b/recipes/cmake/binary/conandata.yml
@@ -2,120 +2,106 @@ sources:
   "3.20.6":
     Linux:
       armv8:
-        "sha256": 9ac2035174d3c62827c85fb052372d70cf35fb565e8d47b8241fbe451c29b2f2
-        "url": https://cmake.org/files/v3.20/cmake-3.20.6-linux-aarch64.tar.gz
+        url: "https://cmake.org/files/v3.20/cmake-3.20.6-linux-aarch64.tar.gz"
+        sha256: "9ac2035174d3c62827c85fb052372d70cf35fb565e8d47b8241fbe451c29b2f2"
       x86_64:
-        "sha256": 458777097903b0f35a0452266b923f0a2f5b62fe331e636e2dcc4b636b768e36
-        "url": https://cmake.org/files/v3.20/cmake-3.20.6-linux-x86_64.tar.gz
+        url: "https://cmake.org/files/v3.20/cmake-3.20.6-linux-x86_64.tar.gz"
+        sha256: "458777097903b0f35a0452266b923f0a2f5b62fe331e636e2dcc4b636b768e36"
     Macos:
-      armv8:
-        "sha256": bc75cfbcbd95851d2e712c884de80814d7a7939441612af0ae6c5ccc2d94929f
-        "url": https://cmake.org/files/v3.20/cmake-3.20.6-macos-universal.tar.gz
-      x86_64:
-        "sha256": bc75cfbcbd95851d2e712c884de80814d7a7939441612af0ae6c5ccc2d94929f
-        "url": https://cmake.org/files/v3.20/cmake-3.20.6-macos-universal.tar.gz
+      universal:
+        url: "https://cmake.org/files/v3.20/cmake-3.20.6-macos10.10-universal.tar.gz"
+        sha256: "e75e95c10089b54fe0a7dfb369a87214e8a0ffb46d0fcf6a9678b38140dba983"
     Windows:
+      armv8: {}
       x86_64:
-        "sha256": f240a38c964712aac474644b3ba21bdc2b4e8d5e31179f67bd2e6f45fa349419
-        "url": https://cmake.org/files/v3.20/cmake-3.20.6-windows-x86_64.zip
+        url: "https://cmake.org/files/v3.20/cmake-3.20.6-windows-x86_64.zip"
+        sha256: "f240a38c964712aac474644b3ba21bdc2b4e8d5e31179f67bd2e6f45fa349419"
   "3.21.7":
     Linux:
       armv8:
-        "sha256": fa7e82170391c71dcc958ff57a63e9d6be9742a8b85a8b1386da9e571980474a
-        "url": https://cmake.org/files/v3.21/cmake-3.21.7-linux-aarch64.tar.gz
+        url: "https://cmake.org/files/v3.21/cmake-3.21.7-linux-aarch64.tar.gz"
+        sha256: "fa7e82170391c71dcc958ff57a63e9d6be9742a8b85a8b1386da9e571980474a"
       x86_64:
-        "sha256": f84e209d903a96e54f398bb8760693969b13fc50bce2f8278a9ee9dca01406b2
-        "url": https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz
+        url: "https://cmake.org/files/v3.21/cmake-3.21.7-linux-x86_64.tar.gz"
+        sha256: "f84e209d903a96e54f398bb8760693969b13fc50bce2f8278a9ee9dca01406b2"
     Macos:
-      armv8:
-        "sha256": 3c968c5877a99a801ea30ff3edd3f5a42e10fb715bef295ba611e62c50a2e87c
-        "url": https://cmake.org/files/v3.21/cmake-3.21.7-macos-universal.tar.gz
-      x86_64:
-        "sha256": 3c968c5877a99a801ea30ff3edd3f5a42e10fb715bef295ba611e62c50a2e87c
-        "url": https://cmake.org/files/v3.21/cmake-3.21.7-macos-universal.tar.gz
+      universal:
+        url: "https://cmake.org/files/v3.21/cmake-3.21.7-macos10.10-universal.tar.gz"
+        sha256: "d79775e35efca40ff1d213155c2d5e2e028d0ce376c5089c97f2fe3c6133af1d"
     Windows:
+      armv8: {}
       x86_64:
-        "sha256": 4c4840e2dc2bf82e8a16081ff506bba54f3a228b91ce36317129fed4035ef2e3
-        "url": https://cmake.org/files/v3.21/cmake-3.21.7-windows-x86_64.zip
+        url: "https://cmake.org/files/v3.21/cmake-3.21.7-windows-x86_64.zip"
+        sha256: "4c4840e2dc2bf82e8a16081ff506bba54f3a228b91ce36317129fed4035ef2e3"
   "3.22.6":
     Linux:
       armv8:
-        "sha256": 79be85d3e76565faacd60695cee11d030f7e7dd8691476144fa25eb93dbd0397
-        "url": https://cmake.org/files/v3.22/cmake-3.22.6-linux-aarch64.tar.gz
+        url: "https://cmake.org/files/v3.22/cmake-3.22.6-linux-aarch64.tar.gz"
+        sha256: "79be85d3e76565faacd60695cee11d030f7e7dd8691476144fa25eb93dbd0397"
       x86_64:
-        "sha256": 09e1b34026c406c5bf4d1b053eadb3a8519cb360e37547ebf4b70ab766d94fbc
-        "url": https://cmake.org/files/v3.22/cmake-3.22.6-linux-x86_64.tar.gz
+        url: "https://cmake.org/files/v3.22/cmake-3.22.6-linux-x86_64.tar.gz"
+        sha256: "09e1b34026c406c5bf4d1b053eadb3a8519cb360e37547ebf4b70ab766d94fbc"
     Macos:
-      armv8:
-        "sha256": b4569e10b0f86ed4fad23aae879a197de6fb14aca057bfc2e3baf236c3e876c5
-        "url": https://cmake.org/files/v3.22/cmake-3.22.6-macos-universal.tar.gz
-      x86_64:
-        "sha256": b4569e10b0f86ed4fad23aae879a197de6fb14aca057bfc2e3baf236c3e876c5
-        "url": https://cmake.org/files/v3.22/cmake-3.22.6-macos-universal.tar.gz
+      universal:
+        url: "https://cmake.org/files/v3.22/cmake-3.22.6-macos10.10-universal.tar.gz"
+        sha256: "873d296000b2fbd5cd306a3455fddc254b485cad988c67bf4ee0ba4fd7a1e057"
     Windows:
+      armv8: {}
       x86_64:
-        "sha256": 48bcc3e71e918b72e2682f9ca9d44dd6c416379071c1ecb530d0633374f91f15
-        "url": https://cmake.org/files/v3.22/cmake-3.22.6-windows-x86_64.zip
+        url: "https://cmake.org/files/v3.22/cmake-3.22.6-windows-x86_64.zip"
+        sha256: "48bcc3e71e918b72e2682f9ca9d44dd6c416379071c1ecb530d0633374f91f15"
   "3.23.5":
     Linux:
       armv8:
-        "sha256": dcf25a81de6bd4e646389a0635b050ed04d0f27e4f07ae22d975391f38f3c4b8
-        "url": https://cmake.org/files/v3.23/cmake-3.23.5-linux-aarch64.tar.gz
+        url: "https://cmake.org/files/v3.23/cmake-3.23.5-linux-aarch64.tar.gz"
+        sha256: "dcf25a81de6bd4e646389a0635b050ed04d0f27e4f07ae22d975391f38f3c4b8"
       x86_64:
-        "sha256": bbd7ad93d2a14ed3608021a9466ae63db76a24efd1fae7a5f7798c1de7ab9344
-        "url": https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.tar.gz
+        url: "https://cmake.org/files/v3.23/cmake-3.23.5-linux-x86_64.tar.gz"
+        sha256: "bbd7ad93d2a14ed3608021a9466ae63db76a24efd1fae7a5f7798c1de7ab9344"
     Macos:
-      armv8:
-        "sha256": 245f07d6e346d2b3fdda600b3705579cf956fdd82ac4f4326b96e7d2c43a9312
-        "url": https://cmake.org/files/v3.23/cmake-3.23.5-macos-universal.tar.gz
-      x86_64:
-        "sha256": 245f07d6e346d2b3fdda600b3705579cf956fdd82ac4f4326b96e7d2c43a9312
-        "url": https://cmake.org/files/v3.23/cmake-3.23.5-macos-universal.tar.gz
+      universal:
+        url: "https://cmake.org/files/v3.23/cmake-3.23.5-macos10.10-universal.tar.gz"
+        sha256: "d3b44c59e72ef9cc13f7a4642de56e69b1b33fc3a6bb003b59b7f2036ace7e03"
     Windows:
+      armv8: {}
       x86_64:
-        "sha256": 51c75f93ebfe295701df205e5e78808b1e707996b26b5c26c3f680ab7b543881
-        "url": https://cmake.org/files/v3.23/cmake-3.23.5-windows-x86_64.zip
+        url: "https://cmake.org/files/v3.23/cmake-3.23.5-windows-x86_64.zip"
+        sha256: "51c75f93ebfe295701df205e5e78808b1e707996b26b5c26c3f680ab7b543881"
   "3.24.4":
     Linux:
       armv8:
-        "sha256": 86f823f2636bf715af89da10e04daa476755a799d451baee66247846e95d7bee
-        "url": https://cmake.org/files/v3.24/cmake-3.24.4-linux-aarch64.tar.gz
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-linux-aarch64.tar.gz"
+        sha256: "86f823f2636bf715af89da10e04daa476755a799d451baee66247846e95d7bee"
       x86_64:
-        "sha256": cac77d28fb8668c179ac02c283b058aeb846fe2133a57d40b503711281ed9f19
-        "url": https://cmake.org/files/v3.24/cmake-3.24.4-linux-x86_64.tar.gz
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-linux-x86_64.tar.gz"
+        sha256: "cac77d28fb8668c179ac02c283b058aeb846fe2133a57d40b503711281ed9f19"
     Macos:
-      armv8:
-        "sha256": 16f68724ccd6c2e63e803d3d1dbc2961e5c84d3e123a7bf91825515d750eeac6
-        "url": https://cmake.org/files/v3.24/cmake-3.24.4-macos-universal.tar.gz
-      x86_64:
-        "sha256": 16f68724ccd6c2e63e803d3d1dbc2961e5c84d3e123a7bf91825515d750eeac6
-        "url": https://cmake.org/files/v3.24/cmake-3.24.4-macos-universal.tar.gz
+      universal:
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-macos10.10-universal.tar.gz"
+        sha256: "3cda3995d6ea06a9d05dfaac633006754d6df5d80cd3d08bf4c284507a550496"
     Windows:
       armv8:
-        "sha256": 55e81f0c95b06a4435b708cdee7d5739e38cc29c909d3d3134c1a3117e09b965
-        "url": https://cmake.org/files/v3.24/cmake-3.24.4-windows-arm64.zip
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-windows-arm64.zip"
+        sha256: "55e81f0c95b06a4435b708cdee7d5739e38cc29c909d3d3134c1a3117e09b965"
       x86_64:
-        "sha256": c135c7ab78143c46e6686b1e9652bc1dd07e0cf71fd4decee777cdca77019c39
-        "url": https://cmake.org/files/v3.24/cmake-3.24.4-windows-x86_64.zip
+        url: "https://cmake.org/files/v3.24/cmake-3.24.4-windows-x86_64.zip"
+        sha256: "c135c7ab78143c46e6686b1e9652bc1dd07e0cf71fd4decee777cdca77019c39"
   "3.25.3":
     Linux:
       armv8:
-        "sha256": cd6e853639f858569e22e6298f009eb24b4702c51c0d5bc1cb36c688f7ce246d
-        "url": https://cmake.org/files/v3.25/cmake-3.25.3-linux-aarch64.tar.gz
+        url: "https://cmake.org/files/v3.25/cmake-3.25.3-linux-aarch64.tar.gz"
+        sha256: "cd6e853639f858569e22e6298f009eb24b4702c51c0d5bc1cb36c688f7ce246d"
       x86_64:
-        "sha256": d4d2ba83301b215857d3b6590cd4434a414fa151c5807693abe587bd6c03581e
-        "url": https://cmake.org/files/v3.25/cmake-3.25.3-linux-x86_64.tar.gz
+        url: "https://cmake.org/files/v3.25/cmake-3.25.3-linux-x86_64.tar.gz"
+        sha256: "d4d2ba83301b215857d3b6590cd4434a414fa151c5807693abe587bd6c03581e"
     Macos:
-      armv8:
-        "sha256": 771548ed2abae17f3fd28dcfa572ba3fe9f970652a72c36c2e1aafdee93a234e
-        "url": https://cmake.org/files/v3.25/cmake-3.25.3-macos-universal.tar.gz
-      x86_64:
-        "sha256": 771548ed2abae17f3fd28dcfa572ba3fe9f970652a72c36c2e1aafdee93a234e
-        "url": https://cmake.org/files/v3.25/cmake-3.25.3-macos-universal.tar.gz
+      universal:
+        url: "https://cmake.org/files/v3.25/cmake-3.25.3-macos10.10-universal.tar.gz"
+        sha256: "ea37a83cd329224c38a1938d2cf7b2656ad971dea9cf759238652746213661f8"
     Windows:
       armv8:
-        "sha256": 3498fea26257eebfbfc89ed17963f3d8d83c19362b90fb23517842de777a522a
-        "url": https://cmake.org/files/v3.25/cmake-3.25.3-windows-arm64.zip
+        url: "https://cmake.org/files/v3.25/cmake-3.25.3-windows-arm64.zip"
+        sha256: "3498fea26257eebfbfc89ed17963f3d8d83c19362b90fb23517842de777a522a"
       x86_64:
-        "sha256": d129425d569140b729210f3383c246dec19c4183f7d0afae1837044942da3b4b
-        "url": https://cmake.org/files/v3.25/cmake-3.25.3-windows-x86_64.zip
+        url: "https://cmake.org/files/v3.25/cmake-3.25.3-windows-x86_64.zip"
+        sha256: "d129425d569140b729210f3383c246dec19c4183f7d0afae1837044942da3b4b"

--- a/recipes/cmake/binary/conanfile.py
+++ b/recipes/cmake/binary/conanfile.py
@@ -38,9 +38,9 @@ class CMakeConan(ConanFile):
         copy(self, "*", src=self.build_folder, dst=self.package_folder)
 
         if self.settings.os == "Macos":
-            docs_folder = os.path.join(self.build_folder, "CMake.app", "Contents", "doc")
+            docs_folder = os.path.join(self.build_folder, "CMake.app", "Contents", "doc", "cmake")
         else:
-            docs_folder = os.path.join(self.build_folder, "doc")
+            docs_folder = os.path.join(self.build_folder, "doc", "cmake")
 
         copy(self, "Copyright.txt", src=docs_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)
 

--- a/recipes/cmake/binary/conanfile.py
+++ b/recipes/cmake/binary/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
 from conan import ConanFile
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, rmdir
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
@@ -43,6 +43,13 @@ class CMakeConan(ConanFile):
             docs_folder = os.path.join(self.build_folder, "doc", "cmake")
 
         copy(self, "Copyright.txt", src=docs_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)
+
+        if self.settings.os != "Macos":
+            # Remove unneeded folders (also cause long paths on Windows)
+            # Note: on macOS we don't want to modify the bundle contents
+            #       to preserve signature validation
+            rmdir(self, os.path.join(self.package_folder, "doc"))
+            rmdir(self, os.path.join(self.package_folder, "man"))
 
     def package_info(self):
         self.cpp_info.includedirs = []

--- a/recipes/cmake/binary/conanfile.py
+++ b/recipes/cmake/binary/conanfile.py
@@ -1,0 +1,53 @@
+import os
+
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
+
+
+required_conan_version = ">=1.51.0"
+
+class CMakeConan(ConanFile):
+    name = "cmake"
+    package_type = "application"
+    description = "CMake, the cross-platform, open-source build system."
+    topics = ("build", "installer")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Kitware/CMake"
+    license = "BSD-3-Clause"
+    settings = "os", "arch"
+
+    def validate(self):
+        if self.settings.arch == "x86":
+            raise ConanInvalidConfiguration("No 32-bit binaries are currently provided for CMake")
+        if self.settings.os == "Windows" and self.settings.arch == "armv8" and Version(self.version) < "3.24":
+            raise ConanInvalidConfiguration("CMake only supports ARM64 binaries on Windows starting from 3.24")
+
+    def build(self):
+        get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)],
+            destination=self.source_folder, strip_root=True)
+
+    def package(self):
+        copy(self, "*", src=self.build_folder, dst=self.package_folder)
+
+        if self.settings.os == "Macos":
+            docs_folder = os.path.join(self.build_folder, "Cmake.app", "Contents", "doc")
+        else:
+            docs_folder = os.path.join(self.build_folder, "doc")
+
+        copy(self, "Copyright.txt", src=docs_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+
+        if self.settings.os == "Macos":
+            bindir = os.path.join(self.package_folder, "CMake.app", "Contents", "bin")
+            self.cpp_info.bindirs = [bindir]
+        else:
+            bindir = os.path.join(self.package_folder, "bin")
+        
+        # Needed for compatibility with v1.x - Remove when 2.0 becomes the default
+        self.output.info(f"Appending PATH environment variable: {bindir}")
+        self.env_info.PATH.append(bindir)

--- a/recipes/cmake/binary/test_package/conanfile.py
+++ b/recipes/cmake/binary/test_package/conanfile.py
@@ -1,0 +1,23 @@
+from six import StringIO
+from conan import ConanFile
+import re
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        output = StringIO()
+        self.run("cmake --version", output)
+        output_str = str(output.getvalue())
+        self.output.info("Installed version: {}".format(output_str))
+        tokens = re.split('[@#]', self.tested_reference_str)
+        require_version = tokens[0].split("/", 1)[1]
+        self.output.info("Expected version: {}".format(require_version))
+        assert_cmake_version = "cmake version %s" % require_version
+        assert(assert_cmake_version in output_str)

--- a/recipes/cmake/binary/test_v1_package/conanfile.py
+++ b/recipes/cmake/binary/test_v1_package/conanfile.py
@@ -1,0 +1,23 @@
+import os
+from six import StringIO
+from conan import ConanFile
+import re
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        output = StringIO()
+        self.run("cmake --version", output=output, run_environment=False)
+        output_str = str(output.getvalue())
+        self.output.info("Installed version: {}".format(output_str))
+        tokens = re.split('[@#]', self.tested_reference_str)
+        require_version = tokens[0].split("/", 1)[1]
+        self.output.info("Expected version: {}".format(require_version))
+        assert_cmake_version = "cmake version %s" % require_version
+        assert(assert_cmake_version in output_str)

--- a/recipes/cmake/config.yml
+++ b/recipes/cmake/config.yml
@@ -1,15 +1,13 @@
 versions:
-  "3.19.8":
-    folder: "3.x.x"
   "3.20.6":
-    folder: "3.x.x"
+    folder: "binary"
   "3.21.7":
-    folder: "3.x.x"
+    folder: "binary"
   "3.22.6":
-    folder: "3.x.x"
+    folder: "binary"
   "3.23.5":
-    folder: "3.x.x"
-  "3.24.3":
-    folder: "3.x.x"
-  "3.25.2":
-    folder: "3.x.x"
+    folder: "binary"
+  "3.24.4":
+    folder: "binary"
+  "3.25.3":
+    folder: "binary"


### PR DESCRIPTION
Specify library name and version:  **cmake/all**

### Changes in this PR:
* Refactor CMake recipe to download the official CMake binaries provided by KitWare, on all 3 mainstream operating systems (Linux, macOS, Windows), on relevant architectures (x86_64 and armv8)
* Remove version 3.19 and update all current versions to the latest available patch version
* Old recipe is kept in the repository for those wishing to build CMake from source, but will no longer be built by our CI service

### Motivation
We aim to address a number of issues, as there is a growing number of recipes in Conan Center depend on `cmake` as provided by Conan Center.

#### Dependency on OpenSSL can can issues in the following scenarios:
* In Conan 1.x build requirement on CMake causes OpenSSL to become part of the dependency graph, and the version required by the CMake recipe may affect the graph resolution - overrides, conflicts and [graph loops](https://github.com/conan-io/conan-center-index/issues/13415#issuecomment-1307408902) have been reported.
* In Conan 2.x different versions of OpenSSL will result in different package_ids for the CMake package, and users may experience missing binaries more often than before, forcing a rebuild from source
* In Conan 2.x, other tool requirements in the “build” dependency graph may also depend on OpenSSL, and may cause conflicts that need to be manually resolved due to dependency on OpenSSL.
* The above scenarios also tend to require frequent bumps of the OpenSSL dependency in the recipe.
* Some users decide to set `with_openssl=False` to avoid the issues above, but this results in limited functionality (CMake is no longer able to fetch files via https, which is required by a lot of scripts. The error will happen during the CMake configuration phase of a downstream library, and it is usually not very evident to users what the problem is).
* The checks performed by the CMake build scripts to detect OpenSSL do not follow modern CMake conventions, leading to interesting issues when interacting with modern targets, see [this comment](https://github.com/conan-io/conan-center-index/pull/16073#discussion_r1110037534).

### Other issues:
* By default, the recipe assumes a working version of CMake is required to build CMake from source, in particular on Windows where this is a requirement. This can limit the usefulness of the recipe for those who wish to rely on Conan-provided build tools.
* The “bootstrap” build option is not tested by our CI (it was actually broken for a while), and requires creative logic to support both build methods result in the same configured build.
* While we have to support Conan 1.x and 2.0 simultaneously, the recipe needs additional logic to handle the fact that CMake can only be built with C++11 support, while there are still users using older compilers, or not using a profile with the cppstd compiler setting.
* For users that choose to not consume binaries from Conan Center, but build them from source - this may cause unnecessary time being spent building CMake from source, in some cases, multiple versions of CMake. CMake takes quite some time to build, in particular on Windows due to the number of build-time checks it performs. In the future, using version ranges and other strategies should help mitigate this.

The issues above are greatly mitigated by providing a pre-built binary of CMake. KitWare official binaries are already built with the mindset to be able to run them on a broad set of Linux/Mac/Windows versions. Given that CMake is strictly used as a build-time only executable (no library usage) - it makes little sense for CMake’s dependencies to enter in contention with actual library dependencies, or to support logic that is more suited for libraries but not for tool requirements (such as building Debug binaries).

The intention is to mitigate these issues as much as we can, while still providing binaries supported in the most common scenarios.  It is assumed that the following issues are likely to be resolved with this PR, or would have not occurred if we had been following this strategy in the past:

- https://github.com/conan-io/conan-center-index/issues/15377
- https://github.com/conan-io/conan-center-index/issues/15766
- https://github.com/conan-io/conan-center-index/issues/1564
- https://github.com/conan-io/conan-center-index/pull/16460 
- https://github.com/conan-io/conan-center-index/issues/13415 
- https://github.com/conan-io/conan-center-index/issues/10133

The recipe that builds CMake from source will still be kept in the repository, for users who need to build it from source (for example, to cover other OSs or architectures). In the future we will evaluate how we can add some minimal CI checks to ensure the source recipe still works as intended.

