### PR TITLE
flatbush: migrate to Conan v2 and add release v1.2.0

### DIFF
--- a/recipes/flatbush/all/conandata.yml
+++ b/recipes/flatbush/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.0":
+    url: "https://github.com/chusitoo/flatbush/archive/refs/tags/v1.2.0.zip"
+    sha256: "d8d0471ad6aba1e4b1160abc38a0fe21a35e3ea1c2a9509ce9910072f7fc24bb"
   "1.1.0":
     url: "https://github.com/chusitoo/flatbush/archive/refs/tags/v1.1.0.zip"
     sha256: "3ef034110b0ea6f7514d3cdc362976e2a9ab321cc9e4b2c847167ad26df0c0f1"

--- a/recipes/flatbush/all/conanfile.py
+++ b/recipes/flatbush/all/conanfile.py
@@ -1,25 +1,46 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd, valid_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.50.0"
 
 class FlatbushConan(ConanFile):
     name = "flatbush"
-    license = "MIT"
-    homepage = "https://github.com/chusitoo/flatbush"
     description = "Flatbush for C++"
+    homepage = "https://github.com/chusitoo/flatbush"
+    license = "MIT"
     topics = ("header-only", "flatbush", "r-tree", "hilbert", "zero-copy", "spatial-index")
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "os", "compiler", "build_type", "arch"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
     def source(self):
-       tools.get(**self.conan_data["sources"][self.version], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        pass
+
+    def build(self):
+        pass
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses")
-        self.copy(pattern="flatbush.h", dst="include")
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "flatbush.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
 
     def package_info(self):
-        if not tools.valid_min_cppstd(self, "20"):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        if not valid_min_cppstd(self, "20"):
             self.cpp_info.defines = ["FLATBUSH_SPAN"]

--- a/recipes/flatbush/all/test_package/CMakeLists.txt
+++ b/recipes/flatbush/all/test_package/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(test_package VERSION 1.0.0 LANGUAGES CXX)
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-find_package(flatbush CONFIG REQUIRED)
+project(test_package LANGUAGES CXX)
 
-add_executable(${PROJECT_NAME} "test_package.cpp")
+find_package(flatbush REQUIRED CONFIG)
 
-target_link_libraries(${PROJECT_NAME} flatbush::flatbush)
+add_executable(${PROJECT_NAME} test_package.cpp)
 
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE flatbush::flatbush)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/flatbush/all/test_package/conanfile.py
+++ b/recipes/flatbush/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
-from conans.tools import Version
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/flatbush/config.yml
+++ b/recipes/flatbush/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.0":
+    folder: "all"
   "1.1.0":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **flatbush/1.2.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
