### PR TITLE
[docs] Complement Conan v2 roadmap about dropping Conan v1 configuration

### DIFF
--- a/docs/v2_roadmap.md
+++ b/docs/v2_roadmap.md
@@ -131,7 +131,7 @@ pull-requests need to work with v1 and v2 to be merged.
 
 ### Conan v2 remote
 
-TBD. Packages built using Conan v2 will become available for users
+Packages built using Conan v2 are available for users on ``conancenter`` remote.
 
 ### Webpage with v2 information
 
@@ -142,3 +142,8 @@ packages and, eventually, v2 information will be the only available.
 
 After this process in completed, we will consider the deprecation and
 decommission of the infrastructure to generate v1 packages.
+
+### CI running Conan v1 dropping configuration support
+
+The change should occur by steps, less used configurations, like older compiler versions, will be dropped first.
+Any changed will notified before to occur, so users can be prepared.


### PR DESCRIPTION
It's clear how Conan v1 will be dropped, so this PR adds an extra information that users will be alerted about before some change occurring.

Plus, Conan v2 packages are now available on conancenter. 


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
