### PR TITLE
Add vir-simd library

### DIFF
--- a/recipes/vir-simd/all/conandata.yml
+++ b/recipes/vir-simd/all/conandata.yml
@@ -2,5 +2,5 @@ sources:
   # Newer versions at the top
   "0.2.0":
     url:
-    - "https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.2.0.tar.gz"
+      - "https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.2.0.tar.gz"
     sha256: "197432196ec73009051188ba686124a469d75d639fc5408613b30ed2981f0b70"

--- a/recipes/vir-simd/all/conandata.yml
+++ b/recipes/vir-simd/all/conandata.yml
@@ -1,0 +1,6 @@
+sources:
+  # Newer versions at the top
+  "0.2.0":
+    url:
+    - "https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.2.0.tar.gz"
+    sha256: "197432196ec73009051188ba686124a469d75d639fc5408613b30ed2981f0b70"

--- a/recipes/vir-simd/all/conanfile.py
+++ b/recipes/vir-simd/all/conanfile.py
@@ -12,8 +12,8 @@ required_conan_version = ">=1.52.0"
 
 class VirSIMDConan(ConanFile):
     name = "vir-simd"
-    description = "This project aims to provide a simple fallback for users of std::experimental::simd (Parallelism TS 2)"
-    license = "LGPL-3.0"
+    description = "A fallback std::experimental::simd (Parallelism TS 2) implementation with additional features"
+    license = "LGPL-3.0-or-later"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/mattkretz/vir-simd"
     topics = ("simd", "parallelism-ts", "cpp17", "header-only")
@@ -50,6 +50,9 @@ class VirSIMDConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
+
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration(f"{self.ref} Windows support is not provided so far.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/vir-simd/all/conanfile.py
+++ b/recipes/vir-simd/all/conanfile.py
@@ -1,0 +1,86 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+import os
+
+
+required_conan_version = ">=1.52.0"
+
+
+class VirSIMDConan(ConanFile):
+    name = "vir-simd"
+    description = "This project aims to provide a simple fallback for users of std::experimental::simd (Parallelism TS 2)"
+    license = "LGPL-3.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/mattkretz/vir-simd"
+    topics = ("simd", "parallelism-ts", "cpp17", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15",
+            "msvc": "14.1",
+            "gcc": "5",
+            "clang": "5",
+            "apple-clang": "5.1",
+        }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    # same package ID for any package
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        # Nothing to do
+        return
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="vir/*.h",
+            dst=os.path.join(self.package_folder, "include"),
+            src=self.source_folder,
+        )
+
+    def package_info(self):
+        # Folders not used for header-only
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        # Set these to the appropriate values if the package has an official FindPACKAGE.cmake
+        # listed in https://cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules
+        # examples: bzip2, freetype, gdal, icu, libcurl, libjpeg, libpng, libtiff, openssl, sqlite3, zlib...
+        self.cpp_info.set_property("cmake_module_file_name", "vir-simd")
+        self.cpp_info.set_property("cmake_module_target_name", "vir-simd::vir-simd")
+        # Set these to the appropriate values if package provides a CMake config file
+        # (package-config.cmake or packageConfig.cmake, with package::package target, usually installed in <prefix>/lib/cmake/<package>/)
+        self.cpp_info.set_property("cmake_file_name", "vir-simd")
+        self.cpp_info.set_property("cmake_target_name", "vir-simd::vir-simd")
+        # Set this to the appropriate value if the package provides a pkgconfig file
+        # (package.pc, usually installed in <prefix>/lib/pkgconfig/)
+        self.cpp_info.set_property("pkg_config_name", "vir-simd")

--- a/recipes/vir-simd/all/conanfile.py
+++ b/recipes/vir-simd/all/conanfile.py
@@ -29,8 +29,8 @@ class VirSIMDConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "Visual Studio": "15",
-            "msvc": "14.1",
-            "gcc": "5",
+            "msvc": "19.15",
+            "gcc": "7",
             "clang": "5",
             "apple-clang": "5.1",
         }

--- a/recipes/vir-simd/all/test_package/CMakeLists.txt
+++ b/recipes/vir-simd/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(vir-simd REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE vir-simd::vir-simd)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/vir-simd/all/test_package/conanfile.py
+++ b/recipes/vir-simd/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/vir-simd/all/test_package/test_package.cpp
+++ b/recipes/vir-simd/all/test_package/test_package.cpp
@@ -1,7 +1,6 @@
 #include <cstdlib>
 #include <iostream>
 #include <vir/simd.h>
-//#include <vir/simd_iota.h>
 
 namespace stdx = vir::stdx;
 
@@ -17,7 +16,6 @@ std::ostream& operator<<(std::ostream& s, const stdx::simd<T, A>& v) {
 int main(void) {
     
     using floatv = stdx::simd<float, stdx::simd_abi::fixed_size<8>>;
-    //constexpr auto a = vir::iota_v<floatv>;
     const floatv a{5};
     
     std::cout << a * 3<< std::endl;

--- a/recipes/vir-simd/all/test_package/test_package.cpp
+++ b/recipes/vir-simd/all/test_package/test_package.cpp
@@ -1,0 +1,26 @@
+#include <cstdlib>
+#include <iostream>
+#include <vir/simd.h>
+//#include <vir/simd_iota.h>
+
+namespace stdx = vir::stdx;
+
+template <class T, class A>
+std::ostream& operator<<(std::ostream& s, const stdx::simd<T, A>& v) {
+    s << '[' << v[0];
+    for (std::size_t i = 1; i < v.size(); ++i) {
+        s << ", " << v[i];
+    }
+    return s << ']';
+}
+
+int main(void) {
+    
+    using floatv = stdx::simd<float, stdx::simd_abi::fixed_size<8>>;
+    //constexpr auto a = vir::iota_v<floatv>;
+    const floatv a{5};
+    
+    std::cout << a * 3<< std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/vir-simd/all/test_v1_package/CMakeLists.txt
+++ b/recipes/vir-simd/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/vir-simd/all/test_v1_package/conanfile.py
+++ b/recipes/vir-simd/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/vir-simd/config.yml
+++ b/recipes/vir-simd/config.yml
@@ -1,0 +1,4 @@
+versions:
+  # Newer versions at the top
+  "0.2.0":
+    folder: all


### PR DESCRIPTION
**vir-simd/0.2.0**

I'd like to add the vir-simd library which provides a fallback implementation for std::experimental::simd, since I think it will be useful.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
