### PR TITLE
brunsli: add new package

### DIFF
--- a/recipes/brunsli/all/conandata.yml
+++ b/recipes/brunsli/all/conandata.yml
@@ -1,12 +1,12 @@
 sources:
-  "cci.20230730":
-    url: "https://github.com/google/brunsli/archive/6f18d495dbabcc5485ffa800d3de8b62229a697f.tar.gz"
-    sha256: "0bb520a48c37b0c71ee057200171fce9be66c8feb556d79e7d95251ccd51f992"
+  "cci.20231024":
+    url: "https://github.com/google/brunsli/archive/0b7bd7b47d1f8fd8682d4818180e0ab42f26d4c3.tar.gz"
+    sha256: "b4ca17e1bbb3a6cae6b840d78422490b75733b4165e5ba066302154d971ec32e"
   "0.1":
     url: "https://github.com/google/brunsli/archive/refs/tags/v0.1.tar.gz"
     sha256: "62762dc740f9fcc9706449c078f12c2a366416486d2882be50a9f201f99ac0bc"
 patches:
-  "cci.20230730":
+  "cci.20231024":
     - patch_file: "patches/cci.20230730/001-cmake-use-conan-deps.patch"
       patch_description: "Use Conan dependencies in CMake"
       patch_type: "conan"

--- a/recipes/brunsli/all/conandata.yml
+++ b/recipes/brunsli/all/conandata.yml
@@ -10,7 +10,13 @@ patches:
     - patch_file: "patches/cci.20230730/001-cmake-use-conan-deps.patch"
       patch_description: "Use Conan dependencies in CMake"
       patch_type: "conan"
+    - patch_file: "patches/cci.20230730/002-fix-shared-windows-build.patch"
+      patch_description: "Fix shared Windows build, do not build executables"
+      patch_type: "conan"
   "0.1":
     - patch_file: "patches/0.1/001-cmake-use-conan-deps.patch"
       patch_description: "Use Conan dependencies in CMake"
+      patch_type: "conan"
+    - patch_file: "patches/0.1/002-fix-shared-windows-build.patch"
+      patch_description: "Fix shared Windows build, do not build executables"
       patch_type: "conan"

--- a/recipes/brunsli/all/conandata.yml
+++ b/recipes/brunsli/all/conandata.yml
@@ -1,0 +1,16 @@
+sources:
+  "cci.20230730":
+    url: "https://github.com/google/brunsli/archive/6f18d495dbabcc5485ffa800d3de8b62229a697f.tar.gz"
+    sha256: "0bb520a48c37b0c71ee057200171fce9be66c8feb556d79e7d95251ccd51f992"
+  "0.1":
+    url: "https://github.com/google/brunsli/archive/refs/tags/v0.1.tar.gz"
+    sha256: "62762dc740f9fcc9706449c078f12c2a366416486d2882be50a9f201f99ac0bc"
+patches:
+  "cci.20230730":
+    - patch_file: "patches/cci.20230730/001-cmake-use-conan-deps.patch"
+      patch_description: "Use Conan dependencies in CMake"
+      patch_type: "conan"
+  "0.1":
+    - patch_file: "patches/0.1/001-cmake-use-conan-deps.patch"
+      patch_description: "Use Conan dependencies in CMake"
+      patch_type: "conan"

