### PR TITLE
libsecret: add dependency on glib::gio component in cpp_info

### DIFF
--- a/recipes/libsecret/all/conanfile.py
+++ b/recipes/libsecret/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.60.0 <2.0 || >=2.0.6"
 
 
 class LibsecretConan(ConanFile):

--- a/recipes/libsecret/all/conanfile.py
+++ b/recipes/libsecret/all/conanfile.py
@@ -1,8 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.build import can_run
-from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout

--- a/recipes/libsecret/all/conanfile.py
+++ b/recipes/libsecret/all/conanfile.py
@@ -104,7 +104,7 @@ class LibsecretConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "libsecret-1")
-        self.cpp_info.requires = ["glib::glib-2.0", "glib::gobject-2.0"]
+        self.cpp_info.requires = ["glib::glib-2.0", "glib::gobject-2.0", "glib::gio-2.0"]
         if self._use_gcrypt:
             self.cpp_info.requires.append("libgcrypt::libgcrypt")
         self.cpp_info.includedirs = [os.path.join("include", "libsecret-1")]

--- a/recipes/libsecret/all/conanfile.py
+++ b/recipes/libsecret/all/conanfile.py
@@ -54,7 +54,7 @@ class LibsecretConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.76.0", transitive_headers=True, transitive_libs=True, run=can_run(self))
+        self.requires("glib/2.76.0", transitive_headers=True, transitive_libs=True)
         if self._use_gcrypt:
             self.requires("libgcrypt/1.8.4")
 
@@ -68,8 +68,7 @@ class LibsecretConan(ConanFile):
         self.tool_requires("meson/1.0.0")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/1.9.3")
-        if not can_run(self):
-            self.tool_requires("glib/2.76.0")
+        self.tool_requires("glib/<host_version>")
 
         if self.settings.os == "Macos":
             # Avoid using gettext from homebrew which may be linked against
@@ -84,9 +83,6 @@ class LibsecretConan(ConanFile):
     def generate(self):
         env = VirtualBuildEnv(self)
         env.generate()
-        if can_run(self):
-            env = VirtualRunEnv(self)
-            env.generate(scope="build")
         tc = MesonToolchain(self)
         tc.project_options["introspection"] = "false"
         tc.project_options["manpage"] = "false"

--- a/recipes/libsecret/all/conanfile.py
+++ b/recipes/libsecret/all/conanfile.py
@@ -71,6 +71,13 @@ class LibsecretConan(ConanFile):
         if not can_run(self):
             self.tool_requires("glib/2.76.0")
 
+        if self.settings.os == "Macos":
+            # Avoid using gettext from homebrew which may be linked against
+            # a different/incompatible libiconv than the one being exposed
+            # in the runtime environment (DYLD_LIBRARY_PATH)
+            # See https://github.com/conan-io/conan-center-index/pull/17502#issuecomment-1542492466
+            self.tool_requires("gettext/0.21")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 


### PR DESCRIPTION
Specify library name and version:  **libsecret/all**

Libsecret depends on glib's gio, but it is not expressed in the cppinfo like the other components from glib.

