### PR TITLE
capnproto: add version 1.0.0

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -25,27 +25,68 @@ sources:
     sha256: "76c7114a3d142ad08b7208b3964a26e72a6320ee81331d3f0b87569fc9c47a28"
 patches:
   "1.0.0":
-    - patch_file: patches/0015-disable-tests-for-1.0.0.patch
+    - patch_file: "patches/0015-disable-tests-for-1.0.0.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"
   "0.10.4":
-    - patch_file: patches/0014-disable-tests-for-0.10.1.patch
+    - patch_file: "patches/0014-disable-tests-for-0.10.1.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"
   "0.10.3":
-    - patch_file: patches/0014-disable-tests-for-0.10.1.patch
+    - patch_file: "patches/0014-disable-tests-for-0.10.1.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"
   "0.10.1":
-    - patch_file: patches/0014-disable-tests-for-0.10.1.patch
+    - patch_file: "patches/0014-disable-tests-for-0.10.1.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"
   "0.10.0":
-    - patch_file: patches/0013-disable-tests-for-0.10.0.patch
+    - patch_file: "patches/0013-disable-tests-for-0.10.0.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"
   "0.9.1":
-    - patch_file: patches/0010-disable-tests-for-0.9.1.patch
-    - patch_file: patches/0011-msvc-cpp17-hassubstring-fix-0.9.1.patch
-    - patch_file: patches/0012-msvc-nogdi-fix-0.9.1.patch
+    - patch_file: "patches/0010-disable-tests-for-0.9.1.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"
+    - patch_file: "patches/0011-msvc-cpp17-hassubstring-fix-0.9.1.patch"
+      patch_description: "fix compilation errors on Windows Clang"
+      patch_type: "portability"
+      patch_source: "https://github.com/capnproto/capnproto/pull/1344"
+    - patch_file: "patches/0012-msvc-nogdi-fix-0.9.1.patch"
+      patch_description: "fix compilation error on Windows"
+      patch_type: "portability"
+      patch_source: "https://github.com/capnproto/capnproto/issues/1421"
   "0.8.0":
-    - patch_file: patches/0001-disable-tests.patch
-    - patch_file: patches/0002-cmake-compat-header-install.patch
-    - patch_file: patches/0003-kj-tls-windows.patch
-    - patch_file: patches/0004-cmake-module-path.patch
-    - patch_file: patches/0005-msvc-16.7-ice-workaround.patch
-    - patch_file: patches/0009-windows-symlink-fix-0.8.0.patch
+    - patch_file: "patches/0001-disable-tests.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"
+    - patch_file: "patches/0002-cmake-compat-header-install.patch"
+      patch_description: "fix compilation error for std::copy with list types"
+      patch_type: "portability"
+      patch_source: "https://github.com/capnproto/capnproto/pull/895"
+    - patch_file: "patches/0003-kj-tls-windows.patch"
+      patch_description: "add kj-tls target"
+      patch_type: "portability"
+      patch_source: "https://github.com/capnproto/capnproto/commit/7da6abf233fdf74a4ad4db56b6e98778b162dd7d"
+    - patch_file: "patches/0004-cmake-module-path.patch"
+      patch_description: "append cmake module path instead set"
+      patch_type: "conan"
+    - patch_file: "patches/0005-msvc-16.7-ice-workaround.patch"
+      patch_description: "Workaround for internal compiler error with msvc 16.7.x"
+      patch_type: "portability"
+      patch_source: "https://github.com/capnproto/capnproto/pull/1058"
+    - patch_file: "patches/0009-windows-symlink-fix-0.8.0.patch"
+      patch_description: "orkaround for install step on Windows where symlinks might be not supported."
+      patch_type: "portability"
+      patch_source: "https://github.com/capnproto/capnproto/pull/1240"
   "0.7.0":
-    - patch_file: patches/0006-symlink.patch
-    - patch_file: patches/0007-cmake-module-path.patch
-    - patch_file: patches/0008-disable-tests.patch
+    - patch_file: "patches/0006-symlink.patch"
+      patch_description: "Fix capnpc extension handling on Windows"
+      patch_type: "portability"
+      patch_source: "https://github.com/capnproto/capnproto/pull/804"
+    - patch_file: "patches/0007-cmake-module-path.patch"
+      patch_description: "append cmake module path instead set"
+      patch_type: "conan"
+    - patch_file: "patches/0008-disable-tests.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"

