### PR TITLE
[coin-clp] Make headers of required packages transitive

### DIFF
--- a/recipes/coin-clp/all/conanfile.py
+++ b/recipes/coin-clp/all/conanfile.py
@@ -49,8 +49,8 @@ class CoinClpConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("coin-utils/2.11.6")
-        self.requires("coin-osi/0.108.7")
+        self.requires("coin-utils/2.11.6", transitive_headers=True)
+        self.requires("coin-osi/0.108.7", transitive_headers=True)
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:


### PR DESCRIPTION
Specify library name and version:  **coin-clp/1.17.7**

The public API of coin-clp contains the headers CoinPragma.hpp (from coin-utils, see c.f. ClpMessage.hpp) and OsiSolverInterface.hpp (from coin-osi, see c.f. OsiClpSolverInterface.hpp)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
