### PR TITLE
liblsl: add version 1.16.2

### DIFF
--- a/recipes/liblsl/all/conandata.yml
+++ b/recipes/liblsl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.16.2":
+    url: "https://github.com/sccn/liblsl/archive/refs/tags/v1.16.2.tar.gz"
+    sha256: "923aa4c81c0fef651c325e3c27aa5b96771540ca2a0933d1b327db27c6dac839"
   "1.16.1":
     url: "https://github.com/sccn/liblsl/archive/refs/tags/v1.16.1.tar.gz"
     sha256: "7410620c26f8e86ae431e7476bf685918e180bd676982a7f7a7817299c8707c5"

--- a/recipes/liblsl/config.yml
+++ b/recipes/liblsl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.16.2":
+    folder: all
   "1.16.1":
     folder: all
   "1.16.0":


### PR DESCRIPTION
Specify library name and version:  **liblsl/1.16.2**

This updates the recipe of liblsl to the latest version.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
