### PR TITLE
[package] dxc/1.7.2212.1 (NEW)

### DIFF
--- a/recipes/dxc/all/conandata.yml
+++ b/recipes/dxc/all/conandata.yml
@@ -1,10 +1,10 @@
 source:
   "1.7.2212.1":
     "Windows":
-    - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/dxc_2023_03_01.zip"
-      sha256: "e4e8cb7326ff7e8a791acda6dfb0cb78cc96309098bfdb0ab1e465dc29162422"
-      strip_root: false
+      - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/dxc_2023_03_01.zip"
+        sha256: "e4e8cb7326ff7e8a791acda6dfb0cb78cc96309098bfdb0ab1e465dc29162422"
+        strip_root: false
     "Linux":
-    - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/linux_dxc_2023_03_01.x86_64.tar.gz"
-      sha256: "5d7560a8cf06dfc701b573a2effa5f3ffe4f5d4099a1951e81bbc60403952c28"
-      strip_root: false
+      - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/linux_dxc_2023_03_01.x86_64.tar.gz"
+        sha256: "5d7560a8cf06dfc701b573a2effa5f3ffe4f5d4099a1951e81bbc60403952c28"
+        strip_root: false

--- a/recipes/dxc/all/conandata.yml
+++ b/recipes/dxc/all/conandata.yml
@@ -1,0 +1,10 @@
+source:
+  "1.7.2212.1":
+    "Windows":
+    - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/dxc_2023_03_01.zip"
+      sha256: "e4e8cb7326ff7e8a791acda6dfb0cb78cc96309098bfdb0ab1e465dc29162422"
+      strip_root: false
+    "Linux":
+    - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/linux_dxc_2023_03_01.x86_64.tar.gz"
+      sha256: "5d7560a8cf06dfc701b573a2effa5f3ffe4f5d4099a1951e81bbc60403952c28"
+      strip_root: false

--- a/recipes/dxc/all/conandata.yml
+++ b/recipes/dxc/all/conandata.yml
@@ -3,8 +3,6 @@ sources:
     "Windows":
       - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/dxc_2023_03_01.zip"
         sha256: "e4e8cb7326ff7e8a791acda6dfb0cb78cc96309098bfdb0ab1e465dc29162422"
-        strip_root: false
     "Linux":
       - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/linux_dxc_2023_03_01.x86_64.tar.gz"
         sha256: "5d7560a8cf06dfc701b573a2effa5f3ffe4f5d4099a1951e81bbc60403952c28"
-        strip_root: false

--- a/recipes/dxc/all/conandata.yml
+++ b/recipes/dxc/all/conandata.yml
@@ -1,4 +1,4 @@
-source:
+sources:
   "1.7.2212.1":
     "Windows":
       - url: "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.7.2212.1/dxc_2023_03_01.zip"

