### PR TITLE
charls: skip building tests

### DIFF
--- a/recipes/charls/all/conanfile.py
+++ b/recipes/charls/all/conanfile.py
@@ -63,7 +63,10 @@ class CharlsConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["CHARLS_INSTALL"] = True
+        tc.cache_variables["CHARLS_BUILD_FUZZ_TEST"] = False
+        tc.cache_variables["CHARLS_BUILD_SAMPLES"] = False
+        tc.cache_variables["CHARLS_BUILD_TESTS"] = False
+        tc.cache_variables["CHARLS_INSTALL"] = True
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Specify library name and version:  **charls/all**

Add flags to skip building tests and samples in the `charls` recipe. This fixes ability to build with Visual Studio 2022, which fails with these errors:

```
C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\bitstreamdamage.cpp(105,54): error C3848: expression having type 'const std::uniform_int_distributio
n<uint32_t>' would lose some const-volatile qualifiers in order to call 'unsigned int std::uniform_int<_Ty>::operator ()<std::mt19937>(_Engine &)' [C:\Users\
conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t,
              _Engine=std::mt19937
          ]
C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\main.cpp(124,44): error C3848: expression having type 'const std::uniform_int_distribution<uint32_t>
' would lose some const-volatile qualifiers in order to call 'unsigned int std::uniform_int<_Ty>::operator ()<std::mt19937>(_Engine &)' [C:\Users\conan\.cona
n2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t,
              _Engine=std::mt19937
          ]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\include\random(1939,28): message : could be 'unsigned int std::uniform_int<
_Ty>::operator ()(_Engine &,const std::uniform_int<_Ty>::param_type &)' [C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t
          ] (compiling source file C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\bitstreamdamage.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\include\random(1939,28): message : could be 'unsigned int std::uniform_int<
_Ty>::operator ()(_Engine &,const std::uniform_int<_Ty>::param_type &)' [C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t
          ] (compiling source file C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\main.cpp)
C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\bitstreamdamage.cpp(105,54): message : 'unsigned int std::uniform_int<_Ty>::operator ()(_Engine &,co
nst std::uniform_int<_Ty>::param_type &)': expects 2 arguments - 1 provided [C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t
          ]
C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\main.cpp(124,44): message : 'unsigned int std::uniform_int<_Ty>::operator ()(_Engine &,const std::un 
iform_int<_Ty>::param_type &)': expects 2 arguments - 1 provided [C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t
          ]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\include\random(1944,28): message : or       'unsigned int std::uniform_int< 
_Ty>::operator ()(_Engine &,unsigned int)' [C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t
          ] (compiling source file C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\bitstreamdamage.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\include\random(1944,28): message : or       'unsigned int std::uniform_int< 
_Ty>::operator ()(_Engine &,unsigned int)' [C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t
          ] (compiling source file C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\main.cpp)
C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\bitstreamdamage.cpp(105,54): message : 'unsigned int std::uniform_int<_Ty>::operator ()(_Engine &,un 
signed int)': expects 2 arguments - 1 provided [C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t
          ]
C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\src\test\main.cpp(124,44): message : 'unsigned int std::uniform_int<_Ty>::operator ()(_Engine &,unsigned int) 
': expects 2 arguments - 1 provided [C:\Users\conan\.conan2\p\b\charlbaf5e7f3ca287\b\build\test\charlstest.vcxproj]
          with
          [
              _Ty=uint32_t
          ]
```

The library itself does build just fine, and in line with our policies, we do not build tests or sample code.