--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/capnproto/capnproto/archive/v1.0.0.tar.gz"
+    sha256: "bcd44dde78055313a7786cb6ab020cbef19b9045b53857f90cce101c9453f715"
   "0.10.4":
     url: "https://github.com/capnproto/capnproto/archive/v0.10.4.tar.gz"
     sha256: "c6f25940688c87ddb24e0c4e475c3213d9b044aad2ba305439cc8c224f559da6"
@@ -19,8 +22,10 @@ sources:
     sha256: "6d8b43a7ec2a764b4dfe4139a7cdd070ad9057f106898050d9f4db3754b98820"
   "0.7.0":
     url: "https://github.com/capnproto/capnproto/archive/v0.7.0.tar.gz"
-    sha256: 76c7114a3d142ad08b7208b3964a26e72a6320ee81331d3f0b87569fc9c47a28
+    sha256: "76c7114a3d142ad08b7208b3964a26e72a6320ee81331d3f0b87569fc9c47a28"
 patches:
+  "1.0.0":
+    - patch_file: patches/0015-disable-tests-for-1.0.0.patch
   "0.10.4":
     - patch_file: patches/0014-disable-tests-for-0.10.1.patch
   "0.10.3":

--- a/recipes/capnproto/all/conanfile.py
+++ b/recipes/capnproto/all/conanfile.py
@@ -218,9 +218,9 @@ class CapnprotoConan(ConanFile):
             self._register_component(component)
 
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["capnpc"].system_libs = ["pthread"]
-            self.cpp_info.components["kj"].system_libs = ["pthread"]
-            self.cpp_info.components["kj-async"].system_libs = ["pthread"]
+            self.cpp_info.components["capnpc"].system_libs = ["pthread", "m"]
+            self.cpp_info.components["kj"].system_libs = ["pthread", "m"]
+            self.cpp_info.components["kj-async"].system_libs = ["pthread", "m"]
         elif self.settings.os == "Windows":
             self.cpp_info.components["kj-async"].system_libs = ["ws2_32"]
 

--- a/recipes/capnproto/all/conanfile.py
+++ b/recipes/capnproto/all/conanfile.py
@@ -93,6 +93,10 @@ class CapnprotoConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support shared libraries for Visual Studio")
         if self.settings.os == "Windows" and Version(self.version) < "0.8.0" and self.options.with_openssl:
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support OpenSSL on Windows pre 0.8.0")
+        # MSVC Release build is not supported in 1.0.0
+        # https://github.com/capnproto/capnproto/issues/1740
+        if Version(self.version) == "1.0.0" and is_msvc(self) and self.settings.build_type == "Release":
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support MSVC Release build")
 
     def build_requirements(self):
         if self.settings.os != "Windows":

--- a/recipes/capnproto/all/conanfile.py
+++ b/recipes/capnproto/all/conanfile.py
@@ -47,7 +47,7 @@ class CapnprotoConan(ConanFile):
         return {
             "Visual Studio": "15",
             "msvc": "191",
-            "gcc": "5",
+            "gcc": "5" if Version(self.version) < "1.0.0" else "7",
             "clang": "5",
             "apple-clang": "5.1",
         }

