### PR TITLE
gurkenlaeufer: relax min compiler versions

### DIFF
--- a/recipes/gurkenlaeufer/all/conanfile.py
+++ b/recipes/gurkenlaeufer/all/conanfile.py
@@ -1,9 +1,7 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import get, copy, rmdir
+from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
-from conan.tools.scm import Version
 import os
 
 
@@ -25,16 +23,6 @@ class GurkenlaeuferConan(ConanFile):
     def _min_cppstd(self):
         return 11
 
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "Visual Studio": "15",
-            "msvc": "14.1",
-            "gcc": "5",
-            "clang": "5",
-            "apple-clang": "5.1",
-        }
-
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -47,11 +35,6 @@ class GurkenlaeuferConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
I had in mind to fix msvc min version, but actually I'm pretty sure that this recipe is a copy/paster of header-only template without having think about min compiler versions, so it's relaxed since it's just C++11.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
