### PR TITLE
zlib: add mirror url for tarball of 1.2.13

### DIFF
--- a/recipes/zlib/all/conandata.yml
+++ b/recipes/zlib/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "1.2.13":
-    url: "https://zlib.net/fossils/zlib-1.2.13.tar.gz"
+    url:
+      - "https://zlib.net/fossils/zlib-1.2.13.tar.gz"
+      - "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz"
     sha256: "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
   "1.2.12":
     url: "https://zlib.net/fossils/zlib-1.2.12.tar.gz"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
