### PR TITLE
concurrentcpp: add version 0.1.7

### DIFF
--- a/recipes/concurrencpp/all/conandata.yml
+++ b/recipes/concurrencpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.7":
+    url: "https://github.com/David-Haim/concurrencpp/archive/refs/tags/v.0.1.7.tar.gz"
+    sha256: "049f3e83ad1828e0b8b518652de1a3160d5849fdff03d521d0a5af0167338e89"
   "0.1.6":
     url: "https://github.com/David-Haim/concurrencpp/archive/refs/tags/v.0.1.6.tar.gz"
     sha256: "e7d5c23a73ff1d7199d361d3402ad2a710dfccf7630b622346df94a7532b4221"
@@ -9,6 +12,9 @@ sources:
     url: "https://github.com/David-Haim/concurrencpp/archive/refs/tags/v.0.1.4.tar.gz"
     sha256: "3ad9424f975b766accc6eaedf4acfe1a20b5fdbb57fa3ae71f400e13d471e86f"
 patches:
+  "0.1.7":
+    - patch_file: "patches/cmake-min-version.patch"
+    - patch_file: "patches/directory-name-0.1.6.patch"
   "0.1.6":
     - patch_file: "patches/cmake-min-version.patch"
     - patch_file: "patches/directory-name-0.1.6.patch"

--- a/recipes/concurrencpp/all/conanfile.py
+++ b/recipes/concurrencpp/all/conanfile.py
@@ -38,6 +38,7 @@ class ConcurrencppConan(ConanFile):
             "Visual Studio": "16",
             "msvc": "192",
             "clang": "11",
+            "gcc": "13",
         }
 
     def export_sources(self):
@@ -60,7 +61,7 @@ class ConcurrencppConan(ConanFile):
         if Version(self.version) <= "0.1.5" and self.options.shared and is_msvc(self):
             # see https://github.com/David-Haim/concurrencpp/issues/75
             raise ConanInvalidConfiguration(f"{self.ref} does not support shared builds with Visual Studio")
-        if self.settings.compiler == "gcc":
+        if Version(self.version) <= "0.1.6" and self.settings.compiler == "gcc":
             raise ConanInvalidConfiguration("gcc is not supported by concurrencpp")
         if Version(self.version) >= "0.1.5" and self.settings.compiler == "apple-clang":
             # apple-clang does not seem to support the C++20 synchronization library which concurrencpp 0.1.5 depends on

--- a/recipes/concurrencpp/config.yml
+++ b/recipes/concurrencpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.1.7":
+    folder: all
   "0.1.6":
     folder: all
   "0.1.5":


### PR DESCRIPTION
Specify library name and version:  **concurrentcpp/***

concurrentcpp/0.1.7 supports gcc 13+.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
