### PR TITLE
Thrust: use cub from Conan

### DIFF
--- a/recipes/thrust/all/conanfile.py
+++ b/recipes/thrust/all/conanfile.py
@@ -31,9 +31,8 @@ class ThrustConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        # TODO: https://github.com/conan-io/conan-center-index/pull/17484
         # Otherwise CUB from system CUDA is used, which is not guaranteed to be compatible
-        # self.requires("cub/1.17.2")
+        self.requires("cub/1.17.2")
 
         if self.options.device_system == "tbb":
             self.requires("onetbb/2021.9.0")


### PR DESCRIPTION
Thrust can now use a custom version of CUB after merging #17411.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
