### PR TITLE
certify: migrate to Conan v2

### DIFF
--- a/recipes/certify/all/conanfile.py
+++ b/recipes/certify/all/conanfile.py
@@ -56,7 +56,7 @@ class CertifyConan(ConanFile):
 
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if not minimum_version:
-            self.output.warn(
+            self.output.warning(
                 f"{self.name} requires C++17. Your compiler is unknown. Assuming it supports C++17."
             )
         elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):

--- a/recipes/certify/all/conanfile.py
+++ b/recipes/certify/all/conanfile.py
@@ -1,23 +1,29 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.43.0"
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
 
 
 class CertifyConan(ConanFile):
     name = "certify"
     description = "Platform-specific TLS keystore abstraction for use with Boost.ASIO and OpenSSL"
-    topics = ("boost", "asio", "tls", "ssl", "https")
+    license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/djarek/certify"
-    license = "BSL-1.0"
+    topics = ("boost", "asio", "tls", "ssl", "https", "header-only")
+
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 17
 
     @property
     def _compilers_minimum_version(self):
@@ -28,17 +34,19 @@ class CertifyConan(ConanFile):
             "apple-clang": "11",
         }
 
-    @property
-    def _min_cppstd(self):
-        return "17"
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.79.0")
-        self.requires("openssl/1.1.1q")
+        self.requires("boost/1.82.0")
+        self.requires("openssl/[>=1.1 <4]")
+
+    def package_id(self):
+        self.info.clear()
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, self._min_cppstd)
+            check_min_cppstd(self, self._min_cppstd)
 
         def lazy_lt_semver(v1, v2):
             lv1 = [int(v) for v in v1.split(".")]
@@ -48,29 +56,38 @@ class CertifyConan(ConanFile):
 
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if not minimum_version:
-            self.output.warn("{} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name))
+            self.output.warn(
+                f"{self.name} requires C++17. Your compiler is unknown. Assuming it supports C++17."
+            )
         elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
-            raise ConanInvalidConfiguration("{} requires C++17, which your compiler does not support.".format(self.name))
-
-    def package_id(self):
-        self.info.header_only()
+            raise ConanInvalidConfiguration(
+                f"{self.name} requires C++17, which your compiler does not support."
+            )
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
-        self.copy(pattern="LICENSE_1_0.txt", dst="licenses",
-                  src=self._source_subfolder)
-        self.copy(pattern="*", dst="include",
-                  src=os.path.join(self._source_subfolder, "include"))
+        copy(
+            self,
+            pattern="LICENSE_1_0.txt",
+            dst=os.path.join(self.package_folder, "licenses"),
+            src=self.source_folder,
+        )
+        copy(
+            self,
+            pattern="*",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "include"),
+        )
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "certify")
         self.cpp_info.set_property("cmake_target_name", "certify::core")
-        self.cpp_info.components["_certify"].requires = ["boost::boost", "openssl::openssl"]
 
+        self.cpp_info.components["_certify"].requires = ["boost::boost", "openssl::openssl"]
         self.cpp_info.components["_certify"].names["cmake_find_package"] = "core"
         self.cpp_info.components["_certify"].names["cmake_find_package_multi"] = "core"
+
         self.cpp_info.names["cmake_find_package"] = "certify"
         self.cpp_info.names["cmake_find_package_multi"] = "certify"

--- a/recipes/certify/all/test_package/CMakeLists.txt
+++ b/recipes/certify/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
 find_package(certify REQUIRED CONFIG)
 

--- a/recipes/certify/all/test_package/conanfile.py
+++ b/recipes/certify/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/certify/all/test_package/test_package.cpp
+++ b/recipes/certify/all/test_package/test_package.cpp
@@ -6,15 +6,15 @@
 #include <iostream>
 
 int main() {
-      boost::asio::io_context ioc{1};
-      boost::asio::ssl::context context{boost::asio::ssl::context_base::method::tls_client};
-      boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream(ioc, context);
-      constexpr auto hostname = "example.com";
+    boost::asio::io_context ioc{1};
+    boost::asio::ssl::context context{boost::asio::ssl::context_base::method::tls_client};
+    boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream(ioc, context);
+    constexpr auto hostname = "example.com";
 
-      BOOST_TEST(boost::certify::sni_hostname(stream).empty());
-      boost::certify::sni_hostname(stream, hostname);
-      BOOST_TEST(boost::certify::sni_hostname(stream) == hostname);
-      std::cout << boost::report_errors();
+    BOOST_TEST(boost::certify::sni_hostname(stream).empty());
+    boost::certify::sni_hostname(stream, hostname);
+    BOOST_TEST(boost::certify::sni_hostname(stream) == hostname);
+    std::cout << boost::report_errors();
 
-      return 0;
+    return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
