### PR TITLE
zookeeper-client-c: add recipe

### DIFF
--- a/recipes/zookeeper-client-c/all/conandata.yml
+++ b/recipes/zookeeper-client-c/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "3.8.1":
+    url: "https://dlcdn.apache.org/zookeeper/zookeeper-3.8.1/apache-zookeeper-3.8.1.tar.gz"
+    sha256: "ccc16850c8ab2553583583234d11c813061b5ea5f3b8ff1d740cde6c1fd1e219"
+patches:
+  "3.8.1":
+    - patch_file: "patches/3.8.1-0001-add-install.patch"
+      patch_description: "add installer, disable cli program"
+      patch_type: "conan"

--- a/recipes/zookeeper-client-c/all/conanfile.py
+++ b/recipes/zookeeper-client-c/all/conanfile.py
@@ -90,8 +90,10 @@ class ZookeeperClientCConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["zookeeper", "hashtable"]
+        self.cpp_info.defines.append("USE_STATIC_LIB")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("rt")
-            self.cpp_info.system_libs.append("pthread")
-            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.extend(["rt", "pthread", "m"])
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["wsock32", "ws2_32", ])

--- a/recipes/zookeeper-client-c/all/conanfile.py
+++ b/recipes/zookeeper-client-c/all/conanfile.py
@@ -25,6 +25,7 @@ class ZookeeperClientCConan(ConanFile):
         "with_cyrus_sasl": False,
         "with_openssl": False,
     }
+    short_paths = True
 
     def export_sources(self):
         export_conandata_patches(self)

