### PR TITLE
libmad: conan v2 support

### DIFF
--- a/recipes/libmad/all/CMakeLists.txt
+++ b/recipes/libmad/all/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.15)
+project(libmad LANGUAGES C)
+
+add_library(libmad
+    ${LIBMAD_SRC_DIR}/bit.c
+    ${LIBMAD_SRC_DIR}/decoder.c
+    ${LIBMAD_SRC_DIR}/fixed.c
+    ${LIBMAD_SRC_DIR}/frame.c
+    ${LIBMAD_SRC_DIR}/huffman.c
+    ${LIBMAD_SRC_DIR}/layer12.c
+    ${LIBMAD_SRC_DIR}/layer3.c
+    ${LIBMAD_SRC_DIR}/stream.c
+    ${LIBMAD_SRC_DIR}/synth.c
+    ${LIBMAD_SRC_DIR}/timer.c
+    ${LIBMAD_SRC_DIR}/version.c
+    ${LIBMAD_SRC_DIR}/huffman.c
+)
+
+target_include_directories(libmad PUBLIC ${LIBMAD_SRC_DIR}/msvc++)
+target_compile_definitions(libmad PRIVATE FPM_DEFAULT ASO_ZEROCHECK HAVE_CONFIG_H)
+set_target_properties(libmad PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+include(GNUInstallDirs)
+install(FILES ${LIBMAD_SRC_DIR}/msvc++/mad.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(
+    TARGETS libmad
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/recipes/libmad/all/CMakeLists.txt
+++ b/recipes/libmad/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(libmad LANGUAGES C)
 
-add_library(libmad
+add_library(mad
     ${LIBMAD_SRC_DIR}/bit.c
     ${LIBMAD_SRC_DIR}/decoder.c
     ${LIBMAD_SRC_DIR}/fixed.c
@@ -16,14 +16,19 @@ add_library(libmad
     ${LIBMAD_SRC_DIR}/huffman.c
 )
 
-target_include_directories(libmad PUBLIC ${LIBMAD_SRC_DIR}/msvc++)
-target_compile_definitions(libmad PRIVATE FPM_DEFAULT ASO_ZEROCHECK HAVE_CONFIG_H)
-set_target_properties(libmad PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+target_include_directories(mad PUBLIC ${LIBMAD_SRC_DIR}/msvc++)
+target_compile_definitions(mad PRIVATE FPM_DEFAULT ASO_ZEROCHECK HAVE_CONFIG_H)
+set_target_properties(mad
+    PROPERTIES
+        VERSION ${LIBMAD_VERSION}
+        SOVERSION ${LIBMAD_VERSION_MAJOR}
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
 
 include(GNUInstallDirs)
 install(FILES ${LIBMAD_SRC_DIR}/msvc++/mad.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(
-    TARGETS libmad
+    TARGETS mad
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/recipes/libmad/all/CMakeLists.txt
+++ b/recipes/libmad/all/CMakeLists.txt
@@ -22,7 +22,6 @@ set_target_properties(mad
     PROPERTIES
         VERSION ${LIBMAD_VERSION}
         SOVERSION ${LIBMAD_VERSION_MAJOR}
-        WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 
 include(GNUInstallDirs)

--- a/recipes/libmad/all/conandata.yml
+++ b/recipes/libmad/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.15.1b":
     url: "https://sourceforge.net/projects/mad/files/libmad/0.15.1b/libmad-0.15.1b.tar.gz"
-    sha256: bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690
+    sha256: "bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690"

--- a/recipes/libmad/all/conanfile.py
+++ b/recipes/libmad/all/conanfile.py
@@ -1,114 +1,109 @@
-from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, replace_in_file, rm
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc
 import os
-import shutil
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.53.0"
 
 
 class LibmadConan(ConanFile):
     name = "libmad"
     description = "MAD is a high-quality MPEG audio decoder."
-    topics = ("conan", "mad", "MPEG", "audio", "decoder")
+    topics = ("mad", "MPEG", "audio", "decoder")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.underbit.com/products/mad/"
     license = "GPL-2.0-or-later"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
 
-    _autotools = None
+    exports_sources = "CMakeLists.txt"
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _is_msvc(self):
-        return self.settings.compiler == "Visual Studio"
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
-    def validate(self):
-        if self.options.shared and self._is_msvc:
-            raise ConanInvalidConfiguration("libmad does not support shared library for MSVC")
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
+    def layout(self):
+        if is_msvc(self):
+            cmake_layout(self, src_folder="src")
+        else:
+            basic_layout(self, src_folder="src")
 
     def build_requirements(self):
-        if not self._is_msvc:
-            self.build_requires("gnu-config/cci.20201022")
-            if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-                self.build_requires("msys2/cci.latest")
+        if not is_msvc(self):
+            self.tool_requires("gnu-config/cci.20210814")
+            if self._settings_build.os == "Windows":
+                self.win_bash = True
+                if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                    self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        if is_msvc(self):
+            tc = CMakeToolchain(self)
+            tc.variables["LIBMAD_SRC_DIR"] = self.source_folder.replace("\\", "/")
+            tc.generate()
+        else:
+            env = VirtualBuildEnv(self)
+            env.generate()
+            tc = AutotoolsToolchain(self)
+            tc.generate()
 
     def build(self):
-        if self._is_msvc:
-            self._build_msvc()
+        if is_msvc(self):
+            replace_in_file(
+                self, os.path.join(self.source_folder, "msvc++", "mad.h"),
+                "# define FPM_INTEL", "# define FPM_DEFAULT",
+            )
+            cmake = CMake(self)
+            cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+            cmake.build()
         else:
-            self._build_autotools()
-
-    def _build_msvc(self):
-        with tools.chdir(os.path.join(self._source_subfolder, "msvc++")):
-            # cl : Command line error D8016: '/ZI' and '/Gy-' command-line options are incompatible
-            tools.replace_in_file("libmad.dsp", "/ZI ", "")
-            if self.settings.arch == "x86_64":
-                tools.replace_in_file("libmad.dsp", "Win32", "x64")
-                tools.replace_in_file("libmad.dsp", "FPM_INTEL", "FPM_DEFAULT")
-                tools.replace_in_file("mad.h", "# define FPM_INTEL", "# define FPM_DEFAULT")
-            with tools.vcvars(self.settings):
-                self.run("devenv libmad.dsp /upgrade")
-            msbuild = MSBuild(self)
-            msbuild.build(project_file="libmad.vcxproj")
-
-    @property
-    def _user_info_build(self):
-        return getattr(self, "user_info_build", self.deps_user_info)
-
-    def _build_autotools(self):
-        shutil.copy(self._user_info_build["gnu-config"].CONFIG_SUB,
-                    os.path.join(self._source_subfolder, "config.sub"))
-        shutil.copy(self._user_info_build["gnu-config"].CONFIG_GUESS,
-                    os.path.join(self._source_subfolder, "config.guess"))
-        autotools = self._configure_autotools()
-        autotools.make()
-
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-        args = []
-        if self.options.shared:
-            args = ["--disable-static", "--enable-shared"]
-        else:
-            args = ["--disable-shared", "--enable-static"]
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        self._autotools.configure(configure_dir=self._source_subfolder, args=args)
-        return self._autotools
+            for gnu_config in [
+                self.conf.get("user.gnu-config:config_guess", check_type=str),
+                self.conf.get("user.gnu-config:config_sub", check_type=str),
+            ]:
+                if gnu_config:
+                    copy(self, os.path.basename(gnu_config), src=os.path.dirname(gnu_config), dst=self.source_folder)
+            autotools = Autotools(self)
+            autotools.configure()
+            autotools.make()
 
     def package(self):
-        self.copy("COPYRIGHT", dst="licenses", src=self._source_subfolder)
-        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
-        self.copy("CREDITS", dst="licenses", src=self._source_subfolder)
-        if self._is_msvc:
-            self.copy(pattern="*.lib", dst="lib", src=self._source_subfolder, keep_path=False)
-            self.copy(pattern="mad.h", dst="include", src=os.path.join(self._source_subfolder, "msvc++"))
+        for license_file in ("COPYRIGHT", "COPYING", "CREDITS"):
+            copy(self, license_file, src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        if is_msvc(self):
+            cmake = CMake(self)
+            cmake.install()
         else:
-            autotools = self._configure_autotools()
+            autotools = Autotools(self)
             autotools.install()
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+            rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+            fix_apple_shared_install_name(self)
 
     def package_info(self):
-        self.cpp_info.libs = ["libmad" if self._is_msvc else "mad"]
+        self.cpp_info.libs = ["libmad" if is_msvc(self) else "mad"]

--- a/recipes/libmad/all/conanfile.py
+++ b/recipes/libmad/all/conanfile.py
@@ -1,6 +1,8 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, replace_in_file
+from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 
@@ -39,6 +41,10 @@ class LibmadConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if is_msvc(self) and self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} shared not supported by msvc")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libmad/all/conanfile.py
+++ b/recipes/libmad/all/conanfile.py
@@ -1,11 +1,7 @@
 from conan import ConanFile
-from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy, get, replace_in_file, rm
-from conan.tools.gnu import Autotools, AutotoolsToolchain
-from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc
+from conan.tools.files import copy, get, replace_in_file
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -31,10 +27,6 @@ class LibmadConan(ConanFile):
 
     exports_sources = "CMakeLists.txt"
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -46,64 +38,32 @@ class LibmadConan(ConanFile):
         self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
-        if is_msvc(self):
-            cmake_layout(self, src_folder="src")
-        else:
-            basic_layout(self, src_folder="src")
-
-    def build_requirements(self):
-        if not is_msvc(self):
-            self.tool_requires("gnu-config/cci.20210814")
-            if self._settings_build.os == "Windows":
-                self.win_bash = True
-                if not self.conf.get("tools.microsoft.bash:path", check_type=str):
-                    self.tool_requires("msys2/cci.latest")
+        cmake_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        if is_msvc(self):
-            tc = CMakeToolchain(self)
-            tc.variables["LIBMAD_SRC_DIR"] = self.source_folder.replace("\\", "/")
-            tc.generate()
-        else:
-            env = VirtualBuildEnv(self)
-            env.generate()
-            tc = AutotoolsToolchain(self)
-            tc.generate()
+        tc = CMakeToolchain(self)
+        tc.variables["LIBMAD_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.variables["LIBMAD_VERSION"] = self.version
+        tc.variables["LIBMAD_VERSION_MAJOR"] = Version(self.version).major
+        tc.generate()
 
     def build(self):
-        if is_msvc(self):
-            replace_in_file(
-                self, os.path.join(self.source_folder, "msvc++", "mad.h"),
-                "# define FPM_INTEL", "# define FPM_DEFAULT",
-            )
-            cmake = CMake(self)
-            cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
-            cmake.build()
-        else:
-            for gnu_config in [
-                self.conf.get("user.gnu-config:config_guess", check_type=str),
-                self.conf.get("user.gnu-config:config_sub", check_type=str),
-            ]:
-                if gnu_config:
-                    copy(self, os.path.basename(gnu_config), src=os.path.dirname(gnu_config), dst=self.source_folder)
-            autotools = Autotools(self)
-            autotools.configure()
-            autotools.make()
+        replace_in_file(
+            self, os.path.join(self.source_folder, "msvc++", "mad.h"),
+            "# define FPM_INTEL", "# define FPM_DEFAULT",
+        )
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        cmake.build()
 
     def package(self):
         for license_file in ("COPYRIGHT", "COPYING", "CREDITS"):
             copy(self, license_file, src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        if is_msvc(self):
-            cmake = CMake(self)
-            cmake.install()
-        else:
-            autotools = Autotools(self)
-            autotools.install()
-            rm(self, "*.la", os.path.join(self.package_folder, "lib"))
-            fix_apple_shared_install_name(self)
+        cmake = CMake(self)
+        cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ["libmad" if is_msvc(self) else "mad"]
+        self.cpp_info.libs = ["mad"]

--- a/recipes/libmad/all/test_package/CMakeLists.txt
+++ b/recipes/libmad/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+project(test_package LANGUAGES C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(libmad REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE libmad::libmad)

--- a/recipes/libmad/all/test_package/conanfile.py
+++ b/recipes/libmad/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libmad/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libmad/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/libmad/all/test_v1_package/conanfile.py
+++ b/recipes/libmad/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
I've replaced build system by a simple CMakeList.txt for 2 reasons:
- msvc build was relying on `.dsp` files which are not supported anymore by `devenv` since Visual Studio 2022.
- these old autotools files didn't scale (no support for macOS M1)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
