### PR TITLE
[onetbb] added tbbbind (via hwloc) support

### DIFF
--- a/recipes/onetbb/all/conandata.yml
+++ b/recipes/onetbb/all/conandata.yml
@@ -35,3 +35,9 @@ patches:
       patch_type: "portability"
       patch_source: "https://github.com/oneapi-src/oneTBB/pull/716.diff"
       patch_file: "patches/fix-overeager-stripping-of-compile-flag.diff"
+    - patch_description: "Use pkg_search_module with IMPORTED_TARGET"
+      patch_type: "portability"
+      patch_source:
+        - "https://github.com/oneapi-src/oneTBB/pull/448.diff"
+        - "https://github.com/oneapi-src/oneTBB/commit/df3096075a00942acbdd3ce9347f5298cc153fd6.diff"
+      patch_file: "patches/pkg-search-module-use-imported-target.diff"

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -1,7 +1,9 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, load, rmdir
+from conan.tools.gnu import PkgConfigDeps
 from conan.tools.scm import Version
 import os
 import re
@@ -26,6 +28,7 @@ class OneTBBConan(ConanFile):
         "fPIC": [True, False],
         "tbbmalloc": [True, False],
         "tbbproxy": [True, False],
+        "tbbbind": [True, False],
         "interprocedural_optimization": [True, False],
     }
     default_options = {
@@ -33,8 +36,28 @@ class OneTBBConan(ConanFile):
         "fPIC": True,
         "tbbmalloc": True,
         "tbbproxy": True,
+        "tbbbind": True,
         "interprocedural_optimization": True,
     }
+
+    @property
+    def _tbbbind_hwloc_version(self):
+        # TBB expects different variables depending on the version
+        return "2_5" if Version(self.version) >= "2021.4.0" else "2_4"
+
+    @property
+    def _tbbbind_supported(self):
+        return Version(self.version) >= "2021.1.1" and not self.settings.os == "Macos"
+
+    @property
+    def _tbbbind_build(self):
+        return self.options.get_safe("tbbbind", False) and self._tbbbind_supported
+
+    @property
+    def _tbbbind_explicit_hwloc(self):
+        # during cross-compilation, oneTBB does not search for HWLOC and we need to specify it explicitly
+        # but then oneTBB creates an imported SHARED target from provided paths, so we have to set shared=True
+        return self._tbbbind_build and cross_building(self)
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -42,6 +65,8 @@ class OneTBBConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if not self._tbbbind_supported:
+            del self.options.tbbbind
         if Version(self.version) < "2021.6.0" or self.settings.os == "Android":
             del self.options.interprocedural_optimization
         if Version(self.version) < "2021.2.0":
@@ -53,8 +78,15 @@ class OneTBBConan(ConanFile):
             self.options.rm_safe("fPIC")
         else:
             del self.options.tbbproxy
+            self.options.rm_safe("tbbbind")
         if not self.options.tbbmalloc:
             self.options.rm_safe("tbbproxy")
+        if self._tbbbind_explicit_hwloc:
+            self.options["hwloc"].shared = True
+
+    def requirements(self):
+        if self._tbbbind_build:
+            self.requires("hwloc/2.9.1")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -76,6 +108,8 @@ class OneTBBConan(ConanFile):
                     "Please consider fixing at least the aforementioned issue in upstream."
                 )
             self.output.warning("oneTBB strongly discourages usage of static linkage")
+        if self._tbbbind_explicit_hwloc and not self.dependencies["hwloc"].options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} requires hwloc:shared=True to be built.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -90,6 +124,17 @@ class OneTBBConan(ConanFile):
             toolchain.variables["TBB_ENABLE_IPO"] = self.options.interprocedural_optimization
         if Version(self.version) >= "2021.6.0" and self.options.get_safe("tbbproxy"):
             toolchain.variables["TBBMALLOC_PROXY_BUILD"] = self.options.tbbproxy
+        toolchain.variables["TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH"] = not self._tbbbind_build
+        if self._tbbbind_build:
+            deps = PkgConfigDeps(self)
+            deps.generate()
+        if self._tbbbind_explicit_hwloc:
+            hwloc_package_folder = self.dependencies["hwloc"].package_folder.replace("\\", "/")
+            hwloc_lib_name = "hwloc.lib" if self.settings.os == "Windows" else "libhwloc.so"
+            toolchain.variables[f"CMAKE_HWLOC_{self._tbbbind_hwloc_version}_LIBRARY_PATH"] = os.path.join(hwloc_package_folder, "lib", hwloc_lib_name)
+            toolchain.variables[f"CMAKE_HWLOC_{self._tbbbind_hwloc_version}_INCLUDE_PATH"] = os.path.join(hwloc_package_folder, "include")
+            if self.settings.os == "Windows":
+                toolchain.variables[f"CMAKE_HWLOC_{self._tbbbind_hwloc_version}_DLL_PATH"] = os.path.join(hwloc_package_folder, "bin", "hwloc.dll")
         toolchain.generate()
 
     def build(self):

