### PR TITLE
fix(zlib): build_requirements missing

### DIFF
--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -78,6 +78,10 @@ class ZlibConan(ConanFile):
                                       '/* may be set to #if 1 by ./configure */',
                                       '#if defined(HAVE_STDARG_H) && (1-HAVE_STDARG_H-1 != 0)')
 
+        
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.15.7 <4]")
+
     def build(self):
         self._patch_sources()
         cmake = CMake(self)

--- a/recipes/zlib/all/test_package/conanfile.py
+++ b/recipes/zlib/all/test_package/conanfile.py
@@ -14,6 +14,9 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+    
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.15.7 <4]")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/zlib/all/test_v1_package/conanfile.py
+++ b/recipes/zlib/all/test_v1_package/conanfile.py
@@ -6,6 +6,9 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package"
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.15.7 <4]")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
Specify library name and version: zlib

I stumbled upon the fact that zlib doesn't define its build requirements, maybe not intentionally.
It seems that zlib supports cmake versions below 3.15.7 but it's currently the lowest version in conan center and the version I tested.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
