### PR TITLE
libxcrypt: add version 4.4.35

### DIFF
--- a/recipes/libxcrypt/all/conandata.yml
+++ b/recipes/libxcrypt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.4.35":
+    url: "https://github.com/besser82/libxcrypt/archive/v4.4.35.tar.gz"
+    sha256: "15981f2ffb82d70f07285f9683c485c4774083057564a2e7e74236c19e8e9f7b"
   "4.4.34":
     url: "https://github.com/besser82/libxcrypt/archive/v4.4.34.tar.gz"
     sha256: "8888bbe9f8530bbd9f8063d65288018d419f91e9b3e3349abb8cb4d0a0397cc5"

--- a/recipes/libxcrypt/config.yml
+++ b/recipes/libxcrypt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.4.35":
+    folder: all
   "4.4.34":
     folder: all
   "4.4.28":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libxcrypt/4.4.35**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
