### PR TITLE
ninja: use static runtime on Linux

### DIFF
--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -30,6 +30,8 @@ class NinjaConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_TESTING"] = False
         if self.settings.os == "Linux" and "libstdc++" in self.settings.compiler.libcxx:
+            # Link C++ library statically on Linux so that it can run on systems
+            # with an older C++ runtime
             tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static-libstdc++ -static-libgcc"
         tc.generate()
 

--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -29,6 +29,8 @@ class NinjaConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_TESTING"] = False
+        if self.settings.os == "Linux" and "libstdc++" in self.settings.compiler.libcxx:
+            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static-libstdc++ -static-libgcc"
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Specify library name and version:  **ninja/all**

This PR ensures that ninja is built with a static C++ runtime on Linux, taking advantage of the fact that Ninja has no dependency on other libraries. 

Additional background:
This recipe erases the `compiler` setting, however it is still relevant at runtime since it requires that the system this executable is run on, has a version of libstdc++ that is _at least_ the same or greater than the one it was built with, which can cause problems on other systems.

More information:
**Before this change**:
```
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-aarch64.so.1]
```
Executable size: 305 KB

**After this PR**:
```
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-aarch64.so.1]
```

Executable size: 1.7 MB

I think the increase in executable size is negligible while still broadening the Linux distros this can run on (the other axis being `glibc`, but our Docker images ensure that is an older version for broader compatibility).


Close: https://github.com/conan-io/conan-center-index/issues/17390