### PR TITLE
pkgconf: less verbose package_info() + bump meson

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -52,7 +52,7 @@ class PkgConfConan(ConanFile):
         self.settings.rm_safe("compiler.cppstd")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
+        self.tool_requires("meson/1.2.1")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -7,7 +7,6 @@ from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import is_msvc, unix_path_package_info_legacy
 from conan.tools.scm import Version
-from conan.errors import ConanInvalidConfiguration
 
 
 required_conan_version = ">=1.57.0"

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -51,11 +51,15 @@ class PkgConfConan(ConanFile):
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
 
+    def package_id(self):
+        if not self.info.options.enable_lib:
+            del self.info.settings.compiler
+
     def build_requirements(self):
         self.tool_requires("meson/1.2.1")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def _patch_sources(self):
         apply_conandata_patches(self)
@@ -111,10 +115,6 @@ class PkgConfConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
-    def package_id(self):
-        if not self.info.options.enable_lib:
-            del self.info.settings.compiler
-
     def package_info(self):
         if self.options.enable_lib:
             self.cpp_info.set_property("pkg_config_name", "libpkgconf")
@@ -143,7 +143,3 @@ class PkgConfConan(ConanFile):
         automake_extra_includes = unix_path_package_info_legacy(self, pkgconf_aclocal.replace("\\", "/"))
         self.env_info.PKG_CONFIG = pkg_config
         self.env_info.AUTOMAKE_CONAN_INCLUDES.append(automake_extra_includes)
-
-        # TODO: to remove in conan v2 once pkg_config generator removed
-        if self.options.enable_lib:
-            self.cpp_info.names["pkg_config"] = "libpkgconf"

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -129,12 +129,10 @@ class PkgConfConan(ConanFile):
             self.cpp_info.libdirs = []
 
         bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH env var: {}".format(bindir))
         self.env_info.PATH.append(bindir)
 
         exesuffix = ".exe" if self.settings.os == "Windows" else ""
         pkg_config = os.path.join(bindir, "pkgconf" + exesuffix).replace("\\", "/")
-        self.output.info("Setting PKG_CONFIG env var: {}".format(pkg_config))
         self.buildenv_info.define_path("PKG_CONFIG", pkg_config)
 
         pkgconf_aclocal = os.path.join(self.package_folder, "bin", "aclocal")
@@ -144,7 +142,6 @@ class PkgConfConan(ConanFile):
 
         # TODO: remove in conanv2
         automake_extra_includes = unix_path_package_info_legacy(self, pkgconf_aclocal.replace("\\", "/"))
-        self.output.info("Appending AUTOMAKE_CONAN_INCLUDES env var: {}".format(automake_extra_includes))
         self.env_info.PKG_CONFIG = pkg_config
         self.env_info.AUTOMAKE_CONAN_INCLUDES.append(automake_extra_includes)
 


### PR DESCRIPTION
Printing env vars in `package_info()` is useless (why not printing other informations like lib name etc for example? It's not the job of the recipe to print these informations, they are available through other way provided by conan) and can be very verbose during conan install because this method can be called multiple consecutive times (I have a conanfile where it's called 13 consecutive times for pkgconf/1.9.3 and 7 times for pkgconf/1.9.5...).



---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
