### PR TITLE
aws-c-mqtt: add missing interface definition if shared + modernize more for conan v2

### DIFF
--- a/recipes/aws-c-mqtt/all/conanfile.py
+++ b/recipes/aws-c-mqtt/all/conanfile.py
@@ -1,9 +1,10 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import get, copy, rmdir
+from conan.tools.files import get, copy, rmdir, save
 from conan.tools.scm import Version
 
 import os
+import textwrap
 
 required_conan_version = ">=1.53.0"
 
@@ -71,25 +72,34 @@ class AwsCMQTT(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-mqtt"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"AWS::aws-c-mqtt": "aws-c-mqtt::aws-c-mqtt"}
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-mqtt")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-mqtt")
-        # TODO: back to root in conan v2
-        self.cpp_info.components["aws-c-mqtt-lib"].libs = ["aws-c-mqtt"]
+        self.cpp_info.libs = ["aws-c-mqtt"]
         if self.options.shared:
-            self.cpp_info.components["aws-c-mqtt-lib"].defines.append("AWS_MQTT_USE_IMPORT_EXPORT")
+            self.cpp_info.defines.append("AWS_MQTT_USE_IMPORT_EXPORT")
 
-        # TODO: to remove in conan v2
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-mqtt"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-mqtt"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-mqtt-lib"].names["cmake_find_package"] = "aws-c-mqtt"
-        self.cpp_info.components["aws-c-mqtt-lib"].names["cmake_find_package_multi"] = "aws-c-mqtt"
-        self.cpp_info.components["aws-c-mqtt-lib"].set_property("cmake_target_name", "AWS::aws-c-mqtt")
-        self.cpp_info.components["aws-c-mqtt-lib"].requires = [
-            "aws-c-common::aws-c-common",
-            "aws-c-cal::aws-c-cal",
-            "aws-c-io::aws-c-io",
-            "aws-c-http::aws-c-http",
-        ]
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/aws-c-mqtt/all/conanfile.py
+++ b/recipes/aws-c-mqtt/all/conanfile.py
@@ -41,13 +41,13 @@ class AwsCMQTT(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-common/0.8.2")
+        self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         self.requires("aws-c-cal/0.5.13")
         if Version(self.version) < "0.7.12":
-            self.requires("aws-c-io/0.10.20")
+            self.requires("aws-c-io/0.10.20", transitive_headers=True)
             self.requires("aws-c-http/0.6.13")
         else:
-            self.requires("aws-c-io/0.13.4")
+            self.requires("aws-c-io/0.13.4", transitive_headers=True)
             self.requires("aws-c-http/0.6.22")
 
     def source(self):

--- a/recipes/aws-c-mqtt/all/conanfile.py
+++ b/recipes/aws-c-mqtt/all/conanfile.py
@@ -1,20 +1,21 @@
 from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy, rmdir
 from conan.tools.scm import Version
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
 import os
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=1.53.0"
 
 
 class AwsCMQTT(ConanFile):
     name = "aws-c-mqtt"
     description = "C99 implementation of the MQTT 3.1.1 specification."
-    license = "Apache-2.0",
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-mqtt"
     topics = ("aws", "amazon", "cloud", "mqtt")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -31,18 +32,12 @@ class AwsCMQTT(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("aws-c-common/0.8.2")
@@ -54,11 +49,8 @@ class AwsCMQTT(ConanFile):
             self.requires("aws-c-io/0.13.4")
             self.requires("aws-c-http/0.6.22")
 
-    def layout(self):
-        cmake_layout(self, src_folder="src")
-
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/aws-c-mqtt/all/conanfile.py
+++ b/recipes/aws-c-mqtt/all/conanfile.py
@@ -82,7 +82,12 @@ class AwsCMQTT(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-mqtt")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-mqtt")
+        # TODO: back to root in conan v2
+        self.cpp_info.components["aws-c-mqtt-lib"].libs = ["aws-c-mqtt"]
+        if self.options.shared:
+            self.cpp_info.components["aws-c-mqtt-lib"].defines.append("AWS_MQTT_USE_IMPORT_EXPORT")
 
+        # TODO: to remove in conan v2
         self.cpp_info.filenames["cmake_find_package"] = "aws-c-mqtt"
         self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-mqtt"
         self.cpp_info.names["cmake_find_package"] = "AWS"
@@ -90,11 +95,9 @@ class AwsCMQTT(ConanFile):
         self.cpp_info.components["aws-c-mqtt-lib"].names["cmake_find_package"] = "aws-c-mqtt"
         self.cpp_info.components["aws-c-mqtt-lib"].names["cmake_find_package_multi"] = "aws-c-mqtt"
         self.cpp_info.components["aws-c-mqtt-lib"].set_property("cmake_target_name", "AWS::aws-c-mqtt")
-
-        self.cpp_info.components["aws-c-mqtt-lib"].libs = ["aws-c-mqtt"]
         self.cpp_info.components["aws-c-mqtt-lib"].requires = [
-            "aws-c-common::aws-c-common-lib",
-            "aws-c-cal::aws-c-cal-lib",
-            "aws-c-io::aws-c-io-lib",
-            "aws-c-http::aws-c-http-lib"
+            "aws-c-common::aws-c-common",
+            "aws-c-cal::aws-c-cal",
+            "aws-c-io::aws-c-io",
+            "aws-c-http::aws-c-http",
         ]

--- a/recipes/aws-c-mqtt/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-mqtt/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(aws-c-mqtt REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-mqtt)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
see https://github.com/awslabs/aws-c-mqtt/blob/v0.8.10/include/aws/mqtt/exports.h

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
