### PR TITLE
apr: allow recipes which support cross_building to consume exising apr binaries

### DIFF
--- a/recipes/apr/all/conanfile.py
+++ b/recipes/apr/all/conanfile.py
@@ -68,8 +68,8 @@ class AprConan(ConanFile):
             basic_layout(self, src_folder="src")
 
     def validate(self):
-        if hasattr(self, "settings_build") and cross_building(self):
             raise ConanInvalidConfiguration("apr recipe doesn't support cross-build yet due to runtime checks")
+        if cross_building(self):
 
     def build_requirements(self):
         if not is_msvc(self):

--- a/recipes/apr/all/conanfile.py
+++ b/recipes/apr/all/conanfile.py
@@ -67,9 +67,9 @@ class AprConan(ConanFile):
         else:
             basic_layout(self, src_folder="src")
 
-    def validate(self):
-            raise ConanInvalidConfiguration("apr recipe doesn't support cross-build yet due to runtime checks")
-        if cross_building(self):
+    def validate_build(self):
+        if cross_building(self) and not is_msvc(self):
+            raise ConanInvalidConfiguration("apr recipe doesn't support cross-build yet due to runtime checks in autoconf")
 
     def build_requirements(self):
         if not is_msvc(self):


### PR DESCRIPTION
Since conancenter only provides x86_64 binaries on windows, it's frequently for necessary for an overall build which uses  to `--settings:host arch=x86 --build missing` to produce 32-bit requires from conancenter recipes to need ` --settings:build=x86-64` in order to satisfy tool_requires.

There are cross_building scenarios apr can't support, but that one would be fine, the current recipe validation is just stricter than it needed to be.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
