### PR TITLE
utfcpp: add utf8::cpp alias

### DIFF
--- a/recipes/utfcpp/all/conanfile.py
+++ b/recipes/utfcpp/all/conanfile.py
@@ -42,7 +42,7 @@ class UtfCppConan(ConanFile):
         )
 
     def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = "add_library(utf8::cpp ALIAS utf8cpp)"
+        content = ""
         for alias, aliased in targets.items():
             content += textwrap.dedent(f"""\
                 if(TARGET {aliased} AND NOT TARGET {alias})
@@ -50,6 +50,7 @@ class UtfCppConan(ConanFile):
                     set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
                 endif()
             """)
+        content += "add_library(utf8::cpp ALIAS utf8cpp)"
         save(self, module_file, content)
 
     @property

--- a/recipes/utfcpp/all/conanfile.py
+++ b/recipes/utfcpp/all/conanfile.py
@@ -38,7 +38,8 @@ class UtfCppConan(ConanFile):
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
-            {"utf8cpp": "utf8cpp::utf8cpp"},
+            {"utf8cpp":   "utf8cpp::utf8cpp",
+             "utf8::cpp": "utf8cpp::utf8cpp"},
         )
 
     def _create_cmake_module_alias_targets(self, module_file, targets):
@@ -50,7 +51,6 @@ class UtfCppConan(ConanFile):
                     set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
                 endif()
             """)
-        content += "add_library(utf8::cpp ALIAS utf8cpp)"
         save(self, module_file, content)
 
     @property

--- a/recipes/utfcpp/all/conanfile.py
+++ b/recipes/utfcpp/all/conanfile.py
@@ -42,7 +42,7 @@ class UtfCppConan(ConanFile):
         )
 
     def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
+        content = "add_library(utf8::cpp ALIAS utf8cpp)"
         for alias, aliased in targets.items():
             content += textwrap.dedent(f"""\
                 if(TARGET {aliased} AND NOT TARGET {alias})
@@ -59,12 +59,12 @@ class UtfCppConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "utf8cpp")
         self.cpp_info.set_property("cmake_target_name", "utf8cpp")
+        self.cpp_info.set_property("cmake_target_aliases", ["utf8::cpp"])
         self.cpp_info.includedirs.append(os.path.join("include", "utf8cpp"))
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.names["cmake_find_package"] = "utf8cpp"
-        self.cpp_info.names["cmake_find_package_multi"] = "utf8cpp"
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+        for generator in ["cmake_find_package", "cmake_find_package_multi"]:
+            self.cpp_info.names[generator] = "utf8cpp"
+            self.cpp_info.build_modules[generator] = [self._module_file_rel_path]

--- a/recipes/utfcpp/all/test_package/CMakeLists.txt
+++ b/recipes/utfcpp/all/test_package/CMakeLists.txt
@@ -5,4 +5,6 @@ find_package(utf8cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE utf8cpp)
+#check alias
+target_link_libraries(${PROJECT_NAME} PRIVATE utf8::cpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)


### PR DESCRIPTION
Specify library name and version:  **utfcpp/all**

Recipe was missing target alias utf8::cpp
https://github.com/nemtrif/utfcpp/blob/dbb2423248dd5b97acd4125a29bdfbf6b36cd7b1/utf8cppConfig.cmake.in#L6C1-L6C37
https://github.com/nemtrif/utfcpp/blob/dbb2423248dd5b97acd4125a29bdfbf6b36cd7b1/CMakeLists.txt#L19C1-L19C37

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
