### PR TITLE
zlib-ng: provide better compatibility with zlib

### DIFF
--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -51,6 +51,8 @@ class ZlibNgConan(ConanFile):
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
+        if self.options.zlib_compat:
+            self.provides = ["zlib"]
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -106,6 +108,12 @@ class ZlibNgConan(ConanFile):
             self.cpp_info.libs = [f"z{suffix}"]
         if self.options.zlib_compat:
             self.cpp_info.defines.append("ZLIB_COMPAT")
+            #copied from zlib
+            self.cpp_info.set_property("cmake_find_mode", "both")
+            self.cpp_info.set_property("cmake_file_name", "ZLIB")
+            self.cpp_info.set_property("cmake_target_name", "ZLIB::ZLIB")
+            self.cpp_info.names["cmake_find_package"] = "ZLIB"
+            self.cpp_info.names["cmake_find_package_multi"] = "ZLIB"
         if self.options.with_gzfileop:
             self.cpp_info.defines.append("WITH_GZFILEOP")
         if not self.options.with_new_strategies:

--- a/recipes/zlib-ng/all/test_package/CMakeLists.txt
+++ b/recipes/zlib-ng/all/test_package/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES C)
 
-find_package(zlib-ng REQUIRED CONFIG)
+if (ZLIB_COMPAT)
+  set(zlib_name ZLIB)
+else()
+  set(zlib_name zlib-ng)
+endif()
+
+find_package(${zlib_name} REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE zlib-ng::zlib-ng)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${zlib_name}::${zlib_name})
 target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/zlib-ng/all/test_package/conanfile.py
+++ b/recipes/zlib-ng/all/test_package/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
@@ -14,6 +14,11 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ZLIB_COMPAT"] = bool(self.dependencies["zlib-ng"].options.zlib_compat)
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/zlib-ng/all/test_v1_package/conanfile.py
+++ b/recipes/zlib-ng/all/test_v1_package/conanfile.py
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["ZLIB_COMPAT"] = self.options["zlib-ng"].zlib_compat
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **zlib-ng/all**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This change will allow zlib-ng to have same file/target names as zlib.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
