### PR TITLE
earcut: fix target name

### DIFF
--- a/recipes/earcut/all/conanfile.py
+++ b/recipes/earcut/all/conanfile.py
@@ -68,5 +68,15 @@ class EarcutPackage(ConanFile):
         copy(self, "LICENSE", self.source_folder,
              os.path.join(self.package_folder, "licenses"))
 
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "earcut_hpp")
+        self.cpp_info.set_property("cmake_target_name", "earcut_hpp::earcut_hpp")
+        
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "earcut_hpp"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "earcut_hpp"
+        self.cpp_info.names["cmake_find_package"] = "earcut_hpp"
+        self.cpp_info.names["cmake_find_package_multi"] = "earcut_hpp"
+
     def package_id(self):
         self.info.clear()

--- a/recipes/earcut/all/test_package/CMakeLists.txt
+++ b/recipes/earcut/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES CXX)
 
-find_package(earcut REQUIRED CONFIG)
+find_package(earcut_hpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} example.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE earcut::earcut)
+target_link_libraries(${PROJECT_NAME} PRIVATE earcut_hpp::earcut_hpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)


### PR DESCRIPTION
Specify library name and version:  **earcut/\***

See [earcut CMakeLists](https://github.com/mapbox/earcut.hpp/blob/a299ad92b93b03aeab5d95195bb34bfc8f0b3263/CMakeLists.txt#L143)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
