### PR TITLE
mosquitto/2.x: use the 1.x test_package in 2.x

### DIFF
--- a/recipes/mosquitto/2.x/test_package/test_package.c
+++ b/recipes/mosquitto/2.x/test_package/test_package.c
@@ -1,19 +1,59 @@
-#include <mosquitto.h>
+#include <stdlib.h>
 #include <stdio.h>
+#ifdef WIN32
+#    include <winsock2.h>
+#endif
 
+#include "mosquitto.h"
 
-int main(int argc, char *argv[])
-{
-	struct mosquitto *mosq;
-	int rc;
+/* Hostname and port for the MQTT broker. */
+#define BROKER_HOSTNAME "localhost"
+#define BROKER_PORT 1883
 
-	mosquitto_lib_init();
-	mosq = mosquitto_new(NULL, true, NULL);
-	if(mosq == NULL){
-		fprintf(stderr, "Error: Out of memory.\n");
-		return 1;
-	}
-	mosquitto_lib_cleanup();
-	return 0;
+void connect_callback(struct mosquitto *mosq, void *obj, int result) {}
+void message_callback(struct mosquitto *mosq, void *obj, const struct mosquitto_message *message) {}
+
+int main(int argc, char * argv []) {
+    struct mosquitto* st_mosquitto = NULL;
+
+    #ifdef WIN32
+        WORD wVersionRequested = MAKEWORD(2, 2);
+        WSADATA wsaData;
+        WSAStartup(wVersionRequested, &wsaData);
+    #endif
+
+    puts("mosquitto_lib_init");
+    if (mosquitto_lib_init() != MOSQ_ERR_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+
+    puts("mosquitto_new");
+    st_mosquitto = mosquitto_new("foobar", true, NULL);
+    if (!st_mosquitto) {
+        return EXIT_FAILURE;
+    }
+
+    puts("mosquitto_connect_callback_set");
+    mosquitto_connect_callback_set(st_mosquitto, connect_callback);
+    mosquitto_message_callback_set(st_mosquitto, message_callback);
+
+    puts("mosquitto_connect");
+    if (mosquitto_connect(st_mosquitto, BROKER_HOSTNAME, BROKER_PORT, 60) != MOSQ_ERR_SUCCESS) {
+        fprintf(stderr, "Could not connect to MQTT broker\n");
+    }
+
+    puts("mosquitto_subscribe");
+    if (mosquitto_subscribe(st_mosquitto, NULL, "#", 0) != MOSQ_ERR_SUCCESS) {
+        fprintf(stderr, "Could not suscribe to MQTT broker\n");
+    }
+
+    puts("mosquitto_destroy");
+    mosquitto_destroy(st_mosquitto);
+
+    puts("mosquitto_lib_cleanup");
+    if (mosquitto_lib_cleanup() != MOSQ_ERR_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
 }
-


### PR DESCRIPTION
Specify library name and version:  **mosquitto/2.x**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

---

Pull request https://github.com/conan-io/conan-center-index/pull/17007 is failing the MacOS build. That branch does two things:
- copied the 1.x _test_package_ to 2.x as it's more comprehensive
- ported 2.x to conan 2

_Note_ 1.x and 2.x refer to _mosquitto_ versions, not conan ones

This is just a test branch to check if the 1.x _test_package_ actually works in with the 2.x recipe (even before porting to conan2) in CI. No intention to merge (yet)

Sister PR to https://github.com/conan-io/conan-center-index/pull/17133 which does the exact opposite (keeps the conan2 port but uses the original 1x _test_package_)

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
