### PR TITLE
libtool: fix build in macOS

### DIFF
--- a/recipes/libtool/all/conanfile.py
+++ b/recipes/libtool/all/conanfile.py
@@ -118,9 +118,11 @@ class LibtoolConan(ConanFile):
     def _patch_sources(self):
         apply_conandata_patches(self)
         config_guess =  self.dependencies.build["gnu-config"].conf_info.get("user.gnu-config:config_guess")
+        if config_guess is not None:
+            shutil.copy(config_guess, os.path.join(self.source_folder, "build-aux", "config.guess"))
         config_sub = self.dependencies.build["gnu-config"].conf_info.get("user.gnu-config:config_sub")
-        shutil.copy(config_sub, os.path.join(self.source_folder, "build-aux", "config.sub"))
-        shutil.copy(config_guess, os.path.join(self.source_folder, "build-aux", "config.guess"))
+        if config_sub is not None:
+            shutil.copy(config_sub, os.path.join(self.source_folder, "build-aux", "config.sub"))
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
Fixes #18379

Specify library name and version:  **libtool/2.4.7**

I am not sure about the fix though, I don't understand how this could be None if it's provided by the gnu-config recipe.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
