### PR TITLE
wayland-protocols: fix source references

### DIFF
--- a/recipes/wayland-protocols/all/conandata.yml
+++ b/recipes/wayland-protocols/all/conandata.yml
@@ -5,7 +5,7 @@ sources:
   "1.27":
     url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.27/wayland-protocols-1.27.tar.bz2"
     sha256: "5d3705c11ac6a43730a3a553a3b5be34b001fe6c531c7ba02659179fa4cc3520"
- "1.26":
+  "1.26":
     url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.26/wayland-protocols-1.26.tar.bz2"
     sha256: "0426ae92841cad054dac8565a90c282deabb60c46a3752c37788b8a322ad12a2"
   "1.25":

--- a/recipes/wayland-protocols/all/conandata.yml
+++ b/recipes/wayland-protocols/all/conandata.yml
@@ -1,7 +1,22 @@
 sources:
   "1.31":
-    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.31/downloads/wayland-protocols-1.31.tar.xz"
-    sha256: "a07fa722ed87676ec020d867714bc9a2f24c464da73912f39706eeef5219e238"
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.31/wayland-protocols-1.31.tar.bz2"
+    sha256: "3d7fa65a6f3c86747f780a628df04d3c7a981776dee2b6a492cc112b3bbe2820"
   "1.27":
-    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.27/downloads/wayland-protocols-1.27.tar.xz"
-    sha256: "9046f10a425d4e2a00965a03acfb6b3fb575a56503ac72c2b86821c69653375c"
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.27/wayland-protocols-1.27.tar.bz2"
+    sha256: "5d3705c11ac6a43730a3a553a3b5be34b001fe6c531c7ba02659179fa4cc3520"
+ "1.26":
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.26/wayland-protocols-1.26.tar.bz2"
+    sha256: "0426ae92841cad054dac8565a90c282deabb60c46a3752c37788b8a322ad12a2"
+  "1.25":
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.25/wayland-protocols-1.25.tar.bz2"
+    sha256: "633c9bed0efb8e773c5780d4442051264d179c154b7d1896ca3b56b5d4da4718"
+  "1.24":
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.24/wayland-protocols-1.24.tar.bz2"
+    sha256: "a165e2da28197b1dcf97fd9ec06b16b030bdc5de6c92162c4b09026e62cfe8f9"
+  "1.23":
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.23/wayland-protocols-1.23.tar.bz2"
+    sha256: "b860c692ff83b4bd6251dc74c579ced3a68ec0743b7af801ef3f501da3fde330"
+  "1.21":
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.21/wayland-protocols-1.21.tar.bz2"
+    sha256: "cf1a62195eb49622fc3c3eda440d0225ee49bd5aa9f1ee993c28fe0796dae783"

--- a/recipes/wayland-protocols/all/conandata.yml
+++ b/recipes/wayland-protocols/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
   "1.31":
-    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.31/wayland-protocols-1.31.tar.bz2"
-    sha256: "3d7fa65a6f3c86747f780a628df04d3c7a981776dee2b6a492cc112b3bbe2820"
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.31/downloads/wayland-protocols-1.31.tar.xz"
+    sha256: "a07fa722ed87676ec020d867714bc9a2f24c464da73912f39706eeef5219e238"
   "1.27":
-    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.27/wayland-protocols-1.27.tar.bz2"
-    sha256: "5d3705c11ac6a43730a3a553a3b5be34b001fe6c531c7ba02659179fa4cc3520"
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.27/downloads/wayland-protocols-1.27.tar.xz"
+    sha256: "9046f10a425d4e2a00965a03acfb6b3fb575a56503ac72c2b86821c69653375c"
   "1.26":
     url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/archive/1.26/wayland-protocols-1.26.tar.bz2"
     sha256: "0426ae92841cad054dac8565a90c282deabb60c46a3752c37788b8a322ad12a2"

--- a/recipes/wayland-protocols/all/conandata.yml
+++ b/recipes/wayland-protocols/all/conandata.yml
@@ -1,22 +1,7 @@
 sources:
   "1.31":
-    url: "https://github.com/wayland-project/wayland-protocols/archive/1.31.tar.gz"
-    sha256: "04d3f66eca99d638ec8dbfdfdf79334290e22028f7d0b04c7034d9ef18a3248a"
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.31/downloads/wayland-protocols-1.31.tar.xz"
+    sha256: "a07fa722ed87676ec020d867714bc9a2f24c464da73912f39706eeef5219e238"
   "1.27":
-    url: "https://github.com/wayland-project/wayland-protocols/archive/1.27.tar.gz"
-    sha256: "6dd6ee86478adf4347f3b8b4f3da62dbe9e44912c9cef21cf99abfe692313df4"
-  "1.26":
-    url: "https://github.com/wayland-project/wayland-protocols/archive/1.26.tar.gz"
-    sha256: "fe56386f436a84e97c3b6a61b76306f205a64425900f247ad0048174b9c32d4d"
-  "1.25":
-    url: "https://github.com/wayland-project/wayland-protocols/archive/1.25.tar.gz"
-    sha256: "4326e2b5e04e459ab4522e83e19bff101a3faf9b085bcf46b6cabbd392cc4458"
-  "1.24":
-    url: "https://github.com/wayland-project/wayland-protocols/archive/1.24.tar.gz"
-    sha256: "71a171f964e4fe25cede281a2939ac5298ddaba9a5dd8a217db66843a532d064"
-  "1.23":
-    url: "https://github.com/wayland-project/wayland-protocols/archive/1.23.tar.gz"
-    sha256: "1ffd6f90eb247ff79de50ac10490ed03100572fb571cebef4df9ec74a271b2af"
-  "1.21":
-    url: "https://github.com/wayland-project/wayland-protocols/archive/refs/tags/1.21.tar.gz"
-    sha256: "4cb4cd8c94534faf95243be957cd6b739b1a2d068218dc8f0762eac3d4707c04"
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.27/downloads/wayland-protocols-1.27.tar.xz"
+    sha256: "9046f10a425d4e2a00965a03acfb6b3fb575a56503ac72c2b86821c69653375c"

--- a/recipes/wayland-protocols/all/conanfile.py
+++ b/recipes/wayland-protocols/all/conanfile.py
@@ -44,15 +44,7 @@ class WaylandProtocolsConan(ConanFile):
         virtual_build_env = VirtualBuildEnv(self)
         virtual_build_env.generate()
 
-    def _patch_sources(self):
-        if Version(self.version) <= "1.23":
-            # fixed upstream in https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/113
-            replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
-                            "dep_scanner = dependency('wayland-scanner', native: true)",
-                            "#dep_scanner = dependency('wayland-scanner', native: true)")
-
     def build(self):
-        self._patch_sources()
         meson = Meson(self)
         meson.configure()
         meson.build()

--- a/recipes/wayland-protocols/all/conanfile.py
+++ b/recipes/wayland-protocols/all/conanfile.py
@@ -1,9 +1,8 @@
 from conan import ConanFile
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
-from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 import os
 


### PR DESCRIPTION
Specify library name and version:  **wayland-protocols/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

It seems that the [wayland-project](https://github.com/wayland-project) organisation on GitHub is no longer having any public repositories. There all the source urls are no longer working. Unfortunately the GitLab setup is not having all the older versions listed in conandata available.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
