### PR TITLE
openssl: add support for `install_ssldirs` and/or `install_fips`

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -483,7 +483,7 @@ class OpenSSLConan(ConanFile):
         command = [self._make_program]
         if install:
             command.append(f"DESTDIR={self.package_folder}")
-            command.append(f"OPENSSLDIR=/etc/ssl")
+            command.append(f"OPENSSLDIR=/res/ssl")
         if targets:
             command.extend(targets)
         if not self._use_nmake:


### PR DESCRIPTION
Specify library name and version:  **openssl/v3.x.x**

The various config files and certs-related files generated and installed via OpenSSL's `install_ssldirs` and `install_fips` targets can sometimes be needed by packages using `openssl`, either directly or repackaged when a final product embeds OpenSSL. Currently only the `install_sw` target is installed.

This PR does the following:
* It adds a package option called `with_ssldirs`
* The default value for `with_ssldirs` is `False` (i.e. same as current behavior where only `install_sw` is called)
* When `with_ssldirs` is `True`, `install_ssldirs` is called at install time
* Also, when `no_fips` is `False`, the `install_fips` target is called at install time

Because of how the `install_ssldirs` and `install_fips` targets heavily depend on the combo of `$(DESTDIR)` and `$(OPENSSLDIR)`, we have to override the previously set value of `OPENSSLDIR` in order for Make to install these files in a known/package-level subdir (i.e. `etc/ssl`). This does not affect the value of OPENSSLDIR that is set in the openssl binary at build time, especially when the user set it via the `openssldir` package option.

So, when the package was created using:
```
conan create --version 3.1.1 3.x.x -o with_ssldirs=True -o openssldir=/opt/mysoftware/etc/ssl
```
The resulting package's `openssl` will still embed the correct `OPENSSLDIR`:
```
~/.conan2/p/b/opensa94ddd3dbc68b/p/bin/openssl version -d                                                                                                                                                            
OPENSSLDIR: "/opt/mysoftware/etc/ssl"
```

Even though the ssl dir config files will be packaged at:
```
 tree ~/.conan2/p/b/opensa94ddd3dbc68b/p/etc/ssl 
├── certs
├── ct_log_list.cnf
├── ct_log_list.cnf.dist
├── fipsmodule.cnf
├── misc
│   ├── CA.pl
│   ├── tsget -> tsget.pl
│   └── tsget.pl
├── openssl.cnf
├── openssl.cnf.dist
└── private

4 directories, 8 files
```


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
