### PR TITLE
glib: revert shared option to be False by default

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -35,7 +35,7 @@ class GLibConan(ConanFile):
         "with_mount": [True, False],
     }
     default_options = {
-        "shared": True,
+        "shared": False,
         "fPIC": True,
         "with_elf": True,
         "with_mount": True,

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake, CMakeDeps, CMakeToolchain
-from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
 from conan.tools.gnu import PkgConfig, PkgConfigDeps
 import os
 
@@ -25,6 +25,15 @@ class TestPackageConan(ConanFile):
         tc.generate()
         virtual_run_env = VirtualRunEnv(self)
         virtual_run_env.generate()
+
+        if self.settings.os == "Macos":
+            env = Environment()
+            # Avoid conflicts with system libiconv
+            # see: https://github.com/conan-io/conan-center-index/pull/17610#issuecomment-1552921286
+            env.define_path("DYLD_FALLBACK_LIBRARY_PATH", "$DYLD_LIBRARY_PATH")
+            env.define_path("DYLD_LIBRARY_PATH", "")
+            env.vars(self, scope="run").save_script("conanrun_macos_runtimepath")
+
         if self.settings.os == "Windows":
             deps = CMakeDeps(self)
             deps.generate()


### PR DESCRIPTION
Specify library name and version:  **glib/all**

Revert the `shared` option to have a `False` value by default, in line with the Conan Center defaults.

The PR that introduced this change: https://github.com/conan-io/conan-center-index/pull/12171 attempted to do so in order to be able to _remove_ the `full_package_mode` on the `glib` dependency found in recipes where `glib` is a dependency. However, `full_package_mode` has not been removed, and most crucially, having `shared=True` by default does _not_ solve the problem mentioned in this issue: https://github.com/conan-io/conan-center-index/issues/11684 - there will still be missing binaries if the exact version of glib changes across the dependency graph. 


Having a default on `shared=True` causes "missing binary" problems in the Conan 2.0 CI pipeline, when `glib` is `tool_requires` - it will require a configuration where `glib` is shared, but all its dependencies are static - we no longer build this sort of binaries in Conan Center (static libraries embedded in shared ones), as it can cause symbol duplication across multiple libraries loaded in the same process.

The problems described in https://github.com/conan-io/conan-center-index/pull/7734 are already solved in Conan 2.0 - so in due time (sooner rather than later), we can due away with the `full_package_mode` as Conan 2.0 can handle this without issue.

### Changes in test package
On macOS, when `*:shared=True`, the `VirtualRunEnv` will generate an entry in `DYLD_LIBRARY_PATH` that contains `libiconv.2.dylib` from Conan. 
When running the `gdbus-codegen` (a Python script) tool in the test_package, the Python interpreter itself was built against a different libiconv, and fails with the following error:
```
   glib/2.75.2 (test package): RUN: /Users/jenkins/w/prod-v2/BuildSingleReference@3/p/glibbe449c3b10b54/p/bin/gdbus-codegen -h
   dyld[22955]: Symbol not found: (_iconv)
     Referenced from: '/usr/local/Cellar/gettext/0.21/lib/libintl.8.dylib'
     Expected in: '/Users/jenkins/w/prod-v2/BuildSingleReference@3/p/libic50650dc30c43d/p/lib/libiconv.2.dylib'
   /bin/sh: line 1: 22955 Abort trap: 6           /Users/jenkins/w/prod-v2/BuildSingleReference@3/p/glibbe449c3b10b54/p/bin/gdbus-codegen -h
```

This PR fixes this by unsetting `DYLD_LIBRARY_PATH` and setting `DYLD_FALLBACK_LIBRARY_PATH` instead - this allows the runtime linker to load the libraries first by their install location, and only if not found would they be loaded from paths in the environment variable. I don't expect this to be something we need to do generally in more recipes, as it is specific to this tool invoking a system managed Python interpreter.
