### PR TITLE
prometheus-cpp: bump dependencies

### DIFF
--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -64,9 +64,9 @@ class PrometheusCppConan(ConanFile):
 
     def requirements(self):
         if self.options.with_pull:
-            self.requires("civetweb/1.15")
+            self.requires("civetweb/1.16")
         if self.options.with_push:
-            self.requires("libcurl/7.86.0")
+            self.requires("libcurl/8.0.1")
         if self.options.get_safe("with_compression"):
             self.requires("zlib/1.2.13")
 


### PR DESCRIPTION
Specify library name and version:  **prometheus-cpp/1.1.0**

Update libcurl and civetweb dependency to relax the transitive OpenSSL deps. Both recipes now use version ranges for OpenSSL.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
