### PR TITLE
aws-c-io: fix interface definition for shared lib on windows + bump s2n + add package_type

### DIFF
--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -86,6 +86,8 @@ class AwsCIO(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-io")
         # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
         self.cpp_info.components["aws-c-io-lib"].libs = ["aws-c-io"]
+        if self.options.shared:
+            self.cpp_info.components["aws-c-io-lib"].defines.append("AWS_IO_USE_IMPORT_EXPORT")
         if self.settings.os == "Macos":
             self.cpp_info.components["aws-c-io-lib"].frameworks.append("Security")
         if self.settings.os == "Windows":

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -43,10 +43,10 @@ class AwsCIO(ConanFile):
         # the versions of aws-c-common and aws-c-io are tied since aws-c-common/0.6.12 and aws-c-io/0.10.10
         # Please refer https://github.com/conan-io/conan-center-index/issues/7763
         if Version(self.version) <= "0.10.9":
-            self.requires("aws-c-common/0.6.11")
+            self.requires("aws-c-common/0.6.11", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.5.11")
         else:
-            self.requires("aws-c-common/0.8.2")
+            self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.5.13")
 
         if self.settings.os in ["Linux", "FreeBSD", "Android"]:

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -49,7 +49,7 @@ class AwsCIO(ConanFile):
             self.requires("aws-c-cal/0.5.13")
 
         if self.settings.os in ["Linux", "FreeBSD", "Android"]:
-            self.requires("s2n/1.3.15")
+            self.requires("s2n/1.3.31")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -1,8 +1,9 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import get, copy, rmdir
+from conan.tools.files import get, copy, rmdir, save
 from conan.tools.scm import Version
 import os
+import textwrap
 
 required_conan_version = ">=1.53.0"
 
@@ -73,26 +74,38 @@ class AwsCIO(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-io"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"AWS::aws-c-io": "aws-c-io::aws-c-io"}
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-io")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-io")
-        # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.components["aws-c-io-lib"].libs = ["aws-c-io"]
+        self.cpp_info.libs = ["aws-c-io"]
         if self.options.shared:
-            self.cpp_info.components["aws-c-io-lib"].defines.append("AWS_IO_USE_IMPORT_EXPORT")
+            self.cpp_info.defines.append("AWS_IO_USE_IMPORT_EXPORT")
         if self.settings.os == "Macos":
-            self.cpp_info.components["aws-c-io-lib"].frameworks.append("Security")
+            self.cpp_info.frameworks.append("Security")
         if self.settings.os == "Windows":
-            self.cpp_info.components["aws-c-io-lib"].system_libs = ["crypt32", "secur32", "shlwapi"]
+            self.cpp_info.system_libs = ["crypt32", "secur32", "shlwapi"]
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-io"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-io"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-io-lib"].names["cmake_find_package"] = "aws-c-io"
-        self.cpp_info.components["aws-c-io-lib"].names["cmake_find_package_multi"] = "aws-c-io"
-        self.cpp_info.components["aws-c-io-lib"].set_property("cmake_target_name", "AWS::aws-c-io")
-        self.cpp_info.components["aws-c-io-lib"].requires = ["aws-c-cal::aws-c-cal", "aws-c-common::aws-c-common"]
-        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
-            self.cpp_info.components["aws-c-io-lib"].requires.append("s2n::s2n")
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy, rmdir
 from conan.tools.scm import Version
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
 required_conan_version = ">=1.53.0"
@@ -93,6 +93,6 @@ class AwsCIO(ConanFile):
         self.cpp_info.components["aws-c-io-lib"].names["cmake_find_package"] = "aws-c-io"
         self.cpp_info.components["aws-c-io-lib"].names["cmake_find_package_multi"] = "aws-c-io"
         self.cpp_info.components["aws-c-io-lib"].set_property("cmake_target_name", "AWS::aws-c-io")
-        self.cpp_info.components["aws-c-io-lib"].requires = ["aws-c-cal::aws-c-cal-lib", "aws-c-common::aws-c-common-lib"]
+        self.cpp_info.components["aws-c-io-lib"].requires = ["aws-c-cal::aws-c-cal", "aws-c-common::aws-c-common"]
         if self.settings.os in ["Linux", "FreeBSD", "Android"]:
-            self.cpp_info.components["aws-c-io-lib"].requires.append("s2n::s2n-lib")
+            self.cpp_info.components["aws-c-io-lib"].requires.append("s2n::s2n")

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -4,15 +4,17 @@ from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
+
 
 class AwsCIO(ConanFile):
     name = "aws-c-io"
     description = "IO and TLS for application protocols"
-    license = "Apache-2.0",
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-io"
     topics = ("aws", "amazon", "cloud", "io", "tls",)
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -29,18 +31,9 @@ class AwsCIO(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -59,8 +52,7 @@ class AwsCIO(ConanFile):
             self.requires("s2n/1.3.15")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-                  destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)


### PR DESCRIPTION
- add AWS_IO_USE_IMPORT_EXPORT interface definition. This definition is mandatory to properly define __delcspec(dllimport) if shared on windows.It's very important since aws-c-io has at least one global symbol in its interface. I've seen this issue while trying to build `aws-c-http` shared against `aws-c-io` shared with Visual Studio. It was failing with `h1_connection.c.obj : error LNK2019: unresolved external symbol g_aws_channel_max_fragment_size referenced in function s_connection_new` (`g_aws_channel_max_fragment_size` is a global symbol defined in `aws-c-io`, so it MUST have `__declspec(dllimport)` at consume time).
- add package_type
- bump s2n

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
