### PR TITLE
[libssh2] Use version range for ZLib dependency

### DIFF
--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -80,7 +80,7 @@ class Libssh2Conan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/[>=1.2.12 <3]")
         if self.options.crypto_backend == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         elif self.options.crypto_backend == "mbedtls":


### PR DESCRIPTION
Specify library name and version:  **libssh2/1.11.0**

Required by #18458

/cc @toge


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
