### PR TITLE
mariadb-connector-c: use version range for openssl

### DIFF
--- a/recipes/mariadb-connector-c/all/conanfile.py
+++ b/recipes/mariadb-connector-c/all/conanfile.py
@@ -60,7 +60,7 @@ class MariadbConnectorcConan(ConanFile):
         if self.options.with_curl:
             self.requires("libcurl/8.0.1")
         if self.options.with_ssl == "openssl":
-            self.requires("openssl/3.1.0")
+            self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):
         if self.settings.os != "Windows" and self.options.with_ssl == "schannel":


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
