### PR TITLE
libiberty provide package_type static-library

### DIFF
--- a/recipes/libiberty/all/conanfile.py
+++ b/recipes/libiberty/all/conanfile.py
@@ -16,6 +16,7 @@ class LibibertyConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gcc.gnu.org/onlinedocs/libiberty"
     license = "LGPL-2.1"
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
@@ -54,8 +55,7 @@ class LibibertyConan(ConanFile):
                 self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
         rmdir(self, os.path.join(self.source_folder, "gcc"))
         rmdir(self, os.path.join(self.source_folder, "libstdc++-v3"))
 


### PR DESCRIPTION
Specify library name and version:  **libiberty/9.1.0**

This MR provides `package_type = static-library` attribute.

(Secondary objective) see if CI generates conan v2 package (detected missing package here https://c3i.jfrog.io/c3i/misc-v2/logs/pr/15726/20-linux-gcc/folly/2020.08.10.00//9b276f5023f4804656038dfee5e53c428c50949e-build.txt)


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
