### PR TITLE
imath: fix for msvc c++20 build

### DIFF
--- a/recipes/imath/all/conanfile.py
+++ b/recipes/imath/all/conanfile.py
@@ -49,6 +49,8 @@ class ImathConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        if self.settings.compiler == "msvc" and self.settings.compiler.cppstd == "20":
+            tc.variables["CMAKE_CXX_FLAGS"] = "/Zc:__cplusplus"        
         tc.generate()
 
     def build(self):

--- a/recipes/imath/all/conanfile.py
+++ b/recipes/imath/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import collect_libs, copy, get, rmdir
+from conan.tools.microsoft import is_msvc
 import os
 
 required_conan_version = ">=1.53.0"
@@ -49,7 +50,9 @@ class ImathConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        if self.settings.compiler == "msvc" and self.settings.compiler.cppstd == "20":
+        if is_msvc(self) and self.settings.compiler.get_safe("cppstd"):
+            # when msvc is working with a C++ standard level higher
+            # than the default, we need the __cplusplus macro to be correct
             tc.variables["CMAKE_CXX_FLAGS"] = "/Zc:__cplusplus"        
         tc.generate()
 


### PR DESCRIPTION
Specify library name and version:  **imath/3.1.7**

The code relies on `__cplusplus` macro to provide implementation of some functionality unavailable before C++20. As msvc doesn't define that macro by default it results in compilation error. See [/Zc:__cplusplus](https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170).

Error details:
```bash
error C2668: 'bit_cast': ambiguous call to overloaded function [E:\conan\packages\t\imatha94c88 
21de43e\b\build\src\ImathTest\ImathTest.vcxproj]
E:\conan\packages\t\imatha94c8821de43e\b\src\src\ImathTest\testFun.cpp(26,5): message : could be 'To bit_cast<uint64_t,double>(From)' [E:\conan\packages\t\imatha94c8821de43e\b 
\build\src\ImathTest\ImathTest.vcxproj]
          with
          [
              To=uint64_t,
              From=double
          ]
D:\dev\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.35.32215\include\bit(33,26): message : or       '_To std::bit_cast<uint64_t,double,0>(const _From &) noexcept 
' [E:\conan\packages\t\imatha94c8821de43e\b\build\src\ImathTest\ImathTest.vcxproj]
          with
          [
              _To=uint64_t,
              _From=double
          ] (compiling source file E:\conan\packages\t\imatha94c8821de43e\b\src\src\ImathTest\testFun.cpp)
```


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
