### PR TITLE
backward-cpp: Add support for `libunwind` and Apple Silicon Macs

### DIFF
--- a/recipes/backward-cpp/all/conanfile.py
+++ b/recipes/backward-cpp/all/conanfile.py
@@ -139,7 +139,7 @@ class BackwardCppConan(ConanFile):
 
         self.cpp_info.libs = ["backward"]
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.extend(["dl"])
+            self.cpp_info.system_libs.extend(["dl", "m"])
         if self.settings.os == "Windows":
             self.cpp_info.system_libs.extend(["psapi", "dbghelp"])
 

--- a/recipes/backward-cpp/all/conanfile.py
+++ b/recipes/backward-cpp/all/conanfile.py
@@ -66,7 +66,7 @@ class BackwardCppConan(ConanFile):
     def requirements(self):
         if self.settings.os in ["Linux", "Android"]:
             if self._has_stack_walking("libunwind"):
-                self.requires("libunwind/1.6.2")
+                self.requires("libunwind/1.6.2", transitive_headers=True)
             if self._has_stack_details("dwarf"):
                 self.requires("libdwarf/20191104", transitive_headers=True, transitive_libs=True)
                 self.requires("libelf/0.8.13")

--- a/recipes/backward-cpp/all/conanfile.py
+++ b/recipes/backward-cpp/all/conanfile.py
@@ -39,11 +39,11 @@ class BackwardCppConan(ConanFile):
             supported_os.append("Windows")
         return supported_os
 
-    def _has_stack_walking(self, type):
-        return self.options.stack_walking == type
+    def _has_stack_walking(self, method):
+        return self.options.stack_walking == method
 
-    def _has_stack_details(self, type):
-        return False if self.settings.os == "Windows" else self.options.stack_details == type
+    def _has_stack_details(self, method):
+        return False if self.settings.os == "Windows" else self.options.stack_details == method
 
     def export_sources(self):
         export_conandata_patches(self)

--- a/recipes/backward-cpp/all/conanfile.py
+++ b/recipes/backward-cpp/all/conanfile.py
@@ -22,8 +22,8 @@ class BackwardCppConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "stack_walking" : ["unwind", "backtrace"],
-        "stack_details" : ["dw", "bfd", "dwarf", "backtrace_symbol"],
+        "stack_walking": ["unwind", "libunwind", "backtrace"],
+        "stack_details": ["dw", "bfd", "dwarf", "backtrace_symbol"],
     }
     default_options = {
         "shared": False,
@@ -65,6 +65,8 @@ class BackwardCppConan(ConanFile):
 
     def requirements(self):
         if self.settings.os in ["Linux", "Android"]:
+            if self._has_stack_walking("libunwind"):
+                self.requires("libunwind/1.6.2")
             if self._has_stack_details("dwarf"):
                 self.requires("libdwarf/20191104", transitive_headers=True, transitive_libs=True)
                 self.requires("libelf/0.8.13")
@@ -78,12 +80,13 @@ class BackwardCppConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 11)
+        if self._has_stack_walking("libunwind") and Version(self.version) < "1.6":
+            raise ConanInvalidConfiguration("Support for libunwind is only available as of 1.6.")
         if self.settings.os == "Macos":
-            if self.settings.arch == "armv8":
-                raise ConanInvalidConfiguration("Macos M1 not supported yet")
+            if self.settings.arch == "armv8" and Version(self.version) < "1.6":
+                raise ConanInvalidConfiguration("Support for Apple Silicon is only available as of 1.6.")
             if not self._has_stack_details("backtrace_symbol"):
-                raise ConanInvalidConfiguration("only stack_details=backtrace_symbol"
-                                                " is supported on Macos")
+                raise ConanInvalidConfiguration("Stack details other than backtrace_symbol are not supported on macOS.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -91,6 +94,7 @@ class BackwardCppConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["STACK_WALKING_UNWIND"] = self._has_stack_walking("unwind")
+        tc.variables["STACK_WALKING_LIBUNWIND"] = self._has_stack_walking("libunwind")
         tc.variables["STACK_WALKING_BACKTRACE"] = self._has_stack_walking("backtrace")
         tc.variables["STACK_DETAILS_AUTO_DETECT"] = False
         tc.variables["STACK_DETAILS_BACKTRACE_SYMBOL"] = self._has_stack_details("backtrace_symbol")
@@ -120,14 +124,15 @@ class BackwardCppConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "Backward")
         self.cpp_info.set_property("cmake_target_name", "Backward::Backward")
 
