### PR TITLE
Draft: foxi: Modernize recipe + fix test_package

### DIFF
--- a/recipes/foxi/all/test_package/CMakeLists.txt
+++ b/recipes/foxi/all/test_package/CMakeLists.txt
@@ -4,4 +4,5 @@ project(test_package LANGUAGES C)
 find_package(foxi REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE foxi::foxi)
+target_compile_definitions(${PROJECT_NAME} PRIVATE ONNXIFI_PATH="${ONNXIFI_PATH}")
+target_link_libraries(${PROJECT_NAME} PRIVATE foxi_loader)

--- a/recipes/foxi/all/test_package/conanfile.py
+++ b/recipes/foxi/all/test_package/conanfile.py
@@ -1,18 +1,44 @@
 from conan import ConanFile
 from conan.tools.build import cross_building
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
+
+    def config_options(self):
+        # we need a shared onnxifi for testing library loading
+        self.options["onnx"].shared = True
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+        self.requires("onnx/1.11.0")
 
     def layout(self):
         cmake_layout(self)
+
+    def _get_libonnxifi_path(self):
+        # deduce onnxifi library path for loading
+        onnx_dep = self.dependencies["onnx"]
+        libonnxifi_prefix = "" if self.settings.os == "Windows" else "lib"
+        if self.settings.os == "Windows":
+            libonnxifi_postfix = ".dll"
+        elif self.settings.os == "Macos":
+            libonnxifi_postfix = ".dylib"
+        else:
+            libonnxifi_postfix = ".so"
+        libonnxifi_name = libonnxifi_prefix + "onnxifi" + libonnxifi_postfix
+        libonnxifi_path = os.path.join(onnx_dep.package_folder, onnx_dep.cpp_info.components["onnxifi"].libdirs[0], libonnxifi_name)
+        return libonnxifi_path
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ONNXIFI_PATH"] = self._get_libonnxifi_path()
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            tc.preprocessor_definitions["ONNXIFI_REQUIRES_PTHREAD_SYMBOLS"] = "1"
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/foxi/all/test_package/test_package.c
+++ b/recipes/foxi/all/test_package/test_package.c
@@ -1,14 +1,29 @@
 #include <foxi/onnxifi_loader.h>
 
 #include <stdio.h>
+#include <dlfcn.h>
+
+#ifndef ONNXIFI_PATH
+#define ONNXIFI_PATH NULL // let the library decide
+#endif
 
 int main() {
+#ifdef ONNXIFI_REQUIRES_PTHREAD_SYMBOLS
+    // We need to load pthreads before loading onnxifi to resolve all missing symbols
+    void* handlePthread = dlopen("libpthread.so", RTLD_GLOBAL | RTLD_LAZY);
+    if(!handlePthread ){
+        fprintf(stderr, "dlopen failed: %s\n", dlerror());
+        return 1;
+    }
+#endif
+
     struct onnxifi_library onnx;
-    int ret = onnxifi_load(ONNXIFI_LOADER_FLAG_VERSION_1_0, NULL, &onnx);
+    int ret = onnxifi_load(ONNXIFI_LOADER_FLAG_VERSION_1_0, ONNXIFI_PATH, &onnx);
     if (!ret) {
         printf("Cannot load onnxifi lib\n");
-        return 0;
+        return -1;
     }
     onnxifi_unload(&onnx);
+    printf("SUCCESS! onnxifi has been loaded & unloaded successfully.\n");
     return 0;
 }


### PR DESCRIPTION
- Use rm_safe, export_conandata_patches, do not provide destination to get
- Use components to match upstream CMakeLists exported targets (foxi is a interface header-only target)
- test_package should only pass if the library is actually able to load libonnxifi
  - Build infrastructure for that (require onnx/1.11.0, then deduce libonnxifi path & forward it to the test)
  - Linking with foxi::foxi is overkill for testing loading. Link against foxi_loader for that

Specify library name and version:  **folly/any**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
