### PR TITLE
boost/<all versions>: error: Cannot configure toolset clang-win: no 'clang-cl.exe' command found or given

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1203,7 +1203,7 @@ class BoostConan(ConanFile):
         compilers_by_conf = self.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
         cxx = compilers_by_conf.get("cpp") or VirtualBuildEnv(self).vars().get("CXX")
         if cxx:
-            return cxx
+            return shutil.which(cxx) or cxx
         if is_apple_os(self) and self.settings.compiler == "apple-clang":
             return XCRun(self).cxx
         compiler_version = str(self.settings.compiler.version)
@@ -1608,7 +1608,7 @@ class BoostConan(ConanFile):
             def add_libprefix(n):
                 """ On MSVC, static libraries are built with a 'lib' prefix. Some libraries do not support shared, so are always built as a static library. """
                 libprefix = ""
-                if is_msvc(self) and (not self._shared or n in self._dependencies["static_only"]):
+                if (is_msvc(self) or self._is_clang_cl) and (not self._shared or n in self._dependencies["static_only"]):
                     libprefix = "lib"
                 return libprefix + n
 


### PR DESCRIPTION
about the problem: https://github.com/conan-io/conan-center-index/issues/18302 (my issue)

Not only me came across with the problem. Today, an unfamiliar person contacted me inquiring about how I resolved a particular issue. As a result, I have decided to proceed with creating a pull request that addresses the problem. Please pay special attention to it.

The message in telegram:
![изображение](https://github.com/conan-io/conan-center-index/assets/81780915/6b0573b3-a2f5-41df-aa60-2f48e214a280)

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
