### PR TITLE
tre: add recipe

### DIFF
--- a/recipes/tre/all/CMakeLists.txt
+++ b/recipes/tre/all/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required (VERSION 3.15)
+project (tre)
+
+set(HEADERS
+    local_includes/regex.h
+    local_includes/tre.h
+    win32/tre-config.h
+)
+file(GLOB SRCS lib/*.c)
+
+include_directories(win32 local_includes)
+add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS)
+add_definitions(-DHAVE_CONFIG_H -DHAVE_MALLOC_H)
+add_library(tre ${SRCS} win32/tre.def)
+
+install(TARGETS tre
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(FILES ${HEADERS}
+    DESTINATION include/tre
+)

--- a/recipes/tre/all/conandata.yml
+++ b/recipes/tre/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20230717":
+    url: "https://github.com/laurikari/tre/archive/07e66d07b44ae95a7a89f79c7ce1090f0f4d64db.tar.gz"
+    sha256: "d2810576685b10c6bf9270793550032bdada04afd963fa4670a08fdc57859bdd"

--- a/recipes/tre/all/conandata.yml
+++ b/recipes/tre/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "cci.20230717":
     url: "https://github.com/laurikari/tre/archive/07e66d07b44ae95a7a89f79c7ce1090f0f4d64db.tar.gz"
-    sha256: "d2810576685b10c6bf9270793550032bdada04afd963fa4670a08fdc57859bdd"
+    sha256: "f2390091a35c31e90efcce88006c2396f5698759f2f7abd136e771c3e0996961"

--- a/recipes/tre/all/conanfile.py
+++ b/recipes/tre/all/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.53.0"
 class TreConan(ConanFile):
     name = "tre"
     description = "TRE is a lightweight, robust, and efficient POSIX-compliant regexp matching library with some exciting features such as approximate (fuzzy) matching."
-    license = ""
+    license = "BSD-2-Clause"
     homepage = "https://github.com/laurikari/tre"
     url = "https://github.com/conan-io/conan-center-index"
     topics = "regex", "fuzzy matching"

--- a/recipes/tre/all/conanfile.py
+++ b/recipes/tre/all/conanfile.py
@@ -1,0 +1,73 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import cmake_layout
+from conan.tools.files import copy, get, replace_in_file
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.microsoft import is_msvc
+
+required_conan_version = ">=1.53.0"
+
+class TreConan(ConanFile):
+    name = "tre"
+    description = "TRE is a lightweight, robust, and efficient POSIX-compliant regexp matching library with some exciting features such as approximate (fuzzy) matching."
+    license = ""
+    homepage = "https://github.com/laurikari/tre"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = "regex", "fuzzy matching"
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("Windows builds are not yet supported")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.generate()
+
+    def _patch_sources(self):
+        if self.settings.os == "Windows" and not is_msvc(self):
+            replace_in_file(self, os.path.join(self.source_folder, "win32", "tre.def"), "tre.dll", "libtre.dll")
+
+    def build(self):
+        self._patch_sources()
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        autotools = Autotools(self)
+        autotools.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["tre"]
+

--- a/recipes/tre/all/conanfile.py
+++ b/recipes/tre/all/conanfile.py
@@ -11,6 +11,7 @@ from conan.tools.microsoft import is_msvc
 
 required_conan_version = ">=1.53.0"
 
+
 class TreConan(ConanFile):
     name = "tre"
     description = "TRE is a lightweight, robust, and efficient POSIX-compliant regexp matching library with some exciting features such as approximate (fuzzy) matching."
@@ -21,14 +22,8 @@ class TreConan(ConanFile):
 
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
-    options = {
-        "shared": [True, False],
-        "fPIC": [True, False],
-    }
-    default_options = {
-        "shared": False,
-        "fPIC": True,
-    }
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -37,21 +32,21 @@ class TreConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
-
     def validate(self):
         if self.settings.os == "Windows":
-            raise ConanInvalidConfiguration("Windows builds are not yet supported")
+            raise ConanInvalidConfiguration("Windows builds are not supported yet")
 
     def build_requirements(self):
         self.tool_requires("libtool/2.4.7")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
 
     def generate(self):
         env = VirtualBuildEnv(self)

--- a/recipes/tre/all/conanfile.py
+++ b/recipes/tre/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.cmake import cmake_layout
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
@@ -75,6 +76,7 @@ class TreConan(ConanFile):
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "tre")

--- a/recipes/tre/all/test_package/CMakeLists.txt
+++ b/recipes/tre/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package LANGUAGES C) # if the project is pure C
+project(test_package LANGUAGES C)
 
 find_package(tre REQUIRED CONFIG)
 

--- a/recipes/tre/all/test_package/CMakeLists.txt
+++ b/recipes/tre/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C) # if the project is pure C
+
+find_package(tre REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE tre::tre)

--- a/recipes/tre/all/test_package/conanfile.py
+++ b/recipes/tre/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/tre/all/test_package/test_package.c
+++ b/recipes/tre/all/test_package/test_package.c
@@ -1,0 +1,21 @@
+#include "tre/tre.h"
+#include <stdio.h>
+
+int main()
+{
+    regex_t rx;
+    tre_regcomp(&rx, "(January|February)", REG_EXTENDED);
+
+    regaparams_t params = {0};
+    tre_regaparams_default(&params);
+
+    regamatch_t match = {0};
+
+    if (!tre_regaexec(&rx, "Janvary", &match, params, 0)) {
+        printf("Levenshtein distance: %d\n", match.cost);
+    } else {
+        printf("Failed to match\n");
+    }
+
+    return 0;
+}

--- a/recipes/tre/config.yml
+++ b/recipes/tre/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20230717":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **tre/cci.20230717**: https://github.com/laurikari/tre

Did not include the last official release v0.8.0, since it's 14 years old and there have been minor improvements since without a version bump.

[![Packaging status](https://repology.org/badge/tiny-repos/tre.svg)](https://repology.org/project/tre/versions)