### PR TITLE
ruy: update to support Conan 2.0

### DIFF
--- a/recipes/ruy/all/CMakeLists.txt
+++ b/recipes/ruy/all/CMakeLists.txt
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 3.4)
-project(cmake_wrapper)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
-add_subdirectory(source_subfolder)

--- a/recipes/ruy/all/conandata.yml
+++ b/recipes/ruy/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "cci.20210622":
-    url: "https://github.com/google/ruy/archive/9c56af3fce210a8a103eda19bd6f47c08a9e3d90.tar.gz"
-    sha256: "8895874cfbf7263b028a6ec55b4b1737af0ea2b7bfedac90fd14d0b0a654f2dc"
   "cci.20220628":
     url: "https://github.com/google/ruy/archive/841ea4172ba904fe3536789497f9565f2ef64129.tar.gz"
     sha256: "fbd20e6c8cd5cf8ef159f69600ea0c7ef0f1401a4c16a9cd04e5a12ffa9c6e14"

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -66,8 +66,7 @@ class RuyConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-                destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -1,8 +1,12 @@
 import os
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, replace_in_file, rm
+from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.57.0"
 
 
 class RuyConan(ConanFile):
@@ -13,8 +17,6 @@ class RuyConan(ConanFile):
     homepage = "https://github.com/google/ruy"
     license = "Apache-2.0"
     topics = ("matrix", "multiplication", "neural", "network", "AI", "tensorflow")
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -24,12 +26,6 @@ class RuyConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
 
     @property
     def _minimum_compilers_version(self):
@@ -41,77 +37,67 @@ class RuyConan(ConanFile):
         }
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 14)
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 14)
 
         minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
         if not minimum_version:
             self.output.warn("Compiler is unknown. Assuming it supports C++14.")
-        elif tools.Version(self.settings.compiler.version) < minimum_version:
+        elif Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("Build requires support for C++14. Minimum version for {} is {}"
                 .format(str(self.settings.compiler), minimum_version))
 
