### PR TITLE
Onnx Static Initialization Bug

### DIFF
--- a/recipes/onnx/all/conanfile.py
+++ b/recipes/onnx/all/conanfile.py
@@ -51,7 +51,7 @@ class OnnxConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.version < "1.9.0":
+        if Version(self.version) < "1.9.0":
             del self.options.disable_static_registration
 
     def configure(self):
@@ -99,7 +99,7 @@ class OnnxConan(ConanFile):
         tc.variables["ONNX_VERIFY_PROTO3"] = Version(self.dependencies.host["protobuf"].ref.version).major == "3"
         if is_msvc(self):
             tc.variables["ONNX_USE_MSVC_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
-        if self.version >= "1.9.0":
+        if Version(self.version) >= "1.9.0":
             tc.variables["ONNX_DISABLE_STATIC_REGISTRATION"] = self.options.get_safe('disable_static_registration')
         tc.generate()
         deps = CMakeDeps(self)


### PR DESCRIPTION
The version check for the "disable_static_registration" on the onnx library wasn't checking correctly and was causing versions that did have the flag to not properly display it. This patch seeks to fix that issue.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
