### PR TITLE
cn-cbor: remove invalid check_min_cppstd

### DIFF
--- a/recipes/cn-cbor/all/conandata.yml
+++ b/recipes/cn-cbor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20200822":
+    url: "https://github.com/jimsch/cn-cbor/archive/f713bf67bcf3e076d47e474ce060252ef8be48c7.zip"
+    sha256: "7fac4e6a0fcc5e1def08b05a153cc7dbbcab1d26fc0c4b7620d2bed7b4518b05"
   "1.0.0":
-    sha256: eca2bcc15b8400037fd95748724287afbb966e34d4d0275a496b4872bcea9d77
-    url: https://github.com/jimsch/cn-cbor/archive/1.0.0.zip
+    url: "https://github.com/jimsch/cn-cbor/archive/1.0.0.zip"
+    sha256: "eca2bcc15b8400037fd95748724287afbb966e34d4d0275a496b4872bcea9d77"

--- a/recipes/cn-cbor/all/conandata.yml
+++ b/recipes/cn-cbor/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "cci.20200822":
-    url: "https://github.com/jimsch/cn-cbor/archive/f713bf67bcf3e076d47e474ce060252ef8be48c7.zip"
-    sha256: "7fac4e6a0fcc5e1def08b05a153cc7dbbcab1d26fc0c4b7620d2bed7b4518b05"
   "1.0.0":
     url: "https://github.com/jimsch/cn-cbor/archive/1.0.0.zip"
     sha256: "eca2bcc15b8400037fd95748724287afbb966e34d4d0275a496b4872bcea9d77"

--- a/recipes/cn-cbor/all/conanfile.py
+++ b/recipes/cn-cbor/all/conanfile.py
@@ -2,7 +2,6 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 
@@ -42,8 +41,6 @@ class CnCborStackConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, 11)
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("Windows shared builds are not supported right now")
 
@@ -52,10 +49,16 @@ class CnCborStackConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["fatal_warnings"] = False
-        tc.variables["coveralls"] = False
-        tc.variables["build_tests"] = False
-        tc.variables["build_docs"] = False
+        tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = self.options.shared
+        tc.cache_variables["CN_CBOR_FATAL_WARNINGS"] = False
+        tc.cache_variables["CN_CBOR_COVERALLS"] = False
+        tc.cache_variables["CN_CBOR_BUILD_TESTS"] = False
+        tc.cache_variables["CN_CBOR_BUILD_DOCS"] = False
+        # For v1.0.0
+        tc.cache_variables["fatal_warnings"] = False
+        tc.cache_variables["coveralls"] = False
+        tc.cache_variables["build_tests"] = False
+        tc.cache_variables["build_docs"] = False
         tc.generate()
 
     def build(self):
@@ -64,7 +67,9 @@ class CnCborStackConan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "LICENSE",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
         os.remove(os.path.join(self.package_folder, "README.md"))

--- a/recipes/cn-cbor/all/test_package/conanfile.py
+++ b/recipes/cn-cbor/all/test_package/conanfile.py
@@ -6,7 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
     def requirements(self):

--- a/recipes/cn-cbor/config.yml
+++ b/recipes/cn-cbor/config.yml
@@ -1,4 +1,5 @@
----
 versions:
+  "cci.20200822":
+    folder: "all"
   "1.0.0":
     folder: "all"

--- a/recipes/cn-cbor/config.yml
+++ b/recipes/cn-cbor/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "cci.20200822":
-    folder: "all"
   "1.0.0":
     folder: "all"


### PR DESCRIPTION
Required by the latest version of `cose-c`.