### PR TITLE
[util-linux-libuuid] Add util-linux-libuuid package

### DIFF
--- a/recipes/util-linux-libuuid/all/conandata.yml
+++ b/recipes/util-linux-libuuid/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.3.0":
+    url: "https://github.com/util-linux/util-linux/archive/refs/tags/v2.39.tar.gz"
+    sha256: "186cb427cd6b4654f381357b60af7ffb0ae9bb50d7af7d87e0723858f7318b80"

--- a/recipes/util-linux-libuuid/all/conandata.yml
+++ b/recipes/util-linux-libuuid/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.3.0":
+  "2.39":
     url: "https://github.com/util-linux/util-linux/archive/refs/tags/v2.39.tar.gz"
     sha256: "186cb427cd6b4654f381357b60af7ffb0ae9bb50d7af7d87e0723858f7318b80"

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -1,0 +1,99 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rm, rmdir, chdir
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class UtilLinuxLibuuidConan(ConanFile):
+    name = "util-linux-libuuid"
+    description = "Universally unique id library"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/util-linux/util-linux.git"
+    license = "BSD-3-Clause"
+    topics = "id", "identifier", "unique", "uuid"
+    package_type = "library"
+    provides = "libuuid"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _has_sys_file_header(self):
+        return self.settings.os in ["FreeBSD", "Linux", "Macos"]
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration(f"{self.ref} is not supported on Windows")
+
+    def build_requirements(self):
+        self.tool_requires("libtool/2.4.7")
+        self.tool_requires("m4/1.4.19")
+        self.tool_requires("pkgconf/1.9.3")
+        self.tool_requires("bison/3.8.2")
+        self.tool_requires("autoconf/2.71")
+        self.tool_requires("automake/1.16.5")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+        tc = AutotoolsToolchain(self)
+        tc.configure_args.append("--disable-all-programs")
+        tc.configure_args.append("--enable-libuuid")
+        if self._has_sys_file_header:
+            tc.extra_defines.append("HAVE_SYS_FILE_H")
+        if "x86" in self.settings.arch:
+            tc.extra_cflags.append("-mstackrealign")
+        tc.generate()
+
+    def build(self):
+        with chdir(self, self.source_folder):
+            self.run("./autogen.sh")
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        copy(self, "COPYING.BSD-3-Clause", src=os.path.join(self.source_folder, "Documentation", "licenses"), dst=os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "bin"))
+        rmdir(self, os.path.join(self.package_folder, "sbin"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "uuid")
+        self.cpp_info.set_property("cmake_target_name", "libuuid::libuuid")
+        self.cpp_info.set_property("cmake_file_name", "libuuid")
+        self.cpp_info.libs = ["uuid"]
+        self.cpp_info.includedirs.append(os.path.join("include", "uuid"))

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rm, rmdir, chdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -46,7 +47,23 @@ class UtilLinuxLibuuidConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
+    def _minimum_compiler_version(self, compiler, build_type):
+        min_version = {
+            "gcc": {
+                "Release": "4",
+                "Debug": "8",
+            },
+            "clang": {
+                "Release": "3",
+                "Debug": "3",
+            },
+        }
+        return min_version[str(compiler)][str(build_type)]
+
     def validate(self):
+        min_version = self._minimum_compiler_version(self.settings.compiler, self.settings.build_type)
+        if Version(self.settings.compiler.version) < min_version:
+            raise ConanInvalidConfiguration(f"{self.settings.compiler} {self.settings.compiler.version} does not meet the minimum version requirement of version {min_version}")
         if self.settings.os == "Windows":
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on Windows")
 

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -62,7 +62,7 @@ class UtilLinuxLibuuidConan(ConanFile):
                 "Debug": "5",
             },
         }
-        return min_version[str(compiler)][str(build_type)]
+        return min_version.get(str(compiler), {}).get(str(build_type), "0")
 
     def validate(self):
         min_version = self._minimum_compiler_version(self.settings.compiler, self.settings.build_type)

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -70,6 +70,11 @@ class UtilLinuxLibuuidConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.settings.compiler} {self.settings.compiler.version} does not meet the minimum version requirement of version {min_version}")
         if self.settings.os == "Windows":
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on Windows")
+        if self.settings.os == "Macos":
+            # FIXME: Add Macos compatibility. This is currently breaking because builds are unable to find libtool-2
+            # This is a bit puzzling given `libtool` is a tool_requires, and I haven't been able to replicate this error
+            # locally.
+            raise ConanInvalidConfiguration(f"{self.ref} is not currently supported on Macos. Please contribute this functionality if you require it.")
 
     def requirements(self):
         if self.settings.os == "Macos":

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -74,7 +74,7 @@ class UtilLinuxLibuuidConan(ConanFile):
     def requirements(self):
         if self.settings.os == "Macos":
             # Required because libintl.{a,dylib} is not distributed via libc on Macos
