### PR TITLE
[sqlpp11] Update library to make it conan v2 compatible

### DIFF
--- a/recipes/sqlpp11/all/conanfile.py
+++ b/recipes/sqlpp11/all/conanfile.py
@@ -52,7 +52,7 @@ class Sqlpp11Conan(ConanFile):
                 if Version(self.settings.compiler.version) < minimum_version:
                     raise ConanInvalidConfiguration(f"{self.name} requires C++14, which your compiler does not support.")
             else:
-                self.output.warn(f"{self.name} requires C++14. Your compiler is unknown. Assuming it supports C++14.")
+                self.output.warning(f"{self.name} requires C++14. Your compiler is unknown. Assuming it supports C++14.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/sqlpp11/all/test_package/CMakeLists.txt
+++ b/recipes/sqlpp11/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(PackageTest CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(Sqlpp11 CONFIG REQUIRED)
 
-add_executable(example example.cpp)
-set_property(TARGET example PROPERTY CXX_STANDARD 14)
-target_link_libraries(example sqlpp11::sqlpp11)
+add_executable(${PROJECT_NAME} example.cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
+target_link_libraries(${PROJECT_NAME} sqlpp11::sqlpp11)

--- a/recipes/sqlpp11/all/test_package/conanfile.py
+++ b/recipes/sqlpp11/all/test_package/conanfile.py
@@ -1,10 +1,20 @@
-from conans import ConanFile, CMake, tools
 import os
 
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
 
-class Sqlpp11TestConan(ConanFile):
+
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,5 +22,5 @@ class Sqlpp11TestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            self.run(os.path.join("bin", "example"), run_environment=True)
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/sqlpp11/all/test_v1_package/CMakeLists.txt
+++ b/recipes/sqlpp11/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/sqlpp11/all/test_v1_package/conanfile.py
+++ b/recipes/sqlpp11/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+import os
+
+from conan.tools.build import cross_building
+from conans import ConanFile, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **sqlpp11/0.61**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This PR updates the `sqlpp11` package to be conan v2 compatible.
The downgrade of the `date/*` version is due to the fact that the original codebase also just depends on version `3.0.0`, as can be seen [here](https://github.com/rbock/sqlpp11/blob/main/dependencies/CMakeLists.txt).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
