### PR TITLE
libmysqlclient: stop it from dictating which compiler to use

### DIFF
--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -208,6 +208,7 @@ class LibMysqlClientCConan(ConanFile):
         tc.cache_variables["ENABLED_PROFILING"] = False
         tc.cache_variables["MYSQL_MAINTAINER_MODE"] = False
         tc.cache_variables["WIX_DIR"] = False
+        tc.cache_variables["FORCE_UNSUPPORTED_COMPILER"] = True
 
         tc.cache_variables["WITH_LZ4"] = "system"
 

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -208,6 +208,9 @@ class LibMysqlClientCConan(ConanFile):
         tc.cache_variables["ENABLED_PROFILING"] = False
         tc.cache_variables["MYSQL_MAINTAINER_MODE"] = False
         tc.cache_variables["WIX_DIR"] = False
+        # Disable additional Linux distro-specific compiler checks. 
+        # The recipe already checks for minimum versions of supported
+        # compilers.
         tc.cache_variables["FORCE_UNSUPPORTED_COMPILER"] = True
 
         tc.cache_variables["WITH_LZ4"] = "system"


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient/\***

On Linux `FORCE_UNSUPPORTED_COMPILER` is disabled by default and libmysqlclient is trying to guess what compiler to use depending on distribution. I use CentOS 7 with built from source gcc 10 and I get this error when building libmysqlclient:
```
-- Running cmake version 3.25.2
-- Found Git: /usr/bin/git (found version "2.36.5")
-- This is .el7. as found from 'rpm -qf /'
-- Looking for a devtoolset compiler
CMake Warning at CMakeLists.txt:392 (MESSAGE):
  Could not find devtoolset compiler/linker in /opt/rh/devtoolset-11


CMake Warning at CMakeLists.txt:394 (MESSAGE):
  You need to install the required packages:

   yum install devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-binutils



CMake Error at CMakeLists.txt:396 (MESSAGE):
  Or you can set CMAKE_C_COMPILER and CMAKE_CXX_COMPILER explicitly.
```

I definetly do not want to use gcc 11 and do not want to install devtoolset. PR enables `FORCE_UNSUPPORTED_COMPILER` option. This prevents libmysqlclient's CMakeLists from guessing the compiler. This also disables unsupported compilers checks but this is handled by conan package.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
