### PR TITLE
tcl: relocatable shared libs on macos + use version range for zlib

### DIFF
--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -50,7 +50,7 @@ class TclConan(ConanFile):
         self.folders.generators = "conan"
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/[>=1.2.11 <2]")
 
     def validate(self):
         if self.settings.os not in ("FreeBSD", "Linux", "Macos", "Windows"):

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -15,7 +15,7 @@ class TclConan(ConanFile):
     license = "TCL"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://tcl.tk"
-    topics = ("tcl", "scripting", "programming")
+    topics = ("scripting", "programming")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -223,29 +223,25 @@ class TclConan(ConanFile):
         self.cpp_info.libs = libs
         self.cpp_info.system_libs = systemlibs
         self.cpp_info.set_property("cmake_file_name", "TCL")
-        self.cpp_info.names["cmake_find_package"] = "TCL"
-        self.cpp_info.names["cmake_find_package_multi"] = "TCL"
 
         if self.settings.os == "Macos":
             self.cpp_info.frameworks = ["CoreFoundation"]
             self.cpp_info.sharedlinkflags = self.cpp_info.exelinkflags
 
-        tcl_library = os.path.join(self.package_folder, "lib", "{}{}".format(self.name, ".".join(self.version.split(".")[:2])))
-        self.output.info("Setting TCL_LIBRARY environment variable to {}".format(tcl_library))
-        self.runenv_info.define_path('TCL_LIBRARY', tcl_library)
-        self.env_info.TCL_LIBRARY = tcl_library
+        tcl_library = os.path.join(self.package_folder, "lib", "tcl{}".format(".".join(self.version.split(".")[:2])))
+        self.runenv_info.define_path("TCL_LIBRARY", tcl_library)
 
         tcl_root = self.package_folder
-        self.output.info("Setting TCL_ROOT environment variable to {}".format(tcl_root))
-        self.runenv_info.define_path('TCL_ROOT', tcl_root)
-        self.env_info.TCL_ROOT = tcl_root
+        self.runenv_info.define_path("TCL_ROOT", tcl_root)
 
         tclsh_list = list(filter(lambda fn: fn.startswith("tclsh"), os.listdir(os.path.join(self.package_folder, "bin"))))
         tclsh = os.path.join(self.package_folder, "bin", tclsh_list[0])
-        self.output.info("Setting TCLSH environment variable to {}".format(tclsh))
-        self.runenv_info.define_path('TCLSH', tclsh)
-        self.env_info.TCLSH = tclsh
+        self.runenv_info.define_path("TCLSH", tclsh)
 
-        bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Adding PATH environment variable: {}".format(bindir))
-        self.env_info.PATH.append(bindir)
+        # TODO: to remove in conan v2
+        self.cpp_info.names["cmake_find_package"] = "TCL"
+        self.cpp_info.names["cmake_find_package_multi"] = "TCL"
+        self.env_info.TCL_LIBRARY = tcl_library
+        self.env_info.TCL_ROOT = tcl_root
+        self.env_info.TCLSH = tclsh
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -198,7 +198,7 @@ class TclConan(ConanFile):
                         "\nTCL_SRC_DIR",
                         "\n#TCL_SRC_DIR")
 
-        #fix_apple_shared_install_name(self)
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
         libs = []


### PR DESCRIPTION
- relocatable shared lib on macOS (see https://github.com/conan-io/conan-center-index/pull/16745#issuecomment-1722299372)
- use version range for zlib
- cleanup topics
- less verbose package_info()

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
