### PR TITLE
opus: Add option to disable stack protector.

### DIFF
--- a/recipes/opus/all/conanfile.py
+++ b/recipes/opus/all/conanfile.py
@@ -20,11 +20,13 @@ class OpusConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "fixed_point": [True, False],
+        "stack_protector": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "fixed_point": False,
+        "stack_protector": True,
     }
 
     def export_sources(self):
@@ -53,6 +55,7 @@ class OpusConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["OPUS_FIXED_POINT"] = self.options.fixed_point
+        tc.variables["OPUS_STACK_PROTECTOR"] = self.options.stack_protector
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Add an option to allow the stack protector to be disabled to make it easier to build with Emscripten. This is already exposed through CMake, so the Conan recipe change is minimal; just add an option & pass it through.

The `OPUS_STACK_PROTECTOR` option defaults to `ON` in the CMake build, so I have defaulted the Conan option to `True` to mirror that.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
