### PR TITLE
updates ncurses to conanv2

### DIFF
--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conans.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.layout import basic_layout
 from conan.tools.files import get, export_conandata_patches, apply_conandata_patches, save, copy
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, check_min_vs, unix_path
@@ -265,7 +265,7 @@ class NCursesConan(ConanFile):
 
     @property
     def _module_file(self):
-        return "CursesFindModuleBackwardCompat.cmake".format(self.name)
+        return "CursesFindModuleBackwardCompat.cmake"
 
     def package_info(self):
         module_rel_path = os.path.join(self._module_subfolder, self._module_file)

--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -272,6 +272,10 @@ class NCursesConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "Curses")
         self.cpp_info.set_property("cmake_build_modules", [module_rel_path])
 
+        # for conan v1 generators
+        self.cpp_info.filenames["cmake_find_package"] = "Curses"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "Curses"
+
         if self._with_tinfo:
             self.cpp_info.components["tinfo"].libs = ["tinfo" + self._lib_suffix]
             self.cpp_info.components["tinfo"].names["pkg_config"] = "tinfo" + self._lib_suffix

--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -216,7 +216,7 @@ class NCursesConan(ConanFile):
         save(ConanFile, module_file, textwrap.dedent("""\
             set(CURSES_FOUND ON)
             get_target_property(CURSES_INCLUDE_DIRS  ncurses::libcurses INTERFACE_INCLUDE_DIRECTORIES)
-            get_target_property(CURSES_LIBRARIES     ncurses::libcurses INTERFACE_LINK_LIBRARIES)
+            set(CURSES_LIBRARIES     ncurses::libcurses)
             get_target_property(_curses_compile_opts ncurses::libcurses INTERFACE_COMPILE_OPTIONS)
             get_target_property(_curses_compile_defs ncurses::libcurses INTERFACE_COMPILE_DEFINITIONS)
             set(CURSES_CFLAGS ${_curses_compile_opts} ${_curses_compile_defs})

--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -1,11 +1,16 @@
-from conans import AutoToolsBuildEnvironment, ConanFile, tools
+from conan import ConanFile
 from conans.errors import ConanInvalidConfiguration
-import contextlib
-import functools
+from conan.tools.layout import basic_layout
+from conan.tools.files import get, export_conandata_patches, apply_conandata_patches, save, copy
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, check_min_vs, unix_path
+from conan.tools.build import cross_building
+from conan.tools.scm import Version
+from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
+from conan.tools.env import Environment, VirtualRunEnv, VirtualBuildEnv
 import os
 import textwrap
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.54.0"
 
 
 class NCursesConan(ConanFile):
@@ -41,12 +46,11 @@ class NCursesConan(ConanFile):
         "with_pcre2": False,
     }
 
-    generators = "pkg_config"
-    exports_sources = "patches/*"
+    def export_sources(self):
+        export_conandata_patches(self)
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     @property
     def _settings_build(self):
@@ -69,6 +73,8 @@ class NCursesConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        self.options.with_ticlib = self._with_ticlib
+        self.options.with_tinfo  = self._with_tinfo
 
     def configure(self):
         if self.options.shared:
@@ -82,22 +88,24 @@ class NCursesConan(ConanFile):
     def requirements(self):
         if self.options.with_pcre2:
             self.requires("pcre2/10.37")
-        if self.settings.compiler == "Visual Studio":
+        if is_msvc(self):
             self.requires("getopt-for-visual-studio/20200201")
             self.requires("dirent/1.23.2")
             if self.options.get_safe("with_extended_colors", False):
                 self.requires("naive-tsearch/0.1.1")
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
 
     def validate(self):
-        if any("arm" in arch for arch in (self.settings.arch, self._settings_build.arch)) and tools.cross_building(self):
+        if any("arm" in arch for arch in (self.settings.arch, self._settings_build.arch)) and cross_building(self):
             # FIXME: Cannot build ncurses from x86_64 to armv8 (Apple M1).  Cross building from Linux/x86_64 to Mingw/x86_64 works flawless.
             # FIXME: Need access to environment of build profile to set build compiler (BUILD_CC/CC_FOR_BUILD)
             raise ConanInvalidConfiguration("Cross building to/from arm is (currently) not supported")
-        if self.options.shared and self.settings.compiler == "Visual Studio" and "MT" in self.settings.compiler.runtime:
+        if self.options.shared and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration("Cannot build shared libraries with static (MT) runtime")
         if self.settings.os == "Windows":
             if self._with_tinfo:
@@ -106,14 +114,22 @@ class NCursesConan(ConanFile):
                 raise ConanInvalidConfiguration("ticlib cannot be built separately as a shared library on Windows")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+                  destination=self.source_folder, strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_autotools(self):
-        autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+    def generate(self):
+        # inject tool_requires env vars in build scope (not needed if there is no tool_requires)
+        env = VirtualBuildEnv(self)
+        env.generate()
+        # inject requires env vars in build scope
+        # it's required in case of native build when there is AutotoolsDeps & at least one dependency which might be shared, because configure tries to run a test executable
+        if not cross_building(self):
+            env = VirtualRunEnv(self)
+            env.generate(scope="build")
+
+        tc = AutotoolsToolchain(self)
         yes_no = lambda v: "yes" if v else "no"
-        conf_args = [
+        tc.configure_args.extend([
             "--with-shared={}".format(yes_no(self.options.shared)),
             "--with-cxx-shared={}".format(yes_no(self.options.shared)),
             "--with-normal={}".format(yes_no(not self.options.shared)),
@@ -134,13 +150,11 @@ class NCursesConan(ConanFile):
             "--without-profile",
             "--with-sp-funcs",
             "--disable-rpath",
-            "--datarootdir={}".format(tools.unix_path(os.path.join(self.package_folder, "res"))),
+            "--datarootdir={}".format(unix_path(self, os.path.join(self.package_folder, "res"))),
             "--disable-pc-files",
-        ]
-        build = None
-        host = None
+        ])
         if self.settings.os == "Windows":
-            conf_args.extend([
+            tc.configure_args.extend([
                 "--disable-macros",
                 "--disable-termcap",
                 "--enable-database",
@@ -148,68 +162,66 @@ class NCursesConan(ConanFile):
                 "--enable-term-driver",
                 "--enable-interop",
             ])
-        if self.settings.compiler == "Visual Studio":
-            build = host = "{}-w64-mingw32-msvc".format(self.settings.arch)
-            conf_args.extend([
+        if is_msvc(self):
+            tc.configure_args.extend([
                 "ac_cv_func_getopt=yes",
                 "ac_cv_func_setvbuf_reversed=no",
             ])
-            autotools.cxx_flags.append("-EHsc")
-            if tools.Version(self.settings.compiler.version) >= 12:
-                autotools.flags.append("-FS")
+            tc.extra_cxxflags.append("-EHsc")
+            if check_min_vs(self, 180, raise_invalid=False):
+                tc.extra_cflags.append("-FS")
         if (self.settings.os, self.settings.compiler) == ("Windows", "gcc"):
             # add libssp (gcc support library) for some missing symbols (e.g. __strcpy_chk)
-            autotools.libs.extend(["mingwex", "ssp"])
-        if build:
-            conf_args.append(f"ac_cv_build={build}")
-        if host:
-            conf_args.append(f"ac_cv_host={host}")
-            conf_args.append(f"ac_cv_target={host}")
-        autotools.configure(args=conf_args, configure_dir=self._source_subfolder, host=host, build=build)
-        return autotools
+            tc.extra_ldflags.extend(["-lmingwex", "-lssp"])
+        tc.generate()
 
-    def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        # generate pkg-config files of dependencies (useless if upstream configure.ac doesn't rely on PKG_CHECK_MODULES macro)
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        # generate dependencies for autotools
+        tc = AutotoolsDeps(self)
+        tc.generate()
 
-    @contextlib.contextmanager
-    def _build_context(self):
-        if self.settings.compiler == "Visual Studio":
-            with tools.vcvars(self):
-                env = {
-                    "CC": "cl -nologo",
-                    "CXX": "cl -nologo",
-                    "LD": "link -nologo",
-                    "LDFLAGS": "",
-                    "NM": "dumpbin -symbols",
-                    "STRIP": ":",
-                    "AR": "lib -nologo",
-                    "RANLIB": ":",
-                }
-                with tools.environment_append(env):
-                    yield
-        else:
-            yield
+        # If Visual Studio is supported
+        if is_msvc(self):
+            env = Environment()
+            # get compile & ar-lib from automake (or eventually lib source code if available)
+            # it's not always required to wrap CC, CXX & AR with these scripts, it depends on how much love was put in
+            # upstream build files
+            automake_conf = self.dependencies.build["automake"].conf_info
+            compile_wrapper = unix_path(self, automake_conf.get("user.automake:compile-wrapper", check_type=str))
+            ar_wrapper = unix_path(self, automake_conf.get("user.automake:lib-wrapper", check_type=str))
+            env.define("CC", f"{compile_wrapper} cl -nologo")
+            env.define("CXX", f"{compile_wrapper} cl -nologo")
+            env.define("LD", "link -nologo")
+            env.define("AR", f"{ar_wrapper} \"lib -nologo\"")
+            env.define("NM", "dumpbin -symbols")
+            env.define("OBJDUMP", ":")
+            env.define("RANLIB", ":")
+            env.define("STRIP", ":")
+            env.vars(self).save_script("conanbuild_msvc")
 
     def build(self):
-        self._patch_sources()
-        with self._build_context():
-            autotools = self._configure_autotools()
-            autotools.make()
+        apply_conandata_patches(self)
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
 
     @property
     def _major_version(self):
-        return tools.Version(self.version).major
+        return Version(self.version).major
 
     @staticmethod
     def _create_cmake_module_alias_targets(module_file):
-        tools.save(module_file, textwrap.dedent("""\
+        save(ConanFile, module_file, textwrap.dedent("""\
             set(CURSES_FOUND ON)
-            set(CURSES_INCLUDE_DIRS ${ncurses_libcurses_INCLUDE_DIRS})
-            set(CURSES_LIBRARIES ${ncurses_libcurses_LINK_LIBS})
-            set(CURSES_CFLAGS ${ncurses_DEFINITIONS} ${ncurses_COMPILE_OPTIONS_C})
-            set(CURSES_HAVE_CURSES_H OFF)
-            set(CURSES_HAVE_NCURSES_H OFF)
+            get_target_property(CURSES_INCLUDE_DIRS  ncurses::libcurses INTERFACE_INCLUDE_DIRECTORIES)
+            get_target_property(CURSES_LIBRARIES     ncurses::libcurses INTERFACE_LINK_LIBRARIES)
+            get_target_property(_curses_compile_opts ncurses::libcurses INTERFACE_COMPILE_OPTIONS)
+            get_target_property(_curses_compile_defs ncurses::libcurses INTERFACE_COMPILE_DEFINITIONS)
+            set(CURSES_CFLAGS ${_curses_compile_opts} ${_curses_compile_defs})
+            set(CURSES_HAVE_CURSES_H ON)
+            set(CURSES_HAVE_NCURSES_H ON)
             if(CURSES_NEED_NCURSES)
                 set(CURSES_HAVE_NCURSES_CURSES_H ON)
                 set(CURSES_HAVE_NCURSES_NCURSES_H ON)
@@ -222,12 +234,11 @@ class NCursesConan(ConanFile):
 
     def package(self):
         # return
-        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
-        with self._build_context():
-            autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-            autotools.install()
+        copy(self, "COPYING", src=self.source_folder, dst="licenses")
+        autotools = Autotools(self)
+        autotools.install()
 
-            os.unlink(os.path.join(self.package_folder, "bin", "ncurses{}{}-config".format(self._suffix, self._major_version)))
+        os.unlink(os.path.join(self.package_folder, "bin", "ncurses{}{}-config".format(self._suffix, self._major_version)))
 
         self._create_cmake_module_alias_targets(os.path.join(self.package_folder, self._module_subfolder, self._module_file))
 
@@ -248,21 +259,19 @@ class NCursesConan(ConanFile):
                 res += ".dll"
         return res
 
-    def package_id(self):
-        self.info.options.with_ticlib = self._with_ticlib
-        self.info.options.with_tinfo = self._with_tinfo
-
     @property
     def _module_subfolder(self):
         return os.path.join("lib", "cmake")
 
     @property
     def _module_file(self):
-        return "conan-official-{}-targets.cmake".format(self.name)
+        return "CursesFindModuleBackwardCompat.cmake".format(self.name)
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "Curses"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "Curses"
+        module_rel_path = os.path.join(self._module_subfolder, self._module_file)
+        self.cpp_info.set_property("cmake_file_name", "Curses")
+        self.cpp_info.set_property("cmake_build_modules", [module_rel_path])
+
         if self._with_tinfo:
             self.cpp_info.components["tinfo"].libs = ["tinfo" + self._lib_suffix]
             self.cpp_info.components["tinfo"].names["pkg_config"] = "tinfo" + self._lib_suffix
@@ -278,18 +287,13 @@ class NCursesConan(ConanFile):
         if self._with_tinfo:
             self.cpp_info.components["libcurses"].requires.append("tinfo")
 
-        if self.settings.compiler == "Visual Studio":
+        if is_msvc(self):
             self.cpp_info.components["libcurses"].requires.extend([
                 "getopt-for-visual-studio::getopt-for-visual-studio",
                 "dirent::dirent",
             ])
             if self.options.get_safe("with_extended_colors", False):
                 self.cpp_info.components["libcurses"].requires.append("naive-tsearch::naive-tsearch")
-
-        module_rel_path = os.path.join(self._module_subfolder, self._module_file)
-        self.cpp_info.components["libcurses"].builddirs.append(self._module_subfolder)
-        self.cpp_info.components["libcurses"].build_modules["cmake_find_package"] = [module_rel_path]
-        self.cpp_info.components["libcurses"].build_modules["cmake_find_package_multi"] = [module_rel_path]
 
         self.cpp_info.components["panel"].libs = ["panel" + self._lib_suffix]
         self.cpp_info.components["panel"].names["pkg_config"] = "panel" + self._lib_suffix
@@ -322,6 +326,8 @@ class NCursesConan(ConanFile):
 
         terminfo = os.path.join(self.package_folder, "res", "terminfo")
         self.output.info("Setting TERMINFO environment variable: {}".format(terminfo))
+        self.buildenv_info.define_path("TERMINFO", terminfo)
+        self.runenv_info.define_path("TERMINFO", terminfo)
         self.env_info.TERMINFO = terminfo
 
         self.user_info.lib_suffix = self._lib_suffix

--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -150,7 +150,7 @@ class NCursesConan(ConanFile):
             "--without-profile",
             "--with-sp-funcs",
             "--disable-rpath",
-            "--datarootdir={}".format(unix_path(self, os.path.join(self.package_folder, "res"))),
+            "--datarootdir=${prefix}/res",
             "--disable-pc-files",
         ])
         if self.settings.os == "Windows":

--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -280,6 +280,9 @@ class NCursesConan(ConanFile):
         self.cpp_info.components["libcurses"].libs = ["ncurses" + self._lib_suffix]
         self.cpp_info.components["libcurses"].names["pkg_config"] = "ncurses" + self._lib_suffix
         self.cpp_info.components["libcurses"].includedirs.append(os.path.join("include", "ncurses" + self._suffix))
+        self.cpp_info.components["libcurses"].build_modules["cmake_find_package"] = [module_rel_path]
+        self.cpp_info.components["libcurses"].build_modules["cmake_find_package_multi"] = [module_rel_path]
+
         if not self.options.shared:
             self.cpp_info.components["libcurses"].defines = ["NCURSES_STATIC"]
             if self.settings.os == "Linux":

--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -72,18 +72,18 @@ class NCursesConan(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
         self.options.with_ticlib = self._with_ticlib
         self.options.with_tinfo  = self._with_tinfo
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
         if not self.options.with_cxx:
-            del self.settings.compiler.libcxx
-            del self.settings.compiler.cppstd
+            self.settings.rm_safe("compiler.libcxx")
+            self.settings.rm_safe("compiler.cppstd")
         if not self.options.with_widec:
-            del self.options.with_extended_colors
+            self.options.rm_safe("with_extended_colors")
 
     def requirements(self):
         if self.options.with_pcre2:

--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -99,6 +99,8 @@ class NCursesConan(ConanFile):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
+            if is_msvc(self):
+                self.tool_requires("automake/1.16.5")
 
     def validate(self):
         if any("arm" in arch for arch in (self.settings.arch, self._settings_build.arch)) and cross_building(self):

--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -234,7 +234,7 @@ class NCursesConan(ConanFile):
 
     def package(self):
         # return
-        copy(self, "COPYING", src=self.source_folder, dst="licenses")
+        copy(self, "COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         autotools = Autotools(self)
         autotools.install()
 

--- a/recipes/ncurses/all/test_package/conanfile.py
+++ b/recipes/ncurses/all/test_package/conanfile.py
@@ -1,10 +1,20 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.env import Environment
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +22,9 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            with tools.environment_append({"TERM": "dumb"}):
-                self.run(os.path.join("bin", "test_package"), run_environment=True)
+        if can_run(self):
+            env = Environment()
+            env.define("TERM", "dumb")
+            with env.vars(self, scope="conanrun").apply() as _:
+                self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")
+

--- a/recipes/ncurses/all/test_v1_package/CMakeLists.txt
+++ b/recipes/ncurses/all/test_v1_package/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
 project(test_package)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 set(CURSES_NEED_NCURSES TRUE)
 find_package(Curses REQUIRED)
 

--- a/recipes/ncurses/all/test_v1_package/conanfile.py
+++ b/recipes/ncurses/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            with tools.environment_append({"TERM": "dumb"}):
+                self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/ncurses/all/test_v1_package/test_package.c
+++ b/recipes/ncurses/all/test_v1_package/test_package.c
@@ -1,0 +1,17 @@
+#include <ncurses.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+    int ret = EXIT_SUCCESS;
+    initscr();
+    addstr("Hello World");
+    refresh();
+    if (curscr == (void*)0) {
+        ret = EXIT_FAILURE;
+    }
+    endwin();
+    printf("ncurses version '%s'\n", curses_version());
+    return ret;
+}


### PR DESCRIPTION
Specify library name and version:  ncurses/6.4

Reason:
I am working on updating cpython to be conanv2 compliant and this is a dep that needs updating

---

- [x ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
