### PR TITLE
libcurl: add version 8.2.0, update libnghttp2, remove older versions

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.2.0":
+    url: "https://curl.se/download/curl-8.2.0.tar.gz"
+    sha256: "c67849462d171a3fee08b605cdd837d18ee22ecc3ee2c6a0393c9cec5d1a137e"
   "8.1.2":
     url: "https://curl.se/download/curl-8.1.2.tar.gz"
     sha256: "2e5a9b8fcdc095bdd2f079561f369de71c5eb3b80f00a702fbe9a8b8d9897891"
@@ -38,9 +41,3 @@ sources:
   "7.78.0":
     url: "https://curl.se/download/curl-7.78.0.tar.gz"
     sha256: "ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7"
-  "7.77.0":
-    url: "https://curl.se/download/curl-7.77.0.tar.gz"
-    sha256: "b0a3428acb60fa59044c4d0baae4e4fc09ae9af1d8a3aa84b2e3fbcd99841f77"
-  "7.76.0":
-    url: "https://curl.se/download/curl-7.76.0.tar.gz"
-    sha256: "3b4378156ba09e224008e81dcce854b7ce4d182b1f9cfb97fe5ed9e9c18c6bd3"

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -334,7 +334,8 @@ class LibcurlConan(ConanFile):
                               "include(CurlSymbolHiding)", "")
 
         # brotli
-        replace_in_file(self, cmakelists, "find_package(Brotli QUIET)", "find_package(brotli REQUIRED CONFIG)")
+        if Version(self.version) < "8.2.0":
+            replace_in_file(self, cmakelists, "find_package(Brotli QUIET)", "find_package(brotli REQUIRED CONFIG)")
         replace_in_file(self, cmakelists, "if(BROTLI_FOUND)", "if(brotli_FOUND)")
         replace_in_file(self, cmakelists, "${BROTLI_LIBRARIES}", "brotli::brotli")
         replace_in_file(self, cmakelists, "${BROTLI_INCLUDE_DIRS}", "${brotli_INCLUDE_DIRS}")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -185,7 +185,7 @@ class LibcurlConan(ConanFile):
         elif self.options.with_ssl == "wolfssl":
             self.requires("wolfssl/5.6.3")
         if self.options.with_nghttp2:
-            self.requires("libnghttp2/1.54.0")
+            self.requires("libnghttp2/1.55.1")
         if self.options.with_libssh2:
             self.requires("libssh2/1.11.0")
         if self.options.with_zlib:

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.2.0":
+    folder: all
   "8.1.2":
     folder: all
   "8.1.1":
@@ -24,8 +26,4 @@ versions:
   "7.79.1":
     folder: all
   "7.78.0":
-    folder: all
-  "7.77.0":
-    folder: all
-  "7.76.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libcurl/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
