### PR TITLE
(#17913) nodejs: Get glibc version from the end of the ldd --version …

### DIFF
--- a/recipes/nodejs/all/conanfile.py
+++ b/recipes/nodejs/all/conanfile.py
@@ -38,7 +38,7 @@ class NodejsConan(ConanFile):
         cmd = ['ldd', '--version'] if conan_version.major == "1" else ['ldd --version']
         buff = StringIO()
         self.run(cmd, buff)
-        return str(re.search(r'GLIBC (\d{1,3}.\d{1,3})', buff.getvalue()).group(1))
+        return str(re.search(r'^ldd.+(\d{1,3}.\d{1,3})\n', buff.getvalue()).group(1))
 
     def validate(self):
         if not self.version in self.conan_data["sources"] or \


### PR DESCRIPTION
…line

The string in the brackets may vary, but the version number at the end seems to be always present:

ldd (Gentoo 2.34-r13 p17) 2.34
ldd (Ubuntu GLIBC 2.27-3ubuntu1.6) 2.27
ldd (Debian GLIBC 2.31-13+deb11u6) 2.31
ldd (GNU libc) 2.26

#17913 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
