### PR TITLE
[ComputeLibrary] Add new package for ARM-software/ComputeLibrary

### DIFF
--- a/recipes/compute_library/all/conandata.yml
+++ b/recipes/compute_library/all/conandata.yml
@@ -4,4 +4,4 @@ sources:
     sha256: "62f514a555409d4401e5250b290cdf8cf1676e4eb775e5bd61ea6a740a8ce24f"
   "23.02.1":
     url: "https://github.com/ARM-software/ComputeLibrary/archive/refs/tags/v23.02.1.tar.gz"
-    sha256: "62f514a555409d4401e5250b290cdf8cf1676e4eb775e5bd61ea6a740a8ce24f"
+    sha256: "c3a443e26539f866969242e690cf0651ef629149741ee18732f954c734da6763"

--- a/recipes/compute_library/all/conandata.yml
+++ b/recipes/compute_library/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "23.08":
+    url: "https://github.com/ARM-software/ComputeLibrary/archive/refs/tags/v23.08.tar.gz"
+    sha256: "62f514a555409d4401e5250b290cdf8cf1676e4eb775e5bd61ea6a740a8ce24f"

--- a/recipes/compute_library/all/conandata.yml
+++ b/recipes/compute_library/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "23.08":
     url: "https://github.com/ARM-software/ComputeLibrary/archive/refs/tags/v23.08.tar.gz"
     sha256: "62f514a555409d4401e5250b290cdf8cf1676e4eb775e5bd61ea6a740a8ce24f"
+  "23.02.1":
+    url: "https://github.com/ARM-software/ComputeLibrary/archive/refs/tags/v23.02.1.tar.gz"
+    sha256: "62f514a555409d4401e5250b290cdf8cf1676e4eb775e5bd61ea6a740a8ce24f"

--- a/recipes/compute_library/all/conanfile.py
+++ b/recipes/compute_library/all/conanfile.py
@@ -102,7 +102,7 @@ class ComputeLibraryConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} does not support Linux with clang. It is only supported on Linux with gcc.")
         if "armv8" not in str(self.settings.arch) and self.options.enable_multi_isa:
             raise ConanInvalidConfiguration(f"{self.ref} does not support multi_isa option for {self.settings.arch}. It is only supported on armv8.")
-        if self.settings.arch == "armv8" and self.build_settings.arch == "x86_64" and self.settings.os == "Macos":
+        if self.settings.arch == "armv8" and self.settings_build.arch == "x86_64" and self.settings.os == "Macos":
             raise ConanInvalidConfiguration(f"Mac Intel is not supported for armv8-a. Please, use Mac M1 as native build.")
 
     def source(self):

--- a/recipes/compute_library/all/conanfile.py
+++ b/recipes/compute_library/all/conanfile.py
@@ -43,7 +43,7 @@ class ComputeLibraryConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "10",
+            "gcc": "6",
             "clang": "5",
             "apple-clang": "5.1",
         }

--- a/recipes/compute_library/all/conanfile.py
+++ b/recipes/compute_library/all/conanfile.py
@@ -27,12 +27,14 @@ class ComputeLibraryConan(ConanFile):
         "enable_openmp": [True, False],
         "enable_opencl": [True, False],
         "enable_neon": [True, False],
+        "enable_multi_isa": [True, False],
     }
     default_options = {
         "shared": False,
         "enable_openmp": False,
         "enable_opencl": True,
         "enable_neon": True,
+        "enable_multi_isa": False,
     }
 
     @property
@@ -121,9 +123,10 @@ class ComputeLibraryConan(ConanFile):
         neon = yes_no(self.options.get_safe("enable_neon"))
         opencl = yes_no(self.options.get_safe("enable_opencl", False))
         openmp = yes_no(self.options.get_safe("enable_openmp"))
+        multi_isa = yes_no(self.options.get_safe("enable_multi_isa"))
         build = "cross_compile" if cross_building(self) else "native"
         with chdir(self, self.source_folder):
