### PR TITLE
Catch2: Add recipe option for CATCH_CONFIG_NO_POSIX_SIGNALS

### DIFF
--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -25,6 +25,7 @@ class Catch2Conan(ConanFile):
         "with_prefix": [True, False],
         "default_reporter": [None, "ANY"],
         "console_width": [None, "ANY"],
+        "no_posix_signals": [True, False],
     }
     default_options = {
         "shared": False,
@@ -32,6 +33,7 @@ class Catch2Conan(ConanFile):
         "with_prefix": False,
         "default_reporter": None,
         "console_width": "80",
+        "no_posix_signals": False,
     }
 
     @property
@@ -102,6 +104,7 @@ class Catch2Conan(ConanFile):
         tc.variables["CATCH_CONFIG_CONSOLE_WIDTH"] = self.options.console_width
         if self.options.default_reporter:
             tc.variables["CATCH_CONFIG_DEFAULT_REPORTER"] = self._default_reporter_str
+        tc.variables["CATCH_CONFIG_NO_POSIX_SIGNALS"] = self.options.no_posix_signals
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Add recipe option to catch to toggle CATCH_CONFIG_NO_POSIX_SIGNALS.

Specify library name and version:  catch2/3.x.x

Adds a recipe option so that conan can be used to build this dependency for bare metal platforms which do not implement some or all of the posix signals.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
