### PR TITLE
libsystemd/253.3: Bump versions and dependencies

### DIFF
--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -1,23 +1,55 @@
 sources:
-  "246.16":
-    url: "https://github.com/systemd/systemd-stable/archive/v246.16.tar.gz"
-    sha256: "b69f9940d65870f090269a28f1047a633d4b80d0001e091d53a031dd40a822d2"
-  "247.11":
-    url: "https://github.com/systemd/systemd-stable/archive/v247.11.tar.gz"
-    sha256: "99537ecf15815d5bac2f8f75b4e04635e1f8e95e7c857c711e42483aa2744f7f"
-  "248.10":
-    url: "https://github.com/systemd/systemd-stable/archive/v248.10.tar.gz"
-    sha256: "dab015c2ccd5cb0427b1c3ec85ac0f02974b38ca643de31932f198a8b60de8da"
-  "249.12":
-    url: "https://github.com/systemd/systemd-stable/archive/v249.12.tar.gz"
-    sha256: "cf8851e94cbd82c65a86ab122747f3e0018b04cd991c7daccbacb4a3ef149b68"
-  "251.4":
-    url: "https://github.com/systemd/systemd-stable/archive/v251.4.tar.gz"
-    sha256: "3459239979f52b8c4ace33734d31c2fb69fa13cf81d04b1b982f7d8d4651e015"
   "252.4":
     url: "https://github.com/systemd/systemd-stable/archive/v252.4.tar.gz"
     sha256: "cf2d27e67663d599a045101c7178cf0ec63d9df2962a54adf7de0d0357724f00"
+  "251.4":
+    url: "https://github.com/systemd/systemd-stable/archive/v251.4.tar.gz"
+    sha256: "3459239979f52b8c4ace33734d31c2fb69fa13cf81d04b1b982f7d8d4651e015"
+  "249.12":
+    url: "https://github.com/systemd/systemd-stable/archive/v249.12.tar.gz"
+    sha256: "cf8851e94cbd82c65a86ab122747f3e0018b04cd991c7daccbacb4a3ef149b68"
+  "248.10":
+    url: "https://github.com/systemd/systemd-stable/archive/v248.10.tar.gz"
+    sha256: "dab015c2ccd5cb0427b1c3ec85ac0f02974b38ca643de31932f198a8b60de8da"
+  "247.11":
+    url: "https://github.com/systemd/systemd-stable/archive/v247.11.tar.gz"
+    sha256: "99537ecf15815d5bac2f8f75b4e04635e1f8e95e7c857c711e42483aa2744f7f"
+  "246.16":
+    url: "https://github.com/systemd/systemd-stable/archive/v246.16.tar.gz"
+    sha256: "b69f9940d65870f090269a28f1047a633d4b80d0001e091d53a031dd40a822d2"
 patches:
+  "252.4":
+    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
+      patch_type: "conan"
+    - patch_file: "patches/251.4/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
+  "251.4":
+    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
+      patch_type: "conan"
+    - patch_file: "patches/251.4/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
+  "249.12":
+    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
+      patch_type: "conan"
+    - patch_file: "patches/249.12/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
+  "248.10":
+    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
+      patch_type: "conan"
+    - patch_file: "patches/247.11/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
+  "247.11":
+    - patch_file: "patches/247.11/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
   "246.16":
     - patch_file: "patches/246.16/0001-Drop-bundled-copy-of-linux-if_arp.h.patch"
       patch_description: "fix build error with Linux headers >= 5.14 by removing a bundled copy of it"
@@ -28,37 +60,5 @@ patches:
       patch_type: "bugfix"
       patch_source: "https://github.com/systemd/systemd-stable/commit/3d0666d9091dd097022f02fae79890b5746285c1"
     - patch_file: "patches/246.16/0003-Remove-dependency-from-coreutils.patch"
