### PR TITLE
tinyxml: enable with_stl by default

### DIFF
--- a/recipes/tinyxml/all/conanfile.py
+++ b/recipes/tinyxml/all/conanfile.py
@@ -25,7 +25,7 @@ class TinyXmlConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_stl": False,
+        "with_stl": True,
     }
 
     exports_sources = "CMakeLists.txt"


### PR DESCRIPTION
Needed for #17347.

Including STL support in a C++ library by default should not be an issue, I assume.