### PR TITLE
[package] lz4/1.9.4 : Bugfix / Patch to support lz4 and xxhash at the same time.

### DIFF
--- a/recipes/lz4/all/conandata.yml
+++ b/recipes/lz4/all/conandata.yml
@@ -9,6 +9,11 @@ sources:
     sha256: 658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
     url: https://github.com/lz4/lz4/archive/v1.9.2.tar.gz
 patches:
+  "1.9.4":
+    - patch_file: "patches/0004-Added-namespace-declaration-for-xxhash-in-CMake.patch"
+      patch_description: "Added namespace/prefix for xxHash functions by altering CMakeLists.txt"
+      patch_type: official 
+      patch_source: "https://github.com/lz4/lz4/pull/1258"
   "1.9.3":
     - patch_file: "patches/0003-cmake-minimum-required-first-1.9.3.patch"
       patch_description: "Move cmake_minimum_required to the top of CMakeFile.txt"

--- a/recipes/lz4/all/conandata.yml
+++ b/recipes/lz4/all/conandata.yml
@@ -12,7 +12,7 @@ patches:
   "1.9.4":
     - patch_file: "patches/0004-Added-namespace-declaration-for-xxhash-in-CMake.patch"
       patch_description: "Added namespace/prefix for xxHash functions by altering CMakeLists.txt"
-      patch_type: official 
+      patch_type: official
       patch_source: "https://github.com/lz4/lz4/pull/1258"
   "1.9.3":
     - patch_file: "patches/0003-cmake-minimum-required-first-1.9.3.patch"

--- a/recipes/lz4/all/patches/0004-Added-namespace-declaration-for-xxhash-in-CMake.patch
+++ b/recipes/lz4/all/patches/0004-Added-namespace-declaration-for-xxhash-in-CMake.patch
@@ -1,0 +1,19 @@
+--- a/build/cmake/CMakeLists.txt
++++ b/build/cmake/CMakeLists.txt
+@@ -131,6 +131,16 @@ if(BUILD_STATIC_LIBS)
+   list(APPEND LZ4_LIBRARIES_BUILT lz4_static)
+ endif()
+ 
++# xxhash namesapce
++if(BUILD_SHARED_LIBS)
++  target_compile_definitions(lz4_shared PRIVATE 
++    XXH_NAMESPACE=LZ4_)
++endif()
++if(BUILD_STATIC_LIBS)
++  target_compile_definitions(lz4_static PRIVATE 
++    XXH_NAMESPACE=LZ4_)
++endif()
++
+ if(BUILD_STATIC_LIBS)
+   set(LZ4_LINK_LIBRARY lz4_static)
+ else()


### PR DESCRIPTION
Specify library name and version:  **lz4/1.9.4**

In the current release of lz4 it is using xxhash (internally, not as a dependency). This results in multiple definitions of the same symbol when using xxhash and lz4 in the same project. I have already created a merged PR on lz4 (https://github.com/lz4/lz4/pull/1258) that alters the CMakeLists.txt to prefix all xxhash functions within LZ4_ to resolve the naming conflict. I talked with the developers of lz4, and it's not intended to add xxhash as an external dependency, and the prefix/pseudo-namespace is the way to go.

This is a PR fixing this issue by applying a patch to CMakeLists.txt (I tested it locally on the current release tag).

fixes #19221 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
