### PR TITLE
openssl: add versions 1.1.1u/3.0.9/3.1.1

### DIFF
--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -26,6 +26,11 @@ sources:
       - "https://www.openssl.org/source/openssl-1.1.1t.tar.gz"
       - "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1t.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1t/openssl-1.1.1t.tar.gz"
+  1.1.1u:
+    sha256: e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6
+    url:
+      - "https://www.openssl.org/source/openssl-1.1.1u.tar.gz"
+      - "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1u/openssl-1.1.1u.tar.gz"
 patches:
   1.0.2u:
     - patch_file: patches/1.0.2u-darwin-arm64.patch
@@ -40,6 +45,10 @@ patches:
       patch_description: "TVOS and WatchOS don't like fork()"
       patch_type: "portability"
   1.1.1t:
+    - patch_file: patches/1.1.1-tvos-watchos.patch
+      patch_description: "TVOS and WatchOS don't like fork()"
+      patch_type: "portability"
+  1.1.1u:
     - patch_file: patches/1.1.1-tvos-watchos.patch
       patch_description: "TVOS and WatchOS don't like fork()"
       patch_type: "portability"

--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -30,6 +30,7 @@ sources:
     sha256: e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6
     url:
       - "https://www.openssl.org/source/openssl-1.1.1u.tar.gz"
+      - "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1u.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1u/openssl-1.1.1u.tar.gz"
 patches:
   1.0.2u:

--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -2,28 +2,35 @@ sources:
   3.1.1:
     url:
       - "https://www.openssl.org/source/openssl-3.1.1.tar.gz"
+      - "https://www.openssl.org/source/old/3.1/openssl-3.1.1.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.1.1/openssl-3.1.1.tar.gz"
     sha256: b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674
   3.1.0:
     url:
       - "https://www.openssl.org/source/openssl-3.1.0.tar.gz"
+      - "https://www.openssl.org/source/old/3.1/openssl-3.1.0.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.1.0/openssl-3.1.0.tar.gz"
     sha256: aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4
   3.0.9:
     url:
       - "https://www.openssl.org/source/openssl-3.0.9.tar.gz"
+      - "https://www.openssl.org/source/old/3.0/openssl-3.0.9.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.0.9/openssl-3.0.9.tar.gz"
     sha256: eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90
   3.0.8:
     url:
       - "https://www.openssl.org/source/openssl-3.0.8.tar.gz"
+      - "https://www.openssl.org/source/old/3.0/openssl-3.0.8.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.0.8/openssl-3.0.8.tar.gz"
     sha256: 6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e
   3.0.7:
     url:
       - "https://www.openssl.org/source/openssl-3.0.7.tar.gz"
+      - "https://www.openssl.org/source/old/3.0/openssl-3.0.7.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.0.7/openssl-3.0.7.tar.gz"
     sha256: 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
   3.0.5:
-    url: https://www.openssl.org/source/openssl-3.0.5.tar.gz
+    url:
+      - "https://www.openssl.org/source/openssl-3.0.5.tar.gz"
+      - "https://www.openssl.org/source/old/3.0/openssl-3.0.5.tar.gz"
     sha256: aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a

--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -2,35 +2,29 @@ sources:
   3.1.1:
     url:
       - "https://www.openssl.org/source/openssl-3.1.1.tar.gz"
-      - "https://www.openssl.org/source/old/3.1/openssl-3.1.1.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.1.1/openssl-3.1.1.tar.gz"
     sha256: b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674
   3.1.0:
     url:
       - "https://www.openssl.org/source/openssl-3.1.0.tar.gz"
-      - "https://www.openssl.org/source/old/3.1/openssl-3.1.0.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.1.0/openssl-3.1.0.tar.gz"
     sha256: aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4
   3.0.9:
     url:
       - "https://www.openssl.org/source/openssl-3.0.9.tar.gz"
-      - "https://www.openssl.org/source/old/3.0/openssl-3.0.9.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.0.9/openssl-3.0.9.tar.gz"
     sha256: eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90
   3.0.8:
     url:
       - "https://www.openssl.org/source/openssl-3.0.8.tar.gz"
-      - "https://www.openssl.org/source/old/3.0/openssl-3.0.8.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.0.8/openssl-3.0.8.tar.gz"
     sha256: 6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e
   3.0.7:
     url:
       - "https://www.openssl.org/source/openssl-3.0.7.tar.gz"
-      - "https://www.openssl.org/source/old/3.0/openssl-3.0.7.tar.gz"
       - "https://github.com/openssl/openssl/releases/download/openssl-3.0.7/openssl-3.0.7.tar.gz"
     sha256: 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
   3.0.5:
     url:
       - "https://www.openssl.org/source/openssl-3.0.5.tar.gz"
-      - "https://www.openssl.org/source/old/3.0/openssl-3.0.5.tar.gz"
     sha256: aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a

--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -1,8 +1,19 @@
 sources:
+  3.1.1:
+    url:
+      - "https://www.openssl.org/source/openssl-3.1.1.tar.gz"
+      - "https://github.com/openssl/openssl/releases/download/openssl-3.1.1/openssl-3.1.1.tar.gz"
+    sha256: b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674
   3.1.0:
     url:
       - "https://www.openssl.org/source/openssl-3.1.0.tar.gz"
+      - "https://github.com/openssl/openssl/releases/download/openssl-3.1.0/openssl-3.1.0.tar.gz"
     sha256: aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4
+  3.0.9:
+    url:
+      - "https://www.openssl.org/source/openssl-3.0.9.tar.gz"
+      - "https://github.com/openssl/openssl/releases/download/openssl-3.0.9/openssl-3.0.9.tar.gz"
+    sha256: eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90
   3.0.8:
     url:
       - "https://www.openssl.org/source/openssl-3.0.8.tar.gz"

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,9 +1,10 @@
 versions:
-  # 3.0.x releases
+  # 3.1.x releases
   3.1.1:
     folder: "3.x.x"
   3.1.0:
     folder: "3.x.x"
+  # 3.0.x releases
   3.0.9:
     folder: "3.x.x"
   3.0.8:

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,6 +1,10 @@
 versions:
   # 3.0.x releases
+  3.1.1:
+    folder: "3.x.x"
   3.1.0:
+    folder: "3.x.x"
+  3.0.9:
     folder: "3.x.x"
   3.0.8:
     folder: "3.x.x"
@@ -10,6 +14,8 @@ versions:
     folder: "3.x.x"
 
   # 1.1.1x releases
+  1.1.1u:
+    folder: "1.x.x"
   1.1.1t:
     folder: "1.x.x"
   1.1.1s:


### PR DESCRIPTION
Specify library name and version:  **openssl/1.1.1u|3.0.9|3.1.1**

Routine upgrade to add latest security patch updates.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
