### PR TITLE
ccache: don't override conan's MSVC runtime choice

### DIFF
--- a/recipes/ccache/all/conandata.yml
+++ b/recipes/ccache/all/conandata.yml
@@ -8,3 +8,8 @@ sources:
   "4.5.1":
     url: "https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.xz"
     sha256: "51186ebe0326365f4e6131e1caa8911de7da4aa6718efc00680322d63a759517"
+patches:
+  "4.7.4":
+    - patch_file: "patches/4.7.4-cmake-msvc-runtime.patch"
+      patch_description: "fixup MSVC runtime"
+      patch_type: "conan"

--- a/recipes/ccache/all/conandata.yml
+++ b/recipes/ccache/all/conandata.yml
@@ -2,12 +2,6 @@ sources:
   "4.7.4":
     url: "https://github.com/ccache/ccache/releases/download/v4.7.4/ccache-4.7.4.tar.xz"
     sha256: "df0c64d15d3efaf0b4f6837dd6b1467e40eeaaa807db25ce79c3a08a46a84e36"
-  "4.6":
-    url: "https://github.com/ccache/ccache/releases/download/v4.6/ccache-4.6.tar.xz"
-    sha256: "3d2bb860f4359169e640f60cf7cc11da5fab5fb9aed55230d78141e49c3945e9"
-  "4.5.1":
-    url: "https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.xz"
-    sha256: "51186ebe0326365f4e6131e1caa8911de7da4aa6718efc00680322d63a759517"
 patches:
   "4.7.4":
     - patch_file: "patches/4.7.4-cmake-msvc-runtime.patch"

--- a/recipes/ccache/all/conanfile.py
+++ b/recipes/ccache/all/conanfile.py
@@ -86,7 +86,7 @@ class CcacheConan(ConanFile):
         del self.info.settings.compiler
 
     def build_requirements(self):
-        self.tool_requires("cmake/3.25.2")
+        self.tool_requires("cmake/3.25.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/ccache/all/conanfile.py
+++ b/recipes/ccache/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, replace_in_file
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
@@ -104,6 +104,14 @@ class CcacheConan(ConanFile):
         deps.generate()
 
     def build(self):
+        # don't allow ccache to override the MSVC runtime library choice from conan
+        replace_in_file(
+            self,
+            os.path.join(self.source_folder, "CMakeLists.txt"),
+            'set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")',
+            ""
+        )
+
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/ccache/all/conanfile.py
+++ b/recipes/ccache/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import copy, get, replace_in_file
+from conan.tools.files import copy, get, apply_conandata_patches, export_conandata_patches
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
@@ -55,6 +55,9 @@ class CcacheConan(ConanFile):
                 "msvc": "191" if Version(self.version) < "4.6" else "192"
             }
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -104,14 +107,7 @@ class CcacheConan(ConanFile):
         deps.generate()
 
     def build(self):
-        # don't allow ccache to override the MSVC runtime library choice from conan
-        replace_in_file(
-            self,
-            os.path.join(self.source_folder, "CMakeLists.txt"),
-            'set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")',
-            ""
-        )
-
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/ccache/all/patches/4.7.4-cmake-msvc-runtime.patch
+++ b/recipes/ccache/all/patches/4.7.4-cmake-msvc-runtime.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -97,7 +97,7 @@
+ 
+   # Link MSVC runtime statically.
+   if(MSVC)
+-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
++
+   # Link MINGW runtime statically.
+   elseif(WIN32)
+     if((CMAKE_CXX_COMPILER_ID STREQUAL GNU) OR (CMAKE_CXX_COMPILER_ID STREQUAL Clang))

--- a/recipes/ccache/config.yml
+++ b/recipes/ccache/config.yml
@@ -1,7 +1,3 @@
 versions:
   "4.7.4":
     folder: all
-  "4.6":
-    folder: all
-  "4.5.1":
-    folder: all


### PR DESCRIPTION
I discovered ccache always wants to build with -MT (or /MT) even if conan wants /MD,
which results in a build failure on my machine as zstd and hiredis was built with /MD.

I wonder how this passed the C3I test?
