### PR TITLE
sdbus-cpp/all: Fix patch_types

### DIFF
--- a/recipes/sdbus-cpp/all/conandata.yml
+++ b/recipes/sdbus-cpp/all/conandata.yml
@@ -19,10 +19,10 @@ patches:
   "1.0.0":
     - patch_file: "patches/0002-correct-readme-cpack-resource-path.patch"
       patch_description: "fix out of tree build by using proper paths in cmake file"
-      patch_type: "backport"
+      patch_type: "bugfix"
       patch_source: "https://github.com/Kistler-Group/sdbus-cpp/commit/0b8f2d97524f354bcaf816b27b6139a5b0c480ba"
   "0.8.3":
     - patch_file: "patches/0001-xml2cpp-Add-missing-EXPAT-include-dirs-136.patch"
       patch_description: "fix build error by adding missing headers"
-      patch_type: "backport"
+      patch_type: "bugfix"
       patch_source: "https://github.com/Kistler-Group/sdbus-cpp/commit/fb008445b15b452f461c34667f4991f5ce06e481"


### PR DESCRIPTION
Specify library name and version:  **sdbus-cpp/all**

In one of the previous pull requests I noticed the following warnings:
```
Schema outlined in https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/conandata_yml_format.md#patches-fields is not followed.

found arbitrary text in 
        patch_type: backport
```
This is because "backport" is not a valid patch_type anymore. The closest type the [documentation](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/conandata_yml_format.md#patches-fields) provides is "bugfix". Technically, it's really a bugfix to the build files.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
