### PR TITLE
date: fix for android

### DIFF
--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -39,7 +39,7 @@ class DateConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.os in ["iOS", "tvOS", "watchOS"]:
+        if self.settings.os in ["iOS", "tvOS", "watchOS", "Android"]:
             self.options.use_system_tz_db = True
 
     def configure(self):


### PR DESCRIPTION
Specify library name and version:  **date/3.0.0**

Error for cross-build from linux to android-arm according to:

https://github.com/HowardHinnant/date/issues/161


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
