### PR TITLE
[config] Fix build log paths

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -101,7 +101,7 @@ configurations:
               compiler.libcxx: ["libstdc++", "libc++"]
               compiler.version: ["11", "12", "13"]
               build_type: ["Release", "Debug"]
-  - id: configs/macos-clang
+  - id: macos-clang
     epochs: [0, 20211221]
     hrname: "macOS, Clang"
     content:
@@ -112,7 +112,7 @@ configurations:
               compiler.version: [ "11.0", "12.0" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
-  - id: configs/macos-clang
+  - id: macos-clang
     epochs: [20220120]
     hrname: "macOS, Clang"
     content:
@@ -123,7 +123,7 @@ configurations:
               compiler.version: [ "13.0" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
-  - id: configs/macos-m1-clang
+  - id: macos-m1-clang
     epochs: [0, 20211221]
     hrname: "macOS, Clang (M1/arm64)"
     build_profile:
@@ -137,7 +137,7 @@ configurations:
               compiler.version: [ "12.0" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
-  - id: configs/macos-m1-clang
+  - id: macos-m1-clang
     epochs: [20220120]
     hrname: "macOS, Clang (M1/arm64)"
     build_profile:
@@ -151,7 +151,7 @@ configurations:
               compiler.version: [ "13.0" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
-  - id: configs/windows-visual_studio
+  - id: windows-visual_studio
     epochs: [0, 20211221, 20220120]
     hrname: "Windows, Visual Studio"
     content:

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -62,7 +62,7 @@ configurations:
               compiler.libcxx: ["libstdc++11"]
               compiler.version: ["11"]
               build_type: ["Release"]
-  - id: configs/macos-clang
+  - id: macos-clang
     epochs: [0, 20211221, 20220120, 20220628]
     hrname: "macOS, Clang"
     build_profile:
@@ -75,7 +75,7 @@ configurations:
               compiler.version: [ "13" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
-  - id: configs/macos-m1-clang
+  - id: macos-m1-clang
     epochs: [0, 20211221, 20220120, 20220628]
     hrname: "macOS M1, Clang"
     build_profile:
@@ -89,7 +89,7 @@ configurations:
               compiler.version: ["13" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
-  - id: configs/windows-msvc
+  - id: windows-msvc
     epochs: [0, 20211221, 20220120, 20220628]
     hrname: "Windows, MSVC"
     build_profile:


### PR DESCRIPTION
We are using the configuration ID to store the log paths of each build. Having `config/` creates unneded folders in Artifactory.

This avoids creating unneeded nested folders when storing the logs in the generic repo of artifactory