### PR TITLE
miniaudio: add version 0.11.17

### DIFF
--- a/recipes/miniaudio/all/conandata.yml
+++ b/recipes/miniaudio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.17":
+    url: "https://github.com/mackron/miniaudio/archive/0.11.17.tar.gz"
+    sha256: "4b139065f7068588b73d507d24e865060e942eb731f988ee5a8f1828155b9480"
   "0.11.16":
     url: "https://github.com/mackron/miniaudio/archive/refs/tags/0.11.16.tar.gz"
     sha256: "13320464820491c61bd178b95818fecb7cd0e68f9677d61e1345df6be8d4d77e"

--- a/recipes/miniaudio/config.yml
+++ b/recipes/miniaudio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.17":
+    folder: all
   "0.11.16":
     folder: all
   "0.11.11":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **miniaudio/0.11.17**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
