### PR TITLE
geos: add package_type (and generate v2 packages)

### DIFF
--- a/recipes/geos/all/conanfile.py
+++ b/recipes/geos/all/conanfile.py
@@ -12,10 +12,10 @@ class GeosConan(ConanFile):
     name = "geos"
     description = "C++11 library for performing operations on two-dimensional vector geometries"
     license = "LGPL-2.1"
-    topics = ("geos", "osgeo", "geometry", "topology", "geospatial")
+    topics = ("osgeo", "geometry", "topology", "geospatial")
     homepage = "https://trac.osgeo.org/geos"
     url = "https://github.com/conan-io/conan-center-index"
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -122,6 +122,4 @@ class GeosConan(ConanFile):
         self.cpp_info.components["geos_c"].requires = ["geos_cpp"]
 
         if self.options.utils:
-            bin_path = os.path.join(self.package_folder, "bin")
-            self.output.info("Appending PATH environment variable: {}".format(bin_path))
-            self.env_info.PATH.append(bin_path)
+            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
v2 packages are missing (required by https://github.com/conan-io/conan-center-index/pull/16152)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
