### PR TITLE
sentry-breakpad: add package_type and fix traits of linux-syscall-support

### DIFF
--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -53,7 +53,7 @@ class SentryBreakpadConan(ConanFile):
 
     def requirements(self):
         if self.settings.os in ("FreeBSD", "Linux"):
-            self.requires("linux-syscall-support/cci.20200813")
+            self.requires("linux-syscall-support/cci.20200813", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -18,6 +18,7 @@ class SentryBreakpadConan(ConanFile):
     license = "Apache-2.0"
     topics = ("breakpad", "error-reporting", "crash-reporting")
     provides = "breakpad"
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],


### PR DESCRIPTION
see https://github.com/conan-io/conan-center-index/pull/16752#issuecomment-1487241864

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
