### PR TITLE
Add version 8.1.0 to the llhttp recipe

### DIFF
--- a/recipes/llhttp/all/conandata.yml
+++ b/recipes/llhttp/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "6.0.6":
     url: https://github.com/nodejs/llhttp/archive/refs/tags/release/v6.0.6.tar.gz
     sha256: "14023d0efce07a996a197d3b6b15020b26526605277e521f5aa10dacc3af67ad"
+  "8.1.0":
+    url: https://github.com/nodejs/llhttp/archive/refs/tags/release/v8.1.0.tar.gz
+    sha256: "9da0d23453e8e242cf3b2bc5d6fb70b1517b8a70520065fcbad6be787e86638e"
 patches:
   "6.0.6":
     - patch_file: "patches/cmake_install_dirs.patch"

--- a/recipes/llhttp/all/conanfile.py
+++ b/recipes/llhttp/all/conanfile.py
@@ -49,6 +49,7 @@ class LlhttpParserConan(ConanFile):
             return self._cmake
 
         self._cmake = CMake(self)
+        self._cmake.definitions["BUILD_STATIC_LIBS"] = "ON"
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/llhttp/config.yml
+++ b/recipes/llhttp/config.yml
@@ -1,3 +1,5 @@
 versions:
   "6.0.6":
     folder: all
+  "8.1.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **llhttp/8.1.0**

I'm submitting this PR because version 8.1.0 has numerous bugfixes over the existing latest version in conan-center, 6.0.6. v8.1.0 is the latest tagged release from October '22. I'm not the author nor am I a contributor, but llhttp is a useful reactive way to write an http client/server in C++.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
