### PR TITLE
armadillo: bump hdf5

### DIFF
--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -186,7 +186,7 @@ class ArmadilloConan(ConanFile):
         # See https://gitlab.com/conradsnicta/armadillo-code/-/issues/227 for more information.
         if self.options.use_hdf5 and Version(self.version) < "12":
             # Use the conan dependency if the system lib isn't being used
-            self.requires("hdf5/1.14.0")
+            self.requires("hdf5/1.14.1")
 
         if self.options.use_blas == "openblas":
             self.requires("openblas/0.3.20")


### PR DESCRIPTION
Let's see if it passes v2 pipeline now that openblas supports conan v2. armadillo is still missing in v2 ready references.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
