### PR TITLE
trantor: add version 1.5.11

### DIFF
--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.11":
+    url: "https://github.com/an-tao/trantor/archive/v1.5.11.tar.gz"
+    sha256: "3cff9653380f65acaa6ffa191620a2783e866a4552c3408a6919759ce4cfc1dc"
   "1.5.10":
     url: "https://github.com/an-tao/trantor/archive/v1.5.10.tar.gz"
     sha256: "2d47775b3091a1a103bea46f5da017dc03c39883f8d717cf6ba24bdcdf01a15d"

--- a/recipes/trantor/config.yml
+++ b/recipes/trantor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.11":
+    folder: "all"
   "1.5.10":
     folder: "all"
   "1.5.8":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **trantor/1.5.11**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
