### PR TITLE
bump nss sqlite3 dep

### DIFF
--- a/recipes/nss/all/conanfile.py
+++ b/recipes/nss/all/conanfile.py
@@ -36,7 +36,7 @@ class NSSConan(ConanFile):
         if self.settings.os == "Windows":
             self.build_requires("mozilla-build/3.3")
         if hasattr(self, "settings_build"):
-            self.build_requires("sqlite3/3.41.2")
+            self.build_requires("sqlite3/3.42.0")
 
     def configure(self):
         self.options["nspr"].shared = True
@@ -49,7 +49,7 @@ class NSSConan(ConanFile):
 
     def requirements(self):
         self.requires("nspr/4.35")
-        self.requires("sqlite3/3.41.2")
+        self.requires("sqlite3/3.42.0")
         self.requires("zlib/1.2.13")
 
     def validate(self):


### PR DESCRIPTION
Specify library name and version:  **nss/all**

The ``sqlite3`` dependency is causing some conflicts, lets try to update it to 3.42.0, to align with other ConanCenter recipes.


