### PR TITLE
meson: add version 1.2.1

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.1":
+    url: "https://github.com/mesonbuild/meson/releases/download/1.2.1/meson-1.2.1.tar.gz"
+    sha256: "b1db3a153087549497ee52b1c938d2134e0338214fe14f7efd16fecd57b639f5"
   "1.2.0":
     url: "https://github.com/mesonbuild/meson/archive/1.2.0.tar.gz"
     sha256: "603489f0aaa6305f806c6cc4a4455a965f22290fc74f65871f589b002110c790"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.1":
+    folder: all
   "1.2.0":
     folder: all
   "1.1.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/1.2.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
