### PR TITLE
paho-mqtt-cpp: update for conan 2.0

### DIFF
--- a/recipes/paho-mqtt-cpp/all/CMakeLists.txt
+++ b/recipes/paho-mqtt-cpp/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(cmake_wrapper)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/paho-mqtt-cpp/all/conandata.yml
+++ b/recipes/paho-mqtt-cpp/all/conandata.yml
@@ -11,13 +11,8 @@ sources:
 patches:
   "1.1":
     - patch_file: "patches/1.1/0001-deadlock_and_remlog-for-1-1.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/1.1/0002-ios_fix.patch"
-      base_path: "source_subfolder"
   "1.0.1":
     - patch_file: "patches/1.0.1/0001-fix-cmake-module-path.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/1.0.1/0002-fix-cmake-find-paho-mqtt-c-static.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/1.0.1/0003-fix-paho-mqtt-cpp-config-cmake.patch"
-      base_path: "source_subfolder"

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -108,9 +108,11 @@ class PahoMqttCppConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "PahoMqttCpp"
         self.cpp_info.names["cmake_find_package_multi"] = "PahoMqttCpp"
-        self.cpp_info.set_property("cmake_file_name", "PahoMqttCpp")
-
+        
         target = "paho-mqttpp3" if self.options.shared else "paho-mqttpp3-static"
