### PR TITLE
fix module defines

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -986,7 +986,14 @@ Examples = bin/datadir/examples""")
             self.cpp_info.components[componentname].libs = [f"Qt5{libname}{libsuffix}"]
             if has_include_dir:
                 self.cpp_info.components[componentname].includedirs = ["include", os.path.join("include", f"Qt{module}")]
-            self.cpp_info.components[componentname].defines = [f"QT_{module.upper()}_LIB"]
+            define = module.upper()
+            if define == "TEST":
+                define = "TESTLIB"
+            elif define == "XCBQPA":
+                define = "XCB_QPA_LIB"
+            elif define.endswith("SUPPORT"):
+                define = define.replace("SUPPORT", "_SUPPORT")
+            self.cpp_info.components[componentname].defines = [f"QT_{define}_LIB"]
             if module != "Core" and "Core" not in requires:
                 requires.append("Core")
             self.cpp_info.components[componentname].requires = _get_corrected_reqs(requires)


### PR DESCRIPTION
fix defines for modules that use a definition that differs from the module name

Specify library name and version:  **qt/5.15.x**

Fixes #16508

Mainly, this will fix QtTest detection in a CMake project with Qt Creator when using the Autotest framework. Qt Creator relies on the symbol QT_TESTLIB_LIB to be defined correctly.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
