### PR TITLE
h5pp: conan v2 support

### DIFF
--- a/recipes/h5pp/all/conandata.yml
+++ b/recipes/h5pp/all/conandata.yml
@@ -1,25 +1,25 @@
 sources:
-  "1.8.3":
-    sha256: 52d439a0008cb76071f0e839d15ca6a4e911a87dc779f0bbd9dc91d98ba0b52b
-    url: https://github.com/DavidAce/h5pp/archive/v1.8.3.tar.gz
-  "1.8.4":
-    sha256: 401f2014d90d9ce318e518e368e7e45fc2aa95b8e30cdc91baa41212df15b831
-    url: https://github.com/DavidAce/h5pp/archive/v1.8.4.tar.gz
-  "1.8.5":
-    sha256: 1e1a42159fccd10b1022445ea0f0690c5314e94b0fc3d5c9fa0f02b165148c18
-    url: https://github.com/DavidAce/h5pp/archive/v1.8.5.tar.gz
-  "1.8.6":
-    sha256: 39d413c9383b00a87153b9480ab6a91ba356d3f30b3598de0c0c8f7f3bd802c7
-    url: https://github.com/DavidAce/h5pp/archive/v1.8.6.tar.gz
-  "1.9.0":
-    sha256: f633b6f76ab20e1767f55068154cf8bf553e39d526ae80947388640c57ea2056
-    url: https://github.com/DavidAce/h5pp/archive/v1.9.0.tar.gz
-  "1.10.0":
-    sha256: 27a3e42ed02d8d9341229d58a517134753e1ea46dab4c40d01bb309098c32f13
-    url: https://github.com/DavidAce/h5pp/archive/v1.10.0.tar.gz
   "1.11.0":
-    sha256: 1c4171275eb50a26ed9da8055397f03a726896c4c49ad0380b16dcb13574ecff
-    url: https://github.com/DavidAce/h5pp/archive/v1.11.0.tar.gz
+    url: "https://github.com/DavidAce/h5pp/archive/v1.11.0.tar.gz"
+    sha256: "1c4171275eb50a26ed9da8055397f03a726896c4c49ad0380b16dcb13574ecff"
+  "1.10.0":
+    url: "https://github.com/DavidAce/h5pp/archive/v1.10.0.tar.gz"
+    sha256: "27a3e42ed02d8d9341229d58a517134753e1ea46dab4c40d01bb309098c32f13"
+  "1.9.0":
+    url: "https://github.com/DavidAce/h5pp/archive/v1.9.0.tar.gz"
+    sha256: "f633b6f76ab20e1767f55068154cf8bf553e39d526ae80947388640c57ea2056"
+  "1.8.6":
+    url: "https://github.com/DavidAce/h5pp/archive/v1.8.6.tar.gz"
+    sha256: "39d413c9383b00a87153b9480ab6a91ba356d3f30b3598de0c0c8f7f3bd802c7"
+  "1.8.5":
+    url: "https://github.com/DavidAce/h5pp/archive/v1.8.5.tar.gz"
+    sha256: "1e1a42159fccd10b1022445ea0f0690c5314e94b0fc3d5c9fa0f02b165148c18"
+  "1.8.4":
+    url: "https://github.com/DavidAce/h5pp/archive/v1.8.4.tar.gz"
+    sha256: "401f2014d90d9ce318e518e368e7e45fc2aa95b8e30cdc91baa41212df15b831"
+  "1.8.3":
+    url: "https://github.com/DavidAce/h5pp/archive/v1.8.3.tar.gz"
+    sha256: "52d439a0008cb76071f0e839d15ca6a4e911a87dc779f0bbd9dc91d98ba0b52b"
 patches:
   "1.9.0":
     - patch_file: "patches/fix-support-new-hdf5-v1.9.0.patch"
@@ -31,4 +31,3 @@ patches:
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
   "1.8.3":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
-

--- a/recipes/h5pp/all/conandata.yml
+++ b/recipes/h5pp/all/conandata.yml
@@ -23,21 +23,21 @@ sources:
 patches:
   "1.9.0":
     - patch_file: "patches/fix-support-new-hdf5-v1.9.0.patch"
