### PR TITLE
#18137 Fix compilation of breakpad with gcc-11

### DIFF
--- a/recipes/breakpad/all/conandata.yml
+++ b/recipes/breakpad/all/conandata.yml
@@ -6,3 +6,4 @@ patches:
   "cci.20210521":
     - patch_file: "patches/0001-Use_conans_lss.patch"
     - patch_file: "patches/0002-Remove-hardcoded-fpic.patch"
+    - patch_file: "patches/0003-Fix-gcc11-compilation.patch"

--- a/recipes/breakpad/all/conanfile.py
+++ b/recipes/breakpad/all/conanfile.py
@@ -31,7 +31,7 @@ class BreakpadConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("linux-syscall-support/cci.20200813")
+        self.requires("linux-syscall-support/cci.20200813", transitive_headers=True)
 
     def validate(self):
         if self.settings.os != "Linux":

--- a/recipes/breakpad/all/patches/0003-Fix-gcc11-compilation.patch
+++ b/recipes/breakpad/all/patches/0003-Fix-gcc11-compilation.patch
@@ -1,0 +1,11 @@
+--- a/src/client/linux/handler/exception_handler.cc
++++ b/src/client/linux/handler/exception_handler.cc
+@@ -138,7 +138,7 @@
+   // SIGSTKSZ may be too small to prevent the signal handlers from overrunning
+   // the alternative stack. Ensure that the size of the alternative stack is
+   // large enough.
+-  static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
++  static const unsigned kSigStackSize = std::max<unsigned>(16384, SIGSTKSZ);
+ 
+   // Only set an alternative stack if there isn't already one, or if the current
+   // one is too small.


### PR DESCRIPTION
Specify library name and version:  **breakpad/cci.20210521**

Fixes #18137