### PR TITLE
fmt: make sure libdirs is empty when header_only=True

### DIFF
--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -118,9 +118,9 @@ class FmtConan(ConanFile):
 
         if self.options.header_only:
             self.cpp_info.components["_fmt"].defines.append("FMT_HEADER_ONLY=1")
+            self.cpp_info.components["_fmt"].libdirs = []
+            self.cpp_info.components["_fmt"].bindirs = []
 
-            self.cpp_info.libdirs = []
-            self.cpp_info.bindirs = []
         else:
             postfix = "d" if self.settings.build_type == "Debug" else ""
             libname = "fmt" + postfix


### PR DESCRIPTION
Specify library name and version:  **fmt/10.1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This PR aims at avoiding the following warning when used in `header_only=True` mode:

```
ld: warning: directory not found for option '-L/Users/gegles/.conan2/p/fmt04167ccd841e1/p/lib'
```

The `libdirs = []` and `bindirs = []` should apply to the component in this situation

Now, when doing ` conan create --version 10.1.0 -o header_only=True all` the warning is gone.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
