### PR TITLE
Enable assimp v5.2.5 with same build setup

### DIFF
--- a/recipes/assimp/5.x/conandata.yml
+++ b/recipes/assimp/5.x/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "5.2.5":
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.2.5.tar.gz"
-    sha256: "baa89858c7e545390273530ba63c61b94c2e09d38c28b0a0311bfa7bde396181"
+    sha256: "b5219e63ae31d895d60d98001ee5bb809fb2c7b2de1e7f78ceeb600063641e1a"
   "5.2.2":
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.2.2.tar.gz"
     sha256: "ad76c5d86c380af65a9d9f64e8fc57af692ffd80a90f613dfc6bd945d0b80bb4"

--- a/recipes/assimp/5.x/conandata.yml
+++ b/recipes/assimp/5.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.2.5":
+    url: "https://github.com/assimp/assimp/archive/refs/tags/v5.2.5.tar.gz"
+    sha256: "baa89858c7e545390273530ba63c61b94c2e09d38c28b0a0311bfa7bde396181"
   "5.2.2":
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.2.2.tar.gz"
     sha256: "ad76c5d86c380af65a9d9f64e8fc57af692ffd80a90f613dfc6bd945d0b80bb4"
@@ -15,6 +18,9 @@ sources:
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.0.0.tar.gz"
     sha256: "b0110a91650d6bb4000e3d5c2185bf77b0ff0a2e7a284bc2c4af81b33988b63c"
 patches:
+  "5.2.5":
+    - patch_file: "patches/0005-fix-unzip.patch"
+    - patch_file: "patches/0006-unvendor-deps-5.2.x.patch"
   "5.2.2":
     - patch_file: "patches/0005-fix-unzip.patch"
     - patch_file: "patches/0006-unvendor-deps-5.2.x.patch"

--- a/recipes/assimp/config.yml
+++ b/recipes/assimp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.2.5":
+    folder: "5.x"
   "5.2.2":
     folder: "5.x"
   "5.1.6":


### PR DESCRIPTION
Specify library name and version:  **assimp/v5.2.5**

5.2.5 has a lot of bug fixes over 5.2.2 which is latest in conancenter.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
