### PR TITLE
onnxruntime: add 1.14.1

### DIFF
--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -1,0 +1,20 @@
+sources:
+  "1.14.1":
+    url: "https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.14.1.tar.gz"
+    sha256: "f998352b131bb89fa7dd1f1d87ddbafe647dfaddd11929b6b5168b3f4ef857de"
+patches:
+  "1.14.1":
+    - patch_file: "patches/1.14.1-0001-cmake-dependencies.patch"
+      patch_description: "CMake: ensure conan dependencies are used (upstreamed future versions)"
+      patch_type: "conan"
+      patch_source: "https://github.com/microsoft/onnxruntime/pull/15323"
+    - patch_file: "patches/1.14.1-0002-cmake-dependencies.patch"
+      patch_description: "CMake: ensure conan dependencies are used"
+      patch_type: "conan"
+    - patch_file: "patches/1.14.1-0003-amx-gas-version.patch"
+      patch_description: "Check GNU AS supports AMX before enabling it"
+      patch_type: "portability"
+      patch_source: "https://github.com/microsoft/onnxruntime/commit/126e7bf15fa4af8621814b82a3f7bd0d786f0239.patch"
+    - patch_file: "patches/1.14.1-0004-abseil-no-string-view.patch"
+      patch_description: "allow to build with abseil built without c++17 support"
+      patch_type: "portability"

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -233,7 +233,7 @@ class OnnxRuntimeConan(ConanFile):
 
         self.cpp_info.includedirs.append("include/onnxruntime/core/session")
 
-        if self.settings.os in {"Linux", "Android", "FreeBSD", "SunOS", "AIX"}:
+        if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
             self.cpp_info.system_libs.append("m")
             self.cpp_info.system_libs.append("pthread")
         if is_apple_os(self):

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -233,10 +233,13 @@ class OnnxRuntimeConan(ConanFile):
 
         self.cpp_info.includedirs.append("include/onnxruntime/core/session")
 
-        if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
+        if self.settings.os in {"Linux", "Android", "FreeBSD", "SunOS", "AIX"}:
             self.cpp_info.system_libs.append("m")
             self.cpp_info.system_libs.append("pthread")
         if is_apple_os(self):
             self.cpp_info.frameworks.append("Foundation")
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("shlwapi")
 
+        # https://github.com/microsoft/onnxruntime/blob/v1.14.1/cmake/CMakeLists.txt#L1584
         self.cpp_info.set_property("pkg_config_name", "onnxruntime")

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -91,21 +91,9 @@ class OnnxRuntimeConan(ConanFile):
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
-    def _cmake_new_enough(self, required_version):
-        try:
-            import re
-            from io import StringIO
-            output = StringIO()
-            self.run("cmake --version", output)
-            m = re.search(r'cmake version (\d+\.\d+\.\d+)', output.getvalue())
-            return Version(m.group(1)) >= required_version
-        except:
-            return False
-
     def build_requirements(self):
         # Required by upstream https://github.com/microsoft/onnxruntime/blob/v1.14.1/cmake/CMakeLists.txt#L5
