### PR TITLE
[docs] Add changelog 17-Aug-2023

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 17-Aug-2023 - 11:42 CEST
+
+- [fix] Fix type error when catching generic exceptions in Jenkins
+- [fix] Bump dependencies no longer allow version range
+- [feature] Show recipe revision on the pull-request summary table
+
 ### 04-Aug-2023 - 10:26 CEST
 
 - [feature] Enable Conan 2.0.8


### PR DESCRIPTION
- The C3I Jenkins captures and process many types of exceptions. This new hotfix will avoid invoking missing methods to properly log all of them.
- The Bump Dependencies is now restricted only to `semver`, `major.minor` and `cci.<DATE>` format.
- For a better logging, RREV (recipe-revision) has been included to the summary output.
