### PR TITLE
fast_float: add version 5.0.0, add BSL-1.0 license

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.0.0":
+    url: "https://github.com/fastfloat/fast_float/archive/v5.0.0.tar.gz"
+    sha256: "86645ab4af22d21d4ba2d980572dfb74faf90c20c52240d7d8d2201f3eaf4252"
   "4.0.0":
     url: "https://github.com/fastfloat/fast_float/archive/v4.0.0.tar.gz"
     sha256: "9470f229b9ea8d116af7c92f2ab8e8ae6b3c3225d15081b859634328f28d4664"

--- a/recipes/fast_float/all/conanfile.py
+++ b/recipes/fast_float/all/conanfile.py
@@ -10,8 +10,8 @@ class FastFloatConan(ConanFile):
     name = "fast_float"
     description = "Fast and exact implementation of the C++ from_chars " \
                   "functions for float and double types."
-    license = ("Apache-2.0", "MIT")
-    topics = ("fast_float", "conversion", "from_chars", "header-only")
+    license = ("Apache-2.0", "MIT", "BSL-1.0")
+    topics = ("conversion", "from_chars", "header-only")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/fastfloat/fast_float"
     package_type = "header-library"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.0.0":
+    folder: all
   "4.0.0":
     folder: all
   "3.11.0":


### PR DESCRIPTION
Specify library name and version:  **fast_float/***

Since 5.0.0, fast_float add bsl-1.0 license.
https://github.com/fastfloat/fast_float/pull/203

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
