### PR TITLE
imgui: add version 1.89.7, 1.89.7-docking

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.89.7":
+    url: "https://github.com/ocornut/imgui/archive/v1.89.7.tar.gz"
+    sha256: "115ee9e242af98a884302ac0f6ca3b2b26b1f10c660205f5e7ad9f1d1c96d269"
+  "1.89.7-docking":
+    url: "https://github.com/ocornut/imgui/archive/v1.89.7-docking.tar.gz"
+    sha256: "28216ec07e87f075b63486d8d5212e4d89542b69bd10a482f1b4b7dc6f1613a0"
   "1.89.5":
     url: "https://github.com/ocornut/imgui/archive/v1.89.5.tar.gz"
     sha256: "eab371005c86dd029523a0c4ba757840787163740d45c1f4e5a110eb21820546"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.89.7":
+    folder: all
+  "1.89.7-docking":
+    folder: all
   "1.89.5":
     folder: all
   "1.89.4":


### PR DESCRIPTION
Specify library name and version:  **imgui/1.89.7**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
