### PR TITLE
fix(protobuf): package can't be created when cross building

### DIFF
--- a/recipes/protobuf/all/test_package/conanfile.py
+++ b/recipes/protobuf/all/test_package/conanfile.py
@@ -17,12 +17,12 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        if cross_building(self) and hasattr(self, "settings_build"):
+        if not cross_building(self):
             self.tool_requires(self.tested_reference_str)
 
     def generate(self):
         VirtualRunEnv(self).generate()
-        if cross_building(self) and hasattr(self, "settings_build"):
+        if cross_building(self):
             VirtualBuildEnv(self).generate()
         else:
             VirtualRunEnv(self).generate(scope="build")
@@ -31,11 +31,13 @@ class TestPackageConan(ConanFile):
         tc.generate()
 
     def build(self):
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.build()
+        if not cross_building(self):
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
 
     def test(self):
-        if can_run(self):
+        if not cross_building(self) and can_run(self):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, env="conanrun")
+


### PR DESCRIPTION
Specify library name and version:  **protobuf/all**

Package cannot be created when cross-building.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
