### PR TITLE
at-spi2-core: add version 2.48.0

### DIFF
--- a/recipes/at-spi2-core/config.yml
+++ b/recipes/at-spi2-core/config.yml
@@ -19,3 +19,5 @@ versions:
     folder: new
   "2.47.1":
     folder: new
+  "2.48.0":
+    folder: new

--- a/recipes/at-spi2-core/new/conandata.yml
+++ b/recipes/at-spi2-core/new/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.48.0":
+    url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.48/at-spi2-core-2.48.0.tar.xz"
+    sha256: "905a5b6f1790b68ee803bffa9f5fab4ceb591fb4fae0b2f8c612c54f1d4e8a30"
   "2.47.1":
     url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.47/at-spi2-core-2.47.1.tar.xz"
     sha256: "c6ba7c160434edebf09d2936933569c936f6ec972301766f2bdac5a4d418153c"
@@ -12,6 +15,8 @@ sources:
     sha256: "ba95f346e93108fbb3462c62437081d582154db279b4052dedc52a706828b192"
     url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.45/at-spi2-core-2.45.1.tar.xz"
 patches:
+  "2.48.0":
+    - patch_file: "patches/93.patch"
   "2.47.1":
     - patch_file: "patches/93.patch"
   "2.46.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **at-spi2-core/2.48.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