-    - patch_type: "bugfix"
-    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
+      patch_type: "bugfix"
+      patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.6":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.6.patch"
-    - patch_type: "bugfix"
-    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
+      patch_type: "bugfix"
+      patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.5":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
-    - patch_type: "bugfix"
-    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
+      patch_type: "bugfix"
+      patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.4":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
-    - patch_type: "bugfix"
-    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
+      patch_type: "bugfix"
+      patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.3":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
-    - patch_type: "bugfix"
-    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
+      patch_type: "bugfix"
+      patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"

--- a/recipes/h5pp/all/conandata.yml
+++ b/recipes/h5pp/all/conandata.yml
@@ -20,3 +20,15 @@ sources:
   "1.11.0":
     sha256: 1c4171275eb50a26ed9da8055397f03a726896c4c49ad0380b16dcb13574ecff
     url: https://github.com/DavidAce/h5pp/archive/v1.11.0.tar.gz
+patches:
+  "1.9.0":
+    - patch_file: "patches/fix-support-new-hdf5-v1.9.0.patch"
+  "1.8.6":
+    - patch_file: "patches/fix-support-new-hdf5-v1.8.6.patch"
+  "1.8.5":
+    - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
+  "1.8.4":
+    - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
+  "1.8.3":
+    - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
+

--- a/recipes/h5pp/all/conandata.yml
+++ b/recipes/h5pp/all/conandata.yml
@@ -23,11 +23,21 @@ sources:
 patches:
   "1.9.0":
     - patch_file: "patches/fix-support-new-hdf5-v1.9.0.patch"
+    - patch_type: "bugfix"
+    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.6":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.6.patch"
+    - patch_type: "bugfix"
+    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.5":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
+    - patch_type: "bugfix"
+    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.4":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
+    - patch_type: "bugfix"
+    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.3":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
+    - patch_type: "bugfix"
+    - patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"

--- a/recipes/h5pp/all/conandata.yml
+++ b/recipes/h5pp/all/conandata.yml
@@ -24,20 +24,25 @@ patches:
   "1.9.0":
     - patch_file: "patches/fix-support-new-hdf5-v1.9.0.patch"
       patch_type: "bugfix"
+      patch_source: "https://github.com/DavidAce/h5pp/commit/a8471cd2a21310bae0564eeed21dc00c457d674d"
       patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.6":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.6.patch"
       patch_type: "bugfix"
+      patch_source: "https://github.com/DavidAce/h5pp/commit/a8471cd2a21310bae0564eeed21dc00c457d674d"
       patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.5":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
       patch_type: "bugfix"
+      patch_source: "https://github.com/DavidAce/h5pp/commit/a8471cd2a21310bae0564eeed21dc00c457d674d"
       patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.4":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
       patch_type: "bugfix"
+      patch_source: "https://github.com/DavidAce/h5pp/commit/a8471cd2a21310bae0564eeed21dc00c457d674d"
       patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"
   "1.8.3":
     - patch_file: "patches/fix-support-new-hdf5-v1.8.3-5.patch"
       patch_type: "bugfix"
+      patch_source: "https://github.com/DavidAce/h5pp/commit/a8471cd2a21310bae0564eeed21dc00c457d674d"
       patch_description: "Adds support for HDF5 versions later than 1.12.1 by allowing the construction of h5pp::hid types from any integral type (not just hid_t)"

--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -61,7 +61,7 @@ class H5ppConan(ConanFile):
             del self.options.with_spdlog
             del self.options.with_zlib
         else:
-            self.options["hdf5"].with_zlib= self.options.with_zlib
+            self.options["hdf5"].with_zlib = self.options.with_zlib
 
     def requirements(self):
         self.requires("hdf5/1.14.0", transitive_headers=True, transitive_libs=True)

--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -16,8 +16,9 @@ class H5ppConan(ConanFile):
     description = "A C++17 wrapper for HDF5 with focus on simplicity"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/DavidAce/h5pp"
-    topics = ("h5pp", "hdf5", "binary", "storage", "header-only", "cpp17")
+    topics = ("hdf5", "binary", "storage", "header-only", "cpp17")
     license = "MIT"
+    package_type="header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
     short_paths = True
