### PR TITLE
getopt-for-visual-studio: modernize more for conan v2 (and generate v2 packages)

### DIFF
--- a/recipes/getopt-for-visual-studio/all/conanfile.py
+++ b/recipes/getopt-for-visual-studio/all/conanfile.py
@@ -1,11 +1,11 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, copy, get, load, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, load, save
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
 import os
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.52.0"
 
 
 class GetoptForVisualStudioConan(ConanFile):
@@ -15,11 +15,14 @@ class GetoptForVisualStudioConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/skandhurkat/Getopt-for-Visual-Studio"
     license = "MIT", "BSD-2-Clause"
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
 
     def export_sources(self):
-        for p in self.conan_data.get("patches", {}).get(self.version, []):
-            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()
@@ -28,12 +31,8 @@ class GetoptForVisualStudioConan(ConanFile):
         if not is_msvc(self):
             raise ConanInvalidConfiguration("getopt-for-visual-studio is only supported for Visual Studio")
 
-    def layout(self):
-        basic_layout(self, src_folder="src")
-
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         apply_conandata_patches(self)
@@ -50,4 +49,3 @@ class GetoptForVisualStudioConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-        self.cpp_info.resdirs = []

--- a/recipes/getopt-for-visual-studio/all/test_package/CMakeLists.txt
+++ b/recipes/getopt-for-visual-studio/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
 find_package(getopt-for-visual-studio)

--- a/recipes/getopt-for-visual-studio/all/test_package/conanfile.py
+++ b/recipes/getopt-for-visual-studio/all/test_package/conanfile.py
@@ -7,12 +7,13 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-
-    def requirements(self):
-        self.requires(self.tested_reference_str)
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/getopt-for-visual-studio/all/test_v1_package/CMakeLists.txt
+++ b/recipes/getopt-for-visual-studio/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.0)
-project(test_package LANGUAGES C)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(getopt-for-visual-studio)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE getopt-for-visual-studio::getopt-for-visual-studio)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
I need v2 packages to be able to generate v2 packages of `giflib` (https://github.com/conan-io/conan-center-index/pull/16566), so that I can generate v2 packages of `leptonica` (https://github.com/conan-io/conan-center-index/pull/16043)...

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
