### PR TITLE
seadex-essentials: Bump versions, remove header option force

### DIFF
--- a/recipes/seadex-essentials/all/conanfile.py
+++ b/recipes/seadex-essentials/all/conanfile.py
@@ -39,7 +39,7 @@ class SeadexEssentialsConan(ConanFile):
             "Visual Studio": "16",
             "msvc": "192",
             "apple-clang": "10"
-        }        
+        }
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -48,14 +48,12 @@ class SeadexEssentialsConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        self.options["fmt/*"].header_only = True
-        self.options["spdlog/*"].header_only = True
 
     def requirements(self):
         # Headers are exposed https://github.com/SeadexGmbH/essentials/blob/622a07dc1530f5668f5dde0ce18007d420c371cd/essentials/include/essentials/log/log_level.hpp#L15
         self.requires("spdlog/1.11.0", transitive_headers=True)
         # Exposes headers and symbols https://github.com/SeadexGmbH/essentials/blob/622a07dc1530f5668f5dde0ce18007d420c371cd/essentials/include/essentials/type_wrapper.hpp#L282
-        self.requires("fmt/9.1.0", transitive_headers=True, transitive_libs=True)
+        self.requires("fmt/10.0.0", transitive_headers=True, transitive_libs=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **seadex-essentials/all**

Fixes the conflicts from https://github.com/conan-io/conan-center-index/issues/18134, while also improving simplifying logic that as @czoido pointed out, is no good either way. 