### PR TITLE
freetype: bump brotli, restore fixed version of libpng, and proper version range for zlib

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -64,13 +64,13 @@ class FreetypeConan(ConanFile):
 
     def requirements(self):
         if self.options.with_png:
-            self.requires("libpng/[>=1.6 <1.7]")
+            self.requires("libpng/1.6.40")
         if self.options.with_zlib:
-            self.requires("zlib/[>=1.2 <1.3]")
+            self.requires("zlib/[>=1.2.10 <2]")
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.get_safe("with_brotli"):
-            self.requires("brotli/1.0.9")
+            self.requires("brotli/1.1.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Version range is not allowed yet for libpng. Version range for zlib is extended.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
