### PR TITLE
libpqxx: add version 7.8.1

### DIFF
--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.8.1":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.8.1.tar.gz"
+    sha256: "0f4c0762de45a415c9fd7357ce508666fa88b9a4a463f5fb76c235bc80dd6a84"
   "7.8.0":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.8.0.tar.gz"
     sha256: "bc471d8d34588f820f38e19e1cc217f399212eef900416cf12f90fab293628af"
@@ -45,6 +48,10 @@ sources:
     url: "https://github.com/jtv/libpqxx/archive/6.4.8.tar.gz"
     sha256: "3f7aba951822e01f1b9f9f353702954773323dd9f9dc376ffb57cb6bbd9a7a2f"
 patches:
+  "7.8.1":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      patch_description: "Keep `CMAKE_MODULE_PATH` to be changed by conan."
+      patch_type: "conan"
   "7.8.0":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       patch_description: "Keep `CMAKE_MODULE_PATH` to be changed by conan."

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.8.1":
+    folder: all
   "7.8.0":
     folder: all
   "7.7.5":


### PR DESCRIPTION
Specify library name and version:  **libpqxx/7.8.1**

This release fixes a build bug in v7.8.0.
If v7.8.1 is supported, v7.8.0 is no longer needed.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
