### PR TITLE
imgui: add version 1.89.5

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.89.5":
+    url: "https://github.com/ocornut/imgui/archive/v1.89.5.tar.gz"
+    sha256: "eab371005c86dd029523a0c4ba757840787163740d45c1f4e5a110eb21820546"
   "1.89.4":
     url: "https://github.com/ocornut/imgui/archive/v1.89.4.tar.gz"
     sha256: "69f1e83adcab3fdd27b522f5075f407361b0d3875e3522b13d33bc2ae2c7d48c"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.89.5":
+    folder: all
   "1.89.4":
     folder: all
   "1.89.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version: imgui/1.89.5

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
