### PR TITLE
[config] Drop Clang 11 from Conan v1 configuration

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -80,17 +80,6 @@ configurations:
               compiler.version: ["5", "7", "9", "10", "11"]
               build_type: ["Release", "Debug"]
   - id: linux-clang
-    epochs: [0]
-    hrname: "Linux, Clang"
-    content:
-      - os: [ "Linux" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "clang":
-              compiler.libcxx: [ "libstdc++", "libc++" ]
-              compiler.version: [ "11" ]
-              build_type: [ "Release", "Debug" ]
-  - id: linux-clang
     epochs: [20211221, 20220120]
     hrname: "Linux, Clang"
     content:
@@ -99,7 +88,7 @@ configurations:
         compiler:
           - "clang":
               compiler.libcxx: ["libstdc++", "libc++"]
-              compiler.version: ["11", "12", "13"]
+              compiler.version: ["12", "13"]
               build_type: ["Release", "Debug"]
   - id: macos-clang
     epochs: [0, 20211221]


### PR DESCRIPTION
After discussing with Conan team, we opted by dropping Linux Clang 11 from Conan v1 configuration. Here are some motivations that we agreed about:

- The Clang 11 was released in 2020 and it's not the most updated compiler, 16 is the latest version.
- Its base Docker image is based on Ubuntu Bionic (18.04) that does not provide a modern libstdc++ version, blocking projects that need C++17 or higher to be built.
- Conan v1 will be sunset in the future so are dropping gradually some configuration as you can see in [discussion](https://github.com/conan-io/conan-center-index/discussions)
- We do not find fixing the `conanio/clang11` Docker image as productive, as we should drop Conan v1 in the future anyway.
- PRs like #16938 are blocked due Clang 11 docker image

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
