### PR TITLE
yyjson: add with_utf8_validation for yyjson>=0.8.0

### DIFF
--- a/recipes/yyjson/all/conanfile.py
+++ b/recipes/yyjson/all/conanfile.py
@@ -48,7 +48,7 @@ class YyjsonConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         if Version(self.version) >= "0.8.0":
-            tc.variables["YYJSON_DISABLE_UTF8_VALIDATION"] = not self.options.with_utf8_validation
+            tc.variables["YYJSON_DISABLE_UTF8_VALIDATION"] = not bool(self.options.with_utf8_validation)
         tc.generate()
 
     def build(self):

--- a/recipes/yyjson/all/conanfile.py
+++ b/recipes/yyjson/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -18,15 +19,19 @@ class YyjsonConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_utf8_validation": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_utf8_validation": True,
     }
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "0.8.0":
+            del self.options.with_utf8_validation
 
     def configure(self):
         if self.options.shared:
@@ -42,6 +47,8 @@ class YyjsonConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        if Version(self.version) >= "0.8.0":
+            tc.variables["YYJSON_DISABLE_UTF8_VALIDATION"] = not self.options.with_utf8_validation
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Specify library name and version:  **yyjson/***

I missed new option for 0.8.0 in https://github.com/conan-io/conan-center-index/pull/19885

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
