### PR TITLE
nudb: migrate to Conan v2

### DIFF
--- a/recipes/nudb/all/conanfile.py
+++ b/recipes/nudb/all/conanfile.py
@@ -1,42 +1,66 @@
-from conans import ConanFile, CMake, tools
 import os
 
-required_conan_version = ">=1.33.0"
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
+
 
 class NudbConan(ConanFile):
     name = "nudb"
-    license = "BSL-1.0"
     description = "A fast key/value insert-only database for SSD drives in C++11"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/CPPAlliance/NuDB"
-    url = "https://github.com/conan-io/conan-center-index/"
     topics = ("header-only", "KVS", "insert-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 11
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.78.0")
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
-
-    def package(self):
-        self.copy("LICENSE*", "licenses", self._source_subfolder)
-        self.copy("*.hpp", "include", src=os.path.join(self._source_subfolder, "include"))
-        self.copy("*.ipp", "include", src=os.path.join(self._source_subfolder, "include"))
+        self.requires("boost/1.82.0")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE*",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        copy(self, "*",
+             dst=os.path.join(self.package_folder, "include"),
+             src=os.path.join(self.source_folder, "include"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "NuDB"
-        self.cpp_info.names["cmake_find_package_multi"] = "NuDB"
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        self.cpp_info.set_property("cmake_target_name", "NuDB")
+        self.cpp_info.set_property("cmake_target_aliases", ["NuDB::nudb"])
+        self.cpp_info.set_property("cmake_find_module", "both")
+
+        self.cpp_info.components["core"].set_property("cmake_target_name", "nudb")
         self.cpp_info.components["core"].names["cmake_find_package"] = "nudb"
         self.cpp_info.components["core"].names["cmake_find_package_multi"] = "nudb"
         self.cpp_info.components["core"].requires = ["boost::thread", "boost::system"]
-        self.cpp_info.set_property("cmake_target_name", "NuDB")
-        self.cpp_info.set_property("cmake_target_module_name", "NuDB::nudb")
-        self.cpp_info.set_property("cmake_find_module", "both")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.names["cmake_find_package"] = "NuDB"
+        self.cpp_info.names["cmake_find_package_multi"] = "NuDB"

--- a/recipes/nudb/all/test_package/CMakeLists.txt
+++ b/recipes/nudb/all/test_package/CMakeLists.txt
@@ -1,10 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(NuDB CONFIG REQUIRED)
+find_package(NuDB REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} NuDB::nudb)

--- a/recipes/nudb/all/test_package/conanfile.py
+++ b/recipes/nudb/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-from conans import ConanFile, CMake, tools
 
 
-class NudbTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class NudbTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/nudb/all/test_v1_package/CMakeLists.txt
+++ b/recipes/nudb/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/nudb/all/test_v1_package/conanfile.py
+++ b/recipes/nudb/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class NudbTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Only substantial changes in the recipe:

* Replaced `cmake_target_name` + `cmake_target_module_name` with `cmake_target_name` + `cmake_target_aliases`. Having different targets for module and config modes seemed bug-prone to me.
* Bumped boost from 1.78 to 1.82
