### PR TITLE
xoshiro-cpp: Conan 2.0 syntax fixes

### DIFF
--- a/recipes/xoshiro-cpp/all/conanfile.py
+++ b/recipes/xoshiro-cpp/all/conanfile.py
@@ -25,7 +25,8 @@ class XoshiroCppConan(ConanFile):
             "apple-clang": "10",
             "clang": "6",
             "gcc": "7",
-            "Visual Studio": "16"
+            "Visual Studio": "16",
+            "msvc": "192"
         }
 
     @property
@@ -54,7 +55,7 @@ class XoshiroCppConan(ConanFile):
                 f"{self.ref} recipe lacks information about the {compiler} compiler, "
                 f"support for the required C++{self._minimum_cpp_standard} features is assumed"
             )
-            self.output.warn(msg)
+            self.output.warning(msg)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **xoshiro-cpp/all**

This PR fixes errors when using the `msvc` compiler (instead of Visual Studio) - as it was not handled in the case. Additionally for Conan 2.0, fixes legacy use of `self.output.warn` which is no longer valid syntax in Conan 2.0.
