### PR TITLE
commata: add version 0.2.4-bug1

### DIFF
--- a/recipes/commata/all/conandata.yml
+++ b/recipes/commata/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.4-bug1":
+    url: "https://github.com/furfurylic/commata/archive/refs/tags/v0.2.4-bug1.tar.gz"
+    sha256: "fcde251d9b41f1601e1f8b2181613b4bf33c4318678700e2b3b54bf24bc9e1e3"
   "0.2.4":
     url: "https://github.com/furfurylic/commata/archive/refs/tags/v0.2.4.tar.gz"
     sha256: "2d154c1ed7bbf6551729bcc5baf581613f6605df080ada35a9e107648d255e2e"

--- a/recipes/commata/config.yml
+++ b/recipes/commata/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.4-bug1":
+    folder: all
   "0.2.4":
     folder: all
   "0.2.3":


### PR DESCRIPTION
Specify library name and version:  **commata/0.2.4-bug1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
