### PR TITLE
qt/6.5.x: Only output a warning when using GCC 9

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -117,6 +117,10 @@ patches:
     - "base_path": "qtwebengine"
       "patch_description": "Workaround for too long .rps file name"
       "patch_file": "patches/c72097e.diff"
+    - base_path: "qtbase"
+      patch_description: "Fix compilation with point releases of GCC 9 prior to 9.3"
+      patch_file: "patches/148895_0001-Fix-FTBFS-qt-6.5.0-on-gcc-9.patch"
+      patch_source: "https://bugreports.qt.io/browse/QTBUG-112920"
   "6.5.1":
     - base_path: "qtwebengine"
       patch_description: "Workaround for too long .rps file name"
@@ -124,6 +128,10 @@ patches:
     - base_path: "qtbase/cmake"
       patch_description: "Fix pri helpers, see PR #6668 and QTBUG-95569"
       patch_file: "patches/qt6.5.0-pri-helpers-fix.diff"
+    - base_path: "qtbase"
+      patch_description: "Fix compilation with point releases of GCC 9 prior to 9.3"
+      patch_file: "patches/148895_0001-Fix-FTBFS-qt-6.5.0-on-gcc-9.patch"
+      patch_source: "https://bugreports.qt.io/browse/QTBUG-112920"
   "6.5.0":
     - base_path: "qtwebengine"
       patch_description: "Workaround for too long .rps file name"
@@ -131,6 +139,10 @@ patches:
     - base_path: "qtbase/cmake"
       patch_description: "Fix pri helpers, see PR #6668 and QTBUG-95569"
       patch_file: "patches/qt6.5.0-pri-helpers-fix.diff"
+    - base_path: "qtbase"
+      patch_description: "Fix compilation with point releases of GCC 9 prior to 9.3"
+      patch_file: "patches/148895_0001-Fix-FTBFS-qt-6.5.0-on-gcc-9.patch"
+      patch_source: "https://bugreports.qt.io/browse/QTBUG-112920"
   "6.4.2":
     - base_path: "qtbase/cmake"
       patch_description: "Fix pri helpers"

--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -109,10 +109,18 @@ patches:
     - "base_path": "qtwebengine"
       "patch_description": "Workaround for too long .rps file name"
       "patch_file": "patches/c72097e_6.6.0.diff"
+    - base_path: "qtbase"
+      patch_description: "Fix compilation with point releases of GCC 9 prior to 9.3"
+      patch_file: "patches/148895_0001-Fix-FTBFS-qt-6.6.0-on-gcc-9.patch"
+      patch_source: "https://bugreports.qt.io/browse/QTBUG-112920"
   "6.5.3":
     - "base_path": "qtwebengine"
       "patch_description": "Workaround for too long .rps file name"
       "patch_file": "patches/c72097e.diff"
+    - base_path: "qtbase"
+      patch_description: "Fix compilation with point releases of GCC 9 prior to 9.3"
+      patch_file: "patches/148895_0001-Fix-FTBFS-qt-6.5.0-on-gcc-9.patch"
+      patch_source: "https://bugreports.qt.io/browse/QTBUG-112920"
   "6.5.2":
     - "base_path": "qtwebengine"
       "patch_description": "Workaround for too long .rps file name"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -247,9 +247,6 @@ class QtConan(ConanFile):
         elif Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("C++17 support required, which your compiler does not support.")
 
-        if Version(self.version) >= "6.5.0" and self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "9":
-            raise ConanInvalidConfiguration("qt 6.5.0 cannot be built with gcc 9, cf QTBUG-112920")
-
         if Version(self.version) >= "6.4.0" and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "12":
             raise ConanInvalidConfiguration("apple-clang >= 12 required by qt >= 6.4.0")
 

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -237,9 +237,6 @@ class QtConan(ConanFile):
                 self.info.settings.compiler == "clang" and Version(self.info.settings.compiler.version) >= "12":
                 raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed\n"\
                                                 "If your distro is modern enough (xcb >= 1.12), set environment variable NOT_ON_C3I=1")
-            if Version(self.version) >= "6.5.0" and self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "9":
-                raise ConanInvalidConfiguration("qt 6.5.0 and newer is not supported with gcc 9 on C3I until gcc 9.3 or newer is used, cf QTBUG-112920\n"\
-                                                "If your using gcc 9.3 or newer, set environment variable NOT_ON_C3I=1")
 
         # C++ minimum standard required
         if self.settings.compiler.get_safe("cppstd"):
@@ -250,11 +247,8 @@ class QtConan(ConanFile):
         elif Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("C++17 support required, which your compiler does not support.")
 
-        if Version(self.version) >= "6.5.0" and self.settings.compiler == "gcc":
-            if Version(self.settings.compiler.version) == "9":
-                self.output.warn("qt 6.5.0 and newer requires gcc 9.3 or newer, cf QTBUG-112920")
-            elif Version(self.settings.compiler.version) in ["9.1", "9.2"]:
-                raise ConanInvalidConfiguration("qt 6.5.0 and newer cannot be built with gcc 9.1 or 9.2, cf QTBUG-112920")
+        if Version(self.version) >= "6.5.0" and self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "9":
+            raise ConanInvalidConfiguration("qt 6.5.0 cannot be built with gcc 9, cf QTBUG-112920")
 
         if Version(self.version) >= "6.4.0" and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "12":
             raise ConanInvalidConfiguration("apple-clang >= 12 required by qt >= 6.4.0")

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -237,6 +237,9 @@ class QtConan(ConanFile):
                 self.info.settings.compiler == "clang" and Version(self.info.settings.compiler.version) >= "12":
                 raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed\n"\
                                                 "If your distro is modern enough (xcb >= 1.12), set environment variable NOT_ON_C3I=1")
