### PR TITLE
hidapi: add required libudev dependency

### DIFF
--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -57,6 +57,8 @@ class HidapiConan(ConanFile):
     def requirements(self):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("libusb/1.0.26")
+        if self.settings.os == "Linux":
+            self.requires("libudev/system")
 
     def validate(self):
         if is_msvc(self) and not self.options.shared:
@@ -143,6 +145,8 @@ class HidapiConan(ConanFile):
 
             self.cpp_info.components["hidraw"].set_property("pkg_config_name", "hidapi-hidraw")
             self.cpp_info.components["hidraw"].libs = ["hidapi-hidraw"]
+            if self.settings.os == "Linux":
+                self.cpp_info.components["hidraw"].requires = ["libudev::libudev"]
             self.cpp_info.components["hidraw"].system_libs = ["pthread", "dl"]
         else:
             self.cpp_info.libs = ["hidapi"]


### PR DESCRIPTION
Specify library name and version:  **hidapi/0.13.1**

The [configure.ac](https://github.com/libusb/hidapi/blob/4ebce6b5059b086d05ca7e091ce04a5fd08ac3ac/configure.ac#L60) file explicitly checks for libudev on Linux on all packaged versions back to 0.10.1.

Fixes: #16770

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
