### PR TITLE
grpc-proto bump protobuf version

### DIFF
--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -59,7 +59,7 @@ class GRPCProto(ConanFile):
         tc.generate()
 
     def requirements(self):
-        self.requires('protobuf/3.21.9', transitive_headers=True)
+        self.requires('protobuf/3.21.9', transitive_headers=True, transitive_libs=True)
         self.requires('googleapis/cci.20221108')
 
     def build_requirements(self):

--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -59,11 +59,11 @@ class GRPCProto(ConanFile):
         tc.generate()
 
     def requirements(self):
-        self.requires('protobuf/3.21.4', transitive_headers=True)
+        self.requires('protobuf/3.21.9', transitive_headers=True)
         self.requires('googleapis/cci.20221108')
 
     def build_requirements(self):
-        self.build_requires('protobuf/3.21.4')
+        self.build_requires('protobuf/3.21.9')
 
     @functools.lru_cache(1)
     def _parse_proto_libraries(self):


### PR DESCRIPTION
Specify library name and version:  **grpc-proto/all**

* bump protobuf version in grpc-proto to resolve version conflict in grpc. 
* add `transitive_libs=True` dependency trait to solve issue when `*:shared=True` - consumers should link to the protobuf library as the use of  `.pb.h` headers tend to cause the consumer to directly reference symbols from protobuf (without their knowledge)

```
[100%] Linking CXX executable test_package
Undefined symbols for architecture arm64:
  "google::protobuf::Message::DebugString() const", referenced from:
      _main in test_package.cpp.o
```

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