-      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
-      patch_type: "conan"
-  "247.11":
-    - patch_file: "patches/247.11/0001-Remove-dependency-from-coreutils.patch"
-      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
-      patch_type: "conan"
-  "248.10":
-    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
-      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
-      patch_type: "conan"
-    - patch_file: "patches/247.11/0001-Remove-dependency-from-coreutils.patch"
-      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
-      patch_type: "conan"
-  "249.12":
-    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
-      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
-      patch_type: "conan"
-    - patch_file: "patches/249.12/0001-Remove-dependency-from-coreutils.patch"
-      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
-      patch_type: "conan"
-  "251.4":
-    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
-      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
-      patch_type: "conan"
-    - patch_file: "patches/251.4/0001-Remove-dependency-from-coreutils.patch"
-      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
-      patch_type: "conan"
-  "252.4":
-    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
-      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
-      patch_type: "conan"
-    - patch_file: "patches/251.4/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"

--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -1,53 +1,53 @@
 sources:
-  "252.4":
-    url: "https://github.com/systemd/systemd-stable/archive/v252.4.tar.gz"
-    sha256: "cf2d27e67663d599a045101c7178cf0ec63d9df2962a54adf7de0d0357724f00"
-  "251.4":
-    url: "https://github.com/systemd/systemd-stable/archive/v251.4.tar.gz"
-    sha256: "3459239979f52b8c4ace33734d31c2fb69fa13cf81d04b1b982f7d8d4651e015"
-  "249.12":
-    url: "https://github.com/systemd/systemd-stable/archive/v249.12.tar.gz"
-    sha256: "cf8851e94cbd82c65a86ab122747f3e0018b04cd991c7daccbacb4a3ef149b68"
-  "248.10":
-    url: "https://github.com/systemd/systemd-stable/archive/v248.10.tar.gz"
-    sha256: "dab015c2ccd5cb0427b1c3ec85ac0f02974b38ca643de31932f198a8b60de8da"
-  "247.11":
-    url: "https://github.com/systemd/systemd-stable/archive/v247.11.tar.gz"
-    sha256: "99537ecf15815d5bac2f8f75b4e04635e1f8e95e7c857c711e42483aa2744f7f"
+  "252.9":
+    url: "https://github.com/systemd/systemd-stable/archive/v252.9.tar.gz"
+    sha256: "c386aac4ba39fa1bca3a3c9ef9df5a737e3184c9c6a04340e34d6d0254007845"
+  "251.15":
+    url: "https://github.com/systemd/systemd-stable/archive/v251.15.tar.gz"
+    sha256: "570b30b5b9a649d7481ca2bd0355a2d659f9a0ebb71a24588c6c365cda90c298"
+  "249.16":
+    url: "https://github.com/systemd/systemd-stable/archive/v249.16.tar.gz"
+    sha256: "e6c8a686023ef0ce402f4abde42245e3ada661e000c4811dc16c8cd9b4c6d885"
+  "248.12":
+    url: "https://github.com/systemd/systemd-stable/archive/v248.12.tar.gz"
+    sha256: "d0826453439363b57a4f092ae078b128a95e87047281a79e8b136116ab83abc9"
+  "247.13":
+    url: "https://github.com/systemd/systemd-stable/archive/v247.13.tar.gz"
+    sha256: "0958bfcebf3ed4e451f6cc49802f338fcc80eb4fe4f0cf5cb5b1b90fa62e5f47"
   "246.16":
     url: "https://github.com/systemd/systemd-stable/archive/v246.16.tar.gz"
     sha256: "b69f9940d65870f090269a28f1047a633d4b80d0001e091d53a031dd40a822d2"
 patches:
-  "252.4":
-    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+  "252.9":
+    - patch_file: "patches/248.12/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
       patch_type: "conan"
-    - patch_file: "patches/251.4/0001-Remove-dependency-from-coreutils.patch"
+    - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
-  "251.4":
-    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+  "251.15":
+    - patch_file: "patches/248.12/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
       patch_type: "conan"
-    - patch_file: "patches/251.4/0001-Remove-dependency-from-coreutils.patch"
+    - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
-  "249.12":
-    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+  "249.16":
+    - patch_file: "patches/248.12/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
       patch_type: "conan"
-    - patch_file: "patches/249.12/0001-Remove-dependency-from-coreutils.patch"
+    - patch_file: "patches/249.16/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
-  "248.10":
-    - patch_file: "patches/248.10/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+  "248.12":
+    - patch_file: "patches/248.12/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
       patch_type: "conan"
