### PR TITLE
libbacktrace: fix windows x86 build

### DIFF
--- a/recipes/libbacktrace/all/conanfile.py
+++ b/recipes/libbacktrace/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, rm
 from conan.tools.gnu import Autotools, AutotoolsToolchain
@@ -70,6 +71,19 @@ class LibbacktraceConan(ConanFile):
         env.generate()
 
         tc = AutotoolsToolchain(self)
+        if cross_building(self) and is_msvc(self):
+            triplet_arch_windows = {"x86_64": "x86_64", "x86": "i686", "armv8": "aarch64"}
+
+            host_arch = triplet_arch_windows.get(str(self.settings.arch))
+            build_arch = triplet_arch_windows.get(str(self._settings_build.arch))
+
+            if host_arch and build_arch:
+                host = f"{host_arch}-w64-mingw32"
+                build = f"{build_arch}-w64-mingw32"
+                tc.configure_args.extend([
+                    f"--host={host}",
+                    f"--build={build}",
+                ])
         if is_msvc(self):
             # https://github.com/conan-io/conan/issues/6514
             tc.extra_cflags.append("-FS")


### PR DESCRIPTION
Specify library name and version:  **libbacktrace/\***

When "crosscompiling" from Windows x86_64 to Windows x86 we get this error during package stage:
```
libbacktrace/cci.20210118: Calling package()
libbacktrace/cci.20210118: Copied 1 file: LICENSE

----Running------
> "C:\conan_tmp\.conan\data\libbacktrace\cci.20210118\_\_\build\9ffec4a59d60a2ccf636e06ba57253e21417f01b\build-debug\conan\conanbuild.bat" && "C:\conan_tmp\.conan\data\libbacktrace\cci.20210118\_\_\build\9ffec4a59d60a2ccf636e06ba57253e21417f01b\build-debug\conan\msys2_mode.bat" && C:\conan_tmp\c667cd\1\bin\msys64\usr\bin\bash.exe --login -c ^". \^"C:\conan_tmp\.conan\data\libbacktrace\cci.20210118\_\_\build\9ffec4a59d60a2ccf636e06ba57253e21417f01b\build-debug\conan\conanbuild.sh\^" ^&^& make install DESTDIR=/c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b -j12^"
-----------------
**********************************************************************
** Visual Studio 2019 Developer Command Prompt v16.11.23
** Copyright (c) 2021 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64_x86'
make[1]: «/c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/build/9ffec4a59d60a2ccf636e06ba57253e21417f01b/build-debug»
 /c/conan_tmp/c667cd/1/bin/msys64/usr/bin/mkdir -p '/c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b/include'
 /c/conan_tmp/c667cd/1/bin/msys64/usr/bin/mkdir -p '/c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b/lib'
 /usr/bin/install -c -m 644 /c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/build/9ffec4a59d60a2ccf636e06ba57253e21417f01b/src/backtrace.h backtrace-supported.h '/c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b/include'
 /bin/sh ./libtool   --mode=install /usr/bin/install -c   libbacktrace.la '/c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b/lib'
libtool: install: /usr/bin/install -c .libs/libbacktrace.lai /c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b/lib/libbacktrace.la
libtool: install: /usr/bin/install -c .libs/libbacktrace.a /c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b/lib/libbacktrace.a
libtool: install: chmod 644 /c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b/lib/libbacktrace.a
libtool: install: : /c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/package/9ffec4a59d60a2ccf636e06ba57253e21417f01b/lib/libbacktrace.a
libtool: install: warning: remember to run `libtool --finish /lib'
make[1]: «/c/conan_tmp/.conan/data/libbacktrace/cci.20210118/_/_/build/9ffec4a59d60a2ccf636e06ba57253e21417f01b/build-debug»
ERROR: Traceback (most recent call last):
  File "C:\Python39\lib\site-packages\conan\tools\files\files.py", line 234, in rename
    os.rename(src, dst)
FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\conan_tmp\\.conan\\data\\libbacktrace\\cci.20210118\\_\\_\\package\\9ffec4a59d60a2ccf636e06ba57253e21417f01b\\lib\\libbacktrace.lib' -> 'C:\\conan_tmp\\.conan\\data\\libbacktrace\\cci.20210118\\_\\_\\package\\9ffec4a59d60a2ccf636e06ba57253e21417f01b\\lib\\backtrace.lib'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Python39\lib\site-packages\conans\errors.py", line 34, in conanfile_exception_formatter
    yield
  File "C:\Python39\lib\site-packages\conans\client\conanfile\package.py", line 52, in _call_package
    conanfile.package()
  File "C:\conan_tmp\.conan\data\libbacktrace\cci.20210118\_\_\export\conanfile.py", line 104, in package
    rename(self, os.path.join(lib_folder, "libbacktrace.lib"),
  File "C:\Python39\lib\site-packages\conan\tools\files\files.py", line 236, in rename
    raise ConanException("rename {} to {} failed: {}".format(src, dst, err))
conans.errors.ConanException: rename C:\conan_tmp\.conan\data\libbacktrace\cci.20210118\_\_\package\9ffec4a59d60a2ccf636e06ba57253e21417f01b\lib\libbacktrace.lib to C:\conan_tmp\.conan\data\libbacktrace\cci.20210118\_\_\package\9ffec4a59d60a2ccf636e06ba57253e21417f01b\lib\backtrace.lib failed: [WinError 2] The system cannot find the file specified: 'C:\\conan_tmp\\.conan\\data\\libbacktrace\\cci.20210118\\_\\_\\package\\9ffec4a59d60a2ccf636e06ba57253e21417f01b\\lib\\libbacktrace.lib' -> 'C:\\conan_tmp\\.conan\\data\\libbacktrace\\cci.20210118\\_\\_\\package\\9ffec4a59d60a2ccf636e06ba57253e21417f01b\\lib\\backtrace.lib'
```

Because conan passes `--host=i686-unknown-windows --build=x86_64-unknown-windows` to the configure script and this prevents libbacktrace build system from using `lib` as extension (see https://github.com/ianlancetaylor/libbacktrace/blob/cdb64b688dda93bbbacbc2b1ccf50ce9329d4748/libtool.m4#L4776-L4784)

Honorable mention: https://github.com/conan-io/conan/issues/12546 & https://github.com/conan-io/conan/issues/7460

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