--- a/recipes/capnproto/all/patches/0015-disable-tests-for-1.0.0.patch
+++ b/recipes/capnproto/all/patches/0015-disable-tests-for-1.0.0.patch
@@ -1,0 +1,176 @@
+diff --git a/c++/Makefile.am b/c++/Makefile.am
+index 1567491..95ebc4a 100644
+--- a/c++/Makefile.am
++++ b/c++/Makefile.am
+@@ -457,171 +457,4 @@ endif LITE_MODE
+ #  src/capnp/benchmark/...
+ #  src/capnp/compiler/...
+ 
+-# Tests ==============================================================
+-
+-test_capnpc_inputs =                                           \
+-  src/capnp/test.capnp                                         \
+-  src/capnp/test-import.capnp                                  \
+-  src/capnp/test-import2.capnp                                 \
+-  src/capnp/compat/json-test.capnp
+-
+-test_capnpc_outputs =                                          \
+-  src/capnp/test.capnp.c++                                     \
+-  src/capnp/test.capnp.h                                       \
+-  src/capnp/test-import.capnp.c++                              \
+-  src/capnp/test-import.capnp.h                                \
+-  src/capnp/test-import2.capnp.c++                             \
+-  src/capnp/test-import2.capnp.h                               \
+-  src/capnp/compat/json-test.capnp.c++                         \
+-  src/capnp/compat/json-test.capnp.h
+-
+-if USE_EXTERNAL_CAPNP
+-
+-test_capnpc_middleman: $(test_capnpc_inputs)
+-	@$(MKDIR_P) src
+-	$(CAPNP) compile --src-prefix=$(srcdir)/src -o$(CAPNPC_CXX):src -I$(srcdir)/src $$(for FILE in $(test_capnpc_inputs); do echo $(srcdir)/$$FILE; done)
+-	touch test_capnpc_middleman
+ 
+-else
+-
+-test_capnpc_middleman: capnp$(EXEEXT) capnpc-c++$(EXEEXT) $(test_capnpc_inputs)
+-	@$(MKDIR_P) src
+-	./capnp$(EXEEXT) compile --src-prefix=$(srcdir)/src -o./capnpc-c++$(EXEEXT):src -I$(srcdir)/src $$(for FILE in $(test_capnpc_inputs); do echo $(srcdir)/$$FILE; done)
+-	touch test_capnpc_middleman
+-
+-endif
+-
+-$(test_capnpc_outputs): test_capnpc_middleman
+-
+-BUILT_SOURCES = $(test_capnpc_outputs)
+-
+-check_LIBRARIES = libcapnp-test.a
+-libcapnp_test_a_SOURCES =                                      \
+-  src/capnp/test-util.c++                                      \
+-  src/capnp/test-util.h
+-nodist_libcapnp_test_a_SOURCES = $(test_capnpc_outputs)
+-
+-if LITE_MODE
+-
+-check_PROGRAMS = capnp-test
+-compiler_tests =
+-capnp_test_LDADD = libcapnp-test.a libcapnp.la libkj-test.la libkj.la
+-
+-else !LITE_MODE
+-
+-check_PROGRAMS = capnp-test capnp-evolution-test capnp-afl-testcase
+-if HAS_FUZZING_ENGINE
+-    check_PROGRAMS += capnp-llvm-fuzzer-testcase
+-endif
+-heavy_tests =                                                  \
+-  src/kj/async-test.c++                                        \
+-  src/kj/async-xthread-test.c++                                \
+-  src/kj/async-coroutine-test.c++                              \
+-  src/kj/async-unix-test.c++                                   \
+-  src/kj/async-unix-xthread-test.c++                           \
+-  src/kj/async-win32-test.c++                                  \
+-  src/kj/async-win32-xthread-test.c++                          \
+-  src/kj/async-io-test.c++                                     \
+-  src/kj/async-queue-test.c++                                  \
+-  src/kj/parse/common-test.c++                                 \
+-  src/kj/parse/char-test.c++                                   \
+-  src/kj/std/iostream-test.c++                                 \
+-  src/kj/compat/url-test.c++                                   \
+-  src/kj/compat/http-test.c++                                  \
+-  $(MAYBE_KJ_GZIP_TESTS)                                       \
+-  $(MAYBE_KJ_TLS_TESTS)                                        \
+-  src/capnp/canonicalize-test.c++                              \
+-  src/capnp/capability-test.c++                                \
+-  src/capnp/membrane-test.c++                                  \
+-  src/capnp/schema-test.c++                                    \
+-  src/capnp/schema-loader-test.c++                             \
+-  src/capnp/schema-parser-test.c++                             \
+-  src/capnp/dynamic-test.c++                                   \
+-  src/capnp/stringify-test.c++                                 \
+-  src/capnp/serialize-async-test.c++                           \
+-  src/capnp/serialize-text-test.c++                            \
+-  src/capnp/rpc-test.c++                                       \
+-  src/capnp/rpc-twoparty-test.c++                              \
+-  src/capnp/ez-rpc-test.c++                                    \
+-  src/capnp/compat/json-test.c++                               \
+-  src/capnp/compat/websocket-rpc-test.c++                      \
+-  src/capnp/compiler/lexer-test.c++                            \
+-  src/capnp/compiler/type-id-test.c++
+-capnp_test_LDADD =                                             \
+-  libcapnp-test.a                                              \
+-  libcapnpc.la                                                 \
+-  libcapnp-rpc.la                                              \
+-  libcapnp-websocket.la                                        \
+-  libcapnp-json.la                                             \
+-  libcapnp.la                                                  \
+-  libkj-http.la                                                \
+-  $(MAYBE_KJ_GZIP_LA)                                          \
+-  $(MAYBE_KJ_TLS_LA)                                           \
+-  libkj-async.la                                               \
+-  libkj-test.la                                                \
+-  libkj.la                                                     \
+-  $(ASYNC_LIBS)                                                \
+-  $(PTHREAD_LIBS)
+-
+-endif !LITE_MODE
+-
+-capnp_test_CPPFLAGS = -Wno-deprecated-declarations
+-capnp_test_SOURCES =                                           \
+-  src/kj/common-test.c++                                       \
+-  src/kj/memory-test.c++                                       \
+-  src/kj/refcount-test.c++                                     \
+-  src/kj/array-test.c++                                        \
+-  src/kj/list-test.c++                                         \
+-  src/kj/string-test.c++                                       \
+-  src/kj/string-tree-test.c++                                  \
+-  src/kj/table-test.c++                                        \
+-  src/kj/map-test.c++                                          \
+-  src/kj/encoding-test.c++                                     \
+-  src/kj/exception-test.c++                                    \
+-  src/kj/debug-test.c++                                        \
+-  src/kj/arena-test.c++                                        \
+-  src/kj/units-test.c++                                        \
+-  src/kj/tuple-test.c++                                        \
+-  src/kj/one-of-test.c++                                       \
+-  src/kj/function-test.c++                                     \
+-  src/kj/io-test.c++                                           \
+-  src/kj/mutex-test.c++                                        \
+-  src/kj/time-test.c++                                         \
+-  src/kj/threadlocal-test.c++                                  \
+-  src/kj/filesystem-test.c++                                   \
+-  src/kj/filesystem-disk-test.c++                              \
+-  src/kj/test-test.c++                                         \
+-  src/capnp/common-test.c++                                    \
+-  src/capnp/blob-test.c++                                      \
+-  src/capnp/endian-test.c++                                    \
+-  src/capnp/endian-fallback-test.c++                           \
+-  src/capnp/endian-reverse-test.c++                            \
+-  src/capnp/layout-test.c++                                    \
+-  src/capnp/any-test.c++                                       \
+-  src/capnp/message-test.c++                                   \
+-  src/capnp/encoding-test.c++                                  \
+-  src/capnp/orphan-test.c++                                    \
+-  src/capnp/serialize-test.c++                                 \
+-  src/capnp/serialize-packed-test.c++                          \
+-  src/capnp/fuzz-test.c++                                      \
+-  $(heavy_tests)
+-
+-if !LITE_MODE
+-capnp_evolution_test_LDADD = libcapnpc.la libcapnp.la libkj.la
+-capnp_evolution_test_SOURCES = src/capnp/compiler/evolution-test.c++
+-
+-capnp_afl_testcase_LDADD = libcapnp-test.a libcapnp-rpc.la libcapnp.la libkj.la libkj-async.la
+-capnp_afl_testcase_SOURCES = src/capnp/afl-testcase.c++
+-
+-if HAS_FUZZING_ENGINE
+-    capnp_llvm_fuzzer_testcase_LDADD = libcapnp-test.a libcapnp-rpc.la libcapnp.la libkj.la libkj-async.la
+-    capnp_llvm_fuzzer_testcase_SOURCES = src/capnp/llvm-fuzzer-testcase.c++
+-    capnp_llvm_fuzzer_testcase_LDFLAGS = $(LIB_FUZZING_ENGINE)
+-endif
+-endif !LITE_MODE
+-
+-if LITE_MODE
+-TESTS = capnp-test
+-else !LITE_MODE
+-TESTS = capnp-test capnp-evolution-test src/capnp/compiler/capnp-test.sh
+-endif !LITE_MODE

--- a/recipes/capnproto/config.yml
+++ b/recipes/capnproto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.10.4":
     folder: all
   "0.10.3":


### PR DESCRIPTION
Specify library name and version:  **capnproto/1.0.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
