### PR TITLE
[OGDF] enable shared build on Windows

### DIFF
--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -26,10 +26,6 @@ class OGDFConan(ConanFile):
         "fPIC": True,
     }
 
-    def validate(self):
-        if is_msvc(self) and self.options.shared:
-            raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
@@ -85,12 +81,13 @@ class OGDFConan(ConanFile):
         copy(self, pattern="LICENSE*.txt", src=self.source_folder, dst=join(self.package_folder, "licenses"))
         copy(self, pattern="*.h", src=join(self.source_folder, "include"), dst=join(self.package_folder, "include"))
         copy(self, pattern="*.h", src=join(self.build_folder, "include"), dst=join(self.package_folder, "include"))
+        copy(self, pattern="*.lib", src=self.build_folder, dst=join(self.package_folder, "lib"), keep_path=False)
         if self.options.shared:
             copy(self, pattern="*.so*", src=self.build_folder, dst=join(self.package_folder, "lib"))
             copy(self, pattern="*.dylib*", src=self.build_folder, dst=join(self.package_folder, "lib"))
+            copy(self, pattern="*.dll", src=self.build_folder, dst=join(self.package_folder, "bin"), keep_path=False)
         else:
             copy(self, pattern="*.a", src=self.build_folder, dst=join(self.package_folder, "lib"))
-            copy(self, pattern="*.lib", src=self.build_folder, dst=join(self.package_folder, "lib"), keep_path=False)
         fix_apple_shared_install_name(self)
 
     def package_info(self):

--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -1,9 +1,7 @@
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import copy, get, replace_in_file, rmdir
-from conan.tools.microsoft import is_msvc
 from os.path import join
 
 required_conan_version = ">=1.53.0"


### PR DESCRIPTION
Specify library name and version:  **OGDF/2022.02**

This enables building with `shared=True` on Windows


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
