### PR TITLE
cuda-samples: add new package

### DIFF
--- a/recipes/cuda-samples/all/conandata.yml
+++ b/recipes/cuda-samples/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "12.2":
+    url: "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v12.2.tar.gz"
+    sha256: "c9fbdee420fd4567edb1239420e2a5c93d9652b4ccf3a828fcb3e0de3152e466"
+  "11.8":
+    url: "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v11.8.tar.gz"
+    sha256: "1bc02c0ca42a323f3c7a05b5682eae703681a91e95b135bfe81f848b2d6a2c51"
+  "10.2":
+    url: "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v10.2.tar.gz"
+    sha256: "f3d224dcc7028d055617360b481947c27346d87dd1ccfbdd134ab24648c084e8"

--- a/recipes/cuda-samples/all/conanfile.py
+++ b/recipes/cuda-samples/all/conanfile.py
@@ -1,0 +1,51 @@
+import os
+
+from conan import ConanFile
+from conan.tools.files import copy, get, rmdir
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
+
+
+class CudaSamplesConan(ConanFile):
+    name = "cuda-samples"
+    description = ("Common headers from NVIDIA CUDA Samples - "
+                   "samples for CUDA developers which demonstrate features in CUDA Toolkit")
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/NVIDIA/cuda-samples"
+    topics = ("cuda", "cuda-kernels", "cuda-driver-api", "cuda-opengl", "nvcudasamples")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # Package only headers under Common/ folder
+        rmdir(self, os.path.join(self.source_folder, "Samples"))
+        rmdir(self, os.path.join(self.source_folder, "bin"))
+        # Skip GL headers and precompiled libs, since these should be provided by separate Conan packages
+        rmdir(self, os.path.join(self.source_folder, "Common", "GL"))
+        rmdir(self, os.path.join(self.source_folder, "Common", "lib"))
+        rmdir(self, os.path.join(self.source_folder, "Common", "data"))
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "*",
+             dst=os.path.join(self.package_folder, "include", "Common"),
+             src=os.path.join(self.source_folder, "Common"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.includedirs.append(os.path.join("include", "Common"))

--- a/recipes/cuda-samples/all/test_package/CMakeLists.txt
+++ b/recipes/cuda-samples/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(cuda-samples REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE cuda-samples::cuda-samples)

--- a/recipes/cuda-samples/all/test_package/conanfile.py
+++ b/recipes/cuda-samples/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cuda-samples/all/test_package/test_package.cpp
+++ b/recipes/cuda-samples/all/test_package/test_package.cpp
@@ -1,0 +1,16 @@
+#include <cstdlib>
+#include <iostream>
+#include <cmath>
+
+#include "nvVector.h"
+#include "nvMatrix.h"
+#include "nvQuaternion.h"
+
+
+int main() {
+    auto q = normalize(nv::quaternion<float>(0, 0, 0, 4));
+
+    std::cout << "Normalized nv::quaternion(): " << q[0] << ", " << q[1] << ", " << q[2] << ", " << q[3] << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/cuda-samples/all/test_package/test_package.cpp
+++ b/recipes/cuda-samples/all/test_package/test_package.cpp
@@ -1,16 +1,16 @@
 #include <cstdlib>
 #include <iostream>
-#include <cmath>
 
-#include "nvVector.h"
-#include "nvMatrix.h"
-#include "nvQuaternion.h"
+// One of the few non-CUDA-specific headers in the CUDA Samples.
+#include "helper_string.h"
 
 
 int main() {
-    auto q = normalize(nv::quaternion<float>(0, 0, 0, 4));
+    char file[] = "hello_world.jpg";
+    char *ext = NULL;
+    getFileExtension(file, &ext);
 
-    std::cout << "Normalized nv::quaternion(): " << q[0] << ", " << q[1] << ", " << q[2] << ", " << q[3] << std::endl;
+    std::cout << "getFileExtension(\"" << file << "\") returned \"" << ext << "\"." << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/recipes/cuda-samples/config.yml
+++ b/recipes/cuda-samples/config.yml
@@ -1,0 +1,7 @@
+versions:
+  "12.2":
+    folder: all
+  "11.8":
+    folder: all
+  "10.2":
+    folder: all


### PR DESCRIPTION
Adds `cuda-samples`: https://github.com/NVIDIA/cuda-samples

Only packages the header files under the `Common/` directory.

These are used by `libfreenect2` when CUDA is enabled, for example (see the [recent PR](https://github.com/conan-io/conan-center-index/pull/18834/files#diff-cb2819ba0ebbd5d06929b0bb8497ce9293f83af7c4532c2896f15cdffb629d46R93-R94)).

I'm not too happy about the size of the "sources" being downloaded vs what actually ends up packaged - 144 MB for just a small subset of the header files. I'm not aware of a good way to fetch a subset of a GitHub repo, though. I even gave downloading the files via a REST API a shot, but it was not much faster and was prone to failure due to rate limits.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
