### PR TITLE
cpprestsdk: add package_type + bump boost & openssl + remove package id boost minor mode

### DIFF
--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -51,8 +51,8 @@ class CppRestSDKConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("boost/1.80.0")
-        self.requires("openssl/1.1.1s")
+        self.requires("boost/1.81.0")
+        self.requires("openssl/3.1.0")
         if self.options.with_compression:
             self.requires("zlib/1.2.13")
         if self.options.with_websockets:

--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -58,7 +58,7 @@ class CppRestSDKConan(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.81.0")
-        self.requires("openssl/3.1.0")
+        self.requires("openssl/[>=1.1 <4]")
         if self.options.with_compression:
             self.requires("zlib/1.2.13")
         if self.options.with_websockets:

--- a/recipes/cpprestsdk/all/test_package/CMakeLists.txt
+++ b/recipes/cpprestsdk/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(cpprestsdk REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} cpprestsdk::cpprest)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE cpprestsdk::cpprest)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)


### PR DESCRIPTION
- bump boost & openssl
- follow import conventions of conan API
- add package_type
- remove boost minor mode (useless in conan v2 and problematic for v1 pipeline)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
