### PR TITLE
arrow: use CMakeDeps set property to match the expected Brotli names

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -505,6 +505,10 @@ class ArrowConan(ConanFile):
         tc.generate()
 
         deps = CMakeDeps(self)
+        if self.options.with_brotli:
+            deps.set_property("brotli::brotlicommon", "cmake_target_name", "Brotli::brotlicommon")
+            deps.set_property("brotli::brotlienc", "cmake_target_name", "Brotli::brotlienc")
+            deps.set_property("brotli::brotlidec", "cmake_target_name", "Brotli::brotlidec")
         deps.generate()
 
     def _patch_sources(self):

--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.scm import Version
 import os
 import glob
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.55.0"
 
 class ArrowConan(ConanFile):
     name = "arrow"

--- a/recipes/arrow/all/patches/1.0.0-0006-fix-cmake.patch
+++ b/recipes/arrow/all/patches/1.0.0-0006-fix-cmake.patch
@@ -2,15 +2,6 @@ diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
 index 300f043..0127a7a 100644
 --- a/cpp/CMakeLists.txt
 +++ b/cpp/CMakeLists.txt
-@@ -654,7 +654,7 @@ endif()
- 
- if(ARROW_WITH_BROTLI)
-   # Order is important for static linking
--  set(ARROW_BROTLI_LIBS Brotli::brotlienc Brotli::brotlidec Brotli::brotlicommon)
-+  set(ARROW_BROTLI_LIBS brotli::brotlienc brotli::brotlidec brotli::brotlicommon)
-   list(APPEND ARROW_LINK_LIBS ${ARROW_BROTLI_LIBS})
-   list(APPEND ARROW_STATIC_LINK_LIBS ${ARROW_BROTLI_LIBS})
- endif()
 @@ -664,7 +664,7 @@ if(ARROW_WITH_BZ2)
  endif()
  
@@ -90,21 +81,6 @@ index 807e2b9..016c8db 100644
    endif()
  
    if(TARGET Boost::system)
