### PR TITLE
screen_capture_lite: add version 17.1.1369

### DIFF
--- a/recipes/screen_capture_lite/all/conandata.yml
+++ b/recipes/screen_capture_lite/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "17.1.1369":
+    url: "https://github.com/smasherprog/screen_capture_lite/archive/refs/tags/17.1.1369.tar.gz"
+    sha256: "72abf1cd9fc538e98547841ec56396ba75a36853e861f7bf721f21c64c34453e"
   "17.1.1327":
     url: "https://github.com/smasherprog/screen_capture_lite/archive/refs/tags/17.1.1327.tar.gz"
     sha256: "bc5c17f3df14c1013268fc0107b52a98c6d032803fd1faea1983772f3b7ac5ed"

--- a/recipes/screen_capture_lite/config.yml
+++ b/recipes/screen_capture_lite/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "17.1.1369":
+    folder: "all"
   "17.1.1327":
     folder: "all"
   "17.1.1173":


### PR DESCRIPTION
Specify library name and version:  **screen_capture_lite/17.1.1369**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
