### PR TITLE
update openssl dependency to use lts version by default

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -93,7 +93,8 @@ class GrpcConan(ConanFile):
         else:
             self.requires("abseil/20230125.3", transitive_headers=True, transitive_libs=True)
         self.requires("c-ares/1.19.1")
-        self.requires("openssl/[>=1.1 <4]")
+        # openssl latest avaliable lts is 3.0.x
+        self.requires("openssl/[>=1.1 <3.1]")
         self.requires("re2/20230301")
         self.requires("zlib/1.2.13")
         self.requires("protobuf/3.21.12", transitive_headers=True, transitive_libs=True, run=can_run(self))


### PR DESCRIPTION
Specify library name and version:  grpc/1.54.3 and 1.48.4

new openssl release model is tracking multiple major releases, so that prefer by default build package with lts version instead of sts

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
