### PR TITLE
aaf: add package type and fix test_package on Windows with Conan 2

### DIFF
--- a/recipes/aaf/all/conanfile.py
+++ b/recipes/aaf/all/conanfile.py
@@ -18,6 +18,7 @@ class AafConan(ConanFile):
     )
     topics = ("multimedia", "crossplatform")
     license = "AAFSDKPSL-2.0"
+    package_type = "static-library"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -84,9 +85,12 @@ class AafConan(ConanFile):
     def package_info(self):
         if self.settings.os == "Windows":
             suffix = "D" if self.settings.build_type == "Debug" else ""
-            self.cpp_info.libs = [f"AAF{suffix}", f"AAFIID{suffix}", "AAFCOAPI"]
+            self.cpp_info.libs = [f"AAF{suffix}", f"AAFIID{suffix}"]
+            # The static library loads a DLL at runtime, on Windows it needs to be able
+            # to find it in PATH, see https://aaf.sourceforge.net/AAFProjectFAQ.html
+            self.runenv_info.prepend_path("PATH", os.path.join(self.package_folder, "bin"))
         else:
-            self.cpp_info.libs = ["aaflib", "aafiid", "com-api"]
+            self.cpp_info.libs = ["aaflib", "aafiid"]
         if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.system_libs = ["dl"]
         elif is_apple_os(self):


### PR DESCRIPTION
Specify library name and version:  **aaf/all**

While this package contained dynamically loaded libraries, the library [documentation](https://aaf.sourceforge.net/AAFProjectFAQ.html) specifies that consumers are to link against two _static_ libraries:
- aaflib
- aafiid

The `aaflib` static library contains logic to load the DLLs _at runtime_,  which it does via `dlopen` - in order for that to work, at runtime it needs to be able to locate those libraries.



This PR:
* removes `AAFCOAPI` and `libcom-api` from being expressed as libraries in the `package_info()`, as these are not meant to be directly linked. This is further supported by the scripts in the original sources, which only places two `.a` files in the `lib` folder, and places the `.so/.dylib/.dll` files in the `bin` folder for all platforms. (see `dist/release-files.unix` for example in the original sources). The original packaging scripts also do *not* package the `.lib` files for on windows for the DLLs.
* set the `package-type` to `static-library`, as for the purposes of consuming the library and how it propagates, the linkage is that of a static library
* define `PATH` in the `runenv_info` such that at runtime, consumers can locate the DLL on Windows. This fixes the `test_package` on Windows, which fails at runtime as it fails to locate the DLL
