### PR TITLE
ada: add version 2.3.1, enable shared build

### DIFF
--- a/recipes/ada/all/conandata.yml
+++ b/recipes/ada/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3.1":
+    url: "https://github.com/ada-url/ada/archive/refs/tags/v2.3.1.tar.gz"
+    sha256: "298992ec0958979090566c7835ea60c14f5330d6372ee092ef6eee1d2e6ac079"
   "2.3.0":
     url: "https://github.com/ada-url/ada/archive/refs/tags/v2.3.0.tar.gz"
     sha256: "932a93f6a745775343ebdbaafca295e07b9513f6aaeb738f9e85dcb397925e33"

--- a/recipes/ada/all/conanfile.py
+++ b/recipes/ada/all/conanfile.py
@@ -47,6 +47,8 @@ class AdaConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        if Version(self.version) < "3.2.0":
+            del self.options.shared
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/ada/all/conanfile.py
+++ b/recipes/ada/all/conanfile.py
@@ -15,13 +15,15 @@ class AdaConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/ada-url/ada"
     topics = ("url", "parser", "WHATWG")
-    package_type = "static-library"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
+        "shared": [True, False],
     }
     default_options = {
         "fPIC": True,
+        "shared": False,
     }
 
     @property

--- a/recipes/ada/all/conanfile.py
+++ b/recipes/ada/all/conanfile.py
@@ -47,7 +47,7 @@ class AdaConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        if Version(self.version) < "3.2.0":
+        if Version(self.version) <= "2.0.0":
             del self.options.shared
 
     def layout(self):

--- a/recipes/ada/all/conanfile.py
+++ b/recipes/ada/all/conanfile.py
@@ -44,6 +44,10 @@ class AdaConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 

--- a/recipes/ada/all/conanfile.py
+++ b/recipes/ada/all/conanfile.py
@@ -45,10 +45,11 @@ class AdaConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
         if Version(self.version) <= "2.0.0":
-            del self.options.shared
+            self.options.rm_safe("shared")
+            self.package_type = "static-library"
+        if self.options.get_safe("shared"):
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/ada/config.yml
+++ b/recipes/ada/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3.1":
+    folder: all
   "2.3.0":
     folder: all
   "2.2.0":


### PR DESCRIPTION
Specify library name and version:  **ada/***

* Add `shared` option, as some versions support it
* Change package type to `library` (since it can now be shared or static)
* In the `configure()` method, conditionally remove the `shared` option for older versions, and set the `package_type` to `static_library` instead - note that there is a limitation in Conan Center CI, but this should be done in `config_options()` instead.
* Add version `2.3.1`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
