### PR TITLE
glib: migrate to elfutils

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -72,7 +72,7 @@ class GLibConan(ConanFile):
         else:
             self.requires("pcre/8.45")
         if self.options.get_safe("with_elf"):
-            self.requires("libelf/0.8.13")
+            self.requires("elfutils/0.186")
         if self.options.get_safe("with_mount"):
             self.requires("libmount/2.36.2")
         if self.options.get_safe("with_selinux"):
@@ -251,7 +251,7 @@ class GLibConan(ConanFile):
             self.cpp_info.components["gio-2.0"].requires.append("libselinux::libselinux")
 
         if self.options.get_safe("with_elf"):
-            self.cpp_info.components["gresource"].requires.append("libelf::libelf")  # this is actually an executable
+            self.cpp_info.components["gresource"].requires.append("elfutils::libelf")  # this is actually an executable
 
         self.env_info.GLIB_COMPILE_SCHEMAS = os.path.join(self.package_folder, "bin", "glib-compile-schemas")
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
Specify library name and version:  **glib/***

elfutils is maintained, contrary to libelf

this is blocked by:
- https://github.com/conan-io/conan-center-index/pull/17272

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
