### PR TITLE
doxygen: test_package should use tool_requires

### DIFF
--- a/recipes/doxygen/all/test_package/conanfile.py
+++ b/recipes/doxygen/all/test_package/conanfile.py
@@ -10,8 +10,8 @@ class TestPackageConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
-    def requirements(self):
-        self.requires(self.tested_reference_str)
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
Specify library name and version:  **doxygen/1.9.2**

Doxygen is a tool, not a library. tool_requires() is necessary to ensure that the Doxygen binary is in the build context, so that it appears in CMAKE_PROGRAM_PATH, which is on the way to CMake finding the executable.

This change fixes problems when building the `test_package` with build and host profiles, such as:

```
conan test recipes/doxygen/all/test_package doxygen/1.9.2@ -pr:h build-profile-macos-intel -pr:b build-profile-macos-intel --options:host doxygen:enable_search=False
...
doxygen/1.9.2 (test package): Calling build()
-- The CXX compiler identification is AppleClang 13.0.0.13000029
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode-13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /Applications/CMake.app/Contents/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
Call Stack (most recent call first):
  /Applications/CMake.app/Contents/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /Applications/CMake.app/Contents/share/cmake-3.25/Modules/FindDoxygen.cmake:677 (find_package_handle_standard_args)
  CMakeLists.txt:6 (find_package)
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