This causes an issue in the `test_package` when `*:shared=True` and the linker is not configured to pass `--as-needed` (it's the default in modern distros, but not in Conan Center).

```
[100%] Linking CXX executable test_package
/usr/bin/cmake -E cmake_link_script CMakeFiles/test_package.dir/link.txt --verbose=1
/usr/local/bin/c++  -m64 -O3 -DNDEBUG  -m64 CMakeFiles/test_package.dir/test_package.cpp.o  -o test_package  -L/home/conan/.conan2/p/libsedbf40cfdd3a8b/p/lib  -L/home/conan/.conan2/p/glibf695b2f38b33d/p/lib  -L/home/conan/.conan2/p/pcre2f38075352b369/p/lib  -L/home/conan/.conan2/p/zlib5fd5adbde7f5c/p/lib  -L/home/conan/.conan2/p/bzip217f1a2b1fc9af/p/lib  -L/home/conan/.conan2/p/libff1166cff32abac/p/lib  -L/home/conan/.conan2/p/libgc57b36e9b58758/p/lib  -L/home/conan/.conan2/p/libca6c70d62f1d61b/p/lib  -L/home/conan/.conan2/p/libgp30cffe18d767b/p/lib -Wl,-rpath,/home/conan/.conan2/p/libsedbf40cfdd3a8b/p/lib:/home/conan/.conan2/p/glibf695b2f38b33d/p/lib:/home/conan/.conan2/p/pcre2f38075352b369/p/lib:/home/conan/.conan2/p/zlib5fd5adbde7f5c/p/lib:/home/conan/.conan2/p/bzip217f1a2b1fc9af/p/lib:/home/conan/.conan2/p/libff1166cff32abac/p/lib:/home/conan/.conan2/p/libgc57b36e9b58758/p/lib:/home/conan/.conan2/p/libca6c70d62f1d61b/p/lib:/home/conan/.conan2/p/libgp30cffe18d767b/p/lib /home/conan/.conan2/p/libsedbf40cfdd3a8b/p/lib/libsecret-1.so /home/conan/.conan2/p/glibf695b2f38b33d/p/lib/libgobject-2.0.so /home/conan/.conan2/p/glibf695b2f38b33d/p/lib/libglib-2.0.so -lpthread 
/opt/conan/binutils/bin/ld: /home/conan/.conan2/p/glibf695b2f38b33d/p/lib/libgio-2.0.so.0: undefined reference to `is_selinux_enabled@LIBSELINUX_1.0'
/opt/conan/binutils/bin/ld: /home/conan/.conan2/p/glibf695b2f38b33d/p/lib/libgio-2.0.so.0: undefined reference to `getfilecon_raw@LIBSELINUX_1.0'
/opt/conan/binutils/bin/ld: /home/conan/.conan2/p/glibf695b2f38b33d/p/lib/libgio-2.0.so.0: undefined reference to `fgetfilecon_raw@LIBSELINUX_1.0'
/opt/conan/binutils/bin/ld: /home/conan/.conan2/p/glibf695b2f38b33d/p/lib/libgio-2.0.so.0: undefined reference to `lgetfilecon_raw@LIBSELINUX_1.0'
/opt/conan/binutils/bin/ld: /home/conan/.conan2/p/glibf695b2f38b33d/p/lib/libgio-2.0.so.0: undefined reference to `freecon@LIBSELINUX_1.0'
/opt/conan/binutils/bin/ld: /home/conan/.conan2/p/glibf695b2f38b33d/p/lib/libgio-2.0.so.0: undefined reference to `setfilecon_raw@LIBSELINUX_1.0'
collect2: error: ld returned 1 exit status
CMakeFiles/test_package.dir/build.make:89: recipe for target 'test_package' failed
make[2]: *** [test_package] Error 1
make[2]: Leaving directory '/cci/recipes/libsecret/all/test_package/build/gcc-11-x86_64-gnu17-release'
CMakeFiles/Makefile2:78: recipe for target 'CMakeFiles/test_package.dir/all' failed
make[1]: *** [CMakeFiles/test_package.dir/all] Error 2
make[1]: Leaving directory '/cci/recipes/libsecret/all/test_package/build/gcc-11-x86_64-gnu17-release'
Makefile:86: recipe for target 'all' failed
make: *** [all] Error 2
```

We can see that the built `libsecret.so` depends on `libgio-2.0.so`:
```
$ readelf -d /home/conan/.conan2/p/libsec053b1eec74d0/p/lib/libsecret-1.so

Dynamic section at offset 0x5bbc0 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libglib-2.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libgio-2.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libgobject-2.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libgcrypt.so.20]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000e (SONAME)             Library soname: [libsecret-1.so.0]
 0x000000000000000c (INIT)               0x16000
```

When linking the test_package executable, the linker will try to locate `libselinux.so` as it is a dependency of `libgio-2.0.so` - however, Conan's CMakeDeps are not giving CMake the necessary information to add the directory of Conan's `libselinux` to the `-rpath`. So what is most likely happening is that the linker is loading `/lib/x86_64-linux-gnu/libselinux.so.1` instead of the one from the Conan cache, and then complaining that the symbols that `libgio-2.0.so.0` expects are not there (because they are not guaranteed to be).

This PR fixes the issue by adding the missing entry in `self.cpp_info.requires`, which in turn causes CMakeDeps to define the correct information for CMake to add the lib directory of selinux inside the Conan cache.
