### PR TITLE
cli11: make bindirs and libdirs empty

### DIFF
--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -8,26 +8,31 @@ required_conan_version = ">=1.52.0"
 
 class CLI11Conan(ConanFile):
     name = "cli11"
-    homepage = "https://github.com/CLIUtils/CLI11"
     description = "A command line parser for C++11 and beyond."
-    topics = "cli-parser", "cpp11", "no-dependencies", "cli", "header-only"
-    url = "https://github.com/conan-io/conan-center-index"
     license = "BSD-3-Clause"
-    settings = "os", "compiler", "build_type", "arch"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/CLIUtils/CLI11"
+    topics = "cli-parser", "cpp11", "no-dependencies", "cli", "header-only"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
 
     @property
     def _min_cppstd(self):
         return "11"
 
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
 
-    def layout(self):
-        cmake_layout(self, src_folder="src")
-
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -50,10 +55,10 @@ class CLI11Conan(ConanFile):
         # since 2.1.1
         rmdir(self, os.path.join(self.package_folder, "share"))
 
-    def package_id(self):
-        self.info.clear()
-
     def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
         self.cpp_info.set_property("cmake_file_name", "CLI11")
         self.cpp_info.set_property("cmake_target_name", "CLI11::CLI11")
         self.cpp_info.set_property("pkg_config_name", "CLI11")

--- a/recipes/cli11/all/test_package/CMakeLists.txt
+++ b/recipes/cli11/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(CLI11 REQUIRED CONFIG)
 


### PR DESCRIPTION
Specify library name and version:  **cli11/***

Try to fix https://github.com/conan-io/conan-center-index/issues/18531.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
