### PR TITLE
restbed: use version range openssl + modernize more for conan v2

### DIFF
--- a/recipes/restbed/all/conanfile.py
+++ b/recipes/restbed/all/conanfile.py
@@ -75,9 +75,9 @@ class RestbedConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("asio/1.24.0")
+        self.requires("asio/1.27.0")
         if self.options.with_openssl:
-            self.requires("openssl/3.0.5")
+            self.requires("openssl/[>=1.1 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/restbed/all/conanfile.py
+++ b/recipes/restbed/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.scm import Version
 import os
 import re
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class RestbedConan(ConanFile):
@@ -18,7 +18,7 @@ class RestbedConan(ConanFile):
     topics = ("restful", "server", "client", "json", "http", "ssl", "tls")
     url = "https://github.com/conan-io/conan-center-index"
     license = "AGPL-3.0-or-later", "LicenseRef-CPL"  # Corvusoft Permissive License (CPL)
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -51,15 +51,19 @@ class RestbedConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            del self.options.ipc
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        if self.settings.os in ("Windows", ):
-            del self.options.ipc
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("asio/1.27.0")
+        if self.options.with_openssl:
+            self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):
         if getattr(self.info.settings.compiler, "cppstd"):
@@ -71,17 +75,8 @@ class RestbedConan(ConanFile):
                     f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support."
                 )
 
-    def layout(self):
-        cmake_layout(self, src_folder="src")
-
-    def requirements(self):
-        self.requires("asio/1.27.0")
-        if self.options.with_openssl:
-            self.requires("openssl/[>=1.1 <4]")
-
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/restbed/all/test_v1_package/CMakeLists.txt
+++ b/recipes/restbed/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(restbed REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE restbed::restbed)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
- add package_type
- remove ipc option in config_options() instead of configure()
- sort methods by order of execution
- use version range for openssl
- bump asio

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
