### PR TITLE
wayland: add ninja to build requirements

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -59,6 +59,7 @@ class WaylandConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("meson/1.0.0")
+        self.tool_requires("ninja/1.11.1")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/1.9.3")
         if cross_building(self):


### PR DESCRIPTION
Specify library name and version:  **wayland/1.21.0**

This fixes build error on Ubuntu:
```bash
ERROR: Could not detect Ninja v1.8.2 or newer
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
