### PR TITLE
eigen(3.4.0): Fix vectorized reductions compilation errors for Eigen::half

### DIFF
--- a/recipes/eigen/all/conandata.yml
+++ b/recipes/eigen/all/conandata.yml
@@ -12,6 +12,11 @@ sources:
     url: "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2"
     sha256: "685adf14bd8e9c015b78097c1dc22f2f01343756f196acdc76a678e1ae352e11"
 patches:
+  "3.4.0":
+    - patch_file: "patches/3.4.0-0001-vec-reduce-half.patch"
+      patch_description: "Fix vectorized reductions compilation errors for Eigen::half"
+      patch_type: "bugfix"
+      patch_source: "https://gitlab.com/libeigen/eigen/-/commit/b0fe14213ec4c8615de485fe4c2bcd4bab0cbd19.patch"
   "3.3.9":
     - patch_file: "patches/0002-cmake-minimum-required.patch"
       patch_description: "CMake: Move cmake_minimum_required() before project()"

--- a/recipes/eigen/all/conanfile.py
+++ b/recipes/eigen/all/conanfile.py
@@ -12,7 +12,8 @@ class EigenConan(ConanFile):
     homepage = "http://eigen.tuxfamily.org"
     description = "Eigen is a C++ template library for linear algebra: matrices, vectors," \
                   " numerical solvers, and related algorithms."
-    topics = ("algebra", "linear-algebra", "matrix", "vector", "numerical")
+    topics = ("algebra", "linear-algebra", "matrix", "vector", "numerical", "header-only")
+    package_type = "header-library"
     license = ("MPL-2.0", "LGPL-3.0-or-later")  # Taking into account the default value of MPL2_only option
 
     settings = "os", "arch", "compiler", "build_type"

--- a/recipes/eigen/all/patches/3.4.0-0001-vec-reduce-half.patch
+++ b/recipes/eigen/all/patches/3.4.0-0001-vec-reduce-half.patch
@@ -1,0 +1,49 @@
+From b0fe14213ec4c8615de485fe4c2bcd4bab0cbd19 Mon Sep 17 00:00:00 2001
+From: Alex Druinsky <adruinsky@google.com>
+Date: Wed, 20 Oct 2021 16:03:12 -0700
+Subject: [PATCH] Fix vectorized reductions for Eigen::half
+
+Fixes compiler errors in expressions that look like
+
+  Eigen::Matrix<Eigen::half, 3, 1>::Random().maxCoeff()
+
+The error comes from the code that creates the initial value for
+vectorized reductions. The fix is to specify the scalar type of the
+reduction's initial value.
+
+The cahnge is necessary for Eigen::half because unlike other types,
+Eigen::half scalars cannot be implicitly created from integers.
+
+
+(cherry picked from commit d0e3791b1a0e2db9edd5f1d1befdb2ac5a40efe0)
+---
+ Eigen/src/Core/PartialReduxEvaluator.h | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/Eigen/src/Core/PartialReduxEvaluator.h b/Eigen/src/Core/PartialReduxEvaluator.h
+index 29abf35b99..17c06f0783 100644
+--- a/Eigen/src/Core/PartialReduxEvaluator.h
++++ b/Eigen/src/Core/PartialReduxEvaluator.h
+@@ -54,12 +54,17 @@ struct packetwise_redux_traits
+ /* Value to be returned when size==0 , by default let's return 0 */
+ template<typename PacketType,typename Func>
+ EIGEN_DEVICE_FUNC
+-PacketType packetwise_redux_empty_value(const Func& ) { return pset1<PacketType>(0); }
++PacketType packetwise_redux_empty_value(const Func& ) {
++  const typename unpacket_traits<PacketType>::type zero(0);
++  return pset1<PacketType>(zero);
++}
+ 
+ /* For products the default is 1 */
+ template<typename PacketType,typename Scalar>
+ EIGEN_DEVICE_FUNC
+-PacketType packetwise_redux_empty_value(const scalar_product_op<Scalar,Scalar>& ) { return pset1<PacketType>(1); }
++PacketType packetwise_redux_empty_value(const scalar_product_op<Scalar,Scalar>& ) {
++  return pset1<PacketType>(Scalar(1));
++}
+ 
+ /* Perform the actual reduction */
+ template<typename Func, typename Evaluator,
+-- 
+GitLab
+


### PR DESCRIPTION
Specify library name and version:  **eigen/3.4.0**

This fixes compilation errors.

According to https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/conandata_yml_format.md#bugfix this might require a new cci version rather than a patch on 3.4.0 however, given it does not change the flow of execution or the results (compile time issue) and it seems there is a precedent in this recipe, I went with a patch on 3.4.0 (the patch itself is a cherry pick from upstream branch 3.4, there is no ETA on a 3.4.1 version upstream)

If this is not deemed acceptable, I will open a PR for a new cci version using the exact same git commit as used in onnxruntime 1.14.1 (before 3.4.0).

The fix is required to build #16849 / #16842

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
