### PR TITLE
[google-cloud-cpp] update to v2.10.1

### DIFF
--- a/recipes/google-cloud-cpp/2.x/conandata.yml
+++ b/recipes/google-cloud-cpp/2.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.10.1":
+    url: "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.10.1.tar.gz"
+    sha256: "dbd8ff9cdda8b991049094c41d9125438098422658c77dc1afab524c589efeda"
   "2.5.0":
     url: "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.5.0.tar.gz"
     sha256: "ac93ef722d08bfb220343bde2f633c7c11f15e34ec3ecd0a57dbd3ff729cc3a6"
@@ -12,5 +15,12 @@ patches:
       patch_description: "Fix problems with INTERFACE proto libraries"
       patch_type: backport
     - patch_file: "patches/2.5.0/003-use-conan-msvc-runtime.patch"
+      patch_description: "Let Conan select the MSVC runtime"
+      patch_type: conan
+  "2.10.1":
+    - patch_file: "patches/2.10.1/001-use-googleapis-conan-package.patch"
+      patch_description: "Use Conan package for googleapis"
+      patch_type: conan
+    - patch_file: "patches/2.10.1/002-use-conan-msvc-runtime.patch"
       patch_description: "Let Conan select the MSVC runtime"
       patch_type: conan

--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -149,108 +149,120 @@ class GoogleCloudCppConan(ConanFile):
 
     _GOOGLEAPIS_VERSIONS = {
         "2.5.0": "cci.20221108",
+        "2.10.1": "cci.20230501",
     }
 
     _GA_COMPONENTS_BASE = {"bigquery", "bigtable", "iam", "pubsub", "spanner", "storage"}
