### PR TITLE
aws-c-cal: modernize more for conan v2 + bump openssl

### DIFF
--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -48,9 +48,9 @@ class AwsCCal(ConanFile):
 
     def requirements(self):
         if Version(self.version) <= "0.5.11":
-            self.requires("aws-c-common/0.6.11")
+            self.requires("aws-c-common/0.6.11", transitive_headers=True)
         else:
-            self.requires("aws-c-common/0.8.2")
+            self.requires("aws-c-common/0.8.2", transitive_headers=True)
         if self._needs_openssl:
             self.requires("openssl/3.1.0")
 

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -49,9 +49,12 @@ class AwsCCal(ConanFile):
 
     def requirements(self):
         if Version(self.version) <= "0.5.11":
-            self.requires("aws-c-common/0.6.11", transitive_headers=True)
+            # transitive_libs probably not strictly required, but it's impossible to write a robust test package
+            # without it for conan v2 (we would have to required aws-c-common in test package, but we can't know
+            # which version to require in test package)
+            self.requires("aws-c-common/0.6.11", transitive_headers=True, transitive_libs=True)
         else:
-            self.requires("aws-c-common/0.8.2", transitive_headers=True)
+            self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         if self._needs_openssl:
             self.requires("openssl/3.1.0")
 

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -58,7 +58,7 @@ class AwsCCal(ConanFile):
         else:
             self.requires("aws-c-common/0.8.2")
         if self._needs_openssl:
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/3.1.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -91,6 +91,8 @@ class AwsCCal(ConanFile):
 
         self.cpp_info.components["aws-c-cal-lib"].libs = ["aws-c-cal"]
         self.cpp_info.components["aws-c-cal-lib"].requires = ["aws-c-common::aws-c-common-lib"]
+        if self.options.shared:
+            self.cpp_info.components["aws-c-cal-lib"].defines.append("AWS_CAL_USE_IMPORT_EXPORT")
         if self.settings.os == "Windows":
             self.cpp_info.components["aws-c-cal-lib"].system_libs.append("ncrypt")
         elif is_apple_os(self):

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -28,7 +28,7 @@ class AwsCCal(ConanFile):
 
     @property
     def _needs_openssl(self):
-        return self.settings.os != "Windows" and not is_apple_os(self)
+        return not (self.settings.os == "Windows" or is_apple_os(self))
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -98,7 +98,6 @@ class AwsCCal(ConanFile):
         elif self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["aws-c-cal-lib"].system_libs.append("dl")
 
-        self.user_info.with_openssl = self._needs_openssl
         if self._needs_openssl:
             self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
             if not self.dependencies["openssl"].options.shared:

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -1,11 +1,11 @@
 from conan import ConanFile
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.51.3"
+required_conan_version = ">=1.53.0"
 
 
 class AwsCCal(ConanFile):
@@ -14,7 +14,8 @@ class AwsCCal(ConanFile):
     topics = ("aws", "amazon", "cloud", "cal", "crypt", )
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-cal"
-    license = "Apache-2.0",
+    license = "Apache-2.0"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -30,8 +31,7 @@ class AwsCCal(ConanFile):
         return self.settings.os != "Windows" and not is_apple_os(self)
 
     def export_sources(self):
-        for p in self.conan_data.get("patches", {}).get(self.version, []):
-            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -39,15 +39,9 @@ class AwsCCal(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -61,8 +55,7 @@ class AwsCCal(ConanFile):
             self.requires("openssl/3.1.0")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -1,9 +1,10 @@
 from conan import ConanFile
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
 from conan.tools.scm import Version
 import os
+import textwrap
 
 required_conan_version = ">=1.53.0"
 
@@ -77,23 +78,43 @@ class AwsCCal(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-cal"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"AWS::aws-c-cal": "aws-c-cal::aws-c-cal"}
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-cal")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-cal")
-        # TODO: back to root level in conan v2
-        self.cpp_info.components["aws-c-cal-lib"].libs = ["aws-c-cal"]
-        self.cpp_info.components["aws-c-cal-lib"].requires = ["aws-c-common::aws-c-common"]
+        self.cpp_info.libs = ["aws-c-cal"]
+        self.cpp_info.requires = ["aws-c-common::aws-c-common"]
         if self.options.shared:
-            self.cpp_info.components["aws-c-cal-lib"].defines.append("AWS_CAL_USE_IMPORT_EXPORT")
+            self.cpp_info.defines.append("AWS_CAL_USE_IMPORT_EXPORT")
         if self.settings.os == "Windows":
-            self.cpp_info.components["aws-c-cal-lib"].system_libs.append("ncrypt")
+            self.cpp_info.system_libs.append("ncrypt")
         elif is_apple_os(self):
-            self.cpp_info.components["aws-c-cal-lib"].frameworks.extend(["CoreFoundation", "Security"])
+            self.cpp_info.frameworks.extend(["CoreFoundation", "Security"])
         elif self.settings.os in ("FreeBSD", "Linux"):
-            self.cpp_info.components["aws-c-cal-lib"].system_libs.append("dl")
+            self.cpp_info.system_libs.append("dl")
 
         if self._needs_openssl:
-            self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
+            self.cpp_info.requires.append("openssl::crypto")
             if not self.dependencies["openssl"].options.shared:
                 # aws-c-cal does not statically link to openssl and searches dynamically for openssl symbols .
                 # Mark these as undefined so the linker will include them.
@@ -110,14 +131,9 @@ class AwsCCal(ConanFile):
                         "HMAC_CTX_init", "HMAC_CTX_cleanup", "HMAC_CTX_reset",
                     ])
                 crypto_link_flags = "-Wl," + ",".join(f"-u{symbol}" for symbol in crypto_symbols)
