### PR TITLE
xqilla: fix compilation with C++17 + several improvements for conan v2

### DIFF
--- a/recipes/xqilla/all/conandata.yml
+++ b/recipes/xqilla/all/conandata.yml
@@ -7,3 +7,6 @@ patches:
     - patch_file: "patches/0001-honor-deps-ldflags.patch"
       patch_description: "Honor LDFLAGS from dependencies"
       patch_type: "conan"
+    - patch_file: "patches/0002-fix-c++17-no-register.patch"
+      patch_description: "Remove register keyword to fix compilation with C++17"
+      patch_type: "portability"

--- a/recipes/xqilla/all/conandata.yml
+++ b/recipes/xqilla/all/conandata.yml
@@ -7,6 +7,6 @@ patches:
     - patch_file: "patches/0001-honor-deps-ldflags.patch"
       patch_description: "Honor LDFLAGS from dependencies"
       patch_type: "conan"
-    - patch_file: "patches/0002-fix-c++17-no-register.patch"
-      patch_description: "Remove register keyword to fix compilation with C++17"
+    - patch_file: "patches/0002-support-cpp17.patch"
+      patch_description: "Fix compilation with C++17"
       patch_type: "portability"

--- a/recipes/xqilla/all/conanfile.py
+++ b/recipes/xqilla/all/conanfile.py
@@ -22,7 +22,7 @@ class XqillaConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://xqilla.sourceforge.net/HomePage"
     license = "Apache-2.0"
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/xqilla/all/conanfile.py
+++ b/recipes/xqilla/all/conanfile.py
@@ -56,7 +56,8 @@ class XqillaConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("xerces-c/3.2.4", transitive_headers=True)
+        # xerces-c is public, see https://c3i.jfrog.io/artifactory/misc-v2/logs/pr/17332/3-linux-gcc/xqilla/2.3.4/ed5ac4a4d7ee70de0440268155f960162d458f1d-test.txt
+        self.requires("xerces-c/3.2.4", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/xqilla/all/conanfile.py
+++ b/recipes/xqilla/all/conanfile.py
@@ -56,7 +56,7 @@ class XqillaConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("xerces-c/3.2.4")
+        self.requires("xerces-c/3.2.4", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/xqilla/all/conanfile.py
+++ b/recipes/xqilla/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
 
 
 class XqillaConan(ConanFile):
@@ -59,7 +59,7 @@ class XqillaConan(ConanFile):
         self.requires("xerces-c/3.2.4")
 
     def validate(self):
-        if self.info.settings.compiler.get_safe("cppstd"):
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         if is_msvc(self):
             raise ConanInvalidConfiguration("xqilla recipe doesn't support msvc build yet")
@@ -73,8 +73,7 @@ class XqillaConan(ConanFile):
                 self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         env = VirtualBuildEnv(self)
@@ -121,10 +120,8 @@ class XqillaConan(ConanFile):
         rename(self, os.path.join(self.package_folder, "licenses", "README"),
                      os.path.join(self.package_folder, "licenses", "LICENSE.mapm"))
         save(self, os.path.join(self.package_folder, "licenses", "LICENSE.yajl"), self._extract_yajl_license())
-
         autotools = Autotools(self)
-        # TODO: replace by autotools.install() once https://github.com/conan-io/conan/issues/12153 fixed
-        autotools.install(args=[f"DESTDIR={unix_path(self, self.package_folder)}"])
+        autotools.install()
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         fix_apple_shared_install_name(self)
 

--- a/recipes/xqilla/all/conanfile.py
+++ b/recipes/xqilla/all/conanfile.py
@@ -56,7 +56,7 @@ class XqillaConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("xerces-c/3.2.3")
+        self.requires("xerces-c/3.2.4")
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/xqilla/all/patches/0002-fix-c++17-no-register.patch
+++ b/recipes/xqilla/all/patches/0002-fix-c++17-no-register.patch
@@ -1,0 +1,135 @@
+--- a/include/xqilla/utils/XPath2Utils.hpp
++++ b/include/xqilla/utils/XPath2Utils.hpp
+@@ -104,8 +104,8 @@ inline bool XPath2Utils::equals(const XMLCh *const str1, const XMLCh *const str2
+   if(str1 == 0) return *str2 == 0; // str2 == 0 is handled by the first line
+   if(str2 == 0) return *str1 == 0; // str1 == 0 is handled by the first line
+ 
+-  register const XMLCh* psz1 = str1;
+-  register const XMLCh* psz2 = str2;
++  const XMLCh* psz1 = str1;
++  const XMLCh* psz2 = str2;
+ 
+   while(*psz1 == *psz2) {
+     // If either has ended, then they both ended, so equal
+@@ -125,7 +125,7 @@ inline int XPath2Utils::compare(const XMLCh *str1, const XMLCh *str2) {
+   if(str1 == 0) return -*str2; // str2 == 0 is handled by the first line
+   if(str2 == 0) return *str1; // str1 == 0 is handled by the first line
+ 
+-  register int cmp;
++  int cmp;
+   while((cmp = *str1 - *str2) == 0) {
+     // If either has ended, then they both ended, so equal
+     if(*str1 == 0) break;
+--- a/src/lexer/XQLexer.cpp
++++ b/src/lexer/XQLexer.cpp
+@@ -14079,9 +14079,9 @@ YY_MALLOC_DECL
+ 
+ YY_DECL
+ 	{
+-	register yy_state_type yy_current_state;
+-	register YY_CHAR *yy_cp, *yy_bp;
+-	register int yy_act;
++	yy_state_type yy_current_state;
++	YY_CHAR *yy_cp, *yy_bp;
++	int yy_act;
+ 
+ #line 209 "../src/lexer/XQLexer.l"
+ 
+@@ -14157,7 +14157,7 @@ YY_DECL
+ yy_match:
+ 		do
+ 			{
+-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
++			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+ 			if ( yy_accept[yy_current_state] )
+ 				{
+ 				yy_last_accepting_state = yy_current_state;
+@@ -16045,9 +16045,9 @@ void yyFlexLexer::LexerOutput( const YY_CHAR* buf, int size )
+ 
+ int yyFlexLexer::yy_get_next_buffer()
+ 	{
+-	register YY_CHAR *dest = yy_current_buffer->yy_ch_buf;
+-	register YY_CHAR *source = yytext_ptr;
+-	register int number_to_move, i;
++	YY_CHAR *dest = yy_current_buffer->yy_ch_buf;
++	YY_CHAR *source = yytext_ptr;
++	int number_to_move, i;
+ 	int ret_val;
+ 
+ 	if ( yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1] )
+@@ -16178,14 +16178,14 @@ int yyFlexLexer::yy_get_next_buffer()
+ 
+ yy_state_type yyFlexLexer::yy_get_previous_state()
+ 	{
+-	register yy_state_type yy_current_state;
+-	register YY_CHAR *yy_cp;
++	yy_state_type yy_current_state;
++	YY_CHAR *yy_cp;
+ 
+ 	yy_current_state = yy_start;
+ 
+ 	for ( yy_cp = yytext_ptr + YY_MORE_ADJ; yy_cp < yy_c_buf_p; ++yy_cp )
+ 		{
+-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
++		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+ 		if ( yy_accept[yy_current_state] )
+ 			{
+ 			yy_last_accepting_state = yy_current_state;
+@@ -16212,10 +16212,10 @@ yy_state_type yyFlexLexer::yy_get_previous_state()
+ 
+ yy_state_type yyFlexLexer::yy_try_NUL_trans( yy_state_type yy_current_state )
+ 	{
+-	register int yy_is_jam;
+-	register YY_CHAR *yy_cp = yy_c_buf_p;
++	int yy_is_jam;
++	YY_CHAR *yy_cp = yy_c_buf_p;
+ 
+-	register YY_CHAR yy_c = 1;
++	YY_CHAR yy_c = 1;
+ 	if ( yy_accept[yy_current_state] )
+ 		{
+ 		yy_last_accepting_state = yy_current_state;
+@@ -16234,9 +16234,9 @@ yy_state_type yyFlexLexer::yy_try_NUL_trans( yy_state_type yy_current_state )
+ 	}
+ 
+ 
+-void yyFlexLexer::yyunput( int c, register YY_CHAR * yy_bp )
++void yyFlexLexer::yyunput( int c, YY_CHAR * yy_bp )
+ 	{
+-	register YY_CHAR *yy_cp = yy_c_buf_p;
++	YY_CHAR *yy_cp = yy_c_buf_p;
+ 
+ 	/* undo effects of setting up yytext */
+ 	*yy_cp = yy_hold_char;
+@@ -16244,10 +16244,10 @@ void yyFlexLexer::yyunput( int c, register YY_CHAR * yy_bp )
+ 	if ( yy_cp < yy_current_buffer->yy_ch_buf + 2 )
+ 		{ /* need to shift things up to make room */
+ 		/* +2 for EOB chars. */
+-		register int number_to_move = yy_n_chars + 2;
+-		register YY_CHAR *dest = &yy_current_buffer->yy_ch_buf[
++		int number_to_move = yy_n_chars + 2;
++		YY_CHAR *dest = &yy_current_buffer->yy_ch_buf[
+ 					yy_current_buffer->yy_buf_size + 2];
+-		register YY_CHAR *source =
++		YY_CHAR *source =
+ 				&yy_current_buffer->yy_ch_buf[number_to_move];
+ 
+ 		while ( source > yy_current_buffer->yy_ch_buf )
+@@ -16561,7 +16561,7 @@ yyconst YY_CHAR *s2;
+ int n;
+ #endif
+ 	{
+-	register int i;
++	int i;
+ 	for ( i = 0; i < n; ++i )
+ 		s1[i] = s2[i];
+ 	}
+@@ -16575,7 +16575,7 @@ static int yy_flex_strlen( s )
+ yyconst YY_CHAR *s;
+ #endif
+ 	{
+-	register int n;
++	int n;
+ 	for ( n = 0; s[n]; ++n )
+ 		;
+ 

--- a/recipes/xqilla/all/patches/0002-support-cpp17.patch
+++ b/recipes/xqilla/all/patches/0002-support-cpp17.patch
@@ -1,3 +1,14 @@
+--- a/include/xqilla/ast/XQDocumentOrder.hpp
++++ b/include/xqilla/ast/XQDocumentOrder.hpp
+@@ -68,7 +68,7 @@ private:
+   public:
+     uniqueLessThanCompareFn(const DynamicContext *context)
+       : context_(context) {}
+-    bool operator()(const Node::Ptr &first, const Node::Ptr &second)
++    bool operator()(const Node::Ptr &first, const Node::Ptr &second) const
+     {
+       return first->uniqueLessThan(second, context_);
+     }
 --- a/include/xqilla/utils/XPath2Utils.hpp
 +++ b/include/xqilla/utils/XPath2Utils.hpp
 @@ -104,8 +104,8 @@ inline bool XPath2Utils::equals(const XMLCh *const str1, const XMLCh *const str2
@@ -133,3 +144,14 @@
  	for ( n = 0; s[n]; ++n )
  		;
  
+--- a/src/runtime/Sequence.cpp
++++ b/src/runtime/Sequence.cpp
+@@ -186,7 +186,7 @@ public:
+   lessThanCompareFn(const DynamicContext *context)
+     : context_(context) {}
+ 
+-  bool operator()(const Item::Ptr &first, const Item::Ptr &second)
++  bool operator()(const Item::Ptr &first, const Item::Ptr &second) const
+   {
+     return ((const Node*)first.get())->lessThan((const Node::Ptr)second, context_);
+   }

--- a/recipes/xqilla/all/test_package/conanfile.py
+++ b/recipes/xqilla/all/test_package/conanfile.py
@@ -13,7 +13,7 @@ class TestPackageConan(ConanFile):
         cmake_layout(self)
 
     def requirements(self):
-        self.requires(self.tested_reference_str)
+        self.requires(self.tested_reference_str, run=can_run(self))
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- fix compilation with C++17 (or higher): remove register keywords. It has been deprecated in C++11 and removed in C++17.
- add package_type
- fix test package with conan v2 client (we call an executable in run scope, so it requires run=True in self.requires)
- remove autotools.install() workaround on Windows since it has been fixed in conan 1.54.0
- use self.settings instead of self.info.settings in validate()
- bump xerces-c

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
