### PR TITLE
at-spi2-core: remove outdated workaround

### DIFF
--- a/recipes/at-spi2-core/all/conanfile.py
+++ b/recipes/at-spi2-core/all/conanfile.py
@@ -47,8 +47,6 @@ class AtSpi2CoreConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        if self.options.shared:
-            self.options["glib"].shared = True
 
     def build_requirements(self):
         self.build_requires("meson/1.1.0")
@@ -108,6 +106,3 @@ class AtSpi2CoreConan(ConanFile):
         self.cpp_info.libs = ['atspi']
         self.cpp_info.includedirs = ["include/at-spi-2.0"]
         self.cpp_info.names["pkg_config"] = "atspi-2"
-
-    def package_id(self):
-        self.info.requires["glib"].full_package_mode()

--- a/recipes/at-spi2-core/all/conanfile.py
+++ b/recipes/at-spi2-core/all/conanfile.py
@@ -49,11 +49,11 @@ class AtSpi2CoreConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def build_requirements(self):
-        self.build_requires("meson/1.1.0")
+        self.build_requires("meson/1.1.1")
         self.build_requires("pkgconf/1.9.3")
 
     def requirements(self):
-        self.requires("glib/2.76.2")
+        self.requires("glib/2.76.3")
         if self.options.with_x11:
             self.requires("xorg/system")
         self.requires("dbus/1.15.2")


### PR DESCRIPTION
Specify library name and version:  **at-spi2-core/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
