### PR TITLE
zookeeper-client-c: use stable url for tarball of source code

### DIFF
--- a/recipes/zookeeper-client-c/all/conandata.yml
+++ b/recipes/zookeeper-client-c/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "3.8.1":
-    url: "https://dlcdn.apache.org/zookeeper/zookeeper-3.8.1/apache-zookeeper-3.8.1.tar.gz"
+    url: "https://archive.apache.org/dist/zookeeper/zookeeper-3.8.1/apache-zookeeper-3.8.1.tar.gz"
     sha256: "ccc16850c8ab2553583583234d11c813061b5ea5f3b8ff1d740cde6c1fd1e219"
 patches:
   "3.8.1":


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/19098

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
