### PR TITLE
Ignore more test_package build dir patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Conan specific
 **/test_package/build/
+**/test_package/build-*/
 **/test_package/test_output/
 conan.lock
 conanbuildinfo.txt


### PR DESCRIPTION
In the binutils recipe (PR #16920) with `basic_layout`, a `recipes/binutils/all/test_package/build-release/`
directory appears.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
