### PR TITLE
[cpuinfo] Add 20230118 20220618 versions

### DIFF
--- a/recipes/cpuinfo/all/conandata.yml
+++ b/recipes/cpuinfo/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "cci.20230118":
+    url: "https://github.com/pytorch/cpuinfo/archive/3dc310302210c1891ffcfb12ae67b11a3ad3a150.tar.gz"
+    sha256: "f2f4df6d2b01036f36c5e372954e536881cdd59f5c2461c67aa0a92c6d755c61"
+  "cci.20220618":
+    url: "https://github.com/pytorch/cpuinfo/archive/082deffc80ce517f81dc2f3aebe6ba671fcd09c9.tar.gz"
+    sha256: "4379348ec3127b37e854a0a66f85ea1d3c606e5f3a6dce235dc9c69ce663c026"
   "cci.20220228":
     url: "https://github.com/pytorch/cpuinfo/archive/6288930068efc8dff4f3c0b95f062fc5ddceba04.tar.gz"
     sha256: "9e9e937b3569320d23d8b1c8c26ed3603affe55c3e4a3e49622e8a2c6d6e1696"

--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -65,9 +65,10 @@ class CpuinfoConan(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                              "SET_PROPERTY(TARGET clog PROPERTY POSITION_INDEPENDENT_CODE ON)",
-                              "")
+        if self.version < "cci.20230118":
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                                  "SET_PROPERTY(TARGET clog PROPERTY POSITION_INDEPENDENT_CODE ON)",
+                                  "")
 
     def build(self):
         self._patch_sources()
@@ -83,6 +84,15 @@ class CpuinfoConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "libcpuinfo")
-        self.cpp_info.libs = ["cpuinfo", "clog"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs = ["pthread"]
+
+        if self.version < "cci.20230118":
+            self.cpp_info.components["clog"].libs = ["clog"]
+            cpuinfo_clog_target = "clog" if self.version < "cci.20220618" else "cpuinfo::clog"
+            self.cpp_info.components["clog"].set_property("cmake_target_name", cpuinfo_clog_target)
+
+        self.cpp_info.components["cpuinfo"].set_property("cmake_target_name", "cpuinfo::cpuinfo")
+        self.cpp_info.components["cpuinfo"].libs = ["cpuinfo"]
+        if self.version < "cci.20230118":
+            self.cpp_info.components["cpuinfo"].requires = ["clog"]
+        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
+            self.cpp_info.components["cpuinfo"].system_libs.append("pthread")

--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -81,6 +81,7 @@ class CpuinfoConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "libcpuinfo")

--- a/recipes/cpuinfo/all/test_package/CMakeLists.txt
+++ b/recipes/cpuinfo/all/test_package/CMakeLists.txt
@@ -4,5 +4,11 @@ project(test_package LANGUAGES C)
 find_package(cpuinfo REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE cpuinfo::cpuinfo)
+if ((${CPUINFO_VERSION} GREATER_EQUAL "20220618") AND (${CPUINFO_VERSION} LESS "20230118"))
+    # in that version range cpuinfo exposed cpuinfo::clog. Check that is available through conan recipe
+    target_link_libraries(${PROJECT_NAME} PRIVATE cpuinfo::cpuinfo cpuinfo::clog)
+else ()
+    target_link_libraries(${PROJECT_NAME} PRIVATE cpuinfo::cpuinfo)
+endif()
+
 target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/cpuinfo/all/test_package/conanfile.py
+++ b/recipes/cpuinfo/all/test_package/conanfile.py
@@ -16,10 +16,8 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def generate(self):
-        cpuinfo_version = self.dependencies["cpuinfo"].ref.version.split('.')[1]
-        self.output.info(f"cpuinfo_version {cpuinfo_version}")
         tc = CMakeToolchain(self)
-        tc.variables["CPUINFO_VERSION"] = cpuinfo_version
+        tc.variables["CPUINFO_VERSION"] = self.dependencies["cpuinfo"].ref.version.split('.')[1]
         tc.generate()
 
     def build(self):

--- a/recipes/cpuinfo/all/test_package/conanfile.py
+++ b/recipes/cpuinfo/all/test_package/conanfile.py
@@ -17,7 +17,7 @@ class TestPackageConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["CPUINFO_VERSION"] = self.dependencies["cpuinfo"].ref.version.split('.')[1]
+        tc.variables["CPUINFO_VERSION"] = str(self.dependencies["cpuinfo"].ref.version).split('.')[1]
         tc.generate()
 
     def build(self):

--- a/recipes/cpuinfo/all/test_package/conanfile.py
+++ b/recipes/cpuinfo/all/test_package/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
@@ -14,6 +14,13 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def generate(self):
+        cpuinfo_version = self.dependencies["cpuinfo"].ref.version.split('.')[1]
+        self.output.info(f"cpuinfo_version {cpuinfo_version}")
+        tc = CMakeToolchain(self)
+        tc.variables["CPUINFO_VERSION"] = cpuinfo_version
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/cpuinfo/all/test_v1_package/conanfile.py
+++ b/recipes/cpuinfo/all/test_v1_package/conanfile.py
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["CPUINFO_VERSION"] = self.deps_cpp_info["cpuinfo"].version.split('.')[1]
         cmake.configure()
         cmake.build()
 

--- a/recipes/cpuinfo/config.yml
+++ b/recipes/cpuinfo/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "cci.20230118":
+    folder: all
+  "cci.20220618":
+    folder: all
   "cci.20220228":
     folder: all
   "cci.20201217":


### PR DESCRIPTION
- Add 20230118 20220618 versions
- Refactor package_info and expose clog as a component. Require that component from cpuinfo only in the specific versions that required it

Specify library name and version:  **cpuinfo/cci.20230118, cpuinfo/cci.20220618,**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Obs: 
cpuinfo exposed `cpuinfo::clog` target and this was missing in the recipe. Other packages like `onnxruntime` were starting to depend on that : https://github.com/microsoft/onnxruntime/blob/2fd25de3600df5680eeb21b5ede9546e6731966a/cmake/onnxruntime_common.cmake#L197 
Also seems that after 20230118 version this 'component' has been merged into `cpuinfo` library.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
