### PR TITLE
Cairo 1.17.8 and transitive headers for freetype

### DIFF
--- a/recipes/cairo/meson/conandata.yml
+++ b/recipes/cairo/meson/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "1.17.8":
+    url: "https://gitlab.freedesktop.org/cairo/cairo/-/archive/1.17.8/cairo-1.17.8.tar.bz2"
+    sha256: "ead4724423eb969f98b456fe1e3ee1e1741fe1c8dfb1a41ca12afa81a6c1665f"
   "1.17.6":
-    sha256: "90496d135c9ef7612c98f8ee358390cdec0825534573778a896ea021155599d2"
     url: "https://gitlab.freedesktop.org/cairo/cairo/-/archive/1.17.6/cairo-1.17.6.tar.bz2"
+    sha256: "90496d135c9ef7612c98f8ee358390cdec0825534573778a896ea021155599d2"
   "1.17.4":
     url:
       - "https://www.cairographics.org/snapshots/cairo-1.17.4.tar.xz"

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -80,7 +80,7 @@ class CairoConan(ConanFile):
             del self.options.with_xlib_xrender
             del self.options.with_xcb
             del self.options.with_symbol_lookup
-        if self.settings.os in ["Macos", "Windows"]:
+        if self.settings.os in ["Macos", "Windows"] or Version(self.version) >= "1.17.8":
             del self.options.with_opengl
 
     def configure(self):
@@ -152,6 +152,7 @@ class CairoConan(ConanFile):
         pkg_deps = PkgConfigDeps(self)
         pkg_deps.generate()
 
+        version = Version(self.version)
         options = dict()
         options["tests"] = "disabled"
         options["zlib"] = is_enabled(self.options.with_zlib)
@@ -170,17 +171,20 @@ class CairoConan(ConanFile):
             options["gl-backend"] = "glesv2"
         elif self.options.get_safe("with_opengl") == "gles3":
             options["gl-backend"] = "glesv3"
-        else:
+        elif version < "1.17.8":
             options["gl-backend"] = "disabled"
-        options["glesv2"] = is_enabled(self.options.get_safe("with_opengl") == "gles2")
-        options["glesv3"] = is_enabled(self.options.get_safe("with_opengl") == "gles3")
+
+        # OpenGL support was removed in 1.17.8
+        if version < "1.17.8":
+            options["glesv2"] = is_enabled(self.options.get_safe("with_opengl") == "gles2")
+            options["glesv3"] = is_enabled(self.options.get_safe("with_opengl") == "gles3")
+
         options["tee"] = is_enabled(self.options.tee)
         options["symbol-lookup"] = is_enabled(self.options.get_safe("with_symbol_lookup"))
 
         # future options to add, see meson_options.txt.
         # for now, disabling explicitly, to avoid non-reproducible auto-detection of system libs
 
-        version = Version(self.version)
         if version < "1.17.6":
             options["cogl"] = "disabled"  # https://gitlab.gnome.org/GNOME/cogl
             options["directfb"] = "disabled"

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -101,7 +101,7 @@ class CairoConan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/1.2.13")
         if self.options.with_freetype:
-            self.requires("freetype/2.13.0")
+            self.requires("freetype/2.13.0", transitive_headers=True)
         if self.options.with_fontconfig:
             self.requires("fontconfig/2.14.2")
         if self.options.with_png:


### PR DESCRIPTION
Specify library name and version:  **cairo/1.17.8**

* Added Cairo 1.17.8
* Enabled transitive headers on freetype dependency

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
