### PR TITLE
restinio: update expected-lite version

### DIFF
--- a/recipes/restinio/all/conanfile.py
+++ b/recipes/restinio/all/conanfile.py
@@ -39,17 +39,25 @@ class RestinioConan(ConanFile):
     def requirements(self):
         self.requires("http_parser/2.9.4")
 
-        if Version(self.version) >= "0.6.17":
-            self.requires("fmt/9.1.0")
-        elif Version(self.version) >= "0.6.16":
-            self.requires("fmt/9.0.0")
-        else:
-            self.requires("fmt/8.1.1")
+        # Set up default versions for requirements
+        requirements = {
+            "fmt": "8.1.1",
+            "expected-lite": "0.5.0",
+            "optional-lite": "3.5.0",
+            "string-view-lite": "1.6.0",
+            "variant-lite": "2.0.0"
+        }
 
-        self.requires("expected-lite/0.5.0")
-        self.requires("optional-lite/3.5.0")
-        self.requires("string-view-lite/1.6.0")
-        self.requires("variant-lite/2.0.0")
+        # Override defaults, if necessary
+        if Version(self.version) >= "0.6.16":
+            requirements["fmt"] = "9.0.0"
+            requirements["expected-lite"] = "0.6.1"
+
+        if Version(self.version) >= "0.6.17":
+            requirements["fmt"] = "9.1.0"
+
+        for (lib, version) in requirements.items():
+            self.requires(f"{lib}/{version}")
 
         if self.options.asio == "standalone":
             if Version(self.version) >= "0.6.9":


### PR DESCRIPTION
Specify library name and version:  **restinio/>0.6.17**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This PR introduces the following changes:
* Makes it easier to modify the version of requirements based off of the restinio version
* Updates the `expected-lite` dependency version to `0.6.1`, which is the same as is used in the restinio repo

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
