### PR TITLE
xerces-c: add cmake to build requirements

### DIFF
--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -100,6 +100,7 @@ class XercesCConan(ConanFile):
     def build_requirements(self):
         if self.options.message_loader == "icu" and not can_run(self):
             self.tool_requires("icu/72.1")
+        self.tool_requires("cmake/3.26.4")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **xerces-c/3.2.4**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Add cmake/3.26.4 as a build requirement

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
