### PR TITLE
upgrades libxft to conanv2

### DIFF
--- a/recipes/libxft/all/conandata.yml
+++ b/recipes/libxft/all/conandata.yml
@@ -11,4 +11,3 @@ patches:
       patch_description: "fix gcc 5 and gcc 11 compilation"
       patch_type: "portability"
       patch_source: "https://gitlab.freedesktop.org/xorg/lib/libxft/-/merge_requests/17"
-      base_path: "source_subfolder"

--- a/recipes/libxft/all/conanfile.py
+++ b/recipes/libxft/all/conanfile.py
@@ -1,7 +1,9 @@
 from conan import ConanFile
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, chdir, rm, rmdir
-from conans import AutoToolsBuildEnvironment
-import functools
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, chdir, rm, rmdir, copy
+from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.env import VirtualRunEnv, VirtualBuildEnv
+from conan.tools.build import cross_building
 
 required_conan_version = ">=1.52.0"
 
@@ -16,28 +18,26 @@ class libxftConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
-    generators = "pkg_config"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
 
     def export_sources(self):
         export_conandata_patches(self)
 
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
     def requirements(self):
         self.requires("xorg/system")
-        self.requires("freetype/2.13.0")
-        self.requires("fontconfig/2.14.2")
+        self.requires("freetype/2.13.0", transitive_headers=True)
+        self.requires("fontconfig/2.14.2", transitive_headers=True)
 
     def build_requirements(self):
-        self.build_requires("pkgconf/1.9.3")
-        self.build_requires("xorg-macros/1.19.3")
-        self.build_requires("libtool/2.4.7")
+        self.tool_requires("pkgconf/1.9.3")
+        self.tool_requires("xorg-macros/1.19.3")
+        self.tool_requires("libtool/2.4.7")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+                  destination=self.source_folder, strip_root=True)
 
     def configure(self):
         del self.settings.compiler.libcxx
@@ -45,29 +45,45 @@ class libxftConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
-    @functools.lru_cache(1)
-    def _configure_autotools(self):
-        args = ["--disable-dependency-tracking"]
+    def generate(self):
+        # inject tool_requires env vars in build scope (not needed if there is no tool_requires)
+        env = VirtualBuildEnv(self)
+        env.generate()
+        # inject requires env vars in build scope
+        # it's required in case of native build when there is AutotoolsDeps & at least one dependency which might be shared, because configure tries to run a test executable
+        if not cross_building(self):
+            env = VirtualRunEnv(self)
+            env.generate(scope="build")
+
+        tc = AutotoolsToolchain(self)
+        tc.configure_args.extend(["--disable-dependency-tracking"])
         if self.options.shared:
-            args.extend(["--disable-static", "--enable-shared"])
+            tc.configure_args.extend(["--disable-static", "--enable-shared"])
         else:
-            args.extend(["--disable-shared", "--enable-static"])
-        autotools = AutoToolsBuildEnvironment(self)
-        autotools.configure(args=args, pkg_config_paths=self.build_folder)
-        return autotools
+            tc.configure_args.extend(["--disable-shared", "--enable-static"])
+        tc.generate()
+
+        # generate pkg-config files of dependencies (useless if upstream configure.ac doesn't rely on PKG_CHECK_MODULES macro)
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        # generate dependencies for autotools
+        tc = AutotoolsDeps(self)
+        tc.generate()
+
 
     def build(self):
         apply_conandata_patches(self)
-        with chdir(self, self._source_subfolder):
-            autotools = self._configure_autotools()
-            autotools.make()
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        autotools.configure()
+        autotools.make()
+
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        with chdir(self, self._source_subfolder):
-            autotools = self._configure_autotools()
-            autotools.install(args=["-j1"])
+        copy(self, pattern="LICENSE", dst="licenses", src=self.source_folder)
+        copy(self, pattern="COPYING", dst="licenses", src=self.source_folder)
+        autotools = Autotools(self)
+        autotools.install()
         rm(self, "*.la", f"{self.package_folder}/lib", recursive=True)
         rmdir(self, f"{self.package_folder}/lib/pkgconfig")
         rmdir(self, f"{self.package_folder}/share")

--- a/recipes/libxft/all/conanfile.py
+++ b/recipes/libxft/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgCon
 from conan.tools.layout import basic_layout
 from conan.tools.env import VirtualRunEnv, VirtualBuildEnv
 from conan.tools.build import cross_building
+import os
 
 required_conan_version = ">=1.52.0"
 
@@ -80,8 +81,9 @@ class libxftConan(ConanFile):
 
 
     def package(self):
-        copy(self, pattern="LICENSE", dst="licenses", src=self.source_folder)
-        copy(self, pattern="COPYING", dst="licenses", src=self.source_folder)
+        license_dir = os.path.join(self.package_folder, "licenses")
+        copy(self, pattern="LICENSE", dst=license_dir, src=self.source_folder)
+        copy(self, pattern="COPYING", dst=license_dir, src=self.source_folder)
         autotools = Autotools(self)
         autotools.install()
         rm(self, "*.la", f"{self.package_folder}/lib", recursive=True)

--- a/recipes/libxft/all/conanfile.py
+++ b/recipes/libxft/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, chdir, rm, rmdir, copy
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, rm, rmdir, copy
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.env import VirtualRunEnv, VirtualBuildEnv

--- a/recipes/libxft/all/conanfile.py
+++ b/recipes/libxft/all/conanfile.py
@@ -41,10 +41,10 @@ class libxftConan(ConanFile):
                   destination=self.source_folder, strip_root=True)
 
     def configure(self):
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
     def generate(self):
         # inject tool_requires env vars in build scope (not needed if there is no tool_requires)

--- a/recipes/libxft/all/test_package/CMakeLists.txt
+++ b/recipes/libxft/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES C)
 
 find_package(libxft REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} libxft::libxft)
+target_link_libraries(${PROJECT_NAME} PRIVATE libxft::libxft)
+

--- a/recipes/libxft/all/test_package/conanfile.py
+++ b/recipes/libxft/all/test_package/conanfile.py
@@ -1,10 +1,20 @@
-from conans import ConanFile, CMake, tools
 import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +22,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libxft/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libxft/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(libxft REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} libxft::libxft)

--- a/recipes/libxft/all/test_v1_package/conanfile.py
+++ b/recipes/libxft/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libxft/all/test_v1_package/test_package.c
+++ b/recipes/libxft/all/test_v1_package/test_package.c
@@ -1,0 +1,10 @@
+#include "X11/Xft/Xft.h"
+
+#include <stdio.h>
+int main()
+{
+    if(!XftInit(""))
+        printf("Could not init Xft\n");
+    printf("Xft version: %d\n", XftGetVersion());
+    return 0;
+}


### PR DESCRIPTION
Specify library name and version:  libxft/2.3.6

Reason:
I am working on updating the cpython conan recipe to be conanv2 compliant.   This is a dependency of ncurses, which is a dep of cpython

---

- [ x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