--- a/recipes/dxc/all/conanfile.py
+++ b/recipes/dxc/all/conanfile.py
@@ -1,0 +1,51 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import get, copy
+
+import os.path
+
+class DXCRecipe(ConanFile):
+    name = "dxc"
+    version = "1.7.2212.1"
+
+    license = "NCSA"
+    author = "Copyright (c) Microsoft Corporation. Copyright (c) 2003-2015 University of Illinois at Urbana-Champaign."
+    url = "https://github.com/microsoft/DirectXShaderCompiler"
+    description = "DirectX Shader Compiler which is based on LLVM/Clang."
+    topics = ("dxc", "hlsl", "dxil", "shader-programs", "directx-shader-compiler")
+
+    settings = "os", "arch"
+    options = {}
+    default_options = {}
+
+    def validate(self):
+        if not str(self.settings.os) in ("Windows", "Linux"):
+            raise ConanInvalidConfiguration("DXC only works on Windows and Linux!")
+
+    def build(self):
+        get(self, **self.conan_data["source"][self.version][str(self.settings.os)][0])
+
+    def package(self):
+        arch = str(self.settings.arch).lower()
+        if arch == "x86_64":
+            arch = "x64"
+
+        if self.settings.os == "Windows":
+            copy(self, "*", os.path.join(self.build_folder, "inc"), os.path.join(self.package_folder, "include"))
+            copy(self, "*", os.path.join(self.build_folder, f"lib/{arch}"), os.path.join(self.package_folder, "lib"))
+            copy(self, "*", os.path.join(self.build_folder, f"bin/{arch}"), os.path.join(self.package_folder, "bin"))
+        else:
+            copy(self, "*", os.path.join(self.build_folder, "include"), os.path.join(self.package_folder, "include"))
+            copy(self, "*", os.path.join(self.build_folder, "lib"), os.path.join(self.package_folder, "lib"))
+            copy(self, "*", os.path.join(self.build_folder, "bin"), os.path.join(self.package_folder, "bin"))
+
+        copy(self, "LICENSE-*", self.build_folder, os.path.join(self.package_folder, "licenses"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["dxcompiler"]
+        self.cpp_info.libdirs = ["lib"]
+        self.cpp_info.includedirs = ["include"]
+        self.cpp_info.bindirs = ["bin"]
+
+        if self.settings.os == "Window":
+            self.cpp_info.defines = ["__DXC_TEST_WINDOWS"]

--- a/recipes/dxc/all/conanfile.py
+++ b/recipes/dxc/all/conanfile.py
@@ -11,7 +11,7 @@ class DXCRecipe(ConanFile):
     homepage = "https://github.com/microsoft/DirectXShaderCompiler"
     description = "DirectX Shader Compiler which is based on LLVM/Clang."
     topics = ("dxc", "hlsl", "dxil", "shader-programs", "directx-shader-compiler")
-    
+
     settings = "os", "arch", "compiler", "build_type"
     options = {}
     default_options = {}
@@ -45,5 +45,7 @@ class DXCRecipe(ConanFile):
         self.cpp_info.includedirs = ["include"]
         self.cpp_info.bindirs = ["bin"]
 
-        if self.settings.os == "Window":
+        if self.settings.os == "Windows":
             self.cpp_info.defines = ["__DXC_TEST_WINDOWS"]
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["m"]

--- a/recipes/dxc/all/conanfile.py
+++ b/recipes/dxc/all/conanfile.py
@@ -7,12 +7,12 @@ import os.path
 class DXCRecipe(ConanFile):
     name = "dxc"
     license = "NCSA"
-    author = "Copyright (c) Microsoft Corporation. Copyright (c) 2003-2015 University of Illinois at Urbana-Champaign."
-    url = "https://github.com/microsoft/DirectXShaderCompiler"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/microsoft/DirectXShaderCompiler"
     description = "DirectX Shader Compiler which is based on LLVM/Clang."
     topics = ("dxc", "hlsl", "dxil", "shader-programs", "directx-shader-compiler")
-
-    settings = "os", "arch"
+    
+    settings = "os", "arch", "compiler", "build_type"
     options = {}
     default_options = {}
 
@@ -21,7 +21,7 @@ class DXCRecipe(ConanFile):
             raise ConanInvalidConfiguration("DXC only works on Windows and Linux!")
 
     def build(self):
-        get(self, **self.conan_data["source"][self.version][str(self.settings.os)][0])
+        get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][0])
 
     def package(self):
         arch = str(self.settings.arch).lower()

--- a/recipes/dxc/all/conanfile.py
+++ b/recipes/dxc/all/conanfile.py
@@ -45,7 +45,5 @@ class DXCRecipe(ConanFile):
         self.cpp_info.includedirs = ["include"]
         self.cpp_info.bindirs = ["bin"]
 
-        if self.settings.os == "Windows":
-            self.cpp_info.defines = ["__DXC_TEST_WINDOWS"]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["m"]

--- a/recipes/dxc/all/conanfile.py
+++ b/recipes/dxc/all/conanfile.py
@@ -6,8 +6,6 @@ import os.path
 
 class DXCRecipe(ConanFile):
     name = "dxc"
-    version = "1.7.2212.1"
-
     license = "NCSA"
     author = "Copyright (c) Microsoft Corporation. Copyright (c) 2003-2015 University of Illinois at Urbana-Champaign."
     url = "https://github.com/microsoft/DirectXShaderCompiler"
