### PR TITLE
sdbus-cpp/all: Conan v2 compatibility fix

### DIFF
--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -65,7 +65,7 @@ class SdbusCppConan(ConanFile):
             check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(str(self.info.settings.compiler))
         if not min_version:
-            self.output.warn("{} recipe lacks information about the {} compiler support.".format(
+            self.output.warning("{} recipe lacks information about the {} compiler support.".format(
                 self.name, self.info.settings.compiler))
         else:
             if Version(self.info.settings.compiler.version) < min_version:

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -58,6 +58,9 @@ class SdbusCppConan(ConanFile):
         self.requires("libsystemd/253.3")
 
     def validate(self):
+        if self.info.settings.os != "Linux":
+            raise ConanInvalidConfiguration("Only Linux supported")
+
         if self.info.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(str(self.info.settings.compiler))
@@ -68,8 +71,6 @@ class SdbusCppConan(ConanFile):
             if Version(self.info.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
                     self.name, self._minimum_cpp_standard, self.info.settings.compiler, self.info.settings.compiler.version))
-        if self.info.settings.os != "Linux":
-            raise ConanInvalidConfiguration("Only Linux supported")
 
     def build_requirements(self):
         self.tool_requires("pkgconf/1.9.3")

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -59,7 +59,7 @@ class SdbusCppConan(ConanFile):
 
     def validate(self):
         if self.info.settings.os != "Linux":
-            raise ConanInvalidConfiguration("Only Linux supported")
+            raise ConanInvalidConfiguration(f"{self.name} only supports Linux")
 
         if self.info.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -18,6 +18,7 @@ class SdbusCppConan(ConanFile):
     description = "High-level C++ D-Bus library for Linux designed" \
                   " to provide easy-to-use yet powerful API in modern C++"
     topics = ("dbus", "sd-bus", "sdbus-c++")
+    package_type = "library"
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "shared": [True, False],


### PR DESCRIPTION
Specify library name and version:  **sdbus-cpp/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

There is no `self.output.warn` method in `conan2`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
