### PR TITLE
mpg123: conditionally add mvec as system_lib dependency

### DIFF
--- a/recipes/mpg123/all/conanfile.py
+++ b/recipes/mpg123/all/conanfile.py
@@ -211,7 +211,8 @@ class Mpg123Conan(ConanFile):
 
         if self.settings.os == "Linux":
             self.cpp_info.components["libmpg123"].system_libs = ["m"]
-            self.cpp_info.components["libsyn123"].system_libs = ["mvec"]
+            if self.settings.arch in ["x86", "x86_64"]:
+                self.cpp_info.components["libsyn123"].system_libs = ["mvec"]
         elif self.settings.os == "Windows":
             self.cpp_info.components["libmpg123"].system_libs = ["shlwapi"]
 


### PR DESCRIPTION
Specify library name and version:  **mpg/123**

`libmvec` is part of `glibc`, but it is not a component that is available for all architectures. On Ubuntu at least this only exists for the intel architectures.

This fixes issue where downstream consumers that depend on `mpg123` cannot build when on `armv8` (due to linker errors as `lmvec` is not resolved). There is currently no mvec for aarch64: https://sourceware.org/bugzilla/show_bug.cgi?id=25422