+    _GA_COMPONENTS_VERSION_2_5_0 = {
+        "accessapproval",
+        "accesscontextmanager",
+        "apigateway",
+        "apigeeconnect",
+        "appengine",
+        "artifactregistry",
+        "asset",
+        "assuredworkloads",
+        "automl",
+        "baremetalsolution",
+        "batch",
+        "beyondcorp",
+        "billing",
+        "binaryauthorization",
+        "certificatemanager",
+        "channel",
+        "cloudbuild",
+        "composer",
+        "connectors",
+        "contactcenterinsights",
+        "container",
+        "containeranalysis",
+        "datacatalog",
+        "datamigration",
+        "dataplex",
+        "dataproc",
+        "datastream",
+        "debugger",
+        "deploy",
+        "dialogflow_cx",
+        "dialogflow_es",
+        "dlp",
+        "documentai",
+        "edgecontainer",
+        "eventarc",
+        "filestore",
+        "functions",
+        "gameservices",
+        "gkehub",
+        "iap",
+        "ids",
+        "iot",
+        "kms",
+        "language",
+        "logging",
+        "managedidentities",
+        "memcache",
+        "monitoring",
+        "networkconnectivity",
+        "networkmanagement",
+        "notebooks",
+        "optimization",
+        "orgpolicy",
+        "osconfig",
+        "oslogin",
+        "policytroubleshooter",
+        "privateca",
+        "profiler",
+        "recommender",
+        "redis",
+        "resourcemanager",
+        "resourcesettings",
+        "retail",
+        "run",
+        "scheduler",
+        "secretmanager",
+        "securitycenter",
+        "servicecontrol",
+        "servicedirectory",
+        "servicemanagement",
+        "serviceusage",
+        "shell",
+        "speech",
+        "storagetransfer",
+        "talent",
+        "tasks",
+        "texttospeech",
+        "tpu",
+        "trace",
+        "translate",
+        "video",
+        "videointelligence",
+        "vision",
+        "vmmigration",
+        "vmwareengine",
+        "vpcaccess",
+        "webrisk",
+        "websecurityscanner",
+        "workflows",
+    }
+    _GA_COMPONENTS_VERSION_2_10_1 = {
+        'advisorynotifications',
+        'alloydb',
+        'apikeys',
+        'confidentialcomputing',
+        'gkemulticloud',
+        'sql',
+        'storageinsights',
+    }
     _GA_COMPONENTS_VERSION = {
-        '2.5.0': {
-            "accessapproval",
-            "accesscontextmanager",
-            "apigateway",
-            "apigeeconnect",
-            "appengine",
-            "artifactregistry",
-            "asset",
-            "assuredworkloads",
-            "automl",
-            "baremetalsolution",
-            "batch",
-            "beyondcorp",
-            "billing",
-            "binaryauthorization",
-            "certificatemanager",
-            "channel",
-            "cloudbuild",
-            "composer",
-            "connectors",
-            "contactcenterinsights",
-            "container",
-            "containeranalysis",
-            "datacatalog",
-            "datamigration",
-            "dataplex",
-            "dataproc",
-            "datastream",
-            "debugger",
-            "deploy",
-            "dialogflow_cx",
-            "dialogflow_es",
-            "dlp",
-            "documentai",
-            "edgecontainer",
-            "eventarc",
-            "filestore",
-            "functions",
-            "gameservices",
-            "gkehub",
-            "iap",
-            "ids",
-            "iot",
-            "kms",
-            "language",
-            "logging",
-            "managedidentities",
-            "memcache",
-            "monitoring",
-            "networkconnectivity",
-            "networkmanagement",
-            "notebooks",
-            "optimization",
-            "orgpolicy",
-            "osconfig",
-            "oslogin",
-            "policytroubleshooter",
-            "privateca",
-            "profiler",
-            "recommender",
-            "redis",
-            "resourcemanager",
-            "resourcesettings",
-            "retail",
-            "run",
-            "scheduler",
-            "secretmanager",
-            "securitycenter",
-            "servicecontrol",
-            "servicedirectory",
-            "servicemanagement",
-            "serviceusage",
-            "shell",
-            "speech",
-            "storagetransfer",
-            "talent",
-            "tasks",
-            "texttospeech",
-            "tpu",
-            "trace",
-            "translate",
-            "video",
-            "videointelligence",
-            "vision",
-            "vmmigration",
-            "vmwareengine",
-            "vpcaccess",
-            "webrisk",
-            "websecurityscanner",
-            "workflows",
-        },
+        '2.5.0': _GA_COMPONENTS_VERSION_2_5_0,
+        '2.10.1': _GA_COMPONENTS_VERSION_2_10_1,
     }
 
     def _components(self):
         result = self._GA_COMPONENTS_BASE
-        for v in sorted(self._GA_COMPONENTS_VERSION.keys()):
+        for v in self._GA_COMPONENTS_VERSION.keys():
             if v > Version(self):
-                break
+                continue
             result = result.union(self._GA_COMPONENTS_VERSION[v])
         # Some protos do not compile due to inconvenient system macros clashing with proto enum values.
         # Protobuf can workaround these problems, but the current version in Conan index (protobuf/3.21.4)
@@ -274,11 +286,31 @@ class GoogleCloudCppConan(ConanFile):
         rmdir(self, path=os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, path=os.path.join(self.package_folder, "lib", "pkgconfig"))
 
+    _INTERFACE_COMPONENTS = {
+        'dialogflow_es_protos',
+        'logging_types_protos',
+        'speech_protos',
+        'texttospeech_protos',
+    }
     def _add_proto_component(self, component):
         PROTOS_SHARED_REQUIRES=["googleapis::googleapis", "grpc::grpc++", "grpc::_grpc", "protobuf::libprotobuf"]
         self.cpp_info.components[component].requires = PROTOS_SHARED_REQUIRES
-        self.cpp_info.components[component].libs = [f"google_cloud_cpp_{component}"]
         self.cpp_info.components[component].names["pkg_config"] = f"google_cloud_cpp_{component}"
