### PR TITLE
service: automatically fix PRS titles

### DIFF
--- a/.github/workflows/fix-pr-title.yml
+++ b/.github/workflows/fix-pr-title.yml
@@ -1,0 +1,48 @@
+name: "[service] Fix Pull Request Title"
+
+on:
+  pull_request_target:
+
+jobs:
+  fix-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            pr = {
+                owner: context.issue.owner,
+                repo: context.issue.repo,
+                pull_number: context.issue.number,
+            }
+            files = await github.rest.pulls.listFiles(pr);
+            recipe = ""
+            for (file of files.data) {
+                filepath = file.filename.split("/")
+                if (filepath.length < 2){
+                    core.debug(`ignore file path too short : ${filepath}`)
+                    continue
+                }
+                if (filepath[0] != "recipes") {
+                    core.debug(`ignore file path not in recipes : ${filepath}`)
+                    continue
+                }
+                if (!recipe){
+                    recipe = filepath[1]
+                    core.debug(`Initializing recipe to ${recipe}`)
+                }
+                else if (recipe != filepath[1]) {
+                    core.setFailed(`pull request is modifying several recipe: ${recipe} and ${filepath[1]}`);
+                    return
+                }
+            }
+            if (!recipe){
+                core.debug("no recipe modified")
+                return
+            }
+            title = (await github.rest.pulls.get(pr)).data.title;
+            if (!title.toLowerCase().includes(recipe)) {
+                core.debug(`Modifying title because it does not contain recipe name ${recipe}: ${title}`)
+                pr.title = recipe + ": " + title
+                await github.rest.pulls.update(pr);
+            }


### PR DESCRIPTION
This is an action which is triggers for each pull-request: it inspects the files modified to identify the package name (from the path of the files modified). If the package name is not present in the PR title (case insensitive comparison), then the PR title is prepended with `package_name: `
I tested it on https://github.com/ericLemanissier/conan-center-index/pull/37. it properly handles then case where:
- a single recipe is modified, and the recipe name is not present in PR title => the title is updated
- a single recipe is modified, and the recipe name is present in PR title => no action
- several recipes are modified => no action
- no recipe is modified => no action


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

