### PR TITLE
opencl-headers: removed copy-paste errors in package_info section, added new versions

### DIFF
--- a/recipes/opencl-headers/all/conandata.yml
+++ b/recipes/opencl-headers/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "2023.04.17":
+    url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2023.04.17.tar.gz"
+    sha256: "0ce992f4167f958f68a37918dec6325be18f848dee29a4521c633aae3304915d"
+  "2023.02.06":
+    url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2023.02.06.tar.gz"
+    sha256: "464d1b04a5e185739065b2d86e4cebf02c154c416d63e6067a5060d7c053c79a"
   "2022.09.30":
     url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2022.09.30.tar.gz"
     sha256: "0ae857ecb28af95a420c800b21ed2d0f437503e104f841ab8db249df5f4fbe5c"

--- a/recipes/opencl-headers/all/conanfile.py
+++ b/recipes/opencl-headers/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, save
 from conan.tools.layout import basic_layout
 import os
+import textwrap
 
 required_conan_version = ">=1.50.0"
 
@@ -16,6 +17,10 @@ class OpenclHeadersConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+
+    @property
+    def _target_name(self):
+        return "OpenCL::Headers"
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -33,22 +38,37 @@ class OpenclHeadersConan(ConanFile):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "*", src=os.path.join(self.source_folder, "CL"), dst=os.path.join(self.package_folder, "include", "CL"))
 
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    def generate(self):
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {self._target_name: f"{self.name}::{self.name}"}
+        )
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "OpenCLHeaders")
-        self.cpp_info.set_property("cmake_target_name", "OpenCL::Headers")
-        self.cpp_info.set_property("pkg_config_name", "OpenCL")
+        self.cpp_info.set_property("cmake_target_name", self._target_name)
+        self.cpp_info.set_property("pkg_config_name", "OpenCL-Headers")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "OpenCLHeaders"
         self.cpp_info.filenames["cmake_find_package_multi"] = "OpenCLHeaders"
-        self.cpp_info.names["cmake_find_package"] = "OpenCL"
-        self.cpp_info.names["cmake_find_package_multi"] = "OpenCL"
-        self.cpp_info.names["pkg_config"] = "OpenCL"
-        self.cpp_info.components["_opencl-headers"].names["cmake_find_package"] = "Headers"
-        self.cpp_info.components["_opencl-headers"].names["cmake_find_package_multi"] = "Headers"
-        self.cpp_info.components["_opencl-headers"].set_property("cmake_target_name", "OpenCL::Headers")
-        self.cpp_info.components["_opencl-headers"].set_property("pkg_config_name", "OpenCL")
-        self.cpp_info.components["_opencl-headers"].bindirs = []
-        self.cpp_info.components["_opencl-headers"].libdirs = []
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/opencl-headers/config.yml
+++ b/recipes/opencl-headers/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "2023.04.17":
+    folder: all
+  "2023.02.06":
+    folder: all
   "2022.09.30":
     folder: all
   "2022.05.18":


### PR DESCRIPTION
Specify library name and version:  **opencl-headers/all**

Scope of changes:
- Added several new versions including latest 2023.04.17
- Fixed `.pc` file name to be aligned with original [OpenCL-Headers.pc](https://github.com/KhronosGroup/OpenCL-Headers/blob/main/OpenCL-Headers.pc.in)

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
