### PR TITLE
libbigwig: conan v2 support; bump deps

### DIFF
--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -88,13 +88,6 @@ class LibBigWigConan(ConanFile):
         self.cpp_info.libs = ["BigWig"]
         self.cpp_info.system_libs = ["m"]
 
-        self.cpp_info.requires = []
-        if self.options.get_safe("with_curl"):
-            self.cpp_info.requires.append("libcurl::libcurl")
-        if self.options.get_safe("with_zlibng"):
-            self.cpp_info.requires.append("zlib-ng::zlib-ng")
-        else:
-            self.cpp_info.requires.append("zlib::zlib")
 
         if not self.options.get_safe("with_curl"):
             self.cpp_info.defines = ["NOCURL"]

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -63,11 +63,6 @@ class LibBigWigConan(ConanFile):
             if not zlib_ng.options.zlib_compat:
                 raise ConanInvalidConfiguration(f"{self.ref} requires the dependency option zlib-ng:zlib_compat=True")
 
-        if self.options.with_curl:
-            libcurl = self.dependencies["libcurl"]
-            if libcurl.options.with_imap or libcurl.options.with_pop3 or libcurl.options.with_smtp:
-                raise ConanInvalidConfiguration(f"{self.ref} requires libcurl using the follow options: -o libcurl:with_imap=False -o libcurl:with_pop3=False -o libcurl:with_smtp=False")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -42,11 +42,11 @@ class LibBigWigConan(ConanFile):
 
     def requirements(self):
         if self.options.with_curl:
-            self.requires("libcurl/7.85.0")
+            self.requires("libcurl/8.0.1")
         if self.options.with_zlibng:
-            self.requires("zlib-ng/2.0.6")
+            self.requires("zlib-ng/2.0.7")
         else:
-            self.requires("zlib/1.2.12")
+            self.requires("zlib/1.2.13")
 
     def validate(self):
         if self.info.settings.os == "Windows":

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -42,7 +42,7 @@ class LibBigWigConan(ConanFile):
 
     def requirements(self):
         if self.options.with_curl:
-            self.requires("libcurl/8.0.1")
+            self.requires("libcurl/8.0.1", transitive_headers=True)
         if self.options.with_zlibng:
             self.requires("zlib-ng/2.0.7")
         else:
@@ -87,7 +87,15 @@ class LibBigWigConan(ConanFile):
         self.cpp_info.libs = ["BigWig"]
         self.cpp_info.system_libs = ["m"]
 
-        if not self.options.with_curl:
+        self.cpp_info.requires = []
+        if self.options.get_safe("with_curl"):
+            self.cpp_info.requires.append("libcurl::libcurl")
+        if self.options.get_safe("with_zlibng"):
+            self.cpp_info.requires.append("zlib-ng::zlib-ng")
+        else:
+            self.cpp_info.requires.append("zlib::zlib")
+
+        if not self.options.get_safe("with_curl"):
             self.cpp_info.defines = ["NOCURL"]
 
         # TODO: Remove in Conan 2.0

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.53.0"
 
 
 class LibBigWigConan(ConanFile):
@@ -89,3 +89,7 @@ class LibBigWigConan(ConanFile):
 
         if not self.options.with_curl:
             self.cpp_info.defines = ["NOCURL"]
+
+        # TODO: Remove in Conan 2.0
+        self.cpp_info.names["cmake_find_package"] = "BigWig"
+        self.cpp_info.names["cmake_find_package_multi"] = "BigWig"

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -27,7 +27,7 @@ class LibBigWigConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_curl": False,
+        "with_curl": True,
         "with_zlibng": False
     }
 

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -43,6 +43,8 @@ class LibBigWigConan(ConanFile):
 
     def requirements(self):
         if self.options.with_curl:
+            # transitive_headers=True is required due to includes in bigWigIO.h
+            # https://github.com/dpryan79/libBigWig/blob/master/bigWigIO.h#L5
             self.requires("libcurl/8.0.1", transitive_headers=True)
         if self.options.with_zlibng:
             self.requires("zlib-ng/2.0.7")

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -33,15 +33,9 @@ class LibBigWigConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -64,7 +58,8 @@ class LibBigWigConan(ConanFile):
                 raise ConanInvalidConfiguration(f"{self.ref} requires the dependency option zlib-ng:zlib_compat=True")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -87,14 +82,10 @@ class LibBigWigConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ["BigWig"]
