### PR TITLE
aws-c-s3: add missing interface definition if shared + modernize more for conan v2

### DIFF
--- a/recipes/aws-c-s3/all/conandata.yml
+++ b/recipes/aws-c-s3/all/conandata.yml
@@ -11,6 +11,3 @@ sources:
   "0.1.27":
     url: "https://github.com/awslabs/aws-c-s3/archive/v0.1.27.tar.gz"
     sha256: "8fccbf967c3b29f0feaa1ba3de158b7ead805c3b4302c45b7cad3429f045920c"
-  "0.1.19":
-    url: "https://github.com/awslabs/aws-c-s3/archive/v0.1.19.tar.gz"
-    sha256: "30e17e31eed18e8d621cd3d3978b2e6eeeee5557bfc3a9d701d0d3e1c4a8a74d"

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -1,18 +1,20 @@
 from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy, rmdir
 from conan.tools.scm import Version
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=1.53.0"
+
 
 class AwsCS3(ConanFile):
     name = "aws-c-s3"
     description = "C99 implementation of the S3 client"
-    license = "Apache-2.0",
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-s3"
     topics = ("aws", "amazon", "cloud", "s3")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -29,18 +31,9 @@ class AwsCS3(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -59,7 +52,7 @@ class AwsCS3(ConanFile):
             self.requires("aws-checksums/0.1.13")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -83,7 +83,12 @@ class AwsCS3(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-s3")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-s3")
+        # TODO: back to root level in conan v2
+        self.cpp_info.components["aws-c-s3-lib"].libs = ["aws-c-s3"]
+        if self.options.shared:
+            self.cpp_info.components["aws-c-s3-lib"].defines.append("AWS_S3_USE_IMPORT_EXPORT")
 
+        # TODO: to remove in conan v2
         self.cpp_info.filenames["cmake_find_package"] = "aws-c-s3"
         self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-s3"
         self.cpp_info.names["cmake_find_package"] = "AWS"
@@ -91,13 +96,11 @@ class AwsCS3(ConanFile):
         self.cpp_info.components["aws-c-s3-lib"].names["cmake_find_package"] = "aws-c-s3"
         self.cpp_info.components["aws-c-s3-lib"].names["cmake_find_package_multi"] = "aws-c-s3"
         self.cpp_info.components["aws-c-s3-lib"].set_property("cmake_target_name", "AWS::aws-c-s3")
-
-        self.cpp_info.components["aws-c-s3-lib"].libs = ["aws-c-s3"]
         self.cpp_info.components["aws-c-s3-lib"].requires = [
-            "aws-c-common::aws-c-common-lib",
-            "aws-c-io::aws-c-io-lib",
-            "aws-c-http::aws-c-http-lib",
-            "aws-c-auth::aws-c-auth-lib"
+            "aws-c-common::aws-c-common",
+            "aws-c-io::aws-c-io",
+            "aws-c-http::aws-c-http",
+            "aws-c-auth::aws-c-auth",
         ]
         if Version(self.version) >= "0.1.36":
-            self.cpp_info.components["aws-c-s3-lib"].requires.append("aws-checksums::aws-checksums-lib")
+            self.cpp_info.components["aws-c-s3-lib"].requires.append("aws-checksums::aws-checksums")

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -1,8 +1,9 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import get, copy, rmdir
+from conan.tools.files import get, copy, rmdir, save
 from conan.tools.scm import Version
 import os
+import textwrap
 
 required_conan_version = ">=1.53.0"
 
@@ -73,27 +74,34 @@ class AwsCS3(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-s3"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"AWS::aws-c-s3": "aws-c-s3::aws-c-s3"}
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-s3")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-s3")
-        # TODO: back to root level in conan v2
-        self.cpp_info.components["aws-c-s3-lib"].libs = ["aws-c-s3"]
+        self.cpp_info.libs = ["aws-c-s3"]
         if self.options.shared:
-            self.cpp_info.components["aws-c-s3-lib"].defines.append("AWS_S3_USE_IMPORT_EXPORT")
+            self.cpp_info.defines.append("AWS_S3_USE_IMPORT_EXPORT")
 
-        # TODO: to remove in conan v2
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-s3"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-s3"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-s3-lib"].names["cmake_find_package"] = "aws-c-s3"
-        self.cpp_info.components["aws-c-s3-lib"].names["cmake_find_package_multi"] = "aws-c-s3"
-        self.cpp_info.components["aws-c-s3-lib"].set_property("cmake_target_name", "AWS::aws-c-s3")
-        self.cpp_info.components["aws-c-s3-lib"].requires = [
-            "aws-c-common::aws-c-common",
-            "aws-c-io::aws-c-io",
-            "aws-c-http::aws-c-http",
-            "aws-c-auth::aws-c-auth",
-        ]
-        if Version(self.version) >= "0.1.36":
-            self.cpp_info.components["aws-c-s3-lib"].requires.append("aws-checksums::aws-checksums")
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -40,15 +40,15 @@ class AwsCS3(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-common/0.8.2")
+        self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         if Version(self.version) < "0.1.49":
-            self.requires("aws-c-io/0.10.20")
+            self.requires("aws-c-auth/0.6.11", transitive_headers=True)
             self.requires("aws-c-http/0.6.13")
-            self.requires("aws-c-auth/0.6.11")
+            self.requires("aws-c-io/0.10.20", transitive_headers=True)
         else:
-            self.requires("aws-c-io/0.13.4")
+            self.requires("aws-c-auth/0.6.17", transitive_headers=True)
             self.requires("aws-c-http/0.6.22")
-            self.requires("aws-c-auth/0.6.17")
+            self.requires("aws-c-io/0.13.4", transitive_headers=True)
         if Version(self.version) >= "0.1.36":
             self.requires("aws-checksums/0.1.13")
 

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -47,6 +47,7 @@ class AwsCS3(ConanFile):
             self.requires("aws-c-io/0.10.20", transitive_headers=True)
         else:
             self.requires("aws-c-auth/0.6.17", transitive_headers=True)
+            self.requires("aws-c-cal/0.5.13")
             self.requires("aws-c-http/0.6.22")
             self.requires("aws-c-io/0.13.4", transitive_headers=True)
         if Version(self.version) >= "0.1.36":

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -41,13 +41,13 @@ class AwsCS3(ConanFile):
 
     def requirements(self):
         self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
+        self.requires("aws-c-cal/0.5.13")
         if Version(self.version) < "0.1.49":
             self.requires("aws-c-auth/0.6.11", transitive_headers=True)
             self.requires("aws-c-http/0.6.13")
             self.requires("aws-c-io/0.10.20", transitive_headers=True)
         else:
             self.requires("aws-c-auth/0.6.17", transitive_headers=True)
-            self.requires("aws-c-cal/0.5.13")
             self.requires("aws-c-http/0.6.22")
             self.requires("aws-c-io/0.13.4", transitive_headers=True)
         if Version(self.version) >= "0.1.36":

--- a/recipes/aws-c-s3/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-s3/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(aws-c-s3 REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-s3)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/aws-c-s3/config.yml
+++ b/recipes/aws-c-s3/config.yml
@@ -7,5 +7,3 @@ versions:
     folder: all
   "0.1.27":
     folder: all
-  "0.1.19":
-    folder: all


### PR DESCRIPTION
see https://github.com/awslabs/aws-c-s3/blob/v0.2.8/include/aws/s3/exports.h

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
