### PR TITLE
asio: Add versions 1.26.0 and 1.27.0

### DIFF
--- a/recipes/asio/all/conandata.yml
+++ b/recipes/asio/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.27.0":
+    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-27-0.tar.gz"
+    sha256: "b31c63867daaba0e460ee2c85dc508a52c81db0a7318e0d2147f444b26f80ed7"
+  "1.26.0":
+    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-26-0.tar.gz"
+    sha256: "935583f86825b7b212479277d03543e0f419a55677fa8cb73a79a927b858a72d"
   "1.24.0":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-24-0.tar.gz"
     sha256: "cbcaaba0f66722787b1a7c33afe1befb3a012b5af3ad7da7ff0f6b8c9b7a8a5b"

--- a/recipes/asio/config.yml
+++ b/recipes/asio/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.27.0":
+    folder: all
+  "1.26.0":
+    folder: all
   "1.24.0":
     folder: all
   "1.23.0":


### PR DESCRIPTION
Specify library name and version:  **asio/1.27.0**

Add newer versions of the standalone Asio library

I need the fixes contained in the newest version, and tested locally that depending on the created conan package works.

---
- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
