### PR TITLE
spdlog_setup: bump dependencies

### DIFF
--- a/recipes/gegles-spdlog_setup/all/conanfile.py
+++ b/recipes/gegles-spdlog_setup/all/conanfile.py
@@ -39,8 +39,8 @@ class SpdlogSetupConan(ConanFile):
 
     def requirements(self):
         self.requires("cpptoml/0.1.1")
-        self.requires("spdlog/1.11.0")
-        self.requires("fmt/9.1.0")
+        self.requires("spdlog/1.12.0")
+        self.requires("fmt/10.0.0")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Specify library name and version:  **spdlog_setup/1.1.0**

Just bump `spdlog` and `fmt` deps to the latest versions.
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
