### PR TITLE
ffmpeg: Fix list options with Conan 2.0.

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -593,7 +593,6 @@ class FFMpegConan(ConanFile):
             args.append("--extra-cflags={}".format(" ".join(tc.cflags)))
         if tc.ldflags:
             args.append("--extra-ldflags={}".format(" ".join(tc.ldflags)))
-        tc.configure_args.extend(args)
         # Custom configure script of ffmpeg understands:
         # --prefix, --bindir, --datadir, --docdir, --incdir, --libdir, --mandir
         # Options --datadir, --docdir, --incdir, and --mandir are not injected by AutotoolsToolchain  but their default value
@@ -608,6 +607,7 @@ class FFMpegConan(ConanFile):
             "--host": None,
             "--target": None,
         })
+        tc.configure_args.extend(args)
         tc.generate()
 
         if is_msvc(self):

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -261,7 +261,7 @@ class FFMpegConan(ConanFile):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:
-            self.requires("xz_utils/5.4.0")
+            self.requires("xz_utils/5.4.2")
         if self.options.with_libiconv:
             self.requires("libiconv/1.17")
         if self.options.with_freetype:
@@ -291,7 +291,7 @@ class FFMpegConan(ConanFile):
         if self.options.with_libwebp:
             self.requires("libwebp/1.3.0")
         if self.options.with_ssl == "openssl":
-            self.requires("openssl/1.1.1t")
+            self.requires("openssl/3.1.0")
         if self.options.get_safe("with_libalsa"):
             self.requires("libalsa/1.2.7.2")
         if self.options.get_safe("with_xcb") or self.options.get_safe("with_vaapi"):


### PR DESCRIPTION
`update_configure_args` from the `AutotoolsToolchain` strips out duplicate configuration flags, even if they have different values. e.g. `--enable-encoder=gif --enable-encoder=mp3`

This commit simply appends those flags after the offending method call to avoid them being stripped.

Specify library name and version:  **ffmpeg/***

fixes #17140

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
