### PR TITLE
[c3i] Configure to list package which are ready for Conan v2

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -40,6 +40,9 @@ tasks:
       text_on_failure: "The v2 pipeline failed. Please, review the errors and note this will be required for pull requests to be merged in the near future."
       collapse_on_success: false
       collapse_on_failure: true
+  list_packages:
+    update_yaml_list_path: ".c3i/conan_v2_ready_references"
+    update_yaml_list_key: "required_for_references"
   scheduled_export_check:
     report_issue_url: https://github.com/conan-io/conan-center-index/issues/15557
     report_issue_append: false


### PR DESCRIPTION
Added new configuration which will be consumed by Jenkins. This configuration shows where Jenkins should take the information about packages which passed by Conan v2 and now should be part of a regression test.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
