### PR TITLE
turtle: fix lib/bindirs

### DIFF
--- a/recipes/turtle/all/conanfile.py
+++ b/recipes/turtle/all/conanfile.py
@@ -24,6 +24,8 @@ class TurtleConan(ConanFile):
 
     def package_id(self):
         self.info.clear()
+
+    def package_info(self):
         self.cpp_info.libdirs = []
         self.cpp_info.bindirs = []
 

--- a/recipes/turtle/all/conanfile.py
+++ b/recipes/turtle/all/conanfile.py
@@ -24,6 +24,8 @@ class TurtleConan(ConanFile):
 
     def package_id(self):
         self.info.clear()
+        self.cpp_info.libdirs = []
+        self.cpp_info.bindirs = []
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Since turtle is header-only recipe, we should unset libdirs and bindirs as per https://github.com/conan-io/conan/issues/13702#issuecomment-1510507647