### PR TITLE
ftxui: add version 4.1.0, add package_type

### DIFF
--- a/recipes/ftxui/all/conandata.yml
+++ b/recipes/ftxui/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.1.0":
+    url: "https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/v4.1.0.tar.gz"
+    sha256: "6f03f5917b44c9bc12335ad891a93813bbb6e738e0bd0c44f97bcc6077c45980"
   "4.0.0":
     url: "https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/v4.0.0.tar.gz"
     sha256: "7276e4117429ebf8e34ea371c3ea4e66eb99e0f234cb4c5c85fca17174a53dfa"
@@ -9,6 +12,10 @@ sources:
     url: "https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/v2.0.0.tar.gz"
     sha256: "d891695ef22176f0c09f8261a37af9ad5b262dd670a81e6b83661a23abc2c54f"
 patches:
+  "4.1.0":
+    - patch_file: "patches/4.0.0-0002-install-dll.patch"
+      patch_description: "add runtime destionation for windows shared build"
+      patch_type: "conan"
   "4.0.0":
     - patch_file: "patches/4.0.0-0002-install-dll.patch"
       patch_description: "add runtime destionation for windows shared build"

--- a/recipes/ftxui/all/conanfile.py
+++ b/recipes/ftxui/all/conanfile.py
@@ -16,6 +16,7 @@ class FTXUIConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/ArthurSonzogni/FTXUI"
     topics = ("ncurses", "terminal", "screen", "tui")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -91,9 +92,13 @@ class FTXUIConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        if Version(self.version) >= "4.1.0":
+            rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "ftxui")
+        if Version(self.version) >= "4.1.0":
+            self.cpp_info.set_property("pkg_config_name", "ftxui")
 
         self.cpp_info.components["ftxui-dom"].set_property("cmake_target_name", "ftxui::dom")
         self.cpp_info.components["ftxui-dom"].libs = ["ftxui-dom"]

--- a/recipes/ftxui/config.yml
+++ b/recipes/ftxui/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.1.0":
+    folder: all
   "4.0.0":
     folder: all
   "3.0.0":


### PR DESCRIPTION
Specify library name and version:  **ftxui/4.1.0**

- add version 4.1.0
  - since 4.1.0, ftxui provides pkgconfig
- add package_type

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
