### PR TITLE
migrate libgpiod to v2

### DIFF
--- a/recipes/libgpiod/all/conanfile.py
+++ b/recipes/libgpiod/all/conanfile.py
@@ -37,12 +37,16 @@ class LibgpiodConan(ConanFile):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("libgpiod supports only Linux")
 
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+           self.options.rm_safe("fPIC")
         if not self.options.enable_bindings_cxx:
-            del self.settings.compiler.libcxx
-            del self.settings.compiler.cppstd
+            self.settings.rm_safe("compiler.libcxx")
+            self.settings.rm_safe("compiler.cppstd")
 
     def build_requirements(self):
         self.build_requires("libtool/2.4.6")

--- a/recipes/libgpiod/all/conanfile.py
+++ b/recipes/libgpiod/all/conanfile.py
@@ -17,6 +17,7 @@ class LibgpiodConan(ConanFile):
     description = "C library and tools for interacting with the linux GPIO character device"
     topics = ("gpio", "libgpiod", "libgpiodcxx", "linux")
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "library"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],

--- a/recipes/libgpiod/all/conanfile.py
+++ b/recipes/libgpiod/all/conanfile.py
@@ -43,7 +43,7 @@ class LibgpiodConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-           self.options.rm_safe("fPIC")
+            self.options.rm_safe("fPIC")
         if not self.options.enable_bindings_cxx:
             self.settings.rm_safe("compiler.libcxx")
             self.settings.rm_safe("compiler.cppstd")

--- a/recipes/libgpiod/all/conanfile.py
+++ b/recipes/libgpiod/all/conanfile.py
@@ -31,7 +31,7 @@ class LibgpiodConan(ConanFile):
     }
 
     def layout(self):
-        basic_layout(self, src_folder="source_subfolder")
+        basic_layout(self, src_folder="src")
 
     def validate(self):
         if self.settings.os != "Linux":

--- a/recipes/libgpiod/all/conanfile.py
+++ b/recipes/libgpiod/all/conanfile.py
@@ -55,7 +55,7 @@ class LibgpiodConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("libtool/2.4.6")
         self.tool_requires("pkgconf/1.7.4")
-        self.tool_requires("autoconf-archive/2021.02.19")
+        self.tool_requires("autoconf-archive/2022.09.03")
         self.tool_requires("linux-headers-generic/5.13.9")
 
     def source(self):

--- a/recipes/libgpiod/all/conanfile.py
+++ b/recipes/libgpiod/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
 from conan import ConanFile
-from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.gnu import Autotools, AutotoolsToolchain, PkgConfigDeps, AutotoolsDeps
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.layout import basic_layout
 from conan.tools.files import get, copy, rmdir, rm
@@ -48,11 +48,14 @@ class LibgpiodConan(ConanFile):
             self.settings.rm_safe("compiler.libcxx")
             self.settings.rm_safe("compiler.cppstd")
 
+    def requirements(self):
+        self.requires("linux-headers-generic/5.13.9")
+
     def build_requirements(self):
-        self.build_requires("libtool/2.4.6")
-        self.build_requires("pkgconf/1.7.4")
-        self.build_requires("autoconf-archive/2021.02.19")
-        self.build_requires("linux-headers-generic/5.13.9")
+        self.tool_requires("libtool/2.4.6")
+        self.tool_requires("pkgconf/1.7.4")
+        self.tool_requires("autoconf-archive/2021.02.19")
+        self.tool_requires("linux-headers-generic/5.13.9")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -67,6 +70,10 @@ class LibgpiodConan(ConanFile):
             "--enable-bindings-cxx={}".format(yes_no(self.options.enable_bindings_cxx)),
             "--enable-tools={}".format(yes_no(self.options.enable_tools))
         })
+        tc.generate()
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        tc = AutotoolsDeps(self)
         tc.generate()
 
     def build(self):

--- a/recipes/libgpiod/all/test_package/CMakeLists.txt
+++ b/recipes/libgpiod/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(libgpiod REQUIRED)
 
 add_executable(${CMAKE_PROJECT_NAME} test_package.c)
-target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${CMAKE_PROJECT_NAME} libgpiod::gpiod)

--- a/recipes/libgpiod/all/test_package/conanfile.py
+++ b/recipes/libgpiod/all/test_package/conanfile.py
@@ -1,11 +1,21 @@
-from conans import ConanFile, CMake, tools
 import os
 
-required_conan_version = ">=1.33.0"
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+required_conan_version = ">=1.53.0"
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+    
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -13,6 +23,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libgpiod/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libgpiod/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/libgpiod/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libgpiod/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup(TARGETS)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
                  ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/libgpiod/all/test_v1_package/conanfile.py
+++ b/recipes/libgpiod/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libgpiod/all/test_v1_package/conanfile.py
+++ b/recipes/libgpiod/all/test_v1_package/conanfile.py
@@ -5,7 +5,7 @@ required_conan_version = ">=1.33.0"
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **libgpiod/1.6.3**

Migrate to Conan 2.x

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
