### PR TITLE
xmlsec: fix url of tarballs + bump dependencies

### DIFF
--- a/recipes/xmlsec/all/conandata.yml
+++ b/recipes/xmlsec/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
   "1.2.32":
-    url: "http://www.aleksey.com/xmlsec/download/xmlsec1-1.2.32.tar.gz"
+    url: "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.32.tar.gz"
     sha256: "e383702853236004e5b08e424b8afe9b53fe9f31aaa7a5382f39d9533eb7c043"
   "1.2.31":
-    url: "http://www.aleksey.com/xmlsec/download/xmlsec1-1.2.31.tar.gz"
+    url: "http://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.31.tar.gz"
     sha256: "9b10bc52cc31e4f76162e3975e50db26b71ab49c571d810b311ca626be5a0b26"
   "1.2.30":
-    url: "http://www.aleksey.com/xmlsec/download/xmlsec1-1.2.30.tar.gz"
+    url: "http://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.30.tar.gz"
     sha256: "2d84360b03042178def1d9ff538acacaed2b3a27411db7b2874f1612ed71abc8"

--- a/recipes/xmlsec/all/conandata.yml
+++ b/recipes/xmlsec/all/conandata.yml
@@ -3,8 +3,8 @@ sources:
     url: "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.32.tar.gz"
     sha256: "e383702853236004e5b08e424b8afe9b53fe9f31aaa7a5382f39d9533eb7c043"
   "1.2.31":
-    url: "http://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.31.tar.gz"
+    url: "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.31.tar.gz"
     sha256: "9b10bc52cc31e4f76162e3975e50db26b71ab49c571d810b311ca626be5a0b26"
   "1.2.30":
-    url: "http://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.30.tar.gz"
+    url: "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.30.tar.gz"
     sha256: "2d84360b03042178def1d9ff538acacaed2b3a27411db7b2874f1612ed71abc8"

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -60,9 +60,9 @@ class XmlSecConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libxml2/2.10.3")
+        self.requires("libxml2/2.10.4")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/3.1.0")
         if self.options.with_xslt:
             self.requires("libxslt/1.1.34")
 
@@ -140,7 +140,15 @@ class XmlSecConan(ConanFile):
             crypto_engines = []
             if self.options.with_openssl:
                 ov = Version(self.dependencies["openssl"].ref.version)
-                crypto_engines.append(f"openssl={ov.major}{ov.minor}0")
+                if ov.major >= "3":
+                    if Version(self.version) < "1.2.35":
+                        # configure.js doesn't understand openssl=300 before xmlsec 1.2.35,
+                        # For these xmlsec versions, setting 110 even for OpenSSL 3.x should be compatible
+                        crypto_engines.append("openssl=110")
+                    else:
+                        crypto_engines.append("openssl=300")
+                else:
+                    crypto_engines.append(f"openssl={ov.major}{ov.minor}0")
 
             yes_no = lambda v: "yes" if v else "no"
             args = [

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -62,7 +62,7 @@ class XmlSecConan(ConanFile):
     def requirements(self):
         self.requires("libxml2/2.10.4", transitive_headers=True)
         if self.options.with_openssl:
-            self.requires("openssl/3.1.0", transitive_headers=True)
+            self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
         if self.options.with_xslt:
             self.requires("libxslt/1.1.34")
 

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -60,7 +60,7 @@ class XmlSecConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libxml2/2.10.4")
+        self.requires("libxml2/2.10.4", transitive_headers=True)
         if self.options.with_openssl:
             self.requires("openssl/3.1.0")
         if self.options.with_xslt:

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -62,7 +62,7 @@ class XmlSecConan(ConanFile):
     def requirements(self):
         self.requires("libxml2/2.10.4", transitive_headers=True)
         if self.options.with_openssl:
-            self.requires("openssl/3.1.0")
+            self.requires("openssl/3.1.0", transitive_headers=True)
         if self.options.with_xslt:
             self.requires("libxslt/1.1.34")
 

--- a/recipes/xmlsec/all/test_package/CMakeLists.txt
+++ b/recipes/xmlsec/all/test_package/CMakeLists.txt
@@ -8,4 +8,7 @@ if(XMLSEC_WITH_XSLT)
 endif()
 
 add_executable(${PROJECT_NAME} sign1.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE LibXml2::LibXml2 LibXslt::LibXslt xmlsec::xmlsec)
+target_link_libraries(${PROJECT_NAME} PRIVATE LibXml2::LibXml2 xmlsec::xmlsec)
+if(XMLSEC_WITH_XSLT)
+    target_link_libraries(${PROJECT_NAME} PRIVATE LibXslt::LibXslt)
+endif()

--- a/recipes/xmlsec/all/test_package/CMakeLists.txt
+++ b/recipes/xmlsec/all/test_package/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
 find_package(xmlsec REQUIRED CONFIG)
+find_package(LibXml2 REQUIRED MODULE)
+if(XMLSEC_WITH_XSLT)
+    find_package(LibXslt REQUIRED MODULE)
+endif()
 
 add_executable(${PROJECT_NAME} sign1.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE xmlsec::xmlsec)
+target_link_libraries(${PROJECT_NAME} PRIVATE LibXml2::LibXml2 LibXslt::LibXslt xmlsec::xmlsec)

--- a/recipes/xmlsec/all/test_package/conanfile.py
+++ b/recipes/xmlsec/all/test_package/conanfile.py
@@ -14,6 +14,7 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+        self.requires("libxml2/2.10.4")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/xmlsec/all/test_package/conanfile.py
+++ b/recipes/xmlsec/all/test_package/conanfile.py
@@ -14,6 +14,7 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+        self.requires("libxml2/2.10.4")
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/xmlsec/all/test_package/conanfile.py
+++ b/recipes/xmlsec/all/test_package/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
@@ -14,7 +14,11 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        self.requires("libxml2/2.10.4")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["XMLSEC_WITH_XSLT"] = self.dependencies["xmlsec"].options.with_xslt
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/xmlsec/all/test_v1_package/conanfile.py
+++ b/recipes/xmlsec/all/test_v1_package/conanfile.py
@@ -4,10 +4,11 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["XMLSEC_WITH_XSLT"] = self.options["xmlsec"].with_xslt
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
- tarballs of versions < 1.2.33 have been removed from https://www.aleksey.com/xmlsec/download/ and only live under https://www.aleksey.com/xmlsec/download/older-releases/
- bump some dependencies, and specially openssl from 1.1.x to 3.x.x

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
