### PR TITLE
dlib: Bump dependencies

### DIFF
--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -4,7 +4,7 @@ from conans.errors import ConanInvalidConfiguration
 import functools
 import os
 
-required_conan_version = ">=1.45.0"
+required_conan_version = ">=1.53.0"
 
 
 class DlibConan(ConanFile):


### PR DESCRIPTION
Specify library name and version:  **dlib/all**

Only bumps to max patch versions. As part of the https://github.com/conan-io/conan-center-index/pull/18416 effort