### PR TITLE
libdwarf specify package_type library 

### DIFF
--- a/recipes/libdwarf/all/conanfile.py
+++ b/recipes/libdwarf/all/conanfile.py
@@ -14,6 +14,7 @@ class LibdwarfConan(ConanFile):
     homepage = "https://www.prevanders.net/dwarf.html"
     topics = ("debug", "dwarf", "dwarf2", "elf")
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],


### PR DESCRIPTION
Specify library name and version:  **libdwarf/all**

This MR adds `package_type=library` to libdwarf. 

Also while iterating over folly recipe I saw there was no conan2 libdwarf package https://c3i.jfrog.io/c3i/misc-v2/logs/pr/15726/20-linux-gcc/folly/2020.08.10.00//9b276f5023f4804656038dfee5e53c428c50949e-build.txt so I'm hoping this MR CI will also generate one.



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
