### PR TITLE
Remove output.warn, no longer supported in Conan 2.0

### DIFF
--- a/recipes/wg21-linear_algebra/all/conanfile.py
+++ b/recipes/wg21-linear_algebra/all/conanfile.py
@@ -42,8 +42,8 @@ class LAConan(ConanFile):
             check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(str(compiler))
         if not min_version:
-            self.output.warn(f"{self.name} recipe lacks information about the "
-                             f"{compiler} compiler support.")
+            raise ConanInvalidConfiguration(f"{self.name} recipe lacks information about the "
+                            f"{compiler} compiler support.")
         else:
             if Version(self.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration(

--- a/recipes/wg21-linear_algebra/all/conanfile.py
+++ b/recipes/wg21-linear_algebra/all/conanfile.py
@@ -41,13 +41,8 @@ class LAConan(ConanFile):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(str(compiler))
-        if not min_version:
-            raise ConanInvalidConfiguration(f"{self.name} recipe lacks information about the "
-                            f"{compiler} compiler support.")
-        else:
-            if Version(self.settings.compiler.version) < min_version:
-                raise ConanInvalidConfiguration(
-                    f"{self.ref} requires at least {compiler} {min_version}")
+        if min_version and Version(self.settings.compiler.version) < min_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires at least {compiler} {min_version}")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **wg21-linear_algebra/0.7.3**

As a maintainer of this library, I am submitting this fix to address the final comment of this review, which was received post-merge: https://github.com/conan-io/conan-center-index/pull/16392
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
