### PR TITLE
libserial: include cstdint for gcc13, add package_type

### DIFF
--- a/recipes/libserial/all/conandata.yml
+++ b/recipes/libserial/all/conandata.yml
@@ -2,3 +2,8 @@ sources:
   "cci.20200930":
     url: "https://github.com/crayzeewulf/libserial/archive/1d1e47a2faae0470f93eb291263b0ce7ea119a81.tar.gz"
     sha256: "a433b04bd42e8b4504e5e1fbe7ec22b648f2872d3d125e58c17b9c6c1b171bba"
+patches:
+  "cci.20200930":
+    - patch_file: "patches/0001-add-cstdint.patch"
+      patch_description: "add cstdint for uint8_t"
+      patch_type: "portability"

--- a/recipes/libserial/all/conanfile.py
+++ b/recipes/libserial/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import get, copy, rm, rmdir
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
@@ -17,6 +17,7 @@ class LibserialConan(ConanFile):
     homepage = "https://github.com/crayzeewulf/libserial"
     topics = ("serial-ports", "rs232", "usb-serial")
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "library"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -36,6 +37,9 @@ class LibserialConan(ConanFile):
             "gcc": "7",
             "clang": "7",
         }
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def configure(self):
         if self.options.shared:
@@ -57,7 +61,7 @@ class LibserialConan(ConanFile):
             )
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -70,6 +74,7 @@ class LibserialConan(ConanFile):
         tc.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/libserial/all/patches/0001-add-cstdint.patch
+++ b/recipes/libserial/all/patches/0001-add-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/src/libserial/SerialPortConstants.h b/src/libserial/SerialPortConstants.h
+index f9d5dc1..0588e3e 100644
+--- a/src/libserial/SerialPortConstants.h
++++ b/src/libserial/SerialPortConstants.h
+@@ -38,6 +38,7 @@
+ #include <string>
+ #include <termios.h>
+ #include <vector>
++#include <cstdint>
+ 
+ namespace LibSerial
+ {


### PR DESCRIPTION
Specify library name and version:  **libserial/***

- include cstdint for gcc13 compilation error
- add package_type

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
