### PR TITLE
fast_float: add version 5.1.0

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.1.0":
+    url: "https://github.com/fastfloat/fast_float/archive/v5.1.0.tar.gz"
+    sha256: "37a0de5473ed6b9617ea4c199c2d5bda45ab027dbe72220fe36cf3000f9f23bf"
   "5.0.0":
     url: "https://github.com/fastfloat/fast_float/archive/v5.0.0.tar.gz"
     sha256: "86645ab4af22d21d4ba2d980572dfb74faf90c20c52240d7d8d2201f3eaf4252"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.1.0":
+    folder: all
   "5.0.0":
     folder: all
   "4.0.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **fast_float/5.1.**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
