### PR TITLE
grpc: use newer openssl

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -92,7 +92,7 @@ class grpcConan(ConanFile):
         else:
             self.requires("abseil/20220623.0", transitive_headers=True)
         self.requires("c-ares/1.18.1")
-        self.requires("openssl/1.1.1t")
+        self.requires("openssl/[>=1.1 <4]")
         self.requires("re2/20220601")
         self.requires("zlib/1.2.13")
         self.requires("protobuf/3.21.9", transitive_headers=True, transitive_libs=True)


### PR DESCRIPTION
Specify library name and version:  **openssl/all**

(DRAFT)

* grpc recipe: bump version of OpenSSL to use version range that covers OpenSSL 1.1.x and OpenSSL 3.x. This should resolve to the highest available unless overridden elsewhere. This should fix conflict issues in Conan 2.x, make it easier to continue maintaining Conan 1.x without version bumps, and users can control the exact version with lockfiles (encouraged) or overrides (discouraged)

---


