### PR TITLE
r8brain-free-src: add version 6.4

### DIFF
--- a/recipes/r8brain-free-src/all/conandata.yml
+++ b/recipes/r8brain-free-src/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.4":
+    url: "https://github.com/avaneev/r8brain-free-src/archive/refs/tags/version-6.4.tar.gz"
+    sha256: "27e6749e140648894b79003fe16a4d416eca3bed8d067e0f00cfb2e246c556ca"
   "6.3":
     url: "https://github.com/avaneev/r8brain-free-src/archive/refs/tags/version-6.3.tar.gz"
     sha256: "f2cd46cd8806294d9be45ed4e6bda5f8ef1dc808625eec3facde784953d2bc23"

--- a/recipes/r8brain-free-src/config.yml
+++ b/recipes/r8brain-free-src/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.4":
+    folder: all
   "6.3":
     folder: all
   "6.2":


### PR DESCRIPTION
Specify library name and version:  **r8brain-free-src/6.4**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
