### PR TITLE
[SCIP] bump version to 8.0.4

### DIFF
--- a/recipes/scip/all/conandata.yml
+++ b/recipes/scip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.0.4":
+    url: "https://github.com/scipopt/scip/archive/refs/tags/v804.tar.gz"
+    sha256: "48be3f568763e3fc209803e9426389df107491371cfcce38f73dcc99ede69a51"
   "8.0.3":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v803.tar.gz"
     sha256: "fe7636f8165a8c9298ff55ed3220d084d4ea31ba9b69d2733beec53e0e4335d6"

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -80,7 +80,6 @@ class SCIPConan(ConanFile):
         if self.options.with_sym == "bliss":
             self.requires("bliss/0.77")
         self.requires("soplex/6.0.3")
-        self.requires("zlib/1.2.13")
 
     def configure(self):
         self.options["soplex"].with_gmp = self.options.with_gmp

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -84,6 +84,7 @@ class SCIPConan(ConanFile):
         if self.options.with_sym == "bliss":
             self.requires("bliss/0.77")
         self.requires(f"soplex/{self.soplex_version_belonging_to_me[self.version]}")
+        self.requires("zlib/[>=1.2.11 <2]")
 
     def configure(self):
         self.options["soplex"].with_gmp = self.options.with_gmp

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -76,7 +76,7 @@ class SCIPConan(ConanFile):
 
     def requirements(self):
         if self.options.with_gmp:
-            self.requires("gmp/6.2.1")
+            self.requires("gmp/6.3.0")
         if self.options.with_sym == "bliss":
             self.requires("bliss/0.77")
         self.requires("soplex/6.0.3")

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -34,6 +34,10 @@ class SCIPConan(ConanFile):
         "with_tpi": False,
         "with_sym": "bliss",
     }
+    soplex_version_belonging_to_me = {
+        "8.0.4": "6.0.4",
+        "8.0.3": "6.0.3"
+    }
 
     @property
     def _min_cppstd(self):
@@ -79,7 +83,7 @@ class SCIPConan(ConanFile):
             self.requires("gmp/6.3.0")
         if self.options.with_sym == "bliss":
             self.requires("bliss/0.77")
-        self.requires("soplex/6.0.3")
+        self.requires(f"soplex/{self.soplex_version_belonging_to_me[self.version]}")
 
     def configure(self):
         self.options["soplex"].with_gmp = self.options.with_gmp

--- a/recipes/scip/config.yml
+++ b/recipes/scip/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "8.0.4":
+    folder: all
   "8.0.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **scip/8.0.4**

SCIP and SoPlex are coupled together: there is a 1-to-1 correspondence between the SCIP version and the SoPlex version, thus the new map in this recipe.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
