### PR TITLE
libyuv: raise if msvc & shared

### DIFF
--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -1,6 +1,8 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.microsoft import is_msvc
 import os
 
 required_conan_version = ">=1.53.0"
@@ -47,6 +49,11 @@ class LibyuvConan(ConanFile):
             self.requires("libjpeg-turbo/2.1.4")
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.1")
+
+    def validate(self):
+        if is_msvc(self) and self.options.shared:
+            # Injecting CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS is not sufficient since there are global symbols
+            raise ConanInvalidConfiguration(f"{self.ref} shared not supported for msvc.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder)

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -46,7 +46,7 @@ class LibyuvConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.1.4")
+            self.requires("libjpeg-turbo/2.1.5")
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.1")
 

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -86,6 +86,8 @@ class LibyuvConan(ConanFile):
             self.cpp_info.requires.append("libjpeg-turbo::jpeg")
         elif self.options.with_jpeg == "mozjpeg":
             self.cpp_info.requires.append("mozjpeg::libjpeg")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
 
         # TODO: to remove in conan v2
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/libyuv/all/patches/1768-0001-fix-cmake.patch
+++ b/recipes/libyuv/all/patches/1768-0001-fix-cmake.patch
@@ -10,14 +10,13 @@
  OPTION( TEST "Built unit tests" OFF )
  
  SET ( ly_base_dir	${PROJECT_SOURCE_DIR} )
-@@ -23,23 +23,23 @@ LIST ( SORT			ly_unittest_sources )
+@@ -23,23 +23,22 @@ LIST ( SORT			ly_unittest_sources )
  INCLUDE_DIRECTORIES( BEFORE ${ly_inc_dir} )
  
  # this creates the static library (.a)
 -ADD_LIBRARY				( ${ly_lib_static} STATIC ${ly_source_files} )
 +ADD_LIBRARY				( ${ly_lib_static} ${ly_source_files} )
 +target_compile_features(${ly_lib_static} PUBLIC cxx_std_11)
-+set_target_properties(${ly_lib_static} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
  
  # this creates the shared library (.so)
 -ADD_LIBRARY				( ${ly_lib_shared} SHARED ${ly_source_files} )

--- a/recipes/libyuv/all/patches/1841-0001-fix-cmake.patch
+++ b/recipes/libyuv/all/patches/1841-0001-fix-cmake.patch
@@ -10,14 +10,13 @@
  OPTION( TEST "Built unit tests" OFF )
  
  SET ( ly_base_dir	${PROJECT_SOURCE_DIR} )
-@@ -27,26 +27,23 @@ if(MSVC)
+@@ -27,26 +27,22 @@ if(MSVC)
  endif()
  
  # this creates the static library (.a)
 -ADD_LIBRARY				( ${ly_lib_static} STATIC ${ly_source_files} )
 +ADD_LIBRARY				( ${ly_lib_static} ${ly_source_files} )
 +target_compile_features(${ly_lib_static} PUBLIC cxx_std_11)
-+set_target_properties(${ly_lib_static} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
  
  # this creates the shared library (.so)
 -ADD_LIBRARY				( ${ly_lib_shared} SHARED ${ly_source_files} )

--- a/recipes/libyuv/all/patches/1854-0001-fix-cmake.patch
+++ b/recipes/libyuv/all/patches/1854-0001-fix-cmake.patch
@@ -10,14 +10,13 @@
  OPTION( TEST "Built unit tests" OFF )
  
  SET ( ly_base_dir	${PROJECT_SOURCE_DIR} )
-@@ -27,15 +27,11 @@ if(MSVC)
+@@ -27,15 +27,10 @@ if(MSVC)
  endif()
  
  # this creates the static library (.a)
 -ADD_LIBRARY				( ${ly_lib_static} STATIC ${ly_source_files} )
 +ADD_LIBRARY				( ${ly_lib_static} ${ly_source_files} )
 +target_compile_features(${ly_lib_static} PUBLIC cxx_std_11)
-+set_target_properties(${ly_lib_static} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
  
  # this creates the shared library (.so)
 -ADD_LIBRARY				( ${ly_lib_shared} SHARED ${ly_source_files} )


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/16831

There are global symbols in libyuv, therefore CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS workaround is not sufficient and leads to an illformed imported lib for Visual Studio.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
