### PR TITLE
[config] Add values for cppstds for conan v2 pipeline

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -107,11 +107,11 @@ configurations:
 
 cppstd:
   apple-clang:
-    "13": ["gnu17"]
+    "13": ["17", "gnu17", "20", "gnu20"]
   gcc:
-    "11": ["gnu17"]
+    "11": ["17", "gnu17", "20", "gnu20"]
   msvc:
-    "192": ["14"]
+    "192": ["14", "17", "20"]
 
 jenkins:
   url: "http://mb-jenkins-my-bloody-jenkins:8080"


### PR DESCRIPTION
Service configuration:

When building packages with Conan 2.0, it will build packages for the first compatible `cppstd` in the list, that is, the first one that does not throw a `ConanInvalidConfiguration`.

This should enable building packages in Conan Center with Conan 2.0 for recipes that require a higher value of `cppstd` .
