### PR TITLE
qt: remove opengl dependency for android

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -386,7 +386,8 @@ class QtConan(ConanFile):
             self.requires("xkbcommon/1.5.0")
             self.requires("xorg/system")
         if self.options.get_safe("opengl", "no") != "no":
-            self.requires("opengl/system")
+            if self.settings.os not in ["Android"]:
+                self.requires("opengl/system")
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.qtwebengine and self.settings.os in ["Linux", "FreeBSD"]:
@@ -1076,7 +1077,8 @@ Examples = bin/datadir/examples""")
                 if self.options.get_safe("with_x11", False):
                     gui_reqs.append("xorg::xorg")
             if self.options.get_safe("opengl", "no") != "no":
-                gui_reqs.append("opengl::opengl")
+                if self.settings.os not in ["Android"]:
+                    gui_reqs.append("opengl::opengl")
             if self.options.get_safe("with_vulkan", False):
                 gui_reqs.append("vulkan-loader::vulkan-loader")
                 if is_apple_os(self):
@@ -1091,6 +1093,8 @@ Examples = bin/datadir/examples""")
                 gui_reqs.append("md4c::md4c")
             _create_module("Gui", gui_reqs)
             _add_build_module("qtGui", self._cmake_qt5_private_file("Gui"))
+            if self.settings.os == "Android":
+                self.cpp_info.components["qtGui"].system_libs.extend(["EGL", "GLESv2"])
 
             event_dispatcher_reqs = ["Core", "Gui"]
             if self.options.with_glib:


### PR DESCRIPTION
Specify library name and version:  **qt/5.x**

conan tries to cross-build `opengl` package by installing aarch64 packages on my x86_64 CentOS which is not possible. android-ndk already contains sysroot which has required libs (OpenGLESv2, EGL). I also believe this is the case when building for iOS and maybe all cross-build scenarios (see also this comment from @SSE4 https://github.com/conan-io/conan-center-index/issues/7123#issuecomment-916116097), but this PR fixes only Android


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
