### PR TITLE
libtiff: allow using zlib-ng instead of zlib

### DIFF
--- a/recipes/libtiff/all/test_package/CMakeLists.txt
+++ b/recipes/libtiff/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(TIFF REQUIRED)

--- a/recipes/libtiff/all/test_package/conanfile.py
+++ b/recipes/libtiff/all/test_package/conanfile.py
@@ -22,5 +22,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
Specify library name and version:  **libtiff/all**

zlib-ng provides better performance.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
