### PR TITLE
libzmq: Support for no encryption in conan v2

### DIFF
--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -22,7 +22,7 @@ class ZeroMQConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "encryption": [None, "none", "libsodium", "tweetnacl"], # None for conan v1 compat, use "none" in conan v2 for no encryption
+        "encryption": [False, "libsodium", "tweetnacl"],
         "with_norm": [True, False],
         "poller": [None, "kqueue", "epoll", "devpoll", "pollset", "poll", "select"],
         "with_draft_api": [True, False],
@@ -71,7 +71,7 @@ class ZeroMQConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["ENABLE_CURVE"] = self.options.encryption == "libsodium" or self.options.encryption == "tweetnacl"
+        tc.variables["ENABLE_CURVE"] = bool(self.options.encryption)
         tc.variables["WITH_LIBSODIUM"] = self.options.encryption == "libsodium"
         tc.variables["ZMQ_BUILD_TESTS"] = False
         tc.variables["WITH_PERF_TOOL"] = False


### PR DESCRIPTION
Specify library name and version:  **libzmq/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

fixes https://github.com/conan-io/conan-center-index/issues/17289

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
