### PR TITLE
[pixman] Remove collect_libs and use library real name

### DIFF
--- a/recipes/pixman/all/conandata.yml
+++ b/recipes/pixman/all/conandata.yml
@@ -1,8 +1,6 @@
 sources:
   "0.40.0":
-    url:
-    - "https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-0.40.0/pixman-pixman-0.40.0.tar.gz"
-    - "https://www.cairographics.org/releases/pixman-0.40.0.tar.gz"
+    url: "https://www.cairographics.org/releases/pixman-0.40.0.tar.gz"
     sha256: "6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc"
   "0.38.4":
     url: "https://www.cairographics.org/releases/pixman-0.38.4.tar.gz"

--- a/recipes/pixman/all/conandata.yml
+++ b/recipes/pixman/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "0.40.0":
-    url: "https://www.cairographics.org/releases/pixman-0.40.0.tar.gz"
+    url:
+    - "https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-0.40.0/pixman-pixman-0.40.0.tar.gz"
+    - "https://www.cairographics.org/releases/pixman-0.40.0.tar.gz"
     sha256: "6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc"
   "0.38.4":
     url: "https://www.cairographics.org/releases/pixman-0.38.4.tar.gz"

--- a/recipes/pixman/all/conanfile.py
+++ b/recipes/pixman/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import (
-    apply_conandata_patches, collect_libs, copy, export_conandata_patches, get,
+    apply_conandata_patches, copy, export_conandata_patches, get,
     rename, replace_in_file, rm, rmdir
 )
 from conan.tools.layout import basic_layout
@@ -93,7 +93,7 @@ class PixmanConan(ConanFile):
             rename(self, os.path.join(lib_folder, f"{prefix}.a"), os.path.join(lib_folder, f"{prefix}.lib"))
 
     def package_info(self):
-        self.cpp_info.libs = collect_libs(self)
+        self.cpp_info.libs = ['pixman-1']
         self.cpp_info.includedirs.append(os.path.join("include", "pixman-1"))
         self.cpp_info.set_property("pkg_config_name", "pixman-1")
         if self.settings.os in ("FreeBSD", "Linux"):

--- a/recipes/pixman/all/conanfile.py
+++ b/recipes/pixman/all/conanfile.py
@@ -93,7 +93,7 @@ class PixmanConan(ConanFile):
             rename(self, os.path.join(lib_folder, f"{prefix}.a"), os.path.join(lib_folder, f"{prefix}.lib"))
 
     def package_info(self):
-        self.cpp_info.libs = ['pixman-1']
+        self.cpp_info.libs = ['libpixman-1'] if self.settings.os == "Windows" else ['pixman-1']
         self.cpp_info.includedirs.append(os.path.join("include", "pixman-1"))
         self.cpp_info.set_property("pkg_config_name", "pixman-1")
         if self.settings.os in ("FreeBSD", "Linux"):


### PR DESCRIPTION
Specify library name and version:  **pixman/0.40.0**

The Pixman library is missing in ConanCenter for Debug build type. I tried to generate again via Tapaholes, but is still missing. This PR should generate a new recipe revision and new packages, fixing the problem (I hope). 

Related to https://github.com/conan-io/conan-center-index/pull/17844

/cc @ericLemanissier 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
