### PR TITLE
taskflow: add version 3.6.0, add package_type

### DIFF
--- a/recipes/taskflow/all/conandata.yml
+++ b/recipes/taskflow/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.0":
+    url: "https://github.com/taskflow/taskflow/archive/v3.6.0.tar.gz"
+    sha256: "5a1cd9cf89f93a97fcace58fd73ed2fc8ee2053bcb43e047acb6bc121c3edf4c"
   "3.5.0":
     url: "https://github.com/taskflow/taskflow/archive/v3.5.0.tar.gz"
     sha256: "33c44e0da7dfda694d2b431724d6c8fd25a889ad0afbb4a32e8da82e2e9c2a92"

--- a/recipes/taskflow/all/conanfile.py
+++ b/recipes/taskflow/all/conanfile.py
@@ -19,7 +19,8 @@ class TaskflowConan(ConanFile):
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/taskflow/taskflow"
-    topics = ("tasking", "parallelism")
+    topics = ("tasking", "parallelism", "header-only")
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     short_paths = True
 
@@ -72,8 +73,7 @@ class TaskflowConan(ConanFile):
             )
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         apply_conandata_patches(self)
@@ -85,6 +85,9 @@ class TaskflowConan(ConanFile):
                   dst=os.path.join(self.package_folder, "include", "taskflow"))
 
     def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
         self.cpp_info.set_property("cmake_file_name", "Taskflow")
         self.cpp_info.set_property("cmake_target_name", "Taskflow::Taskflow")
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/taskflow/config.yml
+++ b/recipes/taskflow/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.0":
+    folder: all
   "3.5.0":
     folder: all
   "3.4.0":


### PR DESCRIPTION
Specify library name and version:  **taskflow/3.6.0**

- add version 3.6.0
- add package_type
- add "header-only" to topics
- remove `destination` arg from `get()`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
