### PR TITLE
vulkan-loader: add 1.3.243, 1.3.250, workaround issue with full_deploy

### DIFF
--- a/recipes/vulkan-loader/all/conandata.yml
+++ b/recipes/vulkan-loader/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.3.250.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.3.250.tar.gz"
+    sha256: "4e4bf5bb93a43686d36218309804d21be6070d344ccd0c73cf695cb66a1e352b"
+  "1.3.243.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.3.243.tar.gz"
+    sha256: "dafcddb1e193a7da3b18d51748c634af9e3d1bfade524773fbf3f297c955396b"
   "1.3.239.0":
     url: "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/sdk-1.3.239.0.tar.gz"
     sha256: "fa2078408793b2173f174173a8784de56b6bbfbcb5fb958a07e46ef126c7eada"

--- a/recipes/vulkan-loader/all/conanfile.py
+++ b/recipes/vulkan-loader/all/conanfile.py
@@ -135,7 +135,7 @@ class VulkanLoaderConan(ConanFile):
         if Version(self.version) < "1.3.234":
             replace_in_file(self, os.path.join(self.source_folder, "cmake", "FindVulkanHeaders.cmake"),
                                   "HINTS ${VULKAN_HEADERS_INSTALL_DIR}/share/vulkan/registry",
-                                  "HINTS ${VULKAN_HEADERS_INSTALL_DIR}/res/vulkan/registry")
+                                  "HINTS ${VULKAN_HEADERS_INSTALL_DIR}/res/vulkan/registry")    
         # Honor settings.compiler.runtime
         replace_in_file(self, os.path.join(self.source_folder, "loader", "CMakeLists.txt"),
                               "if(${configuration} MATCHES \"/MD\")",
@@ -145,14 +145,17 @@ class VulkanLoaderConan(ConanFile):
         # No warnings as errors
         if Version(self.version) < "1.3.212":
             replace_in_file(self, cmakelists, "/WX", "")
-        # This fix is needed due to CMAKE_FIND_PACKAGE_PREFER_CONFIG ON in CMakeToolchain (see https://github.com/conan-io/conan/issues/10387).
-        # Indeed we want to use upstream Find modules of xcb, x11, wayland and directfb. There are properly using pkgconfig under the hood.
-        replace_in_file(self, cmakelists, "find_package(XCB REQUIRED)", "find_package(XCB REQUIRED MODULE)")
-        replace_in_file(self, cmakelists, "find_package(X11 REQUIRED)", "find_package(X11 REQUIRED MODULE)")
+        
+        if Version(self.version) < "1.3.243":
+            # This fix is needed due to CMAKE_FIND_PACKAGE_PREFER_CONFIG ON in CMakeToolchain (see https://github.com/conan-io/conan/issues/10387).
+            # Indeed we want to use upstream Find modules of xcb, x11, wayland and directfb. There are properly using pkgconfig under the hood.
+            replace_in_file(self, cmakelists, "find_package(XCB REQUIRED)", "find_package(XCB REQUIRED MODULE)")
+            replace_in_file(self, cmakelists, "find_package(X11 REQUIRED)", "find_package(X11 REQUIRED MODULE)")
+            replace_in_file(self, cmakelists, "find_package(DirectFB REQUIRED)", "find_package(DirectFB REQUIRED MODULE)")
+
         # find_package(Wayland REQUIRED) was removed, as it was unused
         if Version(self.version) < "1.3.231":
             replace_in_file(self, cmakelists, "find_package(Wayland REQUIRED)", "find_package(Wayland REQUIRED MODULE)")
-        replace_in_file(self, cmakelists, "find_package(DirectFB REQUIRED)", "find_package(DirectFB REQUIRED MODULE)")
 
     def build(self):
         self._patch_sources()

--- a/recipes/vulkan-loader/all/conanfile.py
+++ b/recipes/vulkan-loader/all/conanfile.py
@@ -176,7 +176,7 @@ class VulkanLoaderConan(ConanFile):
         self.cpp_info.libs = [f"vulkan{suffix}"]
 
         # allow to properly set Vulkan_INCLUDE_DIRS in CMake like generators
-        self.cpp_info.includedirs = self.dependencies["vulkan-headers"].cpp_info.aggregated_components().includedirs
+        self.cpp_info.includedirs = self.dependencies["vulkan-headers"].cpp_info.includedirs
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["dl", "pthread", "m"]

--- a/recipes/vulkan-loader/config.yml
+++ b/recipes/vulkan-loader/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.3.250.0":
+    folder: all
+  "1.3.243.0":
+    folder: all
   "1.3.239.0":
     folder: all
   "1.3.236.0":


### PR DESCRIPTION
**vulkan-loader/1.3.243**
**vulkan-loader/1.3.250**

This PR adds versions 1.3.243, 1.3.250 (the stable Vulkan SDK versions).
Also works around conan-io/conan#14022.

Needs #17877.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
