### PR TITLE
qt 5.x: several fixes for conan v2

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -341,7 +341,7 @@ class QtConan(ConanFile):
     def requirements(self):
         self.requires("zlib/1.2.13")
         if self.options.openssl:
-            self.requires("openssl/1.1.1t")
+            self.requires("openssl/[>=1.1 <4]")
         if self.options.with_pcre2:
             self.requires("pcre2/10.42")
         if self.options.get_safe("with_vulkan"):
@@ -349,7 +349,7 @@ class QtConan(ConanFile):
             if is_apple_os(self):
                 self.requires("moltenvk/1.2.2")
         if self.options.with_glib:
-            self.requires("glib/2.76.1")
+            self.requires("glib/2.76.2")
         # if self.options.with_libiconv: # QTBUG-84708
         #     self.requires("libiconv/1.16")# QTBUG-84708
         if self.options.with_doubleconversion and not self.options.multiconfiguration:
@@ -359,7 +359,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.14.2")
         if self.options.get_safe("with_icu", False):
-            self.requires("icu/72.1")
+            self.requires("icu/73.1")
         if self.options.get_safe("with_harfbuzz", False) and not self.options.multiconfiguration:
             self.requires("harfbuzz/7.1.0")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
@@ -370,7 +370,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_libpng", False) and not self.options.multiconfiguration:
             self.requires("libpng/1.6.39")
         if self.options.with_sqlite3 and not self.options.multiconfiguration:
-            self.requires("sqlite3/3.41.1")
+            self.requires("sqlite3/3.41.2")
         if self.options.get_safe("with_mysql", False):
             self.requires("libmysqlclient/8.0.31")
         if self.options.with_pq:
@@ -379,7 +379,7 @@ class QtConan(ConanFile):
             if self.settings.os != "Windows":
                 self.requires("odbc/2.3.11")
         if self.options.get_safe("with_openal", False):
-            self.requires("openal/1.22.2")
+            self.requires("openal-soft/1.22.2")
         if self.options.get_safe("with_libalsa", False):
             self.requires("libalsa/1.2.7.2")
         if self.options.get_safe("with_x11", False):
@@ -410,7 +410,7 @@ class QtConan(ConanFile):
         if self.settings.os in ['Linux', 'FreeBSD'] and self.options.with_gssapi:
             self.requires("krb5/1.18.3") # conan-io/conan-center-index#4102
         if self.options.get_safe("with_atspi"):
-            self.requires("at-spi2-core/2.47.1")
+            self.requires("at-spi2-core/2.48.0")
         if self.options.get_safe("with_md4c", False):
             self.requires("md4c/0.4.8")
 
@@ -433,7 +433,7 @@ class QtConan(ConanFile):
             self.tool_requires("jom/1.1.3")
         if self.options.qtwebengine:
             self.tool_requires("ninja/1.11.1")
-            self.tool_requires("nodejs/16.3.0")
+            self.tool_requires("nodejs/18.15.0")
             self.tool_requires("gperf/3.1")
             # gperf, bison, flex, python >= 2.7.5 & < 3
             if self._settings_build.os == "Windows":
@@ -719,7 +719,7 @@ class QtConan(ConanFile):
                   ("libpq", "PSQL"),
                   ("odbc", "ODBC"),
                   ("sdl2", "SDL2"),
-                  ("openal", "OPENAL"),
+                  ("openal-soft", "OPENAL"),
                   ("zstd", "ZSTD"),
                   ("libalsa", "ALSA"),
                   ("xkbcommon", "XKBCOMMON"),
@@ -1334,7 +1334,7 @@ Examples = bin/datadir/examples""")
             if self.options.get_safe("with_libalsa", False):
                 multimedia_reqs.append("libalsa::libalsa")
             if self.options.with_openal:
-                multimedia_reqs.append("openal::openal")
+                multimedia_reqs.append("openal-soft::openal-soft")
             if self.options.get_safe("with_pulseaudio", False):
                 multimedia_reqs.append("pulseaudio::pulse")
             _create_module("Multimedia", multimedia_reqs)

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -414,6 +414,20 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_md4c", False):
             self.requires("md4c/0.4.8")
 
+    def package_id(self):
+        del self.info.options.cross_compile
+        del self.info.options.sysroot
+        if self.info.options.multiconfiguration:
+            if self.info.settings.compiler == "Visual Studio":
+                if "MD" in self.info.settings.compiler.runtime:
+                    self.info.settings.compiler.runtime = "MD/MDd"
+                else:
+                    self.info.settings.compiler.runtime = "MT/MTd"
+            elif self.info.settings.compiler == "msvc":
+                self.info.settings.compiler.runtime_type = "Release/Debug"
+        if self.info.settings.os == "Android":
+            del self.info.options.android_sdk
+
     def build_requirements(self):
         if self._settings_build.os == "Windows" and is_msvc(self):
             self.tool_requires("jom/1.1.3")
@@ -929,20 +943,6 @@ Examples = bin/datadir/examples""")
 
         if self.options.qtdeclarative:
             _create_private_module("Qml", ["CorePrivate", "Qml"])
