### PR TITLE
paho-mqtt-c: openssl headers are exposed in public headers

### DIFF
--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -56,7 +56,8 @@ class PahoMqttcConan(ConanFile):
 
     def requirements(self):
         if self.options.ssl:
-            self.requires("openssl/1.1.1t")
+            # Headers are exposed https://github.com/eclipse/paho.mqtt.c/blob/f7799da95e347bbc930b201b52a1173ebbad45a7/src/SSLSocket.h#L29
+            self.requires("openssl/1.1.1t", transitive_headers=True)
 
     def validate(self):
         if not self.options.shared and Version(self.version) < "1.3.4":


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


https://github.com/conan-io/conan-center-index/pull/16760/files#r1156719312

Flagged this

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
