### PR TITLE
libsystemd/all: Fix v2 migration linter warnings

### DIFF
--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -82,7 +82,7 @@ class LibsystemdConan(ConanFile):
     @property
     def _so_version(self):
         meson_build = os.path.join(self.source_folder, "meson.build")
-        with open(meson_build, "r") as build_file:
+        with open(meson_build, "r", encoding="utf-8") as build_file:
             for line in build_file:
                 match = re.match(r"^libsystemd_version = '(.*)'$", line)
                 if match:


### PR DESCRIPTION
Specify library name and version:  **libsystemd/all**

This PR is just a little cleanup. The original warning:
```
Lint changed conanfile.py (v2 migration)
 Using open without explicitly specifying an encoding
```
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
