### PR TITLE
fontconfig: minimal change to ensure most recent rrev

### DIFF
--- a/recipes/fontconfig/meson/conanfile.py
+++ b/recipes/fontconfig/meson/conanfile.py
@@ -95,7 +95,7 @@ class FontconfigConan(ConanFile):
         copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
         meson = Meson(self)
         meson.install()
-        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
         rm(self, "*.conf", os.path.join(self.package_folder, "bin", "etc", "fonts", "conf.d"))
         rm(self, "*.def", os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))


### PR DESCRIPTION
The recent changes in `fontconfig` w.r.t to the libuuid dependency were introduced and then subsequently reversed - causing an interesting case where the recipe revision for the most recent commit still has the "earlier" timestamp for the same changes.

This PR touches the recipe minimally to ensure that a new recipe revision with a fresh timestamp is published.
