### PR TITLE
libmysqlclient: fix compilation error on RHEL

### DIFF
--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -133,7 +133,6 @@ class LibMysqlClientCConan(ConanFile):
                                 f"# SET({lib.upper()}_WARN_GIVEN)",
                                 strict=False)
 
-        rmdir(self, os.path.join(self.source_folder, "extra"))
         for folder in ["client", "man", "mysql-test", "libbinlogstandalone"]:
             replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                             f"ADD_SUBDIRECTORY({folder})\n",


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient/***

Try to fix https://github.com/conan-io/conan-center-index/issues/19204.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
