### PR TITLE
zint: add package_type + fix test package for conan v2 + use version range for zlib

### DIFF
--- a/recipes/zint/all/conanfile.py
+++ b/recipes/zint/all/conanfile.py
@@ -50,7 +50,7 @@ class ZintConan(ConanFile):
     def requirements(self):
         if self.options.with_libpng:
             self.requires("libpng/1.6.40")
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_qt:
             self.requires("qt/5.15.10")
 

--- a/recipes/zint/all/conanfile.py
+++ b/recipes/zint/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class ZintConan(ConanFile):
@@ -15,7 +15,7 @@ class ZintConan(ConanFile):
     homepage = "https://sourceforge.net/p/zint/code"
     license = "GPL-3.0"
     topics = ("barcode", "qt")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -39,19 +39,10 @@ class ZintConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
+            self.options.rm_safe("fPIC")
         if not self.options.with_qt:
-            try:
-                del self.settings.compiler.libcxx
-            except Exception:
-                pass
-            try:
-                del self.settings.compiler.cppstd
-            except Exception:
-                pass
+            self.settings.rm_safe("compiler.cppstd")
+            self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -64,12 +55,11 @@ class ZintConan(ConanFile):
             self.requires("qt/5.15.6")
 
     def validate(self):
-        if self.info.options.with_qt and not self.dependencies["qt"].options.gui:
+        if self.options.with_qt and not self.dependencies["qt"].options.gui:
             raise ConanInvalidConfiguration(f"{self.ref} needs qt:gui=True")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/zint/all/conanfile.py
+++ b/recipes/zint/all/conanfile.py
@@ -49,10 +49,10 @@ class ZintConan(ConanFile):
 
     def requirements(self):
         if self.options.with_libpng:
-            self.requires("libpng/1.6.38")
+            self.requires("libpng/1.6.40")
             self.requires("zlib/1.2.13")
         if self.options.with_qt:
-            self.requires("qt/5.15.6")
+            self.requires("qt/5.15.10")
 
     def validate(self):
         if self.options.with_qt and not self.dependencies["qt"].options.gui:

--- a/recipes/zint/all/test_package/CMakeLists.txt
+++ b/recipes/zint/all/test_package/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
+enable_testing()
+
 option(ZINT_WITH_QT "Zint has been built with Qt support")
 if(ZINT_WITH_QT)
     enable_language(CXX)
@@ -8,10 +10,12 @@ endif()
 
 find_package(Zint REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE Zint::Zint)
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE Zint::Zint)
+add_test(NAME test_package COMMAND test_package)
 
 if(ZINT_WITH_QT)
-    add_executable(${PROJECT_NAME}_cpp test_package.cpp)
-    target_link_libraries(${PROJECT_NAME}_cpp PRIVATE Zint::QZint)
+    add_executable(test_package_cpp test_package.cpp)
+    target_link_libraries(test_package_cpp PRIVATE Zint::QZint)
+    add_test(NAME test_package_cpp COMMAND test_package_cpp)
 endif()

--- a/recipes/zint/all/test_package/conanfile.py
+++ b/recipes/zint/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-import os
+from conan.tools.files import chdir
 
 
 class TestPackageConan(ConanFile):
@@ -27,8 +27,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
-            self.run(bin_path, env="conanrun")
-            if self.options["zint"].with_qt:
-                bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package_cpp")
-                self.run(bin_path, env="conanrun")
+            with chdir(self, self.build_folder):
+                self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env="conanrun")

--- a/recipes/zint/all/test_v1_package/CMakeLists.txt
+++ b/recipes/zint/all/test_v1_package/CMakeLists.txt
@@ -1,20 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_v1_package)
 
-option(ZINT_WITH_QT "Zint has been built with Qt support")
-if(ZINT_WITH_QT)
-    enable_language(CXX)
-endif()
+enable_testing()
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(Zint REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE Zint::Zint)
-
-if(ZINT_WITH_QT)
-    add_executable(${PROJECT_NAME}_cpp ../test_package/test_package.cpp)
-    target_link_libraries(${PROJECT_NAME}_cpp PRIVATE Zint::QZint)
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/zint/all/test_v1_package/conanfile.py
+++ b/recipes/zint/all/test_v1_package/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, CMake, tools
-import os
 
 
 class TestPackageConan(ConanFile):
@@ -14,8 +13,4 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
-            if self.options["zint"].with_qt:
-                bin_path = os.path.join("bin", "test_package_cpp")
-                self.run(bin_path, run_environment=True)
+            self.run(f"ctest --output-on-failure -C {self.settings.build_type}", run_environment=True)


### PR DESCRIPTION
- add package_type
- modernize more (use rm_safe)
- fix test package for conan v2 client (legacy self.options["zint"].with_qt and new self.dependencies can't be used in test(), therefore we use the know trick with ctest)
- bump libpng & qt
- use version range for zlib

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
