### PR TITLE
zxing-cpp: add version 2.1.0

### DIFF
--- a/recipes/zxing-cpp/all/conandata.yml
+++ b/recipes/zxing-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.0":
+    url: "https://github.com/zxing-cpp/zxing-cpp/archive/v2.1.0.tar.gz"
+    sha256: "6d54e403592ec7a143791c6526c1baafddf4c0897bb49b1af72b70a0f0c4a3fe"
   "2.0.0":
     url: "https://github.com/zxing-cpp/zxing-cpp/archive/v2.0.0.tar.gz"
     sha256: "12b76b7005c30d34265fc20356d340da179b0b4d43d2c1b35bcca86776069f76"

--- a/recipes/zxing-cpp/config.yml
+++ b/recipes/zxing-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.0":
+    folder: all
   "2.0.0":
     folder: all
   "1.4.0":


### PR DESCRIPTION
Specify library name and version:  **zxing-cpp/2.1.0**

I'm the maintainer of the zxing-cpp project and this PR simply adds the new 2.1 release from two days ago. I'm not a conan users myself and could not test this locally.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
