### PR TITLE
Fix fmt test_package for C++20

### DIFF
--- a/recipes/fmt/all/test_package/test_package.cpp
+++ b/recipes/fmt/all/test_package/test_package.cpp
@@ -46,11 +46,10 @@ int main() {
     fmt::print("{}\n", formatted);
 
     fmt::memory_buffer buf;
-    fmt::format_to(std::begin(buf), "{}", 2.7182818);
+    fmt::format_to(std::back_inserter(buf), "{}", 2.7182818);
     fmt::print("Euler number: {}\n", fmt::to_string(buf));
 
-    const std::string date = fmt::format("The date is {}\n", Date(2012, 12, 9));
-    fmt::print(date);
+    fmt::print("The date is {}\n", Date(2012, 12, 9));
 
     report("{} {} {}\n", "Conan", 42, 3.14159);
 


### PR DESCRIPTION
Specify library name and version:  **fmt/10.0.0**

test_package was having issues with C++20, this fixes the issues in the test_package


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
