### PR TITLE
[armadillo] Add version 12.2.0

### DIFF
--- a/recipes/armadillo/all/conandata.yml
+++ b/recipes/armadillo/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "11.4.3":
     url: "https://sourceforge.net/projects/arma/files/armadillo-11.4.3.tar.xz"
     sha256: "87603263664988af41da2ca4f36205e36ea47a9281fa6cfd463115f3797a1da2"
+  "12.2.0":
+    url: "https://sourceforge.net/projects/arma/files/armadillo-12.2.0.tar.xz"
+    sha256: "b0dce042297e865add3351dad77f78c2c7638d6632f58357b015e50edcbd2186"
 
 patches:
   "10.7.0":
@@ -20,5 +23,9 @@ patches:
       patch_type: "conan"
   "11.4.3":
     - patch_file: "patches/0002-Guard-dependency-discovery-11.4.x.patch"
+      patch_description: "Add find_package statements to inject conan dependencies"
+      patch_type: "conan"
+  "12.2.0":
+    - patch_file: "patches/0003-Guard-dependency-discovery-12.2.x.patch"
       patch_description: "Add find_package statements to inject conan dependencies"
       patch_type: "conan"

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import copy, get, rmdir, apply_conandata_patches, export_conandata_patches
 from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 import os
 
@@ -26,6 +27,7 @@ class ArmadilloConan(ConanFile):
         "hdf5",
     )
     settings = "os", "compiler", "build_type", "arch"
+    package_type = "library"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -98,6 +100,16 @@ class ArmadilloConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
+        if self.options.use_blas == "openblas":
+            # Note that if you're relying on this to build LAPACK, you _must_ have
+            # a fortran compiler installed. If you don't, OpenBLAS will build successfully but
+            # without LAPACK support, which isn't obvious.
+            # This can be achieved by setting the FC environment variable or the conf tools.build:compiler_executables={"fortran": "/path/to/fortran"}
+            # in your conan profile.
+            self.options["openblas"].build_lapack = (
+                self.options.use_lapack == "openblas"
+            )
+
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
@@ -163,19 +175,15 @@ class ArmadilloConan(ConanFile):
         # TODO: "arpack/1.0" # Pending https://github.com/conan-io/conan-center-index/issues/6755
         # TODO: "flexiblas/3.0.4" # Pending https://github.com/conan-io/conan-center-index/issues/6827
 
-        if self.options.use_hdf5:
+        # The armadillo library no longer takes any responsibility for linking hdf5 as of v12.x. This means
+        # it will have to be linked manually by consumers if desired.
+        # See https://gitlab.com/conradsnicta/armadillo-code/-/issues/227 for more information.
+        if self.options.use_hdf5 and Version(self.version) < "12":
             # Use the conan dependency if the system lib isn't being used
             self.requires("hdf5/1.14.0")
 
         if self.options.use_blas == "openblas":
             self.requires("openblas/0.3.20")
-            # Note that if you're relying on this to build LAPACK, you _must_ have
-            # a fortran compiler installed. If you don't, OpenBLAS will build successfully but
-            # without LAPACK support, which isn't obvious.
-            # This can be achieved by setting the FC environment variable in your conan profile
-            self.options["openblas"].build_lapack = (
-                self.options.use_lapack == "openblas"
-            )
         if (
             self.options.use_blas == "intel_mkl"
             and self.options.use_lapack == "intel_mkl"

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -3,6 +3,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import copy, get, rmdir, apply_conandata_patches, export_conandata_patches
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
+from conan.tools.build import cross_building
 from conan.errors import ConanInvalidConfiguration
 import os
 
@@ -120,6 +121,11 @@ class ArmadilloConan(ConanFile):
         ):
             raise ConanInvalidConfiguration(
                 "framework_accelerate can only be used on Macos"
+            )
+
+        if self.options.use_hdf5 and Version(self.version) > "12" and cross_building(self):
+            raise ConanInvalidConfiguration(
+                "Armadillo does not support cross building with hdf5. Set use_hdf5=False and try again."
             )
 
         for value, options in self._co_dependencies.items():

