### PR TITLE
[libnice] Fix cmake_layout import error

### DIFF
--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -59,16 +59,16 @@ class LibniceConan(ConanFile):
                 "-o glib/*:shared=True with static runtime is not supported")
 
     def requirements(self):
-        self.requires("glib/2.77.0")
+        self.requires("glib/2.75.2")
         if self.options.crypto_library == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_gstreamer:
-            self.requires("gstreamer/1.22.3")
+            self.requires("gstreamer/1.19.2")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.0")
-        self.tool_requires("pkgconf/1.9.5")
-        self.tool_requires("glib/2.77.0")  # for glib-mkenums
+        self.tool_requires("meson/1.0.0")
+        self.tool_requires("pkgconf/1.9.3")
+        self.tool_requires("glib/2.75.2")  # for glib-mkenums
         if self.options.with_introspection:
             self.tool_requires("gobject-introspection/1.72.0")
 

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.files import copy, get, rmdir, rename, chdir, rm
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.microsoft import is_msvc_static_runtime
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.errors import ConanInvalidConfiguration
 
 
@@ -107,6 +108,7 @@ class LibniceConan(ConanFile):
             if not self.options.shared:
                 with chdir(self, os.path.join(self.package_folder, "lib")):
                     rename(self, "libnice.a", "nice.lib")
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.libs = ["nice"]

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -59,16 +59,16 @@ class LibniceConan(ConanFile):
                 "-o glib/*:shared=True with static runtime is not supported")
 
     def requirements(self):
-        self.requires("glib/2.75.2")
+        self.requires("glib/2.77.0")
         if self.options.crypto_library == "openssl":
-            self.requires("openssl/1.1.1t")
+            self.requires("openssl/[>=1.1 <4]")
         if self.options.with_gstreamer:
-            self.requires("gstreamer/1.19.2")
+            self.requires("gstreamer/1.22.3")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
-        self.tool_requires("pkgconf/1.9.3")
-        self.tool_requires("glib/2.75.2")  # for glib-mkenums
+        self.tool_requires("meson/1.2.0")
+        self.tool_requires("pkgconf/1.9.5")
+        self.tool_requires("glib/2.77.0")  # for glib-mkenums
         if self.options.with_introspection:
             self.tool_requires("gobject-introspection/1.72.0")
 

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -59,7 +59,7 @@ class LibniceConan(ConanFile):
                 "-o glib/*:shared=True with static runtime is not supported")
 
     def requirements(self):
-        self.requires("glib/2.77.0", transitive_headers=True)
+        self.requires("glib/2.77.0", transitive_headers=True, transitive_libs=True)
         if self.options.crypto_library == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_gstreamer:

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -59,16 +59,16 @@ class LibniceConan(ConanFile):
                 "-o glib/*:shared=True with static runtime is not supported")
 
     def requirements(self):
-        self.requires("glib/2.75.2")
+        self.requires("glib/2.77.0")
         if self.options.crypto_library == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_gstreamer:
-            self.requires("gstreamer/1.19.2")
+            self.requires("gstreamer/1.22.3")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
-        self.tool_requires("pkgconf/1.9.3")
-        self.tool_requires("glib/2.75.2")  # for glib-mkenums
+        self.tool_requires("meson/1.2.0")
+        self.tool_requires("pkgconf/1.9.5")
+        self.tool_requires("glib/2.77.0")  # for glib-mkenums
         if self.options.with_introspection:
             self.tool_requires("gobject-introspection/1.72.0")
 

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -59,7 +59,7 @@ class LibniceConan(ConanFile):
                 "-o glib/*:shared=True with static runtime is not supported")
 
     def requirements(self):
-        self.requires("glib/2.77.0")
+        self.requires("glib/2.77.0", transitive_headers=True)
         if self.options.crypto_library == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_gstreamer:

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -61,7 +61,7 @@ class LibniceConan(ConanFile):
                 "-o glib/*:shared=True with static runtime is not supported")
 
     def requirements(self):
-        self.requires("glib/2.77.1", transitive_headers=True, transitive_libs=True)
+        self.requires("glib/2.77.2", transitive_headers=True, transitive_libs=True)
         if self.options.crypto_library == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_gstreamer:

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -8,6 +8,7 @@ from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.60.0"
 
 class LibniceConan(ConanFile):
     name = "libnice"

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.60.0"
+required_conan_version = ">=1.60.0 <2 || >=2.0.6"
 
 class LibniceConan(ConanFile):
     name = "libnice"

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -69,7 +69,7 @@ class LibniceConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("meson/1.2.0")
         self.tool_requires("pkgconf/1.9.5")
-        self.tool_requires("glib/2.77.0")  # for glib-mkenums
+        self.tool_requires("glib/<host_version>")  # for glib-mkenums
         if self.options.with_introspection:
             self.tool_requires("gobject-introspection/1.72.0")
 

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -60,7 +60,7 @@ class LibniceConan(ConanFile):
                 "-o glib/*:shared=True with static runtime is not supported")
 
     def requirements(self):
-        self.requires("glib/2.77.0", transitive_headers=True, transitive_libs=True)
+        self.requires("glib/2.77.1", transitive_headers=True, transitive_libs=True)
         if self.options.crypto_library == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_gstreamer:

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -67,7 +67,7 @@ class LibniceConan(ConanFile):
             self.requires("gstreamer/1.22.3")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.0")
+        self.tool_requires("meson/1.2.1")
         self.tool_requires("pkgconf/1.9.5")
         self.tool_requires("glib/<host_version>")  # for glib-mkenums
         if self.options.with_introspection:

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -1,7 +1,6 @@
 import os
 from conan import ConanFile
-from conan.tools.cmake import CMake
-from conan.tools.layout import cmake_layout
+from conan.tools.cmake import CMake, cmake_layout
 from conan.tools.build import can_run
 
 

--- a/recipes/libnice/all/test_v1_package/conanfile.py
+++ b/recipes/libnice/all/test_v1_package/conanfile.py
@@ -1,7 +1,5 @@
 import os
-from conan import ConanFile
-from conans import CMake
-from conan.tools.build import can_run
+from conans import ConanFile, CMake, tools
 
 
 class LibniceTestConan(ConanFile):
@@ -14,6 +12,6 @@ class LibniceTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if can_run(self):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **libnice/0.1.21**

- The `cmake_layout` should be imported from `cmake`, not from `layout` otherwise will have a python import error
- Bump dependencies version
- Update test_v1_package to use only Conan legacy imports
- The header `nice/agent.h` exposes `glib-object.h` header, so we need transitive_headers
- Needs transitive libs due `ld: CMakeFiles/example.dir/src/example.c.o: undefined reference to symbol 'g_object_unref'`


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
