### PR TITLE
opentelemetry-cpp: fix visibility of protobuf and gRPC headers

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -96,14 +96,14 @@ class OpenTelemetryCppConan(ConanFile):
             self.requires("abseil/20220623.0", transitive_headers=True)
 
         if self.options.with_otlp:
-            self.requires("protobuf/3.21.9")
+            self.requires("protobuf/3.21.9", transitive_headers=True)
             if Version(self.version) <= "1.4.1":
                 self.requires("opentelemetry-proto/0.11.0")
             else:
                 self.requires("opentelemetry-proto/0.20.0")
 
             if self.options.get_safe("with_otlp_grpc"):
-                self.requires("grpc/1.50.1")
+                self.requires("grpc/1.50.1", transitive_headers=True)
 
         if (self.options.with_zipkin or
            self.options.with_elasticsearch or


### PR DESCRIPTION
Protobuf and gRPC headers must be made available for consumers of the OpenTelemetry package because the generated headers for OTLP refer to them.

This fixes the following compiler errors downstream:

```
In file included from $HOME/.conan2/p/b/opent272c3e9f1254c/p/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h:11:
In file included from $HOME/.conan2/p/b/opent272c3e9f1254c/p/include/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h:22:
$HOME/.conan2/p/b/opent272c3e9f1254c/p/include/opentelemetry/proto/collector/trace/v1/trace_service.pb.h:10:10: fatal error: 'google/protobuf/port_def.inc' file not found
```

```
In file included from $HOME/.conan2/p/b/opentde6f16d8c2837/p/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h:11:
$HOME/.conan2/p/b/opentde6f16d8c2837/p/include/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h:25:10: fatal error: 'grpcpp/generic/async_generic_service.h' file not found
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
