### PR TITLE
aws-c-event-stream: add missing interface definition if shared + modernize more for conan v2

### DIFF
--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -80,21 +80,24 @@ class AwsCEventStream(ConanFile):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
-
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-event-stream"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-event-stream")
-        self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package"] = "aws-c-event-stream"
-        self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package_multi"] = "aws-c-event-stream"
+        # TODO: back to global scope in conan v2
         self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]
-        self.cpp_info.components["aws-c-event-stream-lib"].requires = ["aws-c-common::aws-c-common-lib", "aws-checksums::aws-checksums"]
-        if Version(self.version) >= "0.2":
-            self.cpp_info.components["aws-c-event-stream-lib"].requires.append("aws-c-io::aws-c-io-lib")
+        if self.options.shared:
+            self.cpp_info.components["aws-c-event-stream-lib"].defines.append("AWS_EVENT_STREAM_USE_IMPORT_EXPORT")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "aws-c-event-stream"
         self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-event-stream"
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
+        self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package"] = "aws-c-event-stream"
+        self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package_multi"] = "aws-c-event-stream"
+        self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_name", "AWS::aws-c-event-stream")
+        self.cpp_info.components["aws-c-event-stream-lib"].requires = ["aws-c-common::aws-c-common", "aws-checksums::aws-checksums"]
+        if Version(self.version) >= "0.2":
+            self.cpp_info.components["aws-c-event-stream-lib"].requires.append("aws-c-io::aws-c-io")

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -44,7 +44,7 @@ class AwsCEventStream(ConanFile):
 
     def requirements(self):
         self.requires("aws-checksums/0.1.13")
-        self.requires("aws-c-common/0.8.2")
+        self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         if Version(self.version) >= "0.2":
             if Version(self.version) < "0.2.11":
                 self.requires("aws-c-io/0.10.20")

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -1,8 +1,9 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir, save
 from conan.tools.scm import Version
 import os
+import textwrap
 
 required_conan_version = ">=1.53.0"
 
@@ -74,22 +75,34 @@ class AwsCEventStream(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-event-stream"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"AWS::aws-c-event-stream": "aws-c-event-stream::aws-c-event-stream"}
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-event-stream")
-        # TODO: back to global scope in conan v2
-        self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]
+        self.cpp_info.libs = ["aws-c-event-stream"]
         if self.options.shared:
-            self.cpp_info.components["aws-c-event-stream-lib"].defines.append("AWS_EVENT_STREAM_USE_IMPORT_EXPORT")
+            self.cpp_info.defines.append("AWS_EVENT_STREAM_USE_IMPORT_EXPORT")
 
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-event-stream"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-event-stream"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package"] = "aws-c-event-stream"
-        self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package_multi"] = "aws-c-event-stream"
-        self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_name", "AWS::aws-c-event-stream")
-        self.cpp_info.components["aws-c-event-stream-lib"].requires = ["aws-c-common::aws-c-common", "aws-checksums::aws-checksums"]
-        if Version(self.version) >= "0.2":
-            self.cpp_info.components["aws-c-event-stream-lib"].requires.append("aws-c-io::aws-c-io")
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -1,18 +1,20 @@
 from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
 from conan.tools.scm import Version
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
+
 
 class AwsCEventStream(ConanFile):
     name = "aws-c-event-stream"
     description = "C99 implementation of the vnd.amazon.eventstream content-type"
-    license = "Apache-2.0",
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-event-stream"
     topics = ("aws", "eventstream", "content", )
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -32,18 +34,9 @@ class AwsCEventStream(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -58,8 +51,7 @@ class AwsCEventStream(ConanFile):
                 self.requires("aws-c-io/0.13.4")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-                  destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -43,8 +43,8 @@ class AwsCEventStream(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-checksums/0.1.13")
         self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
+        self.requires("aws-checksums/0.1.13")
         if Version(self.version) >= "0.2":
             if Version(self.version) < "0.2.11":
                 self.requires("aws-c-io/0.10.20")

--- a/recipes/aws-c-event-stream/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-event-stream/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-
-project(test_package C)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(aws-c-event-stream REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-event-stream)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
see https://github.com/awslabs/aws-c-event-stream/blob/v0.2.20/include/aws/event-stream/event_stream_exports.h

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