+        # Starting with 2.10.1 a small number of `*_protos` libraries require
+        # special treatment to avoid ODR violations
+        if Version(self) >= '2.10.1' and component == 'dialogflow_es_protos':
+            self.cpp_info.components[component].libs = ['google_cloud_cpp_cloud_dialogflow_v2_protos']
+            return
+        if Version(self) >= '2.10.1' and component == 'logging_types_protos':
+            self.cpp_info.components[component].libs = ['google_cloud_cpp_logging_type_type_protos']
+            return
+        if Version(self) >= '2.10.1' and component == 'speech_protos':
+            self.cpp_info.components[component].libs = ['google_cloud_cpp_cloud_speech_protos']
+            return
+        if Version(self) >= '2.10.1' and component == 'texttospeech_protos':
+            self.cpp_info.components[component].libs = ['google_cloud_cpp_cloud_texttospeech_protos']
+            return
+        self.cpp_info.components[component].libs = [f"google_cloud_cpp_{component}"]
 
     def _add_grpc_component(self, component, protos, extra=None):
         SHARED_REQUIRES=["grpc_utils", "common", "grpc::grpc++", "grpc::_grpc", "protobuf::libprotobuf", "abseil::absl_memory"]

--- a/recipes/google-cloud-cpp/2.x/patches/2.10.1/001-use-googleapis-conan-package.patch
+++ b/recipes/google-cloud-cpp/2.x/patches/2.10.1/001-use-googleapis-conan-package.patch
@@ -1,0 +1,51 @@
+diff --git a/cmake/CompileProtos.cmake b/cmake/CompileProtos.cmake
+index 9f12300..0e68683 100644
+--- a/cmake/CompileProtos.cmake
++++ b/cmake/CompileProtos.cmake
+@@ -371,21 +371,11 @@ function (google_cloud_cpp_proto_library libname)
+         return()
+     endif ()
+ 
+-    if (${_opt_LOCAL_INCLUDE})
+-        google_cloud_cpp_generate_proto(
+-            proto_sources ${_opt_UNPARSED_ARGUMENTS} LOCAL_INCLUDE
+-            PROTO_PATH_DIRECTORIES ${_opt_PROTO_PATH_DIRECTORIES})
+-    else ()
+-        google_cloud_cpp_generate_proto(
+-            proto_sources ${_opt_UNPARSED_ARGUMENTS} PROTO_PATH_DIRECTORIES
+-            ${_opt_PROTO_PATH_DIRECTORIES})
+-    endif ()
+-
+     add_library(${libname} ${proto_sources})
+     target_compile_features(${libname} PUBLIC cxx_std_14)
+     set_property(TARGET ${libname} PROPERTY PROTO_SOURCES
+                                             ${_opt_UNPARSED_ARGUMENTS})
+-    target_link_libraries(${libname} PUBLIC gRPC::grpc++ gRPC::grpc
++    target_link_libraries(${libname} PUBLIC gRPC::grpc++ gRPC::grpc googleapis::googleapis
+                                             protobuf::libprotobuf)
+     # We want to treat the generated code as "system" headers so they get
+     # ignored by the more aggressive warnings.
+diff --git a/external/googleapis/CMakeLists.txt b/external/googleapis/CMakeLists.txt
+index c771da0..5f7b7c5 100644
+--- a/external/googleapis/CMakeLists.txt
++++ b/external/googleapis/CMakeLists.txt
+@@ -99,11 +99,6 @@ include(EnableWerror)
+ # patch this value.  Setting the value in a single place makes such patching
+ # easier.
+ set(EXTERNAL_GOOGLEAPIS_PREFIX "${PROJECT_BINARY_DIR}/external/googleapis")
+-set(EXTERNAL_GOOGLEAPIS_SOURCE
+-    "${EXTERNAL_GOOGLEAPIS_PREFIX}/src/googleapis_download"
+-    PARENT_SCOPE)
+-set(EXTERNAL_GOOGLEAPIS_SOURCE
+-    "${EXTERNAL_GOOGLEAPIS_PREFIX}/src/googleapis_download")
+ 
+ # Include the functions to compile proto files and maintain proto libraries.
+ include(CompileProtos)
+@@ -196,7 +191,6 @@ function (external_googleapis_add_library proto)
+ endfunction ()
+ 
+ function (external_googleapis_set_version_and_alias short_name)
+-    add_dependencies("google_cloud_cpp_${short_name}" googleapis_download)
+     set_target_properties(
+         "google_cloud_cpp_${short_name}"
+         PROPERTIES EXPORT_NAME google-cloud-cpp::${short_name}

--- a/recipes/google-cloud-cpp/2.x/patches/2.10.1/002-use-conan-msvc-runtime.patch
+++ b/recipes/google-cloud-cpp/2.x/patches/2.10.1/002-use-conan-msvc-runtime.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 48f1ffd..a9da74a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,7 +53,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+ endif ()
+ 
+ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+-include(SelectMSVCRuntime)
+ 
+ option(GOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK
+        "If enabled, check that the user has defined OPENSSL_ROOT_DIR on macOS"
+diff --git a/cmake/GoogleCloudCppCommon.cmake b/cmake/GoogleCloudCppCommon.cmake
+index b487a1b..880c98f 100644
+--- a/cmake/GoogleCloudCppCommon.cmake
++++ b/cmake/GoogleCloudCppCommon.cmake
+@@ -17,9 +17,6 @@
+ # Get the destination directories based on the GNU recommendations.
+ include(GNUInstallDirs)
+ 
+-# Pick the right MSVC runtime libraries.
+-include(SelectMSVCRuntime)
+-
+ # Enable Werror
+ include(EnableWerror)
+ 
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index 0cb7a9a..d9016a0 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -14,9 +14,6 @@
+ # limitations under the License.
+ # ~~~
+ 
+-# Pick the right MSVC runtime libraries.
+-include(SelectMSVCRuntime)
+-
+ add_executable(gcs2cbt gcs2cbt.cc)
+ target_link_libraries(gcs2cbt google-cloud-cpp::bigtable
+                       google-cloud-cpp::storage google-cloud-cpp::grpc_utils)
+diff --git a/external/googleapis/CMakeLists.txt b/external/googleapis/CMakeLists.txt
+index 5f7b7c5..efa6e98 100644
+--- a/external/googleapis/CMakeLists.txt
++++ b/external/googleapis/CMakeLists.txt
+@@ -151,8 +151,6 @@ if (PROTO_INCLUDE_DIR)
+     list(INSERT PROTOBUF_IMPORT_DIRS 0 "${PROTO_INCLUDE_DIR}")
+ endif ()
+ 
+-include(SelectMSVCRuntime)
+-
+ google_cloud_cpp_add_protos_property()
+ 
+ function (external_googleapis_short_name var proto)

--- a/recipes/google-cloud-cpp/2.x/test_package/spanner.cpp
+++ b/recipes/google-cloud-cpp/2.x/test_package/spanner.cpp
@@ -3,7 +3,7 @@
 
 int main(int argc, char *argv[]) {
   if (argc != 1) {
-    std::cerr << "Usage: bigtable\n";
+    std::cerr << "Usage: spanner\n";
     return 1;
   }
   auto const project_id =  std::string{"test-only-invalid"};

--- a/recipes/google-cloud-cpp/config.yml
+++ b/recipes/google-cloud-cpp/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: "all"
   "2.5.0":
     folder: "2.x"
+  "2.10.1":
+    folder: "2.x"


### PR DESCRIPTION
Specify library name and version:  **google-cloud-cpp/2.10.1**

Updates `google-cloud-cpp` to the latest release (v2.10.1).  This is the last in a series of PRs to complete the update.

The patches are substantially smaller in v2.10.1, as compared to v2.5.0, because I changed the package upstream to require fewer patches.  The conanfile required some changes because I never tested supporting more than one version.  I think it will require fewer changes in the future.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
