### PR TITLE
Fix/luple license

### DIFF
--- a/recipes/luple/all/conandata.yml
+++ b/recipes/luple/all/conandata.yml
@@ -2,5 +2,3 @@ sources:
   "1.2":
     - url: "https://github.com/alexpolt/luple/archive/1.2.tar.gz"
       sha256: "810e622b656fa4f1cae5b299db94f550262eb49c81d373cfe770edcea3e8a68b"
-    - url: "https://unlicense.org/UNLICENSE"
-      sha256: "7e12e5df4bae12cb21581ba157ced20e1986a0508dd10d0e8a4ab9a4cf94e85c"

--- a/recipes/luple/all/conanfile.py
+++ b/recipes/luple/all/conanfile.py
@@ -10,13 +10,14 @@ required_conan_version = ">=1.50.0"
 
 class LupleConan(ConanFile):
     name = "luple"
-    license = "Unlicense"
+    license = "Public-domain"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/alexpolt/luple"
     description = "Home to luple, nuple, C++ String Interning, Struct Reader and C++ Type Loophole"
     topics = ("loophole", "luple", "nuple", "struct", "intern")
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+    package_type = "header-library"
 
     @property
     def _min_cppstd(self):
@@ -57,13 +58,13 @@ class LupleConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version][0],
             destination=self.source_folder, strip_root=True)
-        download(self, filename="LICENSE", **self.conan_data["sources"][self.version][1])
 
     def build(self):
         pass
 
     def package(self):
-        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        # This package doesn't have a license file, it is public domain declared in the Readme
+        copy(self, "README.md", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "*.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
 
     def package_info(self):


### PR DESCRIPTION
Specify library name and version:  **luple/all**

This recipe was downloading an "unlicense.org" file as license, not fully accurate 
---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
