### PR TITLE
Update cppitertools for conan v2

### DIFF
--- a/recipes/cppitertools/all/conanfile.py
+++ b/recipes/cppitertools/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.files import get, copy, rename
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=1.50.0"
 
 
 class CppItertoolsConan(ConanFile):

--- a/recipes/cppitertools/all/conanfile.py
+++ b/recipes/cppitertools/all/conanfile.py
@@ -60,6 +60,10 @@ class CppItertoolsConan(ConanFile):
     def package(self):
         copy(self, "*.hpp", src=os.path.join(self.source_folder, self._source_subfolder), dst=os.path.join(self.package_folder,"include", "cppitertools"), excludes=('examples/**', 'test/**'))
         copy(self, "LICENSE.md", src=os.path.join(self.source_folder, self._source_subfolder), dst=os.path.join(self.package_folder,"licenses"))
-
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "cppitertools")
+        self.cpp_info.set_property("cmake_target_name", "cppitertools::cppitertools")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
     def package_id(self):
         self.info.clear()

--- a/recipes/cppitertools/all/conanfile.py
+++ b/recipes/cppitertools/all/conanfile.py
@@ -36,6 +36,7 @@ class CppItertoolsConan(ConanFile):
 
         minimal_version = {
             "Visual Studio": "15",
+            "msvc": "191",
             "gcc": "7",
             "clang": "5.0",
             "apple-clang": "9.1"

--- a/recipes/cppitertools/all/conanfile.py
+++ b/recipes/cppitertools/all/conanfile.py
@@ -61,4 +61,4 @@ class CppItertoolsConan(ConanFile):
         copy(self, "LICENSE.md", src=os.path.join(self.source_folder, self._source_subfolder), dst=os.path.join(self.package_folder,"licenses"))
 
     def package_id(self):
-        self.info.settings.clear()
+        self.info.clear()

--- a/recipes/cppitertools/all/test_package/CMakeLists.txt
+++ b/recipes/cppitertools/all/test_package/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
 find_package(cppitertools REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/cppitertools/all/test_package/conanfile.py
+++ b/recipes/cppitertools/all/test_package/conanfile.py
@@ -1,23 +1,37 @@
 import os
-from conans import ConanFile, CMake, tools
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeDeps
+from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ZIP_LONGEST"] = self.dependencies["cppitertools"].options.zip_longest
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
-        if self.options["cppitertools"].zip_longest:
-            cmake.definitions["ZIP_LONGEST"] = True
         cmake.configure()
         cmake.build()
 
-    def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+    def layout(self):
+        cmake_layout(self)
 
-            if self.options["cppitertools"].zip_longest:
-                bin_path = os.path.join("bin", "test_zip_longest")
-                self.run(bin_path, run_environment=True)
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")
+            # sense if it was built because we don't have access to:
+            # self.dependencies["cppitertools"].options.zip_longest
+            cmd = os.path.join(self.cpp.build.bindir, "test_zip_longest")
+            if os.path.exists(cmd):
+                self.run(cmd, env="conanrun")


### PR DESCRIPTION
Specify library name and version:  **cppitertools/2.1**

I'm updating for it to be conan v2 compatabile

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