+        self.cpp_info.set_property("cmake_file_name", "PahoMqttCpp")
+        self.cpp_info.set_property("cmake_target_name", f"PahoMqttCpp::{target}")
+
         self.cpp_info.components["paho-mqttpp"].set_property("cmake_target_name", f"PahoMqttCpp::{target}")
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package"] = target
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package_multi"] = target

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -67,10 +67,10 @@ class PahoMqttCppConan(ConanFile):
             self.requires("paho-mqtt-c/1.3.9", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("paho-mqtt-c/1.3.1", transitive_headers=True, transitive_libs=True) # https://github.com/eclipse/paho.mqtt.cpp/releases/tag/v1.1
-        # our cmakefiles reference openssl directly with ssl enabled, so we
+        # upstream's cmakefiles reference openssl directly with ssl enabled, so we
         # should directly depend, not just transitively.
         if self.options.ssl:
-            self.requires("openssl/1.1.1t", direct=False)
+            self.requires("openssl/1.1.1t")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -114,7 +114,6 @@ class PahoMqttCppConan(ConanFile):
         self.cpp_info.components["paho-mqttpp"].set_property("cmake_target_name", f"PahoMqttCpp::{target}")
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package"] = target
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package_multi"] = target
-        self.cpp_info.components["paho-mqttpp"].requires = ["paho-mqtt-c::paho-mqtt-c"]
         if self.settings.os == "Windows":
             self.cpp_info.components["paho-mqttpp"].libs = [target]
         else:

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -65,10 +65,11 @@ class PahoMqttCppConan(ConanFile):
     def requirements(self):
         if Version(self.version) >= "1.2.0":
             # Headers are exposed https://github.com/conan-io/conan-center-index/pull/16760#issuecomment-1502420549
-            self.requires("paho-mqtt-c/1.3.9", transitive_headers=True)
+            # Symbols are exposed   "_MQTTProperties_free", referenced from: mqtt::connect_options::~connect_options() in test_package.cpp.o
+            self.requires("paho-mqtt-c/1.3.9", transitive_headers=True, transitive_libs=True)
         else:
              # This is the "official tested" version https://github.com/eclipse/paho.mqtt.cpp/releases/tag/v1.1
-            self.requires("paho-mqtt-c/1.3.1", transitive_headers=True)
+            self.requires("paho-mqtt-c/1.3.1", transitive_headers=True, transitive_libs=True)
 
         # upstream's CMakeLists.txt references openssl directly with ssl enabled, so we
         # should directly depend, not just transitively.

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -56,18 +56,19 @@ class PahoMqttCppConan(ConanFile):
             check_min_cppstd(self, self._min_cppstd)
 
         if self.dependencies["paho-mqtt-c"].options.shared != self.options.shared:
-            raise ConanInvalidConfiguration(f"{self.name} requires paho-mqtt-c to have a matching 'shared' option.")
+            raise ConanInvalidConfiguration(f"{self.ref} requires paho-mqtt-c to have a matching 'shared' option.")
         if self.dependencies["paho-mqtt-c"].options.ssl != self.options.ssl:
-            raise ConanInvalidConfiguration(f"{self.name} requires paho-mqtt-c to have a matching 'ssl' option.")
+            raise ConanInvalidConfiguration(f"{self.ref} requires paho-mqtt-c to have a matching 'ssl' option.")
         if Version(self.version) < "1.2.0" and Version(self.dependencies["paho-mqtt-c"].ref.version) >= "1.3.2":
-            raise ConanInvalidConfiguration(f"{self.name}/{self.version} requires paho-mqtt-c =< 1.3.1")
+            raise ConanInvalidConfiguration(f"{self.ref} requires paho-mqtt-c =< 1.3.1")
 
     def requirements(self):
         if Version(self.version) >= "1.2.0":
-            self.requires("paho-mqtt-c/1.3.9", transitive_headers=True, transitive_libs=True)
+            # Headers are exposed https://github.com/conan-io/conan-center-index/pull/16760#issuecomment-1502420549
+            self.requires("paho-mqtt-c/1.3.9", transitive_headers=True)
         else:
              # This is the "official tested" version https://github.com/eclipse/paho.mqtt.cpp/releases/tag/v1.1
-            self.requires("paho-mqtt-c/1.3.1", transitive_headers=True, transitive_libs=True)
+            self.requires("paho-mqtt-c/1.3.1", transitive_headers=True)
 
         # upstream's CMakeLists.txt references openssl directly with ssl enabled, so we
         # should directly depend, not just transitively.

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -114,7 +114,6 @@ class PahoMqttCppConan(ConanFile):
         self.cpp_info.components["paho-mqttpp"].set_property("cmake_target_name", f"PahoMqttCpp::{target}")
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package"] = target
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package_multi"] = target
-        self.cpp_info.components["paho-mqttpp"].set_property("cmake_target_name", f"PahoMqttCpp::{target}")
         self.cpp_info.components["paho-mqttpp"].requires = ["paho-mqtt-c::paho-mqtt-c"]
         if self.settings.os == "Windows":
             self.cpp_info.components["paho-mqttpp"].libs = [target]

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, rmdir, get, patch
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, rmdir, get
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.build import check_min_cppstd
@@ -54,13 +54,13 @@ class PahoMqttCppConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            check_min_cppstd(self, _min_cppstd)
+            check_min_cppstd(self, self._min_cppstd)
         if self.dependencies["paho-mqtt-c"].options.shared != self.options.shared:
-            raise ConanInvalidConfiguration("{} requires paho-mqtt-c to have a matching 'shared' option.".format(self.name))
+            raise ConanInvalidConfiguration(f"{self.name} requires paho-mqtt-c to have a matching 'shared' option.")
         if self.dependencies["paho-mqtt-c"].options.ssl != self.options.ssl:
-            raise ConanInvalidConfiguration("{} requires paho-mqtt-c to have a matching 'ssl' option.".format(self.name))
+            raise ConanInvalidConfiguration(f"{self.name} requires paho-mqtt-c to have a matching 'ssl' option.")
         if Version(self.version) < "1.2.0" and Version(self.dependencies["paho-mqtt-c"].ref.version) >= "1.3.2":
-            raise ConanInvalidConfiguration("{}/{} requires paho-mqtt-c =< 1.3.1".format(self.name, self.version))
+            raise ConanInvalidConfiguration(f"{self.name}/{self.version} requires paho-mqtt-c =< 1.3.1")
 
     def requirements(self):
         if Version(self.version) >= "1.2.0":

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -1,32 +1,41 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, rmdir, get, patch
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
 import os
-from conans import CMake, ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
 
+
+required_conan_version = ">=1.53.0"
 
 class PahoMqttCppConan(ConanFile):
     name = "paho-mqtt-cpp"
+    description = "The open-source client implementations of MQTT and MQTT-SN"
+    license = "EPL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/eclipse/paho.mqtt.cpp"
     topics = ("mqtt", "iot", "eclipse", "ssl", "paho", "cpp")
-    license = "EPL-1.0"
-    description = "The open-source client implementations of MQTT and MQTT-SN"
-    exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake", "cmake_find_package"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False],
-               "fPIC": [True, False],
-               "ssl": [True, False],
-               }
-    default_options = {"shared": False,
-                       "fPIC": True,
-                       "ssl": True
-                       }
-
-    _cmake = None
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "ssl": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "ssl": True
+    }
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 11
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -34,69 +43,78 @@ class PahoMqttCppConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
-        minimal_cpp_standard = "11"
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, minimal_cpp_standard)
+        self.options["paho-mqtt-c/*"].shared = self.options.shared
+        self.options["paho-mqtt-c/*"].ssl = self.options.ssl
 