-
-    def package_id(self):
-        del self.info.options.cross_compile
-        del self.info.options.sysroot
-        if self.info.options.multiconfiguration:
-            if self.info.settings.compiler == "Visual Studio":
-                if "MD" in self.info.settings.compiler.runtime:
-                    self.info.settings.compiler.runtime = "MD/MDd"
-                else:
-                    self.info.settings.compiler.runtime = "MT/MTd"
-            elif self.info.settings.compiler == "msvc":
-                self.info.settings.compiler.runtime_type = "Release/Debug"
-        if self.info.settings.os == "Android":
-            del self.info.options.android_sdk
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Qt5")

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1422,7 +1422,7 @@ Examples = bin/datadir/examples""")
                 self.cpp_info.components["qtNetwork"].system_libs.append("dnsapi")  # qtnetwork from qtbase requires "DnsFree" which is in "Dnsapi.lib" library
                 self.cpp_info.components["qtNetwork"].system_libs.append("iphlpapi")
                 if self.options.widgets:
-                    self.cpp_info.components["qtWidgets"].system_libs.append("UxTheme")
+                    self.cpp_info.components["qtWidgets"].system_libs.append("uxtheme")
                     self.cpp_info.components["qtWidgets"].system_libs.append("dwmapi")
                 if self.options.get_safe("qtwinextras"):
                     self.cpp_info.components["qtWinExtras"].system_libs.append("dwmapi")  # qtwinextras requires "DwmGetColorizationColor" which is in "dwmapi.lib" library

--- a/recipes/qt/5.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/5.x.x/test_package/CMakeLists.txt
@@ -1,23 +1,9 @@
-cmake_minimum_required(VERSION 3.1.0)
-
-set(CMAKE_CXX_STANDARD 11)
-
-project(test_package)
-
-cmake_policy(SET CMP0020 NEW)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_set_vs_runtime()
-conan_set_libcxx()
-conan_output_dirs_setup()
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(Qt5 COMPONENTS Core Network Sql Concurrent Xml REQUIRED CONFIG)
 
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-
-set(SOURCES test_package.cpp greeter.h example.qrc)
-
-add_executable(${PROJECT_NAME} WIN32 ${SOURCES})
-
-target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Network Qt5::Sql Qt5::Concurrent Qt5::Xml)
+add_executable(${PROJECT_NAME} WIN32 test_package.cpp greeter.h example.qrc)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Network Qt5::Sql Qt5::Concurrent Qt5::Xml)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTORCC ON)

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -1,145 +1,58 @@
 import os
-import shutil
+import textwrap
 
 from conan import ConanFile
-from conans import tools, Meson, RunEnvironment, CMake
-from conan.tools.build import cross_building
-from conan.tools.files import save
-from conan.errors import ConanInvalidConfiguration
-
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.env import VirtualRunEnv
+from conan.tools.files import copy, save
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi", "qmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv"
+    test_type = "explicit"
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str, run=can_run(self))
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and self.settings.compiler == "Visual Studio":
-            self.build_requires("jom/1.1.3")
-        if self._meson_supported():
-            self.build_requires("meson/1.0.1")
+        if not can_run(self):
+            self.tool_requires(self.tested_reference_str)
 
     def generate(self):
-        save(self, "qt.conf", """[Paths]
-Prefix = {}
-ArchData = bin/archdatadir
-HostData = bin/archdatadir
-Data = bin/datadir
-Sysconf = bin/sysconfdir
-LibraryExecutables = bin/archdatadir/bin
-Plugins = bin/archdatadir/plugins
-Imports = bin/archdatadir/imports
-Qml2Imports = bin/archdatadir/qml
-Translations = bin/datadir/translations
-Documentation = bin/datadir/doc
-Examples = bin/datadir/examples""".format(self.dependencies["qt"].package_folder.replace('\\', '/')))
+        qt_install_prefix = self.dependencies["qt"].package_folder.replace("\\", "/")
+        qt_conf = textwrap.dedent(f"""\
+            [Paths]
+            Prefix = {qt_install_prefix}
+            ArchData = bin/archdatadir
+            HostData = bin/archdatadir
+            Data = bin/datadir
+            Sysconf = bin/sysconfdir
+            LibraryExecutables = bin/archdatadir/bin
+            Plugins = bin/archdatadir/plugins
+            Imports = bin/archdatadir/imports
+            Qml2Imports = bin/archdatadir/qml
+            Translations = bin/datadir/translations
+            Documentation = bin/datadir/doc
+            Examples = bin/datadir/examples
+        """)
+        save(self, "qt.conf", qt_conf)
 
-    def _is_mingw(self):
-        return self.settings.os == "Windows" and self.settings.compiler == "gcc"
-
-    def _meson_supported(self):
-        return self.options["qt"].shared and\
-            not cross_building(self) and\
-            not tools.os_info.is_macos and\
-            not self._is_mingw()
-
-    def _qmake_supported(self):
-        return self.options["qt"].shared
-
-    def _build_with_qmake(self):
-        if not self._qmake_supported():
-            return
-        tools.mkdir("qmake_folder")
-        with tools.chdir("qmake_folder"):
-            self.output.info("Building with qmake")
-
-            with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
-                args = [self.source_folder, "DESTDIR=bin"]
-
-                def _getenvpath(var):
-                    val = os.getenv(var)
-                    if val and tools.os_info.is_windows:
-                        val = val.replace("\\", "/")
-                        os.environ[var] = val
-                    return val
-
-                value = _getenvpath("CC")
-                if value:
-                    args += ['QMAKE_CC="' + value + '"',
-                             'QMAKE_LINK_C="' + value + '"',
-                             'QMAKE_LINK_C_SHLIB="' + value + '"']
-
-                value = _getenvpath('CXX')
-                if value:
-                    args += ['QMAKE_CXX="' + value + '"',
-                             'QMAKE_LINK="' + value + '"',
-                             'QMAKE_LINK_SHLIB="' + value + '"']
-
-                self.run("qmake %s" % " ".join(args), run_environment=True)
-                if tools.os_info.is_windows:
-                    if self.settings.compiler == "Visual Studio":
-                        self.run("jom", run_environment=True)
-                    else:
-                        self.run("mingw32-make", run_environment=True)
-                else:
-                    self.run("make", run_environment=True)
-
-    def _build_with_meson(self):
-        if self._meson_supported():
-            self.output.info("Building with Meson")
-            tools.mkdir("meson_folder")
-            with tools.environment_append(RunEnvironment(self).vars):
-                meson = Meson(self)
-                try:
-                    meson.configure(build_folder="meson_folder", defs={"cpp_std": "c++11"})
-                except ConanInvalidConfiguration:
-                    self.output.info(open("meson_folder/meson-logs/meson-log.txt", 'r').read())
-                    raise
-                meson.build()
-
-    def _build_with_cmake_find_package_multi(self):
-        self.output.info("Building with cmake_find_package_multi")
-        env_build = RunEnvironment(self)
-        with tools.environment_append(env_build.vars):
-            cmake = CMake(self, set_cmake_flags=True)
-            if self.settings.os == "Macos":
-                cmake.definitions['CMAKE_OSX_DEPLOYMENT_TARGET'] = '10.14'
-
-            cmake.configure()
-            cmake.build()
+        VirtualRunEnv(self).generate()
+        if can_run(self):
+            VirtualRunEnv(self).generate(scope="build")
 
     def build(self):
-        self._build_with_qmake()
-        self._build_with_meson()
-        self._build_with_cmake_find_package_multi()
-
-    def _test_with_qmake(self):
-        if not self._qmake_supported():
-            return
-        self.output.info("Testing qmake")
-        bin_path = os.path.join("qmake_folder", "bin")
-        if tools.os_info.is_macos:
-            bin_path = os.path.join(bin_path, "test_package.app", "Contents", "MacOS")
-        shutil.copy(os.path.join(self.generators_folder, "qt.conf"), bin_path)
-        self.run(os.path.join(bin_path, "test_package"), run_environment=True)
-
-    def _test_with_meson(self):
-        if self._meson_supported():
-            self.output.info("Testing Meson")
-            shutil.copy(os.path.join(self.generators_folder, "qt.conf"), "meson_folder")
-            self.run(os.path.join("meson_folder", "test_package"), run_environment=True)
-
-    def _test_with_cmake_find_package_multi(self):
-        self.output.info("Testing CMake_find_package_multi")
-        shutil.copy(os.path.join(self.generators_folder, "qt.conf"), "bin")
-        self.run(os.path.join("bin", "test_package"), run_environment=True)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
-        if not cross_building(self, skip_x64_x86=True):
-            self._test_with_qmake()
-            self._test_with_meson()
-            self._test_with_cmake_find_package_multi()
+        if can_run(self):
+            copy(self, "qt.conf", src=self.generators_folder, dst=os.path.join(self.cpp.build.bindirs[0]))
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/qt/5.x.x/test_package/meson.build
+++ b/recipes/qt/5.x.x/test_package/meson.build
@@ -1,6 +1,0 @@
-project('test_package', 'cpp')
-qt5 = import('qt5')
-qt5_dep = dependency('qt5', modules: ['Core', 'Network', 'Sql', 'Concurrent', 'Xml'])
-moc_files = qt5.preprocess(moc_headers : 'greeter.h', qresources : 'example.qrc')
-executable('test_package', 'test_package.cpp', moc_files,
-           dependencies : qt5_dep)

--- a/recipes/qt/5.x.x/test_v1_package/CMakeLists.txt
+++ b/recipes/qt/5.x.x/test_v1_package/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+set(CMAKE_CXX_STANDARD 11)
+
+project(test_package)
+
+cmake_policy(SET CMP0020 NEW)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_set_vs_runtime()
+conan_set_libcxx()
+conan_output_dirs_setup()
+
+find_package(Qt5 COMPONENTS Core Network Sql Concurrent Xml REQUIRED CONFIG)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(SOURCES ../test_package/test_package.cpp ../test_package/greeter.h ../test_package/example.qrc)
+
+add_executable(${PROJECT_NAME} WIN32 ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Network Qt5::Sql Qt5::Concurrent Qt5::Xml)

--- a/recipes/qt/5.x.x/test_v1_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_v1_package/conanfile.py
@@ -1,0 +1,145 @@
+import os
+import shutil
+
+from conan import ConanFile
+from conans import tools, Meson, RunEnvironment, CMake
+from conan.tools.build import cross_building
+from conan.tools.files import save
+from conan.errors import ConanInvalidConfiguration
+
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi", "qmake"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def build_requirements(self):
+        if self._settings_build.os == "Windows" and self.settings.compiler == "Visual Studio":
+            self.build_requires("jom/1.1.3")
+        if self._meson_supported():
+            self.build_requires("meson/1.1.0")
+
+    def generate(self):
+        save(self, "qt.conf", """[Paths]
+Prefix = {}
+ArchData = bin/archdatadir
+HostData = bin/archdatadir
+Data = bin/datadir
+Sysconf = bin/sysconfdir
+LibraryExecutables = bin/archdatadir/bin
+Plugins = bin/archdatadir/plugins
+Imports = bin/archdatadir/imports
+Qml2Imports = bin/archdatadir/qml
+Translations = bin/datadir/translations
+Documentation = bin/datadir/doc
+Examples = bin/datadir/examples""".format(self.dependencies["qt"].package_folder.replace('\\', '/')))
+
+    def _is_mingw(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "gcc"
+
+    def _meson_supported(self):
+        return self.options["qt"].shared and\
+            not cross_building(self) and\
+            not tools.os_info.is_macos and\
+            not self._is_mingw()
+
+    def _qmake_supported(self):
+        return self.options["qt"].shared
+
+    def _build_with_qmake(self):
+        if not self._qmake_supported():
+            return
+        tools.mkdir("qmake_folder")
+        with tools.chdir("qmake_folder"):
+            self.output.info("Building with qmake")
+
+            with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
+                args = [self.source_folder, "DESTDIR=bin"]
+
+                def _getenvpath(var):
+                    val = os.getenv(var)
+                    if val and tools.os_info.is_windows:
+                        val = val.replace("\\", "/")
+                        os.environ[var] = val
+                    return val
+
+                value = _getenvpath("CC")
+                if value:
+                    args += ['QMAKE_CC="' + value + '"',
+                             'QMAKE_LINK_C="' + value + '"',
+                             'QMAKE_LINK_C_SHLIB="' + value + '"']
+
+                value = _getenvpath('CXX')
+                if value:
+                    args += ['QMAKE_CXX="' + value + '"',
+                             'QMAKE_LINK="' + value + '"',
+                             'QMAKE_LINK_SHLIB="' + value + '"']
+
+                self.run("qmake %s" % " ".join(args), run_environment=True)
+                if tools.os_info.is_windows:
+                    if self.settings.compiler == "Visual Studio":
+                        self.run("jom", run_environment=True)
+                    else:
+                        self.run("mingw32-make", run_environment=True)
+                else:
+                    self.run("make", run_environment=True)
+
+    def _build_with_meson(self):
+        if self._meson_supported():
+            self.output.info("Building with Meson")
+            tools.mkdir("meson_folder")
+            with tools.environment_append(RunEnvironment(self).vars):
+                meson = Meson(self)
+                try:
+                    meson.configure(build_folder="meson_folder", defs={"cpp_std": "c++11"})
+                except ConanInvalidConfiguration:
+                    self.output.info(open("meson_folder/meson-logs/meson-log.txt", 'r').read())
+                    raise
+                meson.build()
+
+    def _build_with_cmake_find_package_multi(self):
+        self.output.info("Building with cmake_find_package_multi")
+        env_build = RunEnvironment(self)
+        with tools.environment_append(env_build.vars):
+            cmake = CMake(self, set_cmake_flags=True)
+            if self.settings.os == "Macos":
+                cmake.definitions['CMAKE_OSX_DEPLOYMENT_TARGET'] = '10.14'
+
+            cmake.configure()
+            cmake.build()
+
+    def build(self):
+        self._build_with_qmake()
+        self._build_with_meson()
+        self._build_with_cmake_find_package_multi()
+
+    def _test_with_qmake(self):
+        if not self._qmake_supported():
+            return
+        self.output.info("Testing qmake")
+        bin_path = os.path.join("qmake_folder", "bin")
+        if tools.os_info.is_macos:
+            bin_path = os.path.join(bin_path, "test_package.app", "Contents", "MacOS")
+        shutil.copy(os.path.join(self.generators_folder, "qt.conf"), bin_path)
+        self.run(os.path.join(bin_path, "test_package"), run_environment=True)
+
+    def _test_with_meson(self):
+        if self._meson_supported():
+            self.output.info("Testing Meson")
+            shutil.copy(os.path.join(self.generators_folder, "qt.conf"), "meson_folder")
+            self.run(os.path.join("meson_folder", "test_package"), run_environment=True)
+
+    def _test_with_cmake_find_package_multi(self):
+        self.output.info("Testing CMake_find_package_multi")
+        shutil.copy(os.path.join(self.generators_folder, "qt.conf"), "bin")
+        self.run(os.path.join("bin", "test_package"), run_environment=True)
+
+    def test(self):
+        if not cross_building(self, skip_x64_x86=True):
+            self._test_with_qmake()
+            self._test_with_meson()
+            self._test_with_cmake_find_package_multi()

--- a/recipes/qt/5.x.x/test_v1_package/meson.build
+++ b/recipes/qt/5.x.x/test_v1_package/meson.build
@@ -1,0 +1,6 @@
+project('test_package', 'cpp')
+qt5 = import('qt5')
+qt5_dep = dependency('qt5', modules: ['Core', 'Network', 'Sql', 'Concurrent', 'Xml'])
+moc_files = qt5.preprocess(moc_headers : '../test_package/greeter.h', qresources : '../test_package/example.qrc')
+executable('test_package', '../test_package/test_package.cpp', moc_files,
+           dependencies : qt5_dep)

--- a/recipes/qt/5.x.x/test_v1_package/test_package.pro
+++ b/recipes/qt/5.x.x/test_v1_package/test_package.pro
@@ -1,8 +1,8 @@
-SOURCES += test_package.cpp
+SOURCES += ../test_package/test_package.cpp
 
-HEADERS += greeter.h
+HEADERS += ../test_package/greeter.h
 
-RESOURCES = example.qrc
+RESOURCES = ../test_package/example.qrc
 
 QT -= gui
 QT += network sql concurrent xml


### PR DESCRIPTION
- inject `VirtualRunEnv` in `build` scope (in case of native build) since path to shared libs of several requirements must be visible when executables built during qt build process are executed (because these executables link to some requirements).
- Also fix `DYLD_LIBRARY_PATH` workaround on macOS, it was broken (it's the same usage than previous point, but as usual SIP defeats everything, leading to this workaround).
- as a consequence, also remove some build requirements erroneously added by https://github.com/conan-io/conan-center-index/pull/16404 (see https://github.com/conan-io/conan-center-index/pull/16404#discussion_r1148160492). They are requirements actually, but their shared libs must be visible in PATH/LD_LIBRARY_PATH/DYLD_LIBRARY_PATH during build process as described in previous point.
- don't rely on `is_msvc()` in `package_id()` method, it's forbidden in conan v2.
- lowecase system libs if Windows (`uxtheme` instead of `UxTheme`)
- use modern generators & helpers in test package, and add test_v1_package
- use version range for openssl
- bump several dependencies
- prefer `openal-soft` in requirements over deprecated `openal` recipe

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
