### PR TITLE
harfbuzz: add version 8.1.1

### DIFF
--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.1.1":
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/8.1.1/harfbuzz-8.1.1.tar.xz"
+    sha256: "0305ad702e11906a5fc0c1ba11c270b7f64a8f5390d676aacfd71db129d6565f"
   "8.0.1":
     url: "https://github.com/harfbuzz/harfbuzz/releases/download/8.0.1/harfbuzz-8.0.1.tar.xz"
     sha256: "c1ce780acd385569f25b9a29603d1d5bc71e6940e55bfdd4f7266fad50e42620"

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.1.1":
+    folder: all
   "8.0.1":
     folder: all
   "8.0.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **harfbuzz/8.11**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
