### PR TITLE
mpc: add version 1.3.1, update dependencies, fix homepage

### DIFF
--- a/recipes/mpc/all/conandata.yml
+++ b/recipes/mpc/all/conandata.yml
@@ -1,10 +1,13 @@
 sources:
+  "1.3.1":
+    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
+    sha256: "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
   "1.2.0":
-    url: https://ftp.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz
-    sha256: e90f2d99553a9c19911abdb4305bf8217106a957e3994436428572c8dfe8fda6
+    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz"
+    sha256: "e90f2d99553a9c19911abdb4305bf8217106a957e3994436428572c8dfe8fda6"
   "1.1.0":
-    url: https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
-    sha256: 6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
+    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
+    sha256: "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e"
 patches:
   "1.2.0":
     - patch_file: "patches/1.2.0-0001-asin-missing-limits.patch"

--- a/recipes/mpc/all/conanfile.py
+++ b/recipes/mpc/all/conanfile.py
@@ -39,8 +39,8 @@ class MpcConan(ConanFile):
         self.settings.rm_safe("compiler.cppstd")
 
     def requirements(self):
-        self.requires("gmp/6.2.1", transitive_headers=True)
-        self.requires("mpfr/4.1.0", transitive_headers=True)
+        self.requires("gmp/6.3.0", transitive_headers=True)
+        self.requires("mpfr/4.2.0", transitive_headers=True)
 
     def validate(self):
         # FIXME: add msvc support, upstream has a makefile.vc

--- a/recipes/mpc/all/conanfile.py
+++ b/recipes/mpc/all/conanfile.py
@@ -14,16 +14,22 @@ required_conan_version = ">=1.54.0"
 
 class MpcConan(ConanFile):
     name = "mpc"
-    package_type = "library"
     description = "GNU MPC is a C library for the arithmetic of complex numbers with arbitrarily high precision " \
                   "and correct rounding of the result"
-    topics = ("conan", "mpc", "multiprecision", "math", "mathematics")
-    url = "https://github.com/conan-io/conan-center-index"
-    homepage = "http://www.multiprecision.org/mpc/home.html"
     license = "LGPL-3.0-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.multiprecision.org/"
+    topics = ("multiprecision", "math", "mathematics")
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    package_type = "library"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -38,6 +44,9 @@ class MpcConan(ConanFile):
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
 
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
     def requirements(self):
         self.requires("gmp/6.3.0", transitive_headers=True)
         self.requires("mpfr/4.2.0", transitive_headers=True)
@@ -45,7 +54,7 @@ class MpcConan(ConanFile):
     def validate(self):
         # FIXME: add msvc support, upstream has a makefile.vc
         if is_msvc(self):
-            raise ConanInvalidConfiguration("mpc can be built with msvc, but it's not supported yet in this recipe.")
+            raise ConanInvalidConfiguration(f"{self.ref} can be built with msvc, but it's not supported yet in this recipe.")
 
     @property
     def _settings_build(self):
@@ -57,12 +66,8 @@ class MpcConan(ConanFile):
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
 
-    def layout(self):
-        basic_layout(self, src_folder="src")
-
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         env = VirtualBuildEnv(self)

--- a/recipes/mpc/all/test_package/CMakeLists.txt
+++ b/recipes/mpc/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+project(test_package LANGUAGES C)
 
 find_package(mpc REQUIRED CONFIG)
 

--- a/recipes/mpc/all/test_package/conanfile.py
+++ b/recipes/mpc/all/test_package/conanfile.py
@@ -5,8 +5,9 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/mpc/config.yml
+++ b/recipes/mpc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.1":
+    folder: all
   "1.2.0":
     folder: all
   "1.1.0":


### PR DESCRIPTION
Specify library name and version:  **mpc/***

The old homepage is now 404.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
