### PR TITLE
daw_header_libraries: add version 2.95.0, remove older versions

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.95.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.95.0.tar.gz"
+    sha256: "8799c06f0587b202fd6049d95e70b04675acbfdbf6e86ac3bbd061cbb9d42b54"
   "2.93.1":
     url: "https://github.com/beached/header_libraries/archive/v2.93.1.tar.gz"
     sha256: "200690094237e4a2c37ac81c23c8c5138ba90ccdeeb2a1dda37690a9d32301ad"
@@ -23,18 +26,3 @@ sources:
   "2.74.2":
     url: "https://github.com/beached/header_libraries/archive/v2.74.2.tar.gz"
     sha256: "32871df3d314cc9b4e293a9a8c79968d1c963dfd3dd60965dbf704eb18acb218"
-  "2.73.1":
-    url: "https://github.com/beached/header_libraries/archive/v2.73.1.tar.gz"
-    sha256: "62bd26398afa7eba1aae7bbbf107865044b8be0539d266085c36aed82557ae07"
-  "2.72.0":
-    url: "https://github.com/beached/header_libraries/archive/v2.72.0.tar.gz"
-    sha256: "f681755183af4af35f4741f3bcb7d99c6707911806e39e3acc982f9532aacc08"
-  "2.71.0":
-    url: "https://github.com/beached/header_libraries/archive/v2.71.0.tar.gz"
-    sha256: "50b9ddebdbc808a5714408a45f686fafe9d1d3b78c988df3973c12c9928828b9"
-  "2.68.3":
-    url: "https://github.com/beached/header_libraries/archive/v2.68.3.tar.gz"
-    sha256: "9bb7d25d161b89ad4a0ac857c28734c061cf53f6e80212c7fe70b8e0fd14789f"
-  "1.29.7":
-    url: "https://github.com/beached/header_libraries/archive/refs/tags/v1.29.7.tar.gz"
-    sha256: "524c34f3f5d2af498e7bcaff7802b914ba42acde29f7e3ecce41a035db0bf5bd"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.95.0":
+    folder: all
   "2.93.1":
     folder: all
   "2.92.0":
@@ -14,14 +16,4 @@ versions:
   "2.76.2":
     folder: all
   "2.74.2":
-    folder: all
-  "2.73.1":
-    folder: all
-  "2.72.0":
-    folder: all
-  "2.71.0":
-    folder: all
-  "2.68.3":
-    folder: all
-  "1.29.7":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **daw_header_libraries/***

daw_header_libraries is required by daw_utf_range and daw_json_link.
Both of them require latest version only.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
