### PR TITLE
Correct libexif conandata.yml url for libexif version 0.6.24

### DIFF
--- a/recipes/libexif/all/conandata.yml
+++ b/recipes/libexif/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "0.6.24":
-    url: "https://github.com/libexif/libexif/releases/download/v0.6.23/libexif-0.6.23.tar.gz"
-    sha256: "9271cf58cb46b00f9e2e9b968c7d81c008a69e5457f7d1a50dbf1786eac61b52"
+    url: "https://github.com/libexif/libexif/releases/download/v0.6.24/libexif-0.6.24.tar.bz2"
+    sha256: "d47564c433b733d83b6704c70477e0a4067811d184ec565258ac563d8223f6ae"
   "0.6.23":
     url: "https://github.com/libexif/libexif/releases/download/v0.6.23/libexif-0.6.23.tar.gz"
     sha256: "9271cf58cb46b00f9e2e9b968c7d81c008a69e5457f7d1a50dbf1786eac61b52"


### PR DESCRIPTION
Specify library name and version:  **libexif/0.6.24**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
