### PR TITLE
docs: clarify everything should use CMake 3.15 to match Conan 2.0

### DIFF
--- a/docs/error_knowledge_base.md
+++ b/docs/error_knowledge_base.md
@@ -311,7 +311,9 @@ The CMake definition [CMAKE_VERBOSE_MAKEFILE](https://cmake.org/cmake/help/lates
 
 #### **<a name="KB-H048">#KB-H048</a>: "CMAKE VERSION REQUIRED"**
 
-The file test_package/CMakeLists.txt should require CMake 3.1 by default: [cmake_minimum_required(VERSION 3.1)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html). The CMake wrapper file can require CMake 2.8, because Conan recipe and the test package are totally separated. However, if [CMAKE_CXX_STANDARD](https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html) or [CXX_STANDARD](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD) is explicit, CMake 3.1 is mandatory.
+> **Warning**: This is a legacy Conan 1.x details from the deprecated generators
+
+The file test_package/CMakeLists.txt should require CMake 3.15 by default: [cmake_minimum_required(VERSION 3.15)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html). The CMake wrapper file can require CMake 2.8, because Conan recipe and the test package are totally separated. However, if [CMAKE_CXX_STANDARD](https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html) or [CXX_STANDARD](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD) is explicit, CMake 3.1 is mandatory.
 
 #### **<a name="KB-H049">#KB-H049</a>: "CMAKE WINDOWS EXPORT ALL SYMBOLS"**
 

--- a/docs/package_templates/autotools_package/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/autotools_package/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C) # if the project is pure C
 # project(test_package LANGUAGES CXX) # if the project uses c++
 

--- a/docs/package_templates/autotools_package/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/autotools_package/all/test_v1_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C) # if the project is pure C
 # project(test_package LANGUAGES CXX) # if the project uses c++
 

--- a/docs/package_templates/cmake_package/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/cmake_package/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 
 project(test_package C) # if the project is pure C
 # project(test_package CXX) # if the project uses c++

--- a/docs/package_templates/cmake_package/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/cmake_package/all/test_v1_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/docs/package_templates/header_only/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/header_only/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C) # if the project is pure C
 # project(test_package LANGUAGES CXX) # if the project uses c++
 

--- a/docs/package_templates/header_only/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/header_only/all/test_v1_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C) # if the project is pure C
 project(test_package LANGUAGES CXX) # if the project uses c++
 

--- a/docs/package_templates/msbuild_package/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/msbuild_package/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 
 project(test_package C) # if the project is pure C
 project(test_package CXX) # if the project uses c++

--- a/docs/package_templates/msbuild_package/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/msbuild_package/all/test_v1_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 
 project(test_package C) # if the project is pure C
 project(test_package CXX) # if the project uses c++


### PR DESCRIPTION
Conan 2.0 has the requirement set to 3.15 and thus everything should just default to using that as baseline.