### PR TITLE
libnghttp2: add version 1.55.1

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.55.1":
+    url: "https://github.com/nghttp2/nghttp2/archive/v1.55.1.tar.gz"
+    sha256: "b89dece5bc3382b82c22db8dc8d1e062258cb7af8e4ad55278fa7149645a588d"
   "1.55.0":
     url: "https://github.com/nghttp2/nghttp2/archive/v1.55.0.tar.gz"
     sha256: "6d2a4d246e84cb1e3e581591bd1c50ecc085e50090bc068ed5a67f87c6b4a06e"

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.55.1":
+    folder: all
   "1.55.0":
     folder: all
   "1.54.0":


### PR DESCRIPTION
Specify library name and version:  **libnghttp2/1.55.1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
