### PR TITLE
glib: add version 2.76.1

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.76.1":
+    url: "https://download.gnome.org/sources/glib/2.76/glib-2.76.1.tar.xz"
+    sha256: "43dc0f6a126958f5b454136c4398eab420249c16171a769784486e25f2fda19f"
   "2.76.0":
     url: "https://download.gnome.org/sources/glib/2.76/glib-2.76.0.tar.xz"
     sha256: "525bb703b807142e1aee5ccf222c344e8064b21c0c45677ef594e587874c6797"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.76.1":
+    folder: all
   "2.76.0":
     folder: all
   "2.75.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glib/2.76.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
