### PR TITLE
[libinterpolate]: added version 2.6.4, which adds Windows support.

### DIFF
--- a/recipes/libinterpolate/all/conandata.yml
+++ b/recipes/libinterpolate/all/conandata.yml
@@ -11,5 +11,3 @@ sources:
     url:
       - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.4.tar.gz"
     sha256: "231a39fcc87ffc3e03936f7a21abc78ef309c2f1de79bd3ae72c24d78352d666"
-
-

--- a/recipes/libinterpolate/all/conandata.yml
+++ b/recipes/libinterpolate/all/conandata.yml
@@ -7,3 +7,9 @@ sources:
     url:
       - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.3.tar.gz"
     sha256: "bb2f253c27594b4e56ed9349630086665f529100eac2cd3cba63d198c3a84ff9"
+  "2.6.4":
+    url:
+      - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.4.tar.gz"
+    sha256: "231a39fcc87ffc3e03936f7a21abc78ef309c2f1de79bd3ae72c24d78352d666"
+
+

--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -43,6 +43,10 @@ class PackageConan(ConanFile):
         self.requires("eigen/3.3.7", transitive_headers=True)
 
     def validate(self):
+        if Version(self.version) < "2.6.4" and self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(f"{self.ref} is not supported by {self.settings.os}; Try the version >= 2.6.4")
+        if Version(self.version) >= "2.6.4" and self.settings.os not in ["Linux", "Windows"]:
+            raise ConanInvalidConfiguration(f"{self.ref} is not supported by {self.settings.os}.")
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(

--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -43,9 +43,6 @@ class PackageConan(ConanFile):
         self.requires("eigen/3.3.7", transitive_headers=True)
 
     def validate(self):
-        if self.settings.os != "Linux":
-            raise ConanInvalidConfiguration("libInterpolate currently only supports Linux. Upstream PR's are welcome (https://github.com/CD3/libInterpolate/issues/14).")
-
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(

--- a/recipes/libinterpolate/config.yml
+++ b/recipes/libinterpolate/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "2.6.3":
     folder: all
+  "2.6.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version: libinterpolate/2.6.4

Finally figured out why Windows builds were failing.


---

- [x ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
