### PR TITLE
benchmark: add pfm option

### DIFF
--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -38,7 +38,7 @@ class BenchmarkConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.os != "Linux":
+        if self.settings.os != "Linux" or Version(self.version) < "1.5.4":
             del self.options.enable_libpfm
 
     def configure(self):

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -55,7 +55,7 @@ class BenchmarkConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("enable_libpfm"):
-            self.requires("libpfm4/4.12.0")
+            self.requires("libpfm4/4.13.0")
 
     def build_requirements(self):
         if Version(self.version) >= "1.7.1":

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -25,17 +25,21 @@ class BenchmarkConan(ConanFile):
         "fPIC": [True, False],
         "enable_lto": [True, False],
         "enable_exceptions": [True, False],
+        "enable_libpfm": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_lto": False,
         "enable_exceptions": True,
+        "enable_libpfm": False,
     }
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self.settings.os != "Linux":
+            del self.options.enable_libpfm
 
     def configure(self):
         if self.options.shared:
@@ -48,6 +52,10 @@ class BenchmarkConan(ConanFile):
         check_min_vs(self, "190")
         if Version(self.version) < "1.7.0" and is_msvc(self) and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support msvc shared builds")
+
+    def requirements(self):
+        if self.options.get_safe("enable_libpfm"):
+            self.requires("libpfm4/4.12.0")
 
     def build_requirements(self):
         if Version(self.version) >= "1.7.1":
@@ -62,6 +70,7 @@ class BenchmarkConan(ConanFile):
         tc.variables["BENCHMARK_ENABLE_GTEST_TESTS"] = "OFF"
         tc.variables["BENCHMARK_ENABLE_LTO"] = self.options.enable_lto
         tc.variables["BENCHMARK_ENABLE_EXCEPTIONS"] = self.options.enable_exceptions
+        tc.variables["BENCHMARK_ENABLE_LIBPFM"] = self.options.get_safe("enable_libpfm", False)
         if Version(self.version) >= "1.6.1":
             tc.variables["BENCHMARK_ENABLE_WERROR"] = False
             tc.variables["BENCHMARK_FORCE_WERROR"] = False
@@ -102,6 +111,9 @@ class BenchmarkConan(ConanFile):
             self.cpp_info.components["_benchmark"].system_libs.append("shlwapi")
         elif self.settings.os == "SunOS":
             self.cpp_info.components["_benchmark"].system_libs.append("kstat")
+        if self.options.get_safe("enable_libpfm"):
+            self.cpp_info.components["_benchmark"].requires.append("libpfm4::libpfm4")
+        
 
         self.cpp_info.components["benchmark_main"].set_property("cmake_target_name", "benchmark::benchmark_main")
         self.cpp_info.components["benchmark_main"].libs = ["benchmark_main"]


### PR DESCRIPTION
Specify library name and version:  **benchmark/1.8.0**

Benchmark has a build option for enabling performance counters: https://github.com/google/benchmark/blob/v1.5.4/docs/perf_counters.md

We want to use this feature, therefore I try to add an option which is disabled by default. As far as I have seen this is currently only for Linux supported, and requires the "libpfm4" library, which is available via Conan. This feature was added with version 1.5.4, therefore I include a version check too (even if our supported versions starts with a higher version number). 

Some time past by since I made my last contribution, and this is my very first in the time of Conan 2.x - I hope I did everything in the right way, please correct me if not.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
