### PR TITLE
[cpython] Use util-linux-libuuid instead of deprecated libuuid

### DIFF
--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -187,7 +187,7 @@ class CPythonConan(ConanFile):
                 self.requires("mpdecimal/2.5.0")  # FIXME: no 2.5.1 to troubleshoot apple
         if self.settings.os != "Windows":
             if not tools.is_apple_os(self.settings.os):
-                self.requires("libuuid/1.0.3")
+                self.requires("util-linux-libuuid/2.39")
             self.requires("libxcrypt/4.4.25")
         if self.options.get_safe("with_bz2"):
             self.requires("bzip2/1.0.8")


### PR DESCRIPTION
Transition from deprecated libuuid recipe to util-linux-libuuid, which is actively maintained. See https://github.com/conan-io/conan-center-index/pull/17664 for discussion

The util-linux-libuuid package relies on an actively maintained project, see https://github.com/conan-io/conan-center-index/pull/17664.
The libuuid package uses a stale project. Use the active project instead to fix conflicts.

This should be part of a group of packages merged rapidly. See https://github.com/conan-io/conan-center-index/pull/17995#issuecomment-1614987627 for discussion on challenges involved in a previous migration attempt.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
