### PR TITLE
opentelemetry-proto: support conan v2

### DIFF
--- a/recipes/opentelemetry-proto/all/conanfile.py
+++ b/recipes/opentelemetry-proto/all/conanfile.py
@@ -37,7 +37,7 @@ class OpenTelemetryProtoConan(ConanFile):
         save(self, os.path.join(self.package_folder, "include", "dummy_header.h"), "\n")
 
     def package_info(self):
-        self.conf_info.define("user.myconf:proto_root", os.path.join(self.package_folder, "res"))
+        self.conf_info.define("user.opentelemetry-proto:proto_root", os.path.join(self.package_folder, "res"))
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
         self.cpp_info.resdirs = []

--- a/recipes/opentelemetry-proto/all/conanfile.py
+++ b/recipes/opentelemetry-proto/all/conanfile.py
@@ -12,7 +12,6 @@ class OpenTelemetryProtoConan(ConanFile):
     homepage = "https://github.com/open-telemetry/opentelemetry-proto"
     description = "Protobuf definitions for the OpenTelemetry protocol (OTLP)"
     topics = ("opentelemetry", "telemetry", "otlp")
-    package_type = "unknown"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -40,6 +39,5 @@ class OpenTelemetryProtoConan(ConanFile):
         self.conf_info.define("user.opentelemetry-proto:proto_root", os.path.join(self.package_folder, "res"))
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
-        self.cpp_info.resdirs = []
 
         self.user_info.proto_root = os.path.join(self.package_folder, "res")

--- a/recipes/opentelemetry-proto/all/conanfile.py
+++ b/recipes/opentelemetry-proto/all/conanfile.py
@@ -1,10 +1,9 @@
+from conan import ConanFile
+from conan.tools.files import get, copy, save
+from conan.tools.layout import basic_layout
 import os
-from pathlib import Path
-from conans import ConanFile, tools
 
-
-required_conan_version = ">=1.33.0"
-
+required_conan_version = ">=1.52.0"
 
 class OpenTelemetryProtoConan(ConanFile):
     name = "opentelemetry-proto"
@@ -13,24 +12,34 @@ class OpenTelemetryProtoConan(ConanFile):
     homepage = "https://github.com/open-telemetry/opentelemetry-proto"
     description = "Protobuf definitions for the OpenTelemetry protocol (OTLP)"
     topics = ("opentelemetry", "telemetry", "otlp")
+    package_type = "unknown"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    @property
-    def _source_subfolder(self):
-        return os.path.join(self.source_folder, "source_subfolder")
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder,
-                  strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy("*.proto", dst="res", src=self._source_subfolder)
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.proto",
+            dst=os.path.join(self.package_folder, "res"),
+            src=self.source_folder,
+        )
         # satisfy KB-H014 (header_only recipes require headers)
-        tools.save(os.path.join(self.package_folder, "include", "dummy_header.h"), "\n")
+        save(self, os.path.join(self.package_folder, "include", "dummy_header.h"), "\n")
 
     def package_info(self):
-        self.user_info.proto_root = os.path.join(self.package_folder, "res")
+        self.conf_info.define("user.myconf:proto_root", os.path.join(self.package_folder, "res"))
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
         self.cpp_info.resdirs = []
+
+        self.user_info.proto_root = os.path.join(self.package_folder, "res")

--- a/recipes/opentelemetry-proto/all/test_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_package/conanfile.py
@@ -14,5 +14,5 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def test(self):
-        res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.myconf:proto_root")
+        res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.opentelemetry-proto:proto_root")
         assert os.path.isfile(os.path.join(res_folder, "opentelemetry", "proto", "common", "v1", "common.proto"))

--- a/recipes/opentelemetry-proto/all/test_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain
+from conan.tools.cmake import CMakeDeps, CMakeToolchain
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.layout import basic_layout
 import os

