### PR TITLE
nlohmann_json: add version 3.5.0

### DIFF
--- a/recipes/nlohmann_json/all/conandata.yml
+++ b/recipes/nlohmann_json/all/conandata.yml
@@ -38,6 +38,9 @@ sources:
   "3.7.0":
     sha256: D51A3A8D3EFBB1139D7608E28782EA9EFEA7E7933157E8FF8184901EFD8EE760
     url: https://github.com/nlohmann/json/archive/v3.7.0.tar.gz
+  "3.5.0":
+    sha256: E0B1FC6CC6CA05706CCE99118A87ACA5248BD9DB3113E703023D23F044995C1D
+    url: https://github.com/nlohmann/json/archive/v3.5.0.tar.gz
   "3.4.0":
     sha256: C377963A95989270C943D522BFEFE7B889EF5ED0E1E15D535FD6F6F16ED70732
     url: https://github.com/nlohmann/json/archive/v3.4.0.tar.gz

--- a/recipes/nlohmann_json/config.yml
+++ b/recipes/nlohmann_json/config.yml
@@ -25,6 +25,8 @@ versions:
     folder: all
   "3.7.0":
     folder: all
+  "3.5.0":
+    folder: all
   "3.4.0":
     folder: all
   "3.2.0":


### PR DESCRIPTION
Specify library name and version:  **nlohmann_json/3.5.0**

I am not the author of nlohmann_json.

I am adding version 3.5.0 because it is used by other software I am working on. I am migrating to conan and I wish to isolate any conan issues vs library upgrade issues.

---

- [*] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [*] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [*] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
