### PR TITLE
libelf: conditionally remove shared option and set package type

### DIFF
--- a/recipes/libelf/all/conanfile.py
+++ b/recipes/libelf/all/conanfile.py
@@ -18,7 +18,6 @@ class LibelfConan(ConanFile):
     homepage = "https://directory.fsf.org/wiki/Libelf"
     license = "LGPL-2.0"
     topics = ("elf", "fsf", "libelf", "object-file")
-
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -41,7 +40,10 @@ class LibelfConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.options.shared:
+        if self.settings.os not in ["Linux", "FreeBSD", "Windows"]:
+            self.options.rm_safe("shared")
+            self.package_type = "static-library"
+        if self.options.get_safe("shared"):
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
@@ -51,10 +53,6 @@ class LibelfConan(ConanFile):
             cmake_layout(self, src_folder="src")
         else:
             basic_layout(self, src_folder="src")
-
-    def validate(self):
-        if self.options.shared and self.settings.os not in ["Linux", "FreeBSD", "Windows"]:
-            raise ConanInvalidConfiguration("libelf can not be built as shared library on non linux/FreeBSD/windows platforms")
 
     def build_requirements(self):
         if self.settings.os != "Windows":
@@ -114,7 +112,7 @@ class LibelfConan(ConanFile):
             autotools = Autotools(self)
             autotools.install()
             rmdir(self, os.path.join(self.package_folder, "lib", "locale"))
-            if self.options.shared:
+            if self.options.get_safe("shared"):
                 rm(self, "*.a", os.path.join(self.package_folder, "lib"))
             rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
             rmdir(self, os.path.join(self.package_folder, "share"))


### PR DESCRIPTION
Specify library name and version:  **libelf/all**

When `libelf` is in the graph, and `*:shared=True`, the graph will not properly resolve because this check raises an `InvalidConfiguration` - this would force a consumer to explicitly set `shared=False` for `libelf` on some platforms.

If on certain platforms _only_ the static version can exist, then it's not an option - so we can better reflect this in the `configure()` method: remove the option in those contexts. 

This is currently what is blocking the generation of `glib` with `shared=True` on macOS - it  depends on `libelf`. We should make it depend on the only variant that can exist! 


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
