### PR TITLE
spdlog: bump fmt10.0.0 and apply patch to fix build error

### DIFF
--- a/recipes/spdlog/all/conandata.yml
+++ b/recipes/spdlog/all/conandata.yml
@@ -14,3 +14,9 @@ sources:
   "1.8.5":
     url: "https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz"
     sha256: "944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8"
+patches:
+  "1.11.0":
+    - patch_file: "patches/1.11.0-0001-fix-fmt10-build.patch"
+      patch_description: "Fix fmt 10.0.0 build"
+      patch_type: "conan"
+      patch_source: "https://github.com/gabime/spdlog/pull/2694"

--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.files import get, copy, rmdir, replace_in_file
+from conan.tools.files import get, copy, rmdir, replace_in_file, apply_conandata_patches, export_conandata_patches
 from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
@@ -36,6 +36,9 @@ class SpdlogConan(ConanFile):
         "no_exceptions": False,
     }
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -54,7 +57,7 @@ class SpdlogConan(ConanFile):
         fmt_version = "7.1.3"
 
         if self_version >= "1.11.0":
-            fmt_version = "9.1.0"
+            fmt_version = "10.0.0"
         elif self_version >= "1.10.0":
             fmt_version = "8.1.1"
         elif self_version >= "1.9.0":
@@ -106,6 +109,7 @@ class SpdlogConan(ConanFile):
         replace_in_file(self, os.path.join(self.source_folder, "cmake", "utils.cmake"), "/WX", "")
 
     def build(self):
+        apply_conandata_patches(self)
         self._disable_werror()
         if not self.options.header_only:
             cmake = CMake(self)

--- a/recipes/spdlog/all/patches/1.11.0-0001-fix-fmt10-build.patch
+++ b/recipes/spdlog/all/patches/1.11.0-0001-fix-fmt10-build.patch
@@ -1,0 +1,34 @@
+From 576210a1363822a132657090b9f37e305bd0e2c2 Mon Sep 17 00:00:00 2001
+From: pwqbot <ding00000804@gmail.com>
+Date: Tue, 20 Jun 2023 10:41:48 +0800
+Subject: [PATCH] fix fmt build
+
+---
+ include/spdlog/common.h | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/include/spdlog/common.h b/include/spdlog/common.h
+index f97fd48c..00f4d728 100644
+--- a/include/spdlog/common.h
++++ b/include/spdlog/common.h
+@@ -160,12 +160,19 @@ using format_string_t = fmt::format_string<Args...>;
+ template<class T>
+ using remove_cvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+ 
++template<typename Char>
++#    if FMT_VERSION >= 90101
++using fmt_runtime_string = fmt::runtime_format_string<Char>;
++#    else
++using fmt_runtime_string = fmt::basic_runtime<Char>;
++#    endif
++
+ // clang doesn't like SFINAE disabled constructor in std::is_convertible<> so have to repeat the condition from basic_format_string here,
+ // in addition, fmt::basic_runtime<Char> is only convertible to basic_format_string<Char> but not basic_string_view<Char>
+ template<class T, class Char = char>
+ struct is_convertible_to_basic_format_string
+     : std::integral_constant<bool,
+-          std::is_convertible<T, fmt::basic_string_view<Char>>::value || std::is_same<remove_cvref_t<T>, fmt::basic_runtime<Char>>::value>
++          std::is_convertible<T, fmt::basic_string_view<Char>>::value || std::is_same<remove_cvref_t<T>, fmt_runtime_string<Char>>::value>
+ {};
+ 
+ #    if defined(SPDLOG_WCHAR_FILENAMES) || defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)


### PR DESCRIPTION
Specify library name and version:  **spdlog/1.11.0**

problems:
spdlog 1.11.0 do not support. fmt 10
https://github.com/gabime/spdlog/issues/2782
https://github.com/gabime/spdlog/issues/2767


relate pr:
https://github.com/gabime/spdlog/pull/2694
https://github.com/spack/spack/pull/38082


<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
