### PR TITLE
[doxygen] Backport patch to enable modern compilers for 1.9.4

### DIFF
--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -22,6 +22,7 @@ patches:
     - patch_file: "patches/1.9.4-0001-enable-modern-compilers.patch"
       patch_description: "Enable modern compilers"
       patch_type: "portability"
+      patch_source: "https://github.com/doxygen/doxygen/commit/5198966c8d5fec89116d025c74934ac03ea511fa"
   "1.9.2":
     - patch_file: "patches/1.9.2-0001-imported-target.patch"
       patch_description: "Fix includes"

--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -18,6 +18,10 @@ sources:
     url: "https://sourceforge.net/projects/doxygen/files/doxygen-1.8.17.src.tar.gz"
     sha256: "2cba988af2d495541cbbe5541b3bee0ee11144dcb23a81eada19f5501fd8b599"
 patches:
+  "1.9.4":
+    - patch_file: "patches/1.9.4-0001-enable-modern-compilers.patch"
+      patch_description: "Enable modern compilers"
+      patch_type: "bugfix"
   "1.9.2":
     - patch_file: "patches/1.9.2-0001-imported-target.patch"
       patch_description: "Fix includes"

--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -21,7 +21,7 @@ patches:
   "1.9.4":
     - patch_file: "patches/1.9.4-0001-enable-modern-compilers.patch"
       patch_description: "Enable modern compilers"
-      patch_type: "bugfix"
+      patch_type: "portability"
   "1.9.2":
     - patch_file: "patches/1.9.2-0001-imported-target.patch"
       patch_description: "Fix includes"

--- a/recipes/doxygen/all/patches/1.9.4-0001-enable-modern-compilers.patch
+++ b/recipes/doxygen/all/patches/1.9.4-0001-enable-modern-compilers.patch
@@ -1,0 +1,25 @@
+From 5198966c8d5fec89116d025c74934ac03ea511fa Mon Sep 17 00:00:00 2001
+From: Dimitri van Heesch <doxygen@gmail.com>
+Date: Fri, 6 May 2022 09:55:16 +0200
+Subject: [PATCH] issue #9312: Build: cache.h:53:14: error: 'exchange' is not a
+ member of 'std'
+
+---
+ src/cache.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/cache.h b/src/cache.h
+index 0ff3092ed5..e218eb27d2 100644
+--- a/src/cache.h
++++ b/src/cache.h
+@@ -19,6 +19,7 @@
+ #include <list>
+ #include <unordered_map>
+ #include <mutex>
++#include <utility>
+ #include <ctype.h>
+ 
+ /*! Fixed size cache for value type V using keys of type K.
+-- 
+2.39.1
+


### PR DESCRIPTION
Closes #16741

Specify library name and version:  **doxygen/1.9.4**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
