### PR TITLE
(#17515) [boost]: patch for boost::log

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -65,6 +65,10 @@ patches:
     - patch_file: "patches/1.81.0-locale-fail-on-missing-backend.patch"
       patch_description: "Fails the build when there is no iconv backend"
       patch_type: "conan"
+    - patch_file: "patches/1.81.0-log-file-rotate-deadlock.patch"
+      patch_description: "Boost deadlocks when a log message exceeds log rotate size"
+      patch_type: "official"
+      patch_source: "https://github.com/boostorg/log/issues/209"
   "1.80.0":
     - patch_file: "patches/1.80.0-locale-fail-on-missing-backend.patch"
       patch_description: "Fails the build when there is no iconv backend"

--- a/recipes/boost/all/patches/1.81.0-log-file-rotate-deadlock.patch
+++ b/recipes/boost/all/patches/1.81.0-log-file-rotate-deadlock.patch
@@ -1,0 +1,35 @@
+diff --git a/libs/log/src/text_file_backend.cpp b/src/text_file_backend.cpp
+index 8b8920e..0df9a37 100644
+--- a/libs/log/src/text_file_backend.cpp
++++ b/libs/log/src/text_file_backend.cpp
+@@ -1422,6 +1422,7 @@ BOOST_LOG_API void text_file_backend::consume(record_view const& rec, string_typ
+         rotate_file();
+     }
+
++    const unsigned int last_file_counter = m_pImpl->m_FileCounter - 1u;
+     while (!m_pImpl->m_File.is_open())
+     {
+         filesystem::path new_file_name;
+@@ -1464,6 +1465,7 @@ BOOST_LOG_API void text_file_backend::consume(record_view const& rec, string_typ
+         else
+         {
+             prev_file_name.swap(new_file_name);
++            use_prev_file_name = false;
+         }
+
+         filesystem::create_directories(new_file_name.parent_path());
+@@ -1479,9 +1481,11 @@ BOOST_LOG_API void text_file_backend::consume(record_view const& rec, string_typ
+         m_pImpl->m_FileName.swap(new_file_name);
+         m_pImpl->m_IsFirstFile = false;
+
+-        // Check the file size before invoking the open handler, as it may write more data to the file
++        // Check the file size before invoking the open handler, as it may write more data to the file.
++        // Only do this check if we haven't exhausted the file counter to avoid looping indefinitely.
+         m_pImpl->m_CharactersWritten = static_cast< std::streamoff >(m_pImpl->m_File.tellp());
+-        if (m_pImpl->m_CharactersWritten + formatted_message.size() >= m_pImpl->m_FileRotationSize)
++        if (m_pImpl->m_CharactersWritten > 0 && m_pImpl->m_CharactersWritten + formatted_message.size() >= m_pImpl->m_FileRotationSize &&
++            m_pImpl->m_FileCounter != last_file_counter)
+         {
+             // Avoid running the close handler, as we haven't run the open handler yet
+             struct close_handler_backup_guard
+


### PR DESCRIPTION
* patch to resolve https://github.com/boostorg/log/issues/209

Specify library name and version:  **boost/1.81.0**

Adding a patch for boost 1.81 to fix a potential infinite loop in boost::log. The underlying issue has been resolved in boost::log's master


---

- [*] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [*] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [*] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
