### PR TITLE
octo-logger-cpp: fix msvc min version & few minor fixes

### DIFF
--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -100,6 +100,8 @@ class OctoLoggerCPPConan(ConanFile):
         cmake.install()
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "octo-logger-cpp")
+        self.cpp_info.set_property("cmake_target_name", "octo::octo-logger-cpp")
         self.cpp_info.libs = ["octo-logger-cpp"]
         self.cpp_info.requires = ["fmt::fmt"]
         if self.options.get_safe("with_aws"):

--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -1,10 +1,10 @@
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.files import get, copy
-from conan.tools.build import check_min_cppstd
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.scm import Version
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.50.0"
@@ -37,7 +37,7 @@ class OctoLoggerCPPConan(ConanFile):
             "clang": "9",
             "apple-clang": "11",
             "Visual Studio": "16",
-            "msvc": "1923",
+            "msvc": "192",
         }
 
     @property
@@ -62,10 +62,10 @@ class OctoLoggerCPPConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.info.settings.compiler.get_safe("cppstd"):
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )

--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
-from conan.tools.microsoft import is_msvc
+from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
@@ -67,8 +67,8 @@ class OctoLoggerCPPConan(ConanFile):
             )
         if self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libc++":
             raise ConanInvalidConfiguration(f"{self.ref} does not support clang with libc++. Use libstdc++ instead.")
-        if is_msvc(self) and self.settings.compiler.runtime in ["MTd", "MT"]:
-            raise ConanInvalidConfiguration(f"{self.ref} does not support MSVC MT/MTd configurations, only MD/MDd is supported")
+        if is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration(f"{self.ref} does not support MSVC static runtime. Use dynamic runtime instead.")
         if self.options.get_safe("with_aws"):
             if not self.dependencies["aws-sdk-cpp"].options.logs:
                 raise ConanInvalidConfiguration(f"{self.ref} requires the option aws-sdk-cpp:logs=True")

--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -101,18 +101,9 @@ class OctoLoggerCPPConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["octo-logger-cpp"]
-
-        self.cpp_info.set_property("cmake_file_name", "octo-logger-cpp")
-        self.cpp_info.set_property("cmake_target_name", "octo::octo-logger-cpp")
-        self.cpp_info.set_property("pkg_config_name", "octo-logger-cpp")
         self.cpp_info.requires = ["fmt::fmt"]
         if self.options.get_safe("with_aws"):
             self.cpp_info.requires.extend([
                 "nlohmann_json::nlohmann_json",
                 "aws-sdk-cpp::monitoring"
             ])
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.names["cmake_find_package"] = "octo-logger-cpp"
-        self.cpp_info.names["cmake_find_package_multi"] = "octo-logger-cpp"
-        self.cpp_info.names["pkg_config"] = "octo-logger-cpp"


### PR DESCRIPTION
- msvc min version is 192, not 1923...
- don't use self.info in validate()
- sort methods by order of execution
- fix msvc runtime check
- ~remove hardcoded properties in package_info() since this library doesn't export CMake targets upstream, nor pkgconfig file.~ => kept to not break other octo* libs, but it's a lie. @ofiriluz could you properly export your targets in a CMake config file please (in upstream CMakeLists)?

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
