### PR TITLE
[bimg] Fix imports for test package

### DIFF
--- a/recipes/bimg/all/test_package/conanfile.py
+++ b/recipes/bimg/all/test_package/conanfile.py
@@ -1,10 +1,8 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.layout import cmake_layout
-from conan.tools.cmake import CMake
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
-required_conan_version = ">=1.50.0"
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"


### PR DESCRIPTION
Specify library name and version:  **bimg/cci.20230114**

The `cmake_layout` should be imported from CMake, other otherwise will have python import error.

Required by #16134 

Continues #19026

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
