### PR TITLE
gnu-config: add support to tvOS and watchOS

### DIFF
--- a/recipes/gnu-config/all/conandata.yml
+++ b/recipes/gnu-config/all/conandata.yml
@@ -5,3 +5,8 @@ sources:
   "cci.20201022":
     url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-1c4398015583eb77bc043234f5734be055e64bea.tar.gz"
     sha256: "339eb64757bf5af9e23ca15daa136acdd9d778753377190ce17fba7e1b222aff"
+patches:
+  "cci.20210814":
+    - patch_file: "patches/cci.20210814-0001-tvos-support.patch"
+      patch_description: "add support to tvOS"
+      patch_type: "portability"

--- a/recipes/gnu-config/all/conanfile.py
+++ b/recipes/gnu-config/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanException
-from conan.tools.files import copy, get, load, save
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, load, save
 from conan.tools.layout import basic_layout
 import os
 
@@ -22,6 +22,9 @@ class GnuConfigConan(ConanFile):
 
     def package_id(self):
         self.info.clear()
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -46,6 +49,7 @@ class GnuConfigConan(ConanFile):
         return "\n".join(txt_lines[start_index:end_index])
 
     def package(self):
+        apply_conandata_patches(self)
         save(self, os.path.join(self.package_folder, "licenses", "COPYING"), self._extract_license())
         copy(self, "config.guess", src=self.source_folder, dst=os.path.join(self.package_folder, "bin"))
         copy(self, "config.sub", src=self.source_folder, dst=os.path.join(self.package_folder, "bin"))

--- a/recipes/gnu-config/all/conanfile.py
+++ b/recipes/gnu-config/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanException
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, load, save
+from conan.tools.files import copy, get, load, save
 from conan.tools.layout import basic_layout
 import os
 
@@ -22,9 +22,6 @@ class GnuConfigConan(ConanFile):
 
     def package_id(self):
         self.info.clear()
-
-    def export_sources(self):
-        export_conandata_patches(self)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -49,7 +46,6 @@ class GnuConfigConan(ConanFile):
         return "\n".join(txt_lines[start_index:end_index])
 
     def package(self):
-        apply_conandata_patches(self)
         save(self, os.path.join(self.package_folder, "licenses", "COPYING"), self._extract_license())
         copy(self, "config.guess", src=self.source_folder, dst=os.path.join(self.package_folder, "bin"))
         copy(self, "config.sub", src=self.source_folder, dst=os.path.join(self.package_folder, "bin"))

--- a/recipes/gnu-config/all/patches/cci.20210814-0001-tvos-support.patch
+++ b/recipes/gnu-config/all/patches/cci.20210814-0001-tvos-support.patch
@@ -1,0 +1,11 @@
+--- config.sub	
++++ config.sub
+@@ -1723,7 +1723,7 @@
+ 	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
+ 	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \
+ 	     | hiux* | abug | nacl* | netware* | windows* \
+-	     | os9* | macos* | osx* | ios* \
++	     | os9* | macos* | osx* | ios* | tvos* | watchos* \
+ 	     | mpw* | magic* | mmixware* | mon960* | lnews* \
+ 	     | amigaos* | amigados* | msdos* | newsos* | unicos* | aof* \
+ 	     | aos* | aros* | cloudabi* | sortix* | twizzler* \


### PR DESCRIPTION
Specify library name and version:  **gnu-config/cci.20210804**

The intention is to use this patch to cross-build libraries, with errors like:

```
checking build system type... aarch64-apple-darwin
checking host system type... Invalid configuration `x86_64-apple-tvos': OS `tvos' not recognized
```

For example, it was reported in the issue https://github.com/conan-io/conan-center-index/issues/8990 when building iconv.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
