### PR TITLE
dbg-macro fixes for conan2

### DIFF
--- a/recipes/dbg-macro/all/test_package/CMakeLists.txt
+++ b/recipes/dbg-macro/all/test_package/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(dbg-macro REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE dbg-macro::dbg-macro)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/dbg-macro/all/test_package/conanfile.py
+++ b/recipes/dbg-macro/all/test_package/conanfile.py
@@ -1,18 +1,27 @@
 import os
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import cross_building, can_run
+from conan.tools.files import mkdir
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
+    def layout(self):
+        cmake_layout(self)
+
     def test(self):
-        if not tools.cross_building(self.settings):
-            tools.mkdir("logs/")
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env='conanrun') #run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **dbg-macro/0.4.0**

Bumps conanfile.py to be compatible with conan 2.x

---

- [ ✓] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ✓] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ✓] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
