### PR TITLE
zbar: bump dependencies + few fixes following v2 migration

### DIFF
--- a/recipes/zbar/all/conanfile.py
+++ b/recipes/zbar/all/conanfile.py
@@ -2,11 +2,11 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import cross_building
+from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.files import get, copy, rmdir, rm, export_conandata_patches, apply_conandata_patches
 from conan.tools.gnu import Autotools, AutotoolsToolchain
-from conan.tools.env import Environment
-from conan.tools.scm import Version
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -98,6 +98,9 @@ class ZbarConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
         yes_no = lambda v: "yes" if v else "no"
         tc = AutotoolsToolchain(self)
         tc.configure_args.extend([

--- a/recipes/zbar/all/conanfile.py
+++ b/recipes/zbar/all/conanfile.py
@@ -17,10 +17,11 @@ class ZbarConan(ConanFile):
     license = "LGPL-2.1-only"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://zbar.sourceforge.net/"
-    topics = ("zbar", "barcode", "scanner", "decoder", "reader", "bar")
+    topics = ("barcode", "scanner", "decoder", "reader", "bar")
     description = "ZBar is an open source software suite for reading bar codes\
                    from various sources, such as video streams, image files and raw intensity sensors"
-    settings = "os", "compiler", "build_type", "arch"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],

--- a/recipes/zbar/all/conanfile.py
+++ b/recipes/zbar/all/conanfile.py
@@ -121,8 +121,14 @@ class ZbarConan(ConanFile):
 
     def build(self):
         apply_conandata_patches(self)
-        copy(self, "config.sub", src=self.source_folder, dst=os.path.join(self.source_folder, "config"))
-        copy(self, "config.guess", src=self.source_folder, dst=os.path.join(self.source_folder, "config"))
+        for gnu_config in [
+            self.conf.get("user.gnu-config:config_guess", check_type=str),
+            self.conf.get("user.gnu-config:config_sub", check_type=str),
+        ]:
+            if gnu_config:
+                copy(self, os.path.basename(gnu_config),
+                           src=os.path.dirname(gnu_config),
+                           dst=os.path.join(self.source_folder, "config"))
 
         autotools = Autotools(self)
         if Version(self.version) >= "0.22":

--- a/recipes/zbar/all/conanfile.py
+++ b/recipes/zbar/all/conanfile.py
@@ -77,22 +77,22 @@ class ZbarConan(ConanFile):
         if Version(self.version) >= "0.22":
             self.requires("libiconv/1.17")
 
-    def build_requirements(self):
-        self.tool_requires("gnu-config/cci.20210814")
-        if Version(self.version) >= "0.22":
-            self.tool_requires("gettext/0.21")
-            self.tool_requires("libtool/2.4.7")
-            self.tool_requires("pkgconf/1.9.3")
-
     def validate(self):
         if self.settings.os == "Windows":
             raise ConanInvalidConfiguration("Zbar can't be built on Windows")
         if is_apple_os(self) and not self.options.shared:
             raise ConanInvalidConfiguration("Zbar can't be built static on macOS")
         if self.options.with_xv:            #TODO add when available
-            self.output.warn("There is no Xvideo package available on Conan (yet). This recipe will use the one present on the system (if available).")
+            self.output.warning("There is no Xvideo package available on Conan (yet). This recipe will use the one present on the system (if available).")
         if Version(self.version) >= "0.22" and cross_building(self):
             raise ConanInvalidConfiguration(f"{self.ref} can't be built on cross building environment currently because autopoint(part of gettext) doesn't execute correctly.")
+
+    def build_requirements(self):
+        self.tool_requires("gnu-config/cci.20210814")
+        if Version(self.version) >= "0.22":
+            self.tool_requires("gettext/0.21")
+            self.tool_requires("libtool/2.4.7")
+            self.tool_requires("pkgconf/1.9.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/zbar/all/conanfile.py
+++ b/recipes/zbar/all/conanfile.py
@@ -66,23 +66,22 @@ class ZbarConan(ConanFile):
 
     def requirements(self):
         if self.options.with_jpeg:
-            self.requires("libjpeg/9d")
+            self.requires("libjpeg/9e")
         if self.options.with_imagemagick:
             self.requires("imagemagick/7.0.11-14")
         if self.options.with_gtk:
             self.requires("gtk/4.7.0")
         if self.options.with_qt:
-            self.requires("qt/5.15.5")
+            self.requires("qt/5.15.9")
         if Version(self.version) >= "0.22":
             self.requires("libiconv/1.17")
 
     def build_requirements(self):
         self.tool_requires("gnu-config/cci.20210814")
         if Version(self.version) >= "0.22":
-            self.tool_requires("automake/1.16.5")
             self.tool_requires("gettext/0.21")
-            self.tool_requires("pkgconf/1.7.4")
-            self.tool_requires("libtool/2.4.6")
+            self.tool_requires("libtool/2.4.7")
+            self.tool_requires("pkgconf/1.9.3")
 
     def validate(self):
         if self.settings.os == "Windows":
@@ -125,7 +124,7 @@ class ZbarConan(ConanFile):
         copy(self, "config.guess", src=self.source_folder, dst=os.path.join(self.source_folder, "config"))
 
         autotools = Autotools(self)
-        if Version(self.version) > "0.10":
+        if Version(self.version) >= "0.22":
             autotools.autoreconf()
         autotools.configure()
         autotools.make()


### PR DESCRIPTION
follow up of https://github.com/conan-io/conan-center-index/pull/16569

- bump requirements and build requirements
- add package_type
- use output.warning instead of output.warn (removed in conan v2)
- fix copy of gnu-config files
- add VirtualBuildEnv since there are requirements
- properly handle dependencies:
  - add PkgConfigDeps & AutotoolsDeps
  - libiconv is required even in 0.10
  - remove iconv from system libs if macOS, since we have libiconv in requirements
- cleanup topics

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
