### PR TITLE
libnop: modernize more for conan v2 (and generate v2 packages)

### DIFF
--- a/recipes/libnop/all/conanfile.py
+++ b/recipes/libnop/all/conanfile.py
@@ -15,11 +15,12 @@ class LibnopConan(ConanFile):
                   "deserializing C++ data types without external code " \
                   "generators or runtime support libraries."
     license = "Apache-2.0"
-    topics = ("libnop", "header-only", "serializer")
+    topics = ("header-only", "serializer")
     homepage = "https://github.com/google/libnop"
     url = "https://github.com/conan-io/conan-center-index"
-    no_copy_source = True
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
 
     @property
     def _min_cppstd(self):
@@ -29,8 +30,12 @@ class LibnopConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "Visual Studio": "15",
+            "msvc": "191",
             "gcc": "5",
         }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()
@@ -44,12 +49,8 @@ class LibnopConan(ConanFile):
                 f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler does not support.",
             )
 
-    def layout(self):
-        basic_layout(self, src_folder="src")
-
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         pass
@@ -59,7 +60,5 @@ class LibnopConan(ConanFile):
         copy(self, "*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
 
     def package_info(self):
-        self.cpp_info.libdirs = []
-        self.cpp_info.resdirs = []
         self.cpp_info.bindirs = []
-        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/libnop/all/test_package/conanfile.py
+++ b/recipes/libnop/all/test_package/conanfile.py
@@ -7,12 +7,13 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-
-    def requirements(self):
-        self.requires(self.tested_reference_str)
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/libnop/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libnop/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(libnop REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE libnop::libnop)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
v2 packages are needed to pass v2 pipeline in https://github.com/conan-io/conan-center-index/pull/16037

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
