### PR TITLE
lely-core: update sha256 hash

### DIFF
--- a/recipes/lely-core/all/conandata.yml
+++ b/recipes/lely-core/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.3.2":
     url: "https://gitlab.com/lely_industries/lely-core/-/archive/v2.3.2/lely-core-v2.3.2.tar.gz"
-    sha256: "c37eb6f004ad1a1ec1f891e31a09b72f588da361fa92888e8edfcf215a1d707a"
+    sha256: "9fc4f46dd9224162215ba12abe1881d47aeb1ed530f25d34f0f08882381ea53d"


### PR DESCRIPTION
For some reason, gitlab changes how they package their tarball, this PR update the sha256 hash, I have checked the content of the tarball manually, everything looks good.