### PR TITLE
octo-encryption-cpp: support conan v2, add package_type, relax openssl and cmake versions

### DIFF
--- a/recipes/octo-encryption-cpp/all/conandata.yml
+++ b/recipes/octo-encryption-cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "1.1.0":
-    sha256: f595eb6c44187e8f5f047fc7bd6747ba0d50ad99f526fe87c16fdba9c77b513d
-    url: https://github.com/ofiriluz/octo-encryption-cpp/archive/refs/tags/v1.1.0.tar.gz
+    url: "https://github.com/ofiriluz/octo-encryption-cpp/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "f595eb6c44187e8f5f047fc7bd6747ba0d50ad99f526fe87c16fdba9c77b513d"

--- a/recipes/octo-encryption-cpp/all/conanfile.py
+++ b/recipes/octo-encryption-cpp/all/conanfile.py
@@ -37,7 +37,7 @@ class OctoEncryptionCPPConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("openssl/[>=1.1 <4]")
+        self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/octo-encryption-cpp/all/conanfile.py
+++ b/recipes/octo-encryption-cpp/all/conanfile.py
@@ -4,19 +4,24 @@ from conan.tools.files import get, copy
 from conan.tools.build import check_min_cppstd
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc_static_runtime
 import os
 
-required_conan_version = ">=1.50.0"
-
+required_conan_version = ">=1.53.0"
 
 class OctoEncryptionCPPConan(ConanFile):
     name = "octo-encryption-cpp"
+    description = "Octo encryption library"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/ofiriluz/octo-encryption-cpp"
-    description = "Octo encryption library"
     topics = ("cryptography", "cpp")
-    settings = "os", "compiler", "build_type", "arch"
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    @property
+    def _min_cppstd(self):
+        return 17
 
     @property
     def _compilers_minimum_version(self):
@@ -25,8 +30,33 @@ class OctoEncryptionCPPConan(ConanFile):
             "clang": "9",
             "apple-clang": "11",
             "Visual Studio": "16",
-            "msvc": "1923",
+            "msvc": "192",
         }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("openssl/[>=1.1 <4]")
+
+    def validate(self):
+        if self.info.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+        if self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libc++":
+            raise ConanInvalidConfiguration(f"{self.name} does not support clang with libc++. Use libstdc++ instead.")
+        if is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration(f"{self.ref} does not support MSVC MT/MTd configurations, only MD/MDd is supported")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -35,35 +65,6 @@ class OctoEncryptionCPPConan(ConanFile):
         tc.generate()
         cd = CMakeDeps(self)
         cd.generate()
-
-    def layout(self):
-        cmake_layout(self, src_folder="src")
-
-    def validate(self):
-        if self.info.settings.compiler.cppstd:
-            check_min_cppstd(self, "17")
-
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.name} requires C++17, which your compiler does not support."
-            )
-        else:
-            self.output.warn(f"{self.name} requires C++17. Your compiler is unknown. Assuming it supports C++17.")
-        if self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libc++":
-            raise ConanInvalidConfiguration(f"{self.name} does not support clang with libc++. Use libstdc++ instead.")
-        if self.settings.compiler == "Visual Studio" and self.settings.compiler.runtime in ["MTd", "MT"]:
-            raise ConanInvalidConfiguration(f"{self.name} does not support MSVC MT/MTd configurations, only MD/MDd is supported")
-
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
-
-    def requirements(self):
-        self.requires("openssl/1.1.1q")
-
-    def build_requirements(self):
-        self.build_requires("cmake/3.24.0")
 
     def build(self):
         cmake = CMake(self)
@@ -76,11 +77,14 @@ class OctoEncryptionCPPConan(ConanFile):
         cmake.install()
 
     def package_info(self):
+        self.cpp_info.libs = ["octo-encryption-cpp"]
+
         self.cpp_info.set_property("cmake_file_name", "octo-encryption-cpp")
         self.cpp_info.set_property("cmake_target_name", "octo::octo-encryption-cpp")
         self.cpp_info.set_property("pkg_config_name", "octo-encryption-cpp")
-        self.cpp_info.libs = ["octo-encryption-cpp"]
+        self.cpp_info.requires = ["openssl::openssl"]
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "octo-encryption-cpp"
         self.cpp_info.names["cmake_find_package_multi"] = "octo-encryption-cpp"
         self.cpp_info.names["pkg_config"] = "octo-encryption-cpp"
-        self.cpp_info.requires = ["openssl::openssl"]

--- a/recipes/octo-encryption-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/octo-encryption-cpp/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
 find_package(octo-encryption-cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} octo::octo-encryption-cpp)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_link_libraries(${PROJECT_NAME} PRIVATE octo::octo-encryption-cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/octo-encryption-cpp/all/test_package/conanfile.py
+++ b/recipes/octo-encryption-cpp/all/test_package/conanfile.py
@@ -1,19 +1,16 @@
-from conans import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain
+from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout
+from conan.tools.cmake import cmake_layout, CMake
 import os
-
-required_conan_version = ">=1.43.0"
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeDeps", "VirtualRunEnv"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.generate()
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def layout(self):
         cmake_layout(self)
@@ -25,4 +22,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")


### PR DESCRIPTION
Specify library name and version:  **octo-encryption-cpp/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
