### PR TITLE
onetbb: hide hwloc as static dependency

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -87,7 +87,7 @@ class OneTBBConan(ConanFile):
 
     def requirements(self):
         if self._tbbbind_build:
-            self.requires("hwloc/2.9.2")
+            self.requires("hwloc/2.9.2", visible=self._tbbbind_explicit_hwloc)
 
     def build_requirements(self):
         if not self._tbbbind_explicit_hwloc and not self.conf.get("tools.gnu:pkg_config", check_type=str):


### PR DESCRIPTION
Specify library name and version:  **onetbb/2021.10.0**

**Changes:**
- `hwloc` is a static dependency of shared TBB library called `tbbbind`. So, there is no need for `hwloc` to be `visible`
- The only exception is cross-compilation, where `hwloc` needs to explicitly specified to TBB (`_tbbbind_explicit_hwloc` case). In this case `hwloc` is built as a dynamic library and must be visible.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
