### PR TITLE
minizip-ng: add version 4.0.0

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.0":
+    url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.0.tar.gz"
+    sha256: "f9062e576de026fd5026d65597de3b05263cd4d91400cacdbbe36dfa8a642fff"
   "3.0.9":
     url: "https://github.com/zlib-ng/minizip-ng/archive/3.0.9.tar.gz"
     sha256: "992693a532eb15b20d306e6aeea1a1a6501bd19dca993ebe9a95fd22d6b7fd74"

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -136,9 +136,14 @@ class MinizipNgConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                              "set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE 1)",
-                              "")
+        if Version(self.version) < "4.0.0":
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                                  "set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE 1)",
+                                  "")
+        else:
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                                  "set_target_properties(${MINIZIP_TARGET} PROPERTIES POSITION_INDEPENDENT_CODE 1)",
+                                  "")
 
     def build(self):
         self._patch_sources()
@@ -169,6 +174,9 @@ class MinizipNgConan(ConanFile):
         if self.options.with_bzip2:
             self.cpp_info.components["minizip"].defines.append("HAVE_BZIP2")
 
+        if Version(self.version) >= "4.0.0":
+            self.cpp_info.components["minizip"].includedirs.append(os.path.join("include", "minizip-ng"))
+
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "minizip"
         self.cpp_info.filenames["cmake_find_package_multi"] = "minizip"
@@ -192,3 +200,6 @@ class MinizipNgConan(ConanFile):
             self.cpp_info.components["minizip"].frameworks.extend(["CoreFoundation", "Security"])
         if self.settings.os != "Windows" and self.options.with_iconv:
             self.cpp_info.components["minizip"].requires.append("libiconv::libiconv")
+
+
+

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -99,6 +99,8 @@ class MinizipNgConan(ConanFile):
     def build_requirements(self):
         if self._needs_pkg_config:
             self.tool_requires("pkgconf/1.9.3")
+        if Version(self.version) >= "4.0.0":
+            self.tool_requires("cmake/[>=3.19 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/minizip-ng/config.yml
+++ b/recipes/minizip-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.0":
+    folder: all
   "3.0.9":
     folder: all
   "3.0.8":


### PR DESCRIPTION
Specify library name and version:  **minizip-ng/***

Try to fix #17634.

- add version 4.0.0
  - fix patch for POSITION_INDEPENDENT_CODE
  - add `include/minizip-ng` to include path 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
