### PR TITLE
[so5extra] Add version 1.6.0 and support Conan 2.x

### DIFF
--- a/recipes/so5extra/all/conandata.yml
+++ b/recipes/so5extra/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/Stiffstream/so5extra/archive/v.1.6.0.tar.gz"
+    sha256: "224a156a840d707138189da5ebe78d87814832252f90673db631e93e0171433f"
   "1.5.2":
     url: "https://github.com/Stiffstream/so5extra/archive/v.1.5.2.tar.gz"
     sha256: "5409dc255c970d2085381ceded122b80b9ac896a34bafc5ffc431bae304d485d"

--- a/recipes/so5extra/all/test_package/conanfile.py
+++ b/recipes/so5extra/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/so5extra/all/test_v1_package/CMakeLists.txt
+++ b/recipes/so5extra/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(so5extra REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 target_link_libraries(${PROJECT_NAME} sobjectizer::so5extra)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/so5extra/all/test_v1_package/conanfile.py
+++ b/recipes/so5extra/all/test_v1_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/so5extra/config.yml
+++ b/recipes/so5extra/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.0":
+    folder: all
   "1.5.2":
     folder: all
   "1.5.1":


### PR DESCRIPTION
Specify library name and version:  **so5extra/1.6.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
