### PR TITLE
LibUsb in Dual-Profile fails with automake

### DIFF
--- a/recipes/libusb-compat/all/conanfile.py
+++ b/recipes/libusb-compat/all/conanfile.py
@@ -120,11 +120,13 @@ class LibUSBCompatConan(ConanFile):
     def _build_context(self):
         if self.settings.compiler == "Visual Studio":
             with tools.vcvars(self.settings):
+                # use automake infos from build definition on cross build, otherwise fall back on userinfo.
+                automake = self.deps_user_info.get("automake", self.user_info_build.get("automake"))
                 env = {
-                    "CC": "{} cl -nologo".format(tools.unix_path(self.deps_user_info["automake"].compile)),
-                    "CXX": "{} cl -nologo".format(tools.unix_path(self.deps_user_info["automake"].compile)),
+                    "CC": f"{automake.compile} cl -nologo",
+                    "CXX": f"{automake.compile} cl -nologo",
                     "LD": "link -nologo",
-                    "AR": "{} lib".format(tools.unix_path(self.deps_user_info["automake"].ar_lib)),
+                    "AR": f"{automake.ar_lib} lib",
                     "DLLTOOL": ":",
                     "OBJDUMP": ":",
                     "RANLIB": ":",


### PR DESCRIPTION
* Use build information as well as user infos on build

Specify library name and version:  **libusb-compat/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Dual-Profile Builds will fail when not accessing the right variables.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
