### PR TITLE
zfp: fix conan v2 package build failure

### DIFF
--- a/recipes/zfp/all/conanfile.py
+++ b/recipes/zfp/all/conanfile.py
@@ -54,9 +54,9 @@ class ZfpConan(ConanFile):
 
     def validate(self):
         if self.options.with_cuda:
-            self.output.warn("Conan package for CUDA is not available, this package will be used from system.")
+            self.output.warning("Conan package for CUDA is not available, this package will be used from system.")
         if self.options.with_openmp:
-            self.output.warn("Conan package for OpenMP is not available, this package will be used from system.")
+            self.output.warning("Conan package for OpenMP is not available, this package will be used from system.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **zfp/1.0.0**

Fix zfp recipe failing with conan 2 when `with_cuda` or `with_openmp` options are enabled.

Error message:
```
ERROR: zfp/1.0.0: Error in validate() method, line 59
        self.output.warn("Conan package for OpenMP is not available, this package will be used from system.")
        AttributeError: 'ConanOutput' object has no attribute 'warn'
```
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
