### PR TITLE
openblas: add version 0.3.24

### DIFF
--- a/recipes/openblas/all/conandata.yml
+++ b/recipes/openblas/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.3.24":
+    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.24.tar.gz"
+    sha256: "ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132"
   "0.3.20":
     url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.20.tar.gz"
     sha256: "8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c"

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -34,6 +34,14 @@ class OpenblasConan(ConanFile):
         "dynamic_arch": False,
     }
     short_paths = True
+    package_type = "library"
+
+    @property
+    def _fortran_compiler(self):
+        comp_exe = self.conf.get("tools.build:compiler_executables")
+        if comp_exe and 'fortran' in comp_exe:
+            return comp_exe["fortran"]
+        return None
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -75,9 +83,19 @@ class OpenblasConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
 
+        tc.cache_ variables["NOFORTRAN"] = not self.options.build_lapack
+        # This checks explicit user-specified fortran compiler
         if self.options.build_lapack:
-            self.output.warning("Building with lapack support requires a Fortran compiler.")
-        tc.cache_variables["NOFORTRAN"] = not self.options.build_lapack
+            if not self._fortran_compiler:
+                if Version(self.version) < "0.3.21":
+                    self.output.warning(
+                        "Building with LAPACK support requires a Fortran compiler.")
+                else:
+                    tc.cache_variables["C_LAPACK"] = True
+                    tc.cache_variables["NOFORTRAN"] = True
+                    self.output.info(
+                        "Building LAPACK without Fortran compiler")
+
         tc.cache_variables["BUILD_WITHOUT_LAPACK"] = not self.options.build_lapack
         tc.cache_variables["DYNAMIC_ARCH"] = self.options.dynamic_arch
         tc.cache_variables["USE_THREAD"] = self.options.use_thread
@@ -85,9 +103,8 @@ class OpenblasConan(ConanFile):
         # Required for safe concurrent calls to OpenBLAS routines
         tc.cache_variables["USE_LOCKING"] = not self.options.use_thread
 
-        tc.cache_variables[
-            "MSVC_STATIC_CRT"
-        ] = False  # don't, may lie to consumer, /MD or /MT is managed by conan
+        # don't, may lie to consumer, /MD or /MT is managed by conan
+        tc.cache_variables["MSVC_STATIC_CRT"] = False
 
         # This is a workaround to add the libm dependency on linux,
         # which is required to successfully compile on older gcc versions.
@@ -96,14 +113,15 @@ class OpenblasConan(ConanFile):
         tc.generate()
 
     def build(self):
-        if Version(self.version) >= "0.3.12":
-            search = """message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")"""
-            replace = (
-                """message(FATAL_ERROR "No Fortran compiler found. Cannot build with LAPACK.")"""
-            )
-        else:
-            search = "enable_language(Fortran)"
-            replace = """include(CheckLanguage)
+        if Version(self.version) < "0.3.21":
+            if Version(self.version) >= "0.3.12":
+                search = """message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")"""
+                replace = (
+                    """message(FATAL_ERROR "No Fortran compiler found. Cannot build with LAPACK.")"""
+                )
+            else:
+                search = "enable_language(Fortran)"
+                replace = """include(CheckLanguage)
 check_language(Fortran)
 if(CMAKE_Fortran_COMPILER)
   enable_language(Fortran)
@@ -113,11 +131,12 @@ else()
   set (NO_LAPACK 1)
 endif()"""
 
-        replace_in_file(self,
-            os.path.join(self.source_folder, self.source_folder, "cmake", "f_check.cmake"),
-            search,
-            replace,
-        )
+            replace_in_file(
+                self,
+                os.path.join(self.source_folder, self.source_folder, "cmake", "f_check.cmake"),
+                search,
+                replace,
+            )
         cmake = self._configure_cmake()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **openblas/0.3.24**

This PR adds version 0.3.24 with some minor modifications to the recipe.
OpenBLAS can since 0.3.21 be built with option `build_lapack=True` without a Fortran compiler. This PR adds the functionality to exploit this, by checking `self.conf.get("tools.build:compiler_executables")` and setting appropriate CMake variables to trigger Fortran-less build when appropriate.

This work is a simplified variant of PR #17173, where handling of Fortran runtime and other issues are skipped.
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
