### PR TITLE
kmod: add package_type + bump dependencies

### DIFF
--- a/recipes/kmod/all/conanfile.py
+++ b/recipes/kmod/all/conanfile.py
@@ -17,6 +17,7 @@ class KModConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/kmod-project/kmod"
     license = "LGPL-2.1-only"
+    package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],

--- a/recipes/kmod/all/conanfile.py
+++ b/recipes/kmod/all/conanfile.py
@@ -46,13 +46,13 @@ class KModConan(ConanFile):
 
     def requirements(self):
         if self.options.with_zstd:
-            self.requires("zstd/1.5.4")
+            self.requires("zstd/1.5.5")
         if self.options.with_xz:
-            self.requires("xz_utils/5.4.0")
+            self.requires("xz_utils/5.4.2")
         if self.options.with_zlib:
             self.requires("zlib/1.2.13")
         if self.options.with_openssl:
-            self.requires("openssl/3.0.7")
+            self.requires("openssl/3.1.0")
 
     def validate(self):
         if self.settings.os != "Linux":

--- a/recipes/kmod/all/conanfile.py
+++ b/recipes/kmod/all/conanfile.py
@@ -20,7 +20,6 @@ class KModConan(ConanFile):
     package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
-        "fPIC": [True, False],
         "with_zstd": [True, False],
         "with_xz": [True, False],
         "with_zlib": [True, False],
@@ -29,7 +28,6 @@ class KModConan(ConanFile):
         "logging": [True, False],
     }
     default_options = {
-        "fPIC": True,
         "with_zstd": True,
         "with_xz": True,
         "with_zlib": True,


### PR DESCRIPTION
Since kmod is always a shared lib, fPIC option is removed.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
