### PR TITLE
libwebm: Add recipe for building WebM container library.

### DIFF
--- a/recipes/libwebm/all/conandata.yml
+++ b/recipes/libwebm/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "1.0.0.29":
+    url: "https://chromium.googlesource.com/webm/libwebm/+archive/2f9fc054ab9547ca06071ec68dab9d54960abb2e.tar.gz"
+patches:
+  "1.0.0.29":
+    - patch_file: "patches/1.0.0.29-cmake-install-targets.patch"
+      patch_description: "Always declare the CMake install target for libwebm.a/so"
+      patch_type: "conan"

--- a/recipes/libwebm/all/conanfile.py
+++ b/recipes/libwebm/all/conanfile.py
@@ -1,0 +1,81 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class LibwebmConan(ConanFile):
+    name = "libwebm"
+    description = "Library for muxing and demuxing WebM media container files"
+    topics = ("conan", "libwebm", "webm", "container", "demuxing", "muxing", "media", "audio", "video")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://chromium.googlesource.com/webm/libwebm/"
+    license = "BSD-3-Clause"
+
+    settings = "os", "arch", "compiler", "build_type"
+
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_pes_ts": [True, False],
+        "with_new_parser_api": [True, False],
+    }
+
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_pes_ts": True,
+        "with_new_parser_api": False,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version])
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ENABLE_WEBMTS"] = self.options.with_pes_ts
+        tc.variables["ENABLE_WEBM_PARSER"] = self.options.with_new_parser_api
+        tc.variables["ENABLE_WEBMINFO"] = False
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        copy(self, "LICENSE.TXT", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "WebM")
+        self.cpp_info.set_property("cmake_target_name", "WebM::webm")
+        self.cpp_info.set_property("pkg_config_name", "webm")
+        # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.components["libwebm"].libs = ["webm"]
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.names["cmake_find_package"] = "WebM"
+        self.cpp_info.names["cmake_find_package_multi"] = "WebM"
+        self.cpp_info.components["libwebm"].names["cmake_find_package"] = "webm"
+        self.cpp_info.components["libwebm"].names["cmake_find_package_multi"] = "webm"
+        self.cpp_info.components["libwebm"].set_property("cmake_target_name", "WebM::webm")
+        self.cpp_info.components["libwebm"].set_property("pkg_config_name", "webm")

