### PR TITLE
lief: add version 0.13.1

### DIFF
--- a/recipes/lief/all/conandata.yml
+++ b/recipes/lief/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.13.1":
+    url: "https://github.com/lief-project/LIEF/archive/0.13.1.tar.gz"
+    sha256: "a3a846e9b6ce2acf89ef4687e870f41ca703f18fee3e7f501ebb05ee1aeb1847"
   "0.13.0":
     url: "https://github.com/lief-project/LIEF/archive/0.13.0.tar.gz"
     sha256: "8834e2ccfeefd1003527887357950173fe55e9a712004aa638af67378e28ef55"
@@ -12,6 +15,10 @@ sources:
     url: "https://github.com/lief-project/LIEF/archive/0.10.1.tar.gz"
     sha256: "6f30c98a559f137e08b25bcbb376c0259914b33c307b8b901e01ca952241d00a"
 patches:
+  "0.13.1":
+    - patch_file: "patches/0.13.0-001_link_to_conan.patch"
+      patch_description: "find conan package and link these"
+      patch_type: "conan"
   "0.13.0":
     - patch_file: "patches/0.13.0-001_link_to_conan.patch"
       patch_description: "find conan package and link these"

--- a/recipes/lief/config.yml
+++ b/recipes/lief/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.13.1":
+    folder: "all"
   "0.13.0":
     folder: "all"
   "0.12.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lief/0.13.1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
