### PR TITLE
[cppcommon] Use util-linux-libuuid instead of deprecated libuuid

### DIFF
--- a/recipes/cppcommon/all/conanfile.py
+++ b/recipes/cppcommon/all/conanfile.py
@@ -64,7 +64,7 @@ class CppCommon(ConanFile):
         else:
             self.requires("fmt/10.0.0")
         if self.settings.os == "Linux":
-            self.requires("libuuid/1.0.3")
+            self.requires("util-linux-libuuid/2.39")
 
     def validate(self):
         if self.settings.compiler.cppstd:


### PR DESCRIPTION
Transition from deprecated libuuid recipe to util-linux-libuuid, which is actively maintained. See https://github.com/conan-io/conan-center-index/pull/17664 for discussion

The util-linux-libuuid package relies on an actively maintained project, see https://github.com/conan-io/conan-center-index/pull/17664.
The libuuid package uses a stale project. Use the active project instead to fix conflicts.

This should be part of a group of packages merged rapidly. See https://github.com/conan-io/conan-center-index/pull/17995#issuecomment-1614987627 for discussion on challenges involved in a previous migration attempt.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
