### PR TITLE
New recipe libpointmatcher/1.3.1

### DIFF
--- a/recipes/libpointmatcher/all/conandata.yml
+++ b/recipes/libpointmatcher/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "1.3.1":
+    url: "https://github.com/ethz-asl/libpointmatcher/archive/refs/tags/1.3.1.tar.gz"
+    sha256: "82f93d2e7689efeef8837b8e969919b51c51ad4a1d1fa921c4dd8df4811378ab"
+patches:
+  "1.3.1":
+    - patch_file: "patches/1.3.1-0001-fix-cmake.patch"
+      patch_description: "Fix upstream CMakeLists"
+      patch_type: "conan"

--- a/recipes/libpointmatcher/all/conanfile.py
+++ b/recipes/libpointmatcher/all/conanfile.py
@@ -1,0 +1,88 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class LibpointmatcherConan(ConanFile):
+    name = "libpointmatcher"
+    description = "An Iterative Closest Point (ICP) library for 2D and 3D mapping in Robotics"
+    license = "BSD-3-Clause"
+    topics = ("robotics", "lidar", "point-cloud")
+    homepage = "https://github.com/ethz-asl/libpointmatcher"
+    url = "https://github.com/conan-io/conan-center-index"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_openmp": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_openmp": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return "11"
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("boost/1.81.0", transitive_headers=True)
+        # FIXME: eigen 3.4.0 is not compatible yet (see https://github.com/ethz-asl/libpointmatcher/issues/496)
+        self.requires("eigen/3.3.9", transitive_headers=True)
+        self.requires("libnabo/1.0.7")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["USE_OPEN_MP"] = self.options.with_openmp
+        tc.cache_variables["USE_OPEN_CL"] = False
+        tc.cache_variables["SHARED_LIBS"] = self.options.shared
+        # TODO: to unvendor, but libpointmatcher depends on legacy API of yaml-cpp (0.3.x)
+        tc.variables["USE_SYSTEM_YAML_CPP"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "copyright", src=os.path.join(self.source_folder, "debian"),
+                                dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "libpointmatcher")
+        self.cpp_info.set_property("pkg_config_name", "libpointmatcher")
+        self.cpp_info.libs = ["pointmatcher"]

