### PR TITLE
spdlog: update fmt/10.1.0

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -57,7 +57,7 @@ class SpdlogConan(ConanFile):
         fmt_version = "7.1.3"
 
         if self_version >= "1.11.0":
-            fmt_version = "10.0.0"
+            fmt_version = "10.1.0"
         elif self_version >= "1.10.0":
             fmt_version = "8.1.1"
         elif self_version >= "1.9.0":

--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -56,8 +56,10 @@ class SpdlogConan(ConanFile):
         self_version = Version(self.version)
         fmt_version = "7.1.3"
 
-        if self_version >= "1.11.0":
+        if self_version >= "1.12.0":
             fmt_version = "10.1.0"
+        elif self_version >= "1.11.0":
+            fmt_version = "10.0.0"
         elif self_version >= "1.10.0":
             fmt_version = "8.1.1"
         elif self_version >= "1.9.0":


### PR DESCRIPTION
Specify library name and version:  **spdlog/***

In spdlog/1.11.0 with fmt/10.1.0, there is a compilation error:
```
~/.conan2/p/b/spdloace6fef9ea4cd/p/include/spdlog/logger.h:374:75: error: cannot bind non-const lvalue reference of type ‘int&’ to an rvalue of type ‘int’
  374 |             fmt::vformat_to(fmt::appender(buf), fmt, fmt::make_format_args(std::forward<Args>(args)...));
      |                                                      ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

So I decided to update to fmt/10.1.0 for spdlog/1.12.0 only.
It seems to be reasonable because spdlog officialy supports fmt/10.x.x since 1.12.0.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
