### PR TITLE
libcap/2.69: Bump version

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.69":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.69.tar.xz"
+    sha256: "f311f8f3dad84699d0566d1d6f7ec943a9298b28f714cae3c931dfd57492d7eb"
   "2.68":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.68.tar.xz"
     sha256: "90be3b6d41be5f81ae4b03ec76012b0d27c829293684f6c05b65d5f9cce724b2"
@@ -30,6 +33,13 @@ sources:
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.45.tar.xz"
     sha256: "d66639f765c0e10557666b00f519caf0bd07a95f867dddaee131cd284fac3286"
 patches:
+  "2.69":
+    - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+      patch_description: "allow to configure fPIC option from conan recipe"
+      patch_type: "conan"
+    - patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
+      patch_description: "allow to override compiler via environment variables"
+      patch_type: "conan"
   "2.68":
     - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
       patch_description: "allow to configure fPIC option from conan recipe"

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.69":
+    folder: all
   "2.68":
     folder: all
   "2.66":


### PR DESCRIPTION
Specify library name and version:  **libcap/2.69**

This version contains only the minor fixes.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
