### PR TITLE
Added kdbindings/1.0.3

### DIFF
--- a/recipes/kdbindings/all/conandata.yml
+++ b/recipes/kdbindings/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.3":
+    url: "https://github.com/KDAB/KDBindings/archive/refs/tags/v1.0.3.tar.gz"
+    sha256: "da8de679d12bf123df6a3c63a482a862d4122a2f3d3567c9b3b2fc2c4f574393"

--- a/recipes/kdbindings/all/conanfile.py
+++ b/recipes/kdbindings/all/conanfile.py
@@ -1,0 +1,54 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.scm import Version
+import os
+
+class KDBindingsConan(ConanFile):
+    name = "kdbindings"
+    license = "MIT"
+    topics = ("c++17", "reactive", "kdab", "header-only")
+    description = "Reactive programming & data binding in C++"
+    homepage = "https://github.com/KDAB/KDBindings"
+    url = "https://github.com/conan-io/conan-center-index"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self.source_folder)
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "9",
+            "Visual Studio": "15.7",
+            "clang": "7",
+            "apple-clang": "11",
+        }
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 17)
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++17, which your compiler does not support.")
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "*.h", os.path.join(self.source_folder, "src","kdbindings"), os.path.join(self.package_folder, "include", "kdbindings"))
+        copy(self, "LICENSES/*", dst=os.path.join(self.package_folder,"licenses"), src=self.source_folder)
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "KDBindings")
+        self.cpp_info.set_property("cmake_target_name", "KDAB::KDBindings")
+        self.cpp_info.set_property("cmake_target_aliases", ["KDBindings"])

--- a/recipes/kdbindings/all/test_package/CMakeLists.txt
+++ b/recipes/kdbindings/all/test_package/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+find_package(KDBindings REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE KDAB::KDBindings)
+
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CMAKE_INCLUDE_CURRENT_DIRS ON
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+)

--- a/recipes/kdbindings/all/test_package/conanfile.py
+++ b/recipes/kdbindings/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/kdbindings/all/test_package/main.cpp
+++ b/recipes/kdbindings/all/test_package/main.cpp
@@ -1,0 +1,63 @@
+/*
+  This file is part of KDBindings.
+
+  SPDX-FileCopyrightText: 2021-2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  Author: Leon Matthes <leon.matthes@kdab.com>
+
+  SPDX-License-Identifier: MIT
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#include <ios>
+#include <kdbindings/signal.h>
+
+#include <iostream>
+#include <string>
+
+using namespace KDBindings;
+
+void display()
+{
+    std::cout << "Hello World!" << std::endl;
+}
+
+void displayLabelled(const std::string &label, int value)
+{
+    std::cout << label << ": " << value << std::endl;
+}
+
+class SignalHandler
+{
+public:
+    bool received = 0;
+
+    void receive()
+    {
+        received = true;
+    }
+};
+
+int main()
+{
+    Signal<int> signal;
+
+    // Signal::connect allows connecting functions that take too few arguments.
+    signal.connect(display);
+
+    // As well as functions with too many arguments, as long as default values are provided.
+    signal.connect(displayLabelled, "Emitted value");
+
+    // This is very useful to connect member functions, where the first implicit argument
+    // is a pointer to the "this" object.
+    SignalHandler handler;
+    signal.connect(&SignalHandler::receive, &handler);
+
+    // This will print "Hello World!" and "Emitted value: 5" in an unspecified order.
+    // It will also set handler.received to true
+    signal.emit(5);
+
+    std::cout << std::boolalpha << handler.received << std::endl;
+
+    return 0;
+}

--- a/recipes/kdbindings/config.yml
+++ b/recipes/kdbindings/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.3":
+    folder: all


### PR DESCRIPTION
**kdbindings/1.0.3**

KDBindings enables reactive programming & data binding in C++ From plain C++ you get:
- Signals + Slots.
- Properties templated on the contained type.
- Property bindings allowing reactive code to be written without having to do all the low-level, error prone plumbing by hand. Lazy evaluation of property bindings.
- No more broken bindings.
- Totally stand-alone "header-only" library.

I'm working for KDAB (the company behind this library). I have their support for adding and maintaining this library to conan center index.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
