### PR TITLE
etl: add version 20.37.2, remove older versions

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.37.2":
+    url: "https://github.com/ETLCPP/etl/archive/20.37.2.tar.gz"
+    sha256: "13bd5d9d1bfbc887e3182895ca0291df0008a1c5770ddd12ef6cd2215c2bc6af"
   "20.37.1":
     url: "https://github.com/ETLCPP/etl/archive/20.37.1.tar.gz"
     sha256: "73c29678e478eca9243c1d0c98e727a2249a7973d1429a847c669bccc65dca88"
@@ -23,9 +26,3 @@ sources:
   "20.34.0":
     url: "https://github.com/ETLCPP/etl/archive/20.34.0.tar.gz"
     sha256: "56e25968f20167a161ee50c3eecda3daa91f696660ba59654c1afd22e502c465"
-  "20.33.0":
-    url: "https://github.com/ETLCPP/etl/archive/20.33.0.tar.gz"
-    sha256: "46068e44cc3cbd626fc8adc5344101b4654c675b9a5faec0c80989176419cd7d"
-  "20.32.1":
-    url: "https://github.com/ETLCPP/etl/archive/20.32.1.tar.gz"
-    sha256: "f39c8ccf33190303946dbcb2b251c86b4516234f57e0e87b83c0a28a1bdb059d"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.37.2":
+    folder: all
   "20.37.1":
     folder: all
   "20.37.0":
@@ -14,8 +16,4 @@ versions:
   "20.35.7":
     folder: all
   "20.34.0":
-    folder: all
-  "20.33.0":
-    folder: all
-  "20.32.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **etl/20.37.2**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
