### PR TITLE
fix nativefiledialog/116 on VS 2022

### DIFF
--- a/recipes/nativefiledialog/all/conanfile.py
+++ b/recipes/nativefiledialog/all/conanfile.py
@@ -38,7 +38,8 @@ class NativefiledialogConan(ConanFile):
 
     def build(self):
         if self.settings.compiler == "Visual Studio":
-            generator = "vs" + {"16": "2019",
+            generator = "vs" + {"17": "2022",
+                                "16": "2019",
                                 "15": "2017",
                                 "14": "2015",
                                 "12": "2013",

--- a/recipes/nativefiledialog/all/conanfile.py
+++ b/recipes/nativefiledialog/all/conanfile.py
@@ -1,6 +1,6 @@
 import os
-from conans import ConanFile, MSBuild, AutoToolsBuildEnvironment, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile, MSBuild, AutoToolsBuildEnvironment, tools
+from conan.errors import ConanInvalidConfiguration
 
 
 class NativefiledialogConan(ConanFile):


### PR DESCRIPTION
Specify library name and version:  **nativefiledialog/116**

Fixes #14407

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