--- a/recipes/zookeeper-client-c/all/conanfile.py
+++ b/recipes/zookeeper-client-c/all/conanfile.py
@@ -1,0 +1,96 @@
+from conan import ConanFile
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+class ZookeeperClientCConan(ConanFile):
+    name = "zookeeper-client-c"
+    description = "ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services."
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://zookeeper.apache.org/"
+    topics = ("zookeeper", "client")
+    settings = "os", "arch", "compiler", "build_type"
+    package_type = "static-library"
+    options = {
+        "fPIC": [True, False],
+        "with_cyrus_sasl": [True, False],
+        "with_openssl": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "with_cyrus_sasl": False,
+        "with_openssl": False,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.with_cyrus_sasl:
+            self.requires("cyrus-sasl/2.1.27")
+        if self.options.with_openssl:
+            self.requires("openssl/[>=1.1 <4]")
+
+    def build_requirements(self):
+        self.tool_requires("zulu-openjdk/11.0.15")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["WANT_CPPUNIT"] = False
+        tc.variables["WITH_CYRUS_SASL"] = "ON" if self.options.with_cyrus_sasl else "OFF"
+        tc.variables["WITH_OPENSSL"] = "ON" if self.options.with_openssl else "OFF"
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+
+        # We have to install maven to generate jute files which are required by zookeeper-client
+        get(self,
+            "https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz",
+            destination=os.path.join(self.source_folder, "maven"),
+            strip_root=True
+        )
+        self.run(
+            os.path.join(self.source_folder, "maven", "bin", "mvn") + " compile",
+            cwd=os.path.join(self.source_folder, "zookeeper-jute")
+        )
+
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, "zookeeper-client", "zookeeper-client-c"))
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=os.path.join(self.source_folder, "zookeeper-client", "zookeeper-client-c")
+        )
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["zookeeper", "hashtable"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("rt")
+            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.append("m")

--- a/recipes/zookeeper-client-c/all/conanfile.py
+++ b/recipes/zookeeper-client-c/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
@@ -61,6 +62,8 @@ class ZookeeperClientCConan(ConanFile):
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
+        bvenv = VirtualBuildEnv(self)
+        bvenv.generate()
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/zookeeper-client-c/all/conanfile.py
+++ b/recipes/zookeeper-client-c/all/conanfile.py
@@ -48,7 +48,7 @@ class ZookeeperClientCConan(ConanFile):
             self.requires("openssl/[>=1.1 <4]")
 
     def build_requirements(self):
-        self.tool_requires("zulu-openjdk/11.0.15")
+        self.tool_requires("maven/3.9.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -66,15 +66,7 @@ class ZookeeperClientCConan(ConanFile):
         apply_conandata_patches(self)
 
         # We have to install maven to generate jute files which are required by zookeeper-client
-        get(self,
-            "https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz",
-            destination=os.path.join(self.source_folder, "maven"),
-            strip_root=True
-        )
-        self.run(
-            os.path.join(self.source_folder, "maven", "bin", "mvn") + " compile",
-            cwd=os.path.join(self.source_folder, "zookeeper-jute")
-        )
+        self.run("mvn compile", cwd=os.path.join(self.source_folder, "zookeeper-jute"))
 
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join(self.source_folder, "zookeeper-client", "zookeeper-client-c"))

--- a/recipes/zookeeper-client-c/all/patches/3.8.1-0001-add-install.patch
+++ b/recipes/zookeeper-client-c/all/patches/3.8.1-0001-add-install.patch
@@ -1,0 +1,54 @@
+diff --git a/zookeeper-client/zookeeper-client-c/CMakeLists.txt b/zookeeper-client/zookeeper-client-c/CMakeLists.txt
+index 5d0175e..9349bc0 100644
+--- a/zookeeper-client/zookeeper-client-c/CMakeLists.txt
++++ b/zookeeper-client/zookeeper-client-c/CMakeLists.txt
+@@ -228,16 +228,6 @@ if(CYRUS_SASL_FOUND)
+   target_link_libraries(zookeeper PUBLIC CyrusSASL)
+ endif()
+ 
+-# cli executable
+-add_executable(cli src/cli.c)
+-target_link_libraries(cli zookeeper)
+-
+-# load_gen executable
+-if(WANT_SYNCAPI AND NOT WIN32)
+-  add_executable(load_gen src/load_gen.c)
+-  target_link_libraries(load_gen zookeeper)
+-endif()
+-
+ # tests
+ set(test_sources
+   tests/TestDriver.cc
+@@ -290,3 +280,32 @@ if(WANT_CPPUNIT)
+     "ZKROOT=${CMAKE_CURRENT_SOURCE_DIR}/../.."
+     "CLASSPATH=$CLASSPATH:$CLOVER_HOME/lib/clover*.jar")
+ endif()
++
++include(GNUInstallDirs)
++
++install(
++    TARGETS zookeeper
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)
++
++install(
++    TARGETS hashtable
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)
++
++install(FILES
++  ${CMAKE_CURRENT_SOURCE_DIR}/include/proto.h
++  ${CMAKE_CURRENT_SOURCE_DIR}/include/recordio.h
++  ${CMAKE_CURRENT_SOURCE_DIR}/include/win_getopt.h
++  ${CMAKE_CURRENT_SOURCE_DIR}/include/winconfig.h
++  ${CMAKE_CURRENT_SOURCE_DIR}/include/zookeeper.h
++  ${CMAKE_CURRENT_SOURCE_DIR}/include/zookeeper_log.h
++  ${CMAKE_CURRENT_SOURCE_DIR}/include/zookeeper_version.h
++  ${CMAKE_CURRENT_SOURCE_DIR}/generated/zookeeper.jute.h
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/recipes/zookeeper-client-c/all/test_package/CMakeLists.txt
+++ b/recipes/zookeeper-client-c/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package C)
+
+find_package(zookeeper-client-c REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE zookeeper-client-c::zookeeper-client-c)

--- a/recipes/zookeeper-client-c/all/test_package/conanfile.py
+++ b/recipes/zookeeper-client-c/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/zookeeper-client-c/all/test_package/test_package.c
+++ b/recipes/zookeeper-client-c/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <zookeeper.h>
+#include "zookeeper_log.h"
+
+int main(void) {
+    zookeeper_close(0);
+
+    return 0;
+}

--- a/recipes/zookeeper-client-c/config.yml
+++ b/recipes/zookeeper-client-c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.8.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **zookeeper/3.8.1**

Try to close https://github.com/conan-io/conan-center-index/issues/17787.

While zookkeeper-client-c requires code generated from jute, this recipe requires the installation of jdk and maven, which are needed to execute jute.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
