### PR TITLE
nanorange: add version cci.20200505

### DIFF
--- a/recipes/nanorange/all/conandata.yml
+++ b/recipes/nanorange/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "cci.20200706":
     url: "https://github.com/tcbrindle/NanoRange/archive/bf32251d65673fe170d602777c087786c529ead8.tar.gz"
     sha256: "28cf187174b3097c00aa12cc2a3b554f8f768a3b50a9703174af03ee99c3397c"
+  "cci.20200505":
+    url: "https://github.com/tcbrindle/NanoRange/archive/a536e2747ba6124f1485dfa6acabca35326b1c5b.tar.gz"
+    sha256: "9c4b71e6d26cbb85c9bf6751e6c0404922f75701984a85c312c4cf5838f89e2c"

--- a/recipes/nanorange/config.yml
+++ b/recipes/nanorange/config.yml
@@ -1,3 +1,5 @@
 versions:
   "cci.20200706":
     folder: all
+  "cci.20200505":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **nanorange/cci.20200505**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
