### PR TITLE
Fix constexpr on clang for eastl

### DIFF
--- a/recipes/eastl/all/patches/3.17.03-0002-revert-c++14-constexpr.patch
+++ b/recipes/eastl/all/patches/3.17.03-0002-revert-c++14-constexpr.patch
@@ -9,7 +9,7 @@
 +	#if defined(EA_COMPILER_MSVC_2015)
 +		#define EA_CPP14_CONSTEXPR  // not supported
 +		#define EA_NO_CPP14_CONSTEXPR 
-+	#elif defined(__GNUC__) && (EA_COMPILER_VERSION < 9000)   // Before GCC 9.0
++	#elif defined(__GNUC__) && !defined(__llvm__) && (EA_COMPILER_VERSION < 9000)   // Before GCC 9.0
 +		#define EA_CPP14_CONSTEXPR  // not supported
 +		#define EA_NO_CPP14_CONSTEXPR 
 +	#elif defined(EA_COMPILER_CPP14_ENABLED)

--- a/recipes/eastl/all/test_package/test_package.cpp
+++ b/recipes/eastl/all/test_package/test_package.cpp
@@ -1,4 +1,5 @@
 #include <EASTL/hash_map.h>
+#include <EASTL/string_view.h>
 #include <new>
 
 // https://github.com/electronicarts/EASTL/blob/master/doc/FAQ.md#info15-how-hard-is-it-to-incorporate-eastl-into-my-project
@@ -10,6 +11,7 @@ void *operator new[](size_t size, size_t alignment, size_t alignmentOffset, cons
 }
 
 int main() {
+    constexpr eastl::string_view string = "string_view";
     eastl::hash_map<int, int> map;
     map[0] = 1;
     return 0;


### PR DESCRIPTION
Specify library name and version:  eastl/3.21.12

When building with clang 16, it was not possible to use constexpr with eastl
This is due to _GNUC_ being defined on clang and EA_COMPILER_VERSION being less than 9000

With clang, EA_COMPILER_VERSION is defined to:

`#define EA_COMPILER_VERSION (__clang_major__ * 100 + __clang_minor__)`

see https://github.com/electronicarts/EABase/blob/521cb053d9320636f53226ffc616216cf532f0ef/include/Common/EABase/config/eacompiler.h#L341C53-L341C53

I propose to exclude clang from 

```
	#elif defined(__GNUC__) && (EA_COMPILER_VERSION < 9000)   // Before GCC 9.0
		#define EA_CPP14_CONSTEXPR  // not supported
		#define EA_NO_CPP14_CONSTEXPR 
```
Since it only applies to gcc before 9.0, according to the comment

Also, added a constexpr test case in the test package


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
