### PR TITLE
libmysqlclient: move check_min_cppstd to validate_build

### DIFF
--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -76,11 +76,6 @@ class LibMysqlClientCConan(ConanFile):
         if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross compilation not yet supported by the recipe. Contributions are welcomed.")
 
-        # mysql < 8.0.29 uses `requires` in source code. It is the reserved keyword in C++20.
-        # https://github.com/mysql/mysql-server/blob/mysql-8.0.0/include/mysql/components/services/dynamic_loader.h#L270
-        if self.settings.compiler.get_safe("cppstd") == "20" and Version(self.version) < "8.0.29":
-            raise ConanInvalidConfiguration(f"{self.ref} doesn't support C++20")
-
     def validate(self):
         def loose_lt_semver(v1, v2):
             lv1 = [int(v) for v in v1.split(".")]
@@ -96,6 +91,11 @@ class LibMysqlClientCConan(ConanFile):
         # https://github.com/mysql/mysql-server/blob/mysql-8.0.17/cmake/libutils.cmake#L333-L335
         if self.settings.compiler == "apple-clang" and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support shared library")
+        
+        # mysql < 8.0.29 uses `requires` in source code. It is the reserved keyword in C++20.
+        # https://github.com/mysql/mysql-server/blob/mysql-8.0.0/include/mysql/components/services/dynamic_loader.h#L270
+        if self.settings.compiler.get_safe("cppstd") == "20" and Version(self.version) < "8.0.29":
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support C++20")
 
     def _cmake_new_enough(self, required_version):
         try:

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -91,7 +91,7 @@ class LibMysqlClientCConan(ConanFile):
         # https://github.com/mysql/mysql-server/blob/mysql-8.0.17/cmake/libutils.cmake#L333-L335
         if self.settings.compiler == "apple-clang" and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support shared library")
-        
+
         # mysql < 8.0.29 uses `requires` in source code. It is the reserved keyword in C++20.
         # https://github.com/mysql/mysql-server/blob/mysql-8.0.0/include/mysql/components/services/dynamic_loader.h#L270
         if self.settings.compiler.get_safe("cppstd") == "20" and Version(self.version) < "8.0.29":


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient**

### Summary
* Move `check_min_cppstd` logic to `validate_build()` rather than `validate()`
* Move checks for cross-building to `validate_build()` as well 

### Context
Conan 2.0 profiles now define the `compiler.cppstd` setting by default, and will propagate that when building binaries from source. 

Some libraries, such as `libmysqlclient`'s most recent version, can only be built with C++17 or above. 

When a downstream consumer that depends on `libmysqlclient` is on `cppstd=14`, before this PR they would get that a package for `libmysqlclient` with `cppstd=14` is _not_ possible, and thus will get an error - and would otherwise force the consumer to be on C++17 as well. 

However, `libmysqclient` can be consumed with clients on other versions of the C++ standard. A package _built_ with cppstd=14 cannot exist, but a consumer on a cppstd value can consume it just fine. 

In the past, one might have decided to change the `package_id()` to reflect this. However, Conan 2.0 introduces the newer `compatibility.py`, which will consider other package IDs as candidates based on custom logic: in this case, consumers on `cppstd=14` will consider packages built for other versions of the C++ standard. 

This PR fixes an issue where that logic fails because the `check_min_cppstd` is in the `validate()` method, rather than the `validate_build()` method. This means that the check is performed when _building_ the library from source, but will not prevent users from consuming it. It is still not possible for a package ID with `cppstd=14` to exist, because `validate_build()` will prevent it from happening. 

This should make the following possible, for example, building poco with `cppstd=14`:
```
======== Computing dependency graph ========
Graph root
    cli
Requirements
    bzip2/1.0.8#411fc05e80d47a89045edc1ee6f23c1d - Cache
    expat/2.5.0#7fde619c77c77a50ca72364bc92c4907 - Cache
    libmysqlclient/8.0.31#584fbaf0e33c3b4ea58ed111cf343b2b - Cache
    libpq/14.5#c42ba3a37dc1d8b18c61c91feddfd4c6 - Cache
    lz4/1.9.4#bce1f314775b83c195dffc8e177ff368 - Cache
    openssl/1.1.1t#7d9fc949345908e1b8609d9d9f528a08 - Cache
    pcre2/10.42#2079a0447f9652dffcbbf1eb73ae2d4e - Cache
    poco/1.12.4#67573fdcd8ecf9642fd08ad780033d14 - Cache
    sqlite3/3.40.1#42e44d48d880b6520ae0fea7dc51b3da - Cache
    zlib/1.2.13#13c96f538b52e1600c40b88994de240f - Cache
    zstd/1.5.4#15ac0bc440f89247276d78ea4fdf8b14 - Cache
Build requirements
    nasm/2.15.05#799d63b1672a337584b09635b0f22fc1 - Cache
    strawberryperl/5.32.1.1#8f83d05a60363a422f9033e52d106b47 - Cache

======== Computing necessary packages ========
libmysqlclient/8.0.31: Checking 2 compatible configurations:
libmysqlclient/8.0.31: '13a94f6d7176d8cf4a1317477fbe1dcae66b3ca3': compiler.cppstd=17
libmysqlclient/8.0.31: Main binary package '953888911400f65543a2da36fc54d4f211548d5d' missing. Using compatible package '13a94f6d7176d8cf4a1317477fbe1dcae66b3ca3'
```

Where the last line translates as:
the package `953888911400f65543a2da36fc54d4f211548d5d` (libmysqlclient with cppstd=14, which cannot exist) is missing, but will use `13a94f6d7176d8cf4a1317477fbe1dcae66b3ca3` which was built with cppstd=17, and assuming it is compatible.

