### PR TITLE
expat: add `large_size` option`

### DIFF
--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -20,11 +20,13 @@ class ExpatConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "char_type": ["char", "wchar_t", "ushort"],
+        "large_size": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "char_type": "char",
+        "large_size": False,
     }
 
     def export_sources(self):
@@ -57,6 +59,7 @@ class ExpatConan(ConanFile):
         if is_msvc(self):
             tc.variables["EXPAT_MSVC_STATIC_CRT"] = is_msvc_static_runtime(self)
         tc.variables["EXPAT_BUILD_PKGCONFIG"] = False
+        tc.variables["EXPAT_LARGE_SIZE"] = self.options.large_size
         tc.generate()
 
     def build(self):
@@ -88,6 +91,8 @@ class ExpatConan(ConanFile):
             self.cpp_info.defines.append("XML_UNICODE")
         elif self.options.get_safe("char_type") == "wchar_t":
             self.cpp_info.defines.append("XML_UNICODE_WCHAR_T")
+        if self.options.large_size:
+            self.cpp_info.defines.append("XML_LARGE_SIZE")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")


### PR DESCRIPTION
Specify library name and version:  **expat/***

Try to fix #17541.

Because EXPAT_LARGE_SIZE has been introduced since 2.2.8, all versions in conan recipe support this feature.

https://github.com/libexpat/libexpat/blob/R_2_2_8/expat/Changes

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