-        self.cpp_info.system_libs = ["m"]
         self.cpp_info.set_property("cmake_file_name", "BigWig")
         self.cpp_info.set_property("cmake_target_name", "BigWig::BigWig")
+        self.cpp_info.libs = ["BigWig"]
+        self.cpp_info.system_libs = ["m"]
 
         if not self.options.with_curl:
             self.cpp_info.defines = ["NOCURL"]
-
-        # TODO: Remove in Conan 2.0
-        self.cpp_info.names["cmake_find_package"] = "BigWig"
-        self.cpp_info.names["cmake_find_package_multi"] = "BigWig"

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -15,6 +15,7 @@ class LibBigWigConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/dpryan79/libBigWig"
     license = "MIT"
+    package_type = "library"
     settings = "arch", "build_type", "compiler", "os"
 
     options = {

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -1,8 +1,9 @@
-from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import collect_libs, get, copy
-from conan.errors import ConanInvalidConfiguration
 import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
 
 required_conan_version = ">=1.50.0"
 

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -91,7 +91,7 @@ class LibBigWigConan(ConanFile):
         self.cpp_info.system_libs = ["m"]
 
 
-        if not self.options.get_safe("with_curl"):
+        if not self.options.with_curl:
             self.cpp_info.defines = ["NOCURL"]
 
         # TODO: Remove in Conan 2.0

--- a/recipes/libbigwig/all/test_package/CMakeLists.txt
+++ b/recipes/libbigwig/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES C)
 
-set(CMAKE_C_STANDARD 11)
-
 find_package(BigWig REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE BigWig::BigWig)
-target_compile_features(${PROJECT_NAME} PRIVATE c_std_${CMAKE_C_STANDARD})
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)

--- a/recipes/libbigwig/all/test_package/CMakeLists.txt
+++ b/recipes/libbigwig/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package C)
+project(test_package LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
 
 find_package(BigWig REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE BigWig::BigWig)
-target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_${CMAKE_C_STANDARD})

--- a/recipes/libbigwig/all/test_package/conanfile.py
+++ b/recipes/libbigwig/all/test_package/conanfile.py
@@ -1,7 +1,8 @@
 import os
+
 from conan import ConanFile
-from conan.tools.cmake import CMake, cmake_layout
 from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 
 
 class TestPackageConan(ConanFile):

--- a/recipes/libbigwig/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libbigwig/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package C)
+project(test_package LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 
 find_package(BigWig REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+add_executable(test_package test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE BigWig::BigWig)
-target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_${CMAKE_C_STANDARD})

--- a/recipes/libbigwig/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libbigwig/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES C)
 
-set(CMAKE_C_STANDARD 11)
-
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 
@@ -10,4 +8,4 @@ find_package(BigWig REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE BigWig::BigWig)
-target_compile_features(${PROJECT_NAME} PRIVATE c_std_${CMAKE_C_STANDARD})
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)

--- a/recipes/libbigwig/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libbigwig/all/test_v1_package/CMakeLists.txt
@@ -8,6 +8,6 @@ conan_basic_setup(TARGETS)
 
 find_package(BigWig REQUIRED CONFIG)
 
-add_executable(test_package test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE BigWig::BigWig)
 target_compile_features(${PROJECT_NAME} PRIVATE c_std_${CMAKE_C_STANDARD})

--- a/recipes/libbigwig/all/test_v1_package/conanfile.py
+++ b/recipes/libbigwig/all/test_v1_package/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
-from conans import ConanFile, CMake
 from conan.tools.build import cross_building
+from conans import CMake, ConanFile
 
 
 class TestPackageConan(ConanFile):

--- a/recipes/libbigwig/all/test_v1_package/test_package.c
+++ b/recipes/libbigwig/all/test_v1_package/test_package.c
@@ -1,0 +1,1 @@
+../test_package/test_package.c

--- a/recipes/libbigwig/all/test_v1_package/test_package.c
+++ b/recipes/libbigwig/all/test_v1_package/test_package.c
@@ -1,1 +1,0 @@
-../test_package/test_package.c


### PR DESCRIPTION
Specify library name and version:  **libbigwig/all**

- Modernize recipe
- Bump dependencies
- Change defaults to build with CURL to be consistent with upstream

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
