### PR TITLE
[wayland] Add ECM naming to aliases

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -131,6 +131,7 @@ class WaylandConan(ConanFile):
 
         if self.options.enable_libraries:
             self.cpp_info.components["wayland-server"].libs = ["wayland-server"]
+            self.cpp_info.components["wayland-server"].set_property("cmake_target_aliases", ["Wayland::Server"])
             self.cpp_info.components["wayland-server"].set_property("pkg_config_name", "wayland-server")
             self.cpp_info.components["wayland-server"].requires = ["libffi::libffi"]
             self.cpp_info.components["wayland-server"].system_libs = ["pthread", "m"]
@@ -147,6 +148,7 @@ class WaylandConan(ConanFile):
                 "\n".join(f"{key}={value}" for key, value in pkgconfig_variables.items()))
 
             self.cpp_info.components["wayland-client"].libs = ["wayland-client"]
+            self.cpp_info.components["wayland-client"].set_property("cmake_target_aliases", ["Wayland::Client"])
             self.cpp_info.components["wayland-client"].set_property("pkg_config_name", "wayland-client")
             self.cpp_info.components["wayland-client"].requires = ["libffi::libffi"]
             self.cpp_info.components["wayland-client"].system_libs = ["pthread", "m"]
@@ -164,15 +166,18 @@ class WaylandConan(ConanFile):
 
             self.cpp_info.components["wayland-cursor"].libs = ["wayland-cursor"]
             self.cpp_info.components["wayland-cursor"].set_property("pkg_config_name", "wayland-cursor")
+            self.cpp_info.components["wayland-cursor"].set_property("cmake_target_aliases", ["Wayland::Cursor"])
             self.cpp_info.components["wayland-cursor"].requires = ["wayland-client"]
             self.cpp_info.components["wayland-cursor"].set_property("component_version", self.version)
 
             self.cpp_info.components["wayland-egl"].libs = ["wayland-egl"]
             self.cpp_info.components["wayland-egl"].set_property("pkg_config_name", "wayland-egl")
+            self.cpp_info.components["wayland-egl"].set_property("cmake_target_aliases", "Wayland::Egl")
             self.cpp_info.components["wayland-egl"].requires = ["wayland-client"]
             self.cpp_info.components["wayland-egl"].set_property("component_version", "18.1.0")
 
             self.cpp_info.components["wayland-egl-backend"].set_property("pkg_config_name", "wayland-egl-backend")
+            self.cpp_info.components["wayland-egl-backend"].set_property("cmake_target_aliases", ["Wayland::Egl::Backend"])
             self.cpp_info.components["wayland-egl-backend"].set_property("component_version", "3")
 
             # TODO: to remove in conan v2

--- a/recipes/wayland/all/test_package/CMakeLists.txt
+++ b/recipes/wayland/all/test_package/CMakeLists.txt
@@ -3,5 +3,8 @@ project(test_package LANGUAGES C)
 
 find_package(wayland COMPONENTS wayland-client REQUIRED)
 
+# Test ECM FindWayland way
+find_package(Wayland COMPONENTS Cursor REQUIRED)
+
 add_executable(test_package test_package.c)
-target_link_libraries(test_package PRIVATE wayland::wayland-client)
+target_link_libraries(test_package PRIVATE wayland::wayland-client Wayland::Cursor)

--- a/recipes/wayland/all/test_package/test_package.c
+++ b/recipes/wayland/all/test_package/test_package.c
@@ -1,12 +1,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <wayland-client.h>
+#include <wayland-cursor.h>
 
-int main(int argc, char **argv) {
-
+int main(int argc, char **argv)
+{
     struct wl_display *display = wl_display_connect(NULL);
     if (display == NULL) {
-	    fprintf(stderr, "Can't connect to display\n");
+        fprintf(stderr, "Can't connect to display\n");
     }
     else
     {
@@ -15,6 +16,6 @@ int main(int argc, char **argv) {
         wl_display_disconnect(display);
         printf("disconnected from display\n");
     }
-    
+
     exit(0);
 }


### PR DESCRIPTION
**wayland/1.22.0**

ECM [FindWayland](https://invent.kde.org/frameworks/extra-cmake-modules/-/blob/master/find-modules/FindWayland.cmake) naming is used by quite a few apps for almost a decade.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