@@ -29,6 +30,10 @@ class H5ppConan(ConanFile):
         "with_eigen": True,
         "with_spdlog": True,
     }
+
+    @property
+    def _min_cppstd(self):
+        return "17"
 
     @property
     def _compilers_minimum_version(self):
@@ -68,7 +73,7 @@ class H5ppConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, 17)
+            check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version:
             if Version(self.settings.compiler.version) < minimum_version:
@@ -93,10 +98,18 @@ class H5ppConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "h5pp")
         self.cpp_info.set_property("cmake_target_name", "h5pp::h5pp")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
         self.cpp_info.components["h5pp_headers"].set_property("cmake_target_name", "h5pp::headers")
+        self.cpp_info.components["h5pp_headers"].bindirs = []
+        self.cpp_info.components["h5pp_headers"].libdirs = []
         self.cpp_info.components["h5pp_deps"].set_property("cmake_target_name", "h5pp::deps")
-        self.cpp_info.components["h5pp_flags"].set_property("cmake_target_name", "h5pp::flags")
+        self.cpp_info.components["h5pp_deps"].bindirs = []
+        self.cpp_info.components["h5pp_deps"].libdirs = []
         self.cpp_info.components["h5pp_deps"].requires = ["hdf5::hdf5"]
+        self.cpp_info.components["h5pp_flags"].set_property("cmake_target_name", "h5pp::flags")
+        self.cpp_info.components["h5pp_flags"].bindirs = []
+        self.cpp_info.components["h5pp_flags"].libdirs = []
 
         if Version(self.version) >= "1.10.0":
             if self.options.with_eigen:

--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -79,7 +79,7 @@ class H5ppConan(ConanFile):
             if Version(self.settings.compiler.version) < minimum_version:
                 raise ConanInvalidConfiguration("h5pp requires C++17, which your compiler does not support.")
         else:
-            self.output.warn("h5pp requires C++17. Your compiler is unknown. Assuming it supports C++17.")
+            self.output.warning("h5pp requires C++17. Your compiler is unknown. Assuming it supports C++17.")
 
     def source(self):
         get(self,**self.conan_data["sources"][self.version],

--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -25,10 +25,12 @@ class H5ppConan(ConanFile):
     options = {
         "with_eigen": [True, False],
         "with_spdlog": [True, False],
+        "with_zlib" : [True, False], 
     }
     default_options = {
         "with_eigen": True,
         "with_spdlog": True,
+        "with_zlib" : True,
     }
 
     @property
@@ -57,6 +59,9 @@ class H5ppConan(ConanFile):
             #     that including the headers is intentional.
             del self.options.with_eigen
             del self.options.with_spdlog
+            del self.options.with_zlib
+        else:
+            self.options["hdf5"].with_zlib= self.options.with_zlib
 
     def requirements(self):
         self.requires("hdf5/1.14.0", transitive_headers=True, transitive_libs=True)
@@ -64,6 +69,8 @@ class H5ppConan(ConanFile):
             self.requires("eigen/3.4.0", transitive_headers=True)
         if Version(self.version) < "1.10.0" or self.options.get_safe('with_spdlog'):
             self.requires("spdlog/1.11.0", transitive_headers=True, transitive_libs=True)
+        if Version(self.version) >= "1.10.0" and self.options.with_zlib:
+            self.requires("zlib/1.2.13", transitive_headers=True, transitive_libs=True)
 
     def layout(self):
         basic_layout(self,src_folder="src")
@@ -119,6 +126,9 @@ class H5ppConan(ConanFile):
                 self.cpp_info.components["h5pp_deps"].requires.append("spdlog::spdlog")
                 self.cpp_info.components["h5pp_flags"].defines.append("H5PP_USE_SPDLOG")
                 self.cpp_info.components["h5pp_flags"].defines.append("H5PP_USE_FMT")
+            if self.options.with_zlib:
+                self.cpp_info.components["h5pp_deps"].requires.append("zlib::zlib")
+
         else:
             self.cpp_info.components["h5pp_deps"].requires.append("eigen::eigen")
             self.cpp_info.components["h5pp_deps"].requires.append("spdlog::spdlog")

--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 from conan.tools.files import get
 from conan.tools.files import copy
+from conan.tools.files import apply_conandata_patches,export_conandata_patches
 from conan.tools.build import check_min_cppstd
 from conan.errors import ConanInvalidConfiguration
 import os
@@ -38,6 +39,9 @@ class H5ppConan(ConanFile):
             "apple-clang": "10",
         }
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def config_options(self):
         if Version(self.version) < "1.10.0":
             # These dependencies are always required before h5pp 1.10.0:
