### PR TITLE
config: drop openssl from v2 ready since it does not work for 3.x version

### DIFF
--- a/.c3i/conan_v2_ready_references.yml
+++ b/.c3i/conan_v2_ready_references.yml
@@ -235,7 +235,6 @@ required_for_references:
 - opengl
 - openh264
 - openjpeg
-- openssl
 - opus
 - pcre
 - pcre2


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


to unblock https://github.com/conan-io/conan-center-index/pull/15336

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
