### PR TITLE
exiv2: add version 0.28.0

### DIFF
--- a/recipes/exiv2/all/conandata.yml
+++ b/recipes/exiv2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.28.0":
+    url: "https://github.com/Exiv2/exiv2/releases/download/v0.28.0/exiv2-0.28.0-Source.tar.gz"
+    sha256: "89af3b5ef7277753ef7a7b5374ae017c6b9e304db3b688f1948e73e103491f3d"
   "0.27.5":
     url: "https://github.com/Exiv2/exiv2/releases/download/v0.27.5/exiv2-0.27.5-Source.tar.gz"
     sha256: "35a58618ab236a901ca4928b0ad8b31007ebdc0386d904409d825024e45ea6e2"
@@ -6,16 +9,35 @@ sources:
     url: "https://github.com/Exiv2/exiv2/releases/download/v0.27.4/exiv2-0.27.4-Source.tar.gz"
     sha256: "84366dba7c162af9a7603bcd6c16f40fe0e9af294ba2fd2f66ffffb9fbec904e"
 patches:
+  "0.28.0":
+    - patch_file: "patches/0001-link-0.28.0.patch"
+      patch_description: "use target names instead of variables"
+      patch_type: "conan"
+    - patch_file: "patches/0004-find-expat-0.28.0.patch"
+      patch_description: "enforce usage of FindEXPAT.cmake"
+      patch_type: "conan"
   "0.27.5":
     - patch_file: "patches/0001-link-0.27.5.patch"
+      patch_description: "use target names instead of variables"
+      patch_type: "conan"
     - patch_file: "patches/0003-fix-ios.patch"
+      patch_description: "don't use libproc.h functions in iphone build"
+      patch_type: "portability"
+      patch_source: "https://github.com/Exiv2/exiv2/pull/1718"
     - patch_file: "patches/0004-find-expat.patch"
       patch_description: "enforce usage of FindEXPAT.cmake"
       patch_type: "conan"
   "0.27.4":
     - patch_file: "patches/0001-link.patch"
+      patch_description: "use target names instead of variables"
+      patch_type: "conan"
     - patch_file: "patches/0002-fpic.patch"
+      patch_description: "disable PIC"
+      patch_type: "conan"
     - patch_file: "patches/0003-fix-ios.patch"
+      patch_description: "don't use libproc.h functions in iphone build"
+      patch_type: "portability"
+      patch_source: "https://github.com/Exiv2/exiv2/pull/1718"
     - patch_file: "patches/0004-find-expat.patch"
       patch_description: "enforce usage of FindEXPAT.cmake"
       patch_type: "conan"

--- a/recipes/exiv2/all/patches/0001-link-0.28.0.patch
+++ b/recipes/exiv2/all/patches/0001-link-0.28.0.patch
@@ -1,0 +1,16 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 41a672e..ecd94f3 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -170,11 +170,6 @@ if (MSVC)
+     set_target_properties(exiv2lib PROPERTIES LINK_FLAGS "/ignore:4099")
+ endif()
+ 
+-set_target_properties( exiv2lib_int PROPERTIES
+-    POSITION_INDEPENDENT_CODE ON
+-    COMPILE_DEFINITIONS exiv2lib_EXPORTS
+-)
+-
+ # NOTE: Cannot use target_link_libraries on OBJECT libraries with old versions of CMake
+ target_include_directories(exiv2lib_int PRIVATE ${ZLIB_INCLUDE_DIR})
+ target_include_directories(exiv2lib SYSTEM PRIVATE 

--- a/recipes/exiv2/all/patches/0004-find-expat-0.28.0.patch
+++ b/recipes/exiv2/all/patches/0004-find-expat-0.28.0.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/findDependencies.cmake b/cmake/findDependencies.cmake
+index 1075c30..d8b580d 100644
+--- a/cmake/findDependencies.cmake
++++ b/cmake/findDependencies.cmake
+@@ -60,7 +60,7 @@ if (EXIV2_ENABLE_XMP AND EXIV2_ENABLE_EXTERNAL_XMP)
+     message(FATAL_ERROR "EXIV2_ENABLE_XMP AND EXIV2_ENABLE_EXTERNAL_XMP are mutually exclusive.  You can only choose one of them")
+ else()
+     if (EXIV2_ENABLE_XMP)
+-        find_package(EXPAT REQUIRED)
++        find_package(EXPAT REQUIRED MODULE)
+     elseif (EXIV2_ENABLE_EXTERNAL_XMP)
+         find_package(XmpSdk REQUIRED)
+     endif ()

--- a/recipes/exiv2/all/test_package/CMakeLists.txt
+++ b/recipes/exiv2/all/test_package/CMakeLists.txt
@@ -1,7 +1,11 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
 find_package(exiv2 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} exiv2lib)
+target_link_libraries(${PROJECT_NAME} PRIVATE exiv2lib)
+if(exiv2_VERSION VERSION_GREATER_EQUAL "0.28.0")
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+endif()
+

--- a/recipes/exiv2/config.yml
+++ b/recipes/exiv2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.28.0":
+    folder: all
   "0.27.5":
     folder: all
   "0.27.4":


### PR DESCRIPTION
Specify library name and version:  **exiv2/***

- 0.28.0 requires C++17
- 0.28.0 provides libexiv2-xmp as object library not as static library
- 0.28.0 provides with_brotli and with_inih options

See also https://github.com/Exiv2/exiv2/issues/2406#issuecomment-1529139799

Try to solve https://github.com/conan-io/conan-center-index/issues/19249

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
