### PR TITLE
xmlsec: bump libxml2 to 2.11.4

### DIFF
--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -60,7 +60,7 @@ class XmlSecConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libxml2/2.10.4", transitive_headers=True)
+        self.requires("libxml2/2.11.4", transitive_headers=True)
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
         if self.options.with_xslt:

--- a/recipes/xmlsec/all/test_package/conanfile.py
+++ b/recipes/xmlsec/all/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        self.requires("libxml2/2.10.4")
+        self.requires("libxml2/2.11.4")
 
     def generate(self):
         tc = CMakeToolchain(self)


### PR DESCRIPTION
xmlsec: libxml2 dependency bump to latest version (2.11.4)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
