### PR TITLE
quill: add version 2.8.0, add package_type

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.8.0":
+    url: "https://github.com/odygrd/quill/archive/v2.8.0.tar.gz"
+    sha256: "0461a6c314e3d882f3b9ada487ef1bf558925272509ee41a9fd25f7776db6075"
   "2.7.0":
     url: "https://github.com/odygrd/quill/archive/v2.7.0.tar.gz"
     sha256: "10b8912e4c463a3a86b809076b95bec49aa08393d9ae6b92196cd46314236b87"

--- a/recipes/quill/all/test_package/test_package.cpp
+++ b/recipes/quill/all/test_package/test_package.cpp
@@ -3,8 +3,8 @@
 int main()
 {
     quill::start();
-    quill::Handler *file_handler = quill::file_handler("logfile.log", "w");
-    quill::Logger *my_logger = quill::create_logger("my_logger", file_handler);
+    auto file_handler = quill::file_handler("logfile.log", "w");
+    auto my_logger = quill::create_logger("my_logger", std::move(file_handler));
 
     LOG_INFO(my_logger, "Hello from {}", "Quill");
     LOG_CRITICAL(my_logger, "This is a conan example {}", 1234);

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8.0":
+    folder: "all"
   "2.7.0":
     folder: "all"
   "2.6.0":


### PR DESCRIPTION
Specify library name and version:  **quill/2.8.0**

- add version 2.8.0
  - some cmake options are moved into macro
  - add with_bounded_blocking_queue macro
  - return types of several APIs are changed. (with shared_ptr)
- add package_type

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
