### PR TITLE
s2n: conan v2 support

### DIFF
--- a/recipes/s2n/all/CMakeLists.txt
+++ b/recipes/s2n/all/CMakeLists.txt
@@ -1,13 +1,11 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper LANGUAGES C)
 
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-find_package(OpenSSL REQUIRED COMPONENTS Crypto)
+# We want to discover OpenSSL through CMakeDeps and use OpenSSL::Crypto target for linking
+# https://github.com/aws/s2n-tls/blob/v1.3.31/CMakeLists.txt#L27-L28
+# https://github.com/aws/s2n-tls/blob/v1.3.31/CMakeLists.txt#L379-L381
+find_package(OpenSSL REQUIRED)
 add_library(crypto INTERFACE IMPORTED)
 set_target_properties(crypto PROPERTIES INTERFACE_LINK_LIBRARIES "OpenSSL::Crypto")
 
-set(SEARCH_LIBCRYPTO OFF)
-
-add_subdirectory(source_subfolder)
+add_subdirectory(src)

--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -23,7 +23,5 @@ sources:
 patches:
   "1.1.0":
     - patch_file: "patches/1.1.0/001-try-compile.patch"
-      base_path: "source_subfolder"
   "1.0.11":
     - patch_file: "patches/1.0.11/001-try-compile.patch"
-      base_path: "source_subfolder"

--- a/recipes/s2n/all/conanfile.py
+++ b/recipes/s2n/all/conanfile.py
@@ -1,19 +1,20 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, get, rmdir
-from conans import CMake
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 import os
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.53.0"
 
 
-class S2n(ConanFile):
+class S2nConan(ConanFile):
     name = "s2n"
     description = "An implementation of the TLS/SSL protocols"
     topics = ("aws", "amazon", "cloud", )
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/aws/s2n-tls"
-    license = "Apache-2.0",
+    license = "Apache-2.0"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -24,52 +25,47 @@ class S2n(ConanFile):
         "fPIC": True,
     }
 
-    generators = "cmake", "cmake_find_package"
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+        export_conandata_patches(self)
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("openssl/1.1.1s")
+        self.requires("openssl/1.1.1t")
 
     def validate(self):
         if self.settings.os == "Windows":
             raise ConanInvalidConfiguration("Not supported (yet)")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_TESTING"] = False
-        self._cmake.definitions["UNSAFE_TREAT_WARNINGS_AS_ERRORS"] = False
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = False
+        tc.variables["UNSAFE_TREAT_WARNINGS_AS_ERRORS"] = False
+        tc.variables["SEARCH_LIBCRYPTO"] = False # see CMakeLists wrapper
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         apply_conandata_patches(self)
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "s2n"))
 
@@ -89,3 +85,4 @@ class S2n(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
         self.cpp_info.components["s2n-lib"].names["cmake_find_package"] = "s2n"
         self.cpp_info.components["s2n-lib"].names["cmake_find_package_multi"] = "s2n"
+        self.cpp_info.components["s2n-lib"].set_property("cmake_target_name", "AWS::s2n")

--- a/recipes/s2n/all/test_package/CMakeLists.txt
+++ b/recipes/s2n/all/test_package/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
 find_package(s2n REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} AWS::s2n)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::s2n)

--- a/recipes/s2n/all/test_package/conanfile.py
+++ b/recipes/s2n/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/s2n/all/test_v1_package/CMakeLists.txt
+++ b/recipes/s2n/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/s2n/all/test_v1_package/conanfile.py
+++ b/recipes/s2n/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Mandatory for the dependency graph of `aws-sdk-cpp`, since it's a dependency of `aws-c-io` on Linux (which is a mandatory dependency of `aws-sdk-cpp` since 1.9).

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
