### PR TITLE
[config] Drop some Conan v1 pipeline configurations

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -65,8 +65,8 @@ configurations:
         arch: [ "x86_64" ]
         compiler:
           - "gcc":
-              compiler.libcxx: [ "libstdc++11", "libstdc++" ]
-              compiler.version: [ "5", "7", "8", "9", "10" ]
+              compiler.libcxx: [ "libstdc++11" ]
+              compiler.version: [ "5", "7", "9", "10" ]
               build_type: [ "Release", "Debug" ]
   - id: linux-gcc
     epochs: [20211221, 20220120]
@@ -76,8 +76,8 @@ configurations:
         arch: ["x86_64"]
         compiler:
           - "gcc":
-              compiler.libcxx: ["libstdc++11", "libstdc++"]
-              compiler.version: ["5", "7", "8", "9", "10", "11"]
+              compiler.libcxx: [ "libstdc++11" ]
+              compiler.version: ["5", "7", "9", "10", "11"]
               build_type: ["Release", "Debug"]
   - id: linux-clang
     epochs: [0]
@@ -120,7 +120,7 @@ configurations:
         arch: [ "x86_64" ]
         compiler:
           - "apple-clang":
-              compiler.version: [ "11.0", "12.0", "13.0"]
+              compiler.version: [ "13.0" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
   - id: configs/macos-m1-clang
@@ -148,7 +148,7 @@ configurations:
         arch: [ "armv8" ]
         compiler:
           - "apple-clang":
-              compiler.version: [ "12.0", "13.0" ]
+              compiler.version: [ "13.0" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
   - id: configs/windows-visual_studio
@@ -159,12 +159,12 @@ configurations:
         arch: [ "x86_64" ]
         compiler:
           - "Visual Studio":
-              compiler.version: [ "15", "16" ]
+              compiler.version: [ "16" ]
               build_type:
                 - "Release":
-                    compiler.runtime: [ "MT", "MD" ]
+                    compiler.runtime: [ "MD" ]
                 - "Debug":
-                    compiler.runtime: [ "MTd", "MDd" ]
+                    compiler.runtime: [ "MDd" ]
 
 jenkins:
   url: "http://mb-jenkins-my-bloody-jenkins:8080"

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -98,7 +98,7 @@ configurations:
               compiler.version: [ "192" ]
               build_type:
                 - "Release":
-                    compiler.runtime: [ "static", "dynamic" ]
+                    compiler.runtime: ["dynamic"]
                     compiler.runtime_type: [ "Release" ]
 
 cppstd:


### PR DESCRIPTION
Please, read https://github.com/conan-io/conan-center-index/discussions/16729 to get more information about.

We will drop the follow configurations:

Conan v1:

- compiler.libcxx=libstdc++ for all GCC profiles
- GCC 8
- Apple Clang 11.0 12.0
- Visual Studio 15
- compiler.runtime=MT/MTd for all Visual Studio profiles

Conan v2:

- compiler.runtime=static for all msvc profiles


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
