### PR TITLE
[googleapis] prepare for google-cloud-cpp-2.10.1

### DIFF
--- a/recipes/googleapis/all/conandata.yml
+++ b/recipes/googleapis/all/conandata.yml
@@ -7,6 +7,9 @@
 #     (master branch) https://github.com/grpc/grpc/blob/master/CMakeLists.txt#L347
 
 sources:
+  "cci.20230501":
+    url: "https://github.com/googleapis/googleapis/archive/2da477b6a72168c65fdb4245530cfa702cc4b029.tar.gz"
+    sha256: "3e48e5833fcd2e1fcb8b6a5b7a88e18503b670e8636b868cdb5ac32e00fbdafb"
   "cci.20221108":
     url: "https://github.com/googleapis/googleapis/archive/67b2d7c2fb11188776bc398f02c67fccd8187502.zip"
     sha256: "cca450c34e3a8adc03364686d44748f362e4a9af6d3ef32b918f2d5483a3025e"

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -153,6 +153,13 @@ class GoogleAPIS(ConanFile):
             deactivate_library("//google/cloud/talent/v4:talent_cc_proto")
             deactivate_library("//google/cloud/asset/v1:asset_proto")
             deactivate_library("//google/cloud/asset/v1:asset_cc_proto")
+        # This fails to build on Windows. It is arguably a missing feature of
+        # Protobuf.
+        #     https://github.com/protocolbuffers/protobuf/issues/12774
+        # Fortunately this library is not used by any downstream packages
+        # (grpc-protos, or google-cloud-cpp), and it is only "beta" at the
+        # moment. Simply disable it for now.
+        deactivate_library("//google/cloud/lifesciences/v2beta:lifesciences_cc_proto")
 
         return proto_libraries
 

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -159,6 +159,7 @@ class GoogleAPIS(ConanFile):
         # Fortunately this library is not used by any downstream packages
         # (grpc-protos, or google-cloud-cpp), and it is only "beta" at the
         # moment. Simply disable it for now.
+        deactivate_library("//google/cloud/lifesciences/v2beta:lifesciences_proto")
         deactivate_library("//google/cloud/lifesciences/v2beta:lifesciences_cc_proto")
 
         return proto_libraries

--- a/recipes/googleapis/config.yml
+++ b/recipes/googleapis/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20230501":
+    folder: all
   "cci.20221108":
     folder: all
   "cci.20220711":


### PR DESCRIPTION
Specify library name and version:  **googleapis/cci.20230501**

This is the first in a series of PRs to update `google-cloud-cpp` to v2.10.1.  It updates googleapis to a snapshot circa 2023-05-01 (thus the version).  The SHA matches what `google-cloud-cpp` expects.  Future PRs will update `grpc-protos`, `grpc`, and finally `google-cloud-cpp`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
