### PR TITLE
civetweb: update OpenSSL dependency

### DIFF
--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -82,7 +82,10 @@ class CivetwebConan(ConanFile):
 
     def requirements(self):
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1t")
+            if Version(self.version) >= "1.16":
+                self.requires("openssl/3.1.0")
+            else:
+                self.requires("openssl/1.1.1t")
         if self.options.get_safe("with_zlib"):
             self.requires("zlib/1.2.13")
 
@@ -100,8 +103,9 @@ class CivetwebConan(ConanFile):
             openssl_version = Version(str(self.dependencies["openssl"].ref.version)[:-1])
             tc.variables["CIVETWEB_ENABLE_SSL"] = self.options.with_ssl
             tc.variables["CIVETWEB_ENABLE_SSL_DYNAMIC_LOADING"] = self.options.ssl_dynamic_loading
-            tc.variables["CIVETWEB_SSL_OPENSSL_API_1_0"] = openssl_version.minor == "0"
-            tc.variables["CIVETWEB_SSL_OPENSSL_API_1_1"] = openssl_version.minor == "1"
+            tc.variables["CIVETWEB_SSL_OPENSSL_API_1_0"] = openssl_version.major == "1" and openssl_version.minor == "0"
+            tc.variables["CIVETWEB_SSL_OPENSSL_API_1_1"] = openssl_version.major == "1" and openssl_version.minor == "1"
+            tc.variables["CIVETWEB_SSL_OPENSSL_API_3_0"] = openssl_version.major == "3"
 
         tc.variables["CIVETWEB_BUILD_TESTING"] = False
         tc.variables["CIVETWEB_CXX_ENABLE_LTO"] = False


### PR DESCRIPTION
Specify library name and version:  **civetweb/***

promtheus-cpp depends on curl and civetweb. Curl already requires OpenSSL 3.1.0.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
