### PR TITLE
config: bump pcl from large to xlarge pod

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -192,9 +192,9 @@ pod_size:
   #   - name/version notation takes preference over the name only one
   #   - Both notations can be combined for the same reference name
   large:
-    - "pcl"
     - "duckdb"
     - "ceres-solver"
   xlarge:
     - "llvm"
     - "opengv"
+    - "pcl"


### PR DESCRIPTION
Apparently the already larger pod is not sufficient for PCL and the build in the new PR #18389 keeps getting killed due to running out of memory otherwise.