### PR TITLE
highfive: add v2.7.0 and bump deps

### DIFF
--- a/recipes/highfive/all/conandata.yml
+++ b/recipes/highfive/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.7.0":
+    url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.7.0.tar.gz"
+    sha256: "8e05672ddf81a59ce014b1d065bd9a8c5034dbd91a5c2578e805ef880afa5907"
   "2.6.2":
     url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.6.2.tar.gz"
     sha256: "ab51b9fbb49e877dd1aa7b53b4b26875f41e4e0b8ee0fc2f1d735e0d1e43d708"

--- a/recipes/highfive/all/conanfile.py
+++ b/recipes/highfive/all/conanfile.py
@@ -40,7 +40,7 @@ class HighFiveConan(ConanFile):
         if self.options.with_eigen:
             self.requires("eigen/3.4.0")
         if self.options.with_xtensor:
-            self.requires("xtensor/0.24.2")
+            self.requires("xtensor/0.24.3")
         if self.options.with_opencv:
             self.requires("opencv/4.5.5")
 

--- a/recipes/highfive/config.yml
+++ b/recipes/highfive/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.7.0":
+    folder: all
   "2.6.2":
     folder: all
   "2.5.1":


### PR DESCRIPTION
Specify library name and version:  **highfive/all**

- Add `v2.7.0`
- Bump `xtensor`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
