### PR TITLE
boost: Use the sysroot conf variable

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1277,9 +1277,9 @@ class BoostConan(ConanFile):
         asflags = buildenv_vars.get("ASFLAGS", "") + " "
 
         sysroot = self.conf.get("tools.build:sysroot")
-        sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
-        sysroot = f'"{sysroot}"' if ' ' in sysroot else sysroot
         if sysroot and not is_msvc(self):
+            sysroot = sysroot.replace("\\", "/")
+            sysroot = f'"{sysroot}"' if ' ' in sysroot else sysroot
             cppflags += f"--sysroot={sysroot} "
             ldflags += f"--sysroot={sysroot} "
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1273,13 +1273,14 @@ class BoostConan(ConanFile):
         cflags = " ".join(self.conf.get("tools.build:cflags", default=[], check_type=list)) + " "
         buildenv_vars = VirtualBuildEnv(self).vars()
         cppflags = buildenv_vars.get("CPPFLAGS", "") + " "
-        sysroot = self.conf.get("tools.build:sysroot")
-        if sysroot:
-            cppflags += f"--sysroot={sysroot} "
         ldflags = " ".join(self.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)) + " "
-        if sysroot:
-            ldflags += f"--sysroot={sysroot} "
         asflags = buildenv_vars.get("ASFLAGS", "") + " "
+
+        sysroot = self.conf.get("tools.build:sysroot")
+        sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
+        if sysroot and not is_msvc(self):
+            cppflags += f"--sysroot={sysroot} "
+            ldflags += f"--sysroot={sysroot} "
 
         if self._with_stacktrace_backtrace:
             backtrace_aggregated_cpp_info = self.dependencies["libbacktrace"].cpp_info.aggregated_components()

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1273,7 +1273,12 @@ class BoostConan(ConanFile):
         cflags = " ".join(self.conf.get("tools.build:cflags", default=[], check_type=list)) + " "
         buildenv_vars = VirtualBuildEnv(self).vars()
         cppflags = buildenv_vars.get("CPPFLAGS", "") + " "
+        sysroot = self.conf.get("tools.build:sysroot")
+        if sysroot:
+            cppflags += f"--sysroot={sysroot} "
         ldflags = " ".join(self.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)) + " "
+        if sysroot:
+            ldflags += f"--sysroot={sysroot} "
         asflags = buildenv_vars.get("ASFLAGS", "") + " "
 
         if self._with_stacktrace_backtrace:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1278,6 +1278,7 @@ class BoostConan(ConanFile):
 
         sysroot = self.conf.get("tools.build:sysroot")
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
+        sysroot = f'"{sysroot}"' if ' ' in sysroot else sysroot
         if sysroot and not is_msvc(self):
             cppflags += f"--sysroot={sysroot} "
             ldflags += f"--sysroot={sysroot} "


### PR DESCRIPTION
This allows cross-compiling the Boost recipe.
Related to issue #16051.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