-                self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(crypto_link_flags)
-                self.cpp_info.components["aws-c-cal-lib"].sharedlinkflags.append(crypto_link_flags)
+                self.cpp_info.exelinkflags.append(crypto_link_flags)
+                self.cpp_info.sharedlinkflags.append(crypto_link_flags)
 
-        # TODO: to remove in conan v2
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-cal"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-cal"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package"] = "aws-c-cal"
-        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package_multi"] = "aws-c-cal"
-        self.cpp_info.components["aws-c-cal-lib"].set_property("cmake_target_name", "AWS::aws-c-cal")
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -80,17 +80,9 @@ class AwsCCal(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-cal")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-cal")
-
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-cal"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-cal"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package"] = "aws-c-cal"
-        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package_multi"] = "aws-c-cal"
-        self.cpp_info.components["aws-c-cal-lib"].set_property("cmake_target_name", "AWS::aws-c-cal")
-
+        # TODO: back to root level in conan v2
         self.cpp_info.components["aws-c-cal-lib"].libs = ["aws-c-cal"]
-        self.cpp_info.components["aws-c-cal-lib"].requires = ["aws-c-common::aws-c-common-lib"]
+        self.cpp_info.components["aws-c-cal-lib"].requires = ["aws-c-common::aws-c-common"]
         if self.options.shared:
             self.cpp_info.components["aws-c-cal-lib"].defines.append("AWS_CAL_USE_IMPORT_EXPORT")
         if self.settings.os == "Windows":
@@ -120,3 +112,12 @@ class AwsCCal(ConanFile):
                 crypto_link_flags = "-Wl," + ",".join(f"-u{symbol}" for symbol in crypto_symbols)
                 self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(crypto_link_flags)
                 self.cpp_info.components["aws-c-cal-lib"].sharedlinkflags.append(crypto_link_flags)
+
+        # TODO: to remove in conan v2
+        self.cpp_info.filenames["cmake_find_package"] = "aws-c-cal"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-cal"
+        self.cpp_info.names["cmake_find_package"] = "AWS"
+        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
+        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package"] = "aws-c-cal"
+        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package_multi"] = "aws-c-cal"
+        self.cpp_info.components["aws-c-cal-lib"].set_property("cmake_target_name", "AWS::aws-c-cal")

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -56,7 +56,7 @@ class AwsCCal(ConanFile):
         else:
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         if self._needs_openssl:
-            self.requires("openssl/3.1.0")
+            self.requires("openssl/[>=1.1 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/aws-c-cal/all/test_package/CMakeLists.txt
+++ b/recipes/aws-c-cal/all/test_package/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
 find_package(aws-c-cal REQUIRED CONFIG)
+find_package(aws-c-common REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-cal)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-cal AWS::aws-c-common)

--- a/recipes/aws-c-cal/all/test_package/conanfile.py
+++ b/recipes/aws-c-cal/all/test_package/conanfile.py
@@ -2,7 +2,6 @@ from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 import os
-import io
 
 
 class TestPackageConan(ConanFile):
@@ -23,9 +22,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            stream = io.StringIO()
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
-            self.run(bin_path, env="conanrun", output=stream)
-            self.output.info(stream.getvalue())
-            if self.deps_user_info["aws-c-cal"].with_openssl == "True":
-                assert "found static libcrypto" in stream.getvalue()
+            self.run(bin_path, env="conanrun")

--- a/recipes/aws-c-cal/all/test_package/conanfile.py
+++ b/recipes/aws-c-cal/all/test_package/conanfile.py
@@ -1,13 +1,19 @@
 from conan import ConanFile
+from conan.tools.apple import is_apple_os
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 import os
+import io
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
+
+    @property
+    def _needs_openssl(self):
+        return not (self.settings.os == "Windows" or is_apple_os(self))
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +28,9 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
+            stream = io.StringIO()
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
-            self.run(bin_path, env="conanrun")
+            self.run(bin_path, stream, env="conanrun")
+            self.output.info(stream.getvalue())
+            if self._needs_openssl:
+                assert "found static libcrypto" in stream.getvalue()

--- a/recipes/aws-c-cal/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-cal/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(aws-c-cal REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-cal)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
- conan v2:
  - fix windows/shared (protect double deletion of fPIC)
  - fix test package (logic based on self.user_info can't work for conan v2, and it was anyway wrong to define this user_info for the sole purpose of test package)
- bump openssl to 3.x

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
