### PR TITLE
cgal: add CMake variable CGAL_USE_GMP for compatibility

### DIFF
--- a/recipes/cgal/all/conanfile.py
+++ b/recipes/cgal/all/conanfile.py
@@ -163,6 +163,10 @@ function(CGAL_setup_CGAL_flags target)
 endfunction()
 
 CGAL_setup_CGAL_flags(CGAL::CGAL)
+
+# CGAL use may rely on the presence of those two variables
+set(CGAL_USE_GMP  TRUE CACHE INTERNAL "CGAL library is configured to use GMP")
+set(CGAL_USE_MPFR TRUE CACHE INTERNAL "CGAL library is configured to use MPFR")
 ''')
         save(self, module_file, content)
 


### PR DESCRIPTION
Specify library name and version:  **cgal/5.6**

In a private discussion, a user of the `cgal` package pointed out the lack of the CMake variable `CGAL_USE_GMP`, that they want to use in the downstream project https://bitbucket.org/taucgl/cgal-python-bindings

The upstream CGAL CMake scripts define that variable, as well as `CGAL_USE_MPFR`, when CGAL is configured with GMP, but the Conan package `cgal` does not. This pull-request fixes that.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
