### PR TITLE
[double-conversion] set _ITERATOR_DEBUG_LEVEL=2 for Windows Debug builds

### DIFF
--- a/recipes/double-conversion/all/conanfile.py
+++ b/recipes/double-conversion/all/conanfile.py
@@ -46,6 +46,11 @@ class DoubleConversionConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+
+        if(self.settings.os == "Windows" and self.settings.build_type == "Debug"):
+            tc.preprocessor_definitions["_DEBUG"] = 1
+            tc.preprocessor_definitions["_ITERATOR_DEBUG_LEVEL"] = 2
+
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Specify library name and version:  double-conversion

When building Qt (5.15.2), in Debug, on Windows, the build fails due to a mismatch in the `_ITERATOR_DEBUG_LEVEL` setting between the Qt and the double-conversion packages.  I've noticed that the failure occurs in versions 3.2.1 - which is required by the ConanCenter Qt/5.15.2 package - and 3.3.0.

This patch introduces two preprocessor definitions for Windows Debug builds; the `_ITERATOR_DEBUG_LEVEL=2` definition, which brings it in line with Qt when a debug build is generated, and `_DEBUG=1`, which needs to be set in conjunction with the `_ITERATOR_DEBUG_LEVEL` definition.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
