### PR TITLE
libheif: fix dependencies cannot be found

### DIFF
--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -17,6 +17,7 @@ sources:
 patches:
   "1.16.2":
     - patch_file: "patches/0001-cmake_1.16.2.patch"
+    - patch_file: "patches/0002-plugins_cmake_1.16.2.patch"
   "1.13.0":
     - patch_file: "patches/0001-cmake_1.13.0.patch"
   "1.12.0":

--- a/recipes/libheif/all/patches/0001-cmake_1.16.2.patch
+++ b/recipes/libheif/all/patches/0001-cmake_1.16.2.patch
@@ -20,6 +20,18 @@ index de15948..589eab5 100644
  
  option(ENABLE_PLUGIN_LOADING "Support loading of plugins" ON)
  set(PLUGIN_DIRECTORY "${CMAKE_INSTALL_FULL_LIBDIR}/libheif" CACHE STRING "Plugin install directory")
+@@ -74,9 +74,9 @@
+         find_package(${packageName})
+     endif ()
+
+-    if (${variableName}_FOUND AND WITH_${variableName}_PLUGIN AND PLUGIN_LOADING_SUPPORTED_AND_ENABLED)
++    if (${packageName}_FOUND AND WITH_${packageName}_PLUGIN AND PLUGIN_LOADING_SUPPORTED_AND_ENABLED)
+         set(msg "found (plugin)")
+-    elseif (${variableName}_FOUND)
++    elseif (${packageName}_FOUND)
+         set(msg "found (built-in)")
+     elseif (WITH_${variableName})
+         set(msg "not found")
 @@ -88,11 +88,11 @@ macro(plugin_option variableName packageName displayName displayType defaultPlug
      unset(msg)
  endmacro()

--- a/recipes/libheif/all/patches/0002-plugins_cmake_1.16.2.patch
+++ b/recipes/libheif/all/patches/0002-plugins_cmake_1.16.2.patch
@@ -1,0 +1,31 @@
+--- a/libheif/plugins/CMakeLists.txt
++++ b/libheif/plugins/CMakeLists.txt
+@@ -44,23 +44,23 @@
+ 
+ set(X265_sources encoder_x265.h encoder_x265.cc)
+ set(X265_extra_plugin_sources)
+-plugin_compilation(x265 X265 X265 X265)
++plugin_compilation(x265 x265 X265 X265)
+ 
+ set(LIBDE265_sources decoder_libde265.cc decoder_libde265.h)
+ set(LIBDE265_extra_plugin_sources ../error.cc)
+-plugin_compilation(libde265 LIBDE265 LIBDE265 LIBDE265)
++plugin_compilation(libde265 libde265 LIBDE265 LIBDE265)
+ 
+ set(DAV1D_sources decoder_dav1d.cc decoder_dav1d.h)
+ set(DAV1D_extra_plugin_sources ../common_utils.cc ../common_utils.h)
+-plugin_compilation(dav1d DAV1D DAV1D DAV1D)
++plugin_compilation(dav1d Dav1d DAV1D DAV1D)
+ 
+ set(AOM_DECODER_sources decoder_aom.cc decoder_aom.h)
+ set(AOM_DECODER_extra_plugin_sources)
+-plugin_compilation(aomdec AOM AOM_DECODER AOM_DECODER)
++plugin_compilation(aomdec libaom-av1 AOM_DECODER AOM_DECODER)
+ 
+ set(AOM_ENCODER_sources encoder_aom.cc encoder_aom.h)
+ set(AOM_ENCODER_extra_plugin_sources ../error.cc ../common_utils.cc ../common_utils.h)
+-plugin_compilation(aomenc AOM AOM_ENCODER AOM_ENCODER)
++plugin_compilation(aomenc libaom-av1 AOM_ENCODER AOM_ENCODER)
+ 
+ set(SvtEnc_sources encoder_svt.cc encoder_svt.h)
+ set(SvtEnc_extra_plugin_sources)


### PR DESCRIPTION
Specify library name and version:  **libheif/1.16.2**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

libheif fail to find libde265 when with_libde265 is True.

<details><summary>before fix</summary>
➜  ~ conan install libheif/1.16.2@_/_ -pr:b default -pr:h windows  --build libheif
Configuration (profile_host):
[settings]
arch=x86
arch_build=x86_64
build_type=Debug
compiler=Visual Studio
compiler.runtime=MDd
compiler.version=17
os=Windows
os_build=Windows
[options]
[build_requires]
[env]

Configuration (profile_build):
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=Visual Studio
compiler.runtime=MD
compiler.version=17
os=Windows
os_build=Windows
[options]
[build_requires]
[env]

libheif/1.16.2: Not found in local cache, looking in remotes...
libheif/1.16.2: Trying with 'conan-local'...
libheif/1.16.2: Trying with 'conancenter'...
Downloading conanmanifest.txt completed [0.18k]
Downloading conanfile.py completed [4.58k]
Downloading conan_export.tgz completed [0.36k]
Decompressing conan_export.tgz completed [0.00k]
libheif/1.16.2: Downloaded recipe revision 0
libheif/1.16.2: Forced build from source
Installing package: libheif/1.16.2
Requirements
    libde265/1.0.12 from 'conancenter' - Cache
    libheif/1.16.2 from 'conancenter' - Downloaded
Packages
    libde265/1.0.12:3ff87c4967c72fcb3661a32ff12fe09c988ae4a8 - Cache
    libheif/1.16.2:10c8e0499f28dcc03304c22f523c31175c2ee2dc - Build

Cross-build from 'Windows:x86_64' to 'Windows:x86'
Installing (downloading, building) binaries...
libde265/1.0.12: Already installed!
Downloading conan_sources.tgz completed [0.98k]
Decompressing conan_sources.tgz completed [0.00k]
libheif/1.16.2: Configuring sources in D:\conan\data\libheif\1.16.2\_\_\source\src
Downloading libheif-1.16.2.tar.gz completed [1307.68k]                                   libheif/1.16.2: bheif/1.16.2:
libheif/1.16.2:
libheif/1.16.2: Copying sources to build folder
libheif/1.16.2: Building your package in D:\conan\data\libheif\1.16.2\_\_\build\10c8e0499f28dcc03304c22f523c31175c2ee2dc
libheif/1.16.2: Generator txt created conanbuildinfo.txt
libheif/1.16.2: Calling generate()
libheif/1.16.2: Preset 'default' added to CMakePresets.json. Invoke it manually using 'cmake --preset default'
libheif/1.16.2: If your CMake version is not compatible with CMakePresets (<3.19) call cmake like: 'cmake <path> -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE=D:\conan\data\libheif\1.16.2\_\_\build\10c8e0499f28dcc03304c22f523c31175c2ee2dc\build\generators\conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW'
libheif/1.16.2: Aggregating env generators
libheif/1.16.2: Calling build()
libheif/1.16.2: CMake command: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="D:/conan/data/libheif/1.16.2/_/_/build/10c8e0499f28dcc03304c22f523c31175c2ee2dc/build/generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="D:/conan/data/libheif/1.16.2/_/_/package/10c8e0499f28dcc03304c22f523c31175c2ee2dc" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "D:\conan\data\libheif\1.16.2\_\_\build\10c8e0499f28dcc03304c22f523c31175c2ee2dc\src"
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Using Conan toolchain: D:/conan/data/libheif/1.16.2/_/_/build/10c8e0499f28dcc03304c22f523c31175c2ee2dc/build/generators/conan_toolchain.cmake
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is MSVC 19.37.32822.0
-- The CXX compiler identification is MSVC 19.37.32822.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x86/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x86/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for unistd.h
-- Looking for unistd.h - not found
-- Performing Test has_potentially_evaluated_expression
-- Performing Test has_potentially_evaluated_expression - Failed
-- Conan: Target declared 'de265'
libde265 (HEIC decoder): not found
x265 (HEIC encoder): disabled
Dav1d (AVIF decoder): disabled
CMake Warning at CMakeLists.txt:74 (find_package):
  By not providing "Findlibaom-av1.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "libaom-av1", but CMake did not find one.

  Could not find a package configuration file provided by "libaom-av1" with
  any of the following names:

    libaom-av1Config.cmake
    libaom-av1-config.cmake

  Add the installation prefix of "libaom-av1" to CMAKE_PREFIX_PATH or set
  "libaom-av1_DIR" to a directory containing one of the above files.  If
  "libaom-av1" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:94 (plugin_option)


aom (AVIF encoder): not found
CMake Warning at CMakeLists.txt:74 (find_package):
  By not providing "Findlibaom-av1.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "libaom-av1", but CMake did not find one.

  Could not find a package configuration file provided by "libaom-av1" with
  any of the following names:

    libaom-av1Config.cmake
    libaom-av1-config.cmake

  Add the installation prefix of "libaom-av1" to CMAKE_PREFIX_PATH or set
  "libaom-av1_DIR" to a directory containing one of the above files.  If
  "libaom-av1" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:95 (plugin_option)


aom (AVIF decoder): not found
CMake Warning at CMakeLists.txt:74 (find_package):
  By not providing "FindSvtEnc.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "SvtEnc", but
  CMake did not find one.

  Could not find a package configuration file provided by "SvtEnc" with any
  of the following names:

    SvtEncConfig.cmake
    svtenc-config.cmake

  Add the installation prefix of "SvtEnc" to CMAKE_PREFIX_PATH or set
  "SvtEnc_DIR" to a directory containing one of the above files.  If "SvtEnc"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  CMakeLists.txt:96 (plugin_option)


Svt-av1 (AVIF encoder): not found
Rav1e (AVIF encoder): disabled
CMake Warning at CMakeLists.txt:104 (find_package):
  By not providing "Findlibsharpyuv.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "libsharpyuv", but CMake did not find one.

  Could not find a package configuration file provided by "libsharpyuv" with
  any of the following names:

    libsharpyuvConfig.cmake
    libsharpyuv-config.cmake

  Add the installation prefix of "libsharpyuv" to CMAKE_PREFIX_PATH or set
  "libsharpyuv_DIR" to a directory containing one of the above files.  If
  "libsharpyuv" provides a separate development package or SDK, be sure it
  has been installed.


libsharpyuv: disabled
Not compiling 'x265' backend
Not compiling 'libde265' backend
Not compiling 'dav1d' backend
Not compiling 'aomdec' backend
Not compiling 'aomenc' backend
Not compiling 'svtenc' backend
Not compiling 'rav1e' backend
Not compiling 'libsharpyuv'
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- Configuring done (4.2s)
-- Generating done (0.0s)
</details>

**libde265 (HEIC decoder): not found**

<details><summary>After fix</summary>
➜  ~ conan install libheif/1.16.2@_/_ -pr:b default -pr:h windows  --build libheif
Configuration (profile_host):
[settings]
arch=x86
arch_build=x86_64
build_type=Debug
compiler=Visual Studio
compiler.runtime=MDd
compiler.version=17
os=Windows
os_build=Windows
[options]
[build_requires]
[env]

Configuration (profile_build):
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=Visual Studio
compiler.runtime=MD
compiler.version=17
os=Windows
os_build=Windows
[options]
[build_requires]
[env]

libheif/1.16.2: Forced build from source
Installing package: libheif/1.16.2
Requirements
    libde265/1.0.12 from 'conancenter' - Cache
    libheif/1.16.2 from 'conancenter' - Cache
Packages
    libde265/1.0.12:3ff87c4967c72fcb3661a32ff12fe09c988ae4a8 - Cache
    libheif/1.16.2:10c8e0499f28dcc03304c22f523c31175c2ee2dc - Build

Cross-build from 'Windows:x86_64' to 'Windows:x86'
Installing (downloading, building) binaries...
libde265/1.0.12: Already installed!
libheif/1.16.2: Copying sources to build folder
libheif/1.16.2: Building your package in D:\conan\data\libheif\1.16.2\_\_\build\10c8e0499f28dcc03304c22f523c31175c2ee2dc
libheif/1.16.2: Generator txt created conanbuildinfo.txt
libheif/1.16.2: Calling generate()
libheif/1.16.2: Preset 'default' added to CMakePresets.json. Invoke it manually using 'cmake --preset default'
libheif/1.16.2: If your CMake version is not compatible with CMakePresets (<3.19) call cmake like: 'cmake <path> -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE=D:\conan\data\libheif\1.16.2\_\_\build\10c8e0499f28dcc03304c22f523c31175c2ee2dc\build\generators\conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW'
libheif/1.16.2: Aggregating env generators
libheif/1.16.2: Calling build()
libheif/1.16.2: CMake command: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="D:/conan/data/libheif/1.16.2/_/_/build/10c8e0499f28dcc03304c22f523c31175c2ee2dc/build/generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="D:/conan/data/libheif/1.16.2/_/_/package/10c8e0499f28dcc03304c22f523c31175c2ee2dc" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "D:\conan\data\libheif\1.16.2\_\_\build\10c8e0499f28dcc03304c22f523c31175c2ee2dc\src"
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Using Conan toolchain: D:/conan/data/libheif/1.16.2/_/_/build/10c8e0499f28dcc03304c22f523c31175c2ee2dc/build/generators/conan_toolchain.cmake
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is MSVC 19.37.32822.0
-- The CXX compiler identification is MSVC 19.37.32822.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x86/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.37.32822/bin/Hostx64/x86/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for unistd.h
-- Looking for unistd.h - not found
-- Performing Test has_potentially_evaluated_expression
-- Performing Test has_potentially_evaluated_expression - Failed
-- Conan: Target declared 'de265'
libde265 (HEIC decoder): found (built-in)
x265 (HEIC encoder): disabled
Dav1d (AVIF decoder): disabled
CMake Warning at CMakeLists.txt:74 (find_package):
  By not providing "Findlibaom-av1.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "libaom-av1", but CMake did not find one.

  Could not find a package configuration file provided by "libaom-av1" with
  any of the following names:

    libaom-av1Config.cmake
    libaom-av1-config.cmake

  Add the installation prefix of "libaom-av1" to CMAKE_PREFIX_PATH or set
  "libaom-av1_DIR" to a directory containing one of the above files.  If
  "libaom-av1" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:94 (plugin_option)


aom (AVIF encoder): not found
CMake Warning at CMakeLists.txt:74 (find_package):
  By not providing "Findlibaom-av1.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "libaom-av1", but CMake did not find one.

  Could not find a package configuration file provided by "libaom-av1" with
  any of the following names:

    libaom-av1Config.cmake
    libaom-av1-config.cmake

  Add the installation prefix of "libaom-av1" to CMAKE_PREFIX_PATH or set
  "libaom-av1_DIR" to a directory containing one of the above files.  If
  "libaom-av1" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:95 (plugin_option)


aom (AVIF decoder): not found
CMake Warning at CMakeLists.txt:74 (find_package):
  By not providing "FindSvtEnc.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "SvtEnc", but
  CMake did not find one.

  Could not find a package configuration file provided by "SvtEnc" with any
  of the following names:

    SvtEncConfig.cmake
    svtenc-config.cmake

  Add the installation prefix of "SvtEnc" to CMAKE_PREFIX_PATH or set
  "SvtEnc_DIR" to a directory containing one of the above files.  If "SvtEnc"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  CMakeLists.txt:96 (plugin_option)


Svt-av1 (AVIF encoder): not found
Rav1e (AVIF encoder): disabled
CMake Warning at CMakeLists.txt:104 (find_package):
  By not providing "Findlibsharpyuv.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "libsharpyuv", but CMake did not find one.

  Could not find a package configuration file provided by "libsharpyuv" with
  any of the following names:

    libsharpyuvConfig.cmake
    libsharpyuv-config.cmake

  Add the installation prefix of "libsharpyuv" to CMAKE_PREFIX_PATH or set
  "libsharpyuv_DIR" to a directory containing one of the above files.  If
  "libsharpyuv" provides a separate development package or SDK, be sure it
  has been installed.


libsharpyuv: disabled
Not compiling 'x265' backend
Not compiling 'libde265' backend
Not compiling 'dav1d' backend
Not compiling 'aomdec' backend
Not compiling 'aomenc' backend
Not compiling 'svtenc' backend
Not compiling 'rav1e' backend
Not compiling 'libsharpyuv'
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- Configuring done (4.2s)
-- Generating done (0.0s)
-- Build files have been written to: D:/conan/data/libheif/1.16.2/_/_/build/10c8e0499f28dcc03304c22f523c31175c2ee2dc/build
libheif/1.16.2: CMake command: cmake --build 
</details>

**libde265 (HEIC decoder): found (built-in)**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