+            if Version(self.version) >= "6.5.0" and self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "9":
+                raise ConanInvalidConfiguration("qt 6.5.0 and newer is not supported with gcc 9 on C3I until gcc 9.3 or newer is used, cf QTBUG-112920\n"\
+                                                "If your using gcc 9.3 or newer, set environment variable NOT_ON_C3I=1")
 
         # C++ minimum standard required
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -247,8 +247,11 @@ class QtConan(ConanFile):
         elif Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("C++17 support required, which your compiler does not support.")
 
-        if Version(self.version) >= "6.5.0" and self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "9":
-            raise ConanInvalidConfiguration("qt 6.5.0 cannot be built with gcc 9, cf QTBUG-112920")
+        if Version(self.version) >= "6.5.0" and self.settings.compiler == "gcc":
+            if Version(self.settings.compiler.version) == "9":
+                self.output.warn("qt 6.5.0 and newer requires gcc 9.3 or newer, cf QTBUG-112920")
+            elif Version(self.settings.compiler.version) in ["9.1", "9.2"]:
+                raise ConanInvalidConfiguration("qt 6.5.0 and newer cannot be built with gcc 9.1 or 9.2, cf QTBUG-112920")
 
         if Version(self.version) >= "6.4.0" and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "12":
             raise ConanInvalidConfiguration("apple-clang >= 12 required by qt >= 6.4.0")

--- a/recipes/qt/6.x.x/patches/148895_0001-Fix-FTBFS-qt-6.5.0-on-gcc-9.patch
+++ b/recipes/qt/6.x.x/patches/148895_0001-Fix-FTBFS-qt-6.5.0-on-gcc-9.patch
@@ -1,0 +1,24 @@
+From fba07d6e02084c5aeaed46aa659b52ddef2e6357 Mon Sep 17 00:00:00 2001
+From: shjiu <shanheng.jiu@qt.io>
+Date: Thu, 16 Nov 2023 20:29:24 +0900
+Subject: [PATCH] Fix FTBFS qt 6.5.0 on gcc 9
+
+---
+ src/corelib/text/qstring.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/corelib/text/qstring.cpp b/src/corelib/text/qstring.cpp
+index 7024ccb219..319515ed77 100644
+--- a/src/corelib/text/qstring.cpp
++++ b/src/corelib/text/qstring.cpp
+@@ -461,7 +461,7 @@ static bool simdTestMask(const char *&ptr, const char *end, quint32 maskval)
+     if constexpr (UseSse4_1) {
+ #  ifndef Q_OS_QNX              // compiler fails in the code below
+         __m128i mask;
+-        auto updatePtrSimd = [&](__m128i data) {
++        auto updatePtrSimd = [&](__m128i data) -> bool {
+             __m128i masked = _mm_and_si128(mask, data);
+             __m128i comparison = _mm_cmpeq_epi16(masked, _mm_setzero_si128());
+             uint result = _mm_movemask_epi8(comparison);
+-- 
+2.41.0

--- a/recipes/qt/6.x.x/patches/148895_0001-Fix-FTBFS-qt-6.6.0-on-gcc-9.patch
+++ b/recipes/qt/6.x.x/patches/148895_0001-Fix-FTBFS-qt-6.6.0-on-gcc-9.patch
@@ -1,0 +1,24 @@
+From fba07d6e02084c5aeaed46aa659b52ddef2e6357 Mon Sep 17 00:00:00 2001
+From: shjiu <shanheng.jiu@qt.io>
+Date: Thu, 16 Nov 2023 20:29:24 +0900
+Subject: [PATCH] Fix FTBFS qt 6.5.0 on gcc 9
+
+---
+ src/corelib/text/qstring.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/corelib/text/qstring.cpp b/src/corelib/text/qstring.cpp
+index 7024ccb219..319515ed77 100644
+--- a/src/corelib/text/qstring.cpp
++++ b/src/corelib/text/qstring.cpp
+@@ -471,7 +471,7 @@ static bool simdTestMask(const char *&ptr, const char *end, quint32 maskval)
+     if constexpr (UseSse4_1) {
+ #  ifndef Q_OS_QNX              // compiler fails in the code below
+         __m128i mask;
+-        auto updatePtrSimd = [&](__m128i data) {
++        auto updatePtrSimd = [&](__m128i data) -> bool {
+             __m128i masked = _mm_and_si128(mask, data);
+             __m128i comparison = _mm_cmpeq_epi16(masked, _mm_setzero_si128());
+             uint result = _mm_movemask_epi8(comparison);
+-- 
+2.41.0


### PR DESCRIPTION
Fail explicitly for GCC 9.1 or 9.2 which won't work. Users using any version of GCC 9 may be using newer versions of GCC 9. A warning should suffice in this case, without requiring users to change their settings model to incorporate minor version numbers of the compiler. For details, see https://bugreports.qt.io/browse/QTBUG-112920

Specify library name and version:  **qt/6.5.x**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
