### PR TITLE
bitflags: modernize more for conan v2

### DIFF
--- a/recipes/bitflags/all/conanfile.py
+++ b/recipes/bitflags/all/conanfile.py
@@ -21,31 +21,37 @@ class BitFlags(ConanFile):
     no_copy_source = True
 
     @property
-    def _minimum_compilers_version(self):
-        return {"apple-clang": "5", "clang": "5", "gcc": "7", "Visual Studio": "14"}
+    def _min_cppstd(self):
+        return "11"
 
     @property
-    def _minimum_cpp_standard(self):
-        return 11
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "5",
+            "clang": "5",
+            "gcc": "7",
+            "Visual Studio": "14",
+            "msvc": "190",
+        }
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()
 
     def validate(self):
-        if self.settings.get_safe("compiler.cppstd"):
-            check_min_cppstd(self, self._minimum_cpp_standard)
-        try:
-            if Version(self.settings.compiler.version) < self._minimum_compilers_version[str(self.settings.compiler)]:
-                raise ConanInvalidConfiguration(f"{self.ref} requires a compiler that supports C++{self._minimum_cpp_standard}.")
-        except KeyError:
-            self.output.warn("Unknown compiler encountered. Assuming it supports C++11.")
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
+            )
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True,
-            destination=self.source_folder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
@@ -56,4 +62,3 @@ class BitFlags(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "bitflags::bitflags")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-        self.cpp_info.resdirs = []

--- a/recipes/bitflags/all/conanfile.py
+++ b/recipes/bitflags/all/conanfile.py
@@ -17,6 +17,7 @@ class BitFlags(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/m-peko/bitflags"
     license = "MIT"
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 

--- a/recipes/bitflags/all/test_v1_package/CMakeLists.txt
+++ b/recipes/bitflags/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(bitflags REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE bitflags::bitflags)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
- fix msvc (it was going into a branch calling old self.output.warn which is not available in conan v2)
- add package_type

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
