### PR TITLE
libpfm4: Simplify logic as only Linux is supported

### DIFF
--- a/recipes/libpfm4/all/conandata.yml
+++ b/recipes/libpfm4/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.13.0":
+    url: "https://versaweb.dl.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.13.0.tar.gz"
+    sha256: "d18b97764c755528c1051d376e33545d0eb60c6ebf85680436813fa5b04cc3d1"
   "4.12.0":
     url: "https://versaweb.dl.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.12.0.tar.gz"
     sha256: "4b0c1f53f39a61525b69bebf532c68040c1b984d7544a8ae0844b13cd91e1ee4"

--- a/recipes/libpfm4/all/conanfile.py
+++ b/recipes/libpfm4/all/conanfile.py
@@ -31,7 +31,7 @@ class Libpfm4Conan(ConanFile):
         self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self.source_folder)

--- a/recipes/libpfm4/all/conanfile.py
+++ b/recipes/libpfm4/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.files import get, rmdir, copy, replace_in_file
+from conan.tools.files import get, rmdir, copy, replace_in_file, rm
 from conan.errors import ConanInvalidConfiguration
 import os
 
@@ -41,16 +41,19 @@ class Libpfm4Conan(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
-        if not self.options.shared:
+        if self.options.get_safe("fPIC"):
             # honor fPIC option
             replace_in_file(self, os.path.join(self.source_folder, "rules.mk"), "-fPIC", "")
             replace_in_file(self, os.path.join(self.source_folder, "rules.mk"), "-DPIC", "")
+
+    def _yes_no(self, option):
+        return "y" if option else "n"
 
     def build(self):
         self._patch_sources()
         args = [
             'DBG=',
-            'CONFIG_PFMLIB_SHARED={}'.format("y" if self.options.shared else "n"),
+            f'CONFIG_PFMLIB_SHARED={self._yes_no(self.options.shared)}',
             f'-C {self.source_folder}'
         ]
         autotools = Autotools(self)
@@ -58,20 +61,21 @@ class Libpfm4Conan(ConanFile):
 
     def package(self):
         copy(self, "COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        args = [
+        copy(self, "err.h", dst=os.path.join(self.package_folder, "include", "perfmon"), src=os.path.join(self.source_folder, "include", "perfmon"))
+
+        autotools = Autotools(self)
+        autotools.install(args=[
             'DBG=',
             'LDCONFIG=true',
-            'CONFIG_PFMLIB_SHARED={}'.format("y" if self.options.shared else "n"),
+            f'CONFIG_PFMLIB_SHARED={self._yes_no(self.options.shared)}',
             f'DESTDIR={self.package_folder}{os.sep}',
             f'INCDIR=include{os.sep}',
             f'LIBDIR=lib{os.sep}',
             f'-C {self.source_folder}'
-        ]
-
-        copy(self, "err.h", dst=os.path.join(self.package_folder, "include", "perfmon"), src=os.path.join(self.source_folder, "include", "perfmon"))
-        autotools = Autotools(self)
-        autotools.install(args=args)
+        ])
         rmdir(self, os.path.join(self.package_folder, "usr"))
+        if self.options.shared:
+            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         self.cpp_info.libs = ["pfm"]

--- a/recipes/libpfm4/config.yml
+++ b/recipes/libpfm4/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "4.13.0":
+    folder: all
   "4.12.0":
     folder: all


### PR DESCRIPTION
Saw that it had a validate for Linux only, decided to simplify the recipe logic.

 * Added `package_type`
 * Removed `fPIC` management on Windows, as it does not run there
 * Used `rm_safe`
 * Removed logic conditional to the `os`, it's always Linux


For #17702

Specify library name and version:  **libpfm4/all**
