### PR TITLE
harfbuzz: add version 7.2.0

### DIFF
--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.2.0":
+    url: "https://github.com/harfbuzz/harfbuzz/archive/7.2.0.tar.gz"
+    sha256: "a58446480a2216b0f01f897c635e18e75faf3d40a3b8ee953ce72cf77c9118ac"
   "7.1.0":
     url: "https://github.com/harfbuzz/harfbuzz/releases/download/7.1.0/harfbuzz-7.1.0.tar.xz"
     sha256: "f135a61cd464c9ed6bc9823764c188f276c3850a8dc904628de2a87966b7077b"

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.2.0":
+    folder: all
   "7.1.0":
     folder: all
   "6.0.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **harfbuzz/7.2.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

