### PR TITLE
dice-template-library: add version 1.1.0

### DIFF
--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "a00ee401379eaf6c8af013fb39d6732fa68c3852e14b50789edde6f054647ca2"
   "1.0.0":
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.0.0.tar.gz"
     sha256: "485505ad3f9fb033083e2952bd8b4e68f6b4f123746b20f4ec3af46f4ce66cfe"

--- a/recipes/dice-template-library/config.yml
+++ b/recipes/dice-template-library/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.0":
     folder: all
   "0.3.0":


### PR DESCRIPTION
Specify library name and version:  **dice-template-library/1.1.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
