### PR TITLE
[nasm] Configure assembler compiler by cpp_info

### DIFF
--- a/recipes/nasm/all/conanfile.py
+++ b/recipes/nasm/all/conanfile.py
@@ -17,13 +17,27 @@ class NASMConan(ConanFile):
     homepage = "http://www.nasm.us"
     description = "The Netwide Assembler, NASM, is an 80x86 and x86-64 assembler"
     license = "BSD-2-Clause"
-    topics = ("nasm", "installer", "assembler")
+    topics = ("asm", "installer", "assembler",)
 
     settings = "os", "arch", "compiler", "build_type"
 
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
+
+    @property
+    def _nasm(self):
+        suffix = "w.exe" if is_msvc(self) else ""
+        return os.path.join(self.package_folder, "bin", f"nasm{suffix}")
+
+    @property
+    def _ndisasm(self):
+        suffix = "w.exe" if is_msvc(self) else ""
+        return os.path.join(self.package_folder, "bin", f"ndisasm{suffix}")
+
+    def _chmod_plus_x(self, filename):
+        if os.name == "posix":
+            os.chmod(filename, os.stat(filename).st_mode | 0o111)
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -94,10 +108,21 @@ class NASMConan(ConanFile):
             autotools = Autotools(self)
             autotools.install()
             rmdir(self, os.path.join(self.package_folder, "share"))
+        self._chmod_plus_x(self._nasm)
+        self._chmod_plus_x(self._ndisasm)
 
     def package_info(self):
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
 
+        compiler_executables = {"asm": self._nasm}
+        self.conf_info.update("tools.build:compiler_executables", compiler_executables)
+        self.buildenv_info.define_path("NASM", self._nasm)
+        self.buildenv_info.define_path("NDISASM", self._ndisasm)
+        self.buildenv_info.define_path("AS", self._nasm)
+
         # TODO: Legacy, to be removed on Conan 2.0
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+        self.env_info.NASM = self._nasm
+        self.env_info.NDISASM = self._ndisasm
+        self.env_info.AS = self._nasm


### PR DESCRIPTION
Specify library name and version:  **nasm/2.15.2**


Related to https://github.com/conan-io/conan-center-index/pull/18016

The `nasm` Conan package only stores binaries but forget to configure them properly to packages that will use as a tool requirement.

CMake will try use the system nasm and ignore that one provided by the package, in case not configured. Plus, `AS` variable is used for assembler.

This PR fixes a situation found when building `intel-ipsec-mb` where I needed to pass:

`tc.variables["CMAKE_ASM_NASM_COMPILER"] = os.path.join(self.dependencies.direct_build["nasm"].package_folder, "bin", "nasm")`

So I'm able to use nasm from Conan. Otherwise, CMake (using CMakeToolchain + CMakeDeps) will consume from system.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
