### PR TITLE
Re-added support for gtest/1.8.1 as this is the newest version supported by qnx 7.0

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "1.10.0":
     url: "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
     sha256: "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb"
+  "1.8.1":
+    url: "https://github.com/google/googletest/archive/release-1.8.1.tar.gz"
+    sha256: "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
 patches:
   "1.10.0":
     - patch_file: "patches/gtest-1.10.0.patch"
@@ -17,3 +20,7 @@ patches:
       patch_description: "prevent compiler from complaining while compiling"
       patch_type: "bugfix"
       patch_source: "https://github.com/google/googletest/pull/2507"
+  "1.8.1":
+    - patch_file: "patches/gtest-1.8.1.patch"
+      patch_description: "add CUSTOM_DEBUG_POSTFIX option"
+      patch_type: "conan"

--- a/recipes/gtest/all/patches/gtest-1.8.1.patch
+++ b/recipes/gtest/all/patches/gtest-1.8.1.patch
@@ -1,0 +1,13 @@
+diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
+index 8c1f9ba..2203d3c 100644
+--- a/googletest/cmake/internal_utils.cmake
++++ b/googletest/cmake/internal_utils.cmake
+@@ -166,7 +166,7 @@ function(cxx_library_with_type name type cxx_flags)
+   # Generate debug library name with a postfix.
+   set_target_properties(${name}
+     PROPERTIES
+-    DEBUG_POSTFIX "d")
++    DEBUG_POSTFIX "${CUSTOM_DEBUG_POSTFIX}")
+   if (BUILD_SHARED_LIBS OR type STREQUAL "SHARED")
+     set_target_properties(${name}
+       PROPERTIES

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "1.10.0":
     folder: all
+  "1.8.1":
+    folder: all


### PR DESCRIPTION
gtest/1.8.1

This version of gtest is the latest version supported by QNX 7.0.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
