### PR TITLE
aws-crt-cpp: add missing interface definition if shared

### DIFF
--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -47,22 +47,23 @@ class AwsCrtCpp(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
+        self.requires("aws-c-cal/0.5.13", transitive_headers=True)
         self.requires("aws-c-common/0.8.2", transitive_headers=True)
         self.requires("aws-checksums/0.1.13")
         if Version(self.version) < "0.17.29":
-            self.requires("aws-c-io/0.10.20")
-            self.requires("aws-c-http/0.6.13")
             self.requires("aws-c-auth/0.6.11", transitive_headers=True)
-            self.requires("aws-c-s3/0.1.37")
-            self.requires("aws-c-mqtt/0.7.10", transitive_headers=True)
             self.requires("aws-c-event-stream/0.2.7")
+            self.requires("aws-c-http/0.6.13", transitive_headers=True)
+            self.requires("aws-c-io/0.10.20", transitive_headers=True)
+            self.requires("aws-c-mqtt/0.7.10", transitive_headers=True)
+            self.requires("aws-c-s3/0.1.37")
         else:
-            self.requires("aws-c-io/0.13.4")
-            self.requires("aws-c-http/0.6.22")
             self.requires("aws-c-auth/0.6.17", transitive_headers=True)
-            self.requires("aws-c-s3/0.1.49")
-            self.requires("aws-c-mqtt/0.7.12", transitive_headers=True)
             self.requires("aws-c-event-stream/0.2.15")
+            self.requires("aws-c-http/0.6.22", transitive_headers=True)
+            self.requires("aws-c-io/0.13.4", transitive_headers=True)
+            self.requires("aws-c-mqtt/0.7.12", transitive_headers=True)
+            self.requires("aws-c-s3/0.1.49")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -47,7 +47,7 @@ class AwsCrtCpp(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-common/0.8.2")
+        self.requires("aws-c-common/0.8.2", transitive_headers=True)
         self.requires("aws-checksums/0.1.13")
         if Version(self.version) < "0.17.29":
             self.requires("aws-c-io/0.10.20")

--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -52,16 +52,16 @@ class AwsCrtCpp(ConanFile):
         if Version(self.version) < "0.17.29":
             self.requires("aws-c-io/0.10.20")
             self.requires("aws-c-http/0.6.13")
-            self.requires("aws-c-auth/0.6.11")
+            self.requires("aws-c-auth/0.6.11", transitive_headers=True)
             self.requires("aws-c-s3/0.1.37")
-            self.requires("aws-c-mqtt/0.7.10")
+            self.requires("aws-c-mqtt/0.7.10", transitive_headers=True)
             self.requires("aws-c-event-stream/0.2.7")
         else:
             self.requires("aws-c-io/0.13.4")
             self.requires("aws-c-http/0.6.22")
-            self.requires("aws-c-auth/0.6.17")
+            self.requires("aws-c-auth/0.6.17", transitive_headers=True)
             self.requires("aws-c-s3/0.1.49")
-            self.requires("aws-c-mqtt/0.7.12")
+            self.requires("aws-c-mqtt/0.7.12", transitive_headers=True)
             self.requires("aws-c-event-stream/0.2.15")
 
     def validate(self):

--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -94,23 +94,26 @@ class AwsCrtCpp(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-crt-cpp")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-crt-cpp")
-
-        self.cpp_info.components["aws-crt-cpp-lib"].names["cmake_find_package"] = "aws-crt-cpp"
-        self.cpp_info.components["aws-crt-cpp-lib"].names["cmake_find_package_multi"] = "aws-crt-cpp"
+        # TODO: back to root level in conan v2
         self.cpp_info.components["aws-crt-cpp-lib"].libs = ["aws-crt-cpp"]
-        self.cpp_info.components["aws-crt-cpp-lib"].requires = [
-            "aws-c-event-stream::aws-c-event-stream-lib",
-            "aws-c-common::aws-c-common-lib",
-            "aws-c-io::aws-c-io-lib",
-            "aws-c-http::aws-c-http-lib",
-            "aws-c-auth::aws-c-auth-lib",
-            "aws-c-mqtt::aws-c-mqtt-lib",
-            "aws-c-s3::aws-c-s3-lib",
-            "aws-checksums::aws-checksums-lib"
-        ]
+        if self.options.shared:
+            self.cpp_info.components["aws-crt-cpp-lib"].defines.append("AWS_CRT_CPP_USE_IMPORT_EXPORT")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "aws-crt-cpp"
         self.cpp_info.filenames["cmake_find_package_multi"] = "aws-crt-cpp"
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
+        self.cpp_info.components["aws-crt-cpp-lib"].names["cmake_find_package"] = "aws-crt-cpp"
+        self.cpp_info.components["aws-crt-cpp-lib"].names["cmake_find_package_multi"] = "aws-crt-cpp"
+        self.cpp_info.components["aws-crt-cpp-lib"].set_property("cmake_target_name", "AWS::aws-crt-cpp")
+        self.cpp_info.components["aws-crt-cpp-lib"].requires = [
+            "aws-c-event-stream::aws-c-event-stream",
+            "aws-c-common::aws-c-common",
+            "aws-c-io::aws-c-io",
+            "aws-c-http::aws-c-http",
+            "aws-c-auth::aws-c-auth",
+            "aws-c-mqtt::aws-c-mqtt",
+            "aws-c-s3::aws-c-s3",
+            "aws-checksums::aws-checksums",
+        ]


### PR DESCRIPTION
see https://github.com/awslabs/aws-crt-cpp/blob/v0.19.9/include/aws/crt/Exports.h

closes https://github.com/conan-io/conan-center-index/issues/17382

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
