### PR TITLE
opengv: modernize more for conan v2

### DIFF
--- a/recipes/opengv/all/conanfile.py
+++ b/recipes/opengv/all/conanfile.py
@@ -44,7 +44,7 @@ class opengvConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("eigen/3.4.0")
+        self.requires("eigen/3.4.0", transitive_headers=True)
         if self.options.with_python_bindings:
             self.requires("pybind11/2.10.1")
 

--- a/recipes/opengv/all/test_package/CMakeLists.txt
+++ b/recipes/opengv/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(opengv REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} opengv)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE opengv)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/opengv/all/test_package/conanfile.py
+++ b/recipes/opengv/all/test_package/conanfile.py
@@ -1,19 +1,19 @@
 import os
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake
-from conan.tools.layout import cmake_layout
+from conan.tools.cmake import CMake, cmake_layout
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
-    def requirements(self):
-        self.requires(self.tested_reference_str)
-
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/opengv/all/test_v1_package/CMakeLists.txt
+++ b/recipes/opengv/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(opengv REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} opengv)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
- allow to raise gracefully on Windows by avoiding error during double deletion of fPIC (it's important for c3i to see a ConanInvalidConfiguration instead of a random python error)
- add package_type
- use standard template in test v1 package
- fix import of cmake_layout in test package
- bump pybind11
- use f-string

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
