### PR TITLE
drogon: add version 1.8.6, fix compilation error on 1.8.5 with yaml-cpp

### DIFF
--- a/recipes/drogon/all/conandata.yml
+++ b/recipes/drogon/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.6":
+    url: "https://github.com/drogonframework/drogon/archive/v1.8.6.tar.gz"
+    sha256: "ff02979f28047e97e19e36d1f363b3052b8122975fa8a379305d746dfe5fb004"
   "1.8.5":
     url: "https://github.com/drogonframework/drogon/archive/v1.8.5.tar.gz"
     sha256: "9469f99408c114bc1e89945a3a8dab4640ea6d8cb06e7d42f06c1dfda3f71d2a"
@@ -18,6 +21,13 @@ sources:
     url: "https://github.com/drogonframework/drogon/archive/refs/tags/v1.7.5.tar.gz"
     sha256: "e2af7c55dcabafef16f26f5b3242692f5a2b54c19b7b626840bf9132d24766f6"
 patches:
+  "1.8.6":
+    - patch_file: "patches/1.8.5-0001-remove-shared-libs.patch"
+      patch_description: "remove shared libs option"
+      patch_type: "conan"
+    - patch_file: "patches/1.8.6-0002-find-cci-packages.patch"
+      patch_description: "Fix jsoncpp cmake target name"
+      patch_type: "conan"
   "1.8.5":
     - patch_file: "patches/1.8.5-0001-remove-shared-libs.patch"
       patch_description: "remove shared libs option"

--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -57,6 +57,8 @@ class DrogonConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "1.8.4":
+            del self.options.with_yaml_cpp
 
     def configure(self):
         if self.options.shared:
@@ -128,8 +130,8 @@ class DrogonConan(ConanFile):
             self.requires("sqlite3/3.42.0")
         if self.options.get_safe("with_redis"):
             self.requires("hiredis/1.2.0")
-        if self.options.with_yaml_cpp:
-            self.requires("yaml-cpp/0.7.0")
+        if self.options.get_safe("with_yaml_cpp", False):
+            self.requires("yaml-cpp/0.8.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -146,7 +148,7 @@ class DrogonConan(ConanFile):
         tc.variables["BUILD_DROGON_SHARED"] = self.options.shared
         tc.variables["BUILD_DOC"] = False
         tc.variables["BUILD_BROTLI"] = self.options.with_brotli
-        tc.variables["BUILD_YAML_CONFIG"] = self.options.with_yaml_cpp
+        tc.variables["BUILD_YAML_CONFIG"] = self.options.get_safe("with_yaml_cpp", False)
         tc.variables["BUILD_POSTGRESQL"] = self.options.get_safe("with_postgres", False)
         tc.variables["BUILD_POSTGRESQL_BATCH"] = self.options.get_safe("with_postgres_batch", False)
         tc.variables["BUILD_MYSQL"] = self.options.get_safe("with_mysql", False)

--- a/recipes/drogon/all/patches/1.8.6-0002-find-cci-packages.patch
+++ b/recipes/drogon/all/patches/1.8.6-0002-find-cci-packages.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e3e7fcf..d1032da 100755
+index a3ba35a..26fed2a 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -198,9 +198,9 @@ else()
@@ -24,7 +24,7 @@ index e3e7fcf..d1032da 100755
                  target_compile_definitions(${PROJECT_NAME} PUBLIC HAS_YAML_CPP)
              endif()
          else()
-@@ -442,7 +442,7 @@ if (BUILD_SQLITE)
+@@ -444,7 +444,7 @@ if (BUILD_SQLITE)
      find_package(SQLite3 QUIET)
      find_package(unofficial-sqlite3 QUIET)
      if (SQLite3_FOUND)
@@ -33,7 +33,7 @@ index e3e7fcf..d1032da 100755
          set(DROGON_FOUND_SQLite3 TRUE)
      elseif (unofficial-sqlite3_FOUND)
          target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::sqlite3::sqlite3)
-@@ -465,10 +465,10 @@ if (BUILD_SQLITE)
+@@ -467,10 +467,10 @@ if (BUILD_SQLITE)
  endif (BUILD_SQLITE)
  
  if (BUILD_REDIS)
@@ -47,7 +47,7 @@ index e3e7fcf..d1032da 100755
          set(DROGON_SOURCES
              ${DROGON_SOURCES}
              nosql_lib/redis/src/RedisClientImpl.cc
-@@ -488,10 +488,10 @@ if (BUILD_REDIS)
+@@ -490,10 +490,10 @@ if (BUILD_REDIS)
              nosql_lib/redis/src/SubscribeContext.h
              nosql_lib/redis/src/RedisSubscriberImpl.h)
  
@@ -60,7 +60,7 @@ index e3e7fcf..d1032da 100755
      set(DROGON_SOURCES
          ${DROGON_SOURCES}
          lib/src/RedisClientSkipped.cc
-@@ -500,7 +500,7 @@ if (NOT Hiredis_FOUND)
+@@ -502,7 +502,7 @@ if (NOT Hiredis_FOUND)
      set(private_headers
          ${private_headers}
          lib/src/RedisClientManager.h)

--- a/recipes/drogon/config.yml
+++ b/recipes/drogon/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.6":
+    folder: "all"
   "1.8.5":
     folder: "all"
   "1.8.4":


### PR DESCRIPTION
Specify library name and version:  **drogon/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
