### PR TITLE
openvc: 4.x modernize more for conan v2

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -220,7 +220,8 @@ class OpenCVConan(ConanFile):
         if self.options.get_safe("with_gtk"):
             self.requires("gtk/system")
         if self.options.dnn:
-            self.requires(f"protobuf/{self._protobuf_version}")
+            # Symbols are exposed https://github.com/conan-io/conan-center-index/pull/16678#issuecomment-1507811867
+            self.requires(f"protobuf/{self._protobuf_version}", transitive_libs=True)
         if self.options.with_ade:
             self.requires("ade/0.1.2a")
 
@@ -245,8 +246,7 @@ class OpenCVConan(ConanFile):
                 self.tool_requires(f"protobuf/{self._protobuf_version}")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version][0],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version][0], strip_root=True)
 
         get(self, **self.conan_data["sources"][self.version][1],
             destination=self._contrib_folder, strip_root=True)

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -541,7 +541,7 @@ class OpenCVConan(ConanFile):
             return False
         gtk_version = self.dependencies["gtk"].ref.version
         if gtk_version == "system":
-            return self.options["gtk"].version == 2
+            return self.dependencies["gtk"].options.version == 2
         else:
             return Version(gtk_version) < "3.0.0"
 

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -138,7 +138,8 @@ class OpenCVConan(ConanFile):
             # Following the packager choice, ffmpeg is enabled by default when
             # supported, except on Android. See
             # https://github.com/opencv/opencv/blob/39c3334147ec02761b117f180c9c4518be18d1fa/CMakeLists.txt#L266-L268
-            self.options.with_ffmpeg = self.settings.os != "Android"
+            self.options.with_ffmpeg = False # self.settings.os != "Android"
+            # Currently blocking v2 migration
         else:
             del self.options.with_ffmpeg
 

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -207,7 +207,7 @@ class OpenCVConan(ConanFile):
         if self.options.with_ipp == "intel-ipp":
             self.requires("intel-ipp/2020")
         if self.options.with_webp:
-            self.requires("libwebp/1.2.4")
+            self.requires("libwebp/1.3.0")
         if self.options.get_safe("contrib_freetype"):
             self.requires("freetype/2.12.1")
             self.requires("harfbuzz/6.0.0")

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -83,7 +83,7 @@ class OpenCVConan(ConanFile):
         "with_cufft": False,
         "with_cudnn": False,
         "with_v4l": False,
-        "with_ffmpeg": True,
+        "with_ffmpeg": False, # Currently Blocking Conan 2.0 migration https://github.com/conan-io/conan-center-index/pull/16678#issuecomment-1487662909
         "with_imgcodec_hdr": False,
         "with_imgcodec_pfm": False,
         "with_imgcodec_pxm": False,

--- a/recipes/opencv/4.x/test_package/CMakeLists.txt
+++ b/recipes/opencv/4.x/test_package/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
+option(built_dnn "Enabled if opencv is built dnn" OFF)
 option(built_with_ade "Enabled if opencv is built with ade" OFF)
 option(built_with_ffmpeg "Enabled if opencv is built with ffmpeg" OFF)
 option(built_contrib_sfm "Enabled if opencv is built contrib sfm" OFF)
@@ -16,6 +17,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     $<TARGET_NAME_IF_EXISTS:opencv_videoio>
     $<TARGET_NAME_IF_EXISTS:opencv_sfm>
 )
+if(built_dnn)
+    target_link_libraries(${PROJECT_NAME} PRIVATE opencv_dnn)
+endif()
+
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 if(built_with_ade)
     target_compile_definitions(${PROJECT_NAME} PRIVATE BUILT_WITH_ADE)

--- a/recipes/opencv/4.x/test_package/conanfile.py
+++ b/recipes/opencv/4.x/test_package/conanfile.py
@@ -17,6 +17,7 @@ class TestPackageConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["built_dnn"] = self.dependencies["opencv"].options.dnn
         tc.variables["built_with_ade"] = self.dependencies["opencv"].options.with_ade
         tc.variables["built_with_ffmpeg"] = self.dependencies["opencv"].options.with_ffmpeg
         tc.variables["built_contrib_sfm"] = self.dependencies["opencv"].options.contrib and self.dependencies["opencv"].options.contrib_sfm

--- a/recipes/opencv/4.x/test_v1_package/conanfile.py
+++ b/recipes/opencv/4.x/test_v1_package/conanfile.py
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["built_dnn"] = self.options["opencv"].dnn
         cmake.definitions["built_with_ade"] = self.options["opencv"].with_ade
         cmake.definitions["built_with_ffmpeg"] = self.options["opencv"].with_ffmpeg
         cmake.definitions["built_contrib_sfm"] = self.options["opencv"].contrib and self.options["opencv"].contrib_sfm


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**


Building this locally I ran into a version conflict

```
Graph root
    cli
Requirements
    imath/3.1.6#7f6b123c01e44d29f5170f2141083e44 - Downloaded (conancenter)
    jasper/4.0.0#478d874438e50163be99725c8603281a - Downloaded (conancenter)
    jbig/20160605#2d29fa02aacd76902e0d2cbbc24631ef - Downloaded (conancenter)
    libdeflate/1.17#71f492ef993b45d9b961b36fb85e801f - Downloaded (conancenter)
    libjpeg/9e#68269859e4325ddc3f995d1fd3fc9187 - Downloaded (conancenter)
    libpng/1.6.39#deca555b0890e584fc895ba756e83c06 - Downloaded (conancenter)
    libtiff/4.4.0#e6d8942022c89a22dfbe1a9b77289c7e - Downloaded (conancenter)
    opencv/4.5.5#107c7183c36c63faeb1512659ccd6c70 - Cache
    openexr/3.1.5#88ba2322e127ebe5635fcbfdff4928d2 - Downloaded (conancenter)
    xz_utils/5.4.0#186e94237b66f785e4ea095f2f621a56 - Downloaded (conancenter)
    zlib/1.2.13#13c96f538b52e1600c40b88994de240f - Downloaded (conancenter)
    zstd/1.5.4#15ac0bc440f89247276d78ea4fdf8b14 - Downloaded (conancenter)
ERROR: Version conflict: libtiff/4.4.0->libwebp/1.3.0, opencv/4.5.5->libwebp/1.2.4.
```

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
