### PR TITLE
libxml2: add 2.10.4

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.10.4":
+    url: "https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.4.tar.xz"
+    sha256: "ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45"
   "2.10.3":
     url: "https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.3.tar.xz"
     sha256: "5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.10.4":
+    folder: all
   "2.10.3":
     folder: all
   "2.9.14":


### PR DESCRIPTION
Specify library name and version:  **libxml2/2.10.4**

Fix for CVEs:
* [CVE-2023-29469](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-29469)
* [CVE-2023-28484](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28484)

see also https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.10.4

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
