### PR TITLE
soci: fix linking against dependencies with conanv1

### DIFF
--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -110,6 +110,8 @@ class SociConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
 
+        # MacOS @rpath
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.variables["SOCI_SHARED"] = self.options.shared
         tc.variables["SOCI_STATIC"] = not self.options.shared
         tc.variables["SOCI_TESTS"] = False

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -126,6 +126,9 @@ class SociConan(ConanFile):
         tc.generate()
 
         deps = CMakeDeps(self)
+        deps.set_property("mysql", "cmake_file_name", "MYSQL")
+        deps.set_property("libpq", "cmake_file_name", "POSTGRESQL")
+        deps.set_property("sqlite3", "cmake_file_name", "SQLITE3")
         deps.generate()
 
     def build(self):


### PR DESCRIPTION
soci searches for POSTGRESQL_LIBRARIES etc. instead of what conan defines (PostgreSQL_LIBRARIES).

fixes #11628

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
