### PR TITLE
atk: deprecate in favor of at-spi2-core

### DIFF
--- a/recipes/atk/all/conanfile.py
+++ b/recipes/atk/all/conanfile.py
@@ -20,6 +20,7 @@ class AtkConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.atk.org"
     license = "LGPL-2.1-or-later"
+    deprecated = "at-spi2-core"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/atk/all/conanfile.py
+++ b/recipes/atk/all/conanfile.py
@@ -51,7 +51,7 @@ class AtkConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.75.2")
+        self.requires("glib/2.76.2")
 
     def validate(self):
         if self.options.shared and not self.dependencies["glib"].options.shared:
@@ -64,11 +64,11 @@ class AtkConan(ConanFile):
             raise ConanInvalidConfiguration("this specific configuration is prevented due to internal c3i limitations")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
+        self.tool_requires("meson/1.1.0")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/1.9.3")
         if hasattr(self, "settings_build") and cross_building(self):
-            self.tool_requires("glib/2.75.2")
+            self.tool_requires("glib/2.76.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **atk/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
