### PR TITLE
di: add version 1.3.0

### DIFF
--- a/recipes/di/all/conandata.yml
+++ b/recipes/di/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.2.0":
     url: https://github.com/boost-ext/di/archive/v1.2.0.tar.gz
     sha256: 47ed660a1198f61394d30890cbb9a68b0fd6d17f41283e1de0036d10c1d24a55
+  "1.3.0":
+    url: "https://github.com/boost-ext/di/archive/v1.3.0.tar.gz"
+    sha256: "853e02ade9bf39f2863b470350c3ef55caffc3090d7d9a503724ff480c8d7eff"

--- a/recipes/di/config.yml
+++ b/recipes/di/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.2.0":
     folder: all
+  "1.3.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **di/1.3.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
