### PR TITLE
xtr: bump to 2.1.0

### DIFF
--- a/recipes/xtr/all/conandata.yml
+++ b/recipes/xtr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.0":
+    url: "https://github.com/choll/xtr/archive/refs/tags/2.1.0.tar.gz"
+    sha256: "5abe2e53d91a893d63998968450d9bbfc23c45f552c81e2b7d17694699ab17c4"
   "2.0.1":
     url: "https://github.com/choll/xtr/archive/refs/tags/2.0.1.tar.gz"
     sha256: "92327264541900a2c9d43aaa3070d143d5e91879737fcea8cbf56065330af059"

--- a/recipes/xtr/config.yml
+++ b/recipes/xtr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.0":
+    folder: all
   "2.0.1":
     folder: all
   "2.0.0":


### PR DESCRIPTION
Specify library name and version:  **xtr/2.1.0**

Bump xtr to 2.1.0, I am the library author.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
