### PR TITLE
jasper: remove windows sdk workaround

### DIFF
--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -2,7 +2,6 @@ from conan import ConanFile
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, save
-from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 import textwrap


### PR DESCRIPTION
Specify library name and version:  **jasper/all**

Remove workaround to set `CMAKE_SYSTEM_VERSION` as the infrastructure has been updated such that CMake will no longer prefer an older version of the Windows SDK.
