### PR TITLE
[ffmpeg] replace yasm by nasm

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -322,7 +322,7 @@ class FFMpegConan(ConanFile):
 
     def build_requirements(self):
         if self.settings.arch in ("x86", "x86_64"):
-            self.tool_requires("yasm/1.3.0")
+            self.tool_requires("nasm/2.15.05")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/1.9.3")
         if self._settings_build.os == "Windows":


### PR DESCRIPTION
for better compatibility (esp. latest MSVC versions)

Specify library name and version:  **ffmpeg/all_versions**

Assembler compiler is required to build FFMPEG. The current recipe uses YASM, which latest release is quite old and fails on Windows with the latest MSVC 17.

I propose to replace it by NASM which works fine.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
