### PR TITLE
date: make sure libdirs is empty when `header-only=True`

### DIFF
--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -138,3 +138,4 @@ class DateConan(ConanFile):
             self.cpp_info.components["date-tz"].defines.extend(defines)
         else:
             self.cpp_info.defines.append("DATE_HEADER_ONLY")
+            self.cpp_info.libdirs = []


### PR DESCRIPTION
Specify library name and version:  **date/3.0.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This PR helps remove the following warning on macOS:
```
ld: warning: directory not found for option '-L/Users/gegles/.conan2/p/date512b8c2307f3f/p/lib'
```
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