-            self.run(f"scons Werror=0 validation_tests=0 examples=0 gemm_tuner=0 openmp={openmp} debug={debug} neon={neon} opencl={opencl} os={build_os} arch={arch} build={build} build_dir={self.build_folder} install_dir={self.package_folder} -j{build_jobs(self)} toolchain_prefix=''", env="conanbuild")
+            self.run(f"scons Werror=0 validation_tests=0 examples=0 gemm_tuner=0 multi_isa={multi_isa} openmp={openmp} debug={debug} neon={neon} opencl={opencl} os={build_os} arch={arch} build={build} build_dir={self.build_folder} install_dir={self.package_folder} -j{build_jobs(self)} toolchain_prefix=''", env="conanbuild")
 
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)

--- a/recipes/compute_library/all/conanfile.py
+++ b/recipes/compute_library/all/conanfile.py
@@ -123,7 +123,7 @@ class ComputeLibraryConan(ConanFile):
         openmp = yes_no(self.options.get_safe("enable_openmp"))
         build = "cross_compile" if cross_building(self) else "native"
         with chdir(self, self.source_folder):
-            self.run(f"scons Werror=0 validation_tests=0 examples=0 gemm_tuner=0 openmp={openmp} debug={debug} neon={neon} opencl={opencl} os={build_os} arch={arch} build={build} build_dir={self.build_folder} install_dir={self.package_folder} -j{build_jobs(self)}", env="conanbuild")
+            self.run(f"scons Werror=0 validation_tests=0 examples=0 gemm_tuner=0 openmp={openmp} debug={debug} neon={neon} opencl={opencl} os={build_os} arch={arch} build={build} build_dir={self.build_folder} install_dir={self.package_folder} -j{build_jobs(self)} toolchain_prefix=''", env="conanbuild")
 
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)

--- a/recipes/compute_library/all/conanfile.py
+++ b/recipes/compute_library/all/conanfile.py
@@ -102,7 +102,7 @@ class ComputeLibraryConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} does not support Linux with clang. It is only supported on Linux with gcc.")
         if "armv8" not in str(self.settings.arch) and self.options.enable_multi_isa:
             raise ConanInvalidConfiguration(f"{self.ref} does not support multi_isa option for {self.settings.arch}. It is only supported on armv8.")
-        if self.settings.arch == "armv8" and self.settings_build.arch == "x86_64" and self.settings.os == "Macos":
+        if self.settings.arch == "armv8" and self.settings_build.arch == "x86_64" and self.settings.os == "Macos" and self.settings.compiler == "apple-clang":
             raise ConanInvalidConfiguration(f"Mac Intel is not supported for armv8-a. Please, use Mac M1 as native build.")
 
     def source(self):

--- a/recipes/compute_library/all/conanfile.py
+++ b/recipes/compute_library/all/conanfile.py
@@ -7,7 +7,6 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.gnu import AutotoolsDeps, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 import os
-import sys
 
 
 required_conan_version = ">=1.53.0"

