### PR TITLE
sqlpp11: fix import of Version

### DIFF
--- a/recipes/sqlpp11/all/conanfile.py
+++ b/recipes/sqlpp11/all/conanfile.py
@@ -1,9 +1,9 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.layout import basic_layout
 from conan.tools.files import get, copy
-from conan import Version
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -19,7 +19,6 @@ class Sqlpp11Conan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
-
 
     @property
     def _min_cppstd(self):
@@ -66,6 +65,4 @@ class Sqlpp11Conan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "sqlpp11::sqlpp11")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bindir))
-        self.env_info.PATH.append(bindir)
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
`from conan import Version` was illegal but allowed for some reason. Now it breaks in conan 2.0.10

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
