### PR TITLE
opengl: on Suse systems some opengl header files are in package glproto-devel

### DIFF
--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -35,7 +35,7 @@ class SysConfigOpenGLConan(ConanFile):
         pacman.install(["libglvnd"], update=True, check=True)
 
         zypper = package_manager.Zypper(self)
-        zypper.install(["Mesa-libGL-devel"], ["glproto-devel"], update=True, check=True)
+        zypper.install(["Mesa-libGL-devel", "glproto-devel"], update=True, check=True)
 
         pkg = package_manager.Pkg(self)
         pkg.install(["libglvnd"], update=True, check=True)

--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -35,7 +35,7 @@ class SysConfigOpenGLConan(ConanFile):
         pacman.install(["libglvnd"], update=True, check=True)
 
         zypper = package_manager.Zypper(self)
-        zypper.install(["Mesa-libGL-devel"], update=True, check=True)
+        zypper.install(["Mesa-libGL-devel"], ["glproto-devel"], update=True, check=True)
 
         pkg = package_manager.Pkg(self)
         pkg.install(["libglvnd"], update=True, check=True)


### PR DESCRIPTION
Specify library name and version:  **opengl/system**

On (open)Suse systems some opengl header files are packaged in package glproto-devel. This package installs oa the following header files:
GL/glxint.h GL/glxmd.h GL/glxproto.h GL/glxtokens.h .

These header files are needed to build for example package 'qt' including the QWebEngine library.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
