### PR TITLE
function2: fix msvc for conan v2 + add package_type

### DIFF
--- a/recipes/function2/all/conanfile.py
+++ b/recipes/function2/all/conanfile.py
@@ -25,7 +25,7 @@ class Function2Conan(ConanFile):
         return "14"
 
     @property
-    def _compiler_minimal_version(self):
+    def _compilers_minimum_version(self):
         return {
             "gcc": "5",
             "clang": "3.4",

--- a/recipes/function2/all/conanfile.py
+++ b/recipes/function2/all/conanfile.py
@@ -16,12 +16,13 @@ class Function2Conan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Naios/function2"
     license = "BSL-1.0"
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
     def _min_cppstd(self):
-        return 14
+        return "14"
 
     @property
     def _compiler_minimal_version(self):
@@ -29,7 +30,8 @@ class Function2Conan(ConanFile):
             "gcc": "5",
             "clang": "3.4",
             "apple-clang": "10",
-            "Visual Studio": "14"
+            "Visual Studio": "14",
+            "msvc": "14",
         }
 
     def layout(self):
@@ -41,20 +43,15 @@ class Function2Conan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-        compiler = str(self.settings.compiler)
-        if compiler not in self._compiler_minimal_version:
-            self.output.warn(
-                "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
-            self.output.warn(
-                "%s requires a compiler that supports at least C++%s" % (self.name, self._min_cppstd))
-            return
-        version = Version(self.settings.compiler.version)
-        if version < self._compiler_minimal_version[compiler]:
-            raise ConanInvalidConfiguration("%s requires a compiler that supports at least C++%s" % (self.name, self._min_cppstd))
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
+            )
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         pass

--- a/recipes/function2/all/conanfile.py
+++ b/recipes/function2/all/conanfile.py
@@ -35,7 +35,7 @@ class Function2Conan(ConanFile):
         }
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/function2/all/conanfile.py
+++ b/recipes/function2/all/conanfile.py
@@ -31,7 +31,7 @@ class Function2Conan(ConanFile):
             "clang": "3.4",
             "apple-clang": "10",
             "Visual Studio": "14",
-            "msvc": "14",
+            "msvc": "190",
         }
 
     def layout(self):

--- a/recipes/function2/all/test_v1_package/CMakeLists.txt
+++ b/recipes/function2/all/test_v1_package/CMakeLists.txt
@@ -1,14 +1,8 @@
-cmake_minimum_required(VERSION 3.10)
-
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(function2 REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-
-target_link_libraries(${PROJECT_NAME} PRIVATE function2::function2)
-
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
- do not use self.ouput.warn since it's not v2 compatible
- use standard template to check min compiler version (it fixes issue above actually)
- use standard template in test v1 package
- add package_type

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
