### PR TITLE
qt: add QT_NO_DEBUG define in release build

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -967,6 +967,8 @@ class QtConan(ConanFile):
         ]
         self.cpp_info.components["qtCore"].set_property("pkg_config_custom_content", "\n".join(pkg_config_vars))
 
+        if self.settings.build_type == "Release":
+            self.cpp_info.components['qtCore'].defines.append('QT_NO_DEBUG')
         if self.settings.os == "Windows":
             self.cpp_info.components["qtCore"].system_libs.append("authz")
         if is_msvc(self):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -967,7 +967,7 @@ class QtConan(ConanFile):
         ]
         self.cpp_info.components["qtCore"].set_property("pkg_config_custom_content", "\n".join(pkg_config_vars))
 
-        if self.settings.build_type == "Release":
+        if self.settings.build_type != "Debug":
             self.cpp_info.components['qtCore'].defines.append('QT_NO_DEBUG')
         if self.settings.os == "Windows":
             self.cpp_info.components["qtCore"].system_libs.append("authz")


### PR DESCRIPTION
Specify library name and version:  **qt/6.x**

Qt provided cmake targets (from lib/cmake) set this flag. Conan should also set it for consistency.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
