### PR TITLE
[armadillo] Prevent static builds when use_wrapper=True

### DIFF
--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -190,7 +190,7 @@ class ArmadilloConan(ConanFile):
         if self.options.use_hdf5 and Version(self.version) < "12":
             # Use the conan dependency if the system lib isn't being used
             # Libraries not required to be propagated transitively when the armadillo run-time wrapper is used
-            self.requires("hdf5/1.14.0", transitive_headers=True, transitive_libs=not self.options.use_wrapper)
+            self.requires("hdf5/1.14.1", transitive_headers=True, transitive_libs=not self.options.use_wrapper)
 
         if self.options.use_blas == "openblas":
             # Libraries not required to be propagated transitively when the armadillo run-time wrapper is used

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -189,10 +189,12 @@ class ArmadilloConan(ConanFile):
         # See https://gitlab.com/conradsnicta/armadillo-code/-/issues/227 for more information.
         if self.options.use_hdf5 and Version(self.version) < "12":
             # Use the conan dependency if the system lib isn't being used
-            self.requires("hdf5/1.14.0", transitive_headers=True, transitive_libs=True)
+            # Libraries not required to be propagated transitively when the armadillo run-time wrapper is used
+            self.requires("hdf5/1.14.0", transitive_headers=True, transitive_libs=not self.options.use_wrapper)
 
         if self.options.use_blas == "openblas":
-            self.requires("openblas/0.3.20", transitive_libs=True)
+            # Libraries not required to be propagated transitively when the armadillo run-time wrapper is used
+            self.requires("openblas/0.3.20", transitive_libs=not self.options.use_wrapper)
         if (
             self.options.use_blas == "intel_mkl"
             and self.options.use_lapack == "intel_mkl"

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -174,6 +174,9 @@ class ArmadilloConan(ConanFile):
                 "The wrapper requires the use of an external RNG. Set use_extern_rng=True and try again."
             )
 
+        if not self.options.shared and self.options.use_wrapper:
+            raise ConanInvalidConfiguration("Building the armadillo run-time wrapper library requires armadillo/*:shared=True")
+
     def requirements(self):
         # Optional requirements
         # TODO: "atlas/3.10.3" # Pending https://github.com/conan-io/conan-center-index/issues/6757


### PR DESCRIPTION
For armadillo to wrap other libraries, these other libraries must be either statically compiled into the armadillo binary or dynamically linked to by libarmadillo. This is not possible when armadillo is a static library itself, without doing some unusual modification of the armadillo archive.

This change ensures that armadillo is built as a shared library when use_wrapper=True, which is the only configuration that would enable libarmadillo to be used this way.

For wider context for what this feature should do, see the [armadillo FAQ](https://arma.sourceforge.net/faq.html) and read my initial discussion of the problem in #7840. 

Closes #7840

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
