### PR TITLE
snappy: add with_bmi2 and with_ssse3 options

### DIFF
--- a/recipes/snappy/all/conanfile.py
+++ b/recipes/snappy/all/conanfile.py
@@ -22,7 +22,7 @@ class SnappyConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_bmi2": [True, False, "auto"],
-        "with_ssse3": [True, False "auto"],
+        "with_ssse3": [True, False, "auto"],
     }
     default_options = {
         "shared": False,

--- a/recipes/snappy/all/conanfile.py
+++ b/recipes/snappy/all/conanfile.py
@@ -21,10 +21,14 @@ class SnappyConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_bmi2": [True, False, "auto"],
+        "with_ssse3": [True, False "auto"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_bmi2": "auto",
+        "with_ssse3": "auto",
     }
 
     def export_sources(self):
@@ -33,6 +37,9 @@ class SnappyConan(ConanFile):
     def config_options(self):
         if self.settings.os == 'Windows':
             del self.options.fPIC
+        if self.settings.arch not in ["x86", "x86_64"]:
+            del self.options.with_bmi2
+            del self.options.with_ssse3
 
     def configure(self):
         if self.options.shared:
@@ -60,6 +67,11 @@ class SnappyConan(ConanFile):
             tc.variables["SNAPPY_INSTALL"] = True
         if Version(self.version) >= "1.1.9":
             tc.variables["SNAPPY_BUILD_BENCHMARKS"] = False
+        if self.settings.arch in ["x86", "x86_64"]:
+            if self.options.with_bmi2 != "auto":
+                tc.variables["SNAPPY_HAVE_BMI2"] = self.options.with_bmi2
+            if self.options.with_ssse3 != "auto":
+                tc.variables["SNAPPY_HAVE_SSSE3"] = self.options.with_ssse3
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Specify library name and version:  **snappy/\***

There is a similar PR in vcpkg
See https://github.com/conda-forge/snappy-feedstock/issues/24 and https://github.com/google/snappy/blob/2b63814b15a2aaae54b7943f0cd935892fae628f/CMakeLists.txt#L179


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
