### PR TITLE
fruit: fix import of Version + add package_type + bump boost + remove deprecated option use_boost

### DIFF
--- a/recipes/fruit/all/conanfile.py
+++ b/recipes/fruit/all/conanfile.py
@@ -21,16 +21,17 @@ class FruitConan(ConanFile):
     license = "Apache-2.0"
     topics = ("injection", "framework")
     package_type = "library"
-    settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False],
-               "use_boost": [True, False, "deprecated"],
-               "with_boost": [True, False],
-               "fPIC": [True, False]}
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_boost": [True, False],
+    }
     default_options = {
         "shared": False,
-        "use_boost": "deprecated",
+        "fPIC": True,
         "with_boost": True,
-        "fPIC": True}
+    }
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -39,15 +40,9 @@ class FruitConan(ConanFile):
         if self.settings.os == "Windows":
             self.options.rm_safe("fPIC")
 
-    def package_id(self):
-        del self.info.options.use_boost
-
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        if self.options.use_boost != "deprecated":
-            self.output.warn("use_boost option is deprecated, use the option with_boost instead.")
-            self.options.with_boost = self.options.use_boost
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/fruit/all/conanfile.py
+++ b/recipes/fruit/all/conanfile.py
@@ -20,6 +20,7 @@ class FruitConan(ConanFile):
     homepage = "https://github.com/google/fruit"
     license = "Apache-2.0"
     topics = ("injection", "framework")
+    package_type = "library"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False],
                "use_boost": [True, False, "deprecated"],

--- a/recipes/fruit/all/conanfile.py
+++ b/recipes/fruit/all/conanfile.py
@@ -54,7 +54,7 @@ class FruitConan(ConanFile):
 
     def requirements(self):
         if self.options.with_boost:
-            self.requires("boost/1.80.0")
+            self.requires("boost/1.83.0")
 
     def validate(self):
         if self.settings.compiler.cppstd:

--- a/recipes/fruit/all/conanfile.py
+++ b/recipes/fruit/all/conanfile.py
@@ -3,11 +3,12 @@ import shutil
 import tarfile
 from fnmatch import fnmatch
 
-from conan import ConanFile, Version
+from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, download, export_conandata_patches, get
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 

--- a/recipes/fruit/config.yml
+++ b/recipes/fruit/config.yml
@@ -1,11 +1,11 @@
 versions:
-  "3.4.0":
-    folder: all
-  "3.5.0":
-    folder: all
-  "3.6.0":
+  "3.7.1":
     folder: all
   "3.7.0":
     folder: all
-  "3.7.1":
+  "3.6.0":
+    folder: all
+  "3.5.0":
+    folder: all
+  "3.4.0":
     folder: all


### PR DESCRIPTION
`from conan import Version` doesn't work anymore since conan 2.0.10 (I didn't even know that it was possible)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
