### PR TITLE
ffmpeg: Add av1 support

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -71,6 +71,9 @@ class FFMpegConan(ConanFile):
         "with_audiotoolbox": [True, False],
         "with_videotoolbox": [True, False],
         "with_programs": [True, False],
+        "with_libsvtav1": [True, False],
+        "with_libaom": [True, False],
+        "with_libdav1d": [True, False],
         "disable_everything": [True, False],
         "disable_all_encoders": [True, False],
         "disable_encoders": [None, "ANY"],
@@ -148,6 +151,9 @@ class FFMpegConan(ConanFile):
         "with_audiotoolbox": True,
         "with_videotoolbox": True,
         "with_programs": True,
+        "with_libsvtav1": False,
+        "with_libaom": False,
+        "with_libdav1d": False,
         "disable_everything": False,
         "disable_all_encoders": False,
         "disable_encoders": None,
@@ -216,6 +222,9 @@ class FFMpegConan(ConanFile):
             "with_xcb": ["avdevice"],
             "with_pulse": ["avdevice"],
             "with_sdl": ["with_programs"],
+            "with_libsvtav1": ["avcodec"],
+            "with_libaom": ["avcodec"],
+            "with_libdav1d": ["avcodec"],
         }
 
     @property
@@ -302,6 +311,13 @@ class FFMpegConan(ConanFile):
             self.requires("vaapi/system")
         if self.options.get_safe("with_vdpau"):
             self.requires("vdpau/system")
+        if self.options.with_libsvtav1:
+            self.requires(f"libsvtav1/1.4.1")
+        if self.options.with_libaom:
+            self.requires("libaom-av1/3.6.0")
+        if self.options.with_libdav1d:
+            self.requires(f"dav1d/1.1.0")
+
         if self._version_supports_vulkan and self.options.get_safe("with_vulkan"):
             self.requires("vulkan-loader/1.3.239.0")
 
@@ -444,6 +460,9 @@ class FFMpegConan(ConanFile):
                 "libpulse", self.options.get_safe("with_pulse")),
             opt_enable_disable("vaapi", self.options.get_safe("with_vaapi")),
             opt_enable_disable("vdpau", self.options.get_safe("with_vdpau")),
+            opt_enable_disable("libsvtav1", self.options.with_libsvtav1),
+            opt_enable_disable("libaom", self.options.with_libaom),
+            opt_enable_disable("libdav1d", self.options.with_libdav1d),
             opt_enable_disable("libxcb", self.options.get_safe("with_xcb")),
             opt_enable_disable(
                 "libxcb-shm", self.options.get_safe("with_xcb")),
@@ -929,6 +948,17 @@ class FFMpegConan(ConanFile):
             if self.options.get_safe("with_videotoolbox"):
                 self.cpp_info.components["avcodec"].frameworks.append(
                     "VideoToolbox")
+            if self.options.get_safe("with_libsvtav1"):
+                self.cpp_info.components["avcodec"].requires.append(
+                    "libsvtav1::decoder")
+                self.cpp_info.components["avcodec"].requires.append(
+                    "libsvtav1::encoder")
+            if self.options.get_safe("with_libaom"):
+                self.cpp_info.components["avcodec"].requires.append(
+                    "libaom-av1::libaom-av1")
+            if self.options.get_safe("with_libdav1d"):
+                self.cpp_info.components["avcodec"].requires.append(
+                    "dav1d::dav1d")
 
         if self.options.avformat:
             if self.options.with_bzip2:

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -140,7 +140,7 @@ class FFMpegConan(ConanFile):
         "with_libwebp": True,
         "with_ssl": "openssl",
         "with_libalsa": True,
-        "with_pulse": True,
+        "with_pulse": False,
         "with_vaapi": True,
         "with_vdpau": True,
         "with_vulkan": True,


### PR DESCRIPTION
**ffmpeg/5.X**

Add av1 video encoding and decoding libraries to ffmpeg

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
