### PR TITLE
restinio: bump standalone asio & remove older versions

### DIFF
--- a/recipes/restinio/all/conandata.yml
+++ b/recipes/restinio/all/conandata.yml
@@ -8,30 +8,3 @@ sources:
   "0.6.16":
     url: "https://github.com/Stiffstream/restinio/archive/v.0.6.16.tar.gz"
     sha256: "b3208d746087ba979f51b3a32e08463718c33d58720247d53ffb5bda99f4f92a"
-  "0.6.15":
-    url: "https://github.com/Stiffstream/restinio/archive/v.0.6.15.tar.gz"
-    sha256: "5977e7a21064a42dc690a644adc7ba03037eb4007bfbc36586faf715583967bd"
-  "0.6.14":
-    url: https://github.com/Stiffstream/restinio/archive/v.0.6.14.tar.gz
-    sha256: 9742c051e7199d826697f86e6ba4a9fcb7f00c71a408b5c172134b2206404c4e
-  "0.6.13":
-    url: https://github.com/Stiffstream/restinio/archive/v.0.6.13.tar.gz
-    sha256: 72d7ad40c8d34e69cd79f42145b4059e8a7356114fb13864c3c0ad5a5607b44f
-  "0.6.12":
-    url: https://github.com/Stiffstream/restinio/archive/v.0.6.12.tar.gz
-    sha256: 7176d608afb8e5cd29eec2216e747be262215f5b3ab3df2b3c86e691f1cec79e
-  "0.6.11":
-    url: https://github.com/Stiffstream/restinio/archive/v.0.6.11.tar.gz
-    sha256: 66c25c19efd9dc9683d60f540e9ac09b66245c5afde096fc05ec69cbb502fc5d
-  "0.6.10":
-    url: https://github.com/Stiffstream/restinio/archive/v.0.6.10.tar.gz
-    sha256: dc9cad7e19f1bc255532cee53ab2027c93108c79e27f9fbe971f3ea0b10274a5
-  "0.6.9":
-    url: https://github.com/Stiffstream/restinio/archive/v.0.6.9.tar.gz
-    sha256: fcb05e15a346b4ff27757b89741289864f82f71affe61364325ce70dddefe31f
-  "0.6.8.1":
-    url: https://github.com/Stiffstream/restinio/archive/v.0.6.8.1.tar.gz
-    sha256: 6a365ce645fc7188c287602886eba1a99c797e01b734f0c69bcb370b3494b54c
-  "0.6.8":
-    url: https://github.com/Stiffstream/restinio/archive/v.0.6.8.tar.gz
-    sha256: 92ab0faa9f9de582df787e133acf5c10fb6ab7cecbd96c128997554d8ceda0cd

--- a/recipes/restinio/all/conanfile.py
+++ b/recipes/restinio/all/conanfile.py
@@ -38,27 +38,16 @@ class RestinioConan(ConanFile):
 
     def requirements(self):
         self.requires("http_parser/2.9.4")
-
-        if Version(self.version) >= "0.6.16":
-            self.requires("fmt/10.0.0")
-        else:
-            self.requires("fmt/8.1.1")
-
+        self.requires("fmt/10.0.0")
         self.requires("expected-lite/0.6.3")
         self.requires("optional-lite/3.5.0")
         self.requires("string-view-lite/1.7.0")
         self.requires("variant-lite/2.0.0")
 
         if self.options.asio == "standalone":
-            if Version(self.version) >= "0.6.9":
-                self.requires("asio/1.22.1")
-            else:
-                self.requires("asio/1.16.1")
+            self.requires("asio/1.28.0")
         else:
-            if Version(self.version) >= "0.6.9":
-                self.requires("boost/1.82.0")
-            else:
-                self.requires("boost/1.73.0")
+            self.requires("boost/1.82.0")
 
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]")

--- a/recipes/restinio/config.yml
+++ b/recipes/restinio/config.yml
@@ -5,21 +5,3 @@ versions:
     folder: all
   "0.6.16":
     folder: all
-  "0.6.15":
-    folder: all
-  "0.6.14":
-    folder: all
-  "0.6.13":
-    folder: all
-  "0.6.12":
-    folder: all
-  "0.6.11":
-    folder: all
-  "0.6.10":
-    folder: all
-  "0.6.9":
-    folder: all
-  "0.6.8.1":
-    folder: all
-  "0.6.8":
-    folder: all


### PR DESCRIPTION
Specify library name and version:  **restinio/0.6.18**

* bump standalone asio
* remove older versions as per guidelines [here](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/sources_and_patches.md#removing-old-versions)
  
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
