### PR TITLE
Update conanfile.py for freetype/2.12.1

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -236,7 +236,7 @@ class FreetypeConan(ConanFile):
 
     @staticmethod
     def _chmod_plus_x(filename):
-        if os.name == "posix":
+        if os.name == "posix" and (os.stat(filename).st_mode & 0o111) != 0o111:
             os.chmod(filename, os.stat(filename).st_mode | 0o111)
 
     def package_info(self):


### PR DESCRIPTION
Proposing as fix for 
    https://github.com/conan-io/conan-center-index/issues/16415

chmod is called only when freetype_config file doesn't have execute permission.

Specify library name and version:  **freetype/2.12.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

While using freetype conan package in a shared conan home environment faced permission issues (freetype/2.12.1: In Shared Conan User Home usage, seen PermissionError on "bin/freetype-config"). This is happening as every time package_info method is called, chmod is executed to change the file permissions on "freetype_config" file.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
