### PR TITLE
liburing: Update recipe for version 2.3

### DIFF
--- a/recipes/liburing/all/conandata.yml
+++ b/recipes/liburing/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3":
+    url: "https://github.com/axboe/liburing/archive/liburing-2.3.tar.gz"
+    sha256: "60b367dbdc6f2b0418a6e0cd203ee0049d9d629a36706fcf91dfb9428bae23c8"
   "2.2":
     url: "https://github.com/axboe/liburing/archive/liburing-2.2.tar.gz"
     sha256: "e092624af6aa244ade2d52181cc07751ac5caba2f3d63e9240790db9ed130bbc"

--- a/recipes/liburing/all/conanfile.py
+++ b/recipes/liburing/all/conanfile.py
@@ -58,14 +58,15 @@ class Liburing(ConanFile):
                 "liburing is supported only on linux")
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder='src')
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = AutotoolsToolchain(self)
-        whether = lambda x: "" if x else None
+        def whether(condition):
+            return "" if condition else None
         tc.update_configure_args({
             "--nolibc": whether(not self.options.get_safe("with_libc")),
             "--enable-shared": None,
@@ -92,7 +93,7 @@ class Liburing(ConanFile):
         with chdir(self, self.source_folder):
             at = Autotools(self)
             at.install(
-                args=["ENABLE_SHARED={}".format(1 if self.options.shared else 0)]
+                args=[f"ENABLE_SHARED={1 if self.options.shared else 0}"]
             )
 
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/liburing/all/conanfile.py
+++ b/recipes/liburing/all/conanfile.py
@@ -51,7 +51,8 @@ class LiburingConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("linux-headers-generic/5.13.9")
+        if Version(self.version) < "2.3":
+            self.requires("linux-headers-generic/5.13.9")
 
     def validate(self):
         # FIXME: use kernel version of build/host machine.

--- a/recipes/liburing/config.yml
+++ b/recipes/liburing/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3":
+    folder: all
   "2.2":
     folder: all
   "2.1":


### PR DESCRIPTION
Recent versions of Facebook's folly [depend](https://github.com/facebook/folly/issues/1913) on liburing >= 2.3.

Linux is on kernel major version 6, for which there are no header packages in Conan Center. I was able to build by just removing the requirement.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
