### PR TITLE
[scippp] Remove obsolete exports_sources from recipe

### DIFF
--- a/recipes/scippp/all/conanfile.py
+++ b/recipes/scippp/all/conanfile.py
@@ -12,7 +12,6 @@ class ScipPlusPlus(ConanFile):
     name = "scippp"
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps"
-    exports_sources = "CMakeLists.txt", "source/*", "include/*"
     description = "SCIP++ is a C++ wrapper for SCIP's C interface"
     package_type = "library"
     topics = ("mip", "solver", "linear", "programming")


### PR DESCRIPTION
Specify library name and version:  **scippp/1.0.2**

Removes obsolete `exports_sources`, see https://github.com/conan-io/conan-center-index/pull/19120#discussion_r1305458497

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
