### PR TITLE
gdcm: add with_zlibng option

### DIFF
--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -27,12 +27,14 @@ class GDCMConan(ConanFile):
         "fPIC": [True, False],
         "with_json": [True, False],
         "with_openssl": [True, False],
+        "with_zlibng": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_json": True,
         "with_openssl": True,
+        "with_zlibng": False,
     }
 
     @property
@@ -56,7 +58,10 @@ class GDCMConan(ConanFile):
     def requirements(self):
         self.requires("expat/2.5.0")
         self.requires("openjpeg/2.5.0")
-        self.requires("zlib/1.2.13")
+        if self.options.with_zlibng:
+            self.requires("zlib-ng/2.0.7")
+        else:
+            self.requires("zlib/1.2.13")
         if self.settings.os != "Windows":
             self.requires("libuuid/1.0.3")
             if Version(self.version) >= Version("3.0.20"):
@@ -71,6 +76,10 @@ class GDCMConan(ConanFile):
             check_min_cppstd(self, self._min_cppstd)
         if is_msvc_static_runtime(self) and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} does not support shared and static runtime together.")
+        if self.info.options.with_zlibng:
+            zlib_ng = self.dependencies["zlib-ng"]
+            if not zlib_ng.options.zlib_compat:
+                raise ConanInvalidConfiguration(f"{self.ref} requires the dependency option zlib-ng:zlib_compat=True")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -222,7 +231,11 @@ class GDCMConan(ConanFile):
 
         if self.options.with_openssl:
             self.cpp_info.components["gdcmCommon"].requires.append("openssl::openssl")
-        self.cpp_info.components["gdcmDSED"].requires.extend(["gdcmCommon", "zlib::zlib"])
+
+        def zlib():
+            return "zlib-ng::zlib-ng" if self.options.with_zlibng else "zlib::zlib"
+
+        self.cpp_info.components["gdcmDSED"].requires.extend(["gdcmCommon", zlib()])
         self.cpp_info.components["gdcmIOD"].requires.extend(["gdcmDSED", "gdcmCommon", "expat::expat"])
         self.cpp_info.components["gdcmMSFF"].requires.extend(["gdcmIOD", "gdcmDSED", "gdcmDICT", "openjpeg::openjpeg"])
         if self.options.with_json:


### PR DESCRIPTION
Specify library name and version:  **gdcm/all**

zlib-ng will be needed for new ITK release (5.3.0) so I'm trying to add zlib-ng to libraries that are used by ITK.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
