### PR TITLE
xorg: add package type

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -8,6 +8,7 @@ required_conan_version = ">=1.50.0"
 
 class XorgConan(ConanFile):
     name = "xorg"
+    package_type = "shared-library"
     url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
     homepage = "https://www.x.org/wiki/"


### PR DESCRIPTION
Specify library name and version:  **xorg/system**


In Conan 2.0 the lack of package type affects how dependencies propagate when building shared libraries.

In this case, `"shared-library"` is the most accurate `package_type`. While all the system packages that are being installed by this recipe (`*-dev` packages) have both static and shared,  the `PkgConfig` helper from `conan.tools.gnu` is _not_ passing `--static`, and the libraries propagated via `cpp_info` as `system_libs` are implicitly shared (the linker will prefer them shared if both are available).

