### PR TITLE
safeint: add version 3.0.28

### DIFF
--- a/recipes/safeint/all/conandata.yml
+++ b/recipes/safeint/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.28":
+    url: "https://github.com/dcleblanc/SafeInt/archive/refs/tags/3.0.28.tar.gz"
+    sha256: "d6b164bcea92a746e4d44132e505c7ab1816d1089ba99ebc674ccd4b70262ed5"
   "3.0.27":
     url: "https://github.com/dcleblanc/SafeInt/archive/refs/tags/3.0.27.tar.gz"
     sha256: "489abb253514f819adb7e3aab3273b184c484dfe082fbe2166de2fd3a88dfb2b"

--- a/recipes/safeint/config.yml
+++ b/recipes/safeint/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.28":
+    folder: all
   "3.0.27":
     folder: all
   "3.0.26":


### PR DESCRIPTION
Specify library name and version:  **safeint/3.0.28**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
