### PR TITLE
libde265: add 1.0.11 & package_type

### DIFF
--- a/recipes/libde265/all/conandata.yml
+++ b/recipes/libde265/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.11":
+    url: "https://github.com/strukturag/libde265/releases/download/v1.0.11/libde265-1.0.11.tar.gz"
+    sha256: "2f8f12cabbdb15e53532b7c1eb964d4e15d444db1be802505e6ac97a25035bab"
   "1.0.9":
     url: "https://github.com/strukturag/libde265/releases/download/v1.0.9/libde265-1.0.9.tar.gz"
     sha256: "29bc6b64bf658d81a4446a3f98e0e4636fd4fd3d971b072d440cef987d5439de"

--- a/recipes/libde265/all/conanfile.py
+++ b/recipes/libde265/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rmdir, save
+from conan.tools.scm import Version
 import os
 import textwrap
 
@@ -15,7 +16,7 @@ class Libde265Conan(ConanFile):
     topics = ("codec", "video", "h.265")
     homepage = "https://github.com/strukturag/libde265"
     url = "https://github.com/conan-io/conan-center-index"
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -74,11 +75,15 @@ class Libde265Conan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
         # TODO: to remove in conan v2 once legacy generators removed
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
-            {"libde265": "libde265::libde265"}
+            {
+                "de265": "libde265::libde265",
+                "libde265": "libde265::libde265",
+            }
         )
 
     def _create_cmake_module_alias_targets(self, module_file, targets):
@@ -98,10 +103,11 @@ class Libde265Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "libde265")
-        self.cpp_info.set_property("cmake_target_name", "libde265")
+        self.cpp_info.set_property("cmake_target_name", "de265")
+        self.cpp_info.set_property("cmake_target_aliases", ["libde265"]) # official imported target before 1.0.10
         self.cpp_info.set_property("pkg_config_name", "libde265")
-
-        self.cpp_info.libs = ["libde265"]
+        prefix = "lib" if Version(self.version) < "1.0.10" else ""
+        self.cpp_info.libs = [f"{prefix}de265"]
         if not self.options.shared:
             self.cpp_info.defines = ["LIBDE265_STATIC_BUILD"]
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/libde265/config.yml
+++ b/recipes/libde265/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.11":
+    folder: all
   "1.0.9":
     folder: all
   "1.0.8":


### PR DESCRIPTION
Upstream has changed CMake imported target (inadvertently, I guess, in https://github.com/strukturag/libde265/commit/29698db09134bef7be5b0bb6b270cdd28ee66f1e) from `libde265` to `de265`.
To avoid breaking users, both targets are provided in CMakeDeps and cmake_find_package(_multi).


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