-        if not self._cmake_new_enough("3.24"):
-            self.tool_requires("cmake/3.25.3")
+        self.tool_requires("cmake/[>=3.24 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -69,7 +69,7 @@ class OnnxRuntimeConan(ConanFile):
         self.requires("re2/20230301")
         self.requires("onnx/1.13.1")
         self.requires("flatbuffers/1.12.0")
-        self.requires("boost/1.81.0")  # for mp11
+        self.requires("boost/1.81.0", headers=True, libs=False, run=False)  # for mp11, header only, no need for libraries to link/run
         self.requires("safeint/3.0.28")
         self.requires("nlohmann_json/3.11.2")
         self.requires("eigen/3.4.0")

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -1,0 +1,242 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.env import VirtualBuildEnv
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class OnnxRuntimeConan(ConanFile):
+    name = "onnxruntime"
+    description = "ONNX Runtime: cross-platform, high performance ML inferencing and training accelerator"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "MIT"
+    homepage = "https://onnxruntime.ai"
+    topics = ("deep-learning", "onnx", "neural-networks", "machine-learning", "ai-framework", "hardware-acceleration")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_xnnpack": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_xnnpack": False,
+    }
+    short_paths = True
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "16",
+            "msvc": "192",
+            "gcc": "8",
+            "clang": "5",
+            "apple-clang": "10",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("abseil/20230125.2")
+        self.requires("protobuf/3.21.9")
+        self.requires("date/3.0.1")
+        self.requires("re2/20230301")
+        self.requires("onnx/1.13.1")
+        self.requires("flatbuffers/1.12.0")
+        self.requires("boost/1.81.0")  # for mp11
+        self.requires("safeint/3.0.28")
+        self.requires("nlohmann_json/3.11.2")
+        self.requires("eigen/3.4.0")
+        self.requires("ms-gsl/4.0.0")
+        self.requires("cpuinfo/cci.20220228")
+        if self.settings.os != "Windows":
+            self.requires("nsync/1.25.0")
+        else:
+            self.requires("wil/1.0.230202.1")
+        if self.options.with_xnnpack:
+            self.requires("xnnpack/cci.20220801")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def _cmake_new_enough(self, required_version):
+        try:
+            import re
+            from io import StringIO
+            output = StringIO()
+            self.run("cmake --version", output)
+            m = re.search(r'cmake version (\d+\.\d+\.\d+)', output.getvalue())
+            return Version(m.group(1)) >= required_version
+        except:
+            return False
+
+    def build_requirements(self):
+        # Required by upstream https://github.com/microsoft/onnxruntime/blob/v1.14.1/cmake/CMakeLists.txt#L5
+        if not self._cmake_new_enough("3.24"):
+            self.tool_requires("cmake/3.25.3")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # disable downloading dependencies to ensure conan ones are used
+        tc.variables["FETCHCONTENT_FULLY_DISCONNECTED"] = True
+
+        tc.variables["onnxruntime_BUILD_SHARED_LIB"] = self.options.shared
+        tc.variables["onnxruntime_USE_FULL_PROTOBUF"] = not self.dependencies["protobuf"].options.lite
+        tc.variables["onnxruntime_USE_XNNPACK"] = self.options.with_xnnpack
+
+        tc.variables["onnxruntime_BUILD_UNIT_TESTS"] = False
+        tc.variables["onnxruntime_RUN_ONNX_TESTS"] = False
+        tc.variables["onnxruntime_GENERATE_TEST_REPORTS"] = False
+        tc.variables["onnxruntime_USE_MIMALLOC"] = False
+        tc.variables["onnxruntime_ENABLE_PYTHON"] = False
+        tc.variables["onnxruntime_BUILD_CSHARP"] = False
+        tc.variables["onnxruntime_BUILD_JAVA"] = False
+        tc.variables["onnxruntime_BUILD_NODEJS"] = False
+        tc.variables["onnxruntime_BUILD_OBJC"] = False
+        tc.variables["onnxruntime_BUILD_APPLE_FRAMEWORK"] = False
+        tc.variables["onnxruntime_USE_DNNL"] = False
+        tc.variables["onnxruntime_USE_NNAPI_BUILTIN"] = False
+        tc.variables["onnxruntime_USE_RKNPU"] = False
+        tc.variables["onnxruntime_USE_LLVM"] = False
+        tc.variables["onnxruntime_ENABLE_MICROSOFT_INTERNAL"] = False
+        tc.variables["onnxruntime_USE_VITISAI"] = False
+        tc.variables["onnxruntime_USE_TENSORRT"] = False
+        tc.variables["onnxruntime_SKIP_AND_PERFORM_FILTERED_TENSORRT_TESTS"] = True
+        tc.variables["onnxruntime_USE_TENSORRT_BUILTIN_PARSER"] = False
+        tc.variables["onnxruntime_TENSORRT_PLACEHOLDER_BUILDER"] = False
+        tc.variables["onnxruntime_USE_TVM"] = False
+        tc.variables["onnxruntime_TVM_CUDA_RUNTIME"] = False
+        tc.variables["onnxruntime_TVM_USE_HASH"] = False
+        tc.variables["onnxruntime_CROSS_COMPILING"] = False
+        tc.variables["onnxruntime_DISABLE_CONTRIB_OPS"] = False
+        tc.variables["onnxruntime_DISABLE_ML_OPS"] = False
+        tc.variables["onnxruntime_DISABLE_RTTI"] = False
+        tc.variables["onnxruntime_DISABLE_EXCEPTIONS"] = False
+        tc.variables["onnxruntime_MINIMAL_BUILD"] = False
+        tc.variables["onnxruntime_EXTENDED_MINIMAL_BUILD"] = False
+        tc.variables["onnxruntime_MINIMAL_BUILD_CUSTOM_OPS"] = False
+        tc.variables["onnxruntime_REDUCED_OPS_BUILD"] = False
+        tc.variables["onnxruntime_ENABLE_LANGUAGE_INTEROP_OPS"] = False
+        tc.variables["onnxruntime_USE_DML"] = False
+        tc.variables["onnxruntime_USE_WINML"] = False
+        tc.variables["onnxruntime_BUILD_MS_EXPERIMENTAL_OPS"] = False
+        tc.variables["onnxruntime_USE_TELEMETRY"] = False
+        tc.variables["onnxruntime_ENABLE_LTO"] = False
+        tc.variables["onnxruntime_USE_ACL"] = False
+        tc.variables["onnxruntime_USE_ACL_1902"] = False
+        tc.variables["onnxruntime_USE_ACL_1905"] = False
+        tc.variables["onnxruntime_USE_ACL_1908"] = False
+        tc.variables["onnxruntime_USE_ACL_2002"] = False
+        tc.variables["onnxruntime_USE_ARMNN"] = False
+        tc.variables["onnxruntime_ARMNN_RELU_USE_CPU"] = False
+        tc.variables["onnxruntime_ARMNN_BN_USE_CPU"] = False
+        tc.variables["onnxruntime_ENABLE_NVTX_PROFILE"] = False
+        tc.variables["onnxruntime_ENABLE_TRAINING"] = False
+        tc.variables["onnxruntime_ENABLE_TRAINING_OPS"] = False
+        tc.variables["onnxruntime_ENABLE_TRAINING_APIS"] = False
+        tc.variables["onnxruntime_ENABLE_CPU_FP16_OPS"] = False
+        tc.variables["onnxruntime_USE_NCCL"] = False
+        tc.variables["onnxruntime_BUILD_BENCHMARKS"] = False
+        tc.variables["onnxruntime_USE_ROCM"] = False
+        tc.variables["onnxruntime_GCOV_COVERAGE"] = False
+        tc.variables["onnxruntime_USE_MPI"] = False
+        tc.variables["onnxruntime_ENABLE_MEMORY_PROFILE"] = False
+        tc.variables["onnxruntime_ENABLE_CUDA_LINE_NUMBER_INFO"] = False
+        tc.variables["onnxruntime_BUILD_WEBASSEMBLY"] = False
+        tc.variables["onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB"] = False
+        tc.variables["onnxruntime_ENABLE_WEBASSEMBLY_EXCEPTION_CATCHING"] = False
+        tc.variables["onnxruntime_ENABLE_WEBASSEMBLY_API_EXCEPTION_CATCHING"] = False
+        tc.variables["onnxruntime_ENABLE_WEBASSEMBLY_EXCEPTION_THROWING"] = False
+        tc.variables["onnxruntime_ENABLE_WEBASSEMBLY_THREADS"] = False
+        tc.variables["onnxruntime_ENABLE_WEBASSEMBLY_DEBUG_INFO"] = False
+        tc.variables["onnxruntime_ENABLE_WEBASSEMBLY_PROFILING"] = False
+        tc.variables["onnxruntime_ENABLE_EAGER_MODE"] = False
+        tc.variables["onnxruntime_ENABLE_LAZY_TENSOR"] = False
+        tc.variables["onnxruntime_ENABLE_EXTERNAL_CUSTOM_OP_SCHEMAS"] = False
+        tc.variables["onnxruntime_ENABLE_CUDA_PROFILING"] = False
+        tc.variables["onnxruntime_ENABLE_ROCM_PROFILING"] = False
+        tc.variables["onnxruntime_USE_CANN"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+        vbe = VirtualBuildEnv(self)
+        vbe.generate(scope="build")
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        # https://github.com/microsoft/onnxruntime/blob/v1.14.1/cmake/CMakeLists.txt#L792
+        # onnxruntime is builds its targets with COMPILE_WARNING_AS_ERROR ON
+        # This will most likely lead to build errors on compilers not undergoing CI testing upstream
+        # so disable COMPILE_WARNING_AS_ERROR
+        cmake.configure(build_script_folder="cmake", cli_args=["--compile-no-warning-as-error"])
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+        pkg_config_dir = os.path.join(self.package_folder, "lib", "pkgconfig")
+        rmdir(self, pkg_config_dir)
+
+    def package_info(self):
+        if self.options.shared:
+            self.cpp_info.libs = ["onnxruntime"]
+        else:
+            onnxruntime_libs = [
+                "session",
+                "optimizer",
+                "providers",
+                "framework",
+                "graph",
+                "util",
+                "mlas",
+                "common",
+                "flatbuffers",
+            ]
+            self.cpp_info.libs = [f"onnxruntime_{lib}" for lib in onnxruntime_libs]
+
+        self.cpp_info.includedirs.append("include/onnxruntime/core/session")
+
+        if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.append("pthread")
+        if is_apple_os(self):
+            self.cpp_info.frameworks.append("Foundation")
+
+        self.cpp_info.set_property("pkg_config_name", "onnxruntime")

--- a/recipes/onnxruntime/all/patches/1.14.1-0001-cmake-dependencies.patch
+++ b/recipes/onnxruntime/all/patches/1.14.1-0001-cmake-dependencies.patch
@@ -1,0 +1,247 @@
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -753,7 +753,7 @@ endif()
+ 
+ function(onnxruntime_set_compile_flags target_name)
+     if (CPUINFO_SUPPORTED)
+-      onnxruntime_add_include_to_target(${target_name} cpuinfo)
++      onnxruntime_add_include_to_target(${target_name} cpuinfo::cpuinfo)
+     endif()
+     if(onnxruntime_ENABLE_EAGER_MODE)
+       target_compile_definitions(${target_name} PRIVATE ENABLE_EAGER_MODE)
+@@ -837,7 +837,7 @@ function(onnxruntime_set_compile_flags target_name)
+         target_compile_options(${target_name} PRIVATE "-Wno-unused-parameter")
+       endif()
+       target_compile_definitions(${target_name} PUBLIC -DNSYNC_ATOMIC_CPP11)
+-      target_include_directories(${target_name} PRIVATE "${google_nsync_SOURCE_DIR}/public")
++      onnxruntime_add_include_to_target(${target_name} nsync::nsync_cpp)
+     endif()
+     foreach(ORT_FLAG ${ORT_PROVIDER_FLAGS})
+       target_compile_definitions(${target_name} PRIVATE ${ORT_FLAG})
+@@ -1461,7 +1461,7 @@ if (WIN32)
+   list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${SYS_PATH_LIB})
+   list(APPEND onnxruntime_EXTERNAL_LIBRARIES debug Dbghelp)
+ else()
+-  list(APPEND onnxruntime_EXTERNAL_LIBRARIES nsync_cpp)
++  list(APPEND onnxruntime_EXTERNAL_LIBRARIES nsync::nsync_cpp)
+   list(APPEND onnxruntime_EXTERNAL_LIBRARIES ${CMAKE_DL_LIBS} Threads::Threads)
+ endif()
+ 
+--- a/cmake/external/onnxruntime_external_deps.cmake
++++ b/cmake/external/onnxruntime_external_deps.cmake
+@@ -237,7 +237,10 @@ if (NOT WIN32)
+   #nsync tests failed on Mac Build
+   set(NSYNC_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
+   onnxruntime_fetchcontent_makeavailable(google_nsync)
+-  set(nsync_SOURCE_DIR ${google_nsync_SOURCE_DIR})
++  if(google_nsync_SOURCE_DIR)
++    add_library(nsync::nsync_cpp ALIAS nsync_cpp)
++    target_include_directories(nsync_cpp PUBLIC ${google_nsync_SOURCE_DIR}/public)
++  endif()
+ endif()
+ 
+ if(onnxruntime_USE_CUDA)
+@@ -361,6 +364,12 @@ FetchContent_Declare(
+ 
+ if (CPUINFO_SUPPORTED)
+   onnxruntime_fetchcontent_makeavailable(pytorch_cpuinfo)
++  if(pytorch_cpuinfo_SOURCE_DIR)
++    # shouldn't need to define these aliases after we use a version of cpuinfo with this commit:
++    # https://github.com/pytorch/cpuinfo/commit/082deffc80ce517f81dc2f3aebe6ba671fcd09c9
++    add_library(cpuinfo::cpuinfo ALIAS cpuinfo)
++    add_library(cpuinfo::clog ALIAS clog)
++  endif()
+ endif()
+ 
+ 
+--- a/cmake/onnxruntime_common.cmake
++++ b/cmake/onnxruntime_common.cmake
+@@ -194,8 +194,8 @@ if (ARM64 OR ARM OR X86 OR X64 OR X86_64)
+     # Using it mainly in ARM with Android.
+     # Its functionality in detecting x86 cpu features are lacking, so is support for Windows.
+     if (CPUINFO_SUPPORTED)
+-      onnxruntime_add_include_to_target(onnxruntime_common cpuinfo)
+-      list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo clog)
++      onnxruntime_add_include_to_target(onnxruntime_common cpuinfo::cpuinfo)
++      list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo::cpuinfo cpuinfo::clog)
+     endif()
+   endif()
+ endif()
+--- a/cmake/onnxruntime_flatbuffers.cmake
++++ b/cmake/onnxruntime_flatbuffers.cmake
+@@ -9,7 +9,7 @@ file(GLOB onnxruntime_flatbuffers_srcs CONFIGURE_DEPENDS
+ source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_flatbuffers_srcs})
+ 
+ onnxruntime_add_static_library(onnxruntime_flatbuffers ${onnxruntime_flatbuffers_srcs})
+-onnxruntime_add_include_to_target(onnxruntime_flatbuffers onnx flatbuffers ${GSL_TARGET})
++onnxruntime_add_include_to_target(onnxruntime_flatbuffers onnx flatbuffers::flatbuffers ${GSL_TARGET})
+ if(onnxruntime_ENABLE_INSTRUMENT)
+   target_compile_definitions(onnxruntime_flatbuffers PUBLIC ONNXRUNTIME_ENABLE_INSTRUMENT)
+ endif()
+--- a/cmake/onnxruntime_providers.cmake
++++ b/cmake/onnxruntime_providers.cmake
+@@ -539,10 +539,10 @@ if (onnxruntime_USE_CUDA)
+ 
+   if(APPLE)
+     set_property(TARGET onnxruntime_providers_cuda APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker -exported_symbols_list ${ONNXRUNTIME_ROOT}/core/providers/cuda/exported_symbols.lst")
+-    target_link_libraries(onnxruntime_providers_cuda PRIVATE nsync_cpp)
++    target_link_libraries(onnxruntime_providers_cuda PRIVATE nsync::nsync_cpp)
+   elseif(UNIX)
+     set_property(TARGET onnxruntime_providers_cuda APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/cuda/version_script.lds -Xlinker --gc-sections")
+-    target_link_libraries(onnxruntime_providers_cuda PRIVATE nsync_cpp)
++    target_link_libraries(onnxruntime_providers_cuda PRIVATE nsync::nsync_cpp)
+   elseif(WIN32)
+     set_property(TARGET onnxruntime_providers_cuda APPEND_STRING PROPERTY LINK_FLAGS "-DEF:${ONNXRUNTIME_ROOT}/core/providers/cuda/symbols.def")
+   else()
+@@ -595,10 +595,10 @@ if (onnxruntime_USE_DNNL)
+       INSTALL_RPATH "@loader_path"
+       BUILD_WITH_INSTALL_RPATH TRUE
+       INSTALL_RPATH_USE_LINK_PATH FALSE)
+-    target_link_libraries(onnxruntime_providers_dnnl PRIVATE nsync_cpp)
++    target_link_libraries(onnxruntime_providers_dnnl PRIVATE nsync::nsync_cpp)
+   elseif(UNIX)
+     set_property(TARGET onnxruntime_providers_dnnl APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/dnnl/version_script.lds -Xlinker --gc-sections -Xlinker -rpath=\$ORIGIN")
+-    target_link_libraries(onnxruntime_providers_dnnl PRIVATE nsync_cpp)
++    target_link_libraries(onnxruntime_providers_dnnl PRIVATE nsync::nsync_cpp)
+   elseif(WIN32)
+     set_property(TARGET onnxruntime_providers_dnnl APPEND_STRING PROPERTY LINK_FLAGS "-DEF:${ONNXRUNTIME_ROOT}/core/providers/dnnl/symbols.def")
+   else()
+@@ -728,11 +728,11 @@ if (onnxruntime_USE_TENSORRT)
+ 
+   if(APPLE)
+     set_property(TARGET onnxruntime_providers_tensorrt APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker -exported_symbols_list ${ONNXRUNTIME_ROOT}/core/providers/tensorrt/exported_symbols.lst")
+-    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE nsync_cpp)
++    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE nsync::nsync_cpp)
+   elseif(UNIX)
+     set_property(TARGET onnxruntime_providers_tensorrt APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-deprecated-declarations")
+     set_property(TARGET onnxruntime_providers_tensorrt APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/tensorrt/version_script.lds -Xlinker --gc-sections")
+-    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE nsync_cpp stdc++fs)
++    target_link_libraries(onnxruntime_providers_tensorrt PRIVATE nsync::nsync_cpp stdc++fs)
+   elseif(WIN32)
+     set_property(TARGET onnxruntime_providers_tensorrt APPEND_STRING PROPERTY LINK_FLAGS "-DEF:${ONNXRUNTIME_ROOT}/core/providers/tensorrt/symbols.def")
+   else()
+@@ -1224,7 +1224,7 @@ if (onnxruntime_USE_MIGRAPHX)
+   target_compile_options(onnxruntime_providers_migraphx PRIVATE -Wno-error=sign-compare)
+   set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-deprecated-declarations")
+   set_property(TARGET onnxruntime_providers_migraphx APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/migraphx/version_script.lds -Xlinker --gc-sections")
+-  target_link_libraries(onnxruntime_providers_migraphx PRIVATE nsync_cpp stdc++fs)
++  target_link_libraries(onnxruntime_providers_migraphx PRIVATE nsync::nsync_cpp stdc++fs)
+ 
+   include(CheckLibraryExists)
+   check_library_exists(migraphx::c "migraphx_program_run_async" "/opt/rocm/migraphx/lib" HAS_STREAM_SYNC)
+@@ -1461,7 +1461,7 @@ if (onnxruntime_USE_ROCM)
+ 
+   if(UNIX)
+     set_property(TARGET onnxruntime_providers_rocm APPEND_STRING PROPERTY LINK_FLAGS "-Xlinker --version-script=${ONNXRUNTIME_ROOT}/core/providers/rocm/version_script.lds -Xlinker --gc-sections")
+-    target_link_libraries(onnxruntime_providers_rocm PRIVATE nsync_cpp)
++    target_link_libraries(onnxruntime_providers_rocm PRIVATE nsync::nsync_cpp)
+   else()
+     message(FATAL_ERROR "onnxruntime_providers_rocm unknown platform, need to specify shared library exports for it")
+   endif()
+@@ -1597,7 +1597,7 @@ if (onnxruntime_USE_CANN)
+   onnxruntime_add_include_to_target(onnxruntime_providers_cann onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers Boost::mp11 safeint_interface)
+ 
+   add_dependencies(onnxruntime_providers_cann onnxruntime_providers_shared ${onnxruntime_EXTERNAL_DEPENDENCIES})
+-  target_link_libraries(onnxruntime_providers_cann PRIVATE ascendcl acl_op_compiler fmk_onnx_parser nsync_cpp ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED})
++  target_link_libraries(onnxruntime_providers_cann PRIVATE ascendcl acl_op_compiler fmk_onnx_parser nsync::nsync_cpp ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED})
+   target_link_directories(onnxruntime_providers_cann PRIVATE ${onnxruntime_CANN_HOME}/lib64)
+   target_include_directories(onnxruntime_providers_cann PRIVATE ${ONNXRUNTIME_ROOT} ${CMAKE_CURRENT_BINARY_DIR} ${eigen_INCLUDE_DIRS} ${onnxruntime_CANN_HOME} ${onnxruntime_CANN_HOME}/include)
+ 
+@@ -1619,7 +1619,7 @@ if (onnxruntime_USE_AZURE)
+   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_azure_src})
+   onnxruntime_add_static_library(onnxruntime_providers_azure ${onnxruntime_providers_azure_src})
+   add_dependencies(onnxruntime_providers_azure ${onnxruntime_EXTERNAL_DEPENDENCIES})
+-  onnxruntime_add_include_to_target(onnxruntime_providers_azure onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers Boost::mp11)
++  onnxruntime_add_include_to_target(onnxruntime_providers_azure onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers Boost::mp11)
+   target_link_libraries(onnxruntime_providers_azure PRIVATE onnx onnxruntime_common onnxruntime_framework)
+   set_target_properties(onnxruntime_providers_azure PROPERTIES FOLDER "ONNXRuntime")
+   set_target_properties(onnxruntime_providers_azure PROPERTIES LINKER_LANGUAGE CXX)
+--- a/cmake/onnxruntime_unittests.cmake
++++ b/cmake/onnxruntime_unittests.cmake
+@@ -631,8 +631,8 @@ if(MSVC)
+                 "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/wd6326>")
+ else()
+   target_compile_definitions(onnxruntime_test_utils PUBLIC -DNSYNC_ATOMIC_CPP11)
+-  target_include_directories(onnxruntime_test_utils PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT}
+-          ${nsync_SOURCE_DIR}/public)
++  target_include_directories(onnxruntime_test_utils PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT})
++  onnxruntime_add_include_to_target(onnxruntime_test_utils nsync::nsync_cpp)
+ endif()
+ if (onnxruntime_USE_NCCL)
+   target_include_directories(onnxruntime_test_utils PRIVATE ${NCCL_INCLUDE_DIRS})
+@@ -665,8 +665,8 @@ if(MSVC)
+           "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/utf-8>")
+ else()
+   target_compile_definitions(onnx_test_runner_common PUBLIC -DNSYNC_ATOMIC_CPP11)
+-  target_include_directories(onnx_test_runner_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT}
+-          ${nsync_SOURCE_DIR}/public)
++  target_include_directories(onnx_test_runner_common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT})
++  onnxruntime_add_include_to_target(onnx_test_runner_common nsync::nsync_cpp)
+ endif()
+ if (MSVC AND NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+   #TODO: fix the warnings, they are dangerous
+@@ -995,7 +995,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
+       # "Global initializer calls a non-constexpr function." BENCHMARK_CAPTURE macro needs this.
+       target_compile_options(onnxruntime_mlas_benchmark PRIVATE /wd26426)
+     else()
+-      target_link_libraries(onnxruntime_mlas_benchmark PRIVATE nsync_cpp ${CMAKE_DL_LIBS})
++      target_link_libraries(onnxruntime_mlas_benchmark PRIVATE nsync::nsync_cpp ${CMAKE_DL_LIBS})
+     endif()
+     if (CPUINFO_SUPPORTED AND NOT onnxruntime_BUILD_WEBASSEMBLY)
+       target_link_libraries(onnxruntime_mlas_benchmark PRIVATE cpuinfo)
+@@ -1053,7 +1053,7 @@ if(onnxruntime_ENABLE_EAGER_MODE)
+     list(APPEND onnxruntime_eager_mode_libs onnxruntime_training tensorboard)
+   endif()
+   IF(NOT WIN32)
+-    list(APPEND onnxruntime_eager_mode_libs nsync_cpp)
++    list(APPEND onnxruntime_eager_mode_libs nsync::nsync_cpp)
+   endif()
+   target_link_libraries(onnxruntime_eager_mode_test PRIVATE ${onnxruntime_eager_mode_libs} Threads::Threads ${onnxruntime_EXTERNAL_LIBRARIES})
+   if (onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
+@@ -1113,7 +1113,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
+             ${onnxruntime_EXTERNAL_LIBRARIES}
+             ${GETOPT_LIB_WIDE} ${SYS_PATH_LIB} ${CMAKE_DL_LIBS})
+     if(NOT WIN32)
+-      list(APPEND onnxruntime_perf_test_libs nsync_cpp)
++      list(APPEND onnxruntime_perf_test_libs nsync::nsync_cpp)
+       if(onnxruntime_USE_SNPE)
+         list(APPEND onnxruntime_perf_test_libs onnxruntime_providers_snpe)
+       endif()
+@@ -1157,7 +1157,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
+     # test inference using shared lib
+     set(onnxruntime_shared_lib_test_LIBS onnxruntime_mocked_allocator onnxruntime_test_utils onnxruntime_common onnx_proto)
+     if(NOT WIN32)
+-      list(APPEND onnxruntime_shared_lib_test_LIBS nsync_cpp)
++      list(APPEND onnxruntime_shared_lib_test_LIBS nsync::nsync_cpp)
+       if(onnxruntime_USE_SNPE)
+         list(APPEND onnxruntime_shared_lib_test_LIBS onnxruntime_providers_snpe)
+       endif()
+@@ -1279,7 +1279,7 @@ if (NOT onnxruntime_ENABLE_TRAINING_TORCH_INTEROP)
+     target_link_libraries(onnxruntime_mlas_test PRIVATE cpuinfo)
+   endif()
+   if(NOT WIN32)
+-    target_link_libraries(onnxruntime_mlas_test PRIVATE nsync_cpp ${CMAKE_DL_LIBS})
++    target_link_libraries(onnxruntime_mlas_test PRIVATE nsync::nsync_cpp ${CMAKE_DL_LIBS})
+   endif()
+   if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+     target_link_libraries(onnxruntime_mlas_test PRIVATE ${android_shared_libs})
+--- a/cmake/onnxruntime_webassembly.cmake
++++ b/cmake/onnxruntime_webassembly.cmake
+@@ -97,7 +97,7 @@ target_compile_options(onnx PRIVATE -Wno-unused-parameter -Wno-unused-variable)
+ 
+ if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
+     bundle_static_library(onnxruntime_webassembly
+-      nsync_cpp
++      nsync::nsync_cpp
+       ${PROTOBUF_LIB}
+       onnx
+       onnx_proto
+@@ -172,7 +172,7 @@ else()
+   endif()
+ 
+   target_link_libraries(onnxruntime_webassembly PRIVATE
+-    nsync_cpp
++    nsync::nsync_cpp
+     ${PROTOBUF_LIB}
+     onnx
+     onnx_proto

--- a/recipes/onnxruntime/all/patches/1.14.1-0002-cmake-dependencies.patch
+++ b/recipes/onnxruntime/all/patches/1.14.1-0002-cmake-dependencies.patch
@@ -1,0 +1,191 @@
+--- a/cmake/external/abseil-cpp.cmake
++++ b/cmake/external/abseil-cpp.cmake
+@@ -22,6 +22,7 @@ FetchContent_Declare(
+     URL ${DEP_URL_abseil_cpp}
+     URL_HASH SHA1=${DEP_SHA1_abseil_cpp}
+     PATCH_COMMAND ${ABSL_PATCH_COMMAND}
++    FIND_PACKAGE_ARGS REQUIRED CONFIG NAMES absl
+ )
+ 
+ onnxruntime_fetchcontent_makeavailable(abseil_cpp)
+--- a/cmake/external/eigen.cmake
++++ b/cmake/external/eigen.cmake
+@@ -14,8 +14,11 @@ else ()
+         FetchContent_Declare(
+         eigen
+         URL https://gitlab.com/libeigen/eigen/-/archive/d10b27fe37736d2944630ecd7557cefa95cf87c9/eigen-d10b27fe37736d2944630ecd7557cefa95cf87c9.zip
++        FIND_PACKAGE_ARGS REQUIRED CONFIG NAMES Eigen3
+ 		)
+     endif()
+-    FetchContent_Populate(eigen)
+-    set(eigen_INCLUDE_DIRS  "${eigen_SOURCE_DIR}")
++    # FetchContent_Populate(eigen)
++    # set(eigen_INCLUDE_DIRS  "${eigen_SOURCE_DIR}")
++    onnxruntime_fetchcontent_makeavailable(eigen)
++    get_target_property(eigen_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+ endif()
+--- a/cmake/external/onnxruntime_external_deps.cmake
++++ b/cmake/external/onnxruntime_external_deps.cmake
+@@ -97,7 +97,7 @@ FetchContent_Declare(
+     flatbuffers
+     URL ${DEP_URL_flatbuffers}
+     URL_HASH SHA1=${DEP_SHA1_flatbuffers}
+-    FIND_PACKAGE_ARGS 1.12.0...<2.0.0 NAMES Flatbuffers
++    FIND_PACKAGE_ARGS NAMES flatbuffers
+ )
+ 
+ #Here we support two build mode:
+@@ -136,8 +136,10 @@ FetchContent_Declare(
+       date
+       URL ${DEP_URL_date}
+       URL_HASH SHA1=${DEP_SHA1_date}
++      FIND_PACKAGE_ARGS NAMES date
+     )
+ onnxruntime_fetchcontent_makeavailable(date)
++add_library(date_interface ALIAS date::date)
+ 
+ 
+ 
+@@ -145,6 +147,7 @@ FetchContent_Declare(
+   mp11
+   URL ${DEP_URL_mp11}
+   URL_HASH SHA1=${DEP_SHA1_mp11}
++  FIND_PACKAGE_ARGS NAMES Boost
+ )
+ 
+ set(JSON_BuildTests OFF CACHE INTERNAL "")
+@@ -263,10 +266,12 @@ FetchContent_Declare(
+     safeint
+     URL ${DEP_URL_safeint}
+     URL_HASH SHA1=${DEP_SHA1_safeint}
++    FIND_PACKAGE_ARGS NAMES safeint
+ )
+ 
+ # The next line will generate an error message "fatal: not a git repository", but it is ok. It is from flatbuffers
+ onnxruntime_fetchcontent_makeavailable(Protobuf nlohmann_json mp11 re2 safeint GSL flatbuffers)
++add_library(Boost::mp11 ALIAS Boost::headers)
+ if(NOT flatbuffers_FOUND)
+   if(NOT TARGET flatbuffers::flatbuffers)
+     add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
+@@ -291,6 +296,10 @@ namespace std { using ::getenv; }
+       target_compile_options(flatc PRIVATE /FI${CMAKE_BINARY_DIR}/gdk_cstdlib_wrapper.h)
+     endif()
+   endif()
++else()
++  if(NOT TARGET flatbuffers::flatbuffers)
++    add_library(flatbuffers::flatbuffers ALIAS flatbuffers::flatbuffers_shared)
++  endif()
+ endif()
+ 
+ if (onnxruntime_BUILD_UNIT_TESTS)
+@@ -359,6 +368,7 @@ FetchContent_Declare(
+   URL ${DEP_URL_onnx}
+   URL_HASH SHA1=${DEP_SHA1_onnx}
+   PATCH_COMMAND ${ONNXRUNTIME_ONNX_PATCH_COMMAND}
++  FIND_PACKAGE_ARGS NAMES onnx ONNX
+ )
+ 
+ 
+@@ -386,8 +396,9 @@ endif()
+ set(GSL_TARGET "Microsoft.GSL::GSL")
+ set(GSL_INCLUDE_DIR "$<TARGET_PROPERTY:${GSL_TARGET},INTERFACE_INCLUDE_DIRECTORIES>")
+ 
+-add_library(safeint_interface INTERFACE)
+-target_include_directories(safeint_interface INTERFACE ${safeint_SOURCE_DIR})
++add_library(safeint_interface ALIAS safeint::safeint)
++#target_include_directories(safeint_interface INTERFACE ${safeint_SOURCE_DIR})
++
+ 
+ # XNNPACK EP
+ if (onnxruntime_USE_XNNPACK)
+@@ -416,9 +427,9 @@ set(onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK} WIL
+ # The other libs do not have the problem. All the sources are already there. We can compile them in any order.
+ set(onnxruntime_EXTERNAL_DEPENDENCIES onnx_proto flatbuffers::flatbuffers)
+ 
+-target_compile_definitions(onnx PUBLIC $<TARGET_PROPERTY:onnx_proto,INTERFACE_COMPILE_DEFINITIONS> PRIVATE "__ONNX_DISABLE_STATIC_REGISTRATION")
++# target_compile_definitions(onnx PUBLIC $<TARGET_PROPERTY:onnx_proto,INTERFACE_COMPILE_DEFINITIONS> PRIVATE "__ONNX_DISABLE_STATIC_REGISTRATION")
+ if (NOT onnxruntime_USE_FULL_PROTOBUF)
+-  target_compile_definitions(onnx PUBLIC "__ONNX_NO_DOC_STRINGS")
++  # target_compile_definitions(onnx PUBLIC "__ONNX_NO_DOC_STRINGS")
+ endif()
+ 
+ if (onnxruntime_RUN_ONNX_TESTS)
+--- a/cmake/external/wil.cmake
++++ b/cmake/external/wil.cmake
+@@ -11,12 +11,18 @@ FetchContent_Declare(
+ )
+ #We can not use FetchContent_MakeAvailable(microsoft_wil) at here, since their cmake file
+ #always executes install command without conditions.
+-FetchContent_Populate(microsoft_wil)
+-if(NOT wil_FOUND)
++#FetchContent_Populate(microsoft_wil)
++#if(NOT wil_FOUND)
++#  add_library(WIL INTERFACE)
++#  add_library(WIL::WIL ALIAS WIL)
++#
++#  # The interface's include directory.
++#  target_include_directories(WIL INTERFACE
++#    $<BUILD_INTERFACE:${microsoft_wil_SOURCE_DIR}/include>)
++#endif()
++if(WIN32)
++  FetchContent_MakeAvailable(microsoft_wil)
++else()
+   add_library(WIL INTERFACE)
+   add_library(WIL::WIL ALIAS WIL)
+-
+-  # The interface's include directory.
+-  target_include_directories(WIL INTERFACE
+-    $<BUILD_INTERFACE:${microsoft_wil_SOURCE_DIR}/include>)
+-endif()
+\ No newline at end of file
++endif()
+--- a/cmake/external/xnnpack.cmake
++++ b/cmake/external/xnnpack.cmake
+@@ -25,12 +25,19 @@ set(FXDIV_SOURCE_DIR ${fxdiv_SOURCE_DIR})
+ 
+ FetchContent_Declare(pthreadpool URL ${DEP_URL_pthreadpool} URL_HASH SHA1=${DEP_SHA1_pthreadpool})
+ onnxruntime_fetchcontent_makeavailable(pthreadpool)
+-FetchContent_Declare(googlexnnpack URL ${DEP_URL_googlexnnpack}  URL_HASH SHA1=${DEP_SHA1_googlexnnpack}
+-PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/xnnpack/AddEmscriptenAndIosSupport.patch)
++FetchContent_Declare(
++    googlexnnpack
++    URL ${DEP_URL_googlexnnpack}
++    URL_HASH SHA1=${DEP_SHA1_googlexnnpack}
++    PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/xnnpack/AddEmscriptenAndIosSupport.patch
++    FIND_PACKAGE_ARGS NAMES xnnpack
++)
+ 
+ onnxruntime_fetchcontent_makeavailable(googlexnnpack)
+-set(XNNPACK_DIR ${googlexnnpack_SOURCE_DIR})
+-set(XNNPACK_INCLUDE_DIR ${XNNPACK_DIR}/include)
++# set(XNNPACK_DIR ${googlexnnpack_SOURCE_DIR})
++# set(XNNPACK_INCLUDE_DIR ${XNNPACK_DIR}/include)
++
++add_library(XNNPACK ALIAS xnnpack::xnnpack)
+ 
+ set(onnxruntime_EXTERNAL_LIBRARIES_XNNPACK XNNPACK pthreadpool)
+ 
+--- a/cmake/onnxruntime_common.cmake
++++ b/cmake/onnxruntime_common.cmake
+@@ -195,7 +195,7 @@ if (ARM64 OR ARM OR X86 OR X64 OR X86_64)
+     # Its functionality in detecting x86 cpu features are lacking, so is support for Windows.
+     if (CPUINFO_SUPPORTED)
+       onnxruntime_add_include_to_target(onnxruntime_common cpuinfo::cpuinfo)
+-      list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo::cpuinfo cpuinfo::clog)
++      list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo::cpuinfo)
+     endif()
+   endif()
+ endif()
+--- a/cmake/onnxruntime_providers.cmake
++++ b/cmake/onnxruntime_providers.cmake
+@@ -1561,10 +1561,6 @@ if (onnxruntime_USE_XNNPACK)
+   add_dependencies(onnxruntime_providers_xnnpack onnx ${onnxruntime_EXTERNAL_DEPENDENCIES})
+   set_target_properties(onnxruntime_providers_xnnpack PROPERTIES FOLDER "ONNXRuntime")
+ 
+-  install(DIRECTORY ${ONNXRUNTIME_INCLUDE_DIR}/core/providers/xnnpack
+-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/onnxruntime/core/providers
+-  )
+-
+   set_target_properties(onnxruntime_providers_xnnpack PROPERTIES LINKER_LANGUAGE CXX)
+ 
+   if (NOT onnxruntime_BUILD_SHARED_LIB)

--- a/recipes/onnxruntime/all/patches/1.14.1-0003-amx-gas-version.patch
+++ b/recipes/onnxruntime/all/patches/1.14.1-0003-amx-gas-version.patch
@@ -1,0 +1,42 @@
+From 126e7bf15fa4af8621814b82a3f7bd0d786f0239 Mon Sep 17 00:00:00 2001
+From: JiCheng <wejoncy@163.com>
+Date: Wed, 22 Mar 2023 07:57:22 +0800
+Subject: [PATCH] [AMX] add assembler check (#15055)
+
+### Description
+<!-- Describe your changes. -->
+
+AMX isn't supportted until assembler 2.40 even though the GCC frontend
+supports it.
+
+
+### Motivation and Context
+<!-- - Why is this change required? What problem does it solve?
+- If it fixes an open issue, please link to the issue here. -->
+---
+ cmake/onnxruntime_mlas.cmake | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/onnxruntime_mlas.cmake b/cmake/onnxruntime_mlas.cmake
+index e79e1ed9855..6292a667d4a 100644
+--- a/cmake/onnxruntime_mlas.cmake
++++ b/cmake/onnxruntime_mlas.cmake
+@@ -7,7 +7,17 @@ set(MLAS_SRC_DIR ${ONNXRUNTIME_ROOT}/core/mlas/lib)
+ set(MLAS_AMX_SUPPORTED FALSE)
+ 
+ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 11)
+-  set(MLAS_AMX_SUPPORTED TRUE)
++  # match assembler version, AMX instructions are supported from 2.40
++  if (CMAKE_ASM-ATT_COMPILER_ID STREQUAL "GNU")
++    execute_process(
++        COMMAND ${CMAKE_ASM-ATT_COMPILER} --version
++        OUTPUT_VARIABLE _gas_version
++    )
++    # 2.40 or later
++    if (_gas_version MATCHES "GNU.[Aa]ssembler.*(2\\.[4-9][0-9])")
++        set(MLAS_AMX_SUPPORTED TRUE)
++    endif()
++  endif()
+ endif()
+ 
+ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")

--- a/recipes/onnxruntime/all/patches/1.14.1-0004-abseil-no-string-view.patch
+++ b/recipes/onnxruntime/all/patches/1.14.1-0004-abseil-no-string-view.patch
@@ -1,0 +1,22 @@
+--- a/onnxruntime/core/framework/kernel_type_str_resolver.cc
++++ b/onnxruntime/core/framework/kernel_type_str_resolver.cc
+@@ -20,7 +20,7 @@ Status KernelTypeStrResolver::ResolveKernelTypeStr(const Node& node, std::string
+   ORT_RETURN_IF(op_it == op_kernel_type_str_map_.end(), "Failed to find op_id: ", op_id);
+   const auto& type_str_map = op_it->second;
+ 
+-#ifdef DISABLE_ABSEIL
++#ifndef ABSL_USES_STD_STRING_VIEW
+   // TODO(edgchen1) maybe we can use transparent hash/eq to enable lookup with string_view
+   const auto type_str_it = type_str_map.find(std::string(kernel_type_str));
+ #else
+--- a/onnxruntime/core/framework/ort_value_name_idx_map.h
++++ b/onnxruntime/core/framework/ort_value_name_idx_map.h
+@@ -33,7 +33,7 @@ class OrtValueNameIdxMap {
+   common::Status GetIdx(std::string_view name, int& idx) const {
+     idx = -1;
+ 
+-#ifdef DISABLE_ABSEIL
++#ifndef ABSL_USES_STD_STRING_VIEW
+     auto it = map_.find(std::string(name));
+ #else
+     auto it = map_.find(name);

--- a/recipes/onnxruntime/all/test_package/CMakeLists.txt
+++ b/recipes/onnxruntime/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+find_package(onnxruntime REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE onnxruntime::onnxruntime)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/onnxruntime/all/test_package/conanfile.py
+++ b/recipes/onnxruntime/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/onnxruntime/all/test_package/conanfile.py
+++ b/recipes/onnxruntime/all/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder=".")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/onnxruntime/all/test_package/test_package.cpp
+++ b/recipes/onnxruntime/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+
+#include <onnxruntime_cxx_api.h>
+#include <iostream>
+
+int main() {
+  const auto& api = Ort::GetApi();
+  std::cout << OrtGetApiBase()->GetVersionString() << std::endl;
+  return 0;
+}

--- a/recipes/onnxruntime/all/test_v1_package/CMakeLists.txt
+++ b/recipes/onnxruntime/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/onnxruntime/all/test_v1_package/conanfile.py
+++ b/recipes/onnxruntime/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/onnxruntime/config.yml
+++ b/recipes/onnxruntime/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.14.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version: onnxruntime/1.14.1

Fixes #4806
Fixes #16699
Closes #16842

This is similar to #16842 but I already had some work done before that PR was created and thought I'd share the state of said work.

Differences with #16842:
- nothing is downloaded, only conan packages are used. This comes with some caveats:
  - ~~mac armv8 will fail because eigen 3.4.0 has a bug (onnxruntime pins a git commit before 3.4.0, the not released 3.4.1 has a fix for this), c.f. #16854~~
  - ~~Windows will most likely fail (pending #16701 & update of the requirement/patch)~~
  - unit tests can't be built without onnx sources (requires a proto definition from those sources, not patched)
- ~~no options are implemented yet.~~ only `with_xnnpack` option is implemented.

It's been built and tested on mac arm64 & linux x86_64 (gcc-12).
Unit tests were built with a specific patch (adding the missing onyx proto & patching tests for the location) & run successfully.

~~conan v2 won't build without #1670~~3 EDIT: now available

~~I also opened https://github.com/microsoft/onnxruntime/pull/15323 upstream to get some sense of what part of the patch could be upstreamed.~~ EDIT the PR was merged in onnxruntime/main for a future version, I'll try to see if I can squeeze other changes as well.

Like @gmeeker in #16842, I don't really have time to finish this recipe (and in my case, I don't have the skills to do so), so any help is appreciated.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
