### PR TITLE
Correct xorg-makedepend homepage url

### DIFF
--- a/recipes/xorg-makedepend/all/conanfile.py
+++ b/recipes/xorg-makedepend/all/conanfile.py
@@ -14,7 +14,7 @@ class XorgMakedepend(ConanFile):
     description = "Utility to parse C source files to make dependency lists for Makefiles"
     topics = ("xorg", "dependency", "obsolete")
     license = "MIT"
-    homepage = "https://gitlab.freedesktop.org/xorg/util/cf"
+    homepage = "https://gitlab.freedesktop.org/xorg/util/makedepend"
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "arch", "compiler", "build_type"
 


### PR DESCRIPTION
Specify library name and version:  xorg-makedepend/any

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

fixes #16927

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
