### PR TITLE
Jemalloc, conan 2.x fixes for Linux

### DIFF
--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -1,15 +1,15 @@
 from conan import ConanFile
-from conans import AutoToolsBuildEnvironment, MSBuild
-from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, get, rename, replace_in_file, copy
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.microsoft import MSBuild, visual
 from conan.tools.scm import Version
-from conans import tools as tools_legacy
-from conan.tools.files import apply_conandata_patches, get, rename, replace_in_file
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.layout import basic_layout
 import os
 import shutil
 import string
 
-required_conan_version = ">=1.51.3"
+required_conan_version = ">=1.58.0"
 
 class JemallocConan(ConanFile):
     name = "jemalloc"
@@ -22,7 +22,7 @@ class JemallocConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "prefix": "ANY",
+        "prefix": ["ANY"],
         "enable_cxx": [True, False],
         "enable_fill": [True, False],
         "enable_xmalloc": [True, False],
@@ -51,11 +51,27 @@ class JemallocConan(ConanFile):
     }
     exports_sources = ["patches/**"]
 
-    _autotools = None
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.configure_args.append("--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug")
+        tc.configure_args.append("--enable-cxx" if self.options.enable_cxx else "--disable-cxx")
+        tc.configure_args.append("--enable-fill" if self.options.enable_fill else "--disable-fill")
+        tc.configure_args.append("--enable-xmalloc" if self.options.enable_cxx else "--disable-xmalloc")
+        tc.configure_args.append("--enable-readlinkat" if self.options.enable_readlinkat else "--disable-readlinkat")
+        tc.configure_args.append("--enable-syscall" if self.options.enable_syscall else "--disable-syscall")
+        tc.configure_args.append("--enable-lazy-lock" if self.options.enable_lazy_lock else "--disable-lazy-lock")
+        tc.configure_args.append("--enable-log" if self.options.enable_debug_logging else "--disable-log")
+        tc.configure_args.append("--enable-initial-exec-tls" if self.options.enable_initial_exec_tls else "--disable-initial-exec-tls")
+        tc.configure_args.append("--enable-libdl" if self.options.enable_libdl else "--disable-libdl")
+        if self.options.prefix:
+            tc.configure_args["--with-jemalloc-prefix"] = self.options.prefix
+        if self.options.enable_prof:
+            tc.configure_args.append("--enable-prof")
+        tc.generate()
 
     def configure(self):
         if self.options.shared:
@@ -70,16 +86,15 @@ class JemallocConan(ConanFile):
                 self.settings.compiler == "clang" and \
                 Version(self.settings.compiler.version) < "10":
             raise ConanInvalidConfiguration("clang and libc++ version {} (< 10) is missing a mutex implementation".format(self.settings.compiler.version))
-        if self.settings.compiler == "Visual Studio" and \
-                self.options.shared and \
+        if visual.is_msvc(self) and self.options.shared and \
                 "MT" in self.settings.compiler.runtime:
             raise ConanInvalidConfiguration("Visual Studio build for shared library with MT runtime is not supported")
-        if self.settings.compiler == "Visual Studio" and self.settings.compiler.version != "15":
+        if visual.is_msvc(self) and self.settings.compiler.version != "15":
             # https://github.com/jemalloc/jemalloc/issues/1703
             raise ConanInvalidConfiguration("Only Visual Studio 15 2017 is supported.  Please fix this if other versions are supported")
         if self.settings.build_type not in ("Release", "Debug", None):
             raise ConanInvalidConfiguration("Only Release and Debug build_types are supported")
-        if self.settings.compiler == "Visual Studio" and self.settings.arch not in ("x86_64", "x86"):
+        if visual.is_msvc(self) and self.settings.arch not in ("x86_64", "x86"):
             raise ConanInvalidConfiguration("Unsupported arch")
         if self.settings.compiler == "clang" and Version(self.settings.compiler.version) <= "3.9":
             raise ConanInvalidConfiguration("Unsupported compiler version")