-    - patch_file: "patches/247.11/0001-Remove-dependency-from-coreutils.patch"
+    - patch_file: "patches/247.13/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
-  "247.11":
-    - patch_file: "patches/247.11/0001-Remove-dependency-from-coreutils.patch"
+  "247.13":
+    - patch_file: "patches/247.13/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
   "246.16":

--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "253.3":
+    url: "https://github.com/systemd/systemd-stable/archive/v253.3.tar.gz"
+    sha256: "569775d77084e45d15e103004cf4fbc00d7249c33791471b80f0c3296962bbfd"
   "252.9":
     url: "https://github.com/systemd/systemd-stable/archive/v252.9.tar.gz"
     sha256: "c386aac4ba39fa1bca3a3c9ef9df5a737e3184c9c6a04340e34d6d0254007845"
@@ -18,6 +21,13 @@ sources:
     url: "https://github.com/systemd/systemd-stable/archive/v246.16.tar.gz"
     sha256: "b69f9940d65870f090269a28f1047a633d4b80d0001e091d53a031dd40a822d2"
 patches:
+  "253.3":
+    - patch_file: "patches/253.3/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
+      patch_type: "conan"
+    - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
   "252.9":
     - patch_file: "patches/248.12/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"

--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -132,6 +132,8 @@ class LibsystemdConan(ConanFile):
             unrelated.extend(["sysext", "nscd"])
         if Version(self.version) >= "251.1":
             unrelated.append("link-boot-shared")
+        if Version(self.version) >= "252.1":
+            unrelated.append("link-journalctl-shared")
 
         for opt in unrelated:
             tc.project_options[opt] = "false"

--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -52,23 +52,23 @@ class LibsystemdConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libcap/2.66")
+        self.requires("libcap/2.68")
         self.requires("libmount/2.36.2")
         if self.options.with_selinux:
             self.requires("libselinux/3.3")
         if self.options.with_lz4:
             self.requires("lz4/1.9.4")
         if self.options.with_xz:
-            self.requires("xz_utils/5.4.0")
+            self.requires("xz_utils/5.4.2")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.4")
+            self.requires("zstd/1.5.5")
 
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("Only Linux supported")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
+        self.tool_requires("meson/1.1.0")
         self.tool_requires("m4/1.4.19")
         self.tool_requires("gperf/3.1")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):

--- a/recipes/libsystemd/all/patches/247.13/0001-Remove-dependency-from-coreutils.patch
+++ b/recipes/libsystemd/all/patches/247.13/0001-Remove-dependency-from-coreutils.patch
@@ -1,4 +1,4 @@
-From dd758e85278e15db6e66e9802744f120eeb2285c Mon Sep 17 00:00:00 2001
+From 2dbb0fe320ca75e7e2be6eba8b5fe6fe07a1ece1 Mon Sep 17 00:00:00 2001
 From: Sergey Bobrenok <bobrofon@gmail.com>
 Date: Thu, 18 Aug 2022 21:51:58 +0300
 Subject: [PATCH] Remove dependency from coreutils