--- a/recipes/libwebm/all/patches/1.0.0.29-cmake-install-targets.patch
+++ b/recipes/libwebm/all/patches/1.0.0.29-cmake-install-targets.patch
@@ -1,0 +1,145 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a83d23b..ce8337f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,21 +60,32 @@ endif ()
+ # Source list variables.
+ set(dumpvtt_sources "${LIBWEBM_SRC_DIR}/dumpvtt.cc")
+ 
+-set(libwebm_common_sources
+-    "${LIBWEBM_SRC_DIR}/common/file_util.cc"
++set(libwebm_common_public_headers
+     "${LIBWEBM_SRC_DIR}/common/file_util.h"
+-    "${LIBWEBM_SRC_DIR}/common/hdr_util.cc"
+     "${LIBWEBM_SRC_DIR}/common/hdr_util.h"
++    "${LIBWEBM_SRC_DIR}/common/indent.h"
++    "${LIBWEBM_SRC_DIR}/common/vp9_header_parser.h"
++    "${LIBWEBM_SRC_DIR}/common/vp9_level_stats.h"
++    "${LIBWEBM_SRC_DIR}/common/webm_constants.h"
++    "${LIBWEBM_SRC_DIR}/common/webm_endian.h"
+     "${LIBWEBM_SRC_DIR}/common/webmids.h")
+ 
+-set(mkvmuxer_sources
+-    "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvmuxer.cc"
++set(libwebm_common_sources
++    ${libwebm_common_public_headers}
++    "${LIBWEBM_SRC_DIR}/common/file_util.cc"
++    "${LIBWEBM_SRC_DIR}/common/hdr_util.cc")
++
++set(mkvmuxer_public_headers
+     "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvmuxer.h"
+     "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvmuxertypes.h"
+-    "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvmuxerutil.cc"
+     "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvmuxerutil.h"
++    "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvwriter.h")
++
++set(mkvmuxer_sources
++    ${mkvmuxer_public_headers}
++    "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvmuxer.cc"
++    "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvmuxerutil.cc"
+     "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvwriter.cc"
+-    "${LIBWEBM_SRC_DIR}/mkvmuxer/mkvwriter.h"
+     "${LIBWEBM_SRC_DIR}/common/webmids.h")
+ 
+ set(mkvmuxer_sample_sources
+@@ -87,11 +98,14 @@ set(mkvmuxer_tests_sources
+     "${LIBWEBM_SRC_DIR}/testing/test_util.cc"
+     "${LIBWEBM_SRC_DIR}/testing/test_util.h")
+ 
++set(mkvparser_public_headers
++    "${LIBWEBM_SRC_DIR}/mkvparser/mkvparser.h"
++    "${LIBWEBM_SRC_DIR}/mkvparser/mkvreader.h")
++
+ set(mkvparser_sources
++    ${mkvparser_public_headers}
+     "${LIBWEBM_SRC_DIR}/mkvparser/mkvparser.cc"
+-    "${LIBWEBM_SRC_DIR}/mkvparser/mkvparser.h"
+     "${LIBWEBM_SRC_DIR}/mkvparser/mkvreader.cc"
+-    "${LIBWEBM_SRC_DIR}/mkvparser/mkvreader.h"
+     "${LIBWEBM_SRC_DIR}/common/webmids.h")
+ 
+ set(mkvparser_sample_sources "${LIBWEBM_SRC_DIR}/mkvparser_sample.cc")
+@@ -284,15 +298,11 @@ set(webm_parser_tests_sources
+     "${LIBWEBM_SRC_DIR}/webm_parser/tests/webm_parser_tests.cc")
+ 
+ set(webm_info_sources
++    ${libwebm_common_public_headers}
+     "${LIBWEBM_SRC_DIR}/common/indent.cc"
+-    "${LIBWEBM_SRC_DIR}/common/indent.h"
+     "${LIBWEBM_SRC_DIR}/common/vp9_header_parser.cc"
+-    "${LIBWEBM_SRC_DIR}/common/vp9_header_parser.h"
+     "${LIBWEBM_SRC_DIR}/common/vp9_level_stats.cc"
+-    "${LIBWEBM_SRC_DIR}/common/vp9_level_stats.h"
+-    "${LIBWEBM_SRC_DIR}/common/webm_constants.h"
+     "${LIBWEBM_SRC_DIR}/common/webm_endian.cc"
+-    "${LIBWEBM_SRC_DIR}/common/webm_endian.h"
+     "${LIBWEBM_SRC_DIR}/webm_info.cc")
+ 
+ set(webmts_sources
+@@ -315,12 +325,22 @@ set(webm2pes_tests_sources
+     "${LIBWEBM_SRC_DIR}/m2ts/tests/webm2pes_tests.cc")
+ set(webm2ts_sources "${LIBWEBM_SRC_DIR}/m2ts/vpxpes2ts_main.cc")
+ 
+-set(webvtt_common_sources
+-    "${LIBWEBM_SRC_DIR}/webvtt/vttreader.cc"
++set(webvtt_common_public_headers
+     "${LIBWEBM_SRC_DIR}/webvtt/vttreader.h"
+-    "${LIBWEBM_SRC_DIR}/webvtt/webvttparser.cc"
+     "${LIBWEBM_SRC_DIR}/webvtt/webvttparser.h")
+ 
++set(webvtt_common_sources
++    ${webvtt_common_public_headers}
++    "${LIBWEBM_SRC_DIR}/webvtt/vttreader.cc"
++    "${LIBWEBM_SRC_DIR}/webvtt/webvttparser.cc")
++
++# Public headers that will be installed with the library.
++set(webm_public_headers
++    ${libwebm_common_public_headers}
++    ${mkvmuxer_public_headers}
++    ${mkvparser_public_headers}
++    ${webvtt_common_public_headers})
++
+ # Targets.
+ add_library(mkvmuxer OBJECT ${mkvmuxer_sources})
+ add_library(mkvparser OBJECT ${mkvparser_sources})
+@@ -330,6 +350,8 @@ add_library(webm ${libwebm_common_sources}
+             $<TARGET_OBJECTS:mkvmuxer>
+             $<TARGET_OBJECTS:mkvparser>)
+ 
++
++
+ if (WIN32)
+   # Use libwebm and libwebm.lib for project and library name on Windows (instead
+   # webm and webm.lib).
+@@ -359,17 +381,12 @@ if (ENABLE_WEBM_PARSER)
+   include_directories(webm_parser webm_parser/include)
+   add_library(webm_parser OBJECT ${webm_parser_sources})
+   target_sources(webm PUBLIC $<TARGET_OBJECTS:webm_parser>)
+-  set_target_properties(webm PROPERTIES PUBLIC_HEADER
+-                        "${webm_parser_public_headers}")
+ 
+   add_executable(webm_parser_demo ${webm_parser_demo_sources})
+   target_link_libraries(webm_parser_demo LINK_PUBLIC webm)
+ 
+-  install(TARGETS webm
+-          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-          PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/webm)
++  list(APPEND webm_public_headers
++    ${webm_parser_public_headers})
+ endif ()
+ 
+ if (ENABLE_WEBMTS)
+@@ -451,3 +468,10 @@ if (ENABLE_IWYU)
+     message(STATUS "  See README.libwebm for more information.")
+   endif ()
+ endif ()
++
++set_target_properties(webm PROPERTIES PUBLIC_HEADER "${webm_public_headers}")
++install(TARGETS webm
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/webm)
+\ No newline at end of file

--- a/recipes/libwebm/all/test_package/CMakeLists.txt
+++ b/recipes/libwebm/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES CXX)
+
+find_package(WebM REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE WebM::webm)

--- a/recipes/libwebm/all/test_package/conanfile.py
+++ b/recipes/libwebm/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libwebm/all/test_package/test_package.cpp
+++ b/recipes/libwebm/all/test_package/test_package.cpp
@@ -1,0 +1,16 @@
+#include <cstdint>
+#include <cstdio>
+#include <webm/mkvmuxerutil.h>
+#include <webm/mkvparser.h>
+
+int main(void) {
+  int32_t major, minor, build, revision;
+
+  mkvparser::GetVersion(major, minor, build, revision);
+  printf("Mkv Parser version: %d.%d.%d.%d\n", major, minor, build, revision);
+
+  mkvmuxer::GetVersion(&major, &minor, &build, &revision);
+  printf("Mkv Muxer version: %d.%d.%d.%d\n", major, minor, build, revision);
+
+  return 0;
+}

--- a/recipes/libwebm/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libwebm/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/libwebm/all/test_v1_package/conanfile.py
+++ b/recipes/libwebm/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libwebm/config.yml
+++ b/recipes/libwebm/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0.29"
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libwebm/1.0.0.29**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This adds a recipe for the WebM container library. I have strayed from the CMake build option names with `with_new_parser_api`, but I think this is much clearer than the name that the CMake build uses for the equivalent option, which is `ENABLE_WEBM_PARSER` (which a user inexperienced with the library would assume is the entire purpose of the library IMO).

I needed to include a patch to fix the install target, which is otherwise only available for the nested webm parser. I plan to open a PR with the Google folks in the hope that future versions won't need the patch.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