@@ -99,36 +114,6 @@ class JemallocConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
-
-    @property
-    def _autotools_args(self):
-        conf_args = [
-            "--with-jemalloc-prefix={}".format(self.options.prefix),
-            "--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug",
-            "--enable-cxx" if self.options.enable_cxx else "--disable-cxx",
-            "--enable-fill" if self.options.enable_fill else "--disable-fill",
-            "--enable-xmalloc" if self.options.enable_cxx else "--disable-xmalloc",
-            "--enable-readlinkat" if self.options.enable_readlinkat else "--disable-readlinkat",
-            "--enable-syscall" if self.options.enable_syscall else "--disable-syscall",
-            "--enable-lazy-lock" if self.options.enable_lazy_lock else "--disable-lazy-lock",
-            "--enable-log" if self.options.enable_debug_logging else "--disable-log",
-            "--enable-initial-exec-tls" if self.options.enable_initial_exec_tls else "--disable-initial-exec-tls",
-            "--enable-libdl" if self.options.enable_libdl else "--disable-libdl",
-        ]
-        if self.options.enable_prof:
-            conf_args.append("--enable-prof")
-        if self.options.shared:
-            conf_args.extend(["--enable-shared", "--disable-static"])
-        else:
-            conf_args.extend(["--disable-shared", "--enable-static"])
-        return conf_args
-
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools_legacy.os_info.is_windows)
-        self._autotools.configure(args=self._autotools_args, configure_dir=self.source_folder)
-        return self._autotools
 
     @property
     def _msvc_build_type(self):
@@ -153,31 +138,59 @@ class JemallocConan(ConanFile):
 
         apply_conandata_patches(self)
 
+    # TODO: Remove once Windows has been migrated to conan 2.x
+    @property
+    def _autotools_args(self):
+        conf_args = [
+            "--with-jemalloc-prefix={}".format(self.options.prefix),
+            "--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug",
+            "--enable-cxx" if self.options.enable_cxx else "--disable-cxx",
+            "--enable-fill" if self.options.enable_fill else "--disable-fill",
+            "--enable-xmalloc" if self.options.enable_cxx else "--disable-xmalloc",
+            "--enable-readlinkat" if self.options.enable_readlinkat else "--disable-readlinkat",
+            "--enable-syscall" if self.options.enable_syscall else "--disable-syscall",
+            "--enable-lazy-lock" if self.options.enable_lazy_lock else "--disable-lazy-lock",
+            "--enable-log" if self.options.enable_debug_logging else "--disable-log",
+            "--enable-initial-exec-tls" if self.options.enable_initial_exec_tls else "--disable-initial-exec-tls",
+            "--enable-libdl" if self.options.enable_libdl else "--disable-libdl",
+        ]
+        if self.options.enable_prof:
+            conf_args.append("--enable-prof")
+        if self.options.shared:
+            conf_args.extend(["--enable-shared", "--disable-static"])
+        else:
+            conf_args.extend(["--disable-shared", "--enable-static"])
+        return conf_args
 
     def build(self):
         self._patch_sources()
-        if self.settings.compiler == "Visual Studio":
-            with tools_legacy.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools_legacy.no_op():
-                with tools_legacy.environment_append({"CC": "cl", "CXX": "cl"}) if self.settings.compiler == "Visual Studio" else tools_legacy.no_op():
+        if visual.is_msvc(self):
+            # TODO: someone on windows can fix this up, should still work of conan 1.x
+            from conans import tools as tools_legacy
+            with tools_legacy.vcvars(self.settings):
+                with tools_legacy.environment_append({"CC": "cl", "CXX": "cl"}):
                     with tools_legacy.chdir(self.source_folder):
                         # Do not use AutoToolsBuildEnvironment because we want to run configure as ./configure
                         self.run("./configure {}".format(" ".join(self._autotools_args)), win_bash=tools_legacy.os_info.is_windows)
             msbuild = MSBuild(self)
             # Do not use the 2015 solution: unresolved external symbols: test_hooks_libc_hook and test_hooks_arena_new_hook
             sln_file = os.path.join(self.source_folder, "msvc", "jemalloc_vc2017.sln")
-            msbuild.build(sln_file, targets=["jemalloc"], build_type=self._msvc_build_type)
+            msbuild.build(sln_file, targets=["jemalloc"])
         else:
-            autotools = self._configure_autotools()
+            autotools = Autotools(self)
+            autotools.configure()
             autotools.make()
 
     @property
     def _library_name(self):
         libname = "jemalloc"
-        if self.settings.compiler == "Visual Studio":
+        if visual.is_msvc(self):
             if self.options.shared:
                 if self.settings.build_type == "Debug":
                     libname += "d"
             else:
