### PR TITLE
roaring: add version 0.9.9

### DIFF
--- a/recipes/roaring/all/conandata.yml
+++ b/recipes/roaring/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.9":
+    url: "https://github.com/RoaringBitmap/CRoaring/archive/v0.9.9.tar.gz"
+    sha256: "3083bcbc37e43403111c482ddf317a710972256c23bc83abc8925803a02bdf60"
   "0.9.8":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/v0.9.8.tar.gz"
     sha256: "d83ea18ded541a49f792951a6e71cd20136171ca0a4c15c77ec5cd5b83ca8e63"

--- a/recipes/roaring/config.yml
+++ b/recipes/roaring/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.9":
+    folder: all
   "0.9.8":
     folder: all
   "0.9.6":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **roaring/0.9.9**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
