### PR TITLE
arduinojson: fix cppstd check logic

### DIFF
--- a/recipes/arduinojson/all/conanfile.py
+++ b/recipes/arduinojson/all/conanfile.py
@@ -1,9 +1,8 @@
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, get, save
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
-from conan.tools.build import check_min_cppstd
-from conan.errors import ConanInvalidConfiguration
 import os
 import textwrap
 
@@ -22,35 +21,22 @@ class ArduinojsonConan(ConanFile):
     no_copy_source = True
 
     @property
-    def _compilers_minimum_version(self):
-        return {
-            "Visual Studio": "16",
-            "msvc": "192",
-            "gcc": "6",
-            "clang": "6",
-        }
-
-    def validate(self):
-        if Version(self.version) >= "6.21.0":
-            if self.settings.compiler.get_safe("cppstd"):
-                check_min_cppstd(self, 11)
-            elif str(self.settings.compiler) == 'apple-clang':
-                raise ConanInvalidConfiguration("cppstd needs to be set on apple-clang to activate c++11.")
-            else:
-                minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-                if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-                    raise ConanInvalidConfiguration(f"{self.ref} requires C++11, which your compiler does not support.")
-
-    def package_id(self):
-        self.info.clear()
+    def _min_cppstd(self):
+        return "98" if Version(self.version) < "6.21.0" else "11"
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
     def source(self):
         has_arduinojson_root=Version(self.version) < "6.18.2"
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=has_arduinojson_root)
+        get(self, **self.conan_data["sources"][self.version], strip_root=has_arduinojson_root)
 
     def build(self):
         pass
@@ -85,9 +71,7 @@ class ArduinojsonConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "ArduinoJson")
         self.cpp_info.set_property("cmake_target_name", "ArduinoJson")
         self.cpp_info.bindirs = []
-        self.cpp_info.frameworkdirs = []
         self.cpp_info.libdirs = []
-        self.cpp_info.resdirs = []
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "ArduinoJson"

--- a/recipes/arduinojson/all/test_package/CMakeLists.txt
+++ b/recipes/arduinojson/all/test_package/CMakeLists.txt
@@ -1,7 +1,10 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
 find_package(ArduinoJson REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE ArduinoJson)
+if(ArduinoJson_VERSION VERSION_GREATER_EQUAL "6.21.0")
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+endif()

--- a/recipes/arduinojson/all/test_package/conanfile.py
+++ b/recipes/arduinojson/all/test_package/conanfile.py
@@ -7,12 +7,13 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-
-    def requirements(self):
-        self.requires(self.tested_reference_str)
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/arduinojson/all/test_v1_package/CMakeLists.txt
+++ b/recipes/arduinojson/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(ArduinoJson REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE ArduinoJson)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
Fix cppstd logic again. While there was an issue, the new logic of https://github.com/conan-io/conan-center-index/pull/17250 is also broken.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
