### PR TITLE
Add option to choose grpc library to link to, bump version

### DIFF
--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.1":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v2.5.1.tar.gz"
+    sha256: "571779a25be6eed77a345088e3ded2cccf880c16800ee0075ece57116f14fc35"
   "2.4.0":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v2.4.0.tar.gz"
     sha256: "d71de4f8de91dc0ad44d6a161fc628496b80622a6f9030dcd4c53b516629b8b7"

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -57,7 +57,7 @@ class AsioGrpcConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.name} 'recycling_allocator' cannot be used in combination with the 'unifex' backend.")
 
     def requirements(self):
-        self.requires("grpc/1.50.1")
+        self.requires("grpc/1.50.1", transitive_headers=True)
         if self._local_allocator_option == "boost_container" or self.options.backend == "boost":
             self.requires("boost/1.81.0")
         if self.options.backend == "asio":

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -22,12 +22,12 @@ class AsioGrpcConan(ConanFile):
     options = {
         "backend": ["boost", "asio", "unifex"],
         "local_allocator": ["auto", "memory_resource", "boost_container", "recycling_allocator"],
-        "grpc_link" : ["grpc++", "grpc++_unsecure", None]
+        "grpc_link" : ["grpc++", "grpc++_unsecure"]
     }
     default_options = {
         "backend": "boost",
         "local_allocator": "auto",
-        "grpc_link" : ["grpc++_unsecure"]
+        "grpc_link" : "grpc++_unsecure"
     }
     no_copy_source = True
 
@@ -87,6 +87,10 @@ class AsioGrpcConan(ConanFile):
                 f" C++{self._min_cppstd}."
             )
 
+        if self.options.grpc_link == "grpc++_unsecure" and self.dependencies["grpc"].options.secure:
+            raise ConanInvalidConfiguration("cannot link asio-grpc against grpc++_unsecure if grpc itself is built in secure mode!")
+
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
@@ -111,8 +115,7 @@ class AsioGrpcConan(ConanFile):
         self.cpp_info.libdirs = []
 
         build_modules = [os.path.join("lib", "cmake", "asio-grpc", "AsioGrpcProtobufGenerator.cmake")]
-        if self.options["grpc_link"] is not None:
-            self.cpp_info.requires = [f"grpc::{self.options['grpc_link']}"]
+        self.cpp_info.requires.append(f"grpc::{self.options.grpc_link}")
         if self.options.backend == "boost":
             self.cpp_info.defines = ["AGRPC_BOOST_ASIO"]
             self.cpp_info.requires.append("boost::headers")

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -22,10 +22,12 @@ class AsioGrpcConan(ConanFile):
     options = {
         "backend": ["boost", "asio", "unifex"],
         "local_allocator": ["auto", "memory_resource", "boost_container", "recycling_allocator"],
+        "grpc_link" : ["grpc++", "grpc++_unsecure", None]
     }
     default_options = {
         "backend": "boost",
         "local_allocator": "auto",
+        "grpc_link" : ["grpc++_unsecure"]
     }
     no_copy_source = True
 
@@ -109,8 +111,8 @@ class AsioGrpcConan(ConanFile):
         self.cpp_info.libdirs = []
 
         build_modules = [os.path.join("lib", "cmake", "asio-grpc", "AsioGrpcProtobufGenerator.cmake")]
-
-        self.cpp_info.requires = ["grpc::grpc++_unsecure"]
+        if self.options["grpc_link"] is not None:
+            self.cpp_info.requires = [f"grpc::{self.options['grpc_link']}"]
         if self.options.backend == "boost":
             self.cpp_info.defines = ["AGRPC_BOOST_ASIO"]
             self.cpp_info.requires.append("boost::headers")

--- a/recipes/asio-grpc/all/test_package/CMakeLists.txt
+++ b/recipes/asio-grpc/all/test_package/CMakeLists.txt
@@ -29,6 +29,12 @@ if(${asio-grpc_VERSION} VERSION_GREATER_EQUAL 2)
   target_compile_definitions(${PROJECT_NAME} PRIVATE ASIO_GRPC_V2)
 endif()
 
