### PR TITLE
libfdk_aac: add package_type (and generate v2 packages)

### DIFF
--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -19,7 +19,7 @@ class LibFDKAACConan(ConanFile):
     license = "https://github.com/mstorsjo/fdk-aac/blob/master/NOTICE"
     homepage = "https://sourceforge.net/projects/opencore-amr/"
     topics = ("multimedia", "audio", "fraunhofer", "aac", "decoder", "encoding", "decoding")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],


### PR DESCRIPTION
these packages are mandatory to pass v2 pipeline in https://github.com/conan-io/conan-center-index/pull/15819

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
