### PR TITLE
Add gstreamer to large pod

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -199,6 +199,7 @@ pod_size:
     - "pcl"
     - "duckdb"
     - "ceres-solver"
+    - "gstreamer"
   xlarge:
     - "llvm"
     - "opengv"


### PR DESCRIPTION
Specify library name and version:  **gstreamer/all**

As suggested by @davidsanfal and @danimtb, let's try to put this library in a large pod, see if that helps (Although I suspect no, it's worth a try)

Ping @jwillikers sorry it's taking so long, it's been tricky :)