### PR TITLE
sfml: use cci's minimp3

### DIFF
--- a/recipes/sfml/all/conandata.yml
+++ b/recipes/sfml/all/conandata.yml
@@ -19,6 +19,9 @@ patches:
     - patch_file: "patches/2.6.0-0006-disable-warning-flags.patch"
       patch_description: "Disable warning flags which may cause compilation errors"
       patch_type: "portability"
+    - patch_file: "patches/2.6.0-0007-use-cci-minimp3.patch"
+      patch_description: "use cci minimp3 recipe"
+      patch_type: "conan"
   "2.5.1":
     - patch_file: "patches/2.5.1-0001-cmake-robust-find-deps.patch"
       patch_description: "Robust discovery of dependencies"

--- a/recipes/sfml/all/conanfile.py
+++ b/recipes/sfml/all/conanfile.py
@@ -63,10 +63,11 @@ class SfmlConan(ConanFile):
             self.requires("freetype/2.13.0")
             self.requires("stb/cci.20220909")
         if self.options.audio:
-            # FIXME: use cci's minimp3
             self.requires("flac/1.4.2")
             self.requires("openal-soft/1.22.2")
             self.requires("vorbis/1.3.7")
+            if Version(self.version) >= "2.6.0":
+                self.requires("minimp3/cci.20211201")
 
     def validate(self):
         if self.settings.os not in ["Windows", "Linux", "FreeBSD", "Android", "Macos", "iOS"]:
@@ -259,11 +260,14 @@ class SfmlConan(ConanFile):
                 },
             })
         if self.options.audio:
+            audio_requires = ["system", "flac::flac", "openal-soft::openal-soft", "vorbis::vorbis"]
+            if Version(self.version) >= "2.6.0":
+                audio_requires.append("minimp3::minimp3")
             sfml_components.update({
                 "audio": {
                     "target": "sfml-audio",
                     "libs": [f"sfml-audio{suffix}"],
-                    "requires": ["system", "flac::flac", "openal-soft::openal-soft", "vorbis::vorbis"],
+                    "requires": audio_requires,
                     "system_libs": android(),
                 },
             })

--- a/recipes/sfml/all/patches/2.6.0-0007-use-cci-minimp3.patch
+++ b/recipes/sfml/all/patches/2.6.0-0007-use-cci-minimp3.patch
@@ -1,0 +1,14 @@
+diff --git a/src/SFML/Audio/CMakeLists.txt b/src/SFML/Audio/CMakeLists.txt
+index 27c3386..6c455ca 100644
+--- a/src/SFML/Audio/CMakeLists.txt
++++ b/src/SFML/Audio/CMakeLists.txt
+@@ -82,7 +82,8 @@ sfml_add_library(sfml-audio
+ target_link_libraries(sfml-audio PRIVATE OpenAL::OpenAL)
+ 
+ # minimp3 sources
+-target_include_directories(sfml-audio SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/minimp3")
++find_package(minimp3 REQUIRED CONFIG)
++target_include_directories(sfml-audio SYSTEM PRIVATE ${minimp3_INCLUDE_DIRS})
+ 
+ if(SFML_OS_ANDROID)
+     target_link_libraries(sfml-audio PRIVATE android OpenSLES)


### PR DESCRIPTION
Specify library name and version:  **sfml/2.6.0**

This patch makes use cci's minimp3 instead of the internal minimp3.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
