### PR TITLE
dcmtk: fix openssl detection on Windows

### DIFF
--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -91,15 +91,11 @@ class DCMTKConan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/1.2.13")
         if self.options.with_openssl:
-            if self.settings.os == "Windows":
-                # FIXME: CMake configuration fails to detect Openssl 1.1 on Windows.
-                self.requires("openssl/1.0.2u")
-            else:
-                self.requires("openssl/1.1.1t")
+            self.requires("openssl/1.1.1u")
         if self.options.with_libpng:
-            self.requires("libpng/1.6.39")
+            self.requires("libpng/1.6.40")
         if self.options.with_libtiff:
-            self.requires("libtiff/4.4.0")
+            self.requires("libtiff/4.5.1")
         if self.options.get_safe("with_tcpwrappers"):
             self.requires("tcp-wrappers/7.6")
 
@@ -117,6 +113,7 @@ class DCMTKConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
 
+        cmake.definitions["DCMTK_USE_FIND_PACKAGE"] = True
         # DICOM Data Dictionaries are required
         cmake.definitions["CMAKE_INSTALL_DATADIR"] = self._dcm_datadictionary_path
 


### PR DESCRIPTION
Specify library name and version:  **dcmtk/all**

Allow using newer OpenSSL on Windows. Without this it's impossible to use gdcm and dcmtk at the same time.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
