### PR TITLE
pupnp: fix invalid use of self.options[]

### DIFF
--- a/recipes/pupnp/all/conanfile.py
+++ b/recipes/pupnp/all/conanfile.py
@@ -96,7 +96,7 @@ class PupnpConan(ConanFile):
         features["samples"] = False
         features["blocking_tcp_connections"] = self.options["blocking-tcp"]
         for opt in ("ipv6", "reuseaddr", "webserver", "client", "device", "largefile", "tools", "debug"):
-            features[opt] = self.options[opt]
+            features[opt] = self.options.get_safe(opt)
         for feature, enabled in features.items():
             what = "enable" if enabled else "disable"
             tc.configure_args.append(f"--{what}-{feature}")


### PR DESCRIPTION
`self.options[]` returns a `PackageOptions` object instead of a `PackageOption` one like attribute access or `.get_safe()` does.