### PR TITLE
Docs: update policy on version ranges

### DIFF
--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -175,7 +175,7 @@ for consumer, we do impose some limits on Conan features to provide a smoother f
 
 ### Version Ranges
  
-Version ranges are a useful Conan feature, [documentation here](https://docs.conan.io/1/versioning/version_ranges.html). With the introduction of Conan 2.0, we are currently working to allow the use of version ranges and are allowing this for a handful dependencies. Currently, these are:
+Version ranges are a useful Conan feature, [documentation here](https://docs.conan.io/1/versioning/version_ranges.html). With the introduction of Conan 2.0, we are currently working to allow the use of version ranges and are allowing this for a handful of dependencies. Currently, these are:
 * OpenSSL: `[>=1.1 <4]` for libraries known to be compatible with OpenSSL 1.x and 3.x
 * CMake: `[>3.XX <4]`, where `3.XX` is the minimum version of CMake required by the relevant build scripts.
 

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -174,18 +174,14 @@ for consumer, we do impose some limits on Conan features to provide a smoother f
 * [`python_requires`](https://docs.conan.io/1/reference/conanfile/other.html#python-requires) are not allowed.
 
 ### Version Ranges
+ 
+Version ranges are a useful Conan feature, [documentation here](https://docs.conan.io/1/versioning/version_ranges.html). With the introduction of Conan 2.0, we are currently working to allow the use of version ranges and are allowing this for a handful dependencies. Currently, these are:
+* OpenSSL: `[>=1.1 <4]` for libraries known to be compatible with OpenSSL 1.x and 3.x
+* CMake: `[>3.XX <4]`, where `3.XX` is the minimum version of CMake required by the relevant build scripts.
 
-Version ranges are a useful Conan feature, [documentation here](https://docs.conan.io/1/versioning/version_ranges.html). However,
-in the context of ConanCenter they pose a few key challenges when being used generally to consume packages, most notably:
+Conan maintainers may introduce this for other dependencies over time.
 
-* Non-Deterministic `package-id`: With version ranges the newest compatible package may yield a different `package_id` than the one built
-  and published by ConanCenter resulting in frustrating error "no binaries found". For more context
-  see [this excellent explanation](https://github.com/conan-io/conan-center-index/pull/8831#issuecomment-1024526780).
-
-* Build Reproducibility: If consumers try to download and build the recipe at a later time, it may resolve to a different package version
-  that may generate a different binary (that may or may not be compatible). In order to prevent these types of issues, we have decided to
-  only allow exact requirements versions. This is a complicated issue,
-  [check this thread](https://github.com/conan-io/conan-center-index/pull/9140#discussion_r795461547) for more information.
+Outside of the cases outlined above, version ranges are not allowed in ConanCenter recipes.
 
 ## Handling "internal" dependencies
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -35,7 +35,7 @@ This section gathers the most common questions from the community related to pac
   * [What is the policy for supported python versions?](#what-is-the-policy-for-supported-python-versions)
   * [How to package libraries that depend on proprietary closed-source libraries?](#how-to-package-libraries-that-depend-on-proprietary-closed-source-libraries)
   * [How to protect my project from breaking changes in recipes?](#how-to-protect-my-project-from-breaking-changes-in-recipes)
-  * [Why are version ranges not allowed?](#why-are-version-ranges-not-allowed)
+  * [What's the policy on version ranges?](#whats-the-policy-on-version-ranges)
   * [How to consume a graph of shared libraries?](#how-to-consume-a-graph-of-shared-libraries)
   * [How to watch only specific recipes?](#how-to-watch-only-specific-recipes)
   * [Is it possible to disable Pylint?](#is-it-possible-to-disable-pylint)
@@ -369,9 +369,10 @@ need to modify your project if the recipe changes the binaries, flags,... it pro
 To isolate from these changes there are different strategies you can follow.
 Keep reading in the [consuming recipes section](consuming_recipes.md#isolate-your-project-from-upstream-changes).
 
-## Why are version ranges not allowed?
+## What's the policy on version ranges?
 
-See [Dependencies Version Ranges](adding_packages/dependencies.md#version-ranges) for details.
+Version ranges are currently allowed on a handful of dependencies, but not for general use.
+See [Dependencies Version Ranges](adding_packages/dependencies.md#version-ranges) for additional details.
 
 ## How to consume a graph of shared libraries?
 


### PR DESCRIPTION
As we continue the migration to Conan 2.0, we are going to start allowing version ranges in a limited way, starting with OpenSSL and CMake.

This should have a few advantages:
* No need to update downstream consumers when OpenSSL or CMake are updated. Note that this may still require new binaries being generated for those downstream consumers. 
* Once enough recipes are updated, there should be no version conflicts related to these
* For users that have a profile with settings for which there are no binaries provided by Conan Center, if `--build=missing` is passed, those recipes that have CMake as a tool-requires will now resolve to a single version, rather than multiple versions. This has been problematic in the past if multiple versions of CMake have to be built from source.
