### PR TITLE
minizip-ng: fix duplicate provides with mz_compatibility=True, update dependencies

### DIFF
--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -73,8 +73,6 @@ class MinizipNgConan(ConanFile):
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
-        if self.options.mz_compatibility:
-            self.provides = "minizip"
         if self.options.get_safe("with_libcomp"):
             del self.options.with_zlib
 
@@ -98,7 +96,7 @@ class MinizipNgConan(ConanFile):
 
     def build_requirements(self):
         if self._needs_pkg_config:
-            self.tool_requires("pkgconf/1.9.3")
+            self.tool_requires("pkgconf/1.9.5")
         if Version(self.version) >= "4.0.0":
             self.tool_requires("cmake/[>=3.19 <4]")
 
@@ -177,7 +175,8 @@ class MinizipNgConan(ConanFile):
             self.cpp_info.components["minizip"].defines.append("HAVE_BZIP2")
 
         if Version(self.version) >= "4.0.0":
-            self.cpp_info.components["minizip"].includedirs.append(os.path.join("include", "minizip-ng"))
+            minizip_dir = "minizip" if self.options.mz_compatibility else "minizip-ng"
+            self.cpp_info.components["minizip"].includedirs.append(os.path.join(self.package_folder, "include", minizip_dir))
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "minizip"
@@ -202,6 +201,4 @@ class MinizipNgConan(ConanFile):
             self.cpp_info.components["minizip"].frameworks.extend(["CoreFoundation", "Security"])
         if self.settings.os != "Windows" and self.options.with_iconv:
             self.cpp_info.components["minizip"].requires.append("libiconv::libiconv")
-
-
 


### PR DESCRIPTION
Specify library name and version:  **minizip-ng**

When using minizip with mz_compatibility=True, I met following error.

```
ERROR: Provide Conflict: Both 'minizip-ng/4.0.0' and 'minizip-ng/4.0.0' provide 'minizip'.
```

This PR tries to fix this error and other mz_compatibility issues.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
