### PR TITLE
freetype: also define `Freetype::Freetype` imported target in config file generated by CMakeDeps

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -242,9 +242,9 @@ class FreetypeConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_module_file_name", "Freetype")
-        self.cpp_info.set_property("cmake_module_target_name", "Freetype::Freetype")
         self.cpp_info.set_property("cmake_file_name", "freetype")
-        self.cpp_info.set_property("cmake_target_name", "freetype")
+        self.cpp_info.set_property("cmake_target_name", "Freetype::Freetype")
+        self.cpp_info.set_property("cmake_target_aliases", ["freetype"]) # other possible target name in upstream config file
         self.cpp_info.set_property("cmake_build_modules", [self._module_vars_rel_path])
         self.cpp_info.set_property("pkg_config_name", "freetype2")
         self.cpp_info.libs = collect_libs(self)


### PR DESCRIPTION
This target also exists in upstream config file since 2.13.0 (in addition to `freetype` imported target): https://github.com/freetype/freetype/commit/55a97b0cb133b7a5dc28dfabec77a1b9f742c301

closes https://github.com/conan-io/conan-center-index/issues/16824

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
