### PR TITLE
quazip: fix recipe for conan v2

### DIFF
--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -3,7 +3,6 @@ from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.env import VirtualBuildEnv
 import os
 
 required_conan_version = ">=1.53.0"
@@ -19,7 +18,7 @@ class QuaZIPConan(ConanFile):
     homepage = "https://github.com/stachenov/quazip"
     license = "LGPL-2.1-linking-exception"
     topics = ("zip", "unzip", "compress")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -32,7 +31,7 @@ class QuaZIPConan(ConanFile):
 
     @property
     def _qt_major(self):
-        return Version(self.deps_cpp_info["qt"].version).major
+        return Version(self.dependencies["qt"].ref.version).major
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -49,12 +48,11 @@ class QuaZIPConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
+        self.requires("qt/5.15.9")
         self.requires("zlib/1.2.13")
-        self.requires("qt/5.15.8")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -65,8 +63,6 @@ class QuaZIPConan(ConanFile):
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()
-        tc = VirtualBuildEnv(self)
-        tc.generate(scope="build")
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -50,6 +50,8 @@ class QuaZIPConan(ConanFile):
     def requirements(self):
         self.requires("qt/5.15.9")
         self.requires("zlib/1.2.13")
+        if Version(self.version) >= "1.4":
+            self.requires("bzip2/1.0.8")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
- use self.dependencies
- add package_type
- bump qt
- remove useless VirtualBuildEnv
- add bzip2 to requirements since 1.4 (https://github.com/stachenov/quazip/commit/6709e83fb31bca3d4168f905213b5f92feea32e4). I guess this issue was hidden in c3i because it was able to find system installed bzip2, but basically it fails for me on WSL2 since bzip2 is not installed.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