@@ -50,11 +54,7 @@ class H5ppConan(ConanFile):
             del self.options.with_spdlog
 
     def requirements(self):
-        if Version(self.version) < "1.10.0":
-            self.requires("hdf5/1.12.1", transitive_headers=True, transitive_libs=True)
-        else:
-            self.requires("hdf5/1.14.0", transitive_headers=True, transitive_libs=True)
-
+        self.requires("hdf5/1.14.0", transitive_headers=True, transitive_libs=True)
         if Version(self.version) < "1.10.0" or self.options.get_safe('with_eigen'):
             self.requires("eigen/3.4.0", transitive_headers=True)
         if Version(self.version) < "1.10.0" or self.options.get_safe('with_spdlog'):
@@ -79,6 +79,7 @@ class H5ppConan(ConanFile):
     def source(self):
         get(self,**self.conan_data["sources"][self.version],
                   destination=self.source_folder, strip_root=True)
+        apply_conandata_patches(self)
 
     def package(self):
         if Version(self.version) < "1.9.0":

--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -61,7 +61,7 @@ class H5ppConan(ConanFile):
             self.requires("spdlog/1.11.0", transitive_headers=True, transitive_libs=True)
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self,src_folder="src")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/h5pp/all/patches/fix-support-new-hdf5-v1.8.3-5.patch
+++ b/recipes/h5pp/all/patches/fix-support-new-hdf5-v1.8.3-5.patch
@@ -1,0 +1,13 @@
+diff --git a/h5pp/include/h5pp/details/h5ppHid.h b/h5pp/include/h5pp/details/h5ppHid.h
+index 7bd9f12..1335dd8 100644
+--- a/h5pp/include/h5pp/details/h5ppHid.h
++++ b/h5pp/include/h5pp/details/h5ppHid.h
+@@ -16,7 +16,7 @@ namespace h5pp::hid {
+         hid_base() = default;
+         hid_base(std::initializer_list<int>) = delete;
+         // Use enable_if to avoid implicit conversion from hid_h5x and still have a non-explicit hid_t constructor
+-        template<typename T, typename = std::enable_if_t<std::is_same_v<T, hid_t>>>
++        template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+         hid_base(const T &other) {
+             // constructor from hid_t
+             if constexpr(zeroValueIsOK){

--- a/recipes/h5pp/all/patches/fix-support-new-hdf5-v1.8.6.patch
+++ b/recipes/h5pp/all/patches/fix-support-new-hdf5-v1.8.6.patch
@@ -1,0 +1,22 @@
+diff --git a/h5pp/include/h5pp/details/h5ppHid.h b/h5pp/include/h5pp/details/h5ppHid.h
+index cda2d6d..76ba594 100644
+--- a/h5pp/include/h5pp/details/h5ppHid.h
++++ b/h5pp/include/h5pp/details/h5ppHid.h
+@@ -15,7 +15,7 @@ namespace h5pp::hid {
+         virtual ~hid_base() = default;
+         hid_base()          = default;
+         // Use enable_if to avoid implicit conversion from hid_h5x and still have a non-explicit hid_t constructor
+-        template<typename T, typename = std::enable_if_t<std::is_same_v<T, hid_t>>>
++        template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+         hid_base(const T &other) {
+             // constructor from hid_t
+             if constexpr(zeroValueIsOK) {
+@@ -66,7 +66,7 @@ namespace h5pp::hid {
+             return *this;
+         }
+ 
+-        template<typename T, typename = std::enable_if_t<std::is_same_v<T, hid_t>>>
++        template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+         hid_base &operator=(const T &rhs) {
+             // Copy assignment from hid_t
+             if constexpr(zeroValueIsOK) {

--- a/recipes/h5pp/all/patches/fix-support-new-hdf5-v1.9.0.patch
+++ b/recipes/h5pp/all/patches/fix-support-new-hdf5-v1.9.0.patch
@@ -1,0 +1,23 @@
+diff --git a/include/h5pp/details/h5ppHid.h b/include/h5pp/details/h5ppHid.h
+index b1f4989..8af0eb3 100644
+--- a/include/h5pp/details/h5ppHid.h
++++ b/include/h5pp/details/h5ppHid.h
+@@ -15,7 +15,7 @@ namespace h5pp::hid {
+         virtual ~hid_base() = default;
+         hid_base()          = default;
+         // Use enable_if to avoid implicit conversion from hid_h5x and still have a non-explicit hid_t constructor
+-        template<typename T, typename = std::enable_if_t<std::is_same_v<T, hid_t>>>
++        template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+         hid_base(const T &other) {
+             // constructor from hid_t
+             if constexpr(zeroValueIsOK) {
+@@ -66,7 +66,7 @@ namespace h5pp::hid {
+             return *this;
+         }
+ 
+-        template<typename T, typename = std::enable_if_t<std::is_same_v<T, hid_t>>>
++        template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+         hid_base &operator=(const T &rhs) {
+             // Copy assignment from hid_t
+             if constexpr(zeroValueIsOK) {
+

--- a/recipes/h5pp/all/test_package/CMakeLists.txt
+++ b/recipes/h5pp/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
-target_compile_features(${CMAKE_PROJECT_NAME} PRIVATE cxx_std_17)
+add_executable(test_package test_package.cpp)
+target_compile_features(test_package PRIVATE cxx_std_17)
 
 find_package(h5pp REQUIRED CONFIG)
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE h5pp::h5pp)
+target_link_libraries(test_package PRIVATE h5pp::h5pp)

--- a/recipes/h5pp/all/test_package/conanfile.py
+++ b/recipes/h5pp/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.cmake import CMake, cmake_layout
 
 
 class TestPackageConan(ConanFile):

--- a/recipes/h5pp/all/test_package/conanfile.py
+++ b/recipes/h5pp/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
 import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,5 +21,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            self.run(os.path.join("bin","test_package"), run_environment=True)
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/h5pp/all/test_v1_package/CMakeLists.txt
+++ b/recipes/h5pp/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
+target_compile_features(${CMAKE_PROJECT_NAME} PRIVATE cxx_std_17)
+
+find_package(h5pp REQUIRED CONFIG)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE h5pp::h5pp)

--- a/recipes/h5pp/all/test_v1_package/conanfile.py
+++ b/recipes/h5pp/all/test_v1_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run(os.path.join("bin","test_package"), run_environment=True)

--- a/recipes/h5pp/all/test_v1_package/test_package.cpp
+++ b/recipes/h5pp/all/test_v1_package/test_package.cpp
@@ -1,0 +1,23 @@
+#include <h5pp/h5pp.h>
+
+int main() {
+    using cplx = std::complex<double>;
+
+    static_assert(h5pp::type::sfinae::has_data<std::vector<double>>() and
+                  "h5pp ompile time type-checker failed. Could not properly detect class member data. Check that you are using a supported compiler!");
+
+    std::string outputFilename = "test_package.h5";
+    size_t      logLevel       = 1;
+    h5pp::File  file(outputFilename, H5F_ACC_TRUNC | H5F_ACC_RDWR, logLevel);
+
+    // Generate dummy data
+    std::vector<cplx> vectorComplexWrite = {{-0.191154, 0.326211}, {0.964728, -0.712335}, {-0.0351791, -0.10264}, {0.177544, 0.99999}};
+
+    // Write dummy data to file
+    file.writeDataset(vectorComplexWrite, "vectorComplex");
+
+
+    // Read dummy data from file
+    auto vectorComplexRead = file.readDataset<std::vector<cplx>>("vectorComplex");
+    return 0;
+}


### PR DESCRIPTION
**h5pp/1.11.0**
Updated the recipe and tests to work with conan v2. As far as I can tell the hooks for conan 2 aren't working yet, so I haven't tried that.

Edit: should fix https://github.com/conan-io/conan-center-index/issues/17394 and https://github.com/conan-io/conan-center-index/pull/17395.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
