### PR TITLE
libcbor: add version 0.10.2

### DIFF
--- a/recipes/libcbor/all/conandata.yml
+++ b/recipes/libcbor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.2":
+    url: "https://github.com/PJK/libcbor/archive/v0.10.2.tar.gz"
+    sha256: "e75f712215d7b7e5c89ef322a09b701f7159f028b8b48978865725f00f79875b"
   "0.10.1":
     url: "https://github.com/PJK/libcbor/archive/v0.10.1.tar.gz"
     sha256: "e8fa0a726b18861c24428561c80b3c95aca95f468df4e2f3e3ac618be12d3047"

--- a/recipes/libcbor/config.yml
+++ b/recipes/libcbor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.10.2":
+    folder: "all"
   "0.10.1":
     folder: "all"
   "0.10.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libcbor/0.10.2**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
