### PR TITLE
msgpack-cxx: add version 6.1.0, use download tarballs, update boost

### DIFF
--- a/recipes/msgpack-cxx/all/conandata.yml
+++ b/recipes/msgpack-cxx/all/conandata.yml
@@ -1,22 +1,25 @@
 sources:
+  "6.1.0":
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-6.1.0/msgpack-cxx-6.1.0.tar.gz"
+    sha256: "23ede7e93c8efee343ad8c6514c28f3708207e5106af3b3e4969b3a9ed7039e7"
   "6.0.0":
-    url: "https://github.com/msgpack/msgpack-c/archive/cpp-6.0.0.tar.gz"
-    sha256: "d02f7ffd28b1d38ab9f5f758c4744fadfae92150461fb8154c98ac49226cff90"
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-6.0.0/msgpack-cxx-6.0.0.tar.gz"
+    sha256: "0948d2db98245fb97b9721cfbc3e44c1b832e3ce3b8cfd7485adc368dc084d14"
   "5.0.0":
-    url: "https://github.com/msgpack/msgpack-c/archive/cpp-5.0.0.tar.gz"
-    sha256: "bd6b8e255f0a62cf8f50f1d292f979ac8ea9a4aa121938679d6f419d6df70ea3"
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-5.0.0/msgpack-cxx-5.0.0.tar.gz"
+    sha256: "80f997575acff12b1b64158ef9dbad4cff32595f985532e16c6ea67e317452d5"
   "4.1.3":
-    url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.1.3.tar.gz"
-    sha256: "fd0a685656f11b8aa09ed33bcbdcad3105d25d0034ca3dba9fe957623a42d253"
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-4.1.3/msgpack-cxx-4.1.3.tar.gz"
+    sha256: "2539075ea2f35c15cab5c50ecba00d76fc4cbdcd485840257f15ebb04e8e3e1a"
   "4.1.2":
-    url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.1.2.tar.gz"
-    sha256: "7460ad43552c9d9b56a75f20e1f4fedf18fff1c48715d6cfa91d779b26ca3795"
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-4.1.2/msgpack-cxx-4.1.2.tar.gz"
+    sha256: "eeddd7faeacbc12e10052bd1e3ec78bd26c69bfbbea9f9264c7ffce9b1ede7b1"
   "4.1.1":
-    url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.1.1.tar.gz"
-    sha256: "221cc539e77f5ca02f4f0bbb1edafa9ca8c08de7ba8072d7baf2139930d99182"
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-4.1.1/msgpack-cxx-4.1.1.tar.gz"
+    sha256: "8115c5edcf20bc1408c798a6bdaec16c1e52b1c34859d4982a0fb03300438f0b"
   "4.1.0":
-    url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.1.0.tar.gz"
-    sha256: "634762502a192026bd5db773f9e18d900ad04cfc312b52faee350a5c76e5ccfb"
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-4.1.0/msgpack-cxx-4.1.0.tar.gz"
+    sha256: "11e042ffdafda6fc4ebdc5f4f63b352229b89796c2f8aa3e813116ec1dd8377d"
   "4.0.3":
-    url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.0.3.tar.gz"
-    sha256: "23d737b1e959dfb6ca420564563f098e758adacc0b18003c56abf1b945bd1d4a"
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-4.0.3/msgpack-cxx-4.0.3.tar.gz"
+    sha256: "9b3c1803b9855b7b023d7f181f66ebb0d6941275ba41d692037e0aa27736443f"

--- a/recipes/msgpack-cxx/all/conanfile.py
+++ b/recipes/msgpack-cxx/all/conanfile.py
@@ -34,7 +34,7 @@ class MsgpackCXXConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("use_boost", True):
-            self.requires("boost/1.81.0")
+            self.requires("boost/1.82.0")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/msgpack-cxx/config.yml
+++ b/recipes/msgpack-cxx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.1.0":
+    folder: all
   "6.0.0":
     folder: all
   "5.0.0":


### PR DESCRIPTION
Specify library name and version:  **msgpack-cxx/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
