### PR TITLE
mailio: add package_type + bump openssl & cmake + few improvements

### DIFF
--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -58,7 +58,7 @@ class MailioConan(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.81.0", transitive_headers=True)
-        self.requires("openssl/3.1.0")
+        self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
@@ -71,8 +71,7 @@ class MailioConan(ConanFile):
             )
 
     def build_requirements(self):
-        # mailio requires cmake >= 3.16.3
-        self.tool_requires("cmake/3.25.3")
+        self.tool_requires("cmake/[>3.16.3 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -71,7 +71,7 @@ class MailioConan(ConanFile):
             )
 
     def build_requirements(self):
-        self.tool_requires("cmake/[^3.16.3]")
+        self.tool_requires("cmake/[>3.16.3 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -57,7 +57,7 @@ class MailioConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.81.0")
+        self.requires("boost/1.81.0", transitive_headers=True)
         self.requires("openssl/3.1.0")
 
     def validate(self):

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -71,7 +71,7 @@ class MailioConan(ConanFile):
             )
 
     def build_requirements(self):
-        self.tool_requires("cmake/[^3.16.3]")
+        self.tool_requires("cmake/[>=3.16.3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -1,39 +1,39 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
 
-class mailioConan(ConanFile):
+class MailioConan(ConanFile):
     name = "mailio"
     description = "mailio is a cross platform C++ library for MIME format and SMTP, POP3 and IMAP protocols."
     license = "BSD-2-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/karastojko/mailio"
     topics = ("smtp", "imap", "email", "mail", "libraries", "cpp")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
-        "shared": [True, False]
+        "shared": [True, False],
     }
     default_options = {
         "fPIC": True,
-        "shared": False
+        "shared": False,
     }
     short_paths = True
 
     @property
     def _min_cppstd(self):
-        return 17
+        return "17"
 
     @property
-    def _compiler_required_cpp(self):
+    def _compilers_minimum_version(self):
         return {
             "gcc": "8.3",
             "clang": "6",
@@ -63,29 +63,32 @@ class mailioConan(ConanFile):
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-        try:
-            minimum_required_compiler_version = self._compiler_required_cpp[str(self.settings.compiler)]
-            if Version(self.settings.compiler.version) < minimum_required_compiler_version:
-                raise ConanInvalidConfiguration(f"{self.ref} requires c++{self._min_cppstd} support. The current compiler does not support it.")
-        except KeyError:
-            self.output.warn(f"{self.ref} has no support for the current compiler. Please consider adding it.")
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def build_requirements(self):
         # mailio requires cmake >= 3.16.3
-        self.tool_requires("cmake/3.25.0")
+        self.tool_requires("cmake/3.25.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
         tc = CMakeToolchain(self)
         tc.variables["MAILIO_BUILD_SHARED_LIBRARY"] = self.options.shared
         tc.variables["MAILIO_BUILD_DOCUMENTATION"] = False
         tc.variables["MAILIO_BUILD_EXAMPLES"] = False
         tc.generate()
 
-        dpes = CMakeDeps(self)
-        dpes.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -71,7 +71,7 @@ class MailioConan(ConanFile):
             )
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.16.3]")
+        self.tool_requires("cmake/[>=3.16.3 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -71,7 +71,7 @@ class MailioConan(ConanFile):
             )
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>3.16.3 <4]")
+        self.tool_requires("cmake/[^3.16.3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/mailio/all/conanfile.py
+++ b/recipes/mailio/all/conanfile.py
@@ -33,7 +33,7 @@ class mailioConan(ConanFile):
         return 17
 
     @property
-    def _compiler_required_cpp(self): 
+    def _compiler_required_cpp(self):
         return {
             "gcc": "8.3",
             "clang": "6",
@@ -58,7 +58,7 @@ class mailioConan(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.81.0")
-        self.requires("openssl/1.1.1s")
+        self.requires("openssl/3.1.0")
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):

--- a/recipes/mailio/all/test_package/conanfile.py
+++ b/recipes/mailio/all/test_package/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"


### PR DESCRIPTION
- bump openssl
- bump cmake
- call VirtualBuildEnv since there is a build requirement
- don't use self.output.warn, it's not compatible with conan v2
- cleanup unused imports
- add package_type

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
