### PR TITLE
vc: add package_type + modernize a little bit more

### DIFF
--- a/recipes/vc/all/conanfile.py
+++ b/recipes/vc/all/conanfile.py
@@ -4,17 +4,17 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, replace_in_file, rmdir
 import os
 
-required_conan_version = ">=1.51.1"
+required_conan_version = ">=1.50.0"
 
 
 class VcConan(ConanFile):
     name = "vc"
     description = "SIMD Vector Classes for C++."
     license = "BSD-3-Clause"
-    topics = ("vc", "simd", "vectorization", "parallel", "sse", "avx", "neon")
+    topics = ("simd", "vectorization", "parallel", "sse", "avx", "neon")
     homepage = "https://github.com/VcDevel/Vc"
     url = "https://github.com/conan-io/conan-center-index"
-
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
@@ -31,12 +31,11 @@ class VcConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.info.settings.compiler.get_safe("cppstd"):
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 11)
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/vc/all/test_v1_package/CMakeLists.txt
+++ b/recipes/vc/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(Vc REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE Vc::Vc)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
- package_type is static-library
- use self.settings in validate() instead of self.info.settings. Since we don't need anymore a feature of 1.51.1 (get_safe in self.info), required_conan_version is decreased to 1.50.0
- cleanup topics
- simplify CMakeLists of test_v1_package

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
