### PR TITLE
s2n: remove component workaround for legacy generators

### DIFF
--- a/recipes/s2n/all/conanfile.py
+++ b/recipes/s2n/all/conanfile.py
@@ -40,7 +40,7 @@ class S2nConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("openssl/3.1.0")
+        self.requires("openssl/[>=1 <4]")
 
     def validate(self):
         if self.settings.os == "Windows":

--- a/recipes/s2n/all/conanfile.py
+++ b/recipes/s2n/all/conanfile.py
@@ -40,7 +40,7 @@ class S2nConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("openssl/[>=1 <4]")
+        self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
Remove component workaround to avoid to define a `AWS::AWS` target in legacy generators. Rely on custom cmake module instead.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
