### PR TITLE
avahi/0.8: Disable the use of the setproctitle function on Linux

### DIFF
--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -70,7 +70,7 @@ class AvahiConan(ConanFile):
         tc.configure_args.append("--disable-python")
         tc.configure_args.append("--disable-qt5")
         tc.configure_args.append("--with-systemdsystemunitdir=/lib/systemd/system")
-        if self.settings.os == "linux":
+        if self.settings.os == "Linux":
             tc.configure_args.append("ac_cv_func_setproctitle=no")
         tc.generate()
         AutotoolsDeps(self).generate()

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -70,6 +70,8 @@ class AvahiConan(ConanFile):
         tc.configure_args.append("--disable-python")
         tc.configure_args.append("--disable-qt5")
         tc.configure_args.append("--with-systemdsystemunitdir=/lib/systemd/system")
+        if self.settings.os == "linux":
+            tc.configure_args.append("ac_cv_func_setproctitle=no")
         tc.generate()
         AutotoolsDeps(self).generate()
         PkgConfigDeps(self).generate()


### PR DESCRIPTION
This function is not declared on Linux.
Configure ignores warnings about the missing declaration. This causes issues when building with recent versions of Clang. Support for implicit declarations was removed in newer C standards in Clang. Telling configure that the setproctitle function is not available disables the use of this function in Avahi.

Fixes #17354.

Specify library name and version:  **avahi/0.8**

Note that `setproctitle` is correctly disabled on Linux in Avahi's master branch, so no upstream patches are necessary. I tested this in commit `6395c45` of Avahi locally.
Using both GCC and Clang, results in `ac_cv_func_setproctitle=no` in `config.log` without any manual intervention.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
