### PR TITLE
[changelog] New CCI release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 12-April-2023 - 16:18 CEST
+
+- [feature] Add ListPackages job the posibility to update a list via PR
+- [feature] Add c3i-conan2-ready label when modifying .c3i/conan_v2_ready_references.yml
+- [hotfix] Use Conan helpers to update Conan Center page
+- [hotfix] Automatic Merge reduces the number of requests for each execution
+
 ### 03-April-2023 - 10:26 CEST
 
 - [fix] Remove options usage from build profile.


### PR DESCRIPTION
- New CI job which should run two time every day and update the `.c3i/conan_v2_ready_references.yml` automatically
- Improved Automatic merge to execute less steps, resulting a faster execution

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
