### PR TITLE
Bring ring-lite & tl-function to conan2

### DIFF
--- a/recipes/ring-span-lite/all/conanfile.py
+++ b/recipes/ring-span-lite/all/conanfile.py
@@ -10,8 +10,8 @@ class RingSpanLiteConan(ConanFile):
     name = "ring-span-lite"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/martinmoene/ring-span-lite"
-    description = ("ring-span lite - A ring_span type for C++98, C++11 and later in a \
-                    single-file header-only library ")
+    description = (
+        "ring-span lite - A ring_span type for C++98, C++11 and later in a single-file header-only library ")
     topics = ("cpp98", "cpp11", "cpp14", "cpp17", "ring-span")
     license = "BSL-1.0"
     settings = "os", "arch", "compiler", "build_type"
@@ -31,25 +31,30 @@ class RingSpanLiteConan(ConanFile):
         pass
 
     def package(self):
-        copy(self, "*.hpp", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
-        copy(self, "LICENSE.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp", src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+        copy(self, "LICENSE.txt", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "ring-span-lite")
-        self.cpp_info.set_property("cmake_target_name", "nonstd::ring-span-lite")
+        self.cpp_info.set_property(
+            "cmake_target_name", "nonstd::ring-span-lite")
         self.cpp_info.bindirs = []
         self.cpp_info.frameworkdirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
 
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        # TODO: to remove in conan v2 once cmake_find_package* generators
+        # removed.
         self.cpp_info.filenames["cmake_find_package"] = "ring-span-lite"
         self.cpp_info.filenames["cmake_find_package_multi"] = "ring-span-lite"
         self.cpp_info.names["cmake_find_package"] = "nonstd"
         self.cpp_info.names["cmake_find_package_multi"] = "nonstd"
         self.cpp_info.components["ringspanlite"].names["cmake_find_package"] = "ring-span-lite"
         self.cpp_info.components["ringspanlite"].names["cmake_find_package_multi"] = "ring-span-lite"
-        self.cpp_info.components["ringspanlite"].set_property("cmake_target_name", "nonstd::ring-span-lite")
+        self.cpp_info.components["ringspanlite"].set_property(
+            "cmake_target_name", "nonstd::ring-span-lite")
         self.cpp_info.components["ringspanlite"].bindirs = []
         self.cpp_info.components["ringspanlite"].frameworkdirs = []
         self.cpp_info.components["ringspanlite"].libdirs = []

--- a/recipes/tl-function-ref/all/conanfile.py
+++ b/recipes/tl-function-ref/all/conanfile.py
@@ -35,8 +35,10 @@ class TlfunctionrefConan(ConanFile):
         pass
 
     def package(self):
-        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        copy(self, "*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+        copy(self, "COPYING", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*", src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "tl-function-ref")
@@ -46,14 +48,16 @@ class TlfunctionrefConan(ConanFile):
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
 
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        # TODO: to remove in conan v2 once cmake_find_package* generators
+        # removed.
         self.cpp_info.filenames["cmake_find_package"] = "tl-function-ref"
         self.cpp_info.filenames["cmake_find_package_multi"] = "tl-function-ref"
         self.cpp_info.names["cmake_find_package"] = "tl"
         self.cpp_info.names["cmake_find_package_multi"] = "tl"
         self.cpp_info.components["function-ref"].names["cmake_find_package"] = "function-ref"
         self.cpp_info.components["function-ref"].names["cmake_find_package_multi"] = "function-ref"
-        self.cpp_info.components["function-ref"].set_property("cmake_target_name", "tl::function-ref")
+        self.cpp_info.components["function-ref"].set_property(
+            "cmake_target_name", "tl::function-ref")
         self.cpp_info.components["function-ref"].bindirs = []
         self.cpp_info.components["function-ref"].frameworkdirs = []
         self.cpp_info.components["function-ref"].libdirs = []


### PR DESCRIPTION
This change performs some simple cleanup of these conanfile.py files in order to trigger a conan2 build of each.

Making these changes to bump these two packages from conan 1 to conan 2.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
