### PR TITLE
[doxygen] Statically compile libc/libstdc++ to remove host system dependency

### DIFF
--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -61,9 +61,10 @@ class DoxygenConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
-        host_deps = [dep for _, dep in self.dependencies.host.items()]
-        if all(dep.package_type in ["static-library", "header-library"] for dep in host_deps):
-            self.info.requires.minor_mode()
+        if not Version(conan_version) < "2":
+            host_deps = [dep for _, dep in self.dependencies.host.items()]
+            if all(dep.package_type in ["static-library", "header-library"] for dep in host_deps):
+                self.info.requires.minor_mode()
 
     def compatibility(self):
         # Models Debug builds as equivalent to Release builds as this is a tool_requires package

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -100,7 +100,7 @@ class DoxygenConan(ConanFile):
         tc.variables["win_static"] = is_msvc_static_runtime(self)
         if self.settings.os == "Linux" and "libstdc++" in self.settings.compiler.libcxx:
             # Link C++ library statically on Linux so that it can run on systems with an older C++ runtime
-            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static -static-libstdc++ -static-libgcc"
+            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static-libstdc++ -static-libgcc"
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -65,11 +65,15 @@ class DoxygenConan(ConanFile):
         self.info.requires.full_version_mode()
 
     def compatibility(self):
-        # This will only work when host profile == build profile
-        # For some reason self.settings.compiler here returns the compiler from the build profile
-        compatible_versions = [{"settings": [("compiler.version", v), ("build_type", "Release")]}
-            for v in self.settings.compiler.version.get_definition() if v <= Version(self.settings.compiler.version)]
-        return compatible_versions
+        if (Version(conan_version).major >= 2):
+            # This will only work when host profile == build profile
+            # For some reason self.settings.compiler here returns the compiler from the build profile
+            # Models libc++ compatibility and identifies Debug builds as equivalent to Release builds
+            compatible_versions = [{"settings": [("compiler.version", v), ("build_type", "Release")]}
+                for v in self.settings.compiler.version.get_definition() if v <= Version(self.settings.compiler.version)]
+            return compatible_versions
+        # Models Debug builds as equivalent to Release builds as this is a tool_requires package
+        return [{"settings": [("build_type", "Release")]}]
 
     def validate(self):
         minimum_compiler_version = self._minimum_compiler_version.get(str(self.settings.compiler))

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -5,8 +5,6 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
-import pathlib
-import yaml
 
 required_conan_version = ">=1.52.0"
 
@@ -61,16 +59,11 @@ class DoxygenConan(ConanFile):
             # INFO: Doxygen uses upper case CMake variables to link/include IConv, so we are using patches for targets.
             self.requires("libiconv/1.17")
 
-    def package_id(self):
-        self.info.requires.full_version_mode()
-
     def compatibility(self):
         if (Version(conan_version).major >= 2):
-            # This will only work when host profile == build profile
-            # For some reason self.settings.compiler here returns the compiler from the build profile
             # Models libc++ compatibility and identifies Debug builds as equivalent to Release builds
             compatible_versions = [{"settings": [("compiler.version", v), ("build_type", "Release")]}
-                for v in self.settings.compiler.version.get_definition() if v <= Version(self.settings.compiler.version)]
+                for v in self.settings.compiler.version.possible_values() if v <= Version(self.settings.compiler.version)]
             return compatible_versions
         # Models Debug builds as equivalent to Release builds as this is a tool_requires package
         return [{"settings": [("build_type", "Release")]}]

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -100,7 +100,7 @@ class DoxygenConan(ConanFile):
         tc.variables["win_static"] = is_msvc_static_runtime(self)
         if self.settings.os == "Linux" and "libstdc++" in self.settings.compiler.libcxx:
             # Link C++ library statically on Linux so that it can run on systems with an older C++ runtime
-            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static-libstdc++ -static-libgcc"
+            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static -static-libstdc++ -static-libgcc"
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -1,10 +1,12 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
+import pathlib
+import yaml
 
 required_conan_version = ">=1.52.0"
 
@@ -45,6 +47,12 @@ class DoxygenConan(ConanFile):
             "msvc": "191",
         }
 
