### PR TITLE
xtensor: add missing package_type

### DIFF
--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -12,6 +12,7 @@ required_conan_version = ">=1.52.0"
 
 class XtensorConan(ConanFile):
     name = "xtensor"
+    package_type = "header-library"
     description = "C++ tensors with broadcasting and lazy computing"
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"


### PR DESCRIPTION
Specify library name and version:  **xtensor/all**

Add missing package type. This fixes issue in Conan 2.0 where consumers may get compiler errors due to missing headers from xsimd.

This will cause the package to be generated and published for Conan 2.0 as well.
