### PR TITLE
gdcm: fix compilation with old OpenSSL and bump dependencies

### DIFF
--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -60,7 +60,7 @@ class GDCMConan(ConanFile):
         self.requires("expat/2.5.0")
         self.requires("openjpeg/2.5.0")
         if self.options.with_zlibng:
-            self.requires("zlib-ng/2.0.7")
+            self.requires("zlib-ng/2.1.3")
         else:
             self.requires("zlib/1.2.13")
         if self.settings.os != "Windows":
@@ -68,7 +68,7 @@ class GDCMConan(ConanFile):
             if Version(self.version) >= Version("3.0.20"):
                 self.requires("libiconv/1.17")
         if self.options.with_json:
-            self.requires("json-c/0.16")
+            self.requires("json-c/0.17")
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]")
 
@@ -104,8 +104,8 @@ class GDCMConan(ConanFile):
         # https://sourceforge.net/p/gdcm/bugs/548/
         tc.preprocessor_definitions["CHARLS_NO_DEPRECATED_WARNING"] = "1"
 
-        #gdcm currently uses functionality that is deprecated since OpenSSL 3.0
-        tc.preprocessor_definitions["OPENSSL_API_COMPAT"] = "0x10101000L"
+        #gdcm currently uses functionality that is deprecated since OpenSSL 1.1.0
+        tc.preprocessor_definitions["OPENSSL_API_COMPAT"] = "0x10000000L"
 
         tc.generate()
         deps = CMakeDeps(self)


### PR DESCRIPTION
Specify library name and version:  **gdcm/all**

gdcm uses [ERR_load_crypto_strings ](https://www.openssl.org/docs/man1.1.1/man3/ERR_load_crypto_strings.html)and [OpenSSL_add_all_algorithms](https://www.openssl.org/docs/man1.1.1/man3/OpenSSL_add_all_algorithms.html)  that are deprecated since OpenSSL 1.1.0. Using OPENSSL_API_COMPAT allows compiling this code without additional patching.

Fixes #19323 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