-        self.cpp_info.defines.append("BACKWARD_HAS_UNWIND={}".format(int(self._has_stack_walking("unwind"))))
-        self.cpp_info.defines.append("BACKWARD_HAS_BACKTRACE={}".format(int(self._has_stack_walking("backtrace"))))
+        self.cpp_info.defines.append(f"BACKWARD_HAS_UNWIND={int(self._has_stack_walking('unwind'))}")
+        self.cpp_info.defines.append(f"BACKWARD_HAS_LIBUNWIND={int(self._has_stack_walking('libunwind'))}")
+        self.cpp_info.defines.append(f"BACKWARD_HAS_BACKTRACE={int(self._has_stack_walking('backtrace'))}")
 
-        self.cpp_info.defines.append("BACKWARD_HAS_BACKTRACE_SYMBOL={}".format(int(self._has_stack_details("backtrace_symbol"))))
-        self.cpp_info.defines.append("BACKWARD_HAS_DW={}".format(int(self._has_stack_details("dw"))))
-        self.cpp_info.defines.append("BACKWARD_HAS_BFD={}".format(int(self._has_stack_details("bfd"))))
-        self.cpp_info.defines.append("BACKWARD_HAS_DWARF={}".format(int(self._has_stack_details("dwarf"))))
-        self.cpp_info.defines.append("BACKWARD_HAS_PDB_SYMBOL={}".format(int(self.settings.os == "Windows")))
+        self.cpp_info.defines.append(f"BACKWARD_HAS_BACKTRACE_SYMBOL={int(self._has_stack_details('backtrace_symbol'))}")
+        self.cpp_info.defines.append(f"BACKWARD_HAS_DW={int(self._has_stack_details('dw'))}")
+        self.cpp_info.defines.append(f"BACKWARD_HAS_BFD={int(self._has_stack_details('bfd'))}")
+        self.cpp_info.defines.append(f"BACKWARD_HAS_DWARF={int(self._has_stack_details('dwarf'))}")
+        self.cpp_info.defines.append(f"BACKWARD_HAS_PDB_SYMBOL={int(self.settings.os == 'Windows')}")
 
         self.cpp_info.libs = ["backward"]
         if self.settings.os == "Linux":

--- a/recipes/backward-cpp/all/conanfile.py
+++ b/recipes/backward-cpp/all/conanfile.py
@@ -80,8 +80,11 @@ class BackwardCppConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 11)
-        if self._has_stack_walking("libunwind") and Version(self.version) < "1.6":
-            raise ConanInvalidConfiguration("Support for libunwind is only available as of 1.6.")
+        if self._has_stack_walking("libunwind"):
+            if Version(self.version) < "1.6":
+                raise ConanInvalidConfiguration("Support for libunwind is only available as of 1.6.")
+            if self.settings.os == "Windows":
+                raise ConanInvalidConfiguration("Support for libunwind is only available on Linux and macOS.")
         if self.settings.os == "Macos":
             if self.settings.arch == "armv8" and Version(self.version) < "1.6":
                 raise ConanInvalidConfiguration("Support for Apple Silicon is only available as of 1.6.")

--- a/recipes/backward-cpp/all/patches/backward-cpp-1.5.patch
+++ b/recipes/backward-cpp/all/patches/backward-cpp-1.5.patch
@@ -41,11 +41,17 @@
  
  
  ###############################################################################
-@@ -86,6 +86,19 @@ endif()
+@@ -86,6 +86,25 @@ endif()
  add_library(backward ${libtype} backward.cpp)
  target_compile_definitions(backward PUBLIC ${BACKWARD_DEFINITIONS})
  target_include_directories(backward PUBLIC ${BACKWARD_INCLUDE_DIRS})
 +target_compile_features(backward PUBLIC cxx_std_11)
++if(STACK_WALKING_LIBUNWIND)
++    if(NOT APPLE)
++        find_package(libunwind REQUIRED CONFIG)
++        target_link_libraries(backward PUBLIC libunwind::libunwind)
++    endif()
++endif()
 +if(STACK_DETAILS_DW)
 +    find_package(elfutils REQUIRED CONFIG)
 +    target_link_libraries(backward PUBLIC elfutils::libdw)


### PR DESCRIPTION
Specify library name and version:  **backward-cpp/1.6**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
