### PR TITLE
[docs] Add changelog 2023-Aug-04

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 04-Aug-2023 - 10:26 CEST
+
+- [feature] Enable Conan 2.0.8
+- [feature] Enable Conan 1.60.2
+- [feature] Update Jenkins server version
+- [hotfix] Better error management when having CI build timeout
+
 ### 19-Jul-2023 - 09:45 CEST
 
 - [fix] Fix message processing if no message is passed.


### PR DESCRIPTION
- ConanCenterIndex CI is now running Conan 2.0.9 (latest) and 1.60.2
- Jenkins server used to build packages is now running in a newer version
- When a build take many hours, now internal logs and treatment is better filtered.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
