### PR TITLE
[docs] Change conan v2 feedback message

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -46,9 +46,9 @@ tasks:
     update_labels: false
     user_feedback:
       title: "Conan v2 pipeline"
-      description: "> **Note**: Conan v2 builds may be required once they are on the [v2 ready](https://github.com/conan-io/conan-center-index/blob/master/.c3i/conan_v2_ready_references.yml) list"
+      description: "> **Note**: Conan v2 builds are now mandatory. Please read our [discussion](https://github.com/conan-io/conan-center-index/discussions/19104) about it."
       regression: "> **Regression**: Conan v2 builds are mandatory and they are required for the PR to be merged, because this recipe worked with Conan v2 previously."
-      text_on_failure: "The v2 pipeline failed. Please, review the errors and note this will be required for pull requests to be merged in the near future."
+      text_on_failure: "The v2 pipeline failed. Please, review the errors and note this is required for pull requests to be merged. In case this recipe is still not ported to Conan 2.x, please, comment on the PR and we will help you."
       collapse_on_success: false
       collapse_on_failure: true
   list_packages:

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -48,7 +48,7 @@ tasks:
       title: "Conan v2 pipeline"
       description: "> **Note**: Conan v2 builds are now mandatory. Please read our [discussion](https://github.com/conan-io/conan-center-index/discussions/19104) about it."
       regression: "> **Regression**: Conan v2 builds are mandatory and they are required for the PR to be merged, because this recipe worked with Conan v2 previously."
-      text_on_failure: "The v2 pipeline failed. Please, review the errors and note this is required for pull requests to be merged. In case this recipe is still not ported to Conan 2.x, please, ping @conan-io/barbarians on the PR and we will help you."
+      text_on_failure: "The v2 pipeline failed. Please, review the errors and note this is required for pull requests to be merged. In case this recipe is still not ported to Conan 2.x, please, ping `@conan-io/barbarians` on the PR and we will help you."
       collapse_on_success: false
       collapse_on_failure: true
   list_packages:

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -48,7 +48,7 @@ tasks:
       title: "Conan v2 pipeline"
       description: "> **Note**: Conan v2 builds are now mandatory. Please read our [discussion](https://github.com/conan-io/conan-center-index/discussions/19104) about it."
       regression: "> **Regression**: Conan v2 builds are mandatory and they are required for the PR to be merged, because this recipe worked with Conan v2 previously."
-      text_on_failure: "The v2 pipeline failed. Please, review the errors and note this is required for pull requests to be merged. In case this recipe is still not ported to Conan 2.x, please, comment on the PR and we will help you."
+      text_on_failure: "The v2 pipeline failed. Please, review the errors and note this is required for pull requests to be merged. In case this recipe is still not ported to Conan 2.x, please, ping @conan-io/barbarians on the PR and we will help you."
       collapse_on_success: false
       collapse_on_failure: true
   list_packages:


### PR DESCRIPTION
Following Conan 2.x migration schedule. From now, all PRs should pass by Conan 2.x CI build.

More information in https://github.com/conan-io/conan-center-index/discussions/19104

Most of recipes are ported now to Conan 2.x, and the recommendation for those that are still missing is pinging us in the PR, so we can help to migrate it too.

This PR only updates the feedback message, not the CI behavior. The behavior should be done in a separated PR.


/cc @jcar87 @danimtb @RubenRBS 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
