### PR TITLE
[config] Update conan v2 to 2.0.8

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -3,7 +3,7 @@
 id: 'conan-io/conan-center-index'
 
 conan:
-  version: 2.0.6
+  version: 2.0.8
 
 artifactory:
   url: "https://c3i.jfrog.io/c3i"


### PR DESCRIPTION
Conan 2.0.8 is out!


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
