### PR TITLE
pixman: generate missing binaries

### DIFF
--- a/recipes/pixman/all/conanfile.py
+++ b/recipes/pixman/all/conanfile.py
@@ -54,7 +54,7 @@ class PixmanConan(ConanFile):
             raise ConanInvalidConfiguration("pixman can only be built as a static library on Windows")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.1.1")
+        self.tool_requires("meson/1.1.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **pixman/**

Pixman package does not seem to have any Debug binaries, as can be seen with 
`conan list -r conancenter pixman/*@:* -p build_type=Debug`

cf https://github.com/conan-io/conan-center-index/pull/17712#issuecomment-1565216742

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