--- a/recipes/armadillo/all/patches/0002-Guard-dependency-discovery-11.4.x.patch
+++ b/recipes/armadillo/all/patches/0002-Guard-dependency-discovery-11.4.x.patch
@@ -1,15 +1,3 @@
-From aa49b619333a25d892d119836ca97dd1d833475d Mon Sep 17 00:00:00 2001
-From: Samuel Dowling <samuel.dowling@protonmail.com>
-Date: Thu, 5 Jan 2023 00:02:06 +1030
-Subject: [PATCH 1/1] Guard dependency discovery
-
-* Add guards to prevent usage of custom cmake find package scripts.
-* Remove ability to inject hdf5 include directory into compiled binary
----
- CMakeLists.txt                          | 78 ++++++++++++++++++++-----
- include/armadillo_bits/config.hpp.cmake |  2 +-
- 2 files changed, 64 insertions(+), 16 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index da1ff3a..7bdd808 100644
 --- a/CMakeLists.txt

--- a/recipes/armadillo/all/patches/0003-Guard-dependency-discovery-12.2.x.patch
+++ b/recipes/armadillo/all/patches/0003-Guard-dependency-discovery-12.2.x.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7857f8c..5f87f7e 100644
+index 7d21cf2..86f23a2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -274,7 +274,11 @@ if(APPLE)
+@@ -270,7 +270,11 @@ if(APPLE)
    set(ARMA_USE_ACCELERATE true)
    
    if(ALLOW_OPENBLAS_MACOS)
@@ -15,7 +15,7 @@ index 7857f8c..5f87f7e 100644
      message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
      message(STATUS "")
      message(STATUS "*** If use of OpenBLAS is causing problems,")
-@@ -289,8 +293,16 @@ if(APPLE)
+@@ -285,8 +289,16 @@ if(APPLE)
    endif()
    
    if(ALLOW_BLAS_LAPACK_MACOS)
@@ -34,18 +34,16 @@ index 7857f8c..5f87f7e 100644
      message(STATUS "  BLAS_FOUND = ${BLAS_FOUND}"  )
      message(STATUS "LAPACK_FOUND = ${LAPACK_FOUND}")
      message(STATUS "")
-@@ -329,14 +341,42 @@ if(APPLE)
+@@ -325,19 +337,50 @@ if(APPLE)
    
  else()
    
