### PR TITLE
fast-dds: add version 2.11.1

### DIFF
--- a/recipes/fast-dds/all/conandata.yml
+++ b/recipes/fast-dds/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.11.1":
+    url: "https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.11.1.tar.gz"
+    sha256: "3fe8b9f67a13a5d2aa40c0bd10581bd90f0a192b39c71f92ee233ffe584d3374"
   "2.10.1":
     url: "https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.10.1.tar.gz"
     sha256: "2cc2682db5dc7e87684b7f23166e2f32faf8d5c4b4a8c94c6c21211a8a38f553"
@@ -12,6 +15,10 @@ sources:
     url: "https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.3.2.tar.gz"
     sha256: "4d8183cf4d37c3de9e6fd28d2850dd08023a9079001c4880b23c95f0d8c0b5ce"
 patches:
+  "2.11.1":
+    - patch_file: "patches/2.11.1-0001-fix-find-asio-and-tinyxml2.patch"
+      patch_type: "conan"
+      patch_description: "Fixup find asio and tinyxml2"
   "2.10.1":
     - patch_file: "patches/2.10.1-0001-fix-find-asio-and-tinyxml2.patch"
       patch_type: "conan"

--- a/recipes/fast-dds/all/patches/2.11.1-0001-fix-find-asio-and-tinyxml2.patch
+++ b/recipes/fast-dds/all/patches/2.11.1-0001-fix-find-asio-and-tinyxml2.patch
@@ -1,0 +1,31 @@
+From b8c533b0fb2b92e9bd2aada5e195d7a0b3c0c6a9 Mon Sep 17 00:00:00 2001
+From: Joakim Haugen <joakim.haugen@sintef.no>
+Date: Wed, 10 May 2023 13:17:11 +0200
+Subject: [PATCH] fix find asio and tinyxml2
+
+---
+ CMakeLists.txt | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b01b2c470..7867feff3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -232,9 +232,11 @@ if(NOT BUILD_SHARED_LIBS)
+     set(FASTDDS_STATIC ON)
+ endif()
+ 
+-eprosima_find_package(fastcdr REQUIRED)
+-eprosima_find_thirdparty(Asio asio VERSION 1.10.8)
+-eprosima_find_thirdparty(TinyXML2 tinyxml2)
++eprosima_find_thirdparty(fastcdr REQUIRED)
++eprosima_find_thirdparty(asio REQUIRED)
++eprosima_find_thirdparty(tinyxml2 REQUIRED)
++set(TINYXML2_LIBRARY tinyxml2::tinyxml2)
++set(Asio_INCLUDE_DIR ${asio_INCLUDE_DIR})
+ 
+ find_package(foonathan_memory REQUIRED)
+ message(STATUS "Found foonathan_memory: ${foonathan_memory_DIR}")
+-- 
+2.30.2
+

--- a/recipes/fast-dds/config.yml
+++ b/recipes/fast-dds/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.11.1":
+    folder: all
   "2.10.1":
     folder: all
   "2.3.4":


### PR DESCRIPTION
Specify library name and version:  **fast-dds/2.11.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Add latest version, previous version did not build in GCC 13.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
