### PR TITLE
zmarok-semver: fix double fPIC deletion on Windows if shared & modernize more for conan v2

### DIFF
--- a/recipes/zmarok-semver/all/conanfile.py
+++ b/recipes/zmarok-semver/all/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, copy, get
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 import os
 
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.53.0"
 
 
 class ZmarokSemverConan(ConanFile):
@@ -16,6 +16,7 @@ class ZmarokSemverConan(ConanFile):
     homepage = "https://github.com/zmarko/semver"
     description = "Semantic versioning for cpp14"
     topics = ("versioning", "semver", "semantic")
+    package_type = "library"
     settings = "os", "compiler", "arch", "build_type"
     options = {
         "shared": [True, False],
@@ -26,29 +27,28 @@ class ZmarokSemverConan(ConanFile):
         "fPIC": True,
     }
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-
-    def export_sources(self):
-        for p in self.conan_data.get("patches", {}).get(self.version, []):
-            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
-
-    def validate(self):
-        if self.info.settings.os == "Windows" and self.info.options.shared:
-            raise ConanInvalidConfiguration("Shared library on Windows is not supported.")
-        if self.info.settings.compiler.cppstd:
-            check_min_cppstd(self, 14)
-
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self.source_folder)
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.os == "Windows" and self.options.shared:
+            raise ConanInvalidConfiguration("Shared library on Windows is not supported.")
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 14)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         gt = CMakeToolchain(self)
@@ -77,5 +77,5 @@ class ZmarokSemverConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["semver"]
-        if not self.settings.os in ["Windows"]:
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["m"]

--- a/recipes/zmarok-semver/all/test_v1_package/CMakeLists.txt
+++ b/recipes/zmarok-semver/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.11)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(zmarok-semver CONFIG REQUIRED)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE zmarok-semver::zmarok-semver)
- set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 14)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
- fix double deletion of fPIC option on Windows if shared for conan v2
- add package_type
- use export_conan_data_patches
- add libm to system libs if Linux or FreeBSD only
- don't use self.info in validate()
- use standard template in test_v1_package

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
