### PR TITLE
(18044) Bump perfetto to v35.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "35.0":
+    url: "https://github.com/google/perfetto/archive/refs/tags/v35.0.tar.gz"
+    sha256: "224b6552e60ad0fc7c1447bdf719ddd9ceceaf2b6773b71541c21df5890f4166"
   "34.0":
     url: "https://github.com/google/perfetto/archive/refs/tags/v34.0.tar.gz"
     sha256: "81dbf2fac446a0389c80e309b2060dcccd926012ce2a61621a47e3e432aee8c1"

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "35.0":
+    folder: all
   "34.0":
     folder: all
   "32.1":


### PR DESCRIPTION
Specify library name and version:  **perfetto/35.0**

```
v35.0 - 2023-06-07:
  Tracing service and probes:
    * Compression has been moved from perfetto_cmd to traced. Now compression is
      supported even with write_into_file. The `compress_from_cli` config option
      can be used to restore the old behavior.
    * Changed the android.statsd datasource to batch multiple atoms into
      a single trace packet. This improves performance and information
      density.
  Trace Processor:
    * Fixed protozero parsing code to support field ids larger than
      2^16 - 1. protozero now supports field ids up to 1,000,000
      See https://github.com/google/perfetto/issues/510.
  UI:
    * Add support for deep links into the UI via query parameters.
    * Fixed multiple issues around the display of track event log
      messages See https://github.com/google/perfetto/issues/507.
```

Closes #18044
---

- [ x ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ x ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