--- a/recipes/onetbb/all/patches/pkg-search-module-use-imported-target.diff
+++ b/recipes/onetbb/all/patches/pkg-search-module-use-imported-target.diff
@@ -1,0 +1,97 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 34a23d40..d569d57e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -100,6 +100,8 @@ option(TBB_NO_APPCONTAINER "Apply /APPCONTAINER:NO (for testing binaries for Win
+ option(TBB4PY_BUILD "Enable tbb4py build" OFF)
+ option(TBB_CPF "Enable preview features of the library" OFF)
+ option(TBB_FIND_PACKAGE "Enable search for external oneTBB using find_package instead of build from sources" OFF)
++option(TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH "Disable HWLOC automatic search by pkg-config tool" OFF)
++
+ 
+ if (NOT DEFINED BUILD_SHARED_LIBS)
+     set(BUILD_SHARED_LIBS ON)
+@@ -194,7 +196,7 @@ else()
+     if (NOT "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "mips")
+         add_subdirectory(src/tbbmalloc)
+         add_subdirectory(src/tbbmalloc_proxy)
+-        if (APPLE)
++        if (APPLE OR NOT BUILD_SHARED_LIBS)
+             message(STATUS "TBBBind build target is disabled due to unsupported environment")
+         else()
+             add_subdirectory(src/tbbbind)
+diff --git a/cmake/hwloc_detection.cmake b/cmake/hwloc_detection.cmake
+index f1740662..e1806a0f 100644
+--- a/cmake/hwloc_detection.cmake
++++ b/cmake/hwloc_detection.cmake
+@@ -45,11 +45,15 @@ endforeach()
+ 
+ unset(HWLOC_TARGET_NAME)
+ 
+-if (NOT HWLOC_TARGET_EXPLICITLY_DEFINED)
++if (NOT HWLOC_TARGET_EXPLICITLY_DEFINED AND
++    # No hwloc auto detection for cross compilation
++    NOT CMAKE_CROSSCOMPILING AND
++    NOT TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH
++)
+     find_package(PkgConfig QUIET)
+-    if (PKG_CONFIG_FOUND)
+-        pkg_search_module(HWLOC hwloc)
+-        if (HWLOC_FOUND)
++    if (PKG_CONFIG_FOUND AND NOT CMAKE_VERSION VERSION_LESS 3.6)
++        pkg_search_module(HWLOC hwloc IMPORTED_TARGET)
++        if (TARGET PkgConfig::HWLOC)
+             if (HWLOC_VERSION VERSION_LESS 2)
+                 set(TBBBIND_LIBRARY_NAME tbbbind)
+             elseif(HWLOC_VERSION VERSION_LESS 2.4)
+@@ -60,4 +64,3 @@ if (NOT HWLOC_TARGET_EXPLICITLY_DEFINED)
+         endif()
+     endif()
+ endif()
+-
+diff --git a/src/tbbbind/CMakeLists.txt b/src/tbbbind/CMakeLists.txt
+index da9dabfe..1a4c6ca0 100644
+--- a/src/tbbbind/CMakeLists.txt
++++ b/src/tbbbind/CMakeLists.txt
+@@ -18,12 +18,13 @@ endif()
+ set(CMAKE_SKIP_BUILD_RPATH TRUE)
+ 
+ function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
+-    if (NOT TARGET ${REQUIRED_HWLOC_TARGET} AND NOT DEFINED HWLOC_LIBRARIES)
++    if (NOT TARGET ${REQUIRED_HWLOC_TARGET})
+         message(STATUS "HWLOC target ${REQUIRED_HWLOC_TARGET} doesn't exist."
+                        " The ${TBBBIND_NAME} target cannot be created")
+         return()
+     endif()
+     add_library(${TBBBIND_NAME} tbb_bind.cpp)
++
+     add_library(TBB::${TBBBIND_NAME} ALIAS ${TBBBIND_NAME})
+ 
+     target_compile_definitions(${TBBBIND_NAME}
+@@ -64,14 +65,12 @@ function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
+             PRIVATE
+             ${TBB_LIB_LINK_FLAGS}
+             ${TBB_COMMON_LINK_FLAGS}
+-            ${HWLOC_LIBRARY_DIRS} # pkg-config defined
+         )
+     else()
+         target_link_libraries(${TBBBIND_NAME}
+             PRIVATE
+             ${TBB_LIB_LINK_FLAGS}
+             ${TBB_COMMON_LINK_FLAGS}
+-            ${HWLOC_LIBRARY_DIRS} # pkg-config defined
+         )
+     endif()
+ 
+@@ -90,9 +89,9 @@ function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
+     endif()
+ endfunction()
+ 
+-if (NOT DEFINED HWLOC_TARGET_EXPLICITLY_DEFINED AND DEFINED HWLOC_LIBRARIES)
++if (NOT DEFINED HWLOC_TARGET_EXPLICITLY_DEFINED AND TARGET PkgConfig::HWLOC)
+     message(STATUS "The ${TBBBIND_LIBRARY_NAME} target will be configured using the HWLOC ${HWLOC_VERSION}")
+-    tbbbind_build(${TBBBIND_LIBRARY_NAME} ${HWLOC_LIBRARIES})
++    tbbbind_build(${TBBBIND_LIBRARY_NAME} PkgConfig::HWLOC)
+ else()
+     tbbbind_build(tbbbind     HWLOC::hwloc_1_11)
+     tbbbind_build(tbbbind_2_0 HWLOC::hwloc_2   )


### PR DESCRIPTION
Specify library name and version:  **onetbb/2021.9.0**

**Description:** This PR is submitted as a continuation of adding hwloc library. With adding hwloc as a dependency, TBB provides extra plugin library which provides abilities to detect information about system topology such as number of NUMA nodes, number of P / E cores on CPU.

**Details of implementation:**
- TBB does not support TBBBind library when TBB is built statically (just not implemented in TBB itself)
- TBB has extra cmake option `TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH` to control whether HWLOC should be automatically found by `pkg-config`, but available only since 2021.4. Created patch to have an unified recipe without a lot of conditions which are version dependent.
- Before 2021 major release, TBB does not support HWLOC (no TBBBind is created)
- TBBBind library does not need to be added into `package_info` section, because it's a plugin and loaded in runtime.
- It's good to enable such option by default, because it's aligned with TBB behavior and allows users to use the library ready for all types of processors out of box.

Hope, these notes can help reviewers.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
