### PR TITLE
[docs] Add section about Docker images used by CCI

### DIFF
--- a/docs/developing_recipes_locally.md
+++ b/docs/developing_recipes_locally.md
@@ -221,6 +221,29 @@ If you are working with packages that have system dependencies that are managed 
 docker run -e CONAN_SYSREQUIRES_MODE=enabled conanio/gcc11-ubuntu16.04 conan install fmt/9.0.0@ -if build --build missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=yes
 ```
 
+#### Docker build images used by ConanCenterIndex
+
+The Conan Center Index uses [Conan Docker Tools](https://github.com/conan-io/conan-docker-tools/) to build packages in a variety of environments. All images are hosted in [Docker Hub](https://hub.docker.com/u/conanio). The relation of the images with the build configurations is available according to the Conan configuration, as `node_labels.Linux`, for instance:
+
+
+```yaml
+node_labels:
+  Linux:
+    x86_64:
+      "gcc":
+        default: "linux_gcc_${compiler.version}"
+        "11": "linux_gcc_${compiler.version}_ubuntu16.04"
+      "clang":
+        default: "linux_clang_${compiler.version}_ubuntu16.04"
+        "11": "linux_clang_${compiler.version}"
+```
+
+The configuration files are located in the folder [../.c3i](../.c3i). Currently are the files [config_v1.yml](../.c3i/config_v1.yml) and [config_v2.yml](../.c3i/config_v2.yml). The configuration file `config_v1.yml` is used by the Conan 1.0 client, while `config_v2.yml` is used by the Conan 2.0 client.
+
+The label `linux` refers to any Docker image, while `gcc_${compiler.version}` refers to GCC + a compiler version. For example, `linux_gcc_10` refers to the image `conanio/gcc10`.
+The suffix `_ubuntu16.04` refers to the base image used by the Docker image, in this case, `ubuntu16.04`. So, `"11": "linux_gcc_${compiler.version}_ubuntu16.04"` means that the image `conanio/gcc11-ubuntu16.04`. Thus, all GCC versions use `conanio/gcc<version>`, except for the GCC 11, which uses `conanio/gcc11-ubuntu16.04`. The same applies to Clang.
+
+
 ## Using Conan 2.0
 
 Everything you need to know about the methods, commands line, outputs can be found in the


### PR DESCRIPTION
To support users to know what should be used when reproducing CCI builds, it would be better having the relation of docker images used by CCI. This PR adds a new section explaining the configuration behind Jenkins when fetching Docker images used to build official packages.

closes #19173

/cc @klausholstjacobsen


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
