### PR TITLE
boost: make sure libdirs is empty with header-only=True and used via `boost::boost` target

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1491,6 +1491,8 @@ class BoostConan(ConanFile):
         self.cpp_info.components["_boost_cmake"].set_property("cmake_target_name", "Boost::boost")
         self.cpp_info.components["_boost_cmake"].names["cmake_find_package"] = "boost"
         self.cpp_info.components["_boost_cmake"].names["cmake_find_package_multi"] = "boost"
+        if self.options.header_only:
+            self.cpp_info.components["_boost_cmake"].libdirs = []
 
         if not self.options.header_only:
             self.cpp_info.components["_libboost"].requires = ["headers"]


### PR DESCRIPTION
Specify library name and version:  **boost/1.83**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This PR helps remove the following warning on macOS when boost is used as header-only, but the `boost::boost` target is used in CMake as opposed to the `Boost::headers`:
```
ld: warning: directory not found for option '-L/Users/gegles/.conan2/p/boost3ea68282e5511/p/lib'
```

I faced this issue when using `restinio` that transitively brings in `boost` but internally uses the `boost::boost` CMake target.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
