### PR TITLE
zlib-ng: fix `with_optim` default value

### DIFF
--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -34,7 +34,7 @@ class ZlibNgConan(ConanFile):
         "fPIC": True,
         "zlib_compat": False,
         "with_gzfileop": True,
-        "with_optim": False,
+        "with_optim": True,
         "with_new_strategies": True,
         "with_native_instructions": False,
         "with_reduced_mem": False,


### PR DESCRIPTION
Specify library name and version:  **zlib-ng/***

Try to close https://github.com/conan-io/conan-center-index/issues/19363.

The upstream default value of `WITH_OPTIM` is true at least since 2.0.0.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
