### PR TITLE
vulkan-headers: modernize more + drop maintenance of several versions (and generate v2 packages)

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -23,18 +23,12 @@ sources:
   "1.3.221":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.3.221.tar.gz"
     sha256: "75057d8231bb7a3f6ac091f1b08f50604f07a7e9b4424fd12c035f01787ebf0c"
-  "1.3.219":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.3.219.tar.gz"
-    sha256: "3e5d1b727a5e3a5546e6b0709d520d3f522f0a83808277a313357140645be90c"
   "1.3.216.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/sdk-1.3.216.0.tar.gz"
     sha256: "2c98d1d819fde588fb0f71acebea177f805b3efa26e8260a707a94b1e633be6b"
   "1.3.211.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/sdk-1.3.211.0.tar.gz"
     sha256: "c464bcdc24b7541ac4378a270617a23d4d92699679a73f95dc4b9e1da924810a"
-  "1.3.211":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.3.211.tar.gz"
-    sha256: "67ab69142f69389dfdf5f1c7922e62aa4a03ba286b9229dd7f7f3e827232463c"
   "1.3.204.1":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/sdk-1.3.204.1.tar.gz"
     sha256: "9c4d33f71467c915749fbf48c0c3a8ee7833f15babf398e3463cd88791fb592e"
@@ -59,18 +53,12 @@ sources:
   "1.2.189":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.2.189.tar.gz"
     sha256: "0939d6cb950746f6f9cab59399c0a99628ed186426a972996599f90d34d8a99a"
-  "1.2.184":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.184.tar.gz"
-    sha256: "de1889ff550c1a78e752fbdf71117ac319fb674b0abe080a4e6e9053da2aea85"
   "1.2.182":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.2.182.tar.gz"
     sha256: "38d1c953de7bb2d839556226851feeb690f0d23bc22ac46c823dcb66c97bfdc8"
   "1.2.176.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/sdk-1.2.176.0.tar.gz"
     sha256: "211d8552c5cf8b0607323d69c251d9c4639f89550f8de3d51d3995b5cdd737fb"
-  "1.2.176":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.2.176.tar.gz"
-    sha256: "d77b033e74448341b42d1b6f2b380570e870b0443875f26c9e8a636f01ee6fe7"
   "1.2.172":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.172.tar.gz"
     sha256: "c69619ac2001ac62378a99c56ced14a53801fdc204efb2b1f787c83b47829319"
@@ -89,63 +77,6 @@ sources:
   "1.2.154.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.154.0.tar.gz"
     sha256: "a0528ade4dd3bd826b960ba4ccabc62e92ecedc3c70331b291e0a7671b3520f9"
-  "1.2.151":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.151.tar.gz"
-    sha256: "9a3bb3077c9bb71347d6b9942fa5b728053b67dbd5c1eb9d75a774bccefa18d8"
-  "1.2.150":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.150.tar.gz"
-    sha256: "dc6477b06ed04f4df72cb46915131c1a844980c6f4993954672893b69c2ffb57"
-  "1.2.149":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.149.tar.gz"
-    sha256: "332e35104a911447915ccf03f2d61d7e061d3cf5a09419a032b3b09246dcca85"
-  "1.2.148.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.148.0.tar.gz"
-    sha256: "0803784b701c461ff5cce30bb8c598db5780032cf780c954d676e142bc3c373f"
-  "1.2.141.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.141.0.tar.gz"
-    sha256: "579d112433c89ac8a4a93741bfa6eee8dca4a1d8145363a28d6d9967babc2b07"
   "1.2.140":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.140.tar.gz"
     sha256: "c708a05b0ef673ae783f8968c5396dc207b9f8c7cde2ddb4a9a281e04661185a"
