### PR TITLE
arsenalgear: add transitive_headers to exprtk

### DIFF
--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -59,7 +59,9 @@ class ArsenalgearConan(ConanFile):
         if Version(self.version) < "2.0.0":
             self.requires("boost/1.81.0")
             if self.settings.os in ["Linux", "Macos"]:
-                self.requires("exprtk/0.0.2")
+                # exprtk is used in public header of arsenalgear
+                # https://github.com/JustWhit3/arsenalgear-cpp/blob/v1.2.2/include/math.hpp
+                self.requires("exprtk/0.0.2", transitive_headers=True)
 
     def validate(self):
         # arsenalgear doesn't support Visual Studio(yet).


### PR DESCRIPTION
Specify library name and version:  **exprtk/1.2.2**


While exprtk is used in public header of arsenalgear,
https://github.com/JustWhit3/arsenalgear-cpp/blob/v1.2.2/include/math.hpp
I have to add transitive_headers to exprtk.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
