### PR TITLE
json-schema-validator: fix msvc for conan v2 + add package_type

### DIFF
--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -1,7 +1,10 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools import build, files, microsoft, scm
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 import textwrap
 
@@ -14,9 +17,8 @@ class JsonSchemaValidatorConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/pboettch/json-schema-validator"
     description = "JSON schema validator for JSON for Modern C++ "
-    topics = ("json-schema-validator", "modern-json",
-              "schema-validation", "json")
-
+    topics = ("modern-json", "schema-validation", "json")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -29,8 +31,22 @@ class JsonSchemaValidatorConan(ConanFile):
 
     short_paths = True
 
+    @property
+    def _min_cppstd(self):
+        return "17" if is_msvc(self) and Version(self.version) < "2.1.0" else "11"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15" if Version(self.version) < "2.1.0" else "14",
+            "msvc": "191" if Version(self.version) < "2.1.0" else "190",
+            "gcc": "5" if Version(self.version) < "2.1.0" else "4.9",
+            "clang": "4",
+            "apple-clang": "9"
+        }
+
     def export_sources(self):
-        files.export_conandata_patches(self)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -40,65 +56,55 @@ class JsonSchemaValidatorConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
     def requirements(self):
         self.requires("nlohmann_json/3.11.2", transitive_headers=True)
 
     def validate(self):
-        version = scm.Version(self.version)
-        min_vs_version = "16" if version < "2.1.0" else "14"
-        min_cppstd = "17" if microsoft.is_msvc(self) and version < "2.1.0" else "11"
-        if self.info.settings.get_safe("compiler.cppstd"):
-            build.check_min_cppstd(self, min_cppstd)
-            min_vs_version = "15" if version < "2.1.0" else "14"
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
 
-        compilers = {
-            "Visual Studio": min_vs_version,
-            "gcc": "5" if version < "2.1.0" else "4.9",
-            "clang": "4",
-            "apple-clang": "9"}
-        min_version = compilers.get(str(self.info.settings.compiler))
-        if not min_version:
-            self.output.warn(f"{self.name} recipe lacks information about the {self.info.settings.compiler} compiler support.")
-        else:
-            if scm.Version(self.info.settings.compiler.version) < min_version:
-                raise ConanInvalidConfiguration(f"{self.name} requires c++{min_cppstd} support. The current compiler {self.info.settings.compiler} {self.info.settings.compiler.version} does not support it.")
-
-    def layout(self):
-        cmake_layout(self, src_folder="src")
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def source(self):
-        files.get(self, **self.conan_data["sources"][self.version],
-                  destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        if scm.Version(self.version) < "2.2.0":
+        if Version(self.version) < "2.2.0":
             tc.variables["BUILD_TESTS"] = False
             tc.variables["BUILD_EXAMPLES"] = False
         else:
             tc.variables["JSON_VALIDATOR_BUILD_TESTS"] = False
             tc.variables["JSON_VALIDATOR_BUILD_EXAMPLES"] = False
-        if scm.Version(self.version) < "2.1.0":
-            tc.variables["NLOHMANN_JSON_DIR"] = ";".join(self.deps_cpp_info["nlohmann_json"].include_paths).replace("\\", "/")
+        if Version(self.version) < "2.1.0":
+            nlohmann_json_includedirs = self.dependencies["nlohmann_json"].cpp_info.aggregated_components().includedirs
+            tc.variables["NLOHMANN_JSON_DIR"] = ";".join([p.replace("\\", "/") for p in nlohmann_json_includedirs])
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
 
     def build(self):
-        files.apply_conandata_patches(self)
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def package(self):
-        files.copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
-        if scm.Version(self.version) < "2.1.0":
-            files.copy(self, "json-schema.hpp",
+        if Version(self.version) < "2.1.0":
+            copy(self, "json-schema.hpp",
                        dst=os.path.join(self.package_folder, "include", "nlohmann"),
                        src=os.path.join(self.source_folder, "src"))
-        files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self._create_cmake_module_alias_targets(
@@ -109,13 +115,13 @@ class JsonSchemaValidatorConan(ConanFile):
     def _create_cmake_module_alias_targets(self, module_file, targets):
         content = ""
         for alias, aliased in targets.items():
-            content += textwrap.dedent("""\
+            content += textwrap.dedent(f"""\
                 if(TARGET {aliased} AND NOT TARGET {alias})
                     add_library({alias} INTERFACE IMPORTED)
                     set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
                 endif()
-            """.format(alias=alias, aliased=aliased))
-        files.save(self, module_file, content)
+            """)
+        save(self, module_file, content)
 
     @property
     def _module_file_rel_path(self):
@@ -124,7 +130,7 @@ class JsonSchemaValidatorConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "nlohmann_json_schema_validator")
         self.cpp_info.set_property("cmake_target_name", "nlohmann_json_schema_validator")
-        self.cpp_info.libs = ["json-schema-validator" if scm.Version(self.version) < "2.1.0" else "nlohmann_json_schema_validator"]
+        self.cpp_info.libs = ["json-schema-validator" if Version(self.version) < "2.1.0" else "nlohmann_json_schema_validator"]
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")


### PR DESCRIPTION
- do not use self.ouput.warn since it's not v2 compatible
- use standard template to check min compiler version (it fixes issue above actually)
- don't use self.deps_cpp_info (not v2 compatible), otherwise versions < 2.1.0 are broken
- add package_type

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
