### PR TITLE
vulkan-loader: conditionally remove shared option on platforms where …

### DIFF
--- a/recipes/vulkan-loader/all/conanfile.py
+++ b/recipes/vulkan-loader/all/conanfile.py
@@ -60,7 +60,11 @@ class VulkanLoaderConan(ConanFile):
             del self.options.with_wsi_directfb
 
     def configure(self):
-        if self.options.shared:
+        if not is_apple_os(self):
+            # static builds are not supported
+            self.options.rm_safe("shared")
+            self.package_type = "shared-library"
+        if self.options.get_safe("shared"):
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
@@ -79,8 +83,6 @@ class VulkanLoaderConan(ConanFile):
         if self.options.get_safe("with_wsi_directfb"):
             # TODO: directfb package
             raise ConanInvalidConfiguration("Conan recipe for DirectFB is not available yet.")
-        if not is_apple_os(self) and not self.options.shared:
-            raise ConanInvalidConfiguration(f"Static builds are not supported on {self.settings.os}")
         # FIXME: It should build but Visual Studio 2015 container in CI of CCI seems to lack some Win SDK headers
         check_min_vs(self, "191")
         # TODO: to replace by some version range check


### PR DESCRIPTION
Specify library name and version:  **vulkan-loader/all**

* When `vulkan-loader` is in the graph, and `*:shared=False`, the graph will not properly resolve because this check raises an InvalidConfiguration - this would force a consumer to explicitly set shared=True for `vulkan-loader` on some platforms.

If on certain platforms only the shared version can exist, then it's not really an option - so we can better reflect this in the `configure()` method: remove the option in those contexts. Note that ideally this would be done in the `config_options()` method so that the option is removed before being given a value, but currently there is logic in the CI service that expects to be able to pass this option with a value.

This will allow generating Conan 2.0 binaries for libraries that depend _on_ `vulkan-loader` and pass `*:shared=True` or `*:shared=False` - in those platforms where _only_ the shared variant can exist, then that variant will be used regardless (which is what we would expect from the consumer end).
