### PR TITLE
[sigslot] Portage to Conan 2.0

### DIFF
--- a/recipes/sigslot/all/conanfile.py
+++ b/recipes/sigslot/all/conanfile.py
@@ -1,8 +1,14 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc
+from conan.tools.files import get, copy
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.43.0"
+
+required_conan_version = ">=1.53.0"
 
 
 class SigslotConan(ConanFile):
@@ -13,58 +19,57 @@ class SigslotConan(ConanFile):
     homepage = "https://github.com/palacaze/sigslot"
     license = "MIT"
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "header-library"
     no_copy_source = True
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
 
     @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+    def _min_cppstd(self):
+        return 14
 
-    def validate(self):
-        minimal_cpp_standard = "14"
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, minimal_cpp_standard)
-        minimal_version = {
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15",
+            "msvc": "14.1",
             "gcc": "5",
             "clang": "3.4",
             "apple-clang": "10",
-            "Visual Studio": "15"  # 14 is not supported by the library
         }
-        compiler = str(self.settings.compiler)
-        if compiler not in minimal_version:
-            self.output.warn(
-                "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
-            self.output.warn(
-                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
-            return
-        version = tools.Version(self.settings.compiler.version)
-        if version < minimal_version[compiler]:
-            raise ConanInvalidConfiguration("%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
-        self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy(pattern="signal.hpp", src=os.path.join(self._source_subfolder, "include", "sigslot"), dst=os.path.join("include", "sigslot"))
+        copy(self, pattern="LICENSE", src=self.source_folder, dst="licenses")
+        copy(self, pattern="signal.hpp", src=os.path.join(self.source_folder, "include", "sigslot"), dst=os.path.join("include", "sigslot"))
 
     def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
         self.cpp_info.set_property("cmake_file_name", "PalSigslot")
         self.cpp_info.set_property("cmake_target_name", "Pal::Sigslot")
+
         # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
         self.cpp_info.components["_sigslot"].libs = []
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["_sigslot"].system_libs.append("pthread")
-        elif self.settings.os == "Windows":
-            if self._is_msvc or self.settings.compiler == "clang":
-                self.cpp_info.components["_sigslot"].exelinkflags.append('-OPT:NOICF')
+        elif self.settings.os == "Windows" and (is_msvc(self) or self.settings.compiler == "clang"):
+            self.cpp_info.components["_sigslot"].exelinkflags.append('-OPT:NOICF')
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "PalSigslot"

--- a/recipes/sigslot/all/test_package/CMakeLists.txt
+++ b/recipes/sigslot/all/test_package/CMakeLists.txt
@@ -1,18 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(PalSigslot REQUIRED)
+find_package(PalSigslot REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-
-set_target_properties(
-    ${PROJECT_NAME} PROPERTIES
-
-    CXX_STANDARD 14
-    CXX_STANDARD_REQUIRED ON
-)
-
-target_link_libraries(${PROJECT_NAME} Pal::Sigslot)
+target_link_libraries(${PROJECT_NAME} PRIVATE Pal::Sigslot)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/sigslot/all/test_package/conanfile.py
+++ b/recipes/sigslot/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sigslot/all/test_v1_package/CMakeLists.txt
+++ b/recipes/sigslot/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/sigslot/all/test_v1_package/conanfile.py
+++ b/recipes/sigslot/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **sigslot/1.2.2**

Modernization done based on https://github.com/conan-io/conan-center-index/tree/master/docs/package_templates/header_only

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
