### PR TITLE
screen_capture_lite: use version range for cmake + few minor improvements

### DIFF
--- a/recipes/screen_capture_lite/all/conanfile.py
+++ b/recipes/screen_capture_lite/all/conanfile.py
@@ -78,20 +78,9 @@ class ScreenCaptureLiteConan(ConanFile):
             is_apple_os(self) and Version(self.info.settings.compiler.version) <= "11":
             raise ConanInvalidConfiguration(f"{self.ref} requires CGPreflightScreenCaptureAccess which support macOS SDK 11 later.")
 
-    def _cmake_new_enough(self, required_version):
-        try:
-            import re
-            from io import StringIO
-            output = StringIO()
-            self.run("cmake --version", output=output)
-            m = re.search(r'cmake version (\d+\.\d+\.\d+)', output.getvalue())
-            return Version(m.group(1)) >= required_version
-        except:
-            return False
-
     def build_requirements(self):
-        if Version(self.version) >= "17.1.596" and not self._cmake_new_enough("3.16"):
-            self.tool_requires("cmake/3.25.3")
+        if Version(self.version) >= "17.1.596":
+            self.tool_requires("cmake/[>=3.16 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/screen_capture_lite/all/conanfile.py
+++ b/recipes/screen_capture_lite/all/conanfile.py
@@ -5,7 +5,6 @@ from conan.tools.files import apply_conandata_patches, export_conandata_patches,
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.apple import is_apple_os
 import os
 
 required_conan_version = ">=1.54.0"
@@ -75,7 +74,7 @@ class ScreenCaptureLiteConan(ConanFile):
 
         # Since 17.1.451, screen_capture_lite uses CGPreflightScreenCaptureAccess which is provided by macOS SDK 11 later.
         if Version(self.version) >= "17.1.451" and \
-            is_apple_os(self) and Version(self.settings.compiler.version) <= "11":
+            self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) <= "11":
             raise ConanInvalidConfiguration(f"{self.ref} requires CGPreflightScreenCaptureAccess which support macOS SDK 11 later.")
 
     def build_requirements(self):

--- a/recipes/screen_capture_lite/all/conanfile.py
+++ b/recipes/screen_capture_lite/all/conanfile.py
@@ -62,20 +62,20 @@ class ScreenCaptureLiteConan(ConanFile):
             self.requires("xorg/system")
 
     def validate(self):
-        if self.info.settings.compiler.cppstd:
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
-        if self.info.settings.compiler == "clang" and self.info.settings.compiler.get_safe("libcxx") == "libstdc++":
+        if self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libstdc++":
             raise ConanInvalidConfiguration(f"{self.ref} does not support clang with libstdc++")
 
         # Since 17.1.451, screen_capture_lite uses CGPreflightScreenCaptureAccess which is provided by macOS SDK 11 later.
         if Version(self.version) >= "17.1.451" and \
-            is_apple_os(self) and Version(self.info.settings.compiler.version) <= "11":
+            is_apple_os(self) and Version(self.settings.compiler.version) <= "11":
             raise ConanInvalidConfiguration(f"{self.ref} requires CGPreflightScreenCaptureAccess which support macOS SDK 11 later.")
 
     def build_requirements(self):

--- a/recipes/screen_capture_lite/all/conanfile.py
+++ b/recipes/screen_capture_lite/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.microsoft import is_msvc
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version

--- a/recipes/screen_capture_lite/all/conanfile.py
+++ b/recipes/screen_capture_lite/all/conanfile.py
@@ -30,7 +30,7 @@ class ScreenCaptureLiteConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return 20
+        return "20" if Version(self.version) < "17.1.596" else "17"
 
     @property
     def _compilers_minimum_version(self):

--- a/recipes/screen_capture_lite/all/conanfile.py
+++ b/recipes/screen_capture_lite/all/conanfile.py
@@ -8,7 +8,8 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.apple import is_apple_os
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.54.0"
+
 
 class ScreenCaptureLiteConan(ConanFile):
     name = "screen_capture_lite"
@@ -103,7 +104,6 @@ class ScreenCaptureLiteConan(ConanFile):
             tc.variables["CMAKE_SYSTEM_VERSION"] = "10.0.18362.0"
         if Version(self.version) >= "17.1.613":
             tc.variables["BUILD_CSHARP"] = False
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/screen_capture_lite/all/test_v1_package/conanfile.py
+++ b/recipes/screen_capture_lite/all/test_v1_package/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, CMake
 from conan.tools.build import cross_building
-from conan.tools.microsoft import is_msvc
 import os
 
 


### PR DESCRIPTION
- use version range for cmake
- fix min cppstd, it's C++17 since 17.1.596: https://github.com/smasherprog/screen_capture_lite/blob/17.1.596/CMakeLists.txt#L4
- remove injection of CMP0077 (for BUILD_SHARED_LIBS), it's fixed in conan 1.54.0
- don't use self.info in validate()
- fix a check in validate() related to apple-clang
- remove unused python imports

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
