### PR TITLE
adds range of openssl libs to have wider compatibility

### DIFF
--- a/recipes/jwt-cpp/all/conanfile.py
+++ b/recipes/jwt-cpp/all/conanfile.py
@@ -24,7 +24,7 @@ class JwtCppConan(ConanFile):
         export_conandata_patches(self)
 
     def requirements(self):
-        self.requires("openssl/1.1.1s")
+        self.requires("openssl/[>1.1.1c,<1.1.1u]")
         if not self._supports_generic_json:
             self.requires("picojson/1.3.0")
 


### PR DESCRIPTION
jwt-cpp/0.6.0

This PR adds wider range of openssl libraries that can be used to build it

---

- [*] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [*] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [*] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
