### PR TITLE
[OPENCV] Fix double del when setting dnn option to False

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -155,13 +155,12 @@ class OpenCVConan(ConanFile):
         if not self.options.contrib:
             del self.options.contrib_freetype
             del self.options.contrib_sfm
-        if not self.options.dnn:
+        if not self.options.dnn or not self.options.with_cuda:
             del self.options.dnn_cuda
         if not self.options.with_cuda:
             del self.options.with_cublas
             del self.options.with_cudnn
             del self.options.with_cufft
-            del self.options.dnn_cuda
             del self.options.cuda_arch_bin
         if bool(self.options.with_jpeg):
             if self.options.get_safe("with_jpeg2000") == "jasper":


### PR DESCRIPTION
If opnecv is built with both dnn and with_cuda False, the build fails, because the conanfile.py execute  del self.options.dnn_cuda twice. 
This fixes the issue.

Specify library name and version:  **opencv/4.5.5**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
