### PR TITLE
clang does not support -rpath-link

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -124,7 +124,6 @@ class QtConan(ConanFile):
     no_copy_source = True
     short_paths = True
 
-    @property
     def _is_clang(self):
         return str(self.settings.compiler) in ["clang", "apple-clang"]
 

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -125,6 +125,10 @@ class QtConan(ConanFile):
     short_paths = True
 
     @property
+    def _is_clang(self):
+        return str(self.settings.compiler) in ["clang", "apple-clang"]
+
+    @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
@@ -737,7 +741,7 @@ class QtConan(ConanFile):
 
         libdirs = [l for dependency in self.dependencies.host.values() for l in dependency.cpp_info.aggregated_components().libdirs]
         args.append("QMAKE_LIBDIR+=\"%s\"" % " ".join(libdirs))
-        if not is_msvc(self):
+        if not is_msvc(self) and not self._is_clang():
             args.append("QMAKE_RPATHLINKDIR+=\"%s\"" % ":".join(libdirs))
 
         if "libmysqlclient" in [d.ref.name for d in self.dependencies.direct_host.values()]:


### PR DESCRIPTION
Specify library name and version:  **qt/5.15**

Compaling qt with qtwebengine enabled on m1 mac with clang 13 I got an error
```
linking ../../lib/libQt5WebEngineCore.5.15.10.dylib
ld: unknown option: -rpath-link=
```

it seems like Clang does not support `-rpath-link`


This is the same issue as https://github.com/conan-io/conan-center-index/issues/16639

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
