### PR TITLE
coin-clp: add version 1.17.8

### DIFF
--- a/recipes/coin-clp/all/conandata.yml
+++ b/recipes/coin-clp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.17.8":
+    url: "https://github.com/coin-or/Clp/archive/releases/1.17.8.tar.gz"
+    sha256: "f9931b5ba44f0daf445c6b48fc2c250dc12e667e59ace8ea7b025f158fe31556"
   "1.17.7":
     url: "https://github.com/coin-or/Clp/archive/refs/tags/releases/1.17.7.tar.gz"
     sha256: "c4c2c0e014220ce8b6294f3be0f3a595a37bef58a14bf9bac406016e9e73b0f5"
@@ -6,6 +9,8 @@ sources:
     url: "https://github.com/coin-or/Clp/archive/refs/tags/releases/1.17.6.tar.gz"
     sha256: "afff465b1620cfcbb7b7c17b5d331d412039650ff471c4160c7eb24ae01284c9"
 patches:
+  "1.17.8":
+    - patch_file: "patches/1.17.7-0001-no-pkg-config-check.patch"
   "1.17.7":
     - patch_file: "patches/1.17.7-0001-no-pkg-config-check.patch"
   "1.17.6":

--- a/recipes/coin-clp/config.yml
+++ b/recipes/coin-clp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.17.8":
+    folder: "all"
   "1.17.7":
     folder: "all"
   "1.17.6":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **coin-clp/1.17.8**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->



---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
