### PR TITLE
structopt: migrate to Conan v2

### DIFF
--- a/recipes/structopt/all/conandata.yml
+++ b/recipes/structopt/all/conandata.yml
@@ -13,14 +13,10 @@ sources:
     sha256: "a0552e81312cfafcc5319a25c0571ca2470f43461e9f3f72e5f9d89ea4139505"
 patches:
   "0.1.3":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0.1.0-0001-use-recipes.patch"
+    - patch_file: "patches/0.1.0-0001-use-recipes.patch"
   "0.1.2":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0.1.0-0001-use-recipes.patch"
+    - patch_file: "patches/0.1.0-0001-use-recipes.patch"
   "0.1.1":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0.1.0-0001-use-recipes.patch"
+    - patch_file: "patches/0.1.0-0001-use-recipes.patch"
   "0.1.0":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0.1.0-0001-use-recipes.patch"
+    - patch_file: "patches/0.1.0-0001-use-recipes.patch"

--- a/recipes/structopt/all/conanfile.py
+++ b/recipes/structopt/all/conanfile.py
@@ -1,36 +1,32 @@
 import os
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.33.0"
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.52.0"
+
 
 class StructoptConan(ConanFile):
     name = "structopt"
     description = "Parse command line arguments by defining a struct+"
-    topics = ("structopt", "argument-parser", "cpp17", "header-only",
-        "single-header-lib", "header-library", "command-line", "arguments",
-        "mit-license", "modern-cpp", "structopt", "lightweight", "reflection",
-        "cross-platform", "library", "type-safety", "type-safe", "argparse",
-        "clap",)
     license = "MIT"
-    homepage = "https://github.com/p-ranav/structopt"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/p-ranav/structopt"
+    topics = ("argument-parser", "cpp17", "header-only", "single-header-lib", "command-line",
+              "arguments", "mit-license", "modern-cpp", "lightweight", "reflection",
+              "cross-platform", "type-safety", "type-safe", "argparse", "clap")
+
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    def export_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
-
-    def requirements(self):
-        self.requires("magic_enum/0.8.0")
-        self.requires("visit_struct/1.0")
-
-    def package_id(self):
-        self.info.header_only()
+    def _min_cppstd(self):
+        return 17
 
     @property
     def _compilers_minimum_version(self):
@@ -41,37 +37,55 @@ class StructoptConan(ConanFile):
             "apple-clang": "10",
         }
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("magic_enum/0.9.2")
+        self.requires("visit_struct/1.1.0")
+
+    def package_id(self):
+        self.info.clear()
+
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, "17")
+            check_min_cppstd(self, self._min_cppstd)
 
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version:
-            if tools.Version(self.settings.compiler.version) < minimum_version:
-                raise ConanInvalidConfiguration("structopt: Unsupported compiler: {}-{} "
-                                                "(https://github.com/p-ranav/structopt#compiler-compatibility)."
-                                                .format(self.settings.compiler, self.settings.compiler.version))
+            if Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"structopt: Unsupported compiler: {self.settings.compiler}-{self.settings.compiler.version} "
+                    f"(https://github.com/p-ranav/structopt#compiler-compatibility)."
+                )
         else:
-            self.output.warn("{} requires C++14. Your compiler is unknown. Assuming it supports C++14.".format(self.name))
+            self.output.warning("{} requires C++14. Your compiler is unknown. Assuming it supports C++14.".format(self.name))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.configure(source_folder=self._source_subfolder)
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        tools.rmdir(os.path.join(self._source_subfolder, "include", "structopt", "third_party"))
-
+        apply_conandata_patches(self)
+        rmdir(self, os.path.join(self.source_folder, "include", "structopt", "third_party"))
 
     def package(self):
-        self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.configure()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/structopt/all/conanfile.py
+++ b/recipes/structopt/all/conanfile.py
@@ -35,6 +35,7 @@ class StructoptConan(ConanFile):
             "Visual Studio": "15.0",
             "clang": "5",
             "apple-clang": "10",
+            "msvc": "191",
         }
 
     def export_sources(self):

--- a/recipes/structopt/all/test_package/CMakeLists.txt
+++ b/recipes/structopt/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 find_package(structopt REQUIRED CONFIG)
 

--- a/recipes/structopt/all/test_package/conanfile.py
+++ b/recipes/structopt/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/structopt/all/test_v1_package/CMakeLists.txt
+++ b/recipes/structopt/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/structopt/all/test_v1_package/conanfile.py
+++ b/recipes/structopt/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
