### PR TITLE
[yaclib] Fix import for cmake_layout

### DIFF
--- a/recipes/yaclib/all/conanfile.py
+++ b/recipes/yaclib/all/conanfile.py
@@ -1,9 +1,7 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake, CMakeToolchain
-from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, export_conandata_patches, apply_conandata_patches, save
-from conan.tools.layout import cmake_layout
 from conan.errors import ConanInvalidConfiguration
 import os
 import textwrap

--- a/recipes/yaclib/all/test_v1_package/conanfile.py
+++ b/recipes/yaclib/all/test_v1_package/conanfile.py
@@ -1,5 +1,4 @@
-from conans import ConanFile, CMake
-from conan.tools.build import cross_building
+from conans import ConanFile, CMake, tools
 import os
 
 class TestPackageV1Conan(ConanFile):
@@ -12,6 +11,6 @@ class TestPackageV1Conan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **yaclib/2022.12.20**

- Import `cmake_layout` from `cmake`, otherwise will raise a python import error
- Remove `Version` import as it's unused
- Use only legacy imports for test_v1_package


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
