### PR TITLE
quill: add version 2.9.1

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.9.1":
+    url: "https://github.com/odygrd/quill/archive/v2.9.1.tar.gz"
+    sha256: "921e053118136f63cebb2ca1d7e42456fd0bf9626facb755884709092753c054"
   "2.9.0":
     url: "https://github.com/odygrd/quill/archive/v2.9.0.tar.gz"
     sha256: "dec64c0fbb4bfbafe28fdeeeefac10206285bf2be4a42ec5dfb7987ca4ccb372"

--- a/recipes/quill/all/conanfile.py
+++ b/recipes/quill/all/conanfile.py
@@ -141,7 +141,7 @@ class QuillConan(ConanFile):
         rmdir(self, os.path.join(self.source_folder, "quill", "quill", "include", "quill", "bundled", "fmt"))
         rmdir(self, os.path.join(self.source_folder, "quill", "quill", "src", "bundled", "fmt"))
 
-        if Version(self.version) >= "2.0.0":
+        if "2.0.0" <= Version(self.version) < "2.9.1":
             replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                 """set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/quill/cmake" CACHE STRING "Modules for CMake" FORCE)""",
                 """set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}/quill/cmake")"""

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.9.1":
+    folder: "all"
   "2.9.0":
     folder: "all"
   "2.8.0":


### PR DESCRIPTION
Specify library name and version:  **quill/2.9.1**

- add version 2.9.1
- avoid applying patch since 2.9.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
