### PR TITLE
Use cmake to build libcurl with mingw

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -134,7 +134,7 @@ class LibcurlConan(ConanFile):
 
     @property
     def _is_using_cmake_build(self):
-        return is_msvc(self) or self._is_win_x_android
+        return is_msvc(self) or self._is_mingw() or self._is_win_x_android
 
     @property
     def _has_metalink_option(self):


### PR DESCRIPTION
Specify library name and version:  **libcurl/8.0.1**

CMake build works well on windows with mingw but the libtool always fails to build.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
