### PR TITLE
jwt-cpp: update version range for OpenSSL

### DIFF
--- a/recipes/jwt-cpp/all/conanfile.py
+++ b/recipes/jwt-cpp/all/conanfile.py
@@ -24,7 +24,7 @@ class JwtCppConan(ConanFile):
         export_conandata_patches(self)
 
     def requirements(self):
-        self.requires("openssl/[>1.1.1c,<1.1.1u]")
+        self.requires("openssl/[>=1.1 <4]")
         if not self._supports_generic_json:
             self.requires("picojson/1.3.0")
 


### PR DESCRIPTION
jwt-cpp: fix OpenSSL range - the one that was last merged is not what we intend to have in Conan Center. 
An internal bug was has been raised to fix the bump dependencies bot to avoid this issue in the future.

