### PR TITLE
libxml2: add version 2.11.4

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.11.4":
+    url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.4.tar.xz"
+    sha256: "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7"
   "2.11.3":
     url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.3.tar.xz"
     sha256: "f1acae1664bda006cd81bfc238238217043d586d06659d5c0e3d1bcebe040870"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.11.4":
+    folder: all
   "2.11.3":
     folder: all
   "2.10.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libxml2/1.11.4**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
