### PR TITLE
aws-c-compression: add missing interface definition if shared + modernize more for conan v2

### DIFF
--- a/recipes/aws-c-compression/all/conanfile.py
+++ b/recipes/aws-c-compression/all/conanfile.py
@@ -39,7 +39,7 @@ class AwsCCompression(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-common/0.8.2")
+        self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/aws-c-compression/all/conanfile.py
+++ b/recipes/aws-c-compression/all/conanfile.py
@@ -76,6 +76,8 @@ class AwsCCompression(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-compression")
         # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
         self.cpp_info.components["aws-c-compression-lib"].libs = ["aws-c-compression"]
+        if self.options.shared:
+            self.cpp_info.components["aws-c-compression-lib"].defines.append("AWS_COMPRESSION_USE_IMPORT_EXPORT")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "aws-c-compression"

--- a/recipes/aws-c-compression/all/conanfile.py
+++ b/recipes/aws-c-compression/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 import os
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=1.53.0"
 
 
 class AwsCCompression(ConanFile):
@@ -13,7 +13,7 @@ class AwsCCompression(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-compression"
     license = "Apache-2.0",
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -30,18 +30,9 @@ class AwsCCompression(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -50,8 +41,7 @@ class AwsCCompression(ConanFile):
         self.requires("aws-c-common/0.8.2")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -87,4 +77,4 @@ class AwsCCompression(ConanFile):
         self.cpp_info.components["aws-c-compression-lib"].names["cmake_find_package"] = "aws-c-compression"
         self.cpp_info.components["aws-c-compression-lib"].names["cmake_find_package_multi"] = "aws-c-compression"
         self.cpp_info.components["aws-c-compression-lib"].set_property("cmake_target_name", "AWS::aws-c-compression")
-        self.cpp_info.components["aws-c-compression-lib"].requires = ["aws-c-common::aws-c-common-lib"]
+        self.cpp_info.components["aws-c-compression-lib"].requires = ["aws-c-common::aws-c-common"]

--- a/recipes/aws-c-compression/all/conanfile.py
+++ b/recipes/aws-c-compression/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get, rmdir, save
 import os
+import textwrap
 
 required_conan_version = ">=1.53.0"
 
@@ -61,20 +62,34 @@ class AwsCCompression(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-compression"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"AWS::aws-c-compression": "aws-c-compression::aws-c-compression"}
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-compression")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-compression")
-        # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.components["aws-c-compression-lib"].libs = ["aws-c-compression"]
+        self.cpp_info.libs = ["aws-c-compression"]
         if self.options.shared:
-            self.cpp_info.components["aws-c-compression-lib"].defines.append("AWS_COMPRESSION_USE_IMPORT_EXPORT")
+            self.cpp_info.defines.append("AWS_COMPRESSION_USE_IMPORT_EXPORT")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-compression"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-compression"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-compression-lib"].names["cmake_find_package"] = "aws-c-compression"
-        self.cpp_info.components["aws-c-compression-lib"].names["cmake_find_package_multi"] = "aws-c-compression"
-        self.cpp_info.components["aws-c-compression-lib"].set_property("cmake_target_name", "AWS::aws-c-compression")
-        self.cpp_info.components["aws-c-compression-lib"].requires = ["aws-c-common::aws-c-common"]
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/aws-c-compression/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-compression/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(aws-c-compression REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-compression)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
see https://github.com/awslabs/aws-c-compression/blob/v0.2.16/include/aws/compression/exports.h

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