--- a/recipes/brunsli/all/conanfile.py
+++ b/recipes/brunsli/all/conanfile.py
@@ -42,7 +42,7 @@ class PackageConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("brotli/1.0.9")
+        self.requires("brotli/1.0.9", transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.cppstd:

--- a/recipes/brunsli/all/conanfile.py
+++ b/recipes/brunsli/all/conanfile.py
@@ -36,6 +36,7 @@ class PackageConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        self.options["brotli"].shared = False
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/brunsli/all/conanfile.py
+++ b/recipes/brunsli/all/conanfile.py
@@ -77,4 +77,5 @@ class PackageConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ["brunslidec-c", "brunslienc-c"]
+        self.cpp_info.components["brunslidec-c"].libs = ["brunslidec-c"]
+        self.cpp_info.components["brunslienc-c"].libs = ["brunslienc-c"]

--- a/recipes/brunsli/all/conanfile.py
+++ b/recipes/brunsli/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file, save
@@ -47,6 +48,8 @@ class PackageConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
+        if self.dependencies["brotli"].options.shared:
+            raise ConanInvalidConfiguration("brotli must be built as a static library")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/brunsli/all/conanfile.py
+++ b/recipes/brunsli/all/conanfile.py
@@ -59,6 +59,7 @@ class PackageConan(ConanFile):
         tc.cache_variables["BUILD_TESTING"] = False
         # TODO: add WASM support
         tc.cache_variables["BRUNSLI_EMSCRIPTEN"] = False
+        tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -74,6 +75,11 @@ class PackageConan(ConanFile):
             save(self, os.path.join(self.source_folder, "brunsli.cmake"),
                  "\ninstall(TARGETS brunslicommon-static brunslidec-static brunslienc-static)",
                  append=True)
+        # Fix DLL installation
+        replace_in_file(self, os.path.join(self.source_folder, "brunsli.cmake"),
+                        'LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"',
+                        'LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" '
+                        'RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"')
 
     def build(self):
         self._patch_sources()

--- a/recipes/brunsli/all/conanfile.py
+++ b/recipes/brunsli/all/conanfile.py
@@ -1,0 +1,80 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
+
+required_conan_version = ">=1.53.0"
+
+class PackageConan(ConanFile):
+    name = "brunsli"
+    description = "Practical JPEG Repacker"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/google/brunsli"
+    topics = ("jpeg", "repacker", "codec", "brotli", "wasm")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("brotli/1.0.9")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_TESTING"] = False
+        # TODO: add WASM support
+        tc.cache_variables["BRUNSLI_EMSCRIPTEN"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.set_property("brotli::brotlidec", "cmake_target_name", "brotlidec-static")
+        deps.set_property("brotli::brotlienc", "cmake_target_name", "brotlienc-static")
+        deps.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["brunslidec-c", "brunslienc-c"]

--- a/recipes/brunsli/all/patches/0.1/001-cmake-use-conan-deps.patch
+++ b/recipes/brunsli/all/patches/0.1/001-cmake-use-conan-deps.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -26,7 +26,7 @@
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ set(CMAKE_CXX_STANDARD_REQUIRED YES)
+ 
+-add_subdirectory(third_party)
++find_package(Brotli REQUIRED CONFIG)
+ 
+ # The Brunsli library definition.
+ include(brunsli.cmake)

--- a/recipes/brunsli/all/patches/0.1/002-fix-shared-windows-build.patch
+++ b/recipes/brunsli/all/patches/0.1/002-fix-shared-windows-build.patch
@@ -1,0 +1,43 @@
+Linked static libraries do not export symbols on Windows,
+so build the shared libraries from scratch instead.
+--- brunsli.cmake
++++ brunsli.cmake
+@@ -74,13 +74,21 @@
+ 
+ if(NOT BRUNSLI_EMSCRIPTEN)
+ add_library(brunslidec-c SHARED
++  ${BRUNSLI_COMMON_SOURCES}
++  ${BRUNSLI_COMMON_HEADERS}
++  ${BRUNSLI_DEC_SOURCES}
++  ${BRUNSLI_DEC_HEADERS}
+   c/dec/decode.cc
+ )
+-target_link_libraries(brunslidec-c PRIVATE brunslidec-static)
++target_link_libraries(brunslidec-c PRIVATE brotlidec-static)
+ add_library(brunslienc-c SHARED
++  ${BRUNSLI_COMMON_SOURCES}
++  ${BRUNSLI_COMMON_HEADERS}
++  ${BRUNSLI_ENC_SOURCES}
++  ${BRUNSLI_ENC_HEADERS}
+   c/enc/encode.cc
+ )
+-target_link_libraries(brunslienc-c PRIVATE brunslienc-static)
++target_link_libraries(brunslienc-c PRIVATE brotlienc-static)
+ list(APPEND BRUNSLI_LIBRARIES brunslidec-c brunslienc-c)
+ endif()  # BRUNSLI_EMSCRIPTEN
+ 
+@@ -95,14 +103,6 @@
+ endforeach()
+ 
+ if(NOT BRUNSLI_EMSCRIPTEN)
+-add_executable(cbrunsli c/tools/cbrunsli.cc)
+-target_link_libraries(cbrunsli PRIVATE
+-  brunslienc-static
+-)
+-add_executable(dbrunsli c/tools/dbrunsli.cc)
+-target_link_libraries(dbrunsli PRIVATE
+-  brunslidec-static
+-)
+ else()  # BRUNSLI_EMSCRIPTEN
+ set(WASM_MODULES brunslicodec-wasm brunslidec-wasm brunslienc-wasm)
+ foreach(module IN LISTS WASM_MODULES)

--- a/recipes/brunsli/all/patches/cci.20230730/001-cmake-use-conan-deps.patch
+++ b/recipes/brunsli/all/patches/cci.20230730/001-cmake-use-conan-deps.patch
@@ -1,0 +1,31 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -25,27 +25,7 @@
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ set(CMAKE_CXX_STANDARD_REQUIRED YES)
+ 
+-include(FetchContent)
+-
+-# Add GTest
+-FetchContent_Declare(
+-  GTest
+-  GIT_REPOSITORY https://github.com/google/googletest
+-  GIT_TAG e2239ee6043f73722e7aa812a459f54a28552929 # v1.11.0
+-)
+-# For Windows: Prevent overriding the parent project's compiler/linker settings
+-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+-set(BUILD_GMOCK OFF CACHE INTERNAL "")
+-FetchContent_MakeAvailable(GTest)
+-
+-# Add Brotli
+-FetchContent_Declare(
+-  Brotli
+-  GIT_REPOSITORY https://github.com/google/brotli
+-  GIT_TAG e61745a6b7add50d380cfd7d3883dd6c62fc2c71 # v1.0.9
+-)
+-set(BROTLI_DISABLE_TESTS ON CACHE INTERNAL "")
+-FetchContent_MakeAvailable(Brotli)
++find_package(Brotli REQUIRED CONFIG)
+ 
+ include(CTest)
+ 

--- a/recipes/brunsli/all/patches/cci.20230730/002-fix-shared-windows-build.patch
+++ b/recipes/brunsli/all/patches/cci.20230730/002-fix-shared-windows-build.patch
@@ -1,0 +1,72 @@
+Linked static libraries do not export symbols on Windows,
+so build the shared libraries from scratch instead.
+--- brunsli.cmake
++++ brunsli.cmake
+@@ -77,13 +77,21 @@
+ 
+ if(NOT BRUNSLI_EMSCRIPTEN)
+ add_library(brunslidec-c SHARED
++  ${BRUNSLI_COMMON_SOURCES}
++  ${BRUNSLI_COMMON_HEADERS}
++  ${BRUNSLI_DEC_SOURCES}
++  ${BRUNSLI_DEC_HEADERS}
+   c/dec/decode.cc
+ )
+-target_link_libraries(brunslidec-c PRIVATE brunslidec-static)
++target_link_libraries(brunslidec-c PRIVATE brotlidec-static)
+ add_library(brunslienc-c SHARED
++  ${BRUNSLI_COMMON_SOURCES}
++  ${BRUNSLI_COMMON_HEADERS}
++  ${BRUNSLI_ENC_SOURCES}
++  ${BRUNSLI_ENC_HEADERS}
+   c/enc/encode.cc
+ )
+-target_link_libraries(brunslienc-c PRIVATE brunslienc-static)
++target_link_libraries(brunslienc-c PRIVATE brotlienc-static)
+ list(APPEND BRUNSLI_LIBRARIES brunslidec-c brunslienc-c)
+ endif()  # BRUNSLI_EMSCRIPTEN
+ 
+@@ -95,14 +103,6 @@
+   set_property(TARGET ${lib} PROPERTY POSITION_INDEPENDENT_CODE ON)
+ endforeach()
+ 
+-add_executable(cbrunsli c/tools/cbrunsli.cc)
+-target_link_libraries(cbrunsli PRIVATE
+-  brunslienc-static
+-)
+-add_executable(dbrunsli c/tools/dbrunsli.cc)
+-target_link_libraries(dbrunsli PRIVATE
+-  brunslidec-static
+-)
+ if(BRUNSLI_EMSCRIPTEN)
+ set(WASM_MODULES brunslicodec-wasm brunslidec-wasm brunslienc-wasm)
+ foreach(module IN LISTS WASM_MODULES)
+@@ -121,14 +121,6 @@
+   ${WASM_BASE_FLAGS} \
+   -s MODULARIZE=1 \
+   -s FILESYSTEM=0 \
+-")
+-set_target_properties(cbrunsli PROPERTIES LINK_FLAGS "\
+-  ${WASM_BASE_FLAGS} \
+-  -s NODERAWFS=1 \
+-")
+-set_target_properties(dbrunsli PROPERTIES LINK_FLAGS "\
+-  ${WASM_BASE_FLAGS} \
+-  -s NODERAWFS=1 \
+ ")
+ set(WASM_COMMON_EXPORT "\"_malloc\",\"_free\"")
+ set(WASM_DEC_EXPORT "\"_BrunsliToJpeg\",\"_GetJpegData\",\"_GetJpegLength\",\"_FreeJpeg\",\"_BrunsliDecoderInit\",\"_BrunsliDecoderProcess\",\"_BrunsliDecoderCleanup\"")
+@@ -163,13 +155,6 @@
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+   )
+ endif() # BRUNSLI_EMSCRIPTEN
+-
+-# Gather artifacts in a single directory for easier uploading.
+-set_target_properties(cbrunsli dbrunsli ${BRUNSLI_LIBRARIES} PROPERTIES
+-  ARCHIVE_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/artifacts"
+-  LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/artifacts"
+-  RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/artifacts"
+-)
+ 
+ if (${BUILD_TESTING})
+ 

--- a/recipes/brunsli/all/test_package/CMakeLists.txt
+++ b/recipes/brunsli/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package CXX)
+
+find_package(brunsli REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE brunsli::brunsli)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/brunsli/all/test_package/conanfile.py
+++ b/recipes/brunsli/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/brunsli/all/test_package/test_package.cpp
+++ b/recipes/brunsli/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <brunsli/jpeg_data.h>
+#include <brunsli/types.h>
+#include <brunsli/jpeg_data_reader.h>
+
+int main() {
+    brunsli::JPEGData jpg;
+    const size_t input_size = 100;
+    const uint8_t input_data[input_size] = {};
+    bool ok = brunsli::ReadJpeg(input_data, input_size, brunsli::JPEG_READ_ALL, &jpg);
+}

--- a/recipes/brunsli/config.yml
+++ b/recipes/brunsli/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "cci.20230730":
+  "cci.20231024":
     folder: all
   "0.1":
     folder: all

--- a/recipes/brunsli/config.yml
+++ b/recipes/brunsli/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "cci.20230730":
+    folder: all
+  "0.1":
+    folder: all


### PR DESCRIPTION
Adds **brunsli**, a JPEG repacker library that applies Brotli compression to losslessly repack JPEG files: https://github.com/google/brunsli

Used by GDAL as an optional dependency.

Resolves #8629.

[![Packaging status](https://repology.org/badge/tiny-repos/brunsli.svg)](https://repology.org/project/brunsli/versions)