### PR TITLE
[libsystemd] add 253.6, add dependency to libcrypt

### DIFF
--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "253.6":
+    url: "https://github.com/systemd/systemd-stable/archive/v253.6.tar.gz"
+    sha256: "a0aebcfaa2e001a4d846691631d1722c4cfa1a175e4ea62db6edca0ea3cf1e3e"
   "253.3":
     url: "https://github.com/systemd/systemd-stable/archive/v253.3.tar.gz"
     sha256: "569775d77084e45d15e103004cf4fbc00d7249c33791471b80f0c3296962bbfd"
@@ -21,6 +24,13 @@ sources:
     url: "https://github.com/systemd/systemd-stable/archive/v246.16.tar.gz"
     sha256: "b69f9940d65870f090269a28f1047a633d4b80d0001e091d53a031dd40a822d2"
 patches:
+  "253.6":
+    - patch_file: "patches/253.3/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
+      patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
+      patch_type: "conan"
+    - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
   "253.3":
     - patch_file: "patches/253.3/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"

--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -54,6 +54,8 @@ class LibsystemdConan(ConanFile):
     def requirements(self):
         self.requires("libcap/2.68")
         self.requires("libmount/2.39")
+        if Version(self.version) >= "253.6":
+            self.requires("libxcrypt/4.4.35")
         if self.options.with_selinux:
             self.requires("libselinux/3.3")
         if self.options.with_lz4:

--- a/recipes/libsystemd/config.yml
+++ b/recipes/libsystemd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "253.6":
+    folder: all
   "253.3":
     folder: all
   "252.9":


### PR DESCRIPTION
Specify library name and version:  **libsystemd/253.6**

libsystemd's meson build script had a missing dependency declaration to `libcrypt`.

Problem was issued [here](https://github.com/systemd/systemd/issues/28161) and released in version `253.6`.

The missing dependency is specially a problem when [cross-compiling the library](https://github.com/conan-io/conan-center-index/issues/15101).

I don't know whether there will be more backports to other major versions. If not, this could be provided to other versions via patches.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
