### PR TITLE
flatbuffers/23.3.3: updated cmake required version

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -38,6 +38,12 @@ sources:
 patches:
   "2.0.6":
     - patch_file: "patches/0004-no-flatc-execution-build-time.patch"
+      patch_description: "No flatc execution during build time"
+      patch_type: "conan"
   "2.0.5":
     - patch_file: "patches/0002-apple-no-universal-build.patch"
+      patch_description: "Don't use universal2 architecture"
+      patch_type: "bugfix"
     - patch_file: "patches/0003-no-flatc-execution-build-time.patch"
+      patch_description: "No flatc execution during build time"
+      patch_type: "conan"

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -60,7 +60,9 @@ class FlatbuffersConan(ConanFile):
             check_min_cppstd(self, 11)
 
     def build_requirements(self):
-        if Version(self.version) >= "2.0.7":
+        # since 23.3.3 version, flatbuffers cmake scripts were refactored to use cmake 3.8 version
+        # see https://github.com/google/flatbuffers/pull/7801
+        if Version(self.version) >= "2.0.7" and Version(self.version) < "23.3.3":
             self.tool_requires("cmake/[>=3.16 <4]")
 
     def source(self):


### PR DESCRIPTION
Specify library name and version:  **flatbuffers/23.3.3**

Old versions of flatbuffers, up to and including `v23.1.21`, required CMake 3.16 or newer de-facto, see: https://github.com/google/flatbuffers/blob/v23.1.21/CMakeLists.txt#L4-L16. Since https://github.com/google/flatbuffers/pull/7801 and starting with version 23.3.3, the `cmake_minimum_required` is now 3.8, which mean an explicit `tool_requires` is no longer required as per Conan Center's current conventions.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