+if(${asio-grpc_VERSION} VERSION_GREATER_EQUAL 2.5)
+#use the new initialization of agrpc context
+  target_compile_definitions(${PROJECT_NAME} PRIVATE USE_NEW_INIT)
+  
+endif()
+
 if(CMAKE_CROSSCOMPILING)
   # Assuming protoc plugins needed by `asio_grpc_protobuf_generate` are not
   # available when cross compiling

--- a/recipes/asio-grpc/all/test_package/CMakeLists.txt
+++ b/recipes/asio-grpc/all/test_package/CMakeLists.txt
@@ -1,11 +1,25 @@
 cmake_minimum_required(VERSION 3.14)
 project(test_package LANGUAGES CXX)
 
+option(GRPC_LINK_MANUAL "link grpc library manually here rather than via asio-grpc dependency" OFF)
+
 find_package(asio-grpc REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE asio-grpc::asio-grpc)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} PRIVATE asio-grpc::asio-grpc)
+
+
+if(GRPC_LINK_MANUAL)
+  message(STATUS "LINKING GRPC REQUIREMENTS MANUALLY!")
+  find_package(gRPC REQUIRED)
+  find_package(Protobuf REQUIRED)
+  target_link_libraries(${PROJECT_NAME} PRIVATE gRPC::grpc++)
+endif()
+
+
+
+
 
 # See https://github.com/chriskohlhoff/asio/issues/955
 target_compile_definitions(${PROJECT_NAME}

--- a/recipes/asio-grpc/all/test_package/conanfile.py
+++ b/recipes/asio-grpc/all/test_package/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.env import VirtualRunEnv
 import os
 
 
@@ -16,8 +17,11 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+
+        envvars = VirtualRunEnv(self).vars()
         cmake.configure()
-        cmake.build()
+        with envvars.apply():
+            cmake.build()
 
     def test(self):
         if can_run(self):

--- a/recipes/asio-grpc/all/test_package/conanfile.py
+++ b/recipes/asio-grpc/all/test_package/conanfile.py
@@ -1,19 +1,28 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, cmake_layout, CMakeDeps, CMakeToolchain
 from conan.tools.env import VirtualRunEnv
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeDeps",   "VirtualRunEnv"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
 
     def layout(self):
         cmake_layout(self)
+
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if self.dependencies["asio-grpc"].options.grpc_link == "none":
+            #need to manually link the grpc library, add an option to tell cmake to do that
+            tc.cache_variables["GRPC_LINK_MANUAL"] = True
+
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/asio-grpc/all/test_package/test_package.cpp
+++ b/recipes/asio-grpc/all/test_package/test_package.cpp
@@ -11,7 +11,7 @@
 #endif
 
 int main() {
-  agrpc::GrpcContext grpc_context{std::make_unique<grpc::CompletionQueue>()};
+  agrpc::GrpcContext grpc_context;
 
   boost::asio::post(grpc_context, [] {});
 

--- a/recipes/asio-grpc/all/test_package/test_package.cpp
+++ b/recipes/asio-grpc/all/test_package/test_package.cpp
@@ -11,8 +11,12 @@
 #endif
 
 int main() {
-  agrpc::GrpcContext grpc_context;
 
+#ifndef USE_NEW_INIT
+  agrpc::GrpcContext grpc_context{std::make_unique<grpc::CompletionQueue>()};  
+#else
+  agrpc::GrpcContext grpc_context;
+#endif
   boost::asio::post(grpc_context, [] {});
 
 #ifndef CROSSCOMPILING

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.1":
+    folder: all
   "2.4.0":
     folder: all
   "2.3.0":


### PR DESCRIPTION
Specify library name and version:  **asio-grpc/2.5.1**

addresses: #18102  by adding an option to choose which upstream grpc component we can link to. The default is grpc++_unsecure, which matches upstream package.

The version 2.5.1 is also now included.

The intention was to also allow linking to "no" component of grpc upstream (this would then be compatible with the cmake option ASIO_GRPC_DISABLE_AUTOLINK), however, if we do not include *something* in  self.cpp_info.requires for grpc we get an error. 


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