@@ -19,7 +17,7 @@ class DXCRecipe(ConanFile):
     default_options = {}
 
     def validate(self):
-        if not str(self.settings.os) in ("Windows", "Linux"):
+        if str(self.settings.os) not in ("Windows", "Linux"):
             raise ConanInvalidConfiguration("DXC only works on Windows and Linux!")
 
     def build(self):

--- a/recipes/dxc/all/test_package/CMakeLists.txt
+++ b/recipes/dxc/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package C) # if the project is pure C
+# project(test_package CXX) # if the project uses c++
+
+find_package(package REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+# don't link to ${CONAN_LIBS} or CONAN_PKG::package
+target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
+# In case the target project need a specific C++ standard
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/dxc/all/test_package/CMakeLists.txt
+++ b/recipes/dxc/all/test_package/CMakeLists.txt
@@ -1,12 +1,10 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(test_package C) # if the project is pure C
-# project(test_package CXX) # if the project uses c++
-
-find_package(package REQUIRED CONFIG)
+project(test_package CXX) 
+find_package(dxc REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 # don't link to ${CONAN_LIBS} or CONAN_PKG::package
-target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
+target_link_libraries(${PROJECT_NAME} PRIVATE dxc::dxc)
 # In case the target project need a specific C++ standard
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/dxc/all/test_package/conanfile.py
+++ b/recipes/dxc/all/test_package/conanfile.py
@@ -1,0 +1,28 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+import os
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")
+            self.run("dxc --version")

--- a/recipes/dxc/all/test_package/conanfile.py
+++ b/recipes/dxc/all/test_package/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
 
 import os
 
@@ -15,6 +15,10 @@ class TestPackageConan(ConanFile):
 
     def layout(self):
         cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/dxc/all/test_package/conanfile.py
+++ b/recipes/dxc/all/test_package/conanfile.py
@@ -1,24 +1,20 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
+from conan.tools.cmake import cmake_layout, CMake
 
 import os
 
 # It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
     test_type = "explicit"
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def layout(self):
         cmake_layout(self)
-
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.generate()
 
     def build(self):
         cmake = CMake(self)
@@ -29,4 +25,3 @@ class TestPackageConan(ConanFile):
         if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")
-            self.run("dxc --version")

--- a/recipes/dxc/all/test_package/test_package.cpp
+++ b/recipes/dxc/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#ifdef __DXC_TEST_WINDOWS
+#include <Windows.h>
+#else
+#include <WinAdapter.h>
+#endif
+
+#include <dxcapi.h>
+
+int main() 
+{
+    // It is sufficient to check if the dxcapi.h compiled without issues on all targeted platforms
+    // We will still check integrity by running dcx
+    return 0;
+}

--- a/recipes/dxc/all/test_package/test_package.cpp
+++ b/recipes/dxc/all/test_package/test_package.cpp
@@ -1,4 +1,4 @@
-#ifdef __DXC_TEST_WINDOWS
+#ifdef _MSC_VER
 #include <Windows.h>
 #else
 #include <WinAdapter.h>

--- a/recipes/dxc/all/test_package/test_package.cpp
+++ b/recipes/dxc/all/test_package/test_package.cpp
@@ -8,7 +8,6 @@
 
 int main() 
 {
-    // It is sufficient to check if the dxcapi.h compiled without issues on all targeted platforms
-    // We will still check integrity by running dcx
+    // TODO: Implement a basic example
     return 0;
 }

--- a/recipes/dxc/config.yml
+++ b/recipes/dxc/config.yml
@@ -1,0 +1,4 @@
+versions:
+  # Newer versions at the top
+  "1.7.2212.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **dxc/1.7.2212.1**

**Adding DXC**

DXC is the DirectX Shader Compiler by Microsoft, based on LLVM/Clang. The package uses the prebuilt binaries provided by Microsoft via GitHub. DXC is used to compile HLSL source code into binary dxil shader byte code. The package works on Windows and Linux. It provides the `dxc` executable and all libraries and API's for C++ compiler interactions. The package is useful as a shader build tool and for compiler integration into other applications.

fixes #18930 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
