### PR TITLE
m4: fix windows x86 build and test_package

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
 from conan.tools.gnu import Autotools, AutotoolsToolchain
@@ -67,6 +68,19 @@ class M4Conan(ConanFile):
                 "-rtlib=compiler-rt",
                 "-Wno-unused-command-line-argument",
             ])
+        if cross_building(self) and is_msvc(self):
+            triplet_arch_windows = {"x86_64": "x86_64", "x86": "i686", "armv8": "aarch64"}
+            
+            host_arch = triplet_arch_windows.get(str(self.settings.arch))
+            build_arch = triplet_arch_windows.get(str(self._settings_build.arch))
+
+            if host_arch and build_arch:
+                host = f"{host_arch}-w64-mingw32"
+                build = f"{build_arch}-w64-mingw32"
+                tc.configure_args.extend([
+                    f"--host={host}",
+                    f"--build={build}",
+                ])
         if self.settings.os == "Windows":
             tc.configure_args.append("ac_cv_func__set_invalid_parameter_handler=yes")
         env = tc.environment()

--- a/recipes/m4/all/test_package/conanfile.py
+++ b/recipes/m4/all/test_package/conanfile.py
@@ -26,11 +26,12 @@ class TestPackageConan(ConanFile):
         """))
 
     def test(self):
-        self.run("m4 --version")
-        self.run(f"m4 -P {self._m4_input_path}")
+        extension = ".exe" if self.settings.os == "Windows" else ""
+        self.run(f"m4{extension} --version")
+        self.run(f"m4{extension} -P {self._m4_input_path}")
 
-        self.run(f"m4 -R {self.source_folder}/frozen.m4f {self.source_folder}/test.m4")
+        self.run(f"m4{extension} -R {self.source_folder}/frozen.m4f {self.source_folder}/test.m4")
 
         output = StringIO()
-        self.run(f"m4 -P {self._m4_input_path}", output)
+        self.run(f"m4{extension} -P {self._m4_input_path}", output)
         assert "Harry, Jr. met Sally" in output.getvalue()

--- a/recipes/m4/all/test_v1_package/conanfile.py
+++ b/recipes/m4/all/test_v1_package/conanfile.py
@@ -30,12 +30,13 @@ class TestPackageConan(ConanFile):
                 raise ConanException("M4 environment variable not set")
 
         if not tools.cross_building(self, skip_x64_x86=True):
-            self.run("{} --version".format(m4_bin), run_environment=True)
-            self.run("{} -P {}".format(m4_bin, self._m4_input_path))
+            self.run(f"{m4_bin} --version", run_environment=True)
+            self.run(f"{m4_bin} -P {self._m4_input_path}")
 
-            self.run("m4 -R {0}/frozen.m4f {0}/test.m4".format(os.path.join(self.source_folder, os.pardir, "test_package"), run_environment=True))
+            test_package_dir = os.path.join(self.source_folder, os.pardir, "test_package")
+            self.run(f"{m4_bin} -R {test_package_dir}/frozen.m4f {test_package_dir}/test.m4", run_environment=True)
 
             output = StringIO()
-            self.run("{} -P {}".format(m4_bin, self._m4_input_path), output=output)
+            self.run(f"{m4_bin} -P {self._m4_input_path}", output=output)
 
             assert "Harry, Jr. met Sally" in output.getvalue()


### PR DESCRIPTION
Specify library name and version:  **m4/\***

fixes #18054

I got the fix from libiconv:
https://github.com/conan-io/conan-center-index/blob/10658342a6999c03616d1ed4dc3666a9c6f1ef62/recipes/libiconv/all/conanfile.py#L93C9-L105C19

This also fixes running test_package for Windows x86. I'm not sure why x86_64 runs m4 without extension but x86 requires it. Maybe this is because I use windows docker container.

Honorable mention: https://github.com/conan-io/conan/issues/12546 & https://github.com/conan-io/conan/issues/7460

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
