### PR TITLE
cppserver: use version range for openssl & bump asio

### DIFF
--- a/recipes/cppserver/all/conanfile.py
+++ b/recipes/cppserver/all/conanfile.py
@@ -57,8 +57,8 @@ class CppServer(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("asio/1.24.0")
-        self.requires("openssl/1.1.1s")
+        self.requires("asio/1.27.0")
+        self.requires("openssl/[>=1.1 <4]")
         self.requires("cppcommon/1.0.3.0")
 
     def validate(self):


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
