### PR TITLE
libffi/3.4.3: Add patch to allow building with the C2x standard

### DIFF
--- a/recipes/libffi/all/conandata.yml
+++ b/recipes/libffi/all/conandata.yml
@@ -14,6 +14,10 @@ patches:
     - patch_file: "patches/0004-3.3-fix-complex-type-msvc.patch"
     - patch_file: "patches/0005-3.4.3-do-not-install-libraries-to-arch-dependent-directories.patch"
     - patch_file: "patches/0006-3.4.3-library-no-version-suffix.patch"
+    - patch_file: "patches/0007-3.4.3-forward-declare-open_temp_exec_file.patch"
+      patch_type: "portability"
+      patch_source: "https://github.com/libffi/libffi/pull/764"
+      patch_description: "Forward declare the open_temp_exec_file function which is required by the C99 standard"
   "3.4.2":
     - patch_file: "patches/0002-3.4.2-fix-libtool-path.patch"
     - patch_file: "patches/0004-3.3-fix-complex-type-msvc.patch"

--- a/recipes/libffi/all/patches/0007-3.4.3-forward-declare-open_temp_exec_file.patch
+++ b/recipes/libffi/all/patches/0007-3.4.3-forward-declare-open_temp_exec_file.patch
@@ -1,0 +1,30 @@
+diff --git a/include/ffi_common.h b/include/ffi_common.h
+index 2bd31b0..c53a794 100644
+--- a/include/ffi_common.h
++++ b/include/ffi_common.h
+@@ -128,6 +128,10 @@ void *ffi_data_to_code_pointer (void *data) FFI_HIDDEN;
+    static trampoline. */
+ int ffi_tramp_is_present (void *closure) FFI_HIDDEN;
+ 
++/* Return a file descriptor of a temporary zero-sized file in a
++   writable and executable filesystem. */
++int open_temp_exec_file(void) FFI_HIDDEN;
++
+ /* Extended cif, used in callback from assembly routine */
+ typedef struct
+ {
+diff --git a/src/tramp.c b/src/tramp.c
+index b9d273a..c3f4c99 100644
+--- a/src/tramp.c
++++ b/src/tramp.c
+@@ -39,6 +39,10 @@
+ #ifdef __linux__
+ #define _GNU_SOURCE 1
+ #endif
++
++#include <ffi.h>
++#include <ffi_common.h>
++
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <stdlib.h>


### PR DESCRIPTION
This patch allows building with newer versions of Clang out-of-the-box. Clang 15.0.0 removed support for implicit function declarations. This is mentioned here: https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#c2x-feature-support. This removal breaks builds using the default C standard in Clang. This is because the function open_temp_exec_file is not properly declared.

This patch is from the upstream project and declares the function.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