-            self.requires("gettext/0.21")
+            self.requires("libgettext/0.21")
 
     def build_requirements(self):
         self.tool_requires("libtool/2.4.7")

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -57,6 +57,10 @@ class UtilLinuxLibuuidConan(ConanFile):
                 "Release": "3",
                 "Debug": "3",
             },
+            "apple-clang": {
+                "Release": "5",
+                "Debug": "5",
+            },
         }
         return min_version[str(compiler)][str(build_type)]
 

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -128,7 +128,7 @@ class UtilLinuxLibuuidConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "uuid")
-        self.cpp_info.set_property("cmake_target_name", "libuuid::libuuid")
-        self.cpp_info.set_property("cmake_file_name", "libuuid")
+        self.cpp_info.set_property("cmake_target_name", "LibUUID::LibUUID")
+        self.cpp_info.set_property("cmake_file_name", "LibUUID")
         self.cpp_info.libs = ["uuid"]
         self.cpp_info.includedirs.append(os.path.join("include", "uuid"))

--- a/recipes/util-linux-libuuid/all/test_package/CMakeLists.txt
+++ b/recipes/util-linux-libuuid/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES C)
+
+find_package(libuuid REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE libuuid::libuuid)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/util-linux-libuuid/all/test_package/CMakeLists.txt
+++ b/recipes/util-linux-libuuid/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES C)
 
-find_package(libuuid REQUIRED CONFIG)
+find_package(LibUUID REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE LibUUID::LibUUID)

--- a/recipes/util-linux-libuuid/all/test_package/CMakeLists.txt
+++ b/recipes/util-linux-libuuid/all/test_package/CMakeLists.txt
@@ -4,5 +4,5 @@ project(test_package LANGUAGES C)
 find_package(libuuid REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE libuuid::libuuid)
+target_link_libraries(${PROJECT_NAME} PRIVATE LibUUID::LibUUID)
 target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/util-linux-libuuid/all/test_package/conanfile.py
+++ b/recipes/util-linux-libuuid/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/util-linux-libuuid/all/test_package/test_package.c
+++ b/recipes/util-linux-libuuid/all/test_package/test_package.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+
+#include "uuid/uuid.h"
+
+int main(int argc, char *argv[]) {
+    uuid_t uuid;
+    uuid_generate_time_safe(uuid);
+
+    char uuid_str[37];
+    uuid_unparse_lower(uuid, uuid_str);
+    printf("generate uuid=%s\n", uuid_str);
+
+    uuid_t uuid2;
+    uuid_parse(uuid_str, uuid2);
+
+    int rv;
+    rv = uuid_compare(uuid, uuid2);
+    printf("uuid_compare() result=%d\n", rv);
+
+    uuid_t uuid3;
+    uuid_parse("1b4e28ba-2fa1-11d2-883f-0016d3cca427", uuid3);
+    rv = uuid_compare(uuid, uuid3);
+    printf("uuid_compare() result=%d\n", rv);
+
+    rv = uuid_is_null(uuid);
+    printf("uuid_null() result=%d\n", rv);
+
+    uuid_clear(uuid);
+    rv = uuid_is_null(uuid);
+    printf("uuid_null() result=%d\n", rv);
+
+    return 0;
+}

--- a/recipes/util-linux-libuuid/config.yml
+++ b/recipes/util-linux-libuuid/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.3.0":
+    folder: all

--- a/recipes/util-linux-libuuid/config.yml
+++ b/recipes/util-linux-libuuid/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.3.0":
+  "2.39":
     folder: all


### PR DESCRIPTION
* This is the most actively maintained fork of libuuid
* This package should supersede the existing libuuid recipe, which should be deprecated as an inactive fork of the original libuuid. The existing libuuid recipe does not match what gets installed on linux systems, which causes a symbol conflict when a `system` package is used with `libuuid` in the dependency tree, such as `xorg/system`. See https://github.com/conan-io/conan-center-index/pull/17427#issuecomment-1545476420 for a concrete example of this.

Closes #17337

Specify library name and version:  **libuuid/2.39**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