-  "1.2.135.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.135.0.tar.gz"
-    sha256: "befc69991e1e268db75921c577be32a3f315d01d78b39b74ef87ba6908787b63"
-  "1.2.131.1":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.131.1.tar.gz"
-    sha256: "bd6873060c6988b62b938d7cb7e3152f006f44fbfaa9ce4b7f555b20ec77c53d"
-  "1.1.130.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.130.0.tar.gz"
-    sha256: "9afceeae5020b771246853ad5b098bd4bfeebc859759f26bbe0b87c9272c94d4"
-  "1.1.126.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.126.0.tar.gz"
-    sha256: "34a9a6d3e3bf0745e901f75a08f57d4ff388c7e1c59a8dad0dc8437c54236a13"
-  "1.1.121.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.121.0.tar.gz"
-    sha256: "4643e193a18ea06ff403da3672c86cc7792a77a4b6a1e70852090732792694ab"
-  "1.1.114.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.114.0.tar.gz"
-    sha256: "701cc5391c5c757b48f0b8bc6944586c3d479cff7e1803acac9f59c11e9cebf2"
-  "1.1.108.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.108.0.tar.gz"
-    sha256: "944e88911e47e5d34bc4360e3e5833a0d550e3e7483dfa27a5f4d38525a1b943"
-  "1.1.106.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.106.0.tar.gz"
-    sha256: "61eba1be3c4eed6bef9745ec8d8767869eacb6daff6d5b98951052910b73de8f"
-  "1.1.101.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.101.0.tar.gz"
-    sha256: "59e17335932574e736472b0677390f84150d6bd461e648b13e17d870c42c1c3b"
-  "1.1.97.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.97.0.tar.gz"
-    sha256: "a09c83df5647e53ef511a1f2563dec02fae8f13880808914175dc26b06159f16"
-  "1.1.92.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.92.0.tar.gz"
-    sha256: "89164ad4e2a4767357732fd92248b6ec36a5ab16d988b64f2aa75cdbc28f6f19"
-  "1.1.85.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.85.0.tar.gz"
-    sha256: "d3c6435d101bb9271019c9d0dd159e210a805958dda3bb13344fce9316c6d098"
-  "1.1.82.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.82.0.tar.gz"
-    sha256: "df73da07d547cfbe88a797802401ea8225e4844e13d4fde52a7cb6e00e5179e5"
-  "1.1.77.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.1.77.0.tar.gz"
-    sha256: "b2f532bfd1d8e7594f131a4aa79358bfe4fd0aa59d3292dbafd484223d56ef16"

--- a/recipes/vulkan-headers/all/conanfile.py
+++ b/recipes/vulkan-headers/all/conanfile.py
@@ -13,6 +13,7 @@ class VulkanHeadersConan(ConanFile):
     topics = ("vulkan-headers", "vulkan")
     homepage = "https://github.com/KhronosGroup/Vulkan-Headers"
     url = "https://github.com/conan-io/conan-center-index"
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -23,8 +24,7 @@ class VulkanHeadersConan(ConanFile):
         self.info.clear()
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         pass

--- a/recipes/vulkan-headers/all/test_v1_package/CMakeLists.txt
+++ b/recipes/vulkan-headers/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(VulkanHeaders REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} Vulkan::Headers)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -15,13 +15,9 @@ versions:
     folder: all
   "1.3.221":
     folder: all
-  "1.3.219":
-    folder: all
   "1.3.216.0":
     folder: all
   "1.3.211.0":
-    folder: all
-  "1.3.211":
     folder: all
   "1.3.204.1":
     folder: all
@@ -39,13 +35,9 @@ versions:
     folder: all
   "1.2.189":
     folder: all
-  "1.2.184":
-    folder: all
   "1.2.182":
     folder: all
   "1.2.176.0":
-    folder: all
-  "1.2.176":
     folder: all
   "1.2.172":
     folder: all
@@ -59,43 +51,5 @@ versions:
     folder: all
   "1.2.154.0":
     folder: all
-  "1.2.151":
-    folder: all
-  "1.2.150":
-    folder: all
-  "1.2.149":
-    folder: all
-  "1.2.148.0":
-    folder: all
-  "1.2.141.0":
-    folder: all
   "1.2.140":
-    folder: all
-  "1.2.135.0":
-    folder: all
-  "1.2.131.1":
-    folder: all
-  "1.1.130.0":
-    folder: all
-  "1.1.126.0":
-    folder: all
-  "1.1.121.0":
-    folder: all
-  "1.1.114.0":
-    folder: all
-  "1.1.108.0":
-    folder: all
-  "1.1.106.0":
-    folder: all
-  "1.1.101.0":
-    folder: all
-  "1.1.97.0":
-    folder: all
-  "1.1.92.0":
-    folder: all
-  "1.1.85.0":
-    folder: all
-  "1.1.82.0":
-    folder: all
-  "1.1.77.0":
     folder: all


### PR DESCRIPTION
conan v2 packages of vulkan-headers recipe are missing, they are fundamental for vulkan ecosystem.

I've dropped versions which are not used at all in other conan-center recipes.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
