### PR TITLE
zstd/*: Added "build_programs" option

### DIFF
--- a/recipes/zstd/all/conandata.yml
+++ b/recipes/zstd/all/conandata.yml
@@ -46,7 +46,7 @@ patches:
     - patch_file: "patches/1.5.5-qnx_support.patch"
       patch_description: "Add qnx to platform"
       patch_type: "portability"
-      patch_souce: "https://github.com/facebook/zstd/pull/3745"
+      patch_source: "https://github.com/facebook/zstd/pull/3745"
   "1.5.4":
     - patch_file: "patches/1.5.2-cmake-remove-asm-except-x86_64.patch"
       patch_description: "use assembler codes only on x86_64"

--- a/recipes/zstd/all/conandata.yml
+++ b/recipes/zstd/all/conandata.yml
@@ -43,6 +43,9 @@ patches:
     - patch_file: "patches/1.5.2-cmake-remove-asm-except-x86_64.patch"
       patch_description: "use assembler codes only on x86_64"
       patch_type: "portability"
+    - patch_file: "patches/1.5.5-qnx_support.patch"
+      patch_description: "Add qnx to platform"
+      patch_type: "portability"
   "1.5.4":
     - patch_file: "patches/1.5.2-cmake-remove-asm-except-x86_64.patch"
       patch_description: "use assembler codes only on x86_64"

--- a/recipes/zstd/all/conandata.yml
+++ b/recipes/zstd/all/conandata.yml
@@ -46,6 +46,7 @@ patches:
     - patch_file: "patches/1.5.5-qnx_support.patch"
       patch_description: "Add qnx to platform"
       patch_type: "portability"
+      patch_souce: "https://github.com/facebook/zstd/pull/3745"
   "1.5.4":
     - patch_file: "patches/1.5.2-cmake-remove-asm-except-x86_64.patch"
       patch_description: "use assembler codes only on x86_64"

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -1,11 +1,11 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, replace_in_file, rmdir
+from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, replace_in_file, rmdir, rm
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 import os
 
 required_conan_version = ">=1.53.0"
-
 
 class ZstdConan(ConanFile):
     name = "zstd"
@@ -21,11 +21,13 @@ class ZstdConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "threading": [True, False],
+        "build_programs": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "threading": True,
+        "build_programs": True,
     }
 
     def export_sources(self):
@@ -49,10 +51,14 @@ class ZstdConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["ZSTD_BUILD_PROGRAMS"] = False
-        tc.variables["ZSTD_BUILD_STATIC"] = not self.options.shared
+        tc.variables["ZSTD_BUILD_PROGRAMS"] = self.options.build_programs
+        tc.variables["ZSTD_BUILD_STATIC"] = not self.options.shared or self.options.build_programs
         tc.variables["ZSTD_BUILD_SHARED"] = self.options.shared
         tc.variables["ZSTD_MULTITHREAD_SUPPORT"] = self.options.threading
+
+        if not is_msvc(self):
+            tc.variables["CMAKE_C_FLAGS"] = "-Wno-maybe-uninitialized"
+
         if Version(self.version) < "1.4.3":
             # Generate a relocatable shared lib on Macos
             tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
@@ -77,6 +83,12 @@ class ZstdConan(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+        if self.options.shared and self.options.build_programs:
+            #If we built programs we always build static libs,
+            #but if we only want shared libs in the package then remove the static libs
+            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         zstd_cmake = "libzstd_shared" if self.options.shared else "libzstd_static"
@@ -90,3 +102,8 @@ class ZstdConan(ConanFile):
         self.cpp_info.components["zstdlib"].libs = collect_libs(self)
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["zstdlib"].system_libs.append("pthread")
+
+        if self.options.build_programs:
+            # TODO: Remove after dropping Conan 1.x from ConanCenterIndex
+            bindir = os.path.join(self.package_folder, "bin")
+            self.runenv_info.prepend_path("PATH", bindir)

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -106,4 +106,4 @@ class ZstdConan(ConanFile):
         if self.options.build_programs:
             # TODO: Remove after dropping Conan 1.x from ConanCenterIndex
             bindir = os.path.join(self.package_folder, "bin")
-            self.runenv_info.prepend_path("PATH", bindir)
+            self.env_info.PATH.append(bindir)

--- a/recipes/zstd/all/patches/1.5.5-qnx_support.patch
+++ b/recipes/zstd/all/patches/1.5.5-qnx_support.patch
@@ -1,0 +1,11 @@
+--- programs/platform.h	2023-04-04 22:13:52.000000000 +0200
++++ programs/platform.h	2023-09-03 10:01:58.930595800 +0200
+@@ -89,7 +89,7 @@
+  */
+ #  elif !defined(_WIN32) \
+      && ( defined(__unix__) || defined(__unix) \
+-       || defined(__midipix__) || defined(__VMS) || defined(__HAIKU__) )
++       || defined(_QNX_SOURCE) || defined(__midipix__) || defined(__VMS) || defined(__HAIKU__) )
+ 
+ #    if defined(__linux__) || defined(__linux) || defined(__CYGWIN__)
+ #      ifndef _POSIX_C_SOURCE

