### PR TITLE
aws-sdk-cpp: fix recipe

### DIFF
--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -477,16 +477,16 @@ class AwsSdkCppConan(ConanFile):
         self.cpp_info.components["core"].set_property("cmake_target_name", "AWS::aws-sdk-cpp-core")
         self.cpp_info.components["core"].set_property("pkg_config_name", "aws-sdk-cpp-core")
         self.cpp_info.components["core"].libs = ["aws-cpp-sdk-core"]
-        self.cpp_info.components["core"].requires = ["aws-c-common::aws-c-common-lib"]
+        self.cpp_info.components["core"].requires = ["aws-c-common::aws-c-common"]
         if self._use_aws_crt_cpp:
             self.cpp_info.components["core"].requires.extend([
-                "aws-c-cal::aws-c-cal-lib",
-                "aws-c-http::aws-c-http-lib",
-                "aws-c-io::aws-c-io-lib",
-                "aws-crt-cpp::aws-crt-cpp-lib",
+                "aws-c-cal::aws-c-cal",
+                "aws-c-http::aws-c-http",
+                "aws-c-io::aws-c-io",
+                "aws-crt-cpp::aws-crt-cpp",
             ])
         else:
-            self.cpp_info.components["core"].requires.append("aws-c-event-stream::aws-c-event-stream-lib")
+            self.cpp_info.components["core"].requires.append("aws-c-event-stream::aws-c-event-stream")
 
         # other components
         enabled_sdks = [sdk for sdk in self._sdks if self.options.get_safe(sdk)]


### PR DESCRIPTION
Requirements were changed but this lib not, so it did not build with errors like
```
ERROR: Component 'aws-c-cal::aws-c-cal-lib' not found in 'aws-c-cal' package requirement
```

Specify library name and version:  **aws-sdk-cpp/all-versions**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
- [x] I've manually inserted these changes in downloaded package, after that `conan install` managed to build package successfully 