-        self.options["paho-mqtt-c"].shared = self.options.shared
-        self.options["paho-mqtt-c"].ssl = self.options.ssl
+    def layout(self):
+        # src_folder must use the same source folder name the project
+        cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.options["paho-mqtt-c"].shared != self.options.shared:
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, _min_cppstd)
+        if self.dependencies["paho-mqtt-c"].options.shared != self.options.shared:
             raise ConanInvalidConfiguration("{} requires paho-mqtt-c to have a matching 'shared' option.".format(self.name))
-        if self.options["paho-mqtt-c"].ssl != self.options.ssl:
+        if self.dependencies["paho-mqtt-c"].options.ssl != self.options.ssl:
             raise ConanInvalidConfiguration("{} requires paho-mqtt-c to have a matching 'ssl' option.".format(self.name))
-
-    def requirements(self):
-        if tools.Version(self.version) >= "1.2.0":
-            self.requires("paho-mqtt-c/1.3.9")
-        else:
-            self.requires("paho-mqtt-c/1.3.1") # https://github.com/eclipse/paho.mqtt.cpp/releases/tag/v1.1
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
-
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["PAHO_BUILD_DOCUMENTATION"] = False
-        self._cmake.definitions["PAHO_BUILD_SAMPLES"] = False
-        self._cmake.definitions["PAHO_BUILD_STATIC"] = not self.options.shared
-        self._cmake.definitions["PAHO_BUILD_SHARED"] = self.options.shared
-        self._cmake.definitions["PAHO_WITH_SSL"] = self.options.ssl
-        self._cmake.configure()
-        return self._cmake
-
-    def build(self):
-        # See this conversation https://github.com/conan-io/conan-center-index/pull/4096#discussion_r556119143
-        # Changed by https://github.com/eclipse/paho.mqtt.c/commit/f875768984574fede6065c8ede0a7eac890a6e09
-        # and https://github.com/eclipse/paho.mqtt.c/commit/c116b725fff631180414a6e99701977715a4a690
-        # FIXME: after https://github.com/conan-io/conan/pull/8053#pullrequestreview-541120387
-        if tools.Version(self.version) < "1.2.0" and tools.Version(self.deps_cpp_info["paho-mqtt-c"].version) >= "1.3.2":
+        if Version(self.version) < "1.2.0" and Version(self.dependencies["paho-mqtt-c"].ref.version) >= "1.3.2":
             raise ConanInvalidConfiguration("{}/{} requires paho-mqtt-c =< 1.3.1".format(self.name, self.version))
 
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+    def requirements(self):
+        if Version(self.version) >= "1.2.0":
+            self.requires("paho-mqtt-c/1.3.9", transitive_headers=True, transitive_libs=True)
+        else:
+            self.requires("paho-mqtt-c/1.3.1", transitive_headers=True, transitive_libs=True) # https://github.com/eclipse/paho.mqtt.cpp/releases/tag/v1.1
+        # our cmakefiles reference openssl directly with ssl enabled, so we
+        # should directly depend, not just transitively.
+        if self.options.ssl:
+            self.requires("openssl/1.1.1t", direct=False)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["PAHO_BUILD_DOCUMENTATION"] = False
+        tc.variables["PAHO_BUILD_SAMPLES"] = False
+        tc.variables["PAHO_BUILD_STATIC"] = not self.options.shared
+        tc.variables["PAHO_BUILD_SHARED"] = self.options.shared
+        tc.variables["PAHO_WITH_SSL"] = self.options.ssl
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+        vbuildenv = VirtualBuildEnv(self)
+        vbuildenv.generate(scope="build")
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("edl-v10", src=self._source_subfolder, dst="licenses")
-        self.copy("epl-v10", src=self._source_subfolder, dst="licenses")
-        self.copy("notice.html", src=self._source_subfolder, dst="licenses")
-        cmake = self._configure_cmake()
+        copy(self, "edl-v10", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "epl-v10", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "notice.html", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "PahoMqttCpp"
         self.cpp_info.names["cmake_find_package_multi"] = "PahoMqttCpp"
+        self.cpp_info.set_property("cmake_file_name", "PahoMqttCpp")
+
         target = "paho-mqttpp3" if self.options.shared else "paho-mqttpp3-static"
+        self.cpp_info.components["paho-mqttpp"].set_property("cmake_target_name", f"PahoMqttCpp::{target}")
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package"] = target
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package_multi"] = target
+        self.cpp_info.components["paho-mqttpp"].set_property("cmake_file_name", target)
         self.cpp_info.components["paho-mqttpp"].requires = ["paho-mqtt-c::paho-mqtt-c"]
         if self.settings.os == "Windows":
             self.cpp_info.components["paho-mqttpp"].libs = [target]

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -114,7 +114,7 @@ class PahoMqttCppConan(ConanFile):
         self.cpp_info.components["paho-mqttpp"].set_property("cmake_target_name", f"PahoMqttCpp::{target}")
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package"] = target
         self.cpp_info.components["paho-mqttpp"].names["cmake_find_package_multi"] = target
-        self.cpp_info.components["paho-mqttpp"].set_property("cmake_file_name", target)
+        self.cpp_info.components["paho-mqttpp"].set_property("cmake_target_name", f"PahoMqttCpp::{target}")
         self.cpp_info.components["paho-mqttpp"].requires = ["paho-mqtt-c::paho-mqtt-c"]
         if self.settings.os == "Windows":
             self.cpp_info.components["paho-mqttpp"].libs = [target]

--- a/recipes/paho-mqtt-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/paho-mqtt-cpp/all/test_package/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package(PahoMqttCpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+
+if(TEST_SSL_OPTION)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE TEST_SSL_OPTION)
+endif()
+
 if(PAHO_MQTT_CPP_SHARED)
   target_link_libraries(${PROJECT_NAME} PahoMqttCpp::paho-mqttpp3)
 else()

--- a/recipes/paho-mqtt-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/paho-mqtt-cpp/all/test_package/CMakeLists.txt
@@ -1,13 +1,11 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.8)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+project(test_package C CXX)
 
 find_package(PahoMqttCpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 if(PAHO_MQTT_CPP_SHARED)
   target_link_libraries(${PROJECT_NAME} PahoMqttCpp::paho-mqttpp3)
 else()

--- a/recipes/paho-mqtt-cpp/all/test_package/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/test_package/conanfile.py
@@ -16,7 +16,8 @@ class TestPackageConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["PAHO_MQTT_CPP_SHARED"] = self.dependencies[self.tested_reference_str].options.shared
+        tc.variables["TEST_SSL_OPTION"] = self.dependencies[self.tested_reference_str].options.ssl
+        tc.variables["PAHO_MQTT_CPP_SHARED"] = self.dependencies[self.tested_reference_str].options.shared
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/paho-mqtt-cpp/all/test_package/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/test_package/conanfile.py
@@ -1,17 +1,32 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
 import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["PAHO_MQTT_CPP_SHARED"] = self.dependencies[self.tested_reference_str].options.shared
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["PAHO_MQTT_CPP_SHARED"] = self.options["paho-mqtt-cpp"].shared
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/paho-mqtt-cpp/all/test_package/test_package.cpp
+++ b/recipes/paho-mqtt-cpp/all/test_package/test_package.cpp
@@ -15,6 +15,11 @@ int main(int argc, char* argv[])
     mqtt::async_client cli_async(SERVER_ADDRESS, CLIENT_ID);
     mqtt::client cli(SERVER_ADDRESS, CLIENT_ID);
 
+#ifdef TEST_SSL_OPTION
+    // Build the connect options, including SSL and a LWT message.
+	auto sslopts = mqtt::ssl_options_builder();
+#endif
+
     return 0;
 }
 