--- a/recipes/zstd/all/test_package/conanfile.py
+++ b/recipes/zstd/all/test_package/conanfile.py
@@ -1,10 +1,8 @@
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
-from conan.errors import ConanException
 from io import StringIO
 from conan.tools.files import load, save
-import re
 import os
 
 
@@ -33,14 +31,14 @@ class TestPackageConan(ConanFile):
         if not can_run(self):
             return
 
+        bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+        png_file = os.path.join(self.source_folder, "logo.png")
+        self.run(f"{bin_path} {png_file}", env="conanrun")
+
         zstd_version = load(self, os.path.join(self.generators_folder, "zstd_version"))
 
         output = StringIO()
         self.run(f"zstd --version", output, env="conanrun")
         output_str = str.strip(output.getvalue())
-
-        s = re.search(f"{zstd_version}", output_str)
-        if s == None:
-            raise ConanException(f"zstd command output '{output_str}' should contain version string '{zstd_version}'")
-        else:
-            self.output.info(f"Version verified: '{zstd_version}'")
+        assert zstd_version in output_str, f"zstd command output '{output_str}' should contain version string '{zstd_version}'"
+        self.output.info(f"Version verified: '{zstd_version}'")

--- a/recipes/zstd/all/test_package/conanfile.py
+++ b/recipes/zstd/all/test_package/conanfile.py
@@ -1,14 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
-from io import StringIO
-from conan.tools.files import load, save
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualBuildEnv", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
@@ -17,10 +15,8 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
 
-    def generate(self):
-        zstd_version = self.dependencies["zstd"].ref.version
-        save(self, "zstd_version", f"{zstd_version}")
-
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -35,10 +31,4 @@ class TestPackageConan(ConanFile):
         png_file = os.path.join(self.source_folder, "logo.png")
         self.run(f"{bin_path} {png_file}", env="conanrun")
 
-        zstd_version = load(self, os.path.join(self.generators_folder, "zstd_version"))
-
-        output = StringIO()
-        self.run(f"zstd --version", output, env="conanrun")
-        output_str = str.strip(output.getvalue())
-        assert zstd_version in output_str, f"zstd command output '{output_str}' should contain version string '{zstd_version}'"
-        self.output.info(f"Version verified: '{zstd_version}'")
+        self.run(f"zstd --version")

--- a/recipes/zstd/all/test_package/conanfile.py
+++ b/recipes/zstd/all/test_package/conanfile.py
@@ -6,17 +6,14 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
 
     def requirements(self):
-        self.requires(self.tested_reference_str)
-
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+        self.requires(self.tested_reference_str, run=True)
 
     def build(self):
         cmake = CMake(self)
@@ -31,4 +28,4 @@ class TestPackageConan(ConanFile):
         png_file = os.path.join(self.source_folder, "logo.png")
         self.run(f"{bin_path} {png_file}", env="conanrun")
 
-        self.run(f"zstd --version")
+        self.run(f"zstd --version", env="conanrun")


### PR DESCRIPTION
Library: zstd/*

Added option ("build_programs") to let the consumer choose whether to build executables/programs for zstd along with the static library.
Also added tests to verify the built executables!

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
