### PR TITLE
sentry-crashpad: Fix wrong license being packaged

### DIFF
--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -102,7 +102,8 @@ class SentryCrashpadConan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "LICENSE", src=os.path.join(self.source_folder, "external", "crashpad"),
+                              dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.configure(build_script_folder="external/crashpad")
         cmake.install()


### PR DESCRIPTION
**sentry-crashpad/0.6.0**

Seems to have been mistakenly(?) changed in #12051

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
