### PR TITLE
libuv: add version 1.45.0, support conan v2 more

### DIFF
--- a/recipes/libuv/all/conandata.yml
+++ b/recipes/libuv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.45.0":
+    url: "https://github.com/libuv/libuv/archive/v1.45.0.tar.gz"
+    sha256: "458e34d5ef7f3c0394a2bfd8c39d757cb1553baa5959b9b4b45df63aa027a228"
   "1.44.2":
     url: "https://github.com/libuv/libuv/archive/v1.44.2.tar.gz"
     sha256: "e6e2ba8b4c349a4182a33370bb9be5e23c51b32efb9b9e209d0e8556b73a48da"
@@ -24,6 +27,10 @@ sources:
     url: "https://github.com/libuv/libuv/archive/v1.38.1.zip"
     sha256: "0359369492742eb2a36312fffe26f80bcffe4cec981a4fd72d182b061ee14890"
 patches:
+  "1.45.0":
+    - patch_file: "patches/1.45.0/fix-cmake.patch"
+      patch_description: "separate shared and static library build"
+      patch_type: "conan"
   "1.44.2":
     - patch_file: "patches/1.44.2/fix-cmake.patch"
       patch_description: "separate shared and static library build"

--- a/recipes/libuv/all/conanfile.py
+++ b/recipes/libuv/all/conanfile.py
@@ -112,6 +112,8 @@ class LibuvConan(ConanFile):
             self.cpp_info.system_libs = ["dl", "pthread", "rt"]
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ["iphlpapi", "psapi", "userenv", "ws2_32"]
+            if Version(self.version) >= "1.45.0":
+                self.cpp_info.system_libs.append("dbghelp")
 
         # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
         self.cpp_info.names["pkg_config"] = "libuv" if self.options.shared else "libuv-static"

--- a/recipes/libuv/all/conanfile.py
+++ b/recipes/libuv/all/conanfile.py
@@ -95,7 +95,11 @@ class LibuvConan(ConanFile):
 
     @property
     def _target_lib_name(self):
-        return "uv" if self.options.shared or Version(self.version) >= "1.45.0" else "uv_a"
+        if Version(self.version) < "1.45.0":
+            return "uv" if self.options.shared else "uv_a"
+        if is_msvc(self):
+            return "uv" if self.options.shared else "libuv"
+        return "uv"
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "libuv")

--- a/recipes/libuv/all/conanfile.py
+++ b/recipes/libuv/all/conanfile.py
@@ -75,7 +75,7 @@ class LibuvConan(ConanFile):
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
-            {self._target_lib_name: "libuv::libuv"}
+            {self._target_name: "libuv::libuv"}
         )
 
     def _create_cmake_module_alias_targets(self, module_file, targets):
@@ -94,18 +94,24 @@ class LibuvConan(ConanFile):
         return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     @property
-    def _target_lib_name(self):
+    def _target_name(self):
         if Version(self.version) < "1.45.0":
             return "uv" if self.options.shared else "uv_a"
-        if is_msvc(self):
-            return "uv" if self.options.shared else "libuv"
+        return "uv"
+
+    @property
+    def _lib_name(self):
+        if Version(self.version) < "1.45.0":
+            return "uv" if self.options.shared else "uv_a"
+        if is_msvc(self) and not self.options.shared:
+            return "libuv"
         return "uv"
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "libuv")
-        self.cpp_info.set_property("cmake_target_name", self._target_lib_name)
+        self.cpp_info.set_property("cmake_target_name", self._target_name)
         self.cpp_info.set_property("pkg_config_name", "libuv" if self.options.shared else "libuv-static")
-        self.cpp_info.libs = [self._target_lib_name]
+        self.cpp_info.libs = [self._lib_name]
         if self.options.shared:
             self.cpp_info.defines = ["USING_UV_SHARED=1"]
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/libuv/all/patches/1.45.0/fix-cmake.patch
+++ b/recipes/libuv/all/patches/1.45.0/fix-cmake.patch
@@ -1,0 +1,58 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 93733dd..d9e7acc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -460,8 +460,7 @@ if(LIBUV_BUILD_SHARED)
+   endif()
+   target_link_libraries(uv ${uv_libraries})
+   set_target_properties(uv PROPERTIES OUTPUT_NAME "uv")
+-endif()
+-
++else()
+ add_library(uv_a STATIC ${uv_sources})
+ target_compile_definitions(uv_a PRIVATE ${uv_defines})
+ target_compile_options(uv_a PRIVATE ${uv_cflags})
+@@ -480,6 +479,8 @@ set_target_properties(uv_a PROPERTIES OUTPUT_NAME "uv")
+ if(MSVC)
+   set_target_properties(uv_a PROPERTIES PREFIX "lib")
+ endif()
++endif()
++
+ 
+ if(LIBUV_BUILD_TESTS)
+   # Small hack: use ${uv_test_sources} now to get the runner skeleton,
+@@ -732,18 +733,10 @@ set(UV_VERSION_MAJOR "${CMAKE_MATCH_1}")
+ set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+ set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+ set(prefix ${CMAKE_INSTALL_PREFIX})
+-configure_file(libuv-static.pc.in libuv-static.pc @ONLY)
+ 
+ install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+ install(FILES LICENSE-extra DESTINATION ${CMAKE_INSTALL_DOCDIR})
+-install(FILES ${PROJECT_BINARY_DIR}/libuv-static.pc
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+-install(TARGETS uv_a EXPORT libuvConfig
+-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-install(EXPORT libuvConfig
+-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv
+-	NAMESPACE libuv::)
+ 
+ if(LIBUV_BUILD_SHARED)
+   # The version in the filename is mirroring the behaviour of autotools.
+@@ -757,6 +750,15 @@ if(LIBUV_BUILD_SHARED)
+           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++else()
++  configure_file(libuv-static.pc.in libuv-static.pc @ONLY)
++  install(FILES ${PROJECT_BINARY_DIR}/libuv-static.pc
++          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
++  install(TARGETS uv_a EXPORT libuvConfig
++          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  install(EXPORT libuvConfig
++    	  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libuv
++  	      NAMESPACE libuv::)
+ endif()
+ 
+ if(MSVC)

--- a/recipes/libuv/config.yml
+++ b/recipes/libuv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.45.0":
+    folder: all
   "1.44.2":
     folder: all
   "1.44.1":


### PR DESCRIPTION
Specify library name and version:  **libuv/***

- add version 1.45.0
   - added `LIBUV_BUILD_SHARED` macro
   - rename uv_a.a to uv in static build
- add `package_type`
- use `rm_safe`
- remove destination from `get()`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
