### PR TITLE
openssl: fix configdata.pm path for MinGW on Windows

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -9,6 +9,7 @@ from conan.tools.microsoft import is_msvc, msvc_runtime_flag, unix_path
 
 import fnmatch
 import os
+from pathlib import Path
 import textwrap
 
 required_conan_version = ">=1.57.0"
@@ -517,7 +518,7 @@ class OpenSSLConan(ConanFile):
 
     def build(self):
         self._make()
-        self.run(f"{self._perl} {self.source_folder}/configdata.pm --dump")
+        self.run(f"{self._perl} {Path(self.source_folder).as_posix()}/configdata.pm --dump")
 
     @property
     def _make_program(self):


### PR DESCRIPTION
**openssl/3.x.x**

Fixing #18577

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
