### PR TITLE
add spdlog/1.9.1 version to conandata.yml

### DIFF
--- a/recipes/spdlog/all/conandata.yml
+++ b/recipes/spdlog/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "1.9.2":
     url: "https://github.com/gabime/spdlog/archive/v1.9.2.tar.gz"
     sha256: "6fff9215f5cb81760be4cc16d033526d1080427d236e86d70bb02994f85e3d38"
+  "1.9.1":
+    url: "https://github.com/gabime/spdlog/archive/v1.9.1.tar.gz"
+    sha256: "9a452cfa24408baccc9b2bc2d421d68172a7630c99e9504a14754be840d31a62"
   "1.8.5":
     url: "https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz"
     sha256: "944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8"


### PR DESCRIPTION
Add spdlog/1.9.1 version to `conandata.yml`.

It was tested locally with some test applications to check the `url ` and `sha265 ` are right.

---

- [ X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
