### PR TITLE
Fix fakeit/all: Fixed package_id() to make it dependent on option:integration.

### DIFF
--- a/recipes/fakeit/all/conanfile.py
+++ b/recipes/fakeit/all/conanfile.py
@@ -48,7 +48,10 @@ class FakeItConan(ConanFile):
             raise ConanInvalidConfiguration("%s is not (yet) available on cci" % self.options.integration)
 
     def package_id(self):
-        self.info.clear()
+        # The "integration" option must be kept because it will impact which header is packaged,
+        # therefor self.info.clear() cannot be used.
+        self.info.settings.clear()
+        self.info.requires.clear()
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Specify library name and version:  **fakeit/all**

The fakeit package package only one header, but the header is selected based on the "integration" option, therefor this option must be part of the package id. This PR solves that and fixes #14900.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
