### PR TITLE
fast-cdr: add version 1.1.0

### DIFF
--- a/recipes/fast-cdr/all/conandata.yml
+++ b/recipes/fast-cdr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/eProsima/Fast-CDR/archive/v1.1.0.tar.gz"
+    sha256: "5c4b2ad5493abd30b9475b14856641a8944c98077a36bd0760c1d83c65216e67"
   "1.0.27":
     url: "https://github.com/eProsima/Fast-CDR/archive/v1.0.27.tar.gz"
     sha256: "a9bc8fd31a2c2b95e6d2fb46e6ce1ad733e86dc4442f733479e33ed9cdc54bf6"

--- a/recipes/fast-cdr/all/conanfile.py
+++ b/recipes/fast-cdr/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import collect_libs, copy, get, rm, rmdir, save
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 import os
 import textwrap
 
@@ -39,6 +40,10 @@ class FastCDRConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+
+    def build_requirements(self):
+        if Version(self.version) >= "1.1.0":
+            self.tool_requires("cmake/[>=3.16.3 <4]")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/fast-cdr/config.yml
+++ b/recipes/fast-cdr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.27":
     folder: all
   "1.0.26":


### PR DESCRIPTION
Specify library name and version:  **fast-cdr/1.1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

New version, closes #19012. Needs newer CMake version than installed in Linux build image.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