--- a/recipes/opentelemetry-proto/all/test_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_package/conanfile.py
@@ -7,12 +7,16 @@ class TestPackageConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
+    _res_folder = ""
+
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires(self.tested_reference_str)
 
+    def build(self):
+        self._res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.opentelemetry-proto:proto_root")
+
     def test(self):
-        res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.opentelemetry-proto:proto_root")
-        assert os.path.isfile(os.path.join(res_folder, "opentelemetry", "proto", "common", "v1", "common.proto"))
+        assert os.path.isfile(os.path.join(self._res_folder, "opentelemetry", "proto", "common", "v1", "common.proto"))

--- a/recipes/opentelemetry-proto/all/test_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_package/conanfile.py
@@ -1,9 +1,18 @@
+from conan import ConanFile
+from conan.tools.layout import basic_layout
 import os
-from conans import ConanFile
-
 
 class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def test(self):
-        res_folder = self.deps_user_info["opentelemetry-proto"].proto_root
+        res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.myconf:proto_root")
         assert os.path.isfile(os.path.join(res_folder, "opentelemetry", "proto", "common", "v1", "common.proto"))

--- a/recipes/opentelemetry-proto/all/test_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_package/conanfile.py
@@ -24,7 +24,7 @@ class TestPackageConan(ConanFile):
         tc = VirtualBuildEnv(self)
         tc.generate(scope="build")
 
-        self._res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.opentelemetry-proto:proto_root")
+        self._res_folder = os.path.join(self.dependencies["opentelemetry-proto"].package_folder, "res")
 
     def test(self):
         assert os.path.isfile(os.path.join(self._res_folder, "opentelemetry", "proto", "common", "v1", "common.proto"))

--- a/recipes/opentelemetry-proto/all/test_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_package/conanfile.py
@@ -1,10 +1,11 @@
 from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.layout import basic_layout
 import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
     _res_folder = ""
@@ -15,7 +16,14 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
 
-    def build(self):
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate(scope="build")
+
         self._res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.opentelemetry-proto:proto_root")
 
     def test(self):

--- a/recipes/opentelemetry-proto/all/test_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.layout import basic_layout
 import os
@@ -24,7 +24,11 @@ class TestPackageConan(ConanFile):
         tc = VirtualBuildEnv(self)
         tc.generate(scope="build")
 
-        self._res_folder = os.path.join(self.dependencies["opentelemetry-proto"].package_folder, "res")
+        self._res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.opentelemetry-proto:proto_root")
 
     def test(self):
+        # TODO: to remove in conan v2
+        if self._res_folder == "":
+            self._res_folder = self.deps_user_info["opentelemetry-proto"].proto_root
+
         assert os.path.isfile(os.path.join(self._res_folder, "opentelemetry", "proto", "common", "v1", "common.proto"))

--- a/recipes/opentelemetry-proto/all/test_v1_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_v1_package/conanfile.py
@@ -1,0 +1,7 @@
+from conans import ConanFile, CMake
+import os
+
+class TestPackageV1Conan(ConanFile):
+    def test(self):
+        res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.myconf:proto_root")
+        assert os.path.isfile(os.path.join(res_folder, "opentelemetry", "proto", "common", "v1", "common.proto"))

--- a/recipes/opentelemetry-proto/all/test_v1_package/conanfile.py
+++ b/recipes/opentelemetry-proto/all/test_v1_package/conanfile.py
@@ -3,5 +3,5 @@ import os
 
 class TestPackageV1Conan(ConanFile):
     def test(self):
-        res_folder = self.dependencies["opentelemetry-proto"].conf_info.get("user.myconf:proto_root")
+        res_folder = self.deps_user_info["opentelemetry-proto"].proto_root
         assert os.path.isfile(os.path.join(res_folder, "opentelemetry", "proto", "common", "v1", "common.proto"))


### PR DESCRIPTION
Specify library name and version:  **opentelemetry-proto/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
