### PR TITLE
tensorflow-lite: use version range for cmake + add package_type

### DIFF
--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -81,7 +81,7 @@ class TensorflowLiteConan(ConanFile):
             self.requires("fp16/cci.20210320")
 
     def build_requirements(self):
-        self.tool_requires("cmake/3.25.3")
+        self.tool_requires("cmake/[>=3.16 <4]")
 
     def layout(self):
         cmake_layout(self, src_folder="src", build_folder=f"build_folder/{self.settings.build_type}")

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -1,9 +1,10 @@
 from conan import ConanFile
-from conan.tools.scm import Version
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.build import check_min_cppstd
-from conan.tools.files import get, save, copy, export_conandata_patches, apply_conandata_patches
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import get, save, copy, export_conandata_patches, apply_conandata_patches
+from conan.tools.scm import Version
 from os.path import join
 import textwrap
 
@@ -105,6 +106,8 @@ class TensorflowLiteConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
         tc = CMakeToolchain(self)
         tc.variables.update({
             "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS": True,

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -44,6 +44,7 @@ class TensorflowLiteConan(ConanFile):
         return {
             "gcc": "8",
             "Visual Studio": "15.8",
+            "msvc": "191",
             "clang": "5",
             "apple-clang": "5.1",
         }

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.errors import ConanInvalidConfiguration
 from os.path import join
 import textwrap
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class TensorflowLiteConan(ConanFile):

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -18,7 +18,7 @@ class TensorflowLiteConan(ConanFile):
     description = ("TensorFlow Lite is a set of tools that enables on-device machine learning "
                    "by helping developers run their models on mobile, embedded, and IoT devices.")
     topics = ("machine-learning", "neural-networks", "deep-learning")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/tensorflow-lite/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tensorflow-lite/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(tensorflowlite REQUIRED CONFIG)
-
-add_executable(test_package ../test_package/test_package.cpp)
-target_link_libraries(test_package PRIVATE tensorflow::tensorflowlite)
-target_compile_features(test_package PRIVATE cxx_std_17)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
- use version range for cmake (see https://github.com/tensorflow/tensorflow/blob/v2.10.0/tensorflow/lite/CMakeLists.txt#L29)
- fix required_conan_version (it requires conan >= 1.53.0 due to options.rm_safe)
- add package_type
- add msvc to _compilers_minimum_version
- add VirtualBuildEnv since there is a build requirement
- sort methods by order of execution to make recipe easier to understand
- do not hardcode build_folder, just let cmake_layout does its job

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