@@ -10,10 +10,10 @@ can simply replace '@CONAN_SRC_REL_PATH@' with the actual path there.
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index b9b8ebef45..30c5b6efa1 100644
+index 177cd4fb66..869c2352f6 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -25,9 +25,7 @@ conf.set('PROJECT_VERSION',    meson.project_version(),
+@@ -33,9 +33,7 @@ substs.set('PROJECT_VERSION',      meson.project_version(),
  # the wrong result when systemd is being built as a meson subproject
  project_source_root = meson.current_source_dir()
  project_build_root = meson.current_build_dir()
@@ -23,7 +23,9 @@ index b9b8ebef45..30c5b6efa1 100644
 +relative_source_path = @CONAN_SRC_REL_PATH@
  conf.set_quoted('RELATIVE_SOURCE_PATH', relative_source_path)
  
- conf.set10('BUILD_MODE_DEVELOPER', get_option('mode') == 'developer',
+ conf.set('BUILD_MODE', 'BUILD_MODE_' + get_option('mode').to_upper(),
+
+base-commit: bb47600aeb38c68c857fbf0ee5f66c3144dd81ce
 -- 
-2.37.2
+2.40.1
 

--- a/recipes/libsystemd/all/patches/248.12/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch
+++ b/recipes/libsystemd/all/patches/248.12/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch
@@ -1,4 +1,4 @@
-From 512223a1ada207304787fb24a6da9e844b381239 Mon Sep 17 00:00:00 2001
+From e8ff65fb110f1a1118ab709fe41e1c3dff0b3c40 Mon Sep 17 00:00:00 2001
 From: Sergey Bobrenok <bobrofon@gmail.com>
 Date: Wed, 17 Aug 2022 22:31:13 +0300
 Subject: [PATCH] missing_syscalls.py: Replace unicode with ascii
@@ -25,6 +25,8 @@ index 1bfa31ba37..cc353fe723 100644
      for line in open(filename):
          items = line.split()
          if len(items) >= 2:
+
+base-commit: 786df410b1cb3a2294c9a5d118c958525e7439e6
 -- 
-2.37.2
+2.40.1
 

--- a/recipes/libsystemd/all/patches/249.16/0001-Remove-dependency-from-coreutils.patch
+++ b/recipes/libsystemd/all/patches/249.16/0001-Remove-dependency-from-coreutils.patch
@@ -1,4 +1,4 @@
-From 9c20566484b758204215f945dfa8a1242b8bff8c Mon Sep 17 00:00:00 2001
+From 08ad698a1b3f7c1caf9dac54c68c2878c664ceec Mon Sep 17 00:00:00 2001
 From: Sergey Bobrenok <bobrofon@gmail.com>
 Date: Thu, 18 Aug 2022 21:51:58 +0300
 Subject: [PATCH] Remove dependency from coreutils
@@ -6,25 +6,26 @@ Subject: [PATCH] Remove dependency from coreutils
 In a conan recipe we already know the relative path to the source directory. We
 can simply replace '@CONAN_SRC_REL_PATH@' with the actual path there.
 ---
- meson.build | 5 +----
- 1 file changed, 1 insertion(+), 4 deletions(-)
+ meson.build | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index dbba108ad1..035869fb0d 100644
+index ece21fbd10..aefc82513e 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -25,10 +25,7 @@ conf.set('PROJECT_VERSION',    meson.project_version(),
+@@ -25,9 +25,7 @@ conf.set('PROJECT_VERSION',    meson.project_version(),
  # the wrong result when systemd is being built as a meson subproject
  project_source_root = meson.current_source_dir()
  project_build_root = meson.current_build_dir()
 -relative_source_path = run_command('realpath',
 -                                   '--relative-to=@0@'.format(project_build_root),
--                                   project_source_root,
--                                   check : true).stdout().strip()
+-                                   project_source_root).stdout().strip()
 +relative_source_path = @CONAN_SRC_REL_PATH@
  conf.set_quoted('RELATIVE_SOURCE_PATH', relative_source_path)
  
  conf.set10('BUILD_MODE_DEVELOPER', get_option('mode') == 'developer',
+
+base-commit: 358552f75f0ef03af2d6d0ba0f5423f17eab7f84
 -- 
-2.37.2
+2.40.1
 

--- a/recipes/libsystemd/all/patches/251.15/0001-Remove-dependency-from-coreutils.patch
+++ b/recipes/libsystemd/all/patches/251.15/0001-Remove-dependency-from-coreutils.patch
@@ -1,4 +1,4 @@
-From 319900054fb800f3f3c57806176a71e5f5cff5bd Mon Sep 17 00:00:00 2001
+From 0cd72ba5fc1e0b7927522e91d4a1b5172bbc818e Mon Sep 17 00:00:00 2001
 From: Sergey Bobrenok <bobrofon@gmail.com>
 Date: Thu, 18 Aug 2022 21:51:58 +0300
 Subject: [PATCH] Remove dependency from coreutils
@@ -6,24 +6,27 @@ Subject: [PATCH] Remove dependency from coreutils
 In a conan recipe we already know the relative path to the source directory. We
 can simply replace '@CONAN_SRC_REL_PATH@' with the actual path there.
 ---
- meson.build | 4 +---
- 1 file changed, 1 insertion(+), 3 deletions(-)
+ meson.build | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 177cd4fb66..869c2352f6 100644
+index d27796e85e..1a31824c8c 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -33,9 +33,7 @@ substs.set('PROJECT_VERSION',      meson.project_version(),
+@@ -25,10 +25,7 @@ conf.set('PROJECT_VERSION',    meson.project_version(),
  # the wrong result when systemd is being built as a meson subproject
  project_source_root = meson.current_source_dir()
  project_build_root = meson.current_build_dir()
 -relative_source_path = run_command('realpath',
 -                                   '--relative-to=@0@'.format(project_build_root),
--                                   project_source_root).stdout().strip()
+-                                   project_source_root,
+-                                   check : true).stdout().strip()
 +relative_source_path = @CONAN_SRC_REL_PATH@
  conf.set_quoted('RELATIVE_SOURCE_PATH', relative_source_path)
  
- conf.set('BUILD_MODE', 'BUILD_MODE_' + get_option('mode').to_upper(),
+ conf.set10('BUILD_MODE_DEVELOPER', get_option('mode') == 'developer',
+
+base-commit: a6422b7bd7001dc38d658f3197073a3e22ca9f1b
 -- 
-2.37.2
+2.40.1
 

--- a/recipes/libsystemd/all/patches/253.3/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch
+++ b/recipes/libsystemd/all/patches/253.3/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch
@@ -1,0 +1,32 @@
+From da3472d677dd30065f8745a124d580e5c24d3868 Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Wed, 17 Aug 2022 22:31:13 +0300
+Subject: [PATCH] missing_syscalls.py: Replace unicode with ascii
+
+In some system configurations 'find_program('missing_syscalls.py')' may
+fail with error:
+  'ascii' codec can't decode byte 0xe2 in position 615: ordinal not in range(128)
+  Unusable script 'src/basic/missing_syscalls.py'
+  Program missing_syscalls.py found: NO
+---
+ src/basic/missing_syscalls.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/missing_syscalls.py b/src/basic/missing_syscalls.py
+index 5ccf02adec..14169e67f3 100644
+--- a/src/basic/missing_syscalls.py
++++ b/src/basic/missing_syscalls.py
+@@ -31,7 +31,7 @@ def dictify(f):
+ 
+ @dictify
+ def parse_syscall_table(filename):
+-    print(f'Reading {filename}…')
++    print(f'Reading {filename}...')
+     for line in open(filename):
+         items = line.split()
+         if len(items) >= 2:
+
+base-commit: ed18c2ab79e8b94182d5dcf31d58457763f3e3e1
+-- 
+2.40.1
+

--- a/recipes/libsystemd/config.yml
+++ b/recipes/libsystemd/config.yml
@@ -1,13 +1,13 @@
 versions:
-  "246.16":
-    folder: all
-  "247.11":
-    folder: all
-  "248.10":
-    folder: all
-  "249.12":
+  "252.4":
     folder: all
   "251.4":
     folder: all
-  "252.4":
+  "249.12":
+    folder: all
+  "248.10":
+    folder: all
+  "247.11":
+    folder: all
+  "246.16":
     folder: all

--- a/recipes/libsystemd/config.yml
+++ b/recipes/libsystemd/config.yml
@@ -1,13 +1,13 @@
 versions:
-  "252.4":
+  "252.9":
     folder: all
-  "251.4":
+  "251.15":
     folder: all
-  "249.12":
+  "249.16":
     folder: all
-  "248.10":
+  "248.12":
     folder: all
-  "247.11":
+  "247.13":
     folder: all
   "246.16":
     folder: all

--- a/recipes/libsystemd/config.yml
+++ b/recipes/libsystemd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "253.3":
+    folder: all
   "252.9":
     folder: all
   "251.15":


### PR DESCRIPTION
Specify library name and version:  **libsystemd/253.3**

Changes summary:
* Versions in conandata and config files are sorted to fit contributing recommendations.
* All minor versions updated. The systemd versioning schema is something like `systemd_version.build_patch`, where `build_patch` contains fixes related to build files and security updates. So it should be fine to replace all minor versions.
* Bump dependencies
* Bump version (253.3)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
