### PR TITLE
[xorg] Model uuid dependency

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -23,6 +23,12 @@ class XorgConan(ConanFile):
     def package_id(self):
         self.info.clear()
 
+    def requirements(self):
+        # This is necessary to prevent other packages in the dependency tree from using the "libuuid" recipe
+        # which conflicts with the system installation of `util-linux-libuuid` that `xorg` installs. See #17427, #17485
+        # This has no functional bearing on xorg, however, as it links against the system library installed in util-linux-libs
+        self.requires("util-linux-libuuid/2.39")
+
     def system_requirements(self):
         apt = package_manager.Apt(self)
         apt.install(["libx11-dev", "libx11-xcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "libxau-dev", "libxaw7-dev",


### PR DESCRIPTION
Prevent erroneous linkage against an incompatible uuid interface when libuuid exists in the dependency tree with xorg by adding a dependency on the util-linux-libuuid conan package. This will ensure an error is raised if libuuid is in the same dependency graph as xorg.

This has caused issues in #17427, #17485 and this change is based on the suggestion by @prince-chrismc in https://github.com/conan-io/conan-center-index/pull/17995#issuecomment-1615034107. Read these linked issues for context.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
