### PR TITLE
(#17461) Perfetto: Bump v34.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "34.0":
+    url: "https://github.com/google/perfetto/archive/refs/tags/v34.0.tar.gz"
+    sha256: "81dbf2fac446a0389c80e309b2060dcccd926012ce2a61621a47e3e432aee8c1"
   "32.1":
     url: "https://github.com/google/perfetto/archive/refs/tags/v32.1.tar.gz"
     sha256: "0d1088b4758b3d5f3813178c6de22386329d42407d23aa1479f20dce96e49d78"

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "34.0":
+    folder: all
   "32.1":
     folder: all
   "31.0":


### PR DESCRIPTION
Specify library name and version:  **perfetto/v34.0**


```
v34.0 - 2023-05-02:
  Tracing service and probes:
    * --continuous-dump in tools/java_heap_dump now keeps recording until it
      receives CTRL+C.
  UI:
    * Add support for parsing large integers from Trace Processor into
      bigint. This is the default behaviour for unknown fields and can
      be enabled specifically via the LONG and LONG_NULL column types.
  SDK:
    * Changed the type of the static constexpr metadata on protozero
      generated bindings from a function returning the metadata to
      metadata itself. For a field 'foo' the variable kFoo previously
      defined as:
      `static constexpr FieldMetadata_Foo kFoo() = { return {}; };`
      it is now defined as:
      `static constexpr FieldMetadata_Foo kFoo;`
      This is a breaking change for users who directly access field
      metadata.
    * The new DataSourceBase::OnFlush() method allows users to properly handle
      Flush requests.
```

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
