### PR TITLE
opentelemetry-proto: fix package type and settings

### DIFF
--- a/recipes/opentelemetry-proto/all/conanfile.py
+++ b/recipes/opentelemetry-proto/all/conanfile.py
@@ -13,10 +13,10 @@ class OpenTelemetryProtoConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/open-telemetry/opentelemetry-proto"
     description = "Protobuf definitions for the OpenTelemetry protocol (OTLP)"
-    topics = ("opentelemetry", "telemetry", "otlp", "pre-built")
+    topics = ("opentelemetry", "telemetry", "otlp")
 
-    package_type = "build-scripts"
-    settings = "os", "arch", "compiler", "build_type"
+    package_type = "unknown"
+    settings = ()
 
     def layout(self):
         basic_layout(self, src_folder="src")


### PR DESCRIPTION
opentelemetry-proto packages the protobuf definitions for OpenTelemetry. Marking it as a "build-script" implied visibility=False to downstream packages like opentelemetry, which made a CppInfo quality check fail with "required component package 'opentelemetry-proto::' not in dependencies".

This also removes settings, since there is no actual build step and the package won't be affected by any config properties.

Fixes #18967.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
