### PR TITLE
geos: add version 3.12.0

### DIFF
--- a/recipes/geos/all/conandata.yml
+++ b/recipes/geos/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.12.0":
+    url: "https://github.com/libgeos/geos/releases/download/3.12.0/geos-3.12.0.tar.bz2"
+    sha256: "d96db96011259178a35555a0f6d6e75a739e52a495a6b2aa5efb3d75390fbc39"
   "3.11.2":
     url: "https://github.com/libgeos/geos/releases/download/3.11.2/geos-3.11.2.tar.bz2"
     sha256: "b1f077669481c5a3e62affc49e96eb06f281987a5d36fdab225217e5b825e4cc"

--- a/recipes/geos/all/conanfile.py
+++ b/recipes/geos/all/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.54.0"
 
 class GeosConan(ConanFile):
     name = "geos"
-    description = "C++11 library for performing operations on two-dimensional vector geometries"
+    description = "C++14 library for performing operations on two-dimensional vector geometries"
     license = "LGPL-2.1"
     topics = ("osgeo", "geometry", "topology", "geospatial")
     homepage = "https://trac.osgeo.org/geos"
@@ -49,7 +49,7 @@ class GeosConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, 11)
+            check_min_cppstd(self, 14)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/geos/config.yml
+++ b/recipes/geos/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.12.0":
+    folder: all
   "3.11.2":
     folder: all
   "3.11.1":


### PR DESCRIPTION
Specify library name and version: geos/3.12.0

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Updated to latest upstream version. Fixes, amongst other things, broken builds on GCC-13 with Fedora and Arch (https://github.com/libgeos/geos/issues/860) 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
