### PR TITLE
[cpuinfo] fix bug when compiling for Android

### DIFF
--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -95,5 +95,5 @@ class CpuinfoConan(ConanFile):
         self.cpp_info.components["cpuinfo"].libs = ["cpuinfo"]
         if self.version < "cci.20230118":
             self.cpp_info.components["cpuinfo"].requires = ["clog"]
-        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["cpuinfo"].system_libs.append("pthread")


### PR DESCRIPTION

Specify library name and version:  **cpuinfo/** (all versions impacted)

A bug was introduced by this PR: https://github.com/conan-io/conan-center-index/pull/18164

It shall not require pthread when compiling for Android

See https://stackoverflow.com/questions/38666609/cant-find-lpthread-when-cross-compile-to-arm: "The android libc, bionic, provides built-in support for pthreads, so no additional linking (-lpthreads) is necessary."

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