+    @property
+    def _conan_home(self):
+        conan_home_env = "CONAN_USER_HOME" if Version(conan_version).major < 2 else "CONAN_HOME"
+        conan_home_dir = ".conan" if Version(conan_version).major < 2 else ".conan2"
+        return os.environ.get(conan_home_env, pathlib.Path(pathlib.Path.home(), conan_home_dir))
+
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -59,8 +67,18 @@ class DoxygenConan(ConanFile):
             # INFO: Doxygen uses upper case CMake variables to link/include IConv, so we are using patches for targets.
             self.requires("libiconv/1.17")
 
+    def package_id(self):
+        self.info.requires.full_version_mode()
+
     def compatibility(self):
-        return [{"settings": [("build_type", "Release")]}]
+        # is there a better way of reading all possible versions from settings.yml?
+        settings_yml_path = pathlib.Path(self._conan_home, "settings.yml")
+        with open(settings_yml_path, "r") as f:
+            settings_yml = yaml.safe_load(f)
+
+        compatible_versions = [{"settings": [("compiler.version", v), ("build_type", "Release")]}
+            for v in settings_yml["compiler"][str(self.settings.compiler)]["version"] if v <= Version(self.settings.compiler.version)]
+        return compatible_versions
 
     def validate(self):
         minimum_compiler_version = self._minimum_compiler_version.get(str(self.settings.compiler))

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -61,10 +61,14 @@ class DoxygenConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
-        if not Version(conan_version) < "2":
-            host_deps = [dep for _, dep in self.dependencies.host.items()]
+        host_deps = [dep for _, dep in self.dependencies.host.items()]
+        if Version(conan_version) >= "2":
             if all(dep.package_type in ["static-library", "header-library"] for dep in host_deps):
                 self.info.requires.minor_mode()
+        else:
+            if all(not dep.options.shared for dep in host_deps):
+                self.info.requires.minor_mode()
+
 
     def compatibility(self):
         # Models Debug builds as equivalent to Release builds as this is a tool_requires package

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -47,12 +47,6 @@ class DoxygenConan(ConanFile):
             "msvc": "191",
         }
 
-    @property
-    def _conan_home(self):
-        conan_home_env = "CONAN_USER_HOME" if Version(conan_version).major < 2 else "CONAN_HOME"
-        conan_home_dir = ".conan" if Version(conan_version).major < 2 else ".conan2"
-        return os.environ.get(conan_home_env, pathlib.Path(pathlib.Path.home(), conan_home_dir))
-
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -71,13 +65,10 @@ class DoxygenConan(ConanFile):
         self.info.requires.full_version_mode()
 
     def compatibility(self):
-        # is there a better way of reading all possible versions from settings.yml?
-        settings_yml_path = pathlib.Path(self._conan_home, "settings.yml")
-        with open(settings_yml_path, "r") as f:
-            settings_yml = yaml.safe_load(f)
-
+        # This will only work when host profile == build profile
+        # For some reason self.settings.compiler here returns the compiler from the build profile
         compatible_versions = [{"settings": [("compiler.version", v), ("build_type", "Release")]}
-            for v in settings_yml["compiler"][str(self.settings.compiler)]["version"] if v <= Version(self.settings.compiler.version)]
+            for v in self.settings.compiler.version.get_definition() if v <= Version(self.settings.compiler.version)]
         return compatible_versions
 
     def validate(self):


### PR DESCRIPTION
This is a successor PR to #17051.

* Remove deletion of `self.info.settings.compiler` because this is relevant metadata for executables, as it inserts a dependency on a libstdc++ version at least what it was compiled with. For a detailed explanation of the problem this solves and why it's necessary **please read https://github.com/conan-io/conan-center-index/issues/17034**
* Add model of libstdc++ compatibility to ensure that binaries can not be used with older version of libstdc++ than what it was compiled for.

The previous form of this PR modified the `package_id` to use `full_version_mode` to ensure that the dependency package id's don't impact doxygen's package id - only version changes in dependencies would impact doxygen's package id. This was necessary to allow doxygen built with gcc 10 to be identified as compatible with a gcc 12 profile. Without this, `compiler.version=12` propagates through the entire dependency tree and the package id of the doxygen package built with gcc 10 does not match appropriately and is not resolved as compatible, since it is impacted by the varying package_id of its upstream dependencies.

I've removed this as this was the reason #17051 was rejected, but I do note that it does hamper the existing implementation of `compatibility()` substantially as the benefits are only really seen when the only package in doxygen's tree using a different compiler version is doxygen.

Relates to https://github.com/conan-io/conan-center-index/issues/17034

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
