### PR TITLE
dice-template-library: add version 1.0.0

### DIFF
--- a/recipes/dice-template-library/all/CMakeLists.txt
+++ b/recipes/dice-template-library/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory(source_subfolder)

--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,10 +1,13 @@
 sources:
-  "0.1.0":
-    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v0.1.0.tar.gz"
-    sha256: "1d682283c4a54c4495fc65caa6f9a7674739156ce851227980430052120b2c29"
-  "0.2.0":
-    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v0.2.0.tar.gz"
-    sha256: "0f981aeb5604eb305a190d3aef6625032bbb2a34a0bcd17f17ae0cef19fac384"
+  "1.0.0":
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "485505ad3f9fb033083e2952bd8b4e68f6b4f123746b20f4ec3af46f4ce66cfe"
   "0.3.0":
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v0.3.0.tar.gz"
     sha256: "2c02278f86c7b5fe1c684f5126f30529952a03784fa7c883cc4fd44965b3c33e"
+  "0.2.0":
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v0.2.0.tar.gz"
+    sha256: "0f981aeb5604eb305a190d3aef6625032bbb2a34a0bcd17f17ae0cef19fac384"
+  "0.1.0":
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "1d682283c4a54c4495fc65caa6f9a7674739156ce851227980430052120b2c29"

--- a/recipes/dice-template-library/all/conanfile.py
+++ b/recipes/dice-template-library/all/conanfile.py
@@ -17,7 +17,7 @@ class DiceTemplateLibrary(ConanFile):
                    "the Data Science Group at UPB, found pretty handy.")
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://dice-research.org/"
+    homepage = "https://github.com/dice-group/dice-template-library/"
     topics = ("template", "template-library", "compile-time", "switch", "integral-tuple", "header-only")
 
     package_type = "header-library"

--- a/recipes/dice-template-library/all/test_package/CMakeLists.txt
+++ b/recipes/dice-template-library/all/test_package/CMakeLists.txt
@@ -1,9 +1,12 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 find_package(dice-template-library REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE dice-template-library::dice-template-library)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+
+if(dice-template-library_VERSION VERSION_GREATER_EQUAL "1.0.0")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE DICE_TEMPLATE_LIBRARY_1_0_0_LATER)
+endif()

--- a/recipes/dice-template-library/all/test_package/test_package.cpp
+++ b/recipes/dice-template-library/all/test_package/test_package.cpp
@@ -3,6 +3,33 @@
 
 #include <dice/template-library/integral_template_tuple.hpp>
 
+#ifdef DICE_TEMPLATE_LIBRARY_1_0_0_LATER
+template<std::size_t N>
+struct int_array : std::array<int, N> {
+private:
+	template<std::size_t... IDs>
+	int_array(int value, std::index_sequence<IDs...>) : std::array<int, N>{((void) IDs, value)...} {}
+
+public:
+	int_array() = default;
+	int_array(int value) : int_array(value, std::make_index_sequence<N>{}) {}
+};
+
+template<std::size_t N>
+std::ostream &operator<<(std::ostream &os, int_array<N> const &arr) {
+	if (N == 0) { return os << "0: []"; }
+	os << N << ": [";
+	for (std::size_t i = 0; i < N - 1; ++i) { os << arr[i] << ", "; }
+	return os << arr[N - 1] << ']';
+}
+
+int main() {
+    dice::template_library::integral_template_tuple<5UL, 8, int_array> itt;
+    std::cout << "  " << itt.template get<5>() << '\n';
+}
+
+#else
+
 template <int N> struct Wrapper {
     static constexpr int i = N;
 };
@@ -11,3 +38,4 @@ int main() {
     dice::template_library::integral_template_tuple<Wrapper, 0, 5> tup;
     std::cout << std::boolalpha << "tup.get<3>().i == 3: " << (tup.get<3>().i == 3) << std::endl;
 }
+#endif

--- a/recipes/dice-template-library/config.yml
+++ b/recipes/dice-template-library/config.yml
@@ -1,7 +1,9 @@
 versions:
-  "0.1.0":
+  "1.0.0":
+    folder: all
+  "0.3.0":
     folder: all
   "0.2.0":
     folder: all
-  "0.3.0":
+  "0.1.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **dice-template-library/***

Try to solve these issues.
- https://github.com/dice-group/dice-template-library/issues/18
- https://github.com/dice-group/dice-template-library/issues/7

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
