### PR TITLE
simde: supports all platforms

### DIFF
--- a/recipes/simde/all/conandata.yml
+++ b/recipes/simde/all/conandata.yml
@@ -1,4 +1,6 @@
 sources:
   "0.7.6":
+    # A release tarball exists, but I want to use the archive tarball.
+    # Because the release tarball has only amalgatated(with lots of duplicate lines) header files.
     url: "https://github.com/simd-everywhere/simde/archive/refs/tags/v0.7.6.tar.gz"
     sha256: "c63e6c61392e324728da1c7e5de308cb31410908993a769594f5e21ff8de962b"


### PR DESCRIPTION
Specify library name and version:  **simde/0.7.6**

Simde supports all platforms.
https://github.com/conan-io/conan-center-index/pull/18087#pullrequestreview-1501929198
I removed `validate()` method.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
