### PR TITLE
fix sqlite3 test

### DIFF
--- a/recipes/sqlite3/all/test_package/test_package.c
+++ b/recipes/sqlite3/all/test_package/test_package.c
@@ -25,7 +25,7 @@ int main() {
     printf("Done!\n");
 
     printf("Creating new table...\n");
-    result = sqlite3_exec(db_instance, "CREATE TABLE package(ID INT PRIMARY KEY NOT NULL);", NULL, 0, &errmsg);
+    result = sqlite3_exec(db_instance, "CREATE TABLE IF NOT EXISTS package(ID INT PRIMARY KEY NOT NULL);", NULL, 0, &errmsg);
     if(result != SQLITE_OK) {
         fprintf(stderr, "SQL error: %s\n", errmsg);
         sqlite3_free(errmsg);


### PR DESCRIPTION
Specify library name and version:  **sqlite3/3.39.4**

package tests fails if same package is created twice.

```
conan create . sqlite3/3.39.4    -o sqlite3:shared=True
conan create . sqlite3/3.39.4    -o sqlite3:shared=True
```

I got the error:

```
SQLite Version: 3.39.4
Creating new data base ...
Done!
Creating new table...
SQL error: table package already exists
```



- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
