### PR TITLE
libzippp: fix all shared build on Linux for conan v2 + add package_type

### DIFF
--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -8,6 +8,7 @@ import os
 
 required_conan_version = ">=1.53.0"
 
+
 class LibZipppConan(ConanFile):
     name = "libzippp"
     description = "A simple basic C++ wrapper around the libzip library"
@@ -53,7 +54,7 @@ class LibZipppConan(ConanFile):
                 self.requires(f"libzip/{versions[1]}")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
 
         libzippp_version = str(self.version)

--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -15,6 +15,7 @@ class LibZipppConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/ctabin/libzippp"
     topics = ("zip", "zlib", "libzip", "zip-archives", "zip-editing")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -98,6 +98,8 @@ class LibZipppConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "libzippp")
+        self.cpp_info.set_property("cmake_target_name", "libzippp::libzippp")
         prefix = "lib" if self.settings.os == "Windows" else ""
         postfix = "" if self.options.shared else "_static"
         self.cpp_info.libs = [f"{prefix}zippp{postfix}"]
@@ -105,8 +107,5 @@ class LibZipppConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
 
-        self.cpp_info.names["cmake_find_package"] = "libzippp"
-        self.cpp_info.names["cmake_find_package_multi"] = "libzippp"
-        self.cpp_info.set_property("cmake_file_name", "libzippp")
         if self.options.with_encryption:
             self.cpp_info.defines.append("LIBZIPPP_WITH_ENCRYPTION")

--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -70,6 +70,7 @@ class LibZipppConan(ConanFile):
         tc.variables["CMAKE_CXX_STANDARD"] = 11
         tc.variables["LIBZIPPP_INSTALL"] = True
         tc.variables["LIBZIPPP_INSTALL_HEADERS"] = True
+        tc.variables["LIBZIPPP_BUILD_TESTS"] = False
         tc.variables["LIBZIPPP_ENABLE_ENCRYPTION"] = self.options.with_encryption
         tc.generate()
 


### PR DESCRIPTION
When it has been migrated to CMakeToolchain, a tricky detail has been skipped: this recipe was relying on the implicit behavior that it was built as a subdirectory through the old CMakeLists wrapper, and since upstream CMakeLists has a special logic to enable tests by default if CMakeLists is top project (https://github.com/ctabin/libzippp/blob/libzippp-v6.0-1.9.2/CMakeLists.txt#L30) and that this recipe did not explicitly manage this option, therefore tests were built after the migration and failed on Linux with conan v2 client (see https://github.com/conan-io/conan/issues/13560).

This PR explicitly disables the build of upstream tests.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
