### PR TITLE
Fix create-dmg res folder

### DIFF
--- a/recipes/create-dmg/all/conanfile.py
+++ b/recipes/create-dmg/all/conanfile.py
@@ -39,7 +39,7 @@ class CreateDmgConan(ConanFile):
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(self, pattern="create-dmg", dst=os.path.join(self.package_folder, "bin"), src=self.source_folder)
-        copy(self, pattern="*", dst=os.path.join(self.package_folder, "res", "create-dmg", "support"), src=os.path.join(self.source_folder, "support"))
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "res"), src=os.path.join(self.source_folder, "support"))
 
         rmdir(self, os.path.join(self.package_folder, "share"))
 


### PR DESCRIPTION
The content of the res folder was wrong and the script wasn't working properly:

```
~/.conan/data/create-dmg/1.1.0/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/create-dmg --volname MyApp --background /Users/martindelille/dev/phonations/core/platform/apple/dmg_bg.png --app-drop-link 450 218 --icon MyApp.app 150 218 --window-size 600 450 MyApp.dmg MyApp.app
Creating disk image...
.................................................................................................
created: /Users/martindelille/dev/phonations/core/build/Release/_CPack_Packages/Darwin/External/MyApp_Grand-Mont_23.6.5.3_6c2616171_commercial_dirty/rw.MyApp.dmg
Mounting disk image...
Mount directory: /Volumes/MyApp
Device name:     /dev/disk8
Copying background file '/Users/martindelille/dev/phonations/core/platform/apple/dmg_bg.png'...
Making link to Applications dir...
/Volumes/MyApp
cat: /Users/martindelille/.conan/data/create-dmg/1.1.0/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/res/template.applescript: No such file or directory
Running AppleScript to make Finder stuff pretty: /usr/bin/osascript "/var/folders/yd/11dft2cn0fd4vwmrshfkgtx40000gn/T/createdmg.tmp.XXXXXXXXXX.sURYgo43" "MyApp"
Done running the AppleScript...
Fixing permissions...
...
```

This PR fix that.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
