### PR TITLE
roaring: add version 1.3.0

### DIFF
--- a/recipes/roaring/all/conandata.yml
+++ b/recipes/roaring/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.0":
+    url: "https://github.com/RoaringBitmap/CRoaring/archive/v1.3.0.tar.gz"
+    sha256: "c4fccf6a8cfa6f15f47d0e6f6b202940c2305e3078eb745d25fe9e2739ae5278"
   "1.1.5":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/v1.1.5.tar.gz"
     sha256: "5210a277ce83c3099dfee41d494c28aec61bdbc9160b3b124cb5afeab49cd123"

--- a/recipes/roaring/config.yml
+++ b/recipes/roaring/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.0":
+    folder: all
   "1.1.5":
     folder: all
   "1.1.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **roaring/1.3.0**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
