### PR TITLE
h3: drop cmake_new_enough

### DIFF
--- a/recipes/h3/all/conanfile.py
+++ b/recipes/h3/all/conanfile.py
@@ -46,20 +46,9 @@ class H3Conan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
-    def _cmake_new_enough(self, required_version):
-        try:
-            import re
-            from io import StringIO
-            output = StringIO()
-            self.run("cmake --version", output)
-            m = re.search(r'cmake version (\d+\.\d+\.\d+)', output.getvalue())
-            return Version(m.group(1)) >= required_version
-        except:
-            return False
-
     def build_requirements(self):
-        if Version(self.version) >= "4.1.0" and not self._cmake_new_enough("3.20"):
-            self.tool_requires("cmake/3.25.2")
+        if Version(self.version) >= "4.1.0":
+            self.tool_requires("cmake/[>=3.20 <4")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/h3/all/conanfile.py
+++ b/recipes/h3/all/conanfile.py
@@ -48,7 +48,7 @@ class H3Conan(ConanFile):
 
     def build_requirements(self):
         if Version(self.version) >= "4.1.0":
-            self.tool_requires("cmake/[>=3.20 <4")
+            self.tool_requires("cmake/[>=3.20 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
uses https://github.com/conan-io/conan-center-index/pull/17192 instead

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
