### PR TITLE
foonathan-memory remove crosscompile check

### DIFF
--- a/recipes/foonathan-memory/all/conanfile.py
+++ b/recipes/foonathan-memory/all/conanfile.py
@@ -44,12 +44,6 @@ class FoonathanMemoryConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
-    def validate(self):
-        # FIXME: jenkins servers throw error with this combination
-        # quick fix until somebody can reproduce
-        if hasattr(self, "settings_build") and cross_building(self):
-            raise ConanInvalidConfiguration("Cross building is not yet supported. Contributions are welcome")
-
     def layout(self):
         cmake_layout(self, src_folder="src")
 

--- a/recipes/foonathan-memory/all/conanfile.py
+++ b/recipes/foonathan-memory/all/conanfile.py
@@ -53,7 +53,7 @@ class FoonathanMemoryConan(ConanFile):
         if hasattr(self, "settings_build") and cross_building(self) and \
                 str(self.settings.os) == "Macos" and self.options.with_tools:
             raise ConanInvalidConfiguration(
-                "Cross building tools for macos is not yet supported. Contributions are welcome")
+                "Cross building tools for Macos is not yet supported. Contributions are welcome")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **foonathan-memory/all**

I have tried to reproduce the error with cross compilation but all available versions of foonathan-memory are working while cross compiling to armv8. 

In Versions smaller then 0.7.2 there will be the output:

```
CMake Warning at src/CMakeLists.txt:108 (message):
  cross-compiling, but emulator is not defined, cannot generate
  container_node_sizes_impl.hpp, node size information will be unavailable
```
but it is working. Since 0.7.2, the method how to generate the node sizes seems to be changed and there was no warning at all. 

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
