### PR TITLE
coin-clp: make dependency on coin-utils libs transitive

### DIFF
--- a/recipes/coin-clp/all/conanfile.py
+++ b/recipes/coin-clp/all/conanfile.py
@@ -49,7 +49,7 @@ class CoinClpConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("coin-utils/2.11.6", transitive_headers=True)
+        self.requires("coin-utils/2.11.6", transitive_headers=True, transitive_libs=True)
         self.requires("coin-osi/0.108.7", transitive_headers=True)
 
     def validate(self):

--- a/recipes/coin-clp/all/conanfile.py
+++ b/recipes/coin-clp/all/conanfile.py
@@ -49,6 +49,7 @@ class CoinClpConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
+        # Symbols are exposed https://github.com/conan-io/conan-center-index/pull/16053#issuecomment-1512637106
         self.requires("coin-utils/2.11.6", transitive_headers=True, transitive_libs=True)
         self.requires("coin-osi/0.108.7", transitive_headers=True)
 


### PR DESCRIPTION
Specify library name and version:  **coin-clp/***

This fixes linking problems with coin-clp: https://github.com/conan-io/conan-center-index/pull/16053#issuecomment-1512637106


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
