### PR TITLE
concurrencpp: add 0.1.6

### DIFF
--- a/recipes/concurrencpp/all/conandata.yml
+++ b/recipes/concurrencpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.6":
+    url: "https://github.com/David-Haim/concurrencpp/archive/refs/tags/v.0.1.6.tar.gz"
+    sha256: "e7d5c23a73ff1d7199d361d3402ad2a710dfccf7630b622346df94a7532b4221"
   "0.1.5":
     url: "https://github.com/David-Haim/concurrencpp/archive/refs/tags/v.0.1.5.tar.gz"
     sha256: "330150ebe11b3d30ffcb3efdecc184a34cf50a6bd43b68e294a496225d286651"
@@ -6,6 +9,9 @@ sources:
     url: "https://github.com/David-Haim/concurrencpp/archive/refs/tags/v.0.1.4.tar.gz"
     sha256: "3ad9424f975b766accc6eaedf4acfe1a20b5fdbb57fa3ae71f400e13d471e86f"
 patches:
+  "0.1.6":
+    - patch_file: "patches/cmake-min-version.patch"
+    - patch_file: "patches/directory-name-0.1.6.patch"
   "0.1.5":
     - patch_file: "patches/cmake-min-version.patch"
     - patch_file: "patches/directory-name-0.1.5.patch"

--- a/recipes/concurrencpp/all/conanfile.py
+++ b/recipes/concurrencpp/all/conanfile.py
@@ -57,7 +57,7 @@ class ConcurrencppConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-        if self.options.shared and is_msvc(self):
+        if Version(self.version) <= "0.1.5" and self.options.shared and is_msvc(self):
             # see https://github.com/David-Haim/concurrencpp/issues/75
             raise ConanInvalidConfiguration(f"{self.ref} does not support shared builds with Visual Studio")
         if self.settings.compiler == "gcc":

--- a/recipes/concurrencpp/all/patches/directory-name-0.1.6.patch
+++ b/recipes/concurrencpp/all/patches/directory-name-0.1.6.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -116,8 +116,8 @@ include(CMakePackageConfigHelpers)
+ include(CMakePackageConfigHelpers)
+ include(GNUInstallDirs)
+ 
+-set(concurrencpp_directory "concurrencpp-${PROJECT_VERSION}")
+-set(concurrencpp_include_directory "${CMAKE_INSTALL_INCLUDEDIR}/${concurrencpp_directory}")
++set(concurrencpp_directory "concurrencpp")
++set(concurrencpp_include_directory "${CMAKE_INSTALL_INCLUDEDIR}")
+ 
+ install(
+   TARGETS concurrencpp

--- a/recipes/concurrencpp/config.yml
+++ b/recipes/concurrencpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.1.6":
+    folder: all
   "0.1.5":
     folder: all
   "0.1.4":


### PR DESCRIPTION
Specify library name and version:  **concurrencpp/0.1.6**

This updates the concurrencpp port to the latest version 0.1.6.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
