### PR TITLE
Fix: sha256 sum of data for dice-template-library v1.0.0

### DIFF
--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.0.0":
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.0.0.tar.gz"
-    sha256: "485505ad3f9fb033083e2952bd8b4e68f6b4f123746b20f4ec3af46f4ce66cfe"
+    sha256: "d0c75ec4861e2480dc7d6533125f9c2dfb3574fc2cffd15c66665b1cdfa66561"
   "0.3.0":
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v0.3.0.tar.gz"
     sha256: "2c02278f86c7b5fe1c684f5126f30529952a03784fa7c883cc4fd44965b3c33e"


### PR DESCRIPTION
Specify library name and version:  **dice-template-library/1.0.0**

For some reason the hash was wrong. Probably another hash algorithm was used to generate it. 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
