### PR TITLE
cmake: add `conanbuildinfo.cmake` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/test_package/build-*/
 **/test_package/test_output/
 conan.lock
+conanbuildinfo.cmake
 conanbuildinfo.txt
 conaninfo.txt
 graph_info.json


### PR DESCRIPTION
Specify library name and version: all

While developing cmake recipes it's a bit annoying to not have cmakebuildinfo.cmake git-ignored by default. I thought it was more straighforward to create a PR with the changes, that you are free to accept or dismiss (if there is any reason to not exclude cmakebuildinfo.cmake), rather than opening an issue.

Thanks!