### PR TITLE
fix(protobuf): don't call VirtualRunEnv.generate() twice

### DIFF
--- a/recipes/protobuf/all/test_package/conanfile.py
+++ b/recipes/protobuf/all/test_package/conanfile.py
@@ -21,8 +21,8 @@ class TestPackageConan(ConanFile):
             self.tool_requires(self.tested_reference_str)
 
     def generate(self):
-        VirtualRunEnv(self).generate()
         if cross_building(self) and hasattr(self, "settings_build"):
+            VirtualRunEnv(self).generate()
             VirtualBuildEnv(self).generate()
         else:
             VirtualRunEnv(self).generate(scope="build")


### PR DESCRIPTION
Specify library name and version:  **protobuf/all**

Cross building this package is currently broken.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
