### PR TITLE
CMake [build from source] Added missing definition needed when bootstrapping with OpenSSL

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -97,6 +97,7 @@ class CMakeConan(ConanFile):
                     openssl = self.dependencies["openssl"]
                     bootstrap_cmake_options.append("-DCMAKE_USE_OPENSSL=ON")
                     bootstrap_cmake_options.append(f'-DOPENSSL_USE_STATIC_LIBS={"FALSE" if openssl.options.shared else "TRUE"}')
+                    bootstrap_cmake_options.append(f'-DOPENSSL_ROOT_DIR={openssl.package_path}')
                 else:
                     bootstrap_cmake_options.append("-DCMAKE_USE_OPENSSL=OFF")
             save(self, "bootstrap_args", json.dumps({"bootstrap_cmake_options": ' '.join(arg for arg in bootstrap_cmake_options)}))


### PR DESCRIPTION
Specify library name and version:  **cmake/3.26.3**

<!-- The "build from source" recipe for CMake is missing a definition needed to find the version of OpenSSL provided by Conan and declared as a dependency. Previously this recipe was finding header files from a system-wide installation of OpenSLL or failing if the OpenSSL dev package was not pre-installed. -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
