### PR TITLE
octo-wildcardmatching-cpp: fix several issues and modernize

### DIFF
--- a/recipes/octo-wildcardmatching-cpp/all/conanfile.py
+++ b/recipes/octo-wildcardmatching-cpp/all/conanfile.py
@@ -1,8 +1,9 @@
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.files import get, copy
-from conan.tools.build import check_min_cppstd
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
@@ -16,7 +17,12 @@ class OctoWildcardMatchingCPPConan(ConanFile):
     homepage = "https://github.com/ofiriluz/octo-wildcardmatching-cpp"
     description = "Octo wildcardmatching library"
     topics = ("wildcard", "regex", "patterns", "cpp")
+    package_type = "static-library"
     settings = "os", "compiler", "build_type", "arch"
+
+    @property
+    def _min_cppstd(self):
+        return "17"
 
     @property
     def _compilers_minimum_version(self):
@@ -25,42 +31,38 @@ class OctoWildcardMatchingCPPConan(ConanFile):
             "clang": "9",
             "apple-clang": "11",
             "Visual Studio": "16",
-            "msvc": "1923",
+            "msvc": "192",
         }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+        if self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libc++":
+            raise ConanInvalidConfiguration(f"{self.ref} does not support clang with libc++. Use libstdc++ instead.")
+        if is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration(f"{self.ref} does not support MSVC static runtime. Use dynamic runtime instead.")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["DISABLE_TESTS"] = True
         tc.variables["DISABLE_EXAMPLES"] = True
         tc.generate()
-        cd = CMakeDeps(self)
-        cd.generate()
-
-    def layout(self):
-        cmake_layout(self, src_folder="src")
-
-    def validate(self):
-        if self.info.settings.compiler.cppstd:
-            check_min_cppstd(self, "17")
-
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.name} requires C++17, which your compiler does not support."
-            )
-        else:
-            self.output.warn(f"{self.name} requires C++17. Your compiler is unknown. Assuming it supports C++17.")
-        if self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libc++":
-            raise ConanInvalidConfiguration(f"{self.name} does not support clang with libc++. Use libstdc++ instead.")
-        if self.settings.compiler == "Visual Studio" and self.settings.compiler.runtime in ["MTd", "MT"]:
-            raise ConanInvalidConfiguration(f"{self.name} does not support MSVC MT/MTd configurations, only MD/MDd is supported")
-
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
-
-    def build_requirements(self):
-        self.build_requires("cmake/3.24.0")
 
     def build(self):
         cmake = CMake(self)
@@ -75,8 +77,4 @@ class OctoWildcardMatchingCPPConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "octo-wildcardmatching-cpp")
         self.cpp_info.set_property("cmake_target_name", "octo::octo-wildcardmatching-cpp")
-        self.cpp_info.set_property("pkg_config_name", "octo-wildcardmatching-cpp")
         self.cpp_info.libs = ["octo-wildcardmatching-cpp"]
-        self.cpp_info.names["cmake_find_package"] = "octo-wildcardmatching-cpp"
-        self.cpp_info.names["cmake_find_package_multi"] = "octo-wildcardmatching-cpp"
-        self.cpp_info.names["pkg_config"] = "octo-wildcardmatching-cpp"

--- a/recipes/octo-wildcardmatching-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/octo-wildcardmatching-cpp/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(octo-wildcardmatching-cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} octo::octo-wildcardmatching-cpp)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_link_libraries(${PROJECT_NAME} PRIVATE octo::octo-wildcardmatching-cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/octo-wildcardmatching-cpp/all/test_package/conanfile.py
+++ b/recipes/octo-wildcardmatching-cpp/all/test_package/conanfile.py
@@ -1,22 +1,19 @@
-from conans import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain
+from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout
+from conan.tools.cmake import CMake, cmake_layout
 import os
-
-required_conan_version = ">=1.43.0"
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeDeps", "VirtualRunEnv"
-
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.generate()
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- add package_type
- fix msvc min version
- don't use self.info in validate()
- use version range for cmake
- use tool_requires instead of legacy build_requires
- remove pkgconf properties in package_info() since upstream doesn't create pkgconfig file (I would have removed cmake targets also but upstream seems to rely on these names even though it doesn't export CMake targets in its CMakeLists /cc @ofiriluz)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
