### PR TITLE
amqp-cpp: add version 4.3.26

### DIFF
--- a/recipes/amqp-cpp/all/conandata.yml
+++ b/recipes/amqp-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.3.26":
+    url: "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/v4.3.26.tar.gz"
+    sha256: "2baaab702f3fd9cce40563dc1e23f433cceee7ec3553bd529a98b1d3d7f7911c"
   "4.3.24":
     url: "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/v4.3.24.tar.gz"
     sha256: "c3312f8af813cacabf6c257dfaf41bf9e66606bbf7d62d085a9b7da695355245"
@@ -27,6 +30,8 @@ sources:
     url: "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/v4.1.5.tar.gz"
     sha256: "9840c7fb17bb0c0b601d269e528b7f9cac5ec008dcf8d66bef22434423b468aa"
 patches:
+  "4.3.26":
+    - patch_file: "patches/4.3.24-0001-cmake-openssl-install-directories.patch"
   "4.3.24":
     - patch_file: "patches/4.3.24-0001-cmake-openssl-install-directories.patch"
   "4.3.18":

--- a/recipes/amqp-cpp/config.yml
+++ b/recipes/amqp-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.3.26":
+    folder: all
   "4.3.24":
     folder: all
   "4.3.18":


### PR DESCRIPTION
Specify library name and version:  **amqp-cpp/4.3.26**

This version contains a fix of iterator invalidation / crash when a user space program publishes more messages as a result of an onAck/onNack callback in AMQP::Reliable


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
