### PR TITLE
spdlog: make sure fmt is not bundled

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -115,7 +115,11 @@ class SpdlogConan(ConanFile):
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         if self.options.header_only:
-            copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.source_folder, "include"))
+            copy(self,
+                 src=os.path.join(self.source_folder, "include"),
+                 pattern="*.h", dst=os.path.join(self.package_folder, "include"),
+                 # Unvendor bundled dependencies https://github.com/gabime/spdlog/commit/18495bf25dad3a4e8c2fe3777a5f79acecde27e3
+                 excludes=("fmt/bundled"))
         else:
             cmake = CMake(self)
             cmake.install()

--- a/recipes/spdlog/all/test_package/test_package.cpp
+++ b/recipes/spdlog/all/test_package/test_package.cpp
@@ -1,6 +1,10 @@
 #include <cstdlib>
 #include "spdlog/spdlog.h"
 
+#if __has_include("spdlog/fmt/bundled/core.h")
+   #error "bundled fmt within spdlog should not be present"
+#endif
+
 int main(void) {
     spdlog::info("Welcome to spdlog version {}.{}.{}  !", SPDLOG_VER_MAJOR, SPDLOG_VER_MINOR, SPDLOG_VER_PATCH);
     return EXIT_SUCCESS;


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Discovered this the bug with https://github.com/conan-io/conan-center-index/pull/16654/files#r1164194266


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
