### PR TITLE
argtable: fix test_package Conan 2 compatibility

### DIFF
--- a/recipes/argtable3/all/test_package/conanfile.py
+++ b/recipes/argtable3/all/test_package/conanfile.py
@@ -21,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
-            self.run(f"{bin_path} --help", run_environment=True)
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(f"{bin_path} --help", env="conanrun")


### PR DESCRIPTION
Fixes the following error when using Conan 2.0:

```
======== Testing the package: Executing test ========
argtable3/3.2.0 (test package): Running test()
ERROR: argtable3/3.2.0 (test package): Error in test() method, line 25
	self.run(f"{bin_path} --help", run_environment=True)
	TypeError: run() got an unexpected keyword argument 'run_environment'
```