### PR TITLE
libuuid/1.0.3: Fix missing include for the sys/file.h header

### DIFF
--- a/recipes/libuuid/all/conanfile.py
+++ b/recipes/libuuid/all/conanfile.py
@@ -28,6 +28,10 @@ class LibuuidConan(ConanFile):
         "fPIC": True,
     }
 
+    @property
+    def _has_sys_file_header(self):
+        return self.settings.os in ["FreeBSD", "Linux", "Macos"]
+
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -58,6 +62,8 @@ class LibuuidConan(ConanFile):
         env = VirtualBuildEnv(self)
         env.generate()
         tc = AutotoolsToolchain(self)
+        if self._has_sys_file_header:
+            tc.extra_defines.append("HAVE_SYS_FILE_H")
         if "x86" in self.settings.arch:
             tc.extra_cflags.append("-mstackrealign")
         tc.generate()


### PR DESCRIPTION
This fixes compilation when using Clang 16.
Due to the removal of support for implicit declarations, libuuid fails to build due to an issue where the `<sys/file.h>` header is not included. Specifically, the `flock` function requires `<sys/file.h>` to be included. Since the compiler preprocessor macro `HAVE_SYS_FILE_H` is not defined, that header is not included. This worked previously since the compiler assumed that is was an implicit function declaration. Defining the macro on the necessary platforms solves the issue.

Specify library name and version:  **libuuid/1.0.3**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
