### PR TITLE
fix opensuse naming of libudev dependency

### DIFF
--- a/recipes/libudev/all/conanfile.py
+++ b/recipes/libudev/all/conanfile.py
@@ -37,7 +37,7 @@ class LibUDEVConan(ConanFile):
         pacman.install(["systemd-libs"], update=True, check=True)
 
         zypper = package_manager.Zypper(self)
-        zypper.install(["libudev-devel"], update=True, check=True)
+        zypper.install_substitutes(["libudev-devel"], ["systemd-devel"], update=True, check=True)
 
     def package_info(self):
         self.cpp_info.includedirs = []


### PR DESCRIPTION
Specify library name and version:  **libudev/system**

recent versions of openSUSE Leap (i.e. 15.4) changed the package containing the udev development files from `libudev-devel` to `systemd-devel` bringing it inline with the naming e.g. in fedora. This is a trivial patch to the recipe that allows it to succeed on both older and current versions of openSUSE by using the `install_substitutes` functionality.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
