### PR TITLE
Add flecs version 3.2.4

### DIFF
--- a/recipes/flecs/all/conandata.yml
+++ b/recipes/flecs/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.2.4":
+    url: "https://github.com/SanderMertens/flecs/archive/v3.2.4.tar.gz"
+    sha256: "0b65426053418911cae1c3f347748fba6eb7d4ae8860ce7fcc91ef25f386d4a1"
   "3.1.4":
     url: "https://github.com/SanderMertens/flecs/archive/v3.1.4.tar.gz"
     sha256: "cc73d529ddc47891fc16c7dd965ca9c4239d1caccae024c81364bf3d49286fe0"

--- a/recipes/flecs/config.yml
+++ b/recipes/flecs/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.2.4":
+    folder: all
   "3.1.4":
     folder: all
   "3.1.3":


### PR DESCRIPTION
Specify library name and version:  **flecs/3.2.4**

The latest version wasn't on conan.io, so I wanted to add it.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
