### PR TITLE
jpcre2: migrate to Conan v2

### DIFF
--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -23,7 +23,7 @@ class Jpcre2Conan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("pcre2/10.37")
+        self.requires("pcre2/10.42")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -1,33 +1,44 @@
-from conans import ConanFile, tools
 import os
 
-required_conan_version = ">=1.33.0"
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
 
 
 class Jpcre2Conan(ConanFile):
     name = "jpcre2"
-    homepage = "https://github.com/jpcre2/jpcre2"
     description = "Header-only C++ wrapper for PCRE2 library."
-    topics = ("regex", "pcre2", "header-only", "single-header")
-    url = "https://github.com/conan-io/conan-center-index"
     license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/jpcre2/jpcre2"
+    topics = ("regex", "pcre2", "header-only", "single-header")
 
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("pcre2/10.37")
 
+    def package_id(self):
+        self.info.clear()
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
-        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
-        self.copy("jpcre2.hpp", dst="include", src=os.path.join(self._source_subfolder, "src"))
+        copy(self, "COPYING",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        copy(self, "jpcre2.hpp",
+             dst=os.path.join(self.package_folder, "include"),
+             src=os.path.join(self.source_folder, "src"))
 
-    def package_id(self):
-        self.info.header_only()
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/jpcre2/all/test_package/CMakeLists.txt
+++ b/recipes/jpcre2/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(jpcre2 REQUIRED)
+find_package(jpcre2 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE jpcre2::jpcre2)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/jpcre2/all/test_package/CMakeLists.txt
+++ b/recipes/jpcre2/all/test_package/CMakeLists.txt
@@ -5,4 +5,3 @@ find_package(jpcre2 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE jpcre2::jpcre2)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/jpcre2/all/test_package/conanfile.py
+++ b/recipes/jpcre2/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/jpcre2/all/test_package/test_package.cpp
+++ b/recipes/jpcre2/all/test_package/test_package.cpp
@@ -2,12 +2,10 @@
 
 typedef jpcre2::select<char> jp;
 
-int main(int, char**)
-{
+int main(int, char **) {
     jp::Regex re;
     re.setPattern("Hello (\\S+?)").compile();
-    if (!re.match("Hello conan-center-index"))
-    {
+    if (!re.match("Hello conan-center-index")) {
         return 1;
     }
 

--- a/recipes/jpcre2/all/test_v1_package/CMakeLists.txt
+++ b/recipes/jpcre2/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/jpcre2/all/test_v1_package/conanfile.py
+++ b/recipes/jpcre2/all/test_v1_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/jpcre2/all/test_v1_package/conanfile.py
+++ b/recipes/jpcre2/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **jpcre2/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
