### PR TITLE
capnproto: add version 1.0.1

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.1":
+    url: "https://github.com/capnproto/capnproto/archive/v1.0.1.tar.gz"
+    sha256: "5bdb16f6b389a9e29b04214b9bae1759e8b7fe2b45049d7e3f1f286ba050a200"
   "1.0.0":
     url: "https://github.com/capnproto/capnproto/archive/v1.0.0.tar.gz"
     sha256: "bcd44dde78055313a7786cb6ab020cbef19b9045b53857f90cce101c9453f715"
@@ -24,6 +27,10 @@ sources:
     url: "https://github.com/capnproto/capnproto/archive/v0.7.0.tar.gz"
     sha256: "76c7114a3d142ad08b7208b3964a26e72a6320ee81331d3f0b87569fc9c47a28"
 patches:
+  "1.0.1":
+    - patch_file: "patches/0015-disable-tests-for-1.0.0.patch"
+      patch_description: "disable test build"
+      patch_type: "conan"
   "1.0.0":
     - patch_file: "patches/0015-disable-tests-for-1.0.0.patch"
       patch_description: "disable test build"

--- a/recipes/capnproto/config.yml
+++ b/recipes/capnproto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.1":
+    folder: all
   "1.0.0":
     folder: all
   "0.10.4":


### PR DESCRIPTION
Specify library name and version:  **capnproto/1.0.1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
