### PR TITLE
[doxygen] Model libstdc++ compatibility

### DIFF
--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -60,11 +60,15 @@ class DoxygenConan(ConanFile):
         self.info.requires.full_version_mode()
 
     def compatibility(self):
-        # This will only work when host profile == build profile
-        # For some reason self.settings.compiler here returns the compiler from the build profile
-        compatible_versions = [{"settings": [("compiler.version", v), ("build_type", "Release")]}
-            for v in self.settings.compiler.version.get_definition() if v <= Version(self.settings.compiler.version)]
-        return compatible_versions
+        if (Version(conan_version).major >= 2):
+            # This will only work when host profile == build profile
+            # For some reason self.settings.compiler here returns the compiler from the build profile
+            # Models libc++ compatibility and identifies Debug builds as equivalent to Release builds
+            compatible_versions = [{"settings": [("compiler.version", v), ("build_type", "Release")]}
+                for v in self.settings.compiler.version.get_definition() if v <= Version(self.settings.compiler.version)]
+            return compatible_versions
+        # Models Debug builds as equivalent to Release builds as this is a tool_requires package
+        return [{"settings": [("build_type", "Release")]}]
 
     def validate(self):
         minimum_compiler_version = self._minimum_compiler_version.get(str(self.settings.compiler))

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -45,12 +45,6 @@ class DoxygenConan(ConanFile):
             "msvc": "191",
         }
 
-    @property
-    def _conan_home(self):
-        conan_home_env = "CONAN_USER_HOME" if Version(conan_version).major < 2 else "CONAN_HOME"
-        conan_home_dir = ".conan" if Version(conan_version).major < 2 else ".conan2"
-        return os.environ.get(conan_home_env, pathlib.Path(pathlib.Path.home(), conan_home_dir))
-
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -66,13 +60,10 @@ class DoxygenConan(ConanFile):
         self.info.requires.full_version_mode()
 
     def compatibility(self):
-        # is there a better way of reading all possible versions from settings.yml?
-        settings_yml_path = pathlib.Path(self._conan_home, "settings.yml")
-        with open(settings_yml_path, "r") as f:
-            settings_yml = yaml.safe_load(f)
-
+        # This will only work when host profile == build profile
+        # For some reason self.settings.compiler here returns the compiler from the build profile
         compatible_versions = [{"settings": [("compiler.version", v), ("build_type", "Release")]}
-            for v in settings_yml["compiler"][str(self.settings.compiler)]["version"] if v <= Version(self.settings.compiler.version)]
+            for v in self.settings.compiler.version.get_definition() if v <= Version(self.settings.compiler.version)]
         return compatible_versions
 
     def validate(self):


### PR DESCRIPTION
* Add model of libstdc++ compatibility to ensure that binaries can not be used with older version of libstdc++ than what it was compiled for.
* Remove deletion of self.info.settings.compiler because this _is_ relevant metadata for executables, as it inserts a dependency on a libstdc++ version at least what it was compiled with.
* Modify the dependency version impact on package id to use full_version_mode. This ensures that the dependency package id's don't impact doxygen's package id - only version changes in dependencies will impact doxygen's package id. This is necessary to allow doxygen built with gcc 10 to be identified as compatible with a gcc 12 profile. Without this, compiler.version=12 propagates through the dependency tree and the package id of the doxygen package built with gcc 10 does not match appropriately and is not resolved as compatible.

Relates to #17034

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
