### PR TITLE
cpuinfo: add version cci.20230714, add package_type

### DIFF
--- a/recipes/cpuinfo/all/conandata.yml
+++ b/recipes/cpuinfo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20230714":
+    url: "https://github.com/pytorch/cpuinfo/archive/87d8234510367db49a65535021af5e1838a65ac2.tar.gz"
+    sha256: "109e9d2f95a0d72fe50174b44de5b8c9be3e9551407b882e4ad497e9e068d202"
   "cci.20220228":
     url: "https://github.com/pytorch/cpuinfo/archive/6288930068efc8dff4f3c0b95f062fc5ddceba04.tar.gz"
     sha256: "9e9e937b3569320d23d8b1c8c26ed3603affe55c3e4a3e49622e8a2c6d6e1696"

--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -12,10 +12,10 @@ class CpuinfoConan(ConanFile):
     description = "cpuinfo is a library to detect essential for performance " \
                   "optimization information about host CPU."
     license = "BSD-2-Clause"
-    topics = ("cpu", "cpuid", "cpu-cache", "cpu-model", "instruction-set", "cpu-topology")
-    homepage = "https://github.com/pytorch/cpuinfo"
     url = "https://github.com/conan-io/conan-center-index"
-
+    homepage = "https://github.com/pytorch/cpuinfo"
+    topics = ("cpu", "cpuid", "cpu-cache", "cpu-model", "instruction-set", "cpu-topology")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -65,9 +65,10 @@ class CpuinfoConan(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                              "SET_PROPERTY(TARGET clog PROPERTY POSITION_INDEPENDENT_CODE ON)",
-                              "")
+        if self.version < "cci.20230714":
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                                "SET_PROPERTY(TARGET clog PROPERTY POSITION_INDEPENDENT_CODE ON)",
+                                "")
 
     def build(self):
         self._patch_sources()
@@ -83,6 +84,8 @@ class CpuinfoConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "libcpuinfo")
-        self.cpp_info.libs = ["cpuinfo", "clog"]
+        self.cpp_info.libs = ["cpuinfo"]
+        if self.version < "cci.20230714":
+            self.cpp_info.libs.append("clog")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/recipes/cpuinfo/config.yml
+++ b/recipes/cpuinfo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20230714":
+    folder: all
   "cci.20220228":
     folder: all
   "cci.20201217":


### PR DESCRIPTION
Specify library name and version:  **cpuinfo/***

I have to update cpuinfo recipe for https://github.com/conan-io/conan-center-index/pull/18595.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
