### PR TITLE
magic_enum: add version 0.9.0, minor improvements

### DIFF
--- a/recipes/magic_enum/all/conandata.yml
+++ b/recipes/magic_enum/all/conandata.yml
@@ -1,28 +1,31 @@
 sources:
-  "0.6.5":
-    sha256: "37A69482517C8976CB48CD271DA8C6BA92E07EE2AB2BDD7CAEF4C8158AF77359"
-    url: "https://github.com/Neargye/magic_enum/archive/v0.6.5.tar.gz"
-  "0.6.6":
-    sha256: "1033f9a9315023feebb48f20d5a572149ec72c1e95a52bcf7042a412ff9d2e28"
-    url: "https://github.com/Neargye/magic_enum/archive/v0.6.6.tar.gz"
-  "0.7.0":
-    sha256: "4fe6627407a656d0d73879c0346b251ccdcfb718c37bef5410ba172c7c7d5f9a"
-    url: "https://github.com/Neargye/magic_enum/archive/v0.7.0.tar.gz"
-  "0.7.1":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.7.1.tar.gz"
-    sha256: "11bb590dd055194e92936fa4d0652084c14bd23ac8e4b5a02271b6259a05cec9"
-  "0.7.2":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.7.2.tar.gz"
-    sha256: "a77895ebc684f7a4dd2e4e06529b22e9ae694037f6dee0753d3ce0bbcd5b3e38"
-  "0.7.3":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.7.3.tar.gz"
-    sha256: "b8d0cd848546fee136dc1fa4bb021a1e4dc8fe98e44d8c119faa3ef387636bf7"
-  "0.8.0":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.8.0.tar.gz"
-    sha256: "5e7680e877dd4cf68d9d0c0e3c2a683b432a9ba84fc1993c4da3de70db894c3c"
-  "0.8.1":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.8.1.tar.gz"
-    sha256: "6b948d1680f02542d651fc82154a9e136b341ce55c5bf300736b157e23f9df11"
+  "0.9.0":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.9.0.tar.gz"
+    sha256: "2fb2f602b4660f8af539ee00958132a397e138bda19aa1ceae546de3a143386b"
   "0.8.2":
     url: "https://github.com/Neargye/magic_enum/archive/v0.8.2.tar.gz"
     sha256: "62bd7034bbbfc3d7806001767d5775ab42f3ff33bb38366e1ceb21102f0dff9a"
+  "0.8.1":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.8.1.tar.gz"
+    sha256: "6b948d1680f02542d651fc82154a9e136b341ce55c5bf300736b157e23f9df11"
+  "0.8.0":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.8.0.tar.gz"
+    sha256: "5e7680e877dd4cf68d9d0c0e3c2a683b432a9ba84fc1993c4da3de70db894c3c"
+  "0.7.3":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.7.3.tar.gz"
+    sha256: "b8d0cd848546fee136dc1fa4bb021a1e4dc8fe98e44d8c119faa3ef387636bf7"
+  "0.7.2":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.7.2.tar.gz"
+    sha256: "a77895ebc684f7a4dd2e4e06529b22e9ae694037f6dee0753d3ce0bbcd5b3e38"
+  "0.7.1":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.7.1.tar.gz"
+    sha256: "11bb590dd055194e92936fa4d0652084c14bd23ac8e4b5a02271b6259a05cec9"
+  "0.7.0":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.7.0.tar.gz"
+    sha256: "4fe6627407a656d0d73879c0346b251ccdcfb718c37bef5410ba172c7c7d5f9a"
+  "0.6.6":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.6.6.tar.gz"
+    sha256: "1033f9a9315023feebb48f20d5a572149ec72c1e95a52bcf7042a412ff9d2e28"
+  "0.6.5":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.6.5.tar.gz"
+    sha256: "37A69482517C8976CB48CD271DA8C6BA92E07EE2AB2BDD7CAEF4C8158AF77359"

--- a/recipes/magic_enum/all/conanfile.py
+++ b/recipes/magic_enum/all/conanfile.py
@@ -15,11 +15,12 @@ class MagicEnumConan(ConanFile):
         "Header-only C++17 library provides static reflection for enums, work "
         "with any enum type without any macro or boilerplate code."
     )
-    topics = ("cplusplus", "enum-to-string", "string-to-enum", "serialization",
-              "reflection", "header-only", "compile-time")
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Neargye/magic_enum"
-    license = "MIT"
+    topics = ("cplusplus", "enum-to-string", "string-to-enum", "serialization",
+              "reflection", "header-only", "compile-time")
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -32,6 +33,7 @@ class MagicEnumConan(ConanFile):
         return {
             "gcc": "9",
             "Visual Studio": "15",
+            "msvc": "191",
             "clang": "5",
             "apple-clang": "10",
         }
@@ -52,8 +54,7 @@ class MagicEnumConan(ConanFile):
             )
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         pass
@@ -66,6 +67,4 @@ class MagicEnumConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "magic_enum")
         self.cpp_info.set_property("cmake_target_name", "magic_enum::magic_enum")
         self.cpp_info.bindirs = []
-        self.cpp_info.frameworkdirs = []
         self.cpp_info.libdirs = []
-        self.cpp_info.resdirs = []

--- a/recipes/magic_enum/all/test_v1_package/CMakeLists.txt
+++ b/recipes/magic_enum/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(magic_enum REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE magic_enum::magic_enum)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/magic_enum/config.yml
+++ b/recipes/magic_enum/config.yml
@@ -1,19 +1,21 @@
 versions:
-  "0.6.5":
+  "0.9.0":
     folder: all
-  "0.6.6":
-    folder: all
-  "0.7.0":
-    folder: all
-  "0.7.1":
-    folder: all
-  "0.7.2":
-    folder: all
-  "0.7.3":
-    folder: all
-  "0.8.0":
+  "0.8.2":
     folder: all
   "0.8.1":
     folder: all
-  "0.8.2":
+  "0.8.0":
+    folder: all
+  "0.7.3":
+    folder: all
+  "0.7.2":
+    folder: all
+  "0.7.1":
+    folder: all
+  "0.7.0":
+    folder: all
+  "0.6.6":
+    folder: all
+  "0.6.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **magic_enum/***

- add version 0.9.0
- sort versions in config.yml and conandata.yml
- use add_subdirectory in test_v1_package

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
