### PR TITLE
clove-unit: cleanup recipe and don't suggest unofficial CMake names

### DIFF
--- a/recipes/clove-unit/all/conanfile.py
+++ b/recipes/clove-unit/all/conanfile.py
@@ -1,14 +1,14 @@
 from conan import ConanFile
+from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
-from conan.tools.files import export_conandata_patches, get, copy
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.50.0"
 
 class CloveUnitConan(ConanFile):
     name = "clove-unit"
     description = "Single-header Unit Testing framework for C (interoperable with C++) with test autodiscovery feature"
-    topics = ("clove-unit", "unit-testing", "testing", "unit testing", "test")
+    topics = ("unit-testing", "testing", "unit testing", "test")
     homepage = "https://github.com/fdefelici/clove-unit"
     url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
@@ -16,39 +16,22 @@ class CloveUnitConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
 
-    # Use the export_sources(self) method instead of the exports_sources attribute.
-    # This allows finer grain exportation of patches per version
-    def export_sources(self):
-        export_conandata_patches(self)
-
     def layout(self):
         basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    # Not mandatory when there is no patch, but will suppress warning message about missing build() method
     def build(self):
-        # The attribute no_copy_source should not be used when applying patches in build
-        # apply_conandata_patches(self)
         pass
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "clove-unit.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
 
-    def package_id(self):
-        self.info.clear()
-
     def package_info(self):
-        self.cpp_info.set_property("cmake_file_name", "CloveUnit")
-        self.cpp_info.set_property("cmake_target_name", "CloveUnit::CloveUnit")
-        # Folders not used for header-only
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        # NOTE: needed by conan test phase on test_v1_package folder
-        self.cpp_info.filenames["cmake_find_package"] = "CloveUnit"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "CloveUnit"
-        self.cpp_info.names["cmake_find_package"] = "CloveUnit"
-        self.cpp_info.names["cmake_find_package_multi"] = "CloveUnit"

--- a/recipes/clove-unit/all/test_package/CMakeLists.txt
+++ b/recipes/clove-unit/all/test_package/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-
-find_package(CloveUnit CONFIG REQUIRED)
+find_package(clove-unit CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} CloveUnit::CloveUnit)
+target_link_libraries(${PROJECT_NAME} PRIVATE clove-unit::clove-unit)
 


### PR DESCRIPTION
follow up of https://github.com/conan-io/conan-center-index/pull/17050

- many useless stuff from package template are removed
- fix required_conan_version. conan 1.50.0 is sufficient.
- cmake names are removed. This library doesn't provide a CMake config file.

/cc @fdefelici

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
