### PR TITLE
[config] Add regression message for Conan v2 builds

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -36,7 +36,7 @@ tasks:
     update_labels: false
     user_feedback:
       title: "Conan v2 pipeline"
-      description: "> **Note**: Conan v2 builds are informative and they are not required for the PR to be merged."
+      description: "> **Note**: Conan v2 builds may be required once they are on the [v2 ready](https://github.com/conan-io/conan-center-index/blob/master/.c3i/conan_v2_ready_references.yml) list"
       regression: "> **Regression**: Conan v2 builds are mandatory and they are required for the PR to be merged, because this recipe worked with Conan v2 previously."
       text_on_failure: "The v2 pipeline failed. Please, review the errors and note this will be required for pull requests to be merged in the near future."
       collapse_on_success: false

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -37,6 +37,7 @@ tasks:
     user_feedback:
       title: "Conan v2 pipeline (informative, not required for merge)"
       description: "> **Note**: Conan v2 builds are informative and they are not required for the PR to be merged."
+      regression: "> **Regression**: Conan v2 builds are mandatory and they are required for the PR to be merged, because this recipe worked with Conan v2 previously."
       text_on_failure: "The v2 pipeline failed. Please, review the errors and note this will be required for pull requests to be merged in the near future."
       collapse_on_success: false
       collapse_on_failure: true

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -35,7 +35,7 @@ tasks:
     write_comments: false
     update_labels: false
     user_feedback:
-      title: "Conan v2 pipeline (informative, not required for merge)"
+      title: "Conan v2 pipeline"
       description: "> **Note**: Conan v2 builds are informative and they are not required for the PR to be merged."
       regression: "> **Regression**: Conan v2 builds are mandatory and they are required for the PR to be merged, because this recipe worked with Conan v2 previously."
       text_on_failure: "The v2 pipeline failed. Please, review the errors and note this will be required for pull requests to be merged in the near future."


### PR DESCRIPTION
When a package which is listed in https://github.com/conan-io/conan-center-index/blob/master/.c3i/conan_v2_ready_references.yml fails to build on a new PR, it will be considered a regression error, which means, for that specific package, Conan v2 will be mandatory.

However, the current information on the PR, informs that Conan v2 is only informative and is not mandatory, creating a misinformation.

We are preparing a new feature which will update the message according the situation, so users will not be confused by the build result message.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