+                # TODO: someone on windows can fix this up, should still work of conan 1.x
+                from conans import tools as tools_legacy
                 toolset = tools_legacy.msvs_toolset(self.settings)
                 toolset_number = "".join(c for c in toolset if c in string.digits)
                 libname += "-vc{}-{}".format(toolset_number, self._msvc_build_type)
@@ -191,22 +204,23 @@ class JemallocConan(ConanFile):
         return libname
 
     def package(self):
-        self.copy(pattern="COPYING", src=self.source_folder, dst="licenses")
-        if self.settings.compiler == "Visual Studio":
+        copy(self, pattern="COPYING", src=self.source_folder, dst="licenses")
+        if visual.is_msvc(self):
             arch_subdir = {
                 "x86_64": "x64",
                 "x86": "x86",
             }[str(self.settings.arch)]
-            self.copy("*.lib", src=os.path.join(self.source_folder, "msvc", arch_subdir, self._msvc_build_type), dst=os.path.join(self.package_folder, "lib"))
-            self.copy("*.dll", src=os.path.join(self.source_folder, "msvc", arch_subdir, self._msvc_build_type), dst=os.path.join(self.package_folder, "bin"))
-            self.copy("jemalloc.h", src=os.path.join(self.source_folder, "include", "jemalloc"), dst=os.path.join(self.package_folder, "include", "jemalloc"), keep_path=True)
+            copy(self, "*.lib", src=os.path.join(self.source_folder, "msvc", arch_subdir, self._msvc_build_type), dst=os.path.join(self.package_folder, "lib"))
+            copy(self, "*.dll", src=os.path.join(self.source_folder, "msvc", arch_subdir, self._msvc_build_type), dst=os.path.join(self.package_folder, "bin"))
+            copy(self, "jemalloc.h", src=os.path.join(self.source_folder, "include", "jemalloc"), dst=os.path.join(self.package_folder, "include", "jemalloc"), keep_path=True)
             shutil.copytree(os.path.join(self.source_folder, "include", "msvc_compat"),
                             os.path.join(self.package_folder, "include", "msvc_compat"))
         else:
-            autotools = self._configure_autotools()
+            autotools = Autotools(self)
+            autotools.configure()
             # Use install_lib_XXX and install_include to avoid mixing binaries and dll's
-            autotools.make(target="install_lib_shared" if self.options.shared else "install_lib_static")
-            autotools.make(target="install_include")
+            autotools.install(target="install_lib_shared" if self.options.shared else "install_lib_static")
+            autotools.install(target="install_include")
             if self.settings.os == "Windows" and self.settings.compiler == "gcc":
                 rename(self, os.path.join(self.package_folder, "lib", "{}.lib".format(self._library_name)),
                              os.path.join(self.package_folder, "lib", "lib{}.a".format(self._library_name)))
@@ -214,11 +228,11 @@ class JemallocConan(ConanFile):
                     os.unlink(os.path.join(self.package_folder, "lib", "jemalloc.lib"))
 
     def package_info(self):
-        self.cpp_info.names["pkg_config"] = "jemalloc"
+        self.cpp_info.set_property("pkg_config_name", "jemalloc")
         self.cpp_info.libs = [self._library_name]
         self.cpp_info.includedirs = [os.path.join(self.package_folder, "include"),
                                      os.path.join(self.package_folder, "include", "jemalloc")]
-        if self.settings.compiler == "Visual Studio":
+        if visual.is_msvc(self):
             self.cpp_info.includedirs.append(os.path.join(self.package_folder, "include", "msvc_compat"))
         if not self.options.shared:
             self.cpp_info.defines = ["JEMALLOC_EXPORT="]

--- a/recipes/jemalloc/all/test_package/CMakeLists.txt
+++ b/recipes/jemalloc/all/test_package/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(jemalloc REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} jemalloc::jemalloc)
 set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/jemalloc/all/test_package/conanfile.py
+++ b/recipes/jemalloc/all/test_package/conanfile.py
@@ -1,10 +1,17 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "CMakeDeps", "CMakeToolchain"
+    
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+        
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +19,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")


### PR DESCRIPTION
Specify library name and version:  **jemalloc/5.3.0**

Minimal changes to get jemalloc packaged with conan 2.x on Linux.
Windows should still package with 1.x

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
