### PR TITLE
Fix Macos OS settings name in autotools package template

### DIFF
--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -75,7 +75,7 @@ class PackageConan(ConanFile):
         # validate the minimum cpp standard supported. Only for C++ projects
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 11)
-        if self.settings.os not in ["Linux", "FreeBSD", "MacOS"]:
+        if self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
 
     # if another tool than the compiler or autotools is required to build the project (pkgconf, bison, flex etc)


### PR DESCRIPTION
This fixes the name of the `Macos` OS setting in the autotools_package template.

With the wrong name, v1 pipelines fail with the following error:
```
ERROR: libcoro/0.7: Error in validate() method, line 62
	if self.settings.os not in ["Linux", "FreeBSD", "MacOS"]:
	ConanException: Invalid setting 'MacOS' is not a valid 'settings.os' value.
Possible values are ['AIX', 'Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Linux', 'Macos', 'Neutrino', 'SunOS', 'VxWorks', 'Windows', 'WindowsCE', 'WindowsStore', 'baremetal', 'iOS', 'tvOS', 'watchOS']
Read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-invalid-setting"
```