### PR TITLE
Bump version - OpenCL Headers - 2023.04.17

### DIFF
--- a/recipes/opencl-headers/all/conandata.yml
+++ b/recipes/opencl-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2023.04.17":
+    url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2023.04.17.tar.gz"
+    sha256: "0ce992f4167f958f68a37918dec6325be18f848dee29a4521c633aae3304915d"
   "2022.09.30":
     url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2022.09.30.tar.gz"
     sha256: "0ae857ecb28af95a420c800b21ed2d0f437503e104f841ab8db249df5f4fbe5c"

--- a/recipes/opencl-headers/config.yml
+++ b/recipes/opencl-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2023.04.17":
+    folder: all
   "2022.09.30":
     folder: all
   "2022.05.18":


### PR DESCRIPTION
Specify library name and version:  **opencl-headers/2023.04.17**

Bumping OpenCL Headers version, OpenCL ICD Loader (which use OpenCL Headers as a requirement with same version number) coming next.


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
