### PR TITLE
[util-linux-libuuid] Change CMake target from LibUUID::LibUUID to libuuid::libuuid

### DIFF
--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -109,7 +109,7 @@ class UtilLinuxLibuuidConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "uuid")
-        self.cpp_info.set_property("cmake_target_name", "LibUUID::LibUUID")
-        self.cpp_info.set_property("cmake_file_name", "LibUUID")
+        self.cpp_info.set_property("cmake_target_name", "libuuid::libuuid")
+        self.cpp_info.set_property("cmake_file_name", "libuuid")
         self.cpp_info.libs = ["uuid"]
         self.cpp_info.includedirs.append(os.path.join("include", "uuid"))

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -111,5 +111,8 @@ class UtilLinuxLibuuidConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "uuid")
         self.cpp_info.set_property("cmake_target_name", "libuuid::libuuid")
         self.cpp_info.set_property("cmake_file_name", "libuuid")
+        # Maintain alias to `LibUUID::LibUUID` for previous version of the recipe
+        self.cpp_info.set_property("cmake_target_aliases", ["LibUUID::LibUUID"])
+
         self.cpp_info.libs = ["uuid"]
         self.cpp_info.includedirs.append(os.path.join("include", "uuid"))

--- a/recipes/util-linux-libuuid/all/test_package/CMakeLists.txt
+++ b/recipes/util-linux-libuuid/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES C)
 
-find_package(LibUUID REQUIRED CONFIG)
+find_package(libuuid REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE LibUUID::LibUUID)
+target_link_libraries(${PROJECT_NAME} PRIVATE libuuid::libuuid)
 target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)


### PR DESCRIPTION
This is in line with what conan recipes seem to expect, which will minimise the number of patches required. LibUUID was chosen as the target name given this is what's used internally within cmake, but this isn't a public interface and so there is no common usage to take guidance from.

See discussion in original ticket adding `util-linux-libuuid` after merge: https://github.com/conan-io/conan-center-index/pull/17664#discussion_r1249000485

The following tickets are blocked until this change is merged:

* https://github.com/conan-io/conan-center-index/pull/18552
* https://github.com/conan-io/conan-center-index/pull/18553
* https://github.com/conan-io/conan-center-index/pull/18556
* https://github.com/conan-io/conan-center-index/pull/18557

Closes #18554

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
