### PR TITLE
simple-websocket-server: migrate to Conan v2

### DIFF
--- a/recipes/simple-websocket-server/all/conanfile.py
+++ b/recipes/simple-websocket-server/all/conanfile.py
@@ -40,9 +40,9 @@ class SimpleWebSocketServerConan(ConanFile):
                 self.requires("boost/1.73.0")
         else:
             if self.options.use_asio_standalone:
-                self.requires("asio/1.23.0")
+                self.requires("asio/1.28.0")
             else:
-                self.requires("boost/1.79.0")
+                self.requires("boost/1.82.0")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/simple-websocket-server/all/conanfile.py
+++ b/recipes/simple-websocket-server/all/conanfile.py
@@ -1,33 +1,39 @@
 import os
 
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.52.0"
 
 
 class SimpleWebSocketServerConan(ConanFile):
     name = "simple-websocket-server"
-    homepage = "https://gitlab.com/eidheim/Simple-WebSocket-Server"
-    description = "A very simple, fast, multithreaded, platform independent WebSocket (WS) and WebSocket Secure (WSS) server and client library."
-    topics = ("websocket", "socket", "server", "client", "header-only")
-    url = "https://github.com/conan-io/conan-center-index"
-    settings = "os", "compiler", "arch", "build_type"
-    no_copy_source = True
+    description = (
+        "A very simple, fast, multithreaded, platform independent WebSocket (WS) "
+        "and WebSocket Secure (WSS) server and client library."
+    )
     license = "MIT"
-    options = {
-        "use_asio_standalone": [True, False],
-    }
-    default_options = {
-        "use_asio_standalone": True,
-    }
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://gitlab.com/eidheim/Simple-WebSocket-Server"
+    topics = ("websocket", "socket", "server", "client", "header-only")
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"use_asio_standalone": [True, False]}
+    default_options = {"use_asio_standalone": True}
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("openssl/1.1.1q")
         # only version 2.0.2 upwards is able to build against asio 1.18.0 or higher
-        if tools.Version(self.version) <= "2.0.1":
+        if Version(self.version) <= "2.0.1":
             if self.options.use_asio_standalone:
                 self.requires("asio/1.16.1")
             else:
@@ -38,28 +44,33 @@ class SimpleWebSocketServerConan(ConanFile):
             else:
                 self.requires("boost/1.79.0")
 
-    def configure(self):
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, "11")
+    def package_id(self):
+        self.info.clear()
 
-    def build(self):
-        if tools.Version(self.version) <= "2.0.1" and "asio" in self.deps_cpp_info.deps and tools.Version(self.deps_cpp_info["asio"].version) >= "1.18.0":
-            raise ConanInvalidConfiguration("simple-websocket-server versions <=2.0.1 require asio < 1.18.0")
-        elif tools.Version(self.version) <= "2.0.1" and "boost" in self.deps_cpp_info.deps and tools.Version(self.deps_cpp_info["boost"].version) >= "1.74.0":
-            raise ConanInvalidConfiguration("simple-websocket-server versions <=2.0.1 require boost < 1.74.0")
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
+        if Version(self.version) <= "2.0.1":
+            if self.dependencies.get("asio"):
+                if Version(self.dependencies["asio"].ref.version) >= "1.18.0":
+                    raise ConanInvalidConfiguration("simple-websocket-server versions <=2.0.1 require asio < 1.18.0")
+            elif self.dependencies.get("boost"):
+                if Version(self.dependencies["boost"].ref.version) >= "1.74.0":
+                    raise ConanInvalidConfiguration("simple-websocket-server versions <=2.0.1 require boost < 1.74.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "Simple-WebSocket-Server-v" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*.hpp", dst=os.path.join("include", "simple-websocket-server"), src=self._source_subfolder)
+        copy(self, "LICENSE",
+             dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "*.hpp",
+             dst=os.path.join(self.package_folder, "include", "simple-websocket-server"),
+             src=self.source_folder)
 
     def package_info(self):
-        if self.options.use_asio_standalone:
-            self.cpp_info.defines.append('USE_STANDALONE_ASIO')
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
 
-    def package_id(self):
-        self.info.header_only()
+        if self.options.use_asio_standalone:
+            self.cpp_info.defines.append("USE_STANDALONE_ASIO")

--- a/recipes/simple-websocket-server/all/test_package/CMakeLists.txt
+++ b/recipes/simple-websocket-server/all/test_package/CMakeLists.txt
@@ -1,11 +1,10 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(simple-websocket-server REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE simple-websocket-server::simple-websocket-server)
 set_target_properties(
     ${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 11

--- a/recipes/simple-websocket-server/all/test_package/conanfile.py
+++ b/recipes/simple-websocket-server/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/simple-websocket-server/all/test_v1_package/CMakeLists.txt
+++ b/recipes/simple-websocket-server/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/simple-websocket-server/all/test_v1_package/conanfile.py
+++ b/recipes/simple-websocket-server/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/simple-websocket-server/all/test_v1_package/conanfile.py
+++ b/recipes/simple-websocket-server/all/test_v1_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
