### PR TITLE
norm: add package_type + bump deps + small patch to fix compilation with apple-clang & C++20

### DIFF
--- a/recipes/norm/all/conandata.yml
+++ b/recipes/norm/all/conandata.yml
@@ -6,3 +6,6 @@ patches:
   "1.5.9":
     - patch_file: "patches/0001-fix-pthread.patch"
     - patch_file: "patches/0002-fix-fpic.patch"
+    - patch_file: "patches/0003-cpp20-compat.patch"
+      patch_description: "C++20 compatibility: Fix ambiguous overloaded operator =="
+      patch_type: "portability"

--- a/recipes/norm/all/conanfile.py
+++ b/recipes/norm/all/conanfile.py
@@ -39,7 +39,7 @@ class NormConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libxml2/2.10.3") # dependency of protolib actually
+        self.requires("libxml2/2.10.4") # dependency of protolib actually
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version])

--- a/recipes/norm/all/conanfile.py
+++ b/recipes/norm/all/conanfile.py
@@ -13,7 +13,7 @@ class NormConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.nrl.navy.mil/itd/ncs/products/norm"
     license = "NRL"
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/norm/all/patches/0003-cpp20-compat.patch
+++ b/recipes/norm/all/patches/0003-cpp20-compat.patch
@@ -1,0 +1,11 @@
+--- a/src/common/normNode.cpp
++++ b/src/common/normNode.cpp
+@@ -1621,7 +1621,7 @@ void NormSenderNode::HandleObjectMessage(const NormObjectMsg& msg)
+         {
+             // The hacky use of "sync_id" here keeps the debug message from
+             // printing too often while "waiting to sync" ...
+-            if (0 == sync_id)
++            if (0 == (UINT16)sync_id)
+             {
+                 PLOG(PL_ERROR, "NormSenderNode::HandleObjectMessage() waiting to sync ...\n");
+                 sync_id = 100;


### PR DESCRIPTION
- add package_type
- bump libxml2
- fix compilation with C++20. There was an error with apple-clang 14 and C++20:
  
  ```
  /Users/spaceim/.conan2/p/t/norm134268ea437dd/b/src/src/common/normNode.cpp:1624:19: error: use of overloaded operator '==' is ambiguous (with operand types 'int' and 'NormObjectId')
            if (0 == sync_id)
                ~ ^  ~~~~~~~
  ```

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
