### PR TITLE
gnu-config: export and apply patches

### DIFF
--- a/recipes/gnu-config/all/conanfile.py
+++ b/recipes/gnu-config/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanException
-from conan.tools.files import copy, get, load, save
+from conan.tools.files import copy, get, load, save, apply_conandata_patches, export_conandata_patches
 from conan.tools.layout import basic_layout
 import os
 
@@ -17,6 +17,9 @@ class GnuConfigConan(ConanFile):
     os = "arch", "compiler", "build_type", "arch"
     no_copy_source = True
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -28,6 +31,7 @@ class GnuConfigConan(ConanFile):
             destination=self.source_folder, strip_root=True)
 
     def build(self):
+        apply_conandata_patches(self)
         pass
 
     def _extract_license(self):

--- a/recipes/gnu-config/all/conanfile.py
+++ b/recipes/gnu-config/all/conanfile.py
@@ -32,7 +32,6 @@ class GnuConfigConan(ConanFile):
 
     def build(self):
         apply_conandata_patches(self)
-        pass
 
     def _extract_license(self):
         txt_lines = load(self, os.path.join(self.source_folder, "config.guess")).splitlines()


### PR DESCRIPTION
Specify library name and version:  **gnu-config/cci.20210804**

Fix the PR https://github.com/conan-io/conan-center-index/pull/16802, which added a patch but didn't export and didn't apply the patch.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
