### PR TITLE
lyra: make sure libdirs is empty for this header-only library

### DIFF
--- a/recipes/lyra/all/conanfile.py
+++ b/recipes/lyra/all/conanfile.py
@@ -57,3 +57,4 @@ class LyraConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "bfg"
         self.cpp_info.components["_lyra"].names["cmake_find_package"] = "lyra"
         self.cpp_info.components["_lyra"].names["cmake_find_package_multi"] = "lyra"
+        self.cpp_info.components["_lyra"].libdirs = []


### PR DESCRIPTION
Specify library name and version:  **lyra/1.6.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This PR removes the following warning (on macOS) as no libdirs are needed for a header only lib:
```
ld: warning: directory not found for option '-L/Users/gegles/.conan2/p/b/lyraec857ade44df1/p/lib'
```

This is a much smaller PR than my other one [here](https://github.com/conan-io/conan-center-index/pull/19280) where I do more cleaning up as well. Depending on which gets merged first, I'll either rebase or close the other.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
