### PR TITLE
infra: add Visual Studio 2022 configuration to Conan 2.0 checks (msvc 193)

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -76,7 +76,7 @@ configurations:
               compiler.version: [ "5", "7", "9", "10" ]
               build_type: [ "Release", "Debug" ]
   - id: linux-gcc
-    epochs: [20211221, 20220120]
+    epochs: [20211221, 20220120, 20230606]
     hrname: "Linux, GCC"
     content:
       - os: ["Linux"]
@@ -87,7 +87,7 @@ configurations:
               compiler.version: ["5", "7", "9", "10", "11"]
               build_type: ["Release", "Debug"]
   - id: linux-clang
-    epochs: [20211221, 20220120]
+    epochs: [20211221, 20220120, 20230606]
     hrname: "Linux, Clang"
     content:
       - os: ["Linux"]
@@ -109,7 +109,7 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
   - id: macos-clang
-    epochs: [20220120]
+    epochs: [20220120, 20230606]
     hrname: "macOS, Clang"
     content:
       - os: [ "Macos" ]
@@ -134,7 +134,7 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
   - id: macos-m1-clang
-    epochs: [20220120]
+    epochs: [20220120, 20230606]
     hrname: "macOS, Clang (M1/arm64)"
     build_profile:
       os: "Macos"
@@ -148,7 +148,7 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
   - id: windows-visual_studio
-    epochs: [0, 20211221, 20220120]
+    epochs: [0, 20211221, 20220120, 20230606]
     hrname: "Windows, Visual Studio"
     content:
       - os: [ "Windows" ]

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -92,7 +92,7 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
   - id: windows-msvc
-    epochs: [0, 20211221, 20220120, 20220628]
+    epochs: [0, 20211221, 20220120, 20220628, 20230606]
     hrname: "Windows, MSVC"
     build_profile:
       os: "Windows"
@@ -101,7 +101,7 @@ configurations:
         arch: [ "x86_64" ]
         compiler:
           - "msvc":
-              compiler.version: [ "192" ]
+              compiler.version: [ "192", "193" ]
               build_type:
                 - "Release":
                     compiler.runtime: ["dynamic"]
@@ -114,6 +114,7 @@ cppstd:
     "11": ["17", "gnu17", "20", "gnu20"]
   msvc:
     "192": ["14", "17", "20"]
+    "193": ["14", "17", "20"]
 
 jenkins:
   url: "http://mb-jenkins-my-bloody-jenkins:8080"

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -52,7 +52,7 @@ tasks:
 
 configurations:
   - id: linux-gcc
-    epochs: [0, 20211221, 20220120, 20220628]
+    epochs: [0, 20211221, 20220120, 20220628, 20230606]
     hrname: "Linux, GCC"
     build_profile:
       os: "Linux"
@@ -65,7 +65,7 @@ configurations:
               compiler.version: ["11"]
               build_type: ["Release"]
   - id: macos-clang
-    epochs: [0, 20211221, 20220120, 20220628]
+    epochs: [0, 20211221, 20220120, 20220628, 20230606]
     hrname: "macOS, Clang"
     build_profile:
       os: "Macos"
@@ -78,7 +78,7 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
   - id: macos-m1-clang
-    epochs: [0, 20211221, 20220120, 20220628]
+    epochs: [0, 20211221, 20220120, 20220628, 20230606]
     hrname: "macOS M1, Clang"
     build_profile:
       os: "Macos"

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -92,7 +92,22 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
   - id: windows-msvc
-    epochs: [0, 20211221, 20220120, 20220628, 20230606]
+    epochs: [0, 20211221, 20220120, 20220628]
+    hrname: "Windows, MSVC"
+    build_profile:
+      os: "Windows"
+    content:
+      - os: [ "Windows" ]
+        arch: [ "x86_64" ]
+        compiler:
+          - "msvc":
+              compiler.version: [ "192" ]
+              build_type:
+                - "Release":
+                    compiler.runtime: ["dynamic"]
+                    compiler.runtime_type: [ "Release" ]
+  - id: windows-msvc
+    epochs: [20230606]
     hrname: "Windows, MSVC"
     build_profile:
       os: "Windows"


### PR DESCRIPTION
Add msvc 193 to the Conan 2.0 platform matrix.
