### PR TITLE
[doc] fix msvc version in header-only template

### DIFF
--- a/docs/package_templates/header_only/all/conanfile.py
+++ b/docs/package_templates/header_only/all/conanfile.py
@@ -36,7 +36,7 @@ class PackageConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "Visual Studio": "15",
-            "msvc": "14.1",
+            "msvc": "191",
             "gcc": "5",
             "clang": "5",
             "apple-clang": "5.1",


### PR DESCRIPTION
Version suggested for compiler=msvc is incorrect and fixed in this PR.

It's worth noting that several recipes have incorrect "msvc versions":
- boost-leaf
- cprocessing (https://github.com/conan-io/conan-center-index/pull/19923)
- cub (https://github.com/conan-io/conan-center-index/pull/19922)
- gurkenlaeufer (https://github.com/conan-io/conan-center-index/pull/19919)
- imutils-cpp
- libinterpolate (https://github.com/conan-io/conan-center-index/pull/19918)
- namedtype (https://github.com/conan-io/conan-center-index/pull/19915)
- octo-logger-cpp (https://github.com/conan-io/conan-center-index/pull/19883)
- octo-wildcardmatching-cpp (https://github.com/conan-io/conan-center-index/pull/19884)
- qcoro
- rpclib (https://github.com/conan-io/conan-center-index/pull/19916)
- vir-simd (https://github.com/conan-io/conan-center-index/pull/19917)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
