### PR TITLE
imath: add version 3.1.7

### DIFF
--- a/recipes/imath/all/conandata.yml
+++ b/recipes/imath/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.7":
+    url: "https://github.com/AcademySoftwareFoundation/Imath/archive/v3.1.7.tar.gz"
+    sha256: "bff1fa140f4af0e7f02c6cb78d41b9a7d5508e6bcdfda3a583e35460eb6d4b47"
   "3.1.6":
     url: "https://github.com/AcademySoftwareFoundation/Imath/archive/v3.1.6.tar.gz"
     sha256: "ea5592230f5ab917bea3ceab266cf38eb4aa4a523078d46eac0f5a89c52304db"

--- a/recipes/imath/config.yml
+++ b/recipes/imath/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.1.7":
+    folder: all
   "3.1.6":
     folder: all
   "3.1.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **imath/3.1.7**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
