### PR TITLE
uni-algo: fix broken logic in validate() + cleanup dead code

### DIFF
--- a/recipes/uni-algo/all/conanfile.py
+++ b/recipes/uni-algo/all/conanfile.py
@@ -83,9 +83,10 @@ class UniAlgoConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        tc = CMakeToolchain(self)
-        tc.variables["UNI_ALGO_HEADER_ONLY"] = self.options.header_only
-        tc.generate()
+        if not self.options.header_only:
+            tc = CMakeToolchain(self)
+            tc.variables["UNI_ALGO_HEADER_ONLY"] = self.options.header_only
+            tc.generate()
 
     def build(self):
         if not self.options.header_only:

--- a/recipes/uni-algo/all/conanfile.py
+++ b/recipes/uni-algo/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import export_conandata_patches, get, copy, rmdir
+from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
@@ -44,9 +44,6 @@ class UniAlgoConan(ConanFile):
             "clang": "8",
             "apple-clang": "11",
         }
-
-    def export_sources(self):
-        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/uni-algo/all/conanfile.py
+++ b/recipes/uni-algo/all/conanfile.py
@@ -125,11 +125,5 @@ class UniAlgoConan(ConanFile):
             self.cpp_info.system_libs.append("m")
 
         # see https://github.com/uni-algo/uni-algo/blob/v0.7.1/CMakeLists.txt#L75-L109
-        self.cpp_info.set_property("cmake_file_name", f"{self.name}")
-        self.cpp_info.set_property("cmake_target_name", f"{self.name}::{self.name}")
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = f"{self.name}"
-        self.cpp_info.filenames["cmake_find_package_multi"] = f"{self.name}"
-        self.cpp_info.names["cmake_find_package"] = f"{self.name}"
-        self.cpp_info.names["cmake_find_package_multi"] = f"{self.name}"
+        self.cpp_info.set_property("cmake_file_name", "uni-algo")
+        self.cpp_info.set_property("cmake_target_name", "uni-algo::uni-algo")


### PR DESCRIPTION
- fix logic in `validate()`:
  - it was broken for legacy compiler=Visual Studio because it was testing version of this flavor against version of compiler=msvc flavor...
  - check compiler.cppstd if set
  - consistent min versions between legacy Visual Studio & new msvc
- remove dead code (export_conandata_patches useless here)
- no need to call CMakeToolchain in case of header-only
- simplify definition of cmake_file_name & cmake_target_name. Relying on self.name to explicitly define these properties is not only unnecessarily confusing, but also not future proof in case of recipe renaming. Rule of thumb: never rely on `self.name` to set libs intrinsic values. It's fine for stuff like ConanInvalidConfiguration or creating a custom file because they are related to recipe, not lib underlying logic.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
