### PR TITLE
[LibXft] Migrate LibXft to Conan2

### DIFF
--- a/recipes/libxft/all/conandata.yml
+++ b/recipes/libxft/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3.8":
+    url: "https://www.x.org/archive/individual/lib/libXft-2.3.8.tar.gz"
+    sha256: "32e48fe2d844422e64809e4e99b9d8aed26c1b541a5acf837c5037b8d9f278a8"
   "2.3.6":
     url: "https://www.x.org/archive/individual/lib/libXft-2.3.6.tar.gz"
     sha256: "b7e59f69e0bbabe9438088775f7e5a7c16a572e58b11f9722519385d38192df5"
@@ -11,4 +14,3 @@ patches:
       patch_description: "fix gcc 5 and gcc 11 compilation"
       patch_type: "portability"
       patch_source: "https://gitlab.freedesktop.org/xorg/lib/libxft/-/merge_requests/17"
-      base_path: "source_subfolder"

--- a/recipes/libxft/all/conanfile.py
+++ b/recipes/libxft/all/conanfile.py
@@ -1,12 +1,15 @@
 from conan import ConanFile
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, chdir, rm, rmdir
-from conans import AutoToolsBuildEnvironment
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, rm, rmdir, copy
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
 import functools
+import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.57.0"
 
-class libxftConan(ConanFile):
+class LibxftConan(ConanFile):
     name = "libxft"
+    package_type = "library"
     description = 'X FreeType library'
     topics = ("libxft", "x11", "xorg")
     url = "https://github.com/conan-io/conan-center-index"
@@ -16,11 +19,7 @@ class libxftConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
-    generators = "pkg_config"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    generators = "PkgConfigDeps"
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -35,15 +34,21 @@ class libxftConan(ConanFile):
         self.build_requires("xorg-macros/1.19.3")
         self.build_requires("libtool/2.4.7")
 
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.generate()
 
     def configure(self):
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     @functools.lru_cache(1)
     def _configure_autotools(self):
@@ -52,22 +57,20 @@ class libxftConan(ConanFile):
             args.extend(["--disable-static", "--enable-shared"])
         else:
             args.extend(["--disable-shared", "--enable-static"])
-        autotools = AutoToolsBuildEnvironment(self)
-        autotools.configure(args=args, pkg_config_paths=self.build_folder)
+        autotools = Autotools(self)
+        autotools.configure(args=args)
         return autotools
 
     def build(self):
         apply_conandata_patches(self)
-        with chdir(self, self._source_subfolder):
-            autotools = self._configure_autotools()
-            autotools.make()
+        autotools = self._configure_autotools()
+        autotools.make()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        with chdir(self, self._source_subfolder):
-            autotools = self._configure_autotools()
-            autotools.install(args=["-j1"])
+        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        autotools = self._configure_autotools()
+        autotools.install(args=["-j1"])
         rm(self, "*.la", f"{self.package_folder}/lib", recursive=True)
         rmdir(self, f"{self.package_folder}/lib/pkgconfig")
         rmdir(self, f"{self.package_folder}/share")

--- a/recipes/libxft/all/test_package/CMakeLists.txt
+++ b/recipes/libxft/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(libxft REQUIRED CONFIG)
+find_package(libxft REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} libxft::libxft)
+

--- a/recipes/libxft/all/test_package/conanfile.py
+++ b/recipes/libxft/all/test_package/conanfile.py
@@ -1,10 +1,22 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeToolchain", "CMakeDeps"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self, src_folder="./")
+
+    def requirements(self):
+        self.requires("xorg/system")
+        self.requires("freetype/2.13.0")
+        self.requires("fontconfig/2.14.2")
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +24,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libxft/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libxft/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(libxft REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} libxft::libxft)

--- a/recipes/libxft/all/test_v1_package/conanfile.py
+++ b/recipes/libxft/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libxft/all/test_v1_package/test_package.c
+++ b/recipes/libxft/all/test_v1_package/test_package.c
@@ -1,0 +1,10 @@
+#include "X11/Xft/Xft.h"
+
+#include <stdio.h>
+int main()
+{
+    if(!XftInit(""))
+        printf("Could not init Xft\n");
+    printf("Xft version: %d\n", XftGetVersion());
+    return 0;
+}

--- a/recipes/libxft/config.yml
+++ b/recipes/libxft/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3.8":
+    folder: all
   "2.3.6":
     folder: all
   "2.3.4":


### PR DESCRIPTION
- Moved old test_package to test_v1_package
- Left similar options and changed what the migration guide suggests

Specify library name and version:  **libxft/2.3.8**

Info:
I use conan 2.x and I need libxft to build other libs. I thought that I can help with migrating some packages to conan 2.0. I've read the migration guide, and checked it with conan 1.57 and 2.x. Also, I've checked in docker with Alpine. 
That's my first PR here. Please tell me if something I've missed.
I also ran hooks and linters.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
