### PR TITLE
cpp-httplib: add version 0.12.4

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.12.4":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.12.4.tar.gz"
+    sha256: "1aecc75c64fe979f4c6f8b0308ef11f282c721522072fa02717ff07cc9627d10"
   "0.12.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.12.3.tar.gz"
     sha256: "175ced3c9cdaf221e9edf210297568d8f7d402a41d6db01254ac9e0b25487c54"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.12.4":
+    folder: all
   "0.12.3":
     folder: all
   "0.12.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-httplib/0.12.4**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
