### PR TITLE
catch2: add v2.13.10

### DIFF
--- a/recipes/catch2/2.x.x/conandata.yml
+++ b/recipes/catch2/2.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.13.10":
+    url: "https://github.com/catchorg/Catch2/archive/v2.13.10.tar.gz"
+    sha256: "d54a712b7b1d7708bc7a819a8e6e47b2fde9536f487b89ccbca295072a7d9943"
   "2.13.9":
     url: "https://github.com/catchorg/Catch2/archive/v2.13.9.tar.gz"
     sha256: "06dbc7620e3b96c2b69d57bf337028bf245a211b3cddb843835bfe258f427a52"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -13,6 +13,8 @@ versions:
     folder: 3.x.x
   "3.0.1":
     folder: 3.x.x
+  "2.13.10":
+    folder: 2.x.x
   "2.13.9":
     folder: 2.x.x
   "2.13.8":


### PR DESCRIPTION
Specify library name and version:  **catch2/2.13.10**

Adds the latest Catch2 v2 release: https://github.com/catchorg/Catch2/releases/tag/v2.13.10

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
