### PR TITLE
mppp: update fmt, fix compilation error on with_fmt=True

### DIFF
--- a/recipes/mppp/all/conandata.yml
+++ b/recipes/mppp/all/conandata.yml
@@ -10,6 +10,9 @@ patches:
     - patch_file: "patches/0.27-0001-disable-warning-error.patch"
       patch_description: "disable the flag for treats warning as errors"
       patch_type: "portability"
+    - patch_file: "patches/0.27-0002-remove-fmt-version.patch"
+      patch_description: "remove fmt version number from find_package"
+      patch_type: "conan"
   "0.26":
     - patch_file: "patches/0.26-0001-disable-warning-error.patch"
       patch_description: "disable the flag for treats warning as errors"

--- a/recipes/mppp/all/conandata.yml
+++ b/recipes/mppp/all/conandata.yml
@@ -11,6 +11,7 @@ patches:
       patch_description: "disable the flag for treats warning as errors"
       patch_type: "portability"
     - patch_file: "patches/0.27-0002-remove-fmt-version.patch"
+      # https://github.com/conan-io/conan/issues/14172
       patch_description: "remove fmt version number from find_package"
       patch_type: "conan"
   "0.26":

--- a/recipes/mppp/all/conanfile.py
+++ b/recipes/mppp/all/conanfile.py
@@ -69,7 +69,7 @@ class MpppConan(ConanFile):
         if self.options.with_boost:
             self.requires("boost/1.81.0")
         if self.options.get_safe("with_fmt"):
-            self.requires("fmt/9.1.0")
+            self.requires("fmt/10.0.0", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/mppp/all/conanfile.py
+++ b/recipes/mppp/all/conanfile.py
@@ -61,7 +61,7 @@ class MpppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("gmp/6.2.1")
+        self.requires("gmp/6.2.1", transitive_headers=True)
         if self.options.with_mpfr:
             self.requires("mpfr/4.1.0")
         if self.options.with_mpc:

--- a/recipes/mppp/all/conanfile.py
+++ b/recipes/mppp/all/conanfile.py
@@ -67,7 +67,7 @@ class MpppConan(ConanFile):
         if self.options.with_mpc:
             self.requires("mpc/1.2.0")
         if self.options.with_boost:
-            self.requires("boost/1.81.0")
+            self.requires("boost/1.82.0")
         if self.options.get_safe("with_fmt"):
             self.requires("fmt/10.0.0", transitive_headers=True)
 

--- a/recipes/mppp/all/patches/0.27-0002-remove-fmt-version.patch
+++ b/recipes/mppp/all/patches/0.27-0002-remove-fmt-version.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 22e275f..1a97423 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -414,9 +414,8 @@ endif()
+ 
+ # NOTE: need at least version 6.2
+ # to print 128-bit integers.
+-set(_MPPP_MIN_FMT_VERSION "6.2")
+ if(MPPP_WITH_FMT)
+-    find_package(fmt ${_MPPP_MIN_FMT_VERSION} REQUIRED CONFIG)
++    find_package(fmt REQUIRED CONFIG)
+     message(STATUS "fmt version: ${fmt_VERSION}")
+     target_link_libraries(mp++ PUBLIC fmt::fmt)
+ endif()


### PR DESCRIPTION
Specify library name and version:  **mppp/0.27**

When I created mppp recipe with `with_fmt=True`, there is a compilation error following:
> Could not find a configuration file for package "fmt" that is compatible

It may be caused by `find_package(fmt)` with old version(6.2).
```cmake
set(_MPPP_MIN_FMT_VERSION "6.2")
if(MPPP_WITH_FMT)
    find_package(fmt ${_MPPP_MIN_FMT_VERSION} REQUIRED CONFIG)
```


Then I created the patch to remove version number from `find_package`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
