### PR TITLE
libcurl: update to 8.0.1

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "8.0.0":
-    url: "https://curl.se/download/curl-8.0.0.tar.gz"
-    sha256: "8d437cd8cd70609c70eea0b1cbeb8755145140d1ffe175108e3cebe8619501a6"
+  "8.0.1":
+    url: "https://curl.se/download/curl-8.0.1.tar.gz"
+    sha256: "5fd29000a4089934f121eff456101f0a5d09e2a3e89da1d714adf06c4be887cb"
   "7.88.1":
     url: "https://curl.se/download/curl-7.88.1.tar.gz"
     sha256: "cdb38b72e36bc5d33d5b8810f8018ece1baa29a8f215b4495e495ded82bbf3c7"

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "8.0.0":
+  "8.0.1":
     folder: all
   "7.88.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libcurl/8.0.1**

A minor upgrade fixing a crash in CURL's destructor.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
