### PR TITLE
[grpc-proto] prepare for google-cloud-cpp-v2.10.1

### DIFF
--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -54,10 +54,10 @@ class GRPCProto(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-       # protobuf symbols are exposed from generated structures 
-       # https://github.com/conan-io/conan-center-index/pull/16185#issuecomment-1501174215 
+       # protobuf symbols are exposed from generated structures
+       # https://github.com/conan-io/conan-center-index/pull/16185#issuecomment-1501174215
         self.requires("protobuf/3.21.9", transitive_headers=True, transitive_libs=True, run=can_run(self))
-        self.requires("googleapis/cci.20221108")
+        self.requires("googleapis/cci.20230501")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Specify library name and version:  **grpc-proto/cci.20220627**

This is the second PR in a series to update `google-cloud-cpp` to v2.10.1.  The first PR updated `googleapis` to match the requirements in `google-cloud-cpp`. This PR bumps `grpc-proto` dependency on googleapis.  I will follow up with PRs to update `grpc` and then `google-cloud-cpp`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
