### PR TITLE
Revert "Add gstreamer to large pod"

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -199,7 +199,6 @@ pod_size:
     - "pcl"
     - "duckdb"
     - "ceres-solver"
-    - "gstreamer"
   xlarge:
     - "llvm"
     - "opengv"


### PR DESCRIPTION
This reverts commit 3c62b4dd3271c4f328e84fc447d592d2a2ba2520.

This turns out not be useful for the timeout issue, so revert it back to a normal pod as it's overkill to keep it in a large one