### PR TITLE
onetbb: added 2021.10.0 version

### DIFF
--- a/recipes/onetbb/all/conandata.yml
+++ b/recipes/onetbb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2021.10.0":
+    url: "https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.10.0.tar.gz"
+    sha256: "487023a955e5a3cc6d3a0d5f89179f9b6c0ae7222613a7185b0227ba0c83700b"
   "2021.9.0":
     url: "https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.9.0.tar.gz"
     sha256: "1ce48f34dada7837f510735ff1172f6e2c261b09460e3bf773b49791d247d24e"

--- a/recipes/onetbb/config.yml
+++ b/recipes/onetbb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2021.10.0":
+    folder: all
   "2021.9.0":
     folder: all
   "2021.8.0":


### PR DESCRIPTION
Specify library name and version:  **onetbb/2021.10.0**

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
