### PR TITLE
added platform.converters 0.2.0, 0.1.0 deprecated

### DIFF
--- a/recipes/platform.converters/all/conandata.yml
+++ b/recipes/platform.converters/all/conandata.yml
@@ -1,4 +1,5 @@
 sources:
-  "0.1.0":
-    url: https://github.com/linksplatform/Converters/archive/refs/tags/cpp_0.1.0.zip
-    sha256: a1a9e566b6628b1e09875f9ee93fb7fb600a8371d07e00a25c127e1609375d96
+  "0.2.0":
+    source:
+      url: "https://github.com/linksplatform/Converters/releases/download/cpp_0.2.0/platform.converters_0.2.0.zip"
+      sha256: "dccb042cfe36343ed8061d48fc0176da12590ba7328d908317211a902df81321"

--- a/recipes/platform.converters/all/conanfile.py
+++ b/recipes/platform.converters/all/conanfile.py
@@ -1,8 +1,12 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.52.0"
 
 
 class PlatformConvertersConan(ConanFile):
@@ -17,18 +21,15 @@ class PlatformConvertersConan(ConanFile):
     no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
     def _internal_cpp_subfolder(self):
-        return os.path.join(self._source_subfolder, "cpp", "Platform.Converters")
+        return os.path.join(self.source_folder, "cpp", "Platform.Converters")
 
     @property
     def _compilers_minimum_version(self):
         return {
             "gcc": "10",
             "Visual Studio": "16",
+            "msvc": "192",
             "clang": "14",
             "apple-clang": "14"
         }
@@ -37,29 +38,41 @@ class PlatformConvertersConan(ConanFile):
     def _minimum_cpp_standard(self):
         return 20
 
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
     def validate(self):
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
 
         if not minimum_version:
-            self.output.warn("{} recipe lacks information about the {} compiler support.".format(
-                self.name, self.settings.compiler))
+            self.output.warn(f"{self.name} recipe lacks information about the {self.settings.compiler} compiler support.")
 
-        elif tools.Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration("{}/{} requires c++{}, "
-                                            "which is not supported by {} {}.".format(
-                self.name, self.version, self._minimum_cpp_standard, self.settings.compiler,
-                self.settings.compiler.version))
+        elif Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires c++{self._minimum_cpp_standard}, "
+                                            f"which is not supported by {self.settings.compiler} {self.settings.compiler.version}.")
 
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, self._minimum_cpp_standard)
-
-    def package_id(self):
-        self.info.header_only()
+            check_min_cppstd(self, self._minimum_cpp_standard)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version]["source"], strip_root=True)
 
     def package(self):
-        self.copy("*.h", dst="include", src=self._internal_cpp_subfolder)
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        copy(
+                self,
+                pattern="*.h",
+                dst=os.path.join(self.package_folder, "include"),
+                src=self.source_folder,
+            )
+        copy(self, pattern="LICENSE", dst="licenses", src=self.source_folder)
+    def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "Platform.Converters")
+        self.cpp_info.set_property("cmake_target_name", "Platform.Converters::Platform.Converters")
+        self.cpp_info.set_property("cmake_file_name", "Platform.Converters")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.names["cmake_find_package"] = "Platform.Converters"
+        self.cpp_info.names["cmake_find_package_multi"] = "Platform.Converters"

--- a/recipes/platform.converters/all/test_package/CMakeLists.txt
+++ b/recipes/platform.converters/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(platform.converters CONFIG REQUIRED)
+find_package(Platform.Converters CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} platform.converters::platform.converters)
+target_link_libraries(${PROJECT_NAME} PRIVATE Platform.Converters::Platform.Converters)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)

--- a/recipes/platform.converters/all/test_package/conanfile.py
+++ b/recipes/platform.converters/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
-
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/platform.converters/config.yml
+++ b/recipes/platform.converters/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.0":
+  "0.2.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **platform.converters/0.2.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
