### PR TITLE
clickhouse-cpp: enable `enable_benchmark` and `with_openssl` options

### DIFF
--- a/recipes/clickhouse-cpp/all/conandata.yml
+++ b/recipes/clickhouse-cpp/all/conandata.yml
@@ -2,3 +2,8 @@ sources:
   "2.4.0":
     url: "https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/v2.4.0.tar.gz"
     sha256: "336a1d0b4c4d6bd67bd272afab3bdac51695f8b0e93dd6c85d4d774d6c7df8ad"
+patches:
+  "2.4.0":
+    - patch_file: "patches/2.4.0-0001-enable-benchmark.patch"
+      patch_description: "add find_package to enable benchmark"
+      patch_type: "portability"

--- a/recipes/clickhouse-cpp/all/conanfile.py
+++ b/recipes/clickhouse-cpp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain,CMakeDeps, cmake_layout
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, export_conandata_patches, apply_conandata_patches
 from conan.tools.build import check_min_cppstd
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.scm import Version
@@ -10,38 +10,25 @@ required_conan_version = ">=1.53.0"
 
 class ClickHouseCppConan(ConanFile):
     name = "clickhouse-cpp"
-    homepage = "https://github.com/ClickHouse/clickhouse-cpp"
-    url = "https://github.com/conan-io/conan-center-index"
     description = "ClickHouse C++ API"
     license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ClickHouse/clickhouse-cpp"
     topics = ("database", "db", "clickhouse")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
         "enable_benchmark": [True, False],
-        "with_openssl": [True, False]
+        "with_openssl": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_benchmark": False,
-        "with_openssl": False
+        "with_openssl": False,
     }
-
-    def requirements(self):
-
-        self.requires("lz4/1.9.4")
-
-        self.requires("abseil/20230125.3", transitive_headers=True)
-
-        self.requires("cityhash/cci.20130801")
-        if self.options.with_openssl:
-            self.requires("openssl/[>=1.1 <4]")
-
-    def build_requirements(self):
-        if self.options.enable_benchmark:
-            self.requires("benchmark/1.8.0")
 
     @property
     def _min_cppstd(self):
@@ -58,17 +45,12 @@ class ClickHouseCppConan(ConanFile):
 
     @property
     def _requires_compiler_rt(self):
-        return self.settings.compiler == "clang" and (( self.settings.compiler.libcxx in ["libstdc++", "libstdc++11"] and not self.options.shared) or  self.settings.compiler.libcxx == "libc++" )
+        return self.settings.compiler == "clang" and \
+            ((self.settings.compiler.libcxx in ["libstdc++", "libstdc++11"] and not self.options.shared) or \
+             self.settings.compiler.libcxx == "libc++")
 
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(f"{self.ref} requires C++17, which your compiler does not support.")
-        if self.settings.os == "Windows" and self.options.shared:
-            raise ConanInvalidConfiguration("f{self.ref} does not support shared library on Windows.")
-            # look at https://github.com/ClickHouse/clickhouse-cpp/pull/226
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -81,15 +63,36 @@ class ClickHouseCppConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def requirements(self):
+        self.requires("lz4/1.9.4")
+        self.requires("abseil/20230125.3", transitive_headers=True)
+        self.requires("cityhash/cci.20130801")
+        if self.options.with_openssl:
+            self.requires("openssl/[>=1.1 <4]")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+        if self.settings.os == "Windows" and self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} does not support shared library on Windows.")
+            # look at https://github.com/ClickHouse/clickhouse-cpp/pull/226
+
+    def build_requirements(self):
+        if self.options.enable_benchmark:
+            self.requires("benchmark/1.8.2")
+            self.requires("gtest/1.14.0")
+
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["BUILD_BENCHMARK"] =  self.options.enable_benchmark
+        tc.cache_variables["BUILD_BENCHMARK"] = self.options.enable_benchmark
         tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
-        tc.variables["WITH_OPENSSL"] = self.options.with_openssl
+        tc.cache_variables["WITH_OPENSSL"] = self.options.with_openssl
         tc.cache_variables["WITH_SYSTEM_ABSEIL"] = True
         tc.cache_variables["WITH_SYSTEM_LZ4"] = True
         tc.cache_variables["WITH_SYSTEM_CITYHASH"] = True
@@ -99,6 +102,7 @@ class ClickHouseCppConan(ConanFile):
         cd.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -118,10 +122,11 @@ class ClickHouseCppConan(ConanFile):
             self.cpp_info.sharedlinkflags = ldflags
             self.cpp_info.system_libs.append("gcc_s")
 
+        if self.settings.os == 'Windows':
+            self.cpp_info.system_libs = ['ws2_32', 'wsock32']
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "clickhouse-cpp"
         self.cpp_info.filenames["cmake_find_package_multi"] = "clickhouse-cpp"
         self.cpp_info.names["cmake_find_package"] = "clickhouse-cpp-lib"
         self.cpp_info.names["cmake_find_package_multi"] = "clickhouse-cpp-lib"
-
-        if self.settings.os == 'Windows':
-            self.cpp_info.system_libs = ['ws2_32', 'wsock32']

--- a/recipes/clickhouse-cpp/all/patches/2.4.0-0001-enable-benchmark.patch
+++ b/recipes/clickhouse-cpp/all/patches/2.4.0-0001-enable-benchmark.patch
@@ -1,0 +1,19 @@
+diff --git a/bench/CMakeLists.txt b/bench/CMakeLists.txt
+index ac99470..ffde613 100644
+--- a/bench/CMakeLists.txt
++++ b/bench/CMakeLists.txt
+@@ -1,3 +1,6 @@
++find_package(benchmark REQUIRED)
++find_package(GTest REQUIRED)
++
+ ADD_EXECUTABLE (bench
+     bench.cpp
+ )
+@@ -5,4 +8,7 @@ ADD_EXECUTABLE (bench
+ TARGET_LINK_LIBRARIES (bench
+     clickhouse-cpp-lib
+     benchmark
++    benchmark::benchmark
++    benchmark::benchmark_main
++    GTest::gtest
+ )

--- a/recipes/clickhouse-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/clickhouse-cpp/all/test_package/CMakeLists.txt
@@ -4,6 +4,5 @@ project(test_package LANGUAGES CXX)
 find_package(clickhouse-cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE clickhouse-cpp-lib::clickhouse-cpp-lib )
-
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_link_libraries(${PROJECT_NAME} PRIVATE clickhouse-cpp-lib::clickhouse-cpp-lib)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)


### PR DESCRIPTION
Specify library name and version:  **clickhouse-cpp/***

- set `BUILD_BENCHMARK` and `WITH_OPENSSL` by `cache_variables`
- When `enable_benchmark` is True, clickhouse-cpp requires benchmark and gtest.

Try to close https://github.com/conan-io/conan-center-index/issues/19379.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
