### PR TITLE
readerwriterqueue: fix copying header files

### DIFF
--- a/recipes/readerwriterqueue/all/conanfile.py
+++ b/recipes/readerwriterqueue/all/conanfile.py
@@ -1,6 +1,5 @@
 from conan import ConanFile
 from conan.tools.files import get, copy
-from conan.tools.scm import Version
 from conan.tools.layout import basic_layout
 import os
 

--- a/recipes/readerwriterqueue/all/conanfile.py
+++ b/recipes/readerwriterqueue/all/conanfile.py
@@ -28,10 +28,8 @@ class ReaderWriterQueue(ConanFile):
 
     def package(self):
         copy(self, "LICENSE.md", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        copy(self, "atomicops.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include", "readerwriterqueue"))
-        copy(self, "readerwriterqueue.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include", "readerwriterqueue"))
-        if Version(self.version) >= "1.0.5":
-            copy(self, "readerwritercircularbuffer.h", src=self.source_folder, dst=os.path.join("include", "readerwriterqueue"))
+        copy(self, "*.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include", "readerwriterqueue"),
+             excludes=["benchmarks", "tests"])
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Specify library name and version:  **readerwriterqueue/all**

Fix regression introduced in https://github.com/conan-io/conan-center-index/pull/16353, where a header file is missing for the most recent version of the library.

Close https://github.com/conan-io/conan-center-index/issues/16651
