### PR TITLE
c-ares: add version 1.19.1

### DIFF
--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.19.1":
+    url: "https://github.com/c-ares/c-ares/releases/download/cares-1_19_1/c-ares-1.19.1.tar.gz"
+    sha256: "321700399b72ed0e037d0074c629e7741f6b2ec2dda92956abe3e9671d3e268e"
   "1.19.0":
     url: "https://github.com/c-ares/c-ares/releases/download/cares-1_19_0/c-ares-1.19.0.tar.gz"
     sha256: "bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3"

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.19.1":
+    folder: all
   "1.19.0":
     folder: all
   "1.18.1":


### PR DESCRIPTION
This fixes the following security issues:

- CVE-2023-32067. High. 0-byte UDP payload causes Denial of Service [12]
- CVE-2023-31147. Moderate. Insufficient randomness in generation of DNS query IDs [13]
- CVE-2023-31130. Moderate. Buffer Underwrite in ares_inet_net_pton() [14]
- CVE-2023-31124. Low. AutoTools does not set CARES_RANDOM_FILE during cross compilation [15]

Specify library name and version:  **c-ares/1.19.1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
