### PR TITLE
Add source code build for CMake 3.26.4

### DIFF
--- a/recipes/cmake/3.x.x/conandata.yml
+++ b/recipes/cmake/3.x.x/conandata.yml
@@ -20,3 +20,6 @@ sources:
   "3.25.2":
     url: "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2.tar.gz"
     sha256: "c026f22cb931dd532f648f087d587f07a1843c6e66a3dfca4fb0ea21944ed33c"
+  "3.26.4":
+    url: "https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4.tar.gz"
+    sha256: "313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208"


### PR DESCRIPTION
Specify library name and version:  **cmake/3.26.4**

This adds instructions for building `cmake/3.2.6.4` from source.

The binary package for `cmake/3.26.4` was added previously for `x86_64` and `arm` but this causes breakage for other architectures when a dependency depends on `cmake/3.26.4` since the binaries for them are not present and the recipe doesn't allow for building version 3.26.4 from source.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
