### PR TITLE
zookeeper-client-c: add version 3.9.0

### DIFF
--- a/recipes/zookeeper-client-c/all/conandata.yml
+++ b/recipes/zookeeper-client-c/all/conandata.yml
@@ -1,8 +1,15 @@
 sources:
+  "3.9.0":
+    url: "https://archive.apache.org/dist/zookeeper/zookeeper-3.9.0/apache-zookeeper-3.9.0.tar.gz"
+    sha256: "c7af07e7411c798398bb8cd50f47780d8e014831666c41df6ec6540c143c0da2"
   "3.8.1":
     url: "https://archive.apache.org/dist/zookeeper/zookeeper-3.8.1/apache-zookeeper-3.8.1.tar.gz"
     sha256: "ccc16850c8ab2553583583234d11c813061b5ea5f3b8ff1d740cde6c1fd1e219"
 patches:
+  "3.9.0":
+    - patch_file: "patches/3.8.1-0001-add-install.patch"
+      patch_description: "add installer, disable cli program"
+      patch_type: "conan"
   "3.8.1":
     - patch_file: "patches/3.8.1-0001-add-install.patch"
       patch_description: "add installer, disable cli program"

--- a/recipes/zookeeper-client-c/config.yml
+++ b/recipes/zookeeper-client-c/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "3.9.0":
+    folder: all
   "3.8.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **zookeeper-client-c/3.9.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
