### PR TITLE
aws-libfabric: migrate to Conan v2

### DIFF
--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -90,7 +90,7 @@ class LibfabricConan(ConanFile):
         for p in self._providers:
             tc.configure_args.append("--enable-{}={}".format(p, yes_no_dl(getattr(self.options, p))))
         if self.options.with_libnl:
-            tc.configure_args.append("--with-libnl={}".format(unix_path(self, self.dependencies["libnl"].package_folder))),
+            tc.configure_args.append("--with-libnl={}".format(unix_path(self, self.dependencies["libnl"].package_folder)))
         else:
             tc.configure_args.append("--with-libnl=no")
         if self.settings.build_type == "Debug":

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -1,48 +1,50 @@
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.35.0"
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import cross_building
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import chdir, collect_libs, copy, get, rm, rmdir
+from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import unix_path
+
+required_conan_version = ">=1.53.0"
+
 
 class LibfabricConan(ConanFile):
     name = "aws-libfabric"
     description = "AWS Libfabric"
-    topics = ("fabric", "communication", "framework", "service")
+    license = ("BSD-2-Clause", "GPL-2.0-or-later")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/aws/libfabric"
-    license = "BSD-2-Clause", "GPL-2.0-or-later"
+    topics = ("fabric", "communication", "framework", "service")
+
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     _providers = ["gni", "psm", "psm2", "sockets", "rxm", "tcp", "udp", "usnic", "verbs", "bgq", "shm", "efa", "rxd", "mrail", "rstream", "perf", "hook_debug"]
     options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
         **{ p: [True, False, "shared"] for p in _providers },
         **{
-            "shared": [True, False],
-            "fPIC": [True, False],
             "with_libnl": [True, False],
             "bgq_progress": ["auto", "manual"],
             "bgq_mr": ["basic", "scalable"]
         }
     }
     default_options = {
+        "shared": False,
+        "fPIC": True,
         **{ p: False for p in _providers },
         **{
-            "shared": False,
-            "fPIC": True,
             "tcp": True,
             "with_libnl": False,
             "bgq_progress": "manual",
             "bgq_mr": "basic"
         }
     }
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    _autotools = None
-
-    def build_requirements(self):
-        self.build_requires("libtool/2.4.6")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -52,9 +54,12 @@ class LibfabricConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.with_libnl:
@@ -64,52 +69,56 @@ class LibfabricConan(ConanFile):
         if self.settings.os == "Windows":
             raise ConanInvalidConfiguration("The libfabric package cannot be built on Windows.")
 
+    def build_requirements(self):
+        self.tool_requires("libtool/2.4.7")
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        with tools.chdir(self._source_subfolder):
-            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
-
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+        if not cross_building(self):
+            env = VirtualRunEnv(self)
+            env.generate(scope="build")
         yes_no_dl = lambda v: {"True": "yes", "False": "no", "shared": "dl"}[str(v)]
-        yes_no = lambda v: "yes" if v else "no"
-        args = [
-            "--enable-shared={}".format(yes_no(self.options.shared)),
-            "--enable-static={}".format(yes_no(not self.options.shared)),
+        tc = AutotoolsToolchain(self)
+        tc.configure_args += [
             "--with-bgq-progress={}".format(self.options.bgq_progress),
             "--with-bgq-mr={}".format(self.options.bgq_mr),
         ]
         for p in self._providers:
-            args.append("--enable-{}={}".format(p, yes_no_dl(getattr(self.options, p))))
+            tc.configure_args.append("--enable-{}={}".format(p, yes_no_dl(getattr(self.options, p))))
         if self.options.with_libnl:
-            args.append("--with-libnl={}".format(tools.unix_path(self.deps_cpp_info["libnl"].rootpath))),
+            tc.configure_args.append("--with-libnl={}".format(unix_path(self, self.dependencies["libnl"].package_folder))),
         else:
-            args.append("--with-libnl=no")
+            tc.configure_args.append("--with-libnl=no")
         if self.settings.build_type == "Debug":
-            args.append("--enable-debug")
-        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
-        return self._autotools
+            tc.configure_args.append("--enable-debug")
+        tc.generate()
+        tc = AutotoolsDeps(self)
+        tc.generate()
 
     def build(self):
-        autotools = self._configure_autotools()
-        autotools.make()
+        with chdir(self, self.source_folder):
+            autotools = Autotools(self)
+            autotools.autoreconf()
+            autotools.configure()
+            autotools.make()
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        autotools = self._configure_autotools()
-        autotools.install()
-
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+        copy(self, pattern="COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        with chdir(self, self.source_folder):
+            autotools = Autotools(self)
+            autotools.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rm(self, "*.la", self.package_folder, recursive=True)
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
-        self.cpp_info.names["pkg_config"] = "libfabric"
-        self.cpp_info.libs = self.collect_libs()
+        self.cpp_info.set_property("pkg_config_name", "libfabric")
+        self.cpp_info.libs = collect_libs(self)
         if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.system_libs = ["pthread", "m"]
             if not self.options.shared:

--- a/recipes/aws-libfabric/all/test_package/CMakeLists.txt
+++ b/recipes/aws-libfabric/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(aws-libfabric REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE aws-libfabric::aws-libfabric)

--- a/recipes/aws-libfabric/all/test_package/conanfile.py
+++ b/recipes/aws-libfabric/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/aws-libfabric/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-libfabric/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/aws-libfabric/all/test_v1_package/conanfile.py
+++ b/recipes/aws-libfabric/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **aws-libfabric/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
