### PR TITLE
Fix pkgconf source url

### DIFF
--- a/recipes/pkgconf/all/conandata.yml
+++ b/recipes/pkgconf/all/conandata.yml
@@ -1,12 +1,12 @@
 sources:
   "1.9.3":
-    url: "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.9.3.tar.xz"
+    url: "https://distfiles.ariadne.space/pkgconf/pkgconf-1.9.3.tar.xz"
     sha256: "5fb355b487d54fb6d341e4f18d4e2f7e813a6622cf03a9e87affa6a40565699d"
   "1.7.4":
-    url: "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.7.4.tar.xz"
+    url: "https://distfiles.ariadne.space/pkgconf/pkgconf-1.7.4.tar.xz"
     sha256: "d73f32c248a4591139a6b17777c80d4deab6b414ec2b3d21d0a24be348c476ab"
   "1.7.3":
-    url: "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.7.3.tar.xz"
+    url: "https://distfiles.ariadne.space/pkgconf/pkgconf-1.7.3.tar.xz"
     sha256: "b846aea51cf696c3392a0ae58bef93e2e72f8e7073ca6ad1ed8b01c85871f9c0"
 patches:
   "1.9.3":


### PR DESCRIPTION
Specify library name and version:  **pkgconf/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The old source https://distfiles.dereferenced.org is down, the only info I found about it was https://git.alpinelinux.org/aports/commit/?id=75a42157eee297c14726eb622d5ce50d99fc27ba

Taking their proposed url, unless there is an "official" one?
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
