### PR TITLE
fast-cdr: Bump version to 1.0.27

### DIFF
--- a/recipes/fast-cdr/all/conandata.yml
+++ b/recipes/fast-cdr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.27":
+    url: "https://github.com/eProsima/Fast-CDR/archive/v1.0.27.tar.gz"
+    sha256: "a9bc8fd31a2c2b95e6d2fb46e6ce1ad733e86dc4442f733479e33ed9cdc54bf6"
   "1.0.26":
     url: "https://github.com/eProsima/Fast-CDR/archive/v1.0.26.tar.gz"
     sha256: "812b29dd9fa8b79395dea3f4b810f9ab9e820fa4f0a666338c279b739a36595d"

--- a/recipes/fast-cdr/config.yml
+++ b/recipes/fast-cdr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.27":
+    folder: all
   "1.0.26":
     folder: all
   "1.0.24":


### PR DESCRIPTION
Specify library name and version:  **fast-cdr/1.0.27**

This is a dependency for a newer fast-dds version, which is in preparation

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
