### PR TITLE
aws-c-auth: add missing interface definition if shared + modernize more for conan v2

### DIFF
--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -47,13 +47,13 @@ class AwsCAuth(ConanFile):
         self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         self.requires("aws-c-cal/0.5.13")
         if Version(self.version) < "0.6.17":
-            self.requires("aws-c-io/0.10.20", transitive_headers=True, transitive_libs=True)
-            self.requires("aws-c-http/0.6.13", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-io/0.10.20", transitive_headers=True)
+            self.requires("aws-c-http/0.6.13", transitive_headers=True)
         else:
-            self.requires("aws-c-io/0.13.4", transitive_headers=True, transitive_libs=True)
-            self.requires("aws-c-http/0.6.22", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-io/0.13.4", transitive_headers=True)
+            self.requires("aws-c-http/0.6.22", transitive_headers=True)
         if Version(self.version) >= "0.6.5":
-            self.requires("aws-c-sdkutils/0.1.3", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-sdkutils/0.1.3", transitive_headers=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -81,6 +81,8 @@ class AwsCAuth(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-auth")
         # TODO: back to global scope once conan v1 support dropped
         self.cpp_info.components["aws-c-auth-lib"].libs = ["aws-c-auth"]
+        if self.options.shared:
+            self.cpp_info.components["aws-c-auth-lib"].defines.append("AWS_AUTH_USE_IMPORT_EXPORT")
         self.cpp_info.components["aws-c-auth-lib"].requires = [
             "aws-c-common::aws-c-common-lib",
             "aws-c-cal::aws-c-cal-lib",

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -14,7 +14,7 @@ class AwsCAuth(ConanFile):
         "C99 library implementation of AWS client-side authentication: "
         "standard credentials providers and signing."
     )
-    license = "Apache-2.0",
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-auth"
     topics = ("aws", "amazon", "cloud", "authentication", "credentials", "providers", "signing")
@@ -83,14 +83,6 @@ class AwsCAuth(ConanFile):
         self.cpp_info.components["aws-c-auth-lib"].libs = ["aws-c-auth"]
         if self.options.shared:
             self.cpp_info.components["aws-c-auth-lib"].defines.append("AWS_AUTH_USE_IMPORT_EXPORT")
-        self.cpp_info.components["aws-c-auth-lib"].requires = [
-            "aws-c-common::aws-c-common-lib",
-            "aws-c-cal::aws-c-cal-lib",
-            "aws-c-io::aws-c-io-lib",
-            "aws-c-http::aws-c-http-lib",
-        ]
-        if Version(self.version) >= "0.6.5":
-            self.cpp_info.components["aws-c-auth-lib"].requires.append("aws-c-sdkutils::aws-c-sdkutils-lib")
 
         # TODO: to remove once conan v1 support dropped
         self.cpp_info.filenames["cmake_find_package"] = "aws-c-auth"
@@ -100,3 +92,11 @@ class AwsCAuth(ConanFile):
         self.cpp_info.components["aws-c-auth-lib"].names["cmake_find_package"] = "aws-c-auth"
         self.cpp_info.components["aws-c-auth-lib"].names["cmake_find_package_multi"] = "aws-c-auth"
         self.cpp_info.components["aws-c-auth-lib"].set_property("cmake_target_name", "AWS::aws-c-auth")
+        self.cpp_info.components["aws-c-auth-lib"].requires = [
+            "aws-c-common::aws-c-common",
+            "aws-c-cal::aws-c-cal",
+            "aws-c-io::aws-c-io",
+            "aws-c-http::aws-c-http",
+        ]
+        if Version(self.version) >= "0.6.5":
+            self.cpp_info.components["aws-c-auth-lib"].requires.append("aws-c-sdkutils::aws-c-sdkutils")

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -1,9 +1,10 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import get, copy, rmdir
+from conan.tools.files import get, copy, rmdir, save
 from conan.tools.scm import Version
 
 import os
+import textwrap
 
 required_conan_version = ">=1.53.0"
 
@@ -76,27 +77,34 @@ class AwsCAuth(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-auth"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"AWS::aws-c-auth": "aws-c-auth::aws-c-auth"}
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-auth")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-auth")
-        # TODO: back to global scope once conan v1 support dropped
-        self.cpp_info.components["aws-c-auth-lib"].libs = ["aws-c-auth"]
+        self.cpp_info.libs = ["aws-c-auth"]
         if self.options.shared:
-            self.cpp_info.components["aws-c-auth-lib"].defines.append("AWS_AUTH_USE_IMPORT_EXPORT")
+            self.cpp_info.defines.append("AWS_AUTH_USE_IMPORT_EXPORT")
 
-        # TODO: to remove once conan v1 support dropped
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-auth"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-auth"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-auth-lib"].names["cmake_find_package"] = "aws-c-auth"
-        self.cpp_info.components["aws-c-auth-lib"].names["cmake_find_package_multi"] = "aws-c-auth"
-        self.cpp_info.components["aws-c-auth-lib"].set_property("cmake_target_name", "AWS::aws-c-auth")
-        self.cpp_info.components["aws-c-auth-lib"].requires = [
-            "aws-c-common::aws-c-common",
-            "aws-c-cal::aws-c-cal",
-            "aws-c-io::aws-c-io",
-            "aws-c-http::aws-c-http",
-        ]
-        if Version(self.version) >= "0.6.5":
-            self.cpp_info.components["aws-c-auth-lib"].requires.append("aws-c-sdkutils::aws-c-sdkutils")
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]


### PR DESCRIPTION
see https://github.com/awslabs/aws-c-auth/blob/v0.6.26/include/aws/auth/exports.h

Without this fix, the build of aws-c-s3 "all shared" fails with msvc.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
