### PR TITLE
libcurl: add version 8.1.1, update libnghttp2

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.1.1":
+    url: "https://curl.se/download/curl-8.1.1.tar.gz"
+    sha256: "44915e6708551bff2b4fd1615d593bc843b00ba013012634c04208702e354ab2"
   "8.0.1":
     url: "https://curl.se/download/curl-8.0.1.tar.gz"
     sha256: "5fd29000a4089934f121eff456101f0a5d09e2a3e89da1d714adf06c4be887cb"

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -185,7 +185,7 @@ class LibcurlConan(ConanFile):
         elif self.options.with_ssl == "wolfssl":
             self.requires("wolfssl/5.5.1")
         if self.options.with_nghttp2:
-            self.requires("libnghttp2/1.51.0")
+            self.requires("libnghttp2/1.53.0")
         if self.options.with_libssh2:
             self.requires("libssh2/1.10.0")
         if self.options.with_zlib:

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.1.1":
+    folder: all
   "8.0.1":
     folder: all
   "7.88.1":


### PR DESCRIPTION
Specify library name and version:  **libcurl/***

- add version 8.1.1
- update libnghttp2


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
