### PR TITLE
libgd: Bump zlib requirement to [>=1.3 <2] version range

### DIFF
--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -51,7 +51,7 @@ class LibgdConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/[>=1.3 <2]")
         if self.options.with_png:
             self.requires("libpng/1.6.39")
             if is_msvc(self):


### PR DESCRIPTION
Automatically generated PR to bump zlib requirement to use a version range