### PR TITLE
libgcrypt: expose headers of libgpg-error

### DIFF
--- a/recipes/libgcrypt/all/conanfile.py
+++ b/recipes/libgcrypt/all/conanfile.py
@@ -39,7 +39,7 @@ class LibgcryptConan(ConanFile):
 
     def requirements(self):
         self.requires("libcap/2.66")
-        self.requires("libgpg-error/1.36")
+        self.requires("libgpg-error/1.36", transitive_headers=True)
 
     def validate(self):
         if self.settings.os != "Linux":


### PR DESCRIPTION
Public header of libgpg-error is included by libgcrypt public header: https://github.com/gpg/libgcrypt/blob/ccfa9f2c1427b40483984198c3df41f8057f69f8/src/gcrypt.h.in#L30

I've checked and transitive_libs is not required (libgcrypt header only use static functions or typedef defined in header of libgpg-error).

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
