### PR TITLE
stringzilla: add version 1.2.2

### DIFF
--- a/recipes/stringzilla/all/conandata.yml
+++ b/recipes/stringzilla/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.2":
+    url: "https://github.com/ashvardanian/StringZilla/archive/refs/tags/v1.2.2.tar.gz"
+    sha256: "2e17c49965841647a1c371247f53b2f576e5fb32fe4b84a080d425b12f17703c"
   "1.1.3":
     url: "https://github.com/ashvardanian/StringZilla/archive/refs/tags/v1.1.3.tar.gz"
     sha256: "1856c4d780b2c9a12ccd14d04996b35bec9fe537d0a31209000e12777a86e495"

--- a/recipes/stringzilla/config.yml
+++ b/recipes/stringzilla/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.2":
+    folder: all
   "1.1.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **stringzilla/1.2.2**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
