### PR TITLE
libcap: use cc as native compiler

### DIFF
--- a/recipes/libcap/all/conanfile.py
+++ b/recipes/libcap/all/conanfile.py
@@ -61,11 +61,10 @@ class LibcapConan(ConanFile):
         env.define("lib", "lib")
 
         if cross_building(self):
-            native_cc = env.vars(self).get("CC", VirtualBuildEnv(self).vars().get("CC"))
-            if not native_cc:
-                native_cc = "cc"
-            self.output.info(f"Using native compiler '{native_cc}'")
-            env.define("BUILD_CC", native_cc)
+            # libcap needs to run an executable that is compiled from sources
+            # during the build - so it needs a native compiler (it doesn't matter which)
+            # Assume the `cc` command points to a working C compiler
+            env.define("BUILD_CC", "cc")
 
         tc.generate(env)
 


### PR DESCRIPTION
Specify library name and version:  **libcap/all**

This PR:
* Fix issue where variables defined in `[buildenv]` for cross-compilation are ignored and the wrong compiler is used. 

Background:
* `VirtualBuildEnv` would typically be generated by default, _unless_ it is instantiated explicitly by the recipe maintainer. The call to `VirtualBuildEnv(self).vars().get("CC")` does that instantiation, which causes Conan to skip the generation (would otherwise have to be explicit in the `generate()`. method).  

While this could be addressed by generating `VirtualBuildEnv` explicitly, there is a second problem - that `CC`, if defined, will _not_ point to a native compiler if one is defined - recipes cannot access environment variables defined in the _build_ profiles. 

The `libcap` build scripts compile an executable that runs during the build, and thus that compilation needs to be performed with a native compiler. In this case, it is sufficient to make sure it points to the `cc` command, which is (or was) part of the POSIX specification - all Linux distros to my knowledge still honour this. For this particular and limited use, it is not relevant _which_ compiler is used, so long as the generated executable can run during the build and generate the correct output.


Close https://github.com/conan-io/conan-center-index/issues/16647 and https://github.com/conan-io/conan-center-index/issues/16667