### PR TITLE
libmemcached: Fix recipe logic

### DIFF
--- a/recipes/libmemcached/all/conanfile.py
+++ b/recipes/libmemcached/all/conanfile.py
@@ -52,7 +52,7 @@ class LibmemcachedConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def validate(self):
-        if self.settings.os not in ["Linux", "FreeBSD"] or not is_apple_os(self):
+        if self.settings.os not in ["Linux", "FreeBSD"] and not is_apple_os(self):
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
 
     def _patch_source(self):


### PR DESCRIPTION
Specify library name and version:  **libmemcached/1.0.18**

Demorgan's law, doh!
Due to peculiarity of how conan stores old conanfile.py in ~/.conan local tests passed. Checks on github were pending and didn't catch this either.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
