### PR TITLE
openldap: improve compatibility with different build environments

### DIFF
--- a/recipes/openldap/all/conanfile.py
+++ b/recipes/openldap/all/conanfile.py
@@ -69,7 +69,8 @@ class OpenldapConan(ConanFile):
 
         # Need to link to -pthread instead of -lpthread for gcc 8 shared=True
         # on CI job. Otherwise, linking fails.
-        self._autotools.libs.remove("pthread")
+        if "pthread" in self._autotools.libs:
+            self._autotools.libs.remove("pthread")
         self._configure_vars["LIBS"] = self._configure_vars["LIBS"].replace(
             "-lpthread", "-pthread")
 


### PR DESCRIPTION
**openldap**

Fix compatibility with build environments that don't link to pthread.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
