### PR TITLE
g3log: add version 2.3

### DIFF
--- a/recipes/g3log/all/conandata.yml
+++ b/recipes/g3log/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3":
+    url: "https://github.com/KjellKod/g3log/archive/2.3.tar.gz"
+    sha256: "a27dc3ff0d962cc6e0b4e60890b4904e664b0df16393d27e14c878d7de09b505"
   "2.2":
     url: "https://github.com/KjellKod/g3log/archive/2.2.tar.gz"
     sha256: "9ce18295f71936eaa12d890996ca48fdb578bf0bde16ab652e86b8f30dbe1f1e"

--- a/recipes/g3log/config.yml
+++ b/recipes/g3log/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3":
+    folder: all
   "2.2":
     folder: all
   "2.1":


### PR DESCRIPTION
Specify library name and version:  **g3log/2.3**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
