### PR TITLE
cryptopp/8.7.0: update cryptopp-cmake to 8.7.0.1

### DIFF
--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -4,8 +4,8 @@ sources:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_7_0.tar.gz"
       sha256: "8d6a4064b8e9f34cd3e838f5a12c40067ee7b95ee37d9173ec273cb0913e7ca2"
     cmake:
-      url: "https://github.com/abdes/cryptopp-cmake/archive/CRYPTOPP_8_7_0.tar.gz"
-      sha256: "c113aba8069842edb201b4aaa2925e2c9d6ca081c4fd6b049ff74fedf6e8bae3"
+      url: "https://github.com/abdes/cryptopp-cmake/archive/CRYPTOPP_8_7_0_1.tar.gz"
+      sha256: "49800456bec6432eff4a798d37f6c7760b887adc9f8928e66f44bcb8bf81f157"
   "8.6.0":
     source:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_6_0.tar.gz"


### PR DESCRIPTION
Specify library name and version:  **cryptopp/8.7.0**

Closes #16956

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
