### PR TITLE
gperftools: add version 2.12.0

### DIFF
--- a/recipes/gperftools/all/conandata.yml
+++ b/recipes/gperftools/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.12.0":
+    url: "https://github.com/gperftools/gperftools/releases/download/gperftools-2.12/gperftools-2.12.tar.gz"
+    sha256: "fb611b56871a3d9c92ab0cc41f9c807e8dfa81a54a4a9de7f30e838756b5c7c6"
   "2.11.0":
     url: "https://github.com/gperftools/gperftools/releases/download/gperftools-2.11/gperftools-2.11.tar.gz"
     sha256: "8ffda10e7c500fea23df182d7adddbf378a203c681515ad913c28a64b87e24dc"

--- a/recipes/gperftools/config.yml
+++ b/recipes/gperftools/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.12.0":
+    folder: all
   "2.11.0":
     folder: all
   "2.10.0":


### PR DESCRIPTION
Specify library name and version:  **gperftools/2.12.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
