### PR TITLE
lefticus-tools: fix import of Version + add a layout

### DIFF
--- a/recipes/lefticus-tools/all/conanfile.py
+++ b/recipes/lefticus-tools/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, check_min_vs
 from conan.tools.scm import Version
 import os
@@ -32,6 +33,9 @@ class LefticusToolsConan(ConanFile):
             "clang": "13",
             "apple-clang": "14",
         }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/lefticus-tools/all/conanfile.py
+++ b/recipes/lefticus-tools/all/conanfile.py
@@ -1,9 +1,9 @@
 from conan import ConanFile
-from conan.tools.files import get, copy
-from conan.tools.build import check_min_cppstd
-from conan.tools.microsoft import is_msvc, check_min_vs
 from conan.errors import ConanInvalidConfiguration
-from conan import Version
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.microsoft import is_msvc, check_min_vs
+from conan.tools.scm import Version
 import os
 
 


### PR DESCRIPTION
fix illegal import which breaks in conan 2.0.10

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
