### PR TITLE
magic_enum: Bump to 0.9.1

### DIFF
--- a/recipes/magic_enum/all/conandata.yml
+++ b/recipes/magic_enum/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.1":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.9.1.tar.gz"
+    sha256: "864798f3146de2bb0da766f87d9a64b1742a5d109661b5bf4fdf839040b854d7"
   "0.9.0":
     url: "https://github.com/Neargye/magic_enum/archive/v0.9.0.tar.gz"
     sha256: "2fb2f602b4660f8af539ee00958132a397e138bda19aa1ceae546de3a143386b"

--- a/recipes/magic_enum/config.yml
+++ b/recipes/magic_enum/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.1":
+    folder: all
   "0.9.0":
     folder: all
   "0.8.2":


### PR DESCRIPTION
Specify library name and version:  **magic_enum/0.9.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
