### PR TITLE
boost-leaf: fix deprecation

### DIFF
--- a/recipes/boost-leaf/all/conanfile.py
+++ b/recipes/boost-leaf/all/conanfile.py
@@ -60,7 +60,7 @@ class BoostLEAFConan(ConanFile):
                 f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler ({compiler}-{version}) does not support")
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/boost-leaf/all/conanfile.py
+++ b/recipes/boost-leaf/all/conanfile.py
@@ -19,10 +19,7 @@ class BoostLEAFConan(ConanFile):
               "header-only", "low-latency", "no-dependencies", "single-header")
     settings = "os", "compiler", "arch", "build_type"
     no_copy_source = True
-    deprecated = True
-
-    def configure(self):
-        raise ConanInvalidConfiguration(f"{self.ref} is deprecated in favor of Boost >=1.75.0")
+    deprecated = "boost"       
 
     def package_id(self):
         self.info.clear()
@@ -66,8 +63,7 @@ class BoostLEAFConan(ConanFile):
         basic_layout(self)
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
         copy(self, "LICENSE_1_0.txt", dst=os.path.join(


### PR DESCRIPTION
So it's a warning and not a hard error this was to hard lined for #15190 considering how #14690 was too 

//cc @kammce

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
