### PR TITLE
[cppcheck] Remove deprecated with_z3 option

### DIFF
--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -24,7 +24,6 @@ class CppcheckConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
-
     def requirements(self):
         if self.options.get_safe("have_rules"):
             self.requires("pcre/8.45")

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -15,8 +15,8 @@ class CppcheckConan(ConanFile):
     license = "GPL-3.0-or-later"
     package_type = "application"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"have_rules": [True, False], "with_z3": [True, False, "deprecated"]}
-    default_options = {"have_rules": True, "with_z3": "deprecated"}
+    options = {"have_rules": [True, False]}
+    default_options = {"have_rules": True}
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -24,9 +24,6 @@ class CppcheckConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
-    def configure(self):
-        if self.options.get_safe("with_z3") != "deprecated":
-            self.output.warning("Option \"with_z3\" is deprecated, do not use anymore.")
 
     def requirements(self):
         if self.options.get_safe("have_rules"):
@@ -61,7 +58,6 @@ class CppcheckConan(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
         del self.info.settings.build_type
-        del self.info.options.with_z3
 
     def package_info(self):
         self.cpp_info.includedirs = []


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
