### PR TITLE
[arsenalgear] Bump dependencies: Boost 1.82.0

### DIFF
--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -57,7 +57,7 @@ class ArsenalgearConan(ConanFile):
 
     def requirements(self):
         if Version(self.version) < "2.0.0":
-            self.requires("boost/1.81.0")
+            self.requires("boost/1.82.0")
             if self.settings.os in ["Linux", "Macos"]:
                 # exprtk is used in public header of arsenalgear
                 # https://github.com/JustWhit3/arsenalgear-cpp/blob/v1.2.2/include/math.hpp


### PR DESCRIPTION
Specify library name and version:  **arsenalgear/2.1.0**

Required by #16320

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
