### PR TITLE
(#17909) linux-headers-generic: bindirs and libdirs emptied

### DIFF
--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -41,3 +41,9 @@ class LinuxHeadersGenericConan(ConanFile):
     def package(self):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
         self.copy("include/*.h", src=os.path.join(self._source_subfolder, "usr"))
+
+    def package_info(self):
+        # For header-only packages, libdirs and bindirs are not used
+        # so it's necessary to set those as empty.
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []


### PR DESCRIPTION
linux-headers-generic/5.14.9

According to the documentation (https://docs.conan.io/2/tutorial/creating_packages/other_types_of_packages/header_only_packages.html), for header-only libraries they should be empty. Otherwise non-existent directories are told to the client libraries, and some of the clients' build systems do not tolerate that.

qt/5.12.6 depends on libdrm which in turn depends on linux-headers-generic. qt's own configuration system throws errors if non-existent include and link directories are given as compilation arguments.
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
