### PR TITLE
fix #16059: add missing cmake target name for brotli

### DIFF
--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -120,8 +120,12 @@ class BrotliConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "Brotli"
         self.cpp_info.names["cmake_find_package_multi"] = "Brotli"
         self.cpp_info.components["brotlicommon"].names["pkg_config"] = "libbrotlicommon"
+        self.cpp_info.components["brotlicommon"].set_property("cmake_target_name", "Brotli::brotlicommon")
         self.cpp_info.components["brotlidec"].names["pkg_config"] = "libbrotlidec"
+        self.cpp_info.components["brotlidec"].set_property("cmake_target_name", "Brotli::brotlidec")
         self.cpp_info.components["brotlienc"].names["pkg_config"] = "libbrotlienc"
+        self.cpp_info.components["brotlienc"].set_property("cmake_target_name", "Brotli::brotlienc")
+
 
     def _get_decorated_lib(self, name):
         libname = name


### PR DESCRIPTION
arrow (any maybe other libs) depends on `Brotli::brotlienc`, `Brotli::brotlidec`, `Brotli::brotlicommon` add the missing cmake target names for those to fix #16059

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
