### PR TITLE
spdlog fix: option 'shared' doesn't exist

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -41,10 +41,11 @@ class SpdlogConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.options.shared or self.options.header_only:
-            self.options.rm_safe("fPIC")
         if self.options.header_only:
             del self.options.shared
+            self.options.rm_safe("fPIC")
+        elif self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -41,11 +41,10 @@ class SpdlogConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.get_safe("shared") or self.options.header_only:
+            self.options.rm_safe("fPIC")
         if self.options.header_only:
-            del self.options.shared
-            self.options.rm_safe("fPIC")
-        elif self.options.shared:
-            self.options.rm_safe("fPIC")
+            self.options.rm_safe("shared")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **spdlog/1.11.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

fix issue https://github.com/conan-io/conan-center-index/issues/16652

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
