### PR TITLE
restinio: bump dependencies

### DIFF
--- a/recipes/restinio/all/conanfile.py
+++ b/recipes/restinio/all/conanfile.py
@@ -40,13 +40,13 @@ class RestinioConan(ConanFile):
         self.requires("http_parser/2.9.4")
 
         if Version(self.version) >= "0.6.16":
-            self.requires("fmt/9.1.0")
+            self.requires("fmt/10.0.0")
         else:
             self.requires("fmt/8.1.1")
 
         self.requires("expected-lite/0.6.3")
         self.requires("optional-lite/3.5.0")
-        self.requires("string-view-lite/1.6.0")
+        self.requires("string-view-lite/1.7.0")
         self.requires("variant-lite/2.0.0")
 
         if self.options.asio == "standalone":
@@ -56,7 +56,7 @@ class RestinioConan(ConanFile):
                 self.requires("asio/1.16.1")
         else:
             if Version(self.version) >= "0.6.9":
-                self.requires("boost/1.81.0")
+                self.requires("boost/1.82.0")
             else:
                 self.requires("boost/1.73.0")
 


### PR DESCRIPTION
Specify library name and version:  **restinio/0.6.18**

Bump `fmt`, `string-view-lite` and `boost` dependencies to latest

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
