### PR TITLE
fmi2: add new recipe

### DIFF
--- a/recipes/fmi2/all/conandata.yml
+++ b/recipes/fmi2/all/conandata.yml
@@ -3,5 +3,3 @@ sources:
     url:
       - https://github.com/modelica/fmi-standard/releases/download/v2.0.4/FMI-Standard-2.0.4.zip
     sha256: "79abb211052d28354a0efff0c6b1998b60a973dd75fdcb338db99ae1b970c9b2"
-patches:
-  "2.0.4": []

--- a/recipes/fmi2/all/conandata.yml
+++ b/recipes/fmi2/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "2.0.4":
+    url:
+      - https://github.com/modelica/fmi-standard/releases/download/v2.0.4/FMI-Standard-2.0.4.zip
+    sha256: "79abb211052d28354a0efff0c6b1998b60a973dd75fdcb338db99ae1b970c9b2"
+patches:
+  "2.0.4": []

--- a/recipes/fmi2/all/conanfile.py
+++ b/recipes/fmi2/all/conanfile.py
@@ -1,0 +1,50 @@
+from os import path
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
+
+
+class PackageConan(ConanFile):
+    name = "fmi2"
+    description = "Functional Mock-up Interface (FMI)"
+    license = "BSD-2-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://fmi-standard.org"
+    topics = ("fmi-standard", "co-simulation", "model-exchange", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=False)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, pattern="LICENSE.txt", dst=path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.h",
+            src=path.join(self.source_folder, "headers"),
+            dst=path.join(self.package_folder, "include"),
+        )
+        copy(
+            self,
+            pattern="*.xsd",
+            src=path.join(self.source_folder, "schema"),
+            dst=path.join(self.package_folder, "res"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = ["res"]

--- a/recipes/fmi2/all/test_package/CMakeLists.txt
+++ b/recipes/fmi2/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C CXX)
+
+find_package(fmi2 REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE fmi2::fmi2)

--- a/recipes/fmi2/all/test_package/conanfile.py
+++ b/recipes/fmi2/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/fmi2/all/test_package/test_package.cpp
+++ b/recipes/fmi2/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <cstdlib>
+#include <iostream>
+#include "fmi2Functions.h"
+
+
+int main(void) {
+    std::cout << fmi2Version << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/fmi2/config.yml
+++ b/recipes/fmi2/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **fmi2/2.0.4**

This adds major version 2 of fmi from https://fmi-standard.org/, where the rationale is that fmi v1, v2, v3 can be required at the same time in downstream dependencies. A related PR for fmi1 is #19833. 

This is a dependency of a new package to be added: fmilibrary

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
