### PR TITLE
aws-checksums: add missing interface definition if shared + modernize more for conan v2

### DIFF
--- a/recipes/aws-checksums/all/conanfile.py
+++ b/recipes/aws-checksums/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, rmdir
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, rmdir, save
 import os
+import textwrap
 
 required_conan_version = ">=1.53.0"
 
@@ -68,20 +69,34 @@ class AwsChecksums(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-checksums"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"AWS::aws-checksums": "aws-checksums::aws-checksums"}
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-checksums")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-checksums")
-        # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.components["aws-checksums-lib"].libs = ["aws-checksums"]
+        self.cpp_info.libs = ["aws-checksums"]
         if self.options.shared:
-            self.cpp_info.components["aws-checksums-lib"].defines.append("AWS_CHECKSUMS_USE_IMPORT_EXPORT")
+            self.cpp_info.defines.append("AWS_CHECKSUMS_USE_IMPORT_EXPORT")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "aws-checksums"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-checksums"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-checksums-lib"].names["cmake_find_package"] = "aws-checksums"
-        self.cpp_info.components["aws-checksums-lib"].names["cmake_find_package_multi"] = "aws-checksums"
-        self.cpp_info.components["aws-checksums-lib"].set_property("cmake_target_name", "AWS::aws-checksums")
-        self.cpp_info.components["aws-checksums-lib"].requires = ["aws-c-common::aws-c-common"]
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/aws-checksums/all/conanfile.py
+++ b/recipes/aws-checksums/all/conanfile.py
@@ -3,7 +3,8 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, rmdir
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
+
 
 class AwsChecksums(ConanFile):
     name = "aws-checksums"
@@ -11,10 +12,11 @@ class AwsChecksums(ConanFile):
         "Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient "
         "SW implementations. C interface with language bindings for each of our SDKs."
     )
-    license = "Apache-2.0",
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-checksums"
     topics = ("aws", "checksum", )
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -34,18 +36,9 @@ class AwsChecksums(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -54,8 +47,7 @@ class AwsChecksums(ConanFile):
         self.requires("aws-c-common/0.8.2")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -92,4 +84,4 @@ class AwsChecksums(ConanFile):
         self.cpp_info.components["aws-checksums-lib"].names["cmake_find_package"] = "aws-checksums"
         self.cpp_info.components["aws-checksums-lib"].names["cmake_find_package_multi"] = "aws-checksums"
         self.cpp_info.components["aws-checksums-lib"].set_property("cmake_target_name", "AWS::aws-checksums")
-        self.cpp_info.components["aws-checksums-lib"].requires = ["aws-c-common::aws-c-common-lib"]
+        self.cpp_info.components["aws-checksums-lib"].requires = ["aws-c-common::aws-c-common"]

--- a/recipes/aws-checksums/all/conanfile.py
+++ b/recipes/aws-checksums/all/conanfile.py
@@ -81,6 +81,8 @@ class AwsChecksums(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-checksums")
         # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
         self.cpp_info.components["aws-checksums-lib"].libs = ["aws-checksums"]
+        if self.options.shared:
+            self.cpp_info.components["aws-checksums-lib"].defines.append("AWS_CHECKSUMS_USE_IMPORT_EXPORT")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "aws-checksums"

--- a/recipes/aws-checksums/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-checksums/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(aws-checksums REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-checksums)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
see https://github.com/awslabs/aws-checksums/blob/v0.1.14/include/aws/checksums/exports.h

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