-@@ -936,11 +928,11 @@ macro(build_brotli)
- endmacro()
- 
- if(ARROW_WITH_BROTLI)
--  resolve_dependency(Brotli)
-+  resolve_dependency(brotli)
-   # TODO: Don't use global includes but rather target_include_directories
--  get_target_property(BROTLI_INCLUDE_DIR Brotli::brotlicommon
-+  get_target_property(BROTLI_INCLUDE_DIR brotli::brotlicommon
-                       INTERFACE_INCLUDE_DIRECTORIES)
--  include_directories(SYSTEM ${BROTLI_INCLUDE_DIR})
-+  include_directories(SYSTEM ${brotli_INCLUDE_DIR})
- endif()
- 
- if(PARQUET_REQUIRE_ENCRYPTION AND NOT ARROW_PARQUET)
 @@ -1146,9 +1138,10 @@ if(ARROW_NEED_GFLAGS)
      endif()
    endif()

--- a/recipes/arrow/all/patches/2.0.0-0008-fix-cmake.patch
+++ b/recipes/arrow/all/patches/2.0.0-0008-fix-cmake.patch
@@ -11,15 +11,6 @@ index 515e6af..7488161 100644
  list(GET ARROW_LLVM_VERSIONS 0 ARROW_LLVM_VERSION_PRIMARY)
  string(REGEX
         REPLACE "^([0-9]+)(\\..+)?" "\\1" ARROW_LLVM_VERSION_PRIMARY_MAJOR
-@@ -667,7 +667,7 @@ endif()
- 
- if(ARROW_WITH_BROTLI)
-   # Order is important for static linking
--  set(ARROW_BROTLI_LIBS Brotli::brotlienc Brotli::brotlidec Brotli::brotlicommon)
-+  set(ARROW_BROTLI_LIBS brotli::brotlienc brotli::brotlidec brotli::brotlicommon)
-   list(APPEND ARROW_LINK_LIBS ${ARROW_BROTLI_LIBS})
-   list(APPEND ARROW_STATIC_LINK_LIBS ${ARROW_BROTLI_LIBS})
-   if(Brotli_SOURCE STREQUAL "SYSTEM")
 @@ -683,9 +683,9 @@ if(ARROW_WITH_BZ2)
  endif()
  
@@ -93,21 +84,6 @@ index cc37a3c..8fe6db9 100644
    endif()
  
    if(TARGET Boost::system)
-@@ -973,11 +983,11 @@ macro(build_brotli)
- endmacro()
- 
- if(ARROW_WITH_BROTLI)
--  resolve_dependency(Brotli)
-+  resolve_dependency(brotli)
-   # TODO: Don't use global includes but rather target_include_directories
--  get_target_property(BROTLI_INCLUDE_DIR Brotli::brotlicommon
-+  get_target_property(BROTLI_INCLUDE_DIR brotli::brotlicommon
-                       INTERFACE_INCLUDE_DIRECTORIES)
--  include_directories(SYSTEM ${BROTLI_INCLUDE_DIR})
-+  include_directories(SYSTEM ${brotli_INCLUDE_DIR})
- endif()
- 
- if(PARQUET_REQUIRE_ENCRYPTION AND NOT ARROW_PARQUET)
 @@ -1200,9 +1210,10 @@ if(ARROW_NEED_GFLAGS)
      endif()
    endif()

--- a/recipes/arrow/all/patches/7.0.0-0007-fix-cmake.patch
+++ b/recipes/arrow/all/patches/7.0.0-0007-fix-cmake.patch
@@ -2,15 +2,6 @@ diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
 index 2d7baf1..dff5b1a 100644
 --- a/cpp/CMakeLists.txt
 +++ b/cpp/CMakeLists.txt
-@@ -699,7 +699,7 @@ endif()
- 
- if(ARROW_WITH_BROTLI)
-   # Order is important for static linking
--  set(ARROW_BROTLI_LIBS Brotli::brotlienc Brotli::brotlidec Brotli::brotlicommon)
-+  set(ARROW_BROTLI_LIBS brotli::brotlienc brotli::brotlidec brotli::brotlicommon)
-   list(APPEND ARROW_LINK_LIBS ${ARROW_BROTLI_LIBS})
-   list(APPEND ARROW_STATIC_LINK_LIBS ${ARROW_BROTLI_LIBS})
-   if(Brotli_SOURCE STREQUAL "SYSTEM")
 @@ -715,10 +715,17 @@ if(ARROW_WITH_BZ2)
  endif()
  
@@ -71,18 +62,6 @@ index bc38952..62bf314 100644
      set(BOOST_SYSTEM_LIBRARY ${Boost_SYSTEM_LIBRARY})
      set(BOOST_FILESYSTEM_LIBRARY ${Boost_FILESYSTEM_LIBRARY})
    else()
-@@ -1108,9 +1108,9 @@ macro(build_brotli)
- endmacro()
- 
- if(ARROW_WITH_BROTLI)
--  resolve_dependency(Brotli PC_PACKAGE_NAMES libbrotlidec libbrotlienc)
-+  resolve_dependency(brotli PC_PACKAGE_NAMES libbrotlidec libbrotlienc)
-   # TODO: Don't use global includes but rather target_include_directories
--  get_target_property(BROTLI_INCLUDE_DIR Brotli::brotlicommon
-+  get_target_property(BROTLI_INCLUDE_DIR brotli::brotlicommon
-                       INTERFACE_INCLUDE_DIRECTORIES)
-   include_directories(SYSTEM ${BROTLI_INCLUDE_DIR})
- endif()
 @@ -1302,22 +1302,17 @@ endmacro()
  if(ARROW_NEED_GFLAGS)
    set(ARROW_GFLAGS_REQUIRED_VERSION "2.1.0")


### PR DESCRIPTION

Specify library name and version:  **arrow/all**

Instead of patching the CMakeLists to match the target names generated by CMakeDeps, use CMakeDep's ability to change the target names so that they match the ones in the CMakeLists instead - this should be more robust as patches tend to get lost across versions.

Close: https://github.com/conan-io/conan-center-index/issues/16059
