### PR TITLE
[wayland] Conan >=2.0.11 will complain about passing raw options

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -84,8 +84,8 @@ class WaylandConan(ConanFile):
         tc = MesonToolchain(self)
         tc.project_options["libdir"] = "lib"
         tc.project_options["datadir"] = "res"
-        tc.project_options["libraries"] = self.options.enable_libraries
-        tc.project_options["dtd_validation"] = self.options.enable_dtd_validation
+        tc.project_options["libraries"] = bool(self.options.enable_libraries)
+        tc.project_options["dtd_validation"] = bool(self.options.enable_dtd_validation)
         tc.project_options["documentation"] = False
         if cross_building(self):
             tc.project_options["build.pkg_config_path"] = self.generators_folder


### PR DESCRIPTION
Specify library name and version:  **wayland/***

Conan 2.0.11 introduces a check when MesonToolchain receives raw options values directly.
More information related to this issue: https://github.com/conan-io/conan/issues/14453
