### PR TITLE
libffi/3.4.4: Pull forward the forward declaration patch

### DIFF
--- a/recipes/libffi/all/conandata.yml
+++ b/recipes/libffi/all/conandata.yml
@@ -17,6 +17,10 @@ patches:
     - patch_file: "patches/0004-3.3-fix-complex-type-msvc.patch"
     - patch_file: "patches/0005-3.4.4-do-not-install-libraries-to-arch-dependent-directories.patch"
     - patch_file: "patches/0006-3.4.4-library-no-version-suffix.patch"
+    - patch_file: "patches/0007-3.4.3-forward-declare-open_temp_exec_file.patch"
+      patch_type: "portability"
+      patch_source: "https://github.com/libffi/libffi/pull/764"
+      patch_description: "Forward declare the open_temp_exec_file function which is required by the C99 standard"
   "3.4.3":
     - patch_file: "patches/0002-3.4.3-fix-libtool-path.patch"
     - patch_file: "patches/0004-3.3-fix-complex-type-msvc.patch"


### PR DESCRIPTION
This patch is also necessary for version 3.4.4.
This patch shouldn't need to be carried forward any further after this release since it was upstreamed after the release of 3.4.4.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
