### PR TITLE
nsync: add version 1.26.0

### DIFF
--- a/recipes/nsync/all/conandata.yml
+++ b/recipes/nsync/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.26.0":
+    url: "https://github.com/google/nsync/archive/1.26.0.tar.gz"
+    sha256: "80fc1e605bb3cf5f272811ece39c4fb6761ffcb9b30563301845cc9ff381eb8b"
   "1.25.0":
     url: "https://github.com/google/nsync/archive/1.25.0.tar.gz"
     sha256: "2be9dbfcce417c7abcc2aa6fee351cd4d292518d692577e74a2c6c05b049e442"
@@ -9,6 +12,8 @@ sources:
     sha256: "b7e75b17957c62bd02dd73890bde22da3a564903fcaad651b395453d41d3325b"
     url: "https://github.com/google/nsync/archive/refs/tags/1.23.0.tar.gz"
 patches:
+  "1.26.0":
+    - patch_file: "patches/0001-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
   "1.25.0":
     - patch_file: "patches/0001-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
   "1.24.0":

--- a/recipes/nsync/config.yml
+++ b/recipes/nsync/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.26.0":
+    folder: "all"
   "1.25.0":
     folder: "all"
   "1.24.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  ** nsync/1.26.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