--- a/recipes/compute_library/all/conanfile.py
+++ b/recipes/compute_library/all/conanfile.py
@@ -1,0 +1,115 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import get, copy, rm, chdir
+from conan.tools.build import check_min_cppstd, cross_building, build_jobs
+from conan.tools.scm import Version
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class ComputeLibraryConan(ConanFile):
+    name = "compute_library"
+    description = "The Compute Library is a set of computer vision and machine learning functions optimized for both Arm CPUs and GPUs using SIMD technologies"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ARM-software/ComputeLibrary"
+    topics = ("android", "linux", "machine-learning", "arm", "computer-vision", "neural-network")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "enable_openmp": [True, False],
+        "enable_opencl": [True, False],
+        "enable_neon": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "enable_openmp": False,
+        "enable_opencl": False,
+        "enable_neon": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "10",
+            "clang": "5",
+            "apple-clang": "5.1",
+        }
+
+    def config_options(self):
+        # INFO: Neon option is reserved to arm architecture
+        if "arm" in str(self.settings.arch):
+            del self.options.enable_neon
+        # INFO: OpenCL option only works with g++, according to the documentation
+        if self.settings.compiler == "clang":
+            del self.options.enable_openmp
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def build_requirements(self):
+        self.tool_requires("scons/4.3.0")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+        supported_os = ["Android", "Linux", "OpenBSD", "Macos", "Tizen"]
+        if str(self.settings.os) not in supported_os:
+            raise ConanInvalidConfiguration(f"{self.ref} does not support {self.settings.os}. It is only supported on {supported_os}.")
+        if "arm" not in str(self.settings.arch) and "x86" not in str(self.settings.arch):
+            raise ConanInvalidConfiguration(f"{self.ref} does not support {self.settings.arch}. It is only supported on arm and x86.")
+        if "x86" in str(self.settings.arch) and (self.options.get_safe("enable_neon") or not self.options.enable_opencl):
+            raise ConanInvalidConfiguration(f"{self.ref} can be built for x86_64 targets only with enable_neon=False and enable_opencl=True.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = VirtualBuildEnv(self)
+        tc.generate(scope="build")
+
+    def build(self):
+        # INFO: Using scons to build the library we don't have control over shared/static and install step, it is done all together always
+        yes_no = lambda v: "1" if v else "0"
+        debug = yes_no(self.settings.build_type == "Debug")
+        os = str(self.settings.os).lower()
+        arch = {"armv8": "armv8a", "x86": "x86_32", "armv7": "armv7a", "armv7hf": "armv7a-hf"}.get(str(self.settings.arch), str(self.settings.arch))
+        neon = yes_no(self.options.get_safe("enable_neon"))
+        opencl = yes_no(self.options.enable_opencl)
+        openmp = yes_no(self.options.get_safe("enable_openmp"))
+        build = "cross_compile" if cross_building(self) else "native"
+        with chdir(self, self.source_folder):
+            self.run(f"scons Werror=0 validation_tests=0 examples=0 openmp={openmp} debug={debug} neon={neon} opencl={opencl} os={os} arch={arch} build={build} build_dir={self.build_folder} install_dir={self.package_folder} -j{build_jobs(self)}", env="conanbuildenv")
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        # INFO: Artifacts are installed during build step, so we just need to remove what we don't want
+        rm(self, "*.bazel", self.package_folder, recursive=True)
+        rm(self, "*.cpp", self.package_folder, recursive=True)
+        if self.options.shared:
+            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
+        else:
+            rm(self, "*.so*", os.path.join(self.package_folder, "lib"))
+            rm(self, "*.dylib*", os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        suffix = "" if self.options.shared else "-static"
+        self.cpp_info.libs = [f"arm_compute{suffix}", f"arm_compute_core{suffix}", f"arm_compute_graph{suffix}"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m", "pthread"]

--- a/recipes/compute_library/all/test_package/CMakeLists.txt
+++ b/recipes/compute_library/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(compute_library REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE compute_library::compute_library)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/compute_library/all/test_package/conanfile.py
+++ b/recipes/compute_library/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/compute_library/all/test_package/test_package.cpp
+++ b/recipes/compute_library/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <cstdlib>
+#include <iostream>
+#include "arm_compute/core/Version.h"
+
+
+int main(void) {
+    std::cout << "ComputeLibrary information:" << std::endl;
+    std::cout << arm_compute::build_information() << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/compute_library/config.yml
+++ b/recipes/compute_library/config.yml
@@ -1,3 +1,5 @@
 versions:
   "23.08":
     folder: all
+  "23.02.1":
+    folder: all

--- a/recipes/compute_library/config.yml
+++ b/recipes/compute_library/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "23.08":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **compute_library/23.08**

That's a requirement for #19681 (OpenVino)

The ComputeLibrary has experimental CMake support, but it's restricted to a single linux profile, so it does not work with Mac. The official documentation uses SCons: https://github.com/ARM-software/ComputeLibrary

- The fPIC options is missing because is hardcoded in Scons script, so it would require a patch.
- It's not possible to avoid building all tests, but we don't install them at least
- The steps build and install are executed together, because install is a sub-step of build major step. We can not change without a patch, so we copy/clean during package() method
- It builds both static and shared at same build, there is no option to control it.
 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
