### PR TITLE
clickhouse-cpp: respect fPIC option

### DIFF
--- a/recipes/clickhouse-cpp/all/conanfile.py
+++ b/recipes/clickhouse-cpp/all/conanfile.py
@@ -75,7 +75,8 @@ class ClickHouseCppConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        self.options.rm_safe("fPIC")
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Don't remove it in case of static library.

fixes #18493