### PR TITLE
libpng: add version 1.6.32

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
   "1.6.37":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.37/libpng-1.6.37.tar.xz"
     sha256: "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca"
+  "1.6.32":
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/older-releases/1.6.32/libpng-1.6.32.tar.xz"
+    sha256: "c918c3113de74a692f0a1526ce881dc26067763eb3915c57ef3a0f7b6886f59b"
   "1.5.30":
     url: "https://sourceforge.net/projects/libpng/files/libpng15/1.5.30/libpng-1.5.30.tar.xz"
     sha256: "7d76275fad2ede4b7d87c5fd46e6f488d2a16b5a69dc968ffa840ab39ba756ed"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -7,5 +7,7 @@ versions:
     folder: all
   "1.6.37":
     folder: all
+  "1.6.32":
+    folder: all
   "1.5.30":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libpng/1.6.32**

I am not the author of this library.
I am porting an application to conan. The application used this exact version of libpng, so I added it to conan.

---

- [*] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [*] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [*] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
