### PR TITLE
autoconf: fix msvc debug build for test_package

### DIFF
--- a/recipes/autoconf/all/test_package/conanfile.py
+++ b/recipes/autoconf/all/test_package/conanfile.py
@@ -29,6 +29,9 @@ class TestPackageConan(ConanFile):
         env = VirtualBuildEnv(self)
         env.generate()
         tc = AutotoolsToolchain(self)
+        if is_msvc(self):
+            tc.extra_cflags.append("-FS")
+            tc.extra_cxxflags.append("-FS")
         tc.generate()
         if is_msvc(self):
             env = Environment()

--- a/recipes/autoconf/all/test_v1_package/conanfile.py
+++ b/recipes/autoconf/all/test_v1_package/conanfile.py
@@ -34,6 +34,8 @@ class TestPackageConan(ConanFile):
         self.run("{} --help".format(os.path.join(self.build_folder, "configure").replace("\\", "/")),
                  win_bash=tools.os_info.is_windows)
         autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        if is_msvc(self):
+            autotools.flags.append("-FS")
         with self._build_context():
             autotools.configure()
             autotools.make()


### PR DESCRIPTION
Specify library name and version:  **autoconf/\***

This fixes `fatal error C1041: cannot open program database` when building test_package with Debug build type and msvc compiler. C3I doesn't build this configuration and marks it as duplicated, but our CI is not as smart as C3I :)


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
