### PR TITLE
libpcap: use winflexbison if build machine is Windows

### DIFF
--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -23,7 +23,7 @@ class LibPcapConan(ConanFile):
     description = "libpcap is an API for capturing network traffic"
     license = "BSD-3-Clause"
     topics = ("networking", "pcap", "sniffing", "network-traffic")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -84,8 +84,7 @@ class LibPcapConan(ConanFile):
             self.tool_requires("flex/2.6.4")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         VirtualBuildEnv(self).generate()

--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -77,7 +77,7 @@ class LibPcapConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} can not be built static on Windows")
 
     def build_requirements(self):
-        if is_msvc(self, build_context=True):
+        if self._settings_build.os == "Windows":
             self.tool_requires("winflexbison/2.5.24")
         else:
             self.tool_requires("bison/3.8.2")


### PR DESCRIPTION
`flex` raises if os is Windows, therefore we must use `winflexbison` in build requirements of `libpcap` recipe if build machine is Windows.

closes https://github.com/conan-io/conan/issues/13754

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
