### PR TITLE
config: remove eric from gtk alerts

### DIFF
--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -174,7 +174,7 @@ jobs:
       - uses: ./.github/actions/alert-community
         with:
           files: "recipes/gtk/*/*"
-          reviewers: "@ericLemanissier"
+          reviewers: ""
 
       - uses: ./.github/actions/alert-community
         with:


### PR DESCRIPTION



---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
