### PR TITLE
opencv: fix dnn_cuda being removed twice causing failure

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -156,12 +156,12 @@ class OpenCVConan(ConanFile):
             del self.options.contrib_freetype
             del self.options.contrib_sfm
         if not self.options.dnn:
-            del self.options.dnn_cuda
+            self.options.rm_safe("dnn_cuda")
         if not self.options.with_cuda:
             del self.options.with_cublas
             del self.options.with_cudnn
             del self.options.with_cufft
-            del self.options.dnn_cuda
+            self.options.rm_safe("dnn_cuda")
             del self.options.cuda_arch_bin
         if bool(self.options.with_jpeg):
             if self.options.get_safe("with_jpeg2000") == "jasper":


### PR DESCRIPTION
Specify library name and version:  **opencv/4.x**

OpenCV has two ways you can delete the `dnn_cuda` option, by setting `dnn=False` or `with_cuda=False`. If both are set this leads to a conflict and you get an error like the following. From what I understand using `rm_safe()` should fix this issue.
```
ERROR: opencv/4.5.5: Error in configure() method, line 164
        del self.options.dnn_cuda
        ConanException: option 'dnn_cuda' doesn't exist
Possible options are ['shared', 'fPIC', 'contrib', 'parallel', 'with_ipp', 'with_ade', 'with_jpeg', 'with_png', 'with_tiff', 'with_jpeg2000', 'with_openexr', 'with_eigen', 'with_webp', 'with_gtk', 'with_quirc', 'with_cuda', 'with_v4l', 'with_ffmpeg', 'with_imgcodec_hdr', 'with_imgcodec_pfm', 'with_imgcodec_pxm', 'with_imgcodec_sunraster', 'dnn', 'cuda_arch_bin', 'cpu_baseline', 'cpu_dispatch', 'nonfree']
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