--  include(ARMA_FindMKL)
--  include(ARMA_FindOpenBLAS)
--  include(ARMA_FindATLAS)
--  include(ARMA_FindBLAS)
--  include(ARMA_FindLAPACK)
+-  if(ALLOW_FLEXIBLAS_LINUX AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
+-    include(ARMA_FindFlexiBLAS)
 +  if(USE_MKL)
 +    find_package(MKL)
-+  else()
+   else()
+-    set(FlexiBLAS_FOUND false)
 +    set(MKL_FOUND NO)
 +  endif()
 +
@@ -72,29 +70,34 @@ index 7857f8c..5f87f7e 100644
 +  else()
 +    set(LAPACK_FOUND NO)
 +  endif()
++
++  if(ARMA_USE_HDF5)
++    find_package(HDF5)
++    set(ARMA_LIBS ${ARMA_LIBS} HDF5::HDF5)
+   endif()
    
-   if(ALLOW_FLEXIBLAS_LINUX AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
--    include(ARMA_FindFlexiBLAS)
+-  include(ARMA_FindMKL)
+-  include(ARMA_FindOpenBLAS)
+-  include(ARMA_FindATLAS)     # TODO: remove support for ATLAS in next major version
+-  include(ARMA_FindBLAS)
+-  include(ARMA_FindLAPACK)
+-  
+-  message(STATUS "FlexiBLAS_FOUND = ${FlexiBLAS_FOUND}" )
++  if(ALLOW_FLEXIBLAS_LINUX AND (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
 +    if(USE_SYSTEM_FLEXIBLAS)
 +      include(ARMA_FindFlexiBLAS)
 +    else()
 +      set(FlexiBLAS_FOUND NO)
 +    endif()
-   endif()
-   
++  endif()
++
++  message(STATUS "FlexiBLAS_FOUND = ${FlexiBLAS_FOUND}" )  
    message(STATUS "      MKL_FOUND = ${MKL_FOUND}"       )
-@@ -470,8 +510,6 @@ if(DETECT_HDF5)
-     # HDF5_INCLUDE_DIRS is the correct include directory.  So, in either case we
-     # can use the first element in the list.  Issue a status message, too, just
-     # for good measure.
--    list(GET HDF5_INCLUDE_DIRS 0 ARMA_HDF5_INCLUDE_DIR)
--    message(STATUS "ARMA_HDF5_INCLUDE_DIR = ${ARMA_HDF5_INCLUDE_DIR}")
-     message(STATUS "")
-     message(STATUS "*** If use of HDF5 is causing problems,")
-     message(STATUS "*** rerun cmake with HDF5 detection disabled:")
-@@ -480,7 +518,11 @@ if(DETECT_HDF5)
-   endif()
+   message(STATUS " OpenBLAS_FOUND = ${OpenBLAS_FOUND}"  )
+   message(STATUS "    ATLAS_FOUND = ${ATLAS_FOUND}"     )
+@@ -449,7 +492,11 @@ else()
  endif()
+ 
  
 -include(ARMA_FindARPACK)
 +if(USE_SYSTEM_ARPACK)
@@ -105,7 +108,7 @@ index 7857f8c..5f87f7e 100644
  message(STATUS "ARPACK_FOUND = ${ARPACK_FOUND}")
  
  if(ARPACK_FOUND)
-@@ -488,7 +530,11 @@ if(ARPACK_FOUND)
+@@ -457,7 +504,11 @@ if(ARPACK_FOUND)
    set(ARMA_LIBS ${ARMA_LIBS} ${ARPACK_LIBRARY})
  endif()
  
@@ -118,19 +121,6 @@ index 7857f8c..5f87f7e 100644
  message(STATUS "SuperLU_FOUND = ${SuperLU_FOUND}")
  
  if(SuperLU_FOUND)
-diff --git a/include/armadillo_bits/config.hpp.cmake b/include/armadillo_bits/config.hpp.cmake
-index 3f7f874..998f6ec 100644
---- a/include/armadillo_bits/config.hpp.cmake
-+++ b/include/armadillo_bits/config.hpp.cmake
-@@ -152,7 +152,7 @@
-   #undef  ARMA_USE_HDF5
-   #define ARMA_USE_HDF5
-   
--  #define ARMA_HDF5_INCLUDE_DIR ${ARMA_HDF5_INCLUDE_DIR}/
-+  // #define ARMA_HDF5_INCLUDE_DIR ${ARMA_HDF5_INCLUDE_DIR}/
- #endif
- 
- #if !defined(ARMA_MAT_PREALLOC)
 -- 
-2.36.0
+2.40.0
 

--- a/recipes/armadillo/all/patches/0003-Guard-dependency-discovery-12.2.x.patch
+++ b/recipes/armadillo/all/patches/0003-Guard-dependency-discovery-12.2.x.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7d21cf2..86f23a2 100644
+index 7d21cf2..2669b17 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -270,7 +270,11 @@ if(APPLE)
@@ -34,7 +34,7 @@ index 7d21cf2..86f23a2 100644
      message(STATUS "  BLAS_FOUND = ${BLAS_FOUND}"  )
      message(STATUS "LAPACK_FOUND = ${LAPACK_FOUND}")
      message(STATUS "")
-@@ -325,19 +337,50 @@ if(APPLE)
+@@ -325,19 +337,45 @@ if(APPLE)
    
  else()
    
@@ -69,11 +69,6 @@ index 7d21cf2..86f23a2 100644
 +    include(ARMA_FindLAPACK)
 +  else()
 +    set(LAPACK_FOUND NO)
-+  endif()
-+
-+  if(ARMA_USE_HDF5)
-+    find_package(HDF5)
-+    set(ARMA_LIBS ${ARMA_LIBS} HDF5::HDF5)
    endif()
    
 -  include(ARMA_FindMKL)
@@ -95,7 +90,7 @@ index 7d21cf2..86f23a2 100644
    message(STATUS "      MKL_FOUND = ${MKL_FOUND}"       )
    message(STATUS " OpenBLAS_FOUND = ${OpenBLAS_FOUND}"  )
    message(STATUS "    ATLAS_FOUND = ${ATLAS_FOUND}"     )
-@@ -449,7 +492,11 @@ else()
+@@ -449,7 +487,11 @@ else()
  endif()
  
  
@@ -108,7 +103,7 @@ index 7d21cf2..86f23a2 100644
  message(STATUS "ARPACK_FOUND = ${ARPACK_FOUND}")
  
  if(ARPACK_FOUND)
-@@ -457,7 +504,11 @@ if(ARPACK_FOUND)
+@@ -457,7 +499,11 @@ if(ARPACK_FOUND)
    set(ARMA_LIBS ${ARMA_LIBS} ${ARPACK_LIBRARY})
  endif()
  
@@ -122,5 +117,5 @@ index 7d21cf2..86f23a2 100644
  
  if(SuperLU_FOUND)
 -- 
-2.40.0
+2.41.0
 

--- a/recipes/armadillo/all/test_package/CMakeLists.txt
+++ b/recipes/armadillo/all/test_package/CMakeLists.txt
@@ -2,7 +2,11 @@ cmake_minimum_required(VERSION 3.15)
 project(PackageTest CXX)
 
 find_package(armadillo CONFIG REQUIRED)
+if (LINK_HDF5)
+    find_package(HDF5)
+    set(HDF5_TARGETS HDF5::HDF5)
+endif()
 
 add_executable(example src/example.cpp)
-target_link_libraries(example armadillo::armadillo)
+target_link_libraries(example armadillo::armadillo ${HDF5_TARGETS})
 set_property(TARGET example PROPERTY CXX_STANDARD 11)

--- a/recipes/armadillo/all/test_package/conanfile.py
+++ b/recipes/armadillo/all/test_package/conanfile.py
@@ -25,7 +25,6 @@ class FooTestConan(ConanFile):
         tc = CMakeToolchain(self)
         # using armadillo > 12.x requires explicit consumer linkage against hdf5
         explicit_link_condition = Version(self.dependencies["armadillo"].ref.version) > "12"
-        self.output.warning(f"{explicit_link_condition=}")
         tc.variables["LINK_HDF5"] = explicit_link_condition
         tc.generate()
 

--- a/recipes/armadillo/all/test_package/conanfile.py
+++ b/recipes/armadillo/all/test_package/conanfile.py
@@ -1,20 +1,33 @@
 import os
 
 from conan import ConanFile
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain
 from conan.tools.build import cross_building
+from conan.tools.scm import Version
 
 
 class FooTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     # VirtualBuildEnv and VirtualRunEnv can be avoided if "tools.env.virtualenv:auto_use" is defined
     # (it will be defined in Conan 2.0)
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualBuildEnv", "VirtualRunEnv"
     apply_env = False
     test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+        tested_version = self.tested_reference_str.split('/')[1].split('@')[0]
+        # using armadillo > 12.x requires the consumer to explicitly depend on hdf5
+        if Version(tested_version) > "12":
+            self.requires("hdf5/1.14.0")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # using armadillo > 12.x requires explicit consumer linkage against hdf5
+        explicit_link_condition = Version(self.dependencies["armadillo"].ref.version) > "12"
+        self.output.warning(f"{explicit_link_condition=}")
+        tc.variables["LINK_HDF5"] = explicit_link_condition
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/armadillo/config.yml
+++ b/recipes/armadillo/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "11.4.3":
     folder: all
+  "12.2.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **armadillo/12.2.0**

12.2.0 saw the removal of HDF5 from the armadillo wrapper as per https://gitlab.com/conradsnicta/armadillo-code/-/issues/227. I've added it back in here for consistency with the interface of previous versions and remove the need for consumers to concern themselves with dependency management of armadillo dependencies. This represents a deviation from the way this is being managed upstream though, so happy to take guidance on whether hdf5 should still be included as a dependency in the armadillo recipe for 12.2.0.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
