### PR TITLE
ldns: remove debug print statement

### DIFF
--- a/recipes/ldns/all/conanfile.py
+++ b/recipes/ldns/all/conanfile.py
@@ -106,7 +106,6 @@ class LdnsConan(ConanFile):
         autotools.make()
 
     def package(self):
-        print(self.package_folder)
         autotools = Autotools(self)
         for target in ["install-h", "install-lib"]:
             autotools.install(target=target)


### PR DESCRIPTION
This removes mistakenly committed `print` statement in the ldns recipe.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
