### PR TITLE
glib: add version 2.77.0

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.77.0":
+    url: "https://download.gnome.org/sources/glib/2.77/glib-2.77.0.tar.xz"
+    sha256: "1897fd8ad4ebb523c32fabe7508c3b0b039c089661ae1e7917df0956a320ac4d"
   "2.76.3":
     url: "https://download.gnome.org/sources/glib/2.76/glib-2.76.3.tar.xz"
     sha256: "c0be444e403d7c3184d1f394f89f0b644710b5e9331b54fa4e8b5037813ad32a"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.77.0":
+    folder: all
   "2.76.3":
     folder: all
   "2.76.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glib/2.77.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
