### PR TITLE
expected-lite: make sure libdirs is empty for this header-only library

### DIFF
--- a/recipes/expected-lite/all/conanfile.py
+++ b/recipes/expected-lite/all/conanfile.py
@@ -52,3 +52,4 @@ class ExpectedLiteConan(ConanFile):
         self.cpp_info.components["expectedlite"].names["cmake_find_package"] = "expected-lite"
         self.cpp_info.components["expectedlite"].names["cmake_find_package_multi"] = "expected-lite"
         self.cpp_info.components["expectedlite"].set_property("cmake_target_name", "nonstd::expected-lite")
+        self.cpp_info.components["expectedlite"].libdirs = []


### PR DESCRIPTION
Clean up and removed test_v1_package and v1-specific package_info code

Specify library name and version:  **expected-lite/0.6.3**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

on macOS, before this PR it would generate the following warning:
```
ld: warning: directory not found for option '-L/Users/gegles/.conan2/p/b/expeced3ee1a13d86f/p/lib'
```
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
