### PR TITLE
screen_capture_lite: add version 17.1.1173, add package_type

### DIFF
--- a/recipes/screen_capture_lite/all/conandata.yml
+++ b/recipes/screen_capture_lite/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "17.1.1173":
+    url: "https://github.com/smasherprog/screen_capture_lite/archive/refs/tags/17.1.1173.tar.gz"
+    sha256: "17875fb58f0e5920b13b6ef2516c8e973055347339d3dbaabfa97ef448fdfff2"
   "17.1.613":
     url: "https://github.com/smasherprog/screen_capture_lite/archive/refs/tags/17.1.613.tar.gz"
     sha256: "ab111e52379fc4bca852b9a79535329e12dca9b25a0b87a2ef84ab7348a64064"
@@ -8,7 +11,6 @@ sources:
   "17.1.439":
     url: "https://github.com/smasherprog/screen_capture_lite/archive/refs/tags/17.1.439.tar.gz"
     sha256: "c6e6eead72114dc7ba9f3fb17eeff01b4b53bb3ad3b71a55ebe08b61bbff9dea"
-
 patches:
   "17.1.462":
     - patch_file: "patches/17.1.462-0001-fix-cmake.patch"

--- a/recipes/screen_capture_lite/config.yml
+++ b/recipes/screen_capture_lite/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "17.1.1173":
+    folder: "all"
   "17.1.613":
     folder: "all"
   "17.1.462":


### PR DESCRIPTION
Specify library name and version:  **screen_capture_lite/***

- add version 17.1.1173
- add package_type
- use `rm_safe` in `configure()`
- fix `validate()` not to use check_min_vs
- remove `destination` argument from `get`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
