### PR TITLE
fix ISL to build under conan 2.0

### DIFF
--- a/recipes/isl/all/conandata.yml
+++ b/recipes/isl/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "0.26":
+    url: "https://libisl.sourceforge.io/isl-0.26.tar.gz"
+    sha256: "b10473024cbf17d7db85323121eff0e50f03de14342a03738b4d384b587ce212"
+  "0.25":
+    url: "https://libisl.sourceforge.io/isl-0.25.tar.gz"
+    sha256: "acac270b41f6a533cbe5cf26463877ed5e4107051a5457b9d50b58576a59c6c5"
   "0.24":
     url: "https://libisl.sourceforge.io/isl-0.24.tar.gz"
     sha256: "26e6e4d60ad59b3fff9948eb36743f0c874e124e410ef5bab930d0f546bc580d"

--- a/recipes/isl/all/conanfile.py
+++ b/recipes/isl/all/conanfile.py
@@ -121,9 +121,9 @@ class IslConan(ConanFile):
                 "--with-gmp-prefix={}".format(self.dependencies["gmp"].package_folder.replace("\\", "/")),
             ])
         if self.settings.compiler == "msvc":
-            if tools.Version(self.settings.compiler.version) >= 15:
+            if self.settings.get_safe("compiler.version") >= 15:
                 self._autotools.cflags.append("-Zf")
-            if tools.Version(self.settings.compiler.version) >= 12:
+            if self.settings.get_safe("compiler.version") >= 12:
                 self._autotools.cflags.append("-FS")
         self._autotools.generate()
 

--- a/recipes/isl/all/conanfile.py
+++ b/recipes/isl/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile, tools
+from conan import ConanFile
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conans.errors import ConanInvalidConfiguration
 from conan.tools.env import VirtualBuildEnv
@@ -65,7 +65,7 @@ class IslConan(ConanFile):
         return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+        if self._settings_build.os == "Windows":
             self.build_requires("msys2/cci.latest")
         if self.settings.compiler == "msvc":
             self.build_requires("automake/1.16.4")

--- a/recipes/isl/all/conanfile.py
+++ b/recipes/isl/all/conanfile.py
@@ -1,6 +1,9 @@
-from conans import AutoToolsBuildEnvironment, ConanFile, tools
+from conan import ConanFile, tools
+from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conans.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
 from contextlib import contextmanager
+from conan.tools.files import get, copy, rmdir
 import os
 
 required_conan_version = ">=1.33.0"
@@ -49,7 +52,7 @@ class IslConan(ConanFile):
         if self.options.with_int != "gmp":
             # FIXME: missing imath recipe
             raise ConanInvalidConfiguration("imath is not (yet) available on cci")
-        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) < 16 and self.settings.compiler.runtime == "MDd":
+        if self.settings.compiler == "msvc" and tools.Version(self.settings.compiler.version) < 16 and self.settings.compiler.runtime == "MDd":
             # gmp.lib(bdiv_dbm1c.obj) : fatal error LNK1318: Unexpected PDB error; OK (0)
             raise ConanInvalidConfiguration("isl fails to link with this version of visual studio and MDd runtime")
 
@@ -64,16 +67,20 @@ class IslConan(ConanFile):
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
-        if self.settings.compiler == "Visual Studio":
+        if self.settings.compiler == "msvc":
             self.build_requires("automake/1.16.4")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
+        get(self, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self._source_subfolder)
+    
+    def layout(self):
+        self.folders.source = self._source_subfolder
+        self.folders.build = self._source_subfolder
 
     @contextmanager
     def _build_context(self):
-        if self.settings.compiler == "Visual Studio":
+        if self.settings.compiler == "msvc":
             with tools.vcvars(self.settings):
                 env = {
                     "AR": "{} lib".format(tools.unix_path(self.deps_user_info["automake"].ar_lib)),
@@ -88,45 +95,51 @@ class IslConan(ConanFile):
                     yield
         else:
             yield
-
-    def _configure_autotools(self):
+    
+    def generate(self):
         if self._autotools:
             return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        # TODO: Remove when conan 2.0 is released as this will be default behaviour
+        buildenv = VirtualBuildEnv(self)
+        buildenv.generate()
+        
+        self._autotools = AutotoolsToolchain(self)
+
+        # self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         self._autotools.libs = []
         yes_no = lambda v: "yes" if v else "no"
-        conf_args = [
+        self._autotools.configure_args.extend([
             "--with-int={}".format(self.options.with_int),
             "--enable-portable-binary",
             "--enable-shared={}".format(yes_no(self.options.shared)),
             "--enable-static={}".format(yes_no(not self.options.shared)),
-        ]
+        ])
         if self.options.with_int == "gmp":
-            conf_args.extend([
+            self._autotools.configure_args.extend([
                 "--with-gmp=system",
-                "--with-gmp-prefix={}".format(self.deps_cpp_info["gmp"].rootpath.replace("\\", "/")),
+                #"--with-gmp-prefix={}".format(self.deps_cpp_info["gmp"].rootpath.replace("\\", "/")),
+                "--with-gmp-prefix={}".format(self.dependencies["gmp"].package_folder.replace("\\", "/")),
             ])
-        if self.settings.compiler == "Visual Studio":
+        if self.settings.compiler == "msvc":
             if tools.Version(self.settings.compiler.version) >= 15:
-                self._autotools.flags.append("-Zf")
+                self._autotools.cflags.append("-Zf")
             if tools.Version(self.settings.compiler.version) >= 12:
-                self._autotools.flags.append("-FS")
-        self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder)
-        return self._autotools
+                self._autotools.cflags.append("-FS")
+        self._autotools.generate()
 
     def build(self):
-        with self._build_context():
-            autotools = self._configure_autotools()
-            autotools.make()
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        autotools.configure()
+        autotools.make()
 
     def package(self):
-        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        with self._build_context():
-            autotools = self._configure_autotools()
-            autotools.install()
+        copy(self, "LICENSE", src=self._source_subfolder, dst="licenses")
+        autotools = Autotools(self)
+        autotools.install()
 
         os.unlink(os.path.join(os.path.join(self.package_folder, "lib", "libisl.la")))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "isl"

--- a/recipes/isl/all/conanfile.py
+++ b/recipes/isl/all/conanfile.py
@@ -72,7 +72,7 @@ class IslConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
-                  strip_root=True, destination=self._source_subfolder)
+                  strip_root=True)
     
     def layout(self):
         self.folders.source = self._source_subfolder

--- a/recipes/isl/all/test_package/CMakeLists.txt
+++ b/recipes/isl/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup()
+find_package(ISL)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE isl::isl)

--- a/recipes/isl/all/test_package/conanfile.py
+++ b/recipes/isl/all/test_package/conanfile.py
@@ -1,17 +1,22 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile, tools
+from conan.tools.cmake import CMake
+from conan.tools.build import cross_building
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "CMakeToolchain", 'CMakeDeps'
 
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if not cross_building(self):
+            bin_path = os.path.join(".", "test_package")
+            self.run(bin_path, env='conanrun')


### PR DESCRIPTION
Specify library name and version:  **ISL/0.24.0+0.25.0+0.26.0**

I want to be able to compile GCC (for different cross-compiling targets including AVR) using conan, and I thought I'd try to help migrating the dependencies to conan 2.0 (as it is nice knowing I can get it to work with the most up-to-date tools)


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated. - I have conan 2.0 only, and the hooks seems to work differently (?). I have tried both 0.24 and 0.26 though..
