### PR TITLE
ftxui: Fix sha for version 4.1.1

### DIFF
--- a/recipes/ftxui/all/conandata.yml
+++ b/recipes/ftxui/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "4.1.1":
     url: "https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/v4.1.1.tar.gz"
-    sha256: "355739597588f837d3ade70c4a52614e5f8d9c04b9e31e5621ed5aa9ba92507f"
+    sha256: "9009d093e48b3189487d67fc3e375a57c7b354c0e43fc554ad31bec74a4bc2dd"
   "4.1.0":
     url: "https://github.com/ArthurSonzogni/FTXUI/archive/refs/tags/v4.1.0.tar.gz"
     sha256: "6f03f5917b44c9bc12335ad891a93813bbb6e738e0bd0c44f97bcc6077c45980"


### PR DESCRIPTION
Specify library name and version:  **ftxui/4.1.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

The given sha seems to be wrong.