-        if str(self.settings.compiler) == "clang" and tools.Version(self.settings.compiler.version) <= 5 and self.settings.build_type == "Debug":
+        if str(self.settings.compiler) == "clang" and Version(self.settings.compiler.version) <= 5 and self.settings.build_type == "Debug":
             raise ConanInvalidConfiguration("Debug builds are not supported on older versions of Clang (<=5)")
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("cpuinfo/cci.20201217")
+        self.requires("cpuinfo/cci.20220228")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+                destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["RUY_MINIMAL_BUILD"] = True
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["RUY_MINIMAL_BUILD"] = True
+        tc.cache_variables["RUY_FIND_CPUINFO"] = True
+        tc.generate()
 
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         # 1. Allow Shared builds
-        tools.replace_in_file(os.path.join(self._source_subfolder, "cmake", "ruy_cc_library.cmake"),
+        replace_in_file(self, os.path.join(self.source_folder, "cmake", "ruy_cc_library.cmake"),
                               "add_library(${_NAME} STATIC",
                               "add_library(${_NAME}"
                               )
 
-        # 2. Shared builds fail with undefined symbols without this fix.
-        # This is because ruy only links to 'cpuinfo' but it also needs 'clog' (from the same package)
-        cpuinfoLibs = self.deps_cpp_info["cpuinfo"].libs + self.deps_cpp_info["cpuinfo"].system_libs
-        libsListAsString = ";".join(cpuinfoLibs)
-        if int(self.version.strip('cci.')) < 20220628:
-            tools.replace_in_file(os.path.join(self._source_subfolder, "ruy", "CMakeLists.txt"),
-                                  "set(ruy_6_cpuinfo \"cpuinfo\")",
-                                  f"set(ruy_6_cpuinfo \"{libsListAsString}\")"
-                                  )
-        else:
-            tools.replace_in_file(os.path.join(self._source_subfolder, "ruy", "CMakeLists.txt"),
-                                  "set(ruy_6_cpuinfo_cpuinfo \"cpuinfo::cpuinfo\")",
-                                  f"set(ruy_6_cpuinfo_cpuinfo \"{libsListAsString}\")"
-                                  )
-
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*.h", dst=os.path.join("include", "ruy"), src=os.path.join(self._source_subfolder, "ruy"))
-        self.copy(pattern="*", dst="lib", src="lib")
-        self.copy(pattern="*", dst="bin", src="bin")
-
-        tools.remove_files_by_mask(self.package_folder, "*.pdb")
+        cmake = CMake(self)
+        cmake.install()
+        
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        rm(self, "*.pdb", self.package_folder, recursive=True ) # TODO double check cmake.install() brings this in
+        # TODO: delete cmake generated files
 
     def package_info(self):
+        # TODO; double check if components are needed
         self.cpp_info.libs = ["ruy_frontend",
                             "ruy_context",
                             "ruy_trmul",

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file, rm, rmdir
+from conan.tools.files import  copy, get, replace_in_file, rmdir
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
@@ -92,13 +92,10 @@ class RuyConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        rm(self, "*.pdb", self.package_folder, recursive=True ) # TODO double check cmake.install() brings this in
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        # TODO; double check if components are needed
         self.cpp_info.libs = ["ruy_frontend",
                             "ruy_context",
                             "ruy_trmul",

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file, rm
+from conan.tools.files import copy, get, replace_in_file, rm, rmdir
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
@@ -95,7 +95,7 @@ class RuyConan(ConanFile):
         
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         rm(self, "*.pdb", self.package_folder, recursive=True ) # TODO double check cmake.install() brings this in
-        # TODO: delete cmake generated files
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         # TODO; double check if components are needed

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -31,6 +31,7 @@ class RuyConan(ConanFile):
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "15",
+            "msvc": "191", 
             "gcc": "5",
             "clang": "3.4",
             "apple-clang": "5.1",
@@ -42,7 +43,7 @@ class RuyConan(ConanFile):
 
         minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
         if not minimum_version:
-            self.output.warn("Compiler is unknown. Assuming it supports C++14.")
+            self.output.warning("Compiler is unknown. Assuming it supports C++14.")
         elif Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("Build requires support for C++14. Minimum version for {} is {}"
                 .format(str(self.settings.compiler), minimum_version))

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -73,6 +73,9 @@ class RuyConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.cache_variables["RUY_MINIMAL_BUILD"] = True
         tc.cache_variables["RUY_FIND_CPUINFO"] = True
+        # Ruy public headers don't have API decorators,
+        # export everything to support shared libraries on Windows
+        tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/ruy/all/test_package/CMakeLists.txt
+++ b/recipes/ruy/all/test_package/CMakeLists.txt
@@ -7,4 +7,4 @@ find_package(ruy REQUIRED)
 add_executable(${PROJECT_NAME} test_package.cpp)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ruy::ruy)
-
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/ruy/all/test_package/CMakeLists.txt
+++ b/recipes/ruy/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(test_package LANGUAGES CXX)
 
-find_package(ruy REQUIRED)
+find_package(ruy REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 

--- a/recipes/ruy/all/test_package/CMakeLists.txt
+++ b/recipes/ruy/all/test_package/CMakeLists.txt
@@ -1,11 +1,10 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.15)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(ruy REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ruy::ruy)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ruy::ruy)
+

--- a/recipes/ruy/all/test_package/conanfile.py
+++ b/recipes/ruy/all/test_package/conanfile.py
@@ -14,13 +14,6 @@ class TestPackageConan(ConanFile):
     def layout(self):
         cmake_layout(self)
 
-    def generate(self):
-        tc = CMakeToolchain(self)
-        if not self.settings.compiler.get_safe("cppstd"):
-            # Conan 1.x profiles that may not have cppstd defined
-            tc.variables['CMAKE_CXX_STANDARD'] = "11"
-        tc.generate()
-
     def build(self):
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/ruy/all/test_package/conanfile.py
+++ b/recipes/ruy/all/test_package/conanfile.py
@@ -5,7 +5,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
     def requirements(self):

--- a/recipes/ruy/all/test_package/conanfile.py
+++ b/recipes/ruy/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-from conans import ConanFile, CMake, tools
-
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/ruy/all/test_package/conanfile.py
+++ b/recipes/ruy/all/test_package/conanfile.py
@@ -1,11 +1,11 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
 import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def requirements(self):
@@ -13,6 +13,13 @@ class TestPackageConan(ConanFile):
 
     def layout(self):
         cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if not self.settings.compiler.get_safe("cppstd"):
+            # Conan 1.x profiles that may not have cppstd defined
+            tc.variables['CMAKE_CXX_STANDARD'] = "11"
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/ruy/all/test_v1_package/CMakeLists.txt
+++ b/recipes/ruy/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(ruy REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ruy::ruy)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/ruy/all/test_v1_package/conanfile.py
+++ b/recipes/ruy/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/ruy/all/test_v1_package/test_package.cpp
+++ b/recipes/ruy/all/test_v1_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include <cstdint>
+#include <iostream>
+
+#include "ruy/ruy.h"
+
+int main() {
+
+  ruy::Context context;
+  const float lhs_data[] = {1, 2, 3, 4};
+  const float rhs_data[] = {1, 2, 3, 4};
+  float dst_data[4];
+
+  ruy::Matrix<float> lhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
+  lhs.set_data(lhs_data);
+  ruy::Matrix<float> rhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
+  rhs.set_data(rhs_data);
+  ruy::Matrix<float> dst;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
+  dst.set_data(dst_data);
+
+  ruy::MulParams<float, float> mul_params;
+  ruy::Mul(lhs, rhs, mul_params, &context, &dst);
+
+  std::cout << "ruy's test_package ran successfully \n";
+}

--- a/recipes/ruy/config.yml
+++ b/recipes/ruy/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "cci.20210622":
-    folder: all
   "cci.20220628":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **ruy/all**

Changes in this PR:

* Use newer Conan 2.0 integrations, while maintaining compatibility with Conan 1.x
* Remove older version which has outdated CMake scripts, with limitations. Newer versions are more "conventional modern cmake" - this allows us to remove workarounds to handle the cpuinfo dependency
* Add workaround to ensure that `cmake_minimum_required()` is the first thing called in the project - this is an upstream issue which has been reported: https://github.com/google/ruy/issues/328
* Bump dependency on cpuinfo to latest