--- a/recipes/paho-mqtt-cpp/all/test_package/test_package.cpp
+++ b/recipes/paho-mqtt-cpp/all/test_package/test_package.cpp
@@ -17,7 +17,8 @@ int main(int argc, char* argv[])
 
 #ifdef TEST_SSL_OPTION
     // Build the connect options, including SSL and a LWT message.
-	auto sslopts = mqtt::ssl_options_builder();
+	// auto sslopts = mqtt::ssl_options_builder(); // This was added in v1.2.0
+    auto sslopts = mqtt::ssl_options();
 #endif
 
     return 0;

--- a/recipes/paho-mqtt-cpp/all/test_v1_package/CMakeLists.txt
+++ b/recipes/paho-mqtt-cpp/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/paho-mqtt-cpp/all/test_v1_package/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/paho-mqtt-cpp/all/test_v1_package/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/test_v1_package/conanfile.py
@@ -10,6 +10,8 @@ class TestPackageV1Conan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["PAHO_MQTT_CPP_SHARED"] = self.options["paho-mqtt-cpp"].shared
+        cmake.definitions["TEST_SSL_OPTION"] = self.options["paho-mqtt-cpp"].ssl
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **paho-mqtt-cpp/1.2** (also 1.0.1 and 1.1 should their recipes be updated).

Existing recipe is not conan 2.0 compatible.  Blocker for internal projects.

This does raise an error with the hook for (KB-H055) (Both 'requires' attribute and 'requirements()' method should not be declared at same recipe) but I've not been able to identify why this assert is being triggered as there is no requires attribute set.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
