### PR TITLE
sophus: update sophus version schema, update download link and modernize more

### DIFF
--- a/recipes/sophus/all/conandata.yml
+++ b/recipes/sophus/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "22.10":
-    url: "https://github.com/strasdat/Sophus/archive/refs/tags/v22.10.tar.gz"
-    sha256: "270709b83696da179447cf743357e36a8b9bc8eed5ff4b9d66d33fe691010bad"
-  "22.04.1":
-    url: "https://github.com/strasdat/Sophus/archive/refs/tags/v22.04.1.tar.gz"
-    sha256: "635dc536e7768c91e89d537608226b344eef901b51fbc51c9f220c95feaa0b54"
+  "1.22.10":
+    url: "https://github.com/strasdat/Sophus/archive/refs/tags/1.22.10.tar.gz"
+    sha256: "eb1da440e6250c5efc7637a0611a5b8888875ce6ac22bf7ff6b6769bbc958082"
+  "1.22.4":
+    url: "https://github.com/strasdat/Sophus/archive/refs/tags/1.22.4.tar.gz"
+    sha256: "13597381636c5a0757bb89451bf3c98a0978e49b89739b66571a4bdd950caa81"
   "1.0.0":
     url: "https://github.com/strasdat/Sophus/archive/v1.0.0.tar.gz"
     sha256: "b4c8808344fe429ec026eca7eb921cef27fe9ff8326a48b72c53c4bf0804ad53"

--- a/recipes/sophus/all/conanfile.py
+++ b/recipes/sophus/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.53.0"
 
 
 class SophusConan(ConanFile):
@@ -15,7 +15,7 @@ class SophusConan(ConanFile):
     homepage = "https://strasdat.github.io/Sophus/"
     license = "MIT"
     no_copy_source = True
-
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "with_fmt": [True, False],
@@ -25,11 +25,11 @@ class SophusConan(ConanFile):
     }
 
     def requirements(self):
-        self.requires("eigen/3.4.0")
-        if self.options.with_fmt and Version(self.version) >= Version("22.10"):
-            self.requires("fmt/9.1.0")
-        elif self.options.with_fmt and Version(self.version) >= Version("22.04.1"):
-            self.requires("fmt/8.1.1")
+        self.requires("eigen/3.4.0", transitive_headers=True)
+        if self.options.with_fmt and Version(self.version) >= Version("1.22.10"):
+            self.requires("fmt/9.1.0", transitive_headers=True)
+        elif self.options.with_fmt and Version(self.version) >= Version("1.22.4"):
+            self.requires("fmt/8.1.1", transitive_headers=True)
 
     def package_id(self):
         self.info.clear()
@@ -56,12 +56,6 @@ class SophusConan(ConanFile):
         self.cpp_info.resdirs = []
         if not self.options.with_fmt:
             self.cpp_info.defines.append("SOPHUS_USE_BASIC_LOGGING=1")
-
-        # TODO: remove this block if required_conan_version changed to 1.51.1 or higher
-        #       (see https://github.com/conan-io/conan/pull/11790)
-        self.cpp_info.requires = ["eigen::eigen"]
-        if self.options.with_fmt and Version(self.version) >= Version("22.04.1"):
-            self.cpp_info.requires.append("fmt::fmt")
 
         # TODO: to remove in conan v2 once cmake_find_package* generator removed
         self.cpp_info.names["cmake_find_package"] = "Sophus"

--- a/recipes/sophus/config.yml
+++ b/recipes/sophus/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "22.10":
+  "1.22.10":
     folder: all
-  "22.04.1":
+  "1.22.4":
     folder: all
   "1.0.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **sophus **

sophus update its versioning scheme (https://github.com/strasdat/Sophus/releases), the old download link is 404


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
