### PR TITLE
pfr: fix msvc for conan v2 + add package_type

### DIFF
--- a/recipes/pfr/all/conandata.yml
+++ b/recipes/pfr/all/conandata.yml
@@ -1,13 +1,13 @@
 sources:
-  "1.0.4":
-    url: "https://github.com/boostorg/pfr/archive/refs/tags/1.0.4.tar.gz"
-    sha256: "01ecb27c850f50c589bad9a741ec9af6b06fe07ed673946c4bbb1960eb0f126e"
-  "2.0.2":
-    url: "https://github.com/boostorg/pfr/archive/refs/tags/2.0.2.tar.gz"
-    sha256: "1f03ebd3728d7df166d40d992ac071927d483474aa0f947e78a573c4ca288c04"
   "2.0.3":
     url: "https://github.com/boostorg/pfr/archive/refs/tags/2.0.3.tar.gz"
     sha256: "c7d1950b56a07678423759f0bcdf37312f9861e3e9e59c45331903891213e2f2"
+  "2.0.2":
+    url: "https://github.com/boostorg/pfr/archive/refs/tags/2.0.2.tar.gz"
+    sha256: "1f03ebd3728d7df166d40d992ac071927d483474aa0f947e78a573c4ca288c04"
+  "1.0.4":
+    url: "https://github.com/boostorg/pfr/archive/refs/tags/1.0.4.tar.gz"
+    sha256: "01ecb27c850f50c589bad9a741ec9af6b06fe07ed673946c4bbb1960eb0f126e"
 patches:
   "1.0.4":
     - patch_file: "patches/50_add_license.patch"

--- a/recipes/pfr/all/conanfile.py
+++ b/recipes/pfr/all/conanfile.py
@@ -13,15 +13,16 @@ required_conan_version = ">=1.52.0"
 class PfrConan(ConanFile):
     name = "pfr"
     description = "std::tuple like methods for user defined types without any macro or boilerplate code"
-    topics = ("boost", "pfr", "reflection", "magic_get")
+    topics = ("boost", "reflection", "magic_get")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/boostorg/pfr"
     license = "BSL-1.0"
-    settings = "os", "compiler", "build_type", "arch"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
 
     @property
-    def _minimum_cpp_standard(self):
-        return 14
+    def _min_cppstd(self):
+        return "14"
 
     @property
     def _minimum_compilers_version(self):
@@ -30,35 +31,30 @@ class PfrConan(ConanFile):
             "clang": "3.8",
             "gcc": "5.5",
             "Visual Studio": "14",
+            "msvc": "190",
         }
 
     def export_sources(self):
         export_conandata_patches(self)
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
-            check_min_cppstd(self, self._minimum_cpp_standard)
+            check_min_cppstd(self, self._min_cppstd)
 
-        compiler = self.settings.compiler
-        try:
-            min_version = self._minimum_compilers_version[str(compiler)]
-            if Version(compiler.version) < min_version:
-                msg = (
-                    "{} requires C++{} features which are not supported by compiler {} {}."
-                ).format(self.name, self._minimum_cpp_standard, compiler, compiler.version)
-                raise ConanInvalidConfiguration(msg)
-        except KeyError:
-            msg = (
-                "{} recipe lacks information about the {} compiler, "
-                "support for the required C++{} features is assumed"
-            ).format(self.name, compiler, self._minimum_cpp_standard)
-            self.output.warn(msg)
+        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         apply_conandata_patches(self)
@@ -69,5 +65,6 @@ class PfrConan(ConanFile):
         copy(self, pattern="*", dst=os.path.join(self.package_folder, "include"),
              src=os.path.join(self.source_folder, "include"))
 
-    def package_id(self):
-        self.info.clear()
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/pfr/all/test_package/conanfile.py
+++ b/recipes/pfr/all/test_package/conanfile.py
@@ -7,19 +7,19 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
 
-    def generate(self):
-        ct = CMakeToolchain(self)
-        ct.variables["PfrMajorVersion"] = Version(self.dependencies["pfr"].ref.version).major
-        ct.generate()
-
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["PfrMajorVersion"] = Version(self.dependencies["pfr"].ref.version).major
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/pfr/config.yml
+++ b/recipes/pfr/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "1.0.4":
+  "2.0.3":
     folder: "all"
   "2.0.2":
     folder: "all"
-  "2.0.3":
+  "1.0.4":
     folder: "all"


### PR DESCRIPTION
- do not use self.ouput.warn since it's not v2 compatible
- use standard template to check min compiler version (it fixes issue above actually)
- order by desc versions in conandata.yml & config.yml
- add package_type

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
