### PR TITLE
bshoshany-thread-pool: conan v2 support

### DIFF
--- a/recipes/bshoshany-thread-pool/all/test_package/CMakeLists.txt
+++ b/recipes/bshoshany-thread-pool/all/test_package/CMakeLists.txt
@@ -1,14 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 find_package(bshoshany-thread-pool REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} bshoshany-thread-pool::bshoshany-thread-pool)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/bshoshany-thread-pool/all/test_package/conanfile.py
+++ b/recipes/bshoshany-thread-pool/all/test_package/conanfile.py
@@ -1,17 +1,27 @@
 import os
-from conans import ConanFile, CMake, tools
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 
 
-class TestPackageConan(ConanFile):
-    settings = "arch", "build_type", "compiler", "os"
-    generators = "cmake", "cmake_find_package_multi"
+class BshoshanyThreadPoolTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/bshoshany-thread-pool/all/test_v1_package/CMakeLists.txt
+++ b/recipes/bshoshany-thread-pool/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(bshoshany-thread-pool REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} bshoshany-thread-pool::bshoshany-thread-pool)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/bshoshany-thread-pool/all/test_v1_package/conanfile.py
+++ b/recipes/bshoshany-thread-pool/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import CMake, ConanFile, tools
+
+
+class BshoshanyThreadPoolTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run("{0}".format(bin_path), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **bshoshany-thread-pool/all**

Modernize recipe:
- Update `test_package` to work with Conan2
- Add `test_v1_package`
- Fix `validate()` in `conanfile.py` (calling `self.output.warn` raises)

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
