### PR TITLE
daw_header_libraries: add version 2.92.0

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.92.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.92.0.tar.gz"
+    sha256: "96835f0ff4d3082a38b4ef4c14653c88e193cd26a08cd406fdbfadcfd654d136"
   "2.88.0":
     url: "https://github.com/beached/header_libraries/archive/v2.88.0.tar.gz"
     sha256: "2a634763f3d34f206f6b352ac9609a89d501059afea0ba7c857bd55adc435890"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.92.0":
+    folder: all
   "2.88.0":
     folder: all
   "2.85.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_header_libraries/2.92.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
