### PR TITLE
microprofile: fix license URL

### DIFF
--- a/recipes/microprofile/all/conandata.yml
+++ b/recipes/microprofile/all/conandata.yml
@@ -2,7 +2,7 @@ sources:
     "3.1":
         - url: "https://github.com/jonasmr/microprofile/archive/refs/tags/v3.1.tar.gz"
           sha256: "300e1d0d21e4c13ad1de72c5309ba02fbdb3bcbbe26e5ad9ff8b798380781527"
-        - url: "https://unlicense.org/UNLICENSE"
+        - url: "https://raw.githubusercontent.com/jonasmr/microprofile/v4.0/LICENSE"
           sha256: "7e12e5df4bae12cb21581ba157ced20e1986a0508dd10d0e8a4ab9a4cf94e85c"
 patches:
     "3.1":


### PR DESCRIPTION
Specify library name and version:  **microprofile/3.1**

Since `https://unlicense.org/UNLICENSE` is currently unavailable, this package cannot be built at the moment. This PR changes the license URL to the one in the upstream repository (the [LICENSE](https://github.com/jonasmr/microprofile/blob/v4.0/LICENSE) file),

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
