### PR TITLE
Onnx expose ONNX_DISABLE_STATIC_REGISTRATION with recipe option

### DIFF
--- a/recipes/onnx/all/conanfile.py
+++ b/recipes/onnx/all/conanfile.py
@@ -51,6 +51,8 @@ class OnnxConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self.version < "1.9.0":
+            del self.options.disable_static_registration
 
     def configure(self):
         if self.options.shared:
@@ -97,7 +99,8 @@ class OnnxConan(ConanFile):
         tc.variables["ONNX_VERIFY_PROTO3"] = Version(self.dependencies.host["protobuf"].ref.version).major == "3"
         if is_msvc(self):
             tc.variables["ONNX_USE_MSVC_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
-        tc.variables["ONNX_DISABLE_STATIC_REGISTRATION"] = self.options.disable_static_registration
+        if self.version >= "1.9.0":
+            tc.variables["ONNX_DISABLE_STATIC_REGISTRATION"] = self.options.get_safe('disable_static_registration')
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/onnx/all/conanfile.py
+++ b/recipes/onnx/all/conanfile.py
@@ -26,10 +26,12 @@ class OnnxConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "disable_static_registration": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "disable_static_registration": False,
     }
 
     @property
@@ -95,6 +97,7 @@ class OnnxConan(ConanFile):
         tc.variables["ONNX_VERIFY_PROTO3"] = Version(self.dependencies.host["protobuf"].ref.version).major == "3"
         if is_msvc(self):
             tc.variables["ONNX_USE_MSVC_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
+        tc.variables["ONNX_DISABLE_STATIC_REGISTRATION"] = self.options.disable_static_registration
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
Specify library name and version:  **onnx/any**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Expose cmake `ONNX_DISABLE_STATIC_REGISTRATION` (Disabled by default as CMakeLists.txt default value).

This option is required to True when using packaged onnx with onnxruntime. See https://github.com/microsoft/onnxruntime/issues/8556#issuecomment-1005672965

This PR provides a programatic way to overcome https://github.com/conan-io/conan-center-index/issues/17380 (`-o onnx:disable_static_registration=True`).

onnxruntime package probably should require this option set to True (but not sure if CCI currently can consume non-default options).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
