### PR TITLE
redis-plus-plus: fix build with ssl

### DIFF
--- a/recipes/redis-plus-plus/all/patches/1.3.7-0001-fix-dependencies-injection.patch
+++ b/recipes/redis-plus-plus/all/patches/1.3.7-0001-fix-dependencies-injection.patch
@@ -12,7 +12,15 @@ index 69794d9..fbb75b7 100644
      else()
          message(FATAL_ERROR "invalid REDIS_PLUS_PLUS_BUILD_ASYNC")
      endif()
-@@ -191,7 +190,7 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
+@@ -131,7 +130,6 @@ if(hiredis_FOUND)
+     list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS hiredis::hiredis)
+
+     if(REDIS_PLUS_PLUS_USE_TLS)
+-        find_package(hiredis_ssl REQUIRED)
+         list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS hiredis::hiredis_ssl)
+         find_package(OpenSSL REQUIRED)
+         list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${OPENSSL_LIBRARIES})
+@@ -191,7 +189,7 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
  
      if(REDIS_PLUS_PLUS_BUILD_ASYNC)
          target_include_directories(${STATIC_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_ASYNC_FUTURE_HEADER}>)


### PR DESCRIPTION
Fixes a missing hiredis_ssl cmake config file for 1.3.7

Specify library name and version:  **redis-plus-plus/1.3.7**

When ssl is enabled, the build currently fails with
```
CMake Error at CMakeLists.txt:133 (find_package):
  By not providing "Findhiredis_ssl.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "hiredis_ssl", but CMake did not find one.

  Could not find a package configuration file provided by "hiredis_ssl" with
  any of the following names:

    hiredis_sslConfig.cmake
    hiredis_ssl-config.cmake

  Add the installation prefix of "hiredis_ssl" to CMAKE_PREFIX_PATH or set
  "hiredis_ssl_DIR" to a directory containing one of the above files.  If
  "hiredis_ssl" provides a separate development package or SDK, be sure it
  has been installed.
```


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