--- a/recipes/libpointmatcher/all/patches/1.3.1-0001-fix-cmake.patch
+++ b/recipes/libpointmatcher/all/patches/1.3.1-0001-fix-cmake.patch
@@ -1,0 +1,208 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.11)
++cmake_minimum_required(VERSION 3.15)
+ 
+ include(CheckSymbolExists)
+ 
+@@ -46,6 +46,7 @@ if( BUILD_32 )
+ endif( BUILD_32 )
+ 
+ # Ensure proper build type
++if(0)
+ if (NOT CMAKE_BUILD_TYPE)
+   message("-- No build type specified; defaulting to CMAKE_BUILD_TYPE=Release.")
+   set(CMAKE_BUILD_TYPE Release CACHE STRING
+@@ -65,12 +66,14 @@ endif (NOT CMAKE_BUILD_TYPE)
+ if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+   add_definitions(-O3)
+ endif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
++endif()
+ 
+ # For Windows
+ if( MSVC )
+ 	add_definitions( /D _VARIADIC_MAX=10 ) # VS2012 does not support tuples correctly yet
+ 	add_definitions( /D _USE_MATH_DEFINES) # defines M_PI for Visual Studio
+ 	add_definitions( /D _ENABLE_EXTENDED_ALIGNED_STORAGE) # this variable must be defined with VS2017 to acknowledge alignment changes of aligned_storage
++    add_compile_options(/bigobj)
+ endif()
+ 
+ #======================= installation =====================================
+@@ -120,19 +123,16 @@ if (Boost_MINOR_VERSION GREATER 47)
+ 	find_package(Boost COMPONENTS thread filesystem system program_options date_time chrono REQUIRED)
+ endif (Boost_MINOR_VERSION GREATER 47)
+ include_directories(${Boost_INCLUDE_DIRS})
+-set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${Boost_LIBRARIES})
++set(EXTERNAL_LIBS ${EXTERNAL_LIBS} Boost::headers Boost::thread Boost::filesystem Boost::system Boost::program_options Boost::date_time Boost::chrono)
+ 
+ 
+ #--------------------
+ # DEPENDENCY: eigen 3
+ #--------------------
+-find_path(EIGEN_INCLUDE_DIR Eigen/Core
+-	/usr/local/include/eigen3
+-	/usr/include/eigen3
+-)
++find_package(Eigen3 REQUIRED CONFIG)
++set(EXTERNAL_LIBS ${EXTERNAL_LIBS} Eigen3::Eigen )
+ 
+ # Suppress Eigen's warning by adding it to the system's library
+-include_directories(SYSTEM "${EIGEN_INCLUDE_DIR}")
+ 
+ #TODO: this should be a more standard way
+ #find_package(Eigen3 REQUIRED)
+@@ -143,10 +143,9 @@ include_directories(SYSTEM "${EIGEN_INCLUDE_DIR}")
+ #--------------------
+ # DEPENDENCY: nabo
+ #--------------------
+-find_package(libnabo REQUIRED PATHS ${LIBNABO_INSTALL_DIR})
++find_package(libnabo REQUIRED CONFIG)
+ #include(libnaboConfig)
+-include_directories(${libnabo_INCLUDE_DIRS})
+-set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${libnabo_LIBRARIES})
++set(EXTERNAL_LIBS ${EXTERNAL_LIBS} libnabo::nabo)
+ message(STATUS "libnabo found, version ${libnabo_VERSION} (include=${libnabo_INCLUDE_DIRS} libs=${libnabo_LIBRARIES})")
+ 
+ #--------------------
+@@ -215,8 +214,7 @@ else(USE_SYSTEM_YAML_CPP)
+         #get_property(yaml-cpp-pm_INCLUDE TARGET yaml-cpp-pm PROPERTY INCLUDE_DIRECTORIES)
+         #include_directories(${yaml-cpp-pm_INCLUDE})
+ 
+-        get_property(yaml-cpp-pm_LIB TARGET yaml-cpp-pm PROPERTY LOCATION)
+-        set (EXTERNAL_LIBS ${EXTERNAL_LIBS} ${yaml-cpp-pm_LIB} )
++        set (EXTERNAL_LIBS ${EXTERNAL_LIBS} yaml-cpp-pm )
+         set (EXTRA_DEPS ${EXTRA_DEPS} yaml-cpp-pm)
+         set(yamlcpp_FOUND)
+ 
+@@ -241,6 +239,7 @@ endif (POSIX_TIMERS AND NOT APPLE)
+ #========================== libpointmatcher itself ==============================
+ 
+ # Check the compiler version as we need full C++11 support.
++if(0)
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+ 	# using Clang
+ 	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.3")
+@@ -276,6 +275,7 @@ if (CMAKE_VERSION VERSION_LESS "3.1")
+ else ()
+ 	set (CMAKE_CXX_STANDARD 11)
+ endif ()
++endif()
+ 
+ # SOURCE
+ 
+@@ -350,12 +350,12 @@ file(GLOB_RECURSE POINTMATCHER_HEADERS "pointmatcher/*.h")
+ 
+ # MacOS and Windows deal with shared/dynamic library differently. For
+ # simplicity, we only authorize static library in those cases.
+-if(APPLE OR WIN32)
++if(0)
+ 
+ 	add_library(pointmatcher ${POINTMATCHER_SRC} ${POINTMATCHER_HEADERS} )
+ 	install(TARGETS pointmatcher ARCHIVE DESTINATION ${INSTALL_LIB_DIR})
+ 
+-else(APPLE OR WIN32)
++else()
+ 	set(SHARED_LIBS "true" CACHE BOOL "To build shared (true) or static (false) library")
+ 
+ 	if (SHARED_LIBS)
+@@ -369,14 +369,15 @@ else(APPLE OR WIN32)
+ 		add_library(pointmatcher ${POINTMATCHER_SRC} ${POINTMATCHER_HEADERS} )
+ 		install(TARGETS pointmatcher ARCHIVE DESTINATION ${INSTALL_LIB_DIR})
+ 	endif(SHARED_LIBS)
+-endif(APPLE OR WIN32)
++    set_target_properties(pointmatcher PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
++    target_compile_features(pointmatcher PUBLIC cxx_std_11)
++endif()
+ 
+ target_include_directories(pointmatcher PRIVATE ${CMAKE_SOURCE_DIR}/pointmatcher)
+ target_include_directories(pointmatcher PRIVATE ${CMAKE_SOURCE_DIR}/pointmatcher/DataPointsFilters)
+ target_include_directories(pointmatcher PRIVATE ${CMAKE_SOURCE_DIR}/pointmatcher/DataPointsFilters/utils)
+ 
+ # link all libraries to libpointmatcher
+-add_definitions(-Wall)
+ #target_link_libraries(pointmatcher ${yaml-cpp_LIBRARIES} ${libnabo_LIBRARIES})
+ target_link_libraries(pointmatcher ${EXTERNAL_LIBS})
+ 
+@@ -432,11 +433,8 @@ endif(GENERATE_API_DOC)
+ #=============== trigger other makefile ======================
+ 
+ # Example programs
+-add_subdirectory(examples)
+ # Evaluation programs
+-add_subdirectory(evaluations)
+ # Unit testing
+-add_subdirectory(utest)
+ 
+ 
+ #=================== allow find_package() =========================
+@@ -451,6 +449,7 @@ add_subdirectory(utest)
+ # 1- local build #
+ 
+ # Register the local build in case one doesn't use "make install"
++if(0)
+ export(PACKAGE libpointmatcher)
+ 
+ # Create variable for the local build tree
+@@ -537,3 +536,4 @@ configure_file(
+ 
+ add_custom_target(uninstall
+     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
++endif()
+--- a/contrib/CMakeLists.txt
++++ b/contrib/CMakeLists.txt
+@@ -1,8 +1,6 @@
+ # External libraries packed with libpointmatcher
+ 
+ # GTest
+-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+-add_library(gtest gtest/gtest-all.cc)
+ 
+ # Wrapped yaml-cpp
+ if(NOT USE_SYSTEM_YAML_CPP)
+--- a/contrib/yaml-cpp-pm/CMakeLists.txt
++++ b/contrib/yaml-cpp-pm/CMakeLists.txt
+@@ -19,7 +19,6 @@ set(YAML_CPP_BUILD_CONTRIB  OFF)
+ # --> General
+ # see http://www.cmake.org/cmake/help/cmake2.6docs.html#variable:BUILD_SHARED_LIBS
+ #     http://www.cmake.org/cmake/help/cmake2.6docs.html#command:add_library
+-set(BUILD_SHARED_LIBS OFF)
+ 
+ # --> Apple
+ option(APPLE_UNIVERSAL_BIN "Apple: Build universal binary" OFF)
+@@ -55,7 +54,6 @@ endif()
+ 
+ if(WIN32)
+ 	if(BUILD_SHARED_LIBS)
+-		add_definitions(-D${PROJECT_NAME}_DLL)	# use or build Windows DLL
+ 	endif()
+ 	if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+ 		set(CMAKE_INSTALL_PREFIX "C:/")
+@@ -63,7 +61,7 @@ if(WIN32)
+ endif()
+ 
+ # GCC / Clang specialities
+-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
++if(0)
+ 	### General stuff
+ 	if(WIN32)
+ 		set(CMAKE_SHARED_LIBRARY_PREFIX "")	# DLLs do not have a "lib" prefix
+@@ -105,7 +103,7 @@ endif()
+ ###
+ ### Library
+ ###
+-add_library(yaml-cpp-pm
++add_library(yaml-cpp-pm OBJECT
+ 	${sources}
+ 	${public_headers}
+ 	${private_headers}
+@@ -113,6 +111,9 @@ add_library(yaml-cpp-pm
+ 	${contrib_public_headers}
+ 	${contrib_private_headers}
+ )
++if(BUILD_SHARED_LIBS)
++    set_target_properties(yaml-cpp-pm PROPERTIES POSITION_INDEPENDENT_CODE ON)
++endif()
+ 
+ set_target_properties(yaml-cpp-pm PROPERTIES
+ 	VERSION "${YAML_CPP_VERSION}"

--- a/recipes/libpointmatcher/all/test_package/CMakeLists.txt
+++ b/recipes/libpointmatcher/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+find_package(libpointmatcher REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE libpointmatcher::libpointmatcher)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/libpointmatcher/all/test_package/conanfile.py
+++ b/recipes/libpointmatcher/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libpointmatcher/all/test_package/test_package.cpp
+++ b/recipes/libpointmatcher/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <pointmatcher/PointMatcher.h>
+
+int main()
+{
+    auto rigidTrans = PointMatcher<float>::get().REG(Transformation).create("RigidTransformation");
+    return 0;
+}

--- a/recipes/libpointmatcher/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libpointmatcher/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/libpointmatcher/all/test_v1_package/conanfile.py
+++ b/recipes/libpointmatcher/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libpointmatcher/config.yml
+++ b/recipes/libpointmatcher/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.3.1":
+    folder: all


### PR DESCRIPTION
There are at least 2 issues to fix for v2 pipeline:
- libpointmatcher is broken with eigen 3.4.0, so it depends on eigen 3.3.9 (until a fix can be found: https://github.com/ethz-asl/libpointmatcher/issues/496). But libnabo (another dependency of libpointmatcher) depends on eigen 3.4.0 in its recipe, so v2 pipeline will hard fail since conan v2 client is super strict regarding version override.
- libpointmatcher depends on yaml-cpp 0.3.0 (vendored), which relies on auto_ptr, so it will fail to compile with C++17 or higher.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
