### PR TITLE
gtk system: use newer pkgconfig

### DIFF
--- a/recipes/gtk/system/test_package/CMakeLists.txt
+++ b/recipes/gtk/system/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+cmake_minimum_required(VERSION 3.15)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+project(test_package LANGUAGES C)
+
+find_package(gtk REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+target_link_libraries(${PROJECT_NAME} PRIVATE gtk::gtk)
+

--- a/recipes/gtk/system/test_package/conanfile.py
+++ b/recipes/gtk/system/test_package/conanfile.py
@@ -1,10 +1,20 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
+# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +22,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gtk/system/test_v1_package/CMakeLists.txt
+++ b/recipes/gtk/system/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/gtk/system/test_v1_package/conanfile.py
+++ b/recipes/gtk/system/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/gtk/system/test_v1_package/test_package.c
+++ b/recipes/gtk/system/test_v1_package/test_package.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+#include <gtk/gtk.h>
+
+int main(void) {
+    gtk_window_new (GTK_WINDOW_TOPLEVEL);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Specify library name and version:  **gtk/system**

Use Conan's built-in `pkg_config.fill_cpp_info` instead of recipe-local implementation.
