### PR TITLE
Use version range for openssl dependency including version 3.x

### DIFF
--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -82,9 +82,7 @@ class Libssh2Conan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/1.2.13")
         if self.options.crypto_backend == "openssl":
-            self.requires("openssl/1.1.1t")
-            # Version 3.x not currently working
-            # self.requires("openssl/[>=1.1 <4]")
+            self.requires("openssl/[>=1.1 <4]")
         elif self.options.crypto_backend == "mbedtls":
             # libssh2/<=1.10.0 doesn't support mbedtls/3.x.x
             self.requires("mbedtls/2.25.0")


### PR DESCRIPTION
Specify library name and version:  **libssh2/1.11.0**

Using the version range for the dependency on openssl.

Support for openssl 3.x was marked at *not working* in a comment that I added previously, but that appears to have been a local configuration issue. It is working now.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
