### PR TITLE
xorg-cf-files: remove package_type

### DIFF
--- a/recipes/xorg-cf-files/all/conanfile.py
+++ b/recipes/xorg-cf-files/all/conanfile.py
@@ -13,7 +13,7 @@ required_conan_version = ">=1.57.0"
 
 class XorgCfFilesConan(ConanFile):
     name = "xorg-cf-files"
-    package_type = "build-scripts"
+    # package_type = "build-scripts" # see https://github.com/conan-io/conan/issues/13431
     description = "Imake configuration files & templates"
     topics = ("imake", "xorg", "template", "configuration", "obsolete")
     license = "MIT"


### PR DESCRIPTION
Specify library name and version:  **xorg-cf-files/all**

Workaround issue in Conan 2.0 where `package_type="build-scripts"` but a package is not created during `conan create .`, see https://github.com/conan-io/conan/issues/13431.

