### PR TITLE
opencl-icd-loader: added versions from 2023 year

### DIFF
--- a/recipes/opencl-icd-loader/all/conandata.yml
+++ b/recipes/opencl-icd-loader/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "2023.04.17":
+    url: "https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/refs/tags/v2023.04.17.tar.gz"
+    sha256: "173bdc4f321d550b6578ad2aafc2832f25fbb36041f095e6221025f74134b876"
+  "2023.02.06":
+    url: "https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/refs/tags/v2023.02.06.tar.gz"
+    sha256: "f31a932b470c1e115d6a858b25c437172809b939953dc1cf20a3a15e8785d698"
   "2022.09.30":
     url: "https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/refs/tags/v2022.09.30.tar.gz"
     sha256: "e9522fb736627dd4feae2a9c467a864e7d25bb715f808de8a04eea5a7d394b74"

--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
@@ -75,6 +76,8 @@ class OpenclIcdLoaderConan(ConanFile):
         cmake.install()
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
         rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/recipes/opencl-icd-loader/config.yml
+++ b/recipes/opencl-icd-loader/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "2023.04.17":
+    folder: all
+  "2023.02.06":
+    folder: all
   "2022.09.30":
     folder: all
   "2022.05.18":


### PR DESCRIPTION
Specify library name and version:  **opencl-icd-loader/2023.x.y**

Reason: to overcome the issue https://github.com/conan-io/conan/issues/14007

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
