### PR TITLE
cpu_features: Fixed CMake target name to match project

### DIFF
--- a/recipes/cpu_features/all/conanfile.py
+++ b/recipes/cpu_features/all/conanfile.py
@@ -71,7 +71,7 @@ class CpuFeaturesConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "CpuFeatures")
-        self.cpp_info.set_property("cmake_target_name", "CpuFeatures::cpu_features")
+        self.cpp_info.set_property("cmake_target_name", "CpuFeature::cpu_features")
 
         # TODO: back to global scope once cmake_find_package* generators removed
         self.cpp_info.components["libcpu_features"].libs = ["cpu_features"]
@@ -84,7 +84,7 @@ class CpuFeaturesConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "CpuFeatures"
         self.cpp_info.components["libcpu_features"].names["cmake_find_package"] = "cpu_features"
         self.cpp_info.components["libcpu_features"].names["cmake_find_package_multi"] = "cpu_features"
-        self.cpp_info.components["libcpu_features"].set_property("cmake_target_name", "CpuFeatures::cpu_features")
+        self.cpp_info.components["libcpu_features"].set_property("cmake_target_name", "CpuFeature::cpu_features")
 
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bin_path))

--- a/recipes/cpu_features/all/test_package/CMakeLists.txt
+++ b/recipes/cpu_features/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(CpuFeatures REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE CpuFeatures::cpu_features)
+target_link_libraries(${PROJECT_NAME} PRIVATE CpuFeature::cpu_features)


### PR DESCRIPTION
Specify library name and version:  **cpu_features/***

CMake target name is incorrect.
Exports CpuFeatures::cpu_features, when it should been CpuFeature::cpu_features
From project docs https://github.com/google/cpu_features/tree/main/cmake

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
