### PR TITLE
directshowbaseclasses: migrate to Conan v2

### DIFF
--- a/recipes/directshowbaseclasses/all/CMakeLists.txt
+++ b/recipes/directshowbaseclasses/all/CMakeLists.txt
@@ -1,10 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(strmbas)
 
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-set(DSROOT "${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/Samples/Win7Samples/multimedia/directshow/baseclasses")
+set(DSROOT "${CMAKE_CURRENT_SOURCE_DIR}/src/Samples/Win7Samples/multimedia/directshow/baseclasses")
 
 file(GLOB SOURCES "${DSROOT}/*.cpp")
 file(GLOB HEADERS "${DSROOT}/*.h")
@@ -20,8 +17,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${DSROOT})
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE UNICODE=1 _UNICODE=1)
 
+include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
   PUBLIC_HEADER DESTINATION include)

--- a/recipes/directshowbaseclasses/all/CMakeLists.txt
+++ b/recipes/directshowbaseclasses/all/CMakeLists.txt
@@ -17,6 +17,8 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${DSROOT})
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE UNICODE=1 _UNICODE=1)
 
-include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
   PUBLIC_HEADER DESTINATION include)

--- a/recipes/directshowbaseclasses/all/conanfile.py
+++ b/recipes/directshowbaseclasses/all/conanfile.py
@@ -20,28 +20,12 @@ class DirectShowBaseClassesConan(ConanFile):
     homepage = "https://docs.microsoft.com/en-us/windows/desktop/directshow/directshow-base-classes"
     topics = ("directshow", "dshow")
 
-    package_type = "library"
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
-    options = {
-        "shared": [True, False],
-        "fPIC": [True, False],
-    }
-    default_options = {
-        "shared": False,
-        "fPIC": True,
-    }
     short_paths = True
 
     def export_sources(self):
         copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -61,7 +45,7 @@ class DirectShowBaseClassesConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(build_script_folder=self.export_sources_folder)
+        cmake.configure(build_script_folder=self.source_path.parent)
         cmake.build()
 
     def package(self):

--- a/recipes/directshowbaseclasses/all/conanfile.py
+++ b/recipes/directshowbaseclasses/all/conanfile.py
@@ -30,6 +30,7 @@ class DirectShowBaseClassesConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
+    short_paths = True
 
     def export_sources(self):
         copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)

--- a/recipes/directshowbaseclasses/all/conanfile.py
+++ b/recipes/directshowbaseclasses/all/conanfile.py
@@ -1,40 +1,75 @@
-from conans import ConanFile, CMake, tools
 import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+
+required_conan_version = ">=1.53.0"
 
 
 class DirectShowBaseClassesConan(ConanFile):
     name = "directshowbaseclasses"
-    description = "Microsoft DirectShow Base Classes are a set of C++ classes and utility functions designed for " \
-                  "implementing DirectShow filters"
+    description = (
+        "Microsoft DirectShow Base Classes are a set of C++ classes and "
+        "utility functions designed for implementing DirectShow filters"
+    )
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://docs.microsoft.com/en-us/windows/desktop/directshow/directshow-base-classes"
-    topics = ("conan", "directshow", "dshow")
-    license = "MIT"
-    exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
-    settings = {"os": ["Windows"], "arch": ["x86", "x86_64"], "compiler": None, "build_type": None}
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
-    short_paths = True
+    topics = ("directshow", "dshow")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def export_sources(self):
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.os != "Windows":
+            raise ConanInvalidConfiguration(f"{self.ref} can only be used on Windows.")
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename('Windows-classic-samples-%s' % self.version, self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self.export_sources_folder)
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ['strmbasd' if self.settings.build_type == 'Debug' else 'strmbase']
-        self.cpp_info.system_libs = ['strmiids', 'winmm']
+        self.cpp_info.libs = ["strmbasd" if self.settings.build_type == "Debug" else "strmbase"]
+        self.cpp_info.system_libs = ["strmiids", "winmm"]

--- a/recipes/directshowbaseclasses/all/test_package/CMakeLists.txt
+++ b/recipes/directshowbaseclasses/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(directshowbaseclasses REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE directshowbaseclasses::directshowbaseclasses)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/directshowbaseclasses/all/test_package/conanfile.py
+++ b/recipes/directshowbaseclasses/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,5 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/directshowbaseclasses/all/test_v1_package/CMakeLists.txt
+++ b/recipes/directshowbaseclasses/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/directshowbaseclasses/all/test_v1_package/conanfile.py
+++ b/recipes/directshowbaseclasses/all/test_v1_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)


### PR DESCRIPTION
TODO

- [x] `Add 'short_paths = True' in your recipe.`
- [x] `Package with 'shared=True' option did not contain any shared artifact`