### PR TITLE
Fix openimageio duplicate IMath includes

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -51,12 +51,14 @@ class OpenColorIOConan(ConanFile):
             self.requires("openexr/2.5.7")
         else:
             self.requires("openexr/3.1.7")
+            self.requires("imath/3.1.6")
+
         self.requires("yaml-cpp/0.7.0")
         if Version(self.version) < "2.0.0":
             self.requires("tinyxml/2.6.2")
         else:
             self.requires("pystring/1.1.4")
-        self.requires("imath/3.1.6")
+
         if Version(self.version) >= "2.2.0":
             self.requires("minizip-ng/3.0.7")
 


### PR DESCRIPTION
Specify library name and version:  **opencolorio/2.1.0**

Require `imath/3.1.6` only when using `openexr/3.1.7` as `imath` is part of open exr 2.x.x versions.
Currently `openimageio/2.4.7.1` can not be built with cache cleared due to duplicated IMath includes.

We get tons of redefinition errors: 
```
~/.conan/data/openexr/2.5.4/_/_/package/be7c7ddd85063690fecab75a01562df151c61ad9/include/OpenEXR/half.h:676:1: error: redefinition of ‘bool Imath_3_1::half::isNan() const’
  676 | half::isNan () const
      | ^~~~
In file included from ~/.conan/data/openimageio/2.4.7.1/_/_/build/3b8626e7c738cbaa73a42a0d4cf6a182a761d03a/build_subfolder/include/OpenImageIO/half.h:12,
                 from ~/.conan/data/openimageio/2.4.7.1/_/_/build/3b8626e7c738cbaa73a42a0d4cf6a182a761d03a/build_subfolder/include/OpenImageIO/Imath.h:9,
                 from ~/.conan/data/openimageio/2.4.7.1/_/_/build/3b8626e7c738cbaa73a42a0d4cf6a182a761d03a/source_subfolder/src/libtexture/texturesys.cpp:13:
~/.conan/data/imath/3.1.6/_/_/package/a25d6c83542b56b72fdaa05a85db5d46f5f0f71c/include/Imath/half.h:835:1: note: ‘constexpr bool Imath_3_1::half::isNan() const’ previously defined here
  835 | half::isNan() const IMATH_NOEXCEPT
      | ^~~~
In file included from ~/.conan/data/openexr/2.5.4/_/_/package/be7c7ddd85063690fecab75a01562df151c61ad9/include/OpenEXR/ImathColor.h:48,
                 from ~/.conan/data/openimageio/2.4.7.1/_/_/build/3b8626e7c738cbaa73a42a0d4cf6a182a761d03a/build_subfolder/include/OpenImageIO/Imath.h:25,
                 from ~/.conan/data/openimageio/2.4.7.1/_/_/build/3b8626e7c738cbaa73a42a0d4cf6a182a761d03a/source_subfolder/src/libtexture/texturesys.cpp:13:
```

I have tested locally the fix. With this change to `opencolorio`, I can build `openimageio/2.4.7.1`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
