### PR TITLE
dataframe: remove dllimport of templates in 2.0.0

### DIFF
--- a/recipes/dataframe/all/conandata.yml
+++ b/recipes/dataframe/all/conandata.yml
@@ -37,3 +37,7 @@ patches:
     - patch_file: "patches/2.0.0-0001-use-abs.patch"
       patch_description: "use std::abs instead fabsf/fabsl"
       patch_type: "portability"
+    - patch_file: "patches/2.0.0-0002-no-export-templates.patch"
+      patch_description: "Do not export symbols which are templates"
+      patch_type: "portability"
+      patch_source: "https://github.com/hosseinmoein/DataFrame/pull/235"

--- a/recipes/dataframe/all/conanfile.py
+++ b/recipes/dataframe/all/conanfile.py
@@ -152,7 +152,7 @@ class DataFrameConan(ConanFile):
             if Version(self.version) < "1.20.0" and not self.options.shared:
                 # weird but required in those versions of dataframe
                 self.cpp_info.defines.append("LIBRARY_EXPORTS")
-        if "1.20.0" <= Version(self.version) < "2.0.0" and self.options.shared:
+        if Version(self.version) >= "1.20.0" and self.options.shared:
             self.cpp_info.defines.append("HMDF_SHARED")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed

--- a/recipes/dataframe/all/patches/2.0.0-0002-no-export-templates.patch
+++ b/recipes/dataframe/all/patches/2.0.0-0002-no-export-templates.patch
@@ -1,0 +1,223 @@
+--- a/include/DataFrame/Vectors/HeteroConstPtrView.h
++++ b/include/DataFrame/Vectors/HeteroConstPtrView.h
+@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #pragma once
+ 
+ #include <DataFrame/Vectors/VectorPtrView.h>
+-#include <DataFrame/DataFrameExports.h>
+ 
+ #include <functional>
+ #include <new>
+@@ -49,7 +48,7 @@ struct  HeteroConstPtrView {
+ 
+     using size_type = size_t;
+ 
+-    HMDF_API HeteroConstPtrView();
++    HeteroConstPtrView();
+     template<typename T>
+     HeteroConstPtrView(const T *begin_ptr, const T *end_ptr);
+ 
+@@ -69,13 +68,13 @@ struct  HeteroConstPtrView {
+     HeteroConstPtrView(VectorConstPtrView<T, A> &vec);
+     template<typename T>
+     HeteroConstPtrView(VectorConstPtrView<T, A> &&vec);
+-    HMDF_API HeteroConstPtrView(const HeteroConstPtrView &that);
+-    HMDF_API HeteroConstPtrView(HeteroConstPtrView &&that);
++    HeteroConstPtrView(const HeteroConstPtrView &that);
++    HeteroConstPtrView(HeteroConstPtrView &&that);
+ 
+     ~HeteroConstPtrView() { clear(); }
+ 
+-    HMDF_API HeteroConstPtrView &operator= (const HeteroConstPtrView &rhs);
+-    HMDF_API HeteroConstPtrView &operator= (HeteroConstPtrView &&rhs);
++    HeteroConstPtrView &operator= (const HeteroConstPtrView &rhs);
++    HeteroConstPtrView &operator= (HeteroConstPtrView &&rhs);
+ 
+     template<typename T>
+     VectorConstPtrView<T, A> &get_vector();
+@@ -86,7 +85,7 @@ struct  HeteroConstPtrView {
+     typename VectorConstPtrView<T, A>::size_type
+     size () const { return (get_vector<T>().size()); }
+ 
+-    HMDF_API void clear();
++    void clear();
+ 
+     template<typename T>
+     bool empty() const noexcept;
+--- a/include/DataFrame/Vectors/HeteroConstView.h
++++ b/include/DataFrame/Vectors/HeteroConstView.h
+@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #pragma once
+ 
+ #include <DataFrame/Vectors/VectorView.h>
+-#include <DataFrame/DataFrameExports.h>
+ 
+ #include <functional>
+ #include <type_traits>
+@@ -48,7 +47,7 @@ struct HeteroConstView  {
+ 
+     using size_type = size_t;
+ 
+-    HMDF_API HeteroConstView();
++    HeteroConstView();
+     template<typename T>
+     HeteroConstView(const T *begin_ptr, const T *end_ptr);
+ 
+@@ -65,13 +64,13 @@ struct HeteroConstView  {
+     template<typename T>
+     void set_begin_end_special(const T *bp, const T *ep_1);
+ 
+-    HMDF_API HeteroConstView(const HeteroConstView &that);
+-    HMDF_API HeteroConstView(HeteroConstView &&that);
++    HeteroConstView(const HeteroConstView &that);
++    HeteroConstView(HeteroConstView &&that);
+ 
+     ~HeteroConstView() { clear(); }
+ 
+-    HMDF_API HeteroConstView &operator= (const HeteroConstView &rhs);
+-    HMDF_API HeteroConstView &operator= (HeteroConstView &&rhs);
++    HeteroConstView &operator= (const HeteroConstView &rhs);
++    HeteroConstView &operator= (HeteroConstView &&rhs);
+ 
+     template<typename T>
+     VectorConstView<T, A> &get_vector();
+@@ -82,7 +81,7 @@ struct HeteroConstView  {
+     typename VectorConstView<T, A>::size_type
+     size () const { return (get_vector<T>().size()); }
+ 
+-    HMDF_API void clear();
++    void clear();
+ 
+     template<typename T>
+     bool empty() const noexcept;
+--- a/include/DataFrame/Vectors/HeteroPtrView.h
++++ b/include/DataFrame/Vectors/HeteroPtrView.h
+@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #pragma once
+ 
+ #include <DataFrame/Vectors/VectorPtrView.h>
+-#include <DataFrame/DataFrameExports.h>
+ 
+ #include <functional>
+ #include <new>
+@@ -49,7 +48,7 @@ struct HeteroPtrView {
+ 
+     using size_type = size_t;
+ 
+-    HMDF_API HeteroPtrView();
++    HeteroPtrView();
+     template<typename T>
+     HeteroPtrView(T *begin_ptr, T *end_ptr);
+ 
+@@ -69,13 +68,13 @@ struct HeteroPtrView {
+     HeteroPtrView(VectorPtrView<T, A> &vec);
+     template<typename T>
+     HeteroPtrView(VectorPtrView<T, A> &&vec);
+-    HMDF_API HeteroPtrView(const HeteroPtrView &that);
+-    HMDF_API HeteroPtrView(HeteroPtrView &&that);
++    HeteroPtrView(const HeteroPtrView &that);
++    HeteroPtrView(HeteroPtrView &&that);
+ 
+     ~HeteroPtrView() { clear(); }
+ 
+-    HMDF_API HeteroPtrView &operator= (const HeteroPtrView &rhs);
+-    HMDF_API HeteroPtrView &operator= (HeteroPtrView &&rhs);
++    HeteroPtrView &operator= (const HeteroPtrView &rhs);
++    HeteroPtrView &operator= (HeteroPtrView &&rhs);
+ 
+     template<typename T>
+     VectorPtrView<T, A> &get_vector();
+@@ -91,7 +90,7 @@ struct HeteroPtrView {
+     typename VectorPtrView<T, A>::
+     size_type size () const { return (get_vector<T>().size()); }
+ 
+-    HMDF_API void clear();
++    void clear();
+ 
+     template<typename T>
+     bool empty() const noexcept;
+--- a/include/DataFrame/Vectors/HeteroVector.h
++++ b/include/DataFrame/Vectors/HeteroVector.h
+@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #pragma once
+ 
+-#include <DataFrame/DataFrameExports.h>
+ #include <DataFrame/Utils/AlignedAllocator.h>
+ #include <DataFrame/Vectors/HeteroConstPtrView.h>
+ #include <DataFrame/Vectors/HeteroConstView.h>
+@@ -58,14 +57,14 @@ struct HeteroVector  {
+ 
+     using size_type = size_t;
+ 
+-    HMDF_API HeteroVector();
+-    HMDF_API HeteroVector(const HeteroVector &that);
+-    HMDF_API HeteroVector(HeteroVector &&that);
++    HeteroVector();
++    HeteroVector(const HeteroVector &that);
++    HeteroVector(HeteroVector &&that);
+ 
+     ~HeteroVector() { clear(); }
+ 
+-    HMDF_API HeteroVector &operator= (const HeteroVector &rhs);
+-    HMDF_API HeteroVector &operator= (HeteroVector &&rhs);
++    HeteroVector &operator= (const HeteroVector &rhs);
++    HeteroVector &operator= (HeteroVector &&rhs);
+ 
+     template<typename T>
+     std::vector<T, typename allocator_declare<T, A>::type> &get_vector();
+@@ -104,7 +103,7 @@ struct HeteroVector  {
+     template<typename T>
+     size_type size () const { return (get_vector<T>().size()); }
+ 
+-    HMDF_API void clear();
++    void clear();
+ 
+     template<typename T>
+     void erase(size_type pos);
+--- a/include/DataFrame/Vectors/HeteroView.h
++++ b/include/DataFrame/Vectors/HeteroView.h
+@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #pragma once
+ 
+ #include <DataFrame/Vectors/VectorView.h>
+-#include <DataFrame/DataFrameExports.h>
+ 
+ #include <functional>
+ #include <new>
+@@ -49,7 +48,7 @@ struct HeteroView  {
+ 
+     using size_type = size_t;
+ 
+-    HMDF_API HeteroView();
++    HeteroView();
+     template<typename T>
+     HeteroView(T *begin_ptr, T *end_ptr);
+ 
+@@ -65,13 +64,13 @@ struct HeteroView  {
+     template<typename T>
+     void set_begin_end_special(T *bp, T *ep_1);
+ 
+-    HMDF_API HeteroView(const HeteroView &that);
+-    HMDF_API HeteroView(HeteroView &&that);
++    HeteroView(const HeteroView &that);
++    HeteroView(HeteroView &&that);
+ 
+     ~HeteroView() { clear(); }
+ 
+-    HMDF_API HeteroView &operator= (const HeteroView &rhs);
+-    HMDF_API HeteroView &operator= (HeteroView &&rhs);
++    HeteroView &operator= (const HeteroView &rhs);
++    HeteroView &operator= (HeteroView &&rhs);
+ 
+     template<typename T>
+     VectorView<T, A> &get_vector();
+@@ -82,7 +81,7 @@ struct HeteroView  {
+     typename VectorView<T, A>::
+     size_type size () const { return (get_vector<T>().size()); }
+ 
+-    HMDF_API void clear();
++    void clear();
+ 
+     template<typename T>
+     bool empty() const noexcept;


### PR DESCRIPTION
follow up of https://github.com/conan-io/conan-center-index/pull/16848#discussion_r1158549411

From https://github.com/hosseinmoein/DataFrame/pull/235

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
