### PR TITLE
(#17449) Use self.info.settings.os in source() method

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -595,7 +595,7 @@ class QtConan(ConanFile):
 
     def source(self):
         destination = self.source_folder
-        if self.settings.os == "Windows":
+        if self.info.settings.os == "Windows":
             # Don't use os.path.join, or it removes the \\?\ prefix, which enables long paths
             destination = f"\\\\?\\{self.source_folder}"
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
  - Use self.info.settings.os instead of self.settings.os in source() method to avoid a "ConanException: 'self.settings' access in 'source()' method is forbidden"

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
