### PR TITLE
sentry-native: Properly platform and version protect the new wer option

### DIFF
--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -68,6 +68,9 @@ class SentryNativeConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+        if self.settings.os != "Windows" or Version(self.version) < "0.6.0":
+            del self.options.wer
+
         # Configure default transport
         if self.settings.os == "Windows":
             self.options.transport = "winhttp"
@@ -160,7 +163,8 @@ class SentryNativeConan(ConanFile):
         tc.variables["SENTRY_TRANSPORT"] = self.options.transport
         tc.variables["SENTRY_PIC"] = self.options.get_safe("fPIC", True)
         tc.variables["SENTRY_INTEGRATION_QT"] = self.options.qt
-        tc.variables["CRASHPAD_WER_ENABLED"] = self.options.wer
+        if self.options.get_safe("wer", False):
+            tc.variables["CRASHPAD_WER_ENABLED"] = True
         tc.generate()
         CMakeDeps(self).generate()
         if self.options.backend == "breakpad":


### PR DESCRIPTION
**sentry-native/0.6.0**

Feedback from #16530

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
