### PR TITLE
Update zlib dependency from zlib/1.2.13 to zlib/1.3

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -336,7 +336,7 @@ class ArrowConan(ConanFile):
             self.options.get_safe("runtime_simd_level") != None:
             self.requires("xsimd/9.0.1")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_zstd:
             self.requires("zstd/1.5.2")
         if self.options.with_re2:

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -179,7 +179,7 @@ class AssimpConan(ConanFile):
         if self._depends_on_rapidjson:
             self.requires("rapidjson/cci.20220822")
         if self._depends_on_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self._depends_on_draco:
             self.requires("draco/1.5.6")
         if self._depends_on_clipper:

--- a/recipes/binutils/all/conanfile.py
+++ b/recipes/binutils/all/conanfile.py
@@ -138,7 +138,7 @@ class BinutilsConan(ConanFile):
             self.tool_requires("flex/2.6.4")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -531,7 +531,7 @@ class BoostConan(ConanFile):
 
     def requirements(self):
         if self._with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self._with_bzip2:
             self.requires("bzip2/1.0.8")
         if self._with_lzma:

--- a/recipes/c-blosc/all/conanfile.py
+++ b/recipes/c-blosc/all/conanfile.py
@@ -60,7 +60,7 @@ class CbloscConan(ConanFile):
         if self.options.with_snappy:
             self.requires("snappy/1.1.10")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
 

--- a/recipes/c-blosc2/all/conanfile.py
+++ b/recipes/c-blosc2/all/conanfile.py
@@ -69,7 +69,7 @@ class CBlosc2Conan(ConanFile):
         if self.options.with_zlib in ["zlib-ng", "zlib-ng-compat"]:
             self.requires("zlib-ng/2.1.3")
         elif self.options.with_zlib == "zlib":
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
 

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -92,7 +92,7 @@ class CairoConan(ConanFile):
                 self.requires("xorg/system")
         if self.options.get_safe("with_glib", True):
             self.requires("glib/2.76.3")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("pixman/0.40.0")
         self.requires("libpng/1.6.40")
 

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -99,7 +99,7 @@ class CairoConan(ConanFile):
         if self.options.with_lzo:
             self.requires("lzo/2.10")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_freetype:
             self.requires("freetype/2.13.0")
         if self.options.with_fontconfig:

--- a/recipes/capnproto/all/conanfile.py
+++ b/recipes/capnproto/all/conanfile.py
@@ -79,7 +79,7 @@ class CapnprotoConan(ConanFile):
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]")
         if self.options.get_safe("with_zlib"):
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/cfitsio/all/conanfile.py
+++ b/recipes/cfitsio/all/conanfile.py
@@ -56,7 +56,7 @@ class CfitsioConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.threadsafe and self.settings.os == "Windows" and \
            self.settings.compiler.get_safe("threads") != "posix":
             self.requires("pthreads4w/3.0.0")

--- a/recipes/cnpy/all/conanfile.py
+++ b/recipes/cnpy/all/conanfile.py
@@ -41,7 +41,7 @@ class CnpyConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13", transitive_headers=True, transitive_libs=True)
+        self.requires("zlib/1.3", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/coin-utils/all/conanfile.py
+++ b/recipes/coin-utils/all/conanfile.py
@@ -54,7 +54,7 @@ class CoinUtilsConan(ConanFile):
 
     def requirements(self):
         self.requires("bzip2/1.0.8")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:

--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -60,7 +60,7 @@ class CppRestSDKConan(ConanFile):
         self.requires("boost/1.83.0")
         self.requires("openssl/[>=1.1 <4]")
         if self.options.with_compression:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_websockets:
             self.requires("websocketpp/0.8.2")
 

--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -89,7 +89,7 @@ class DCMTKConan(ConanFile):
         if self.options.with_libxml2:
             self.requires("libxml2/2.10.3")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_openssl:
             if self.settings.os == "Windows":
                 # FIXME: CMake configuration fails to detect Openssl 1.1 on Windows.

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -52,7 +52,7 @@ class DoxygenConan(ConanFile):
     def requirements(self):
         if self.options.enable_search:
             self.requires("xapian-core/1.4.19")
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -76,7 +76,7 @@ class Exiv2Conan(ConanFile):
         self.requires("libiconv/1.17")
         if self.options.with_png:
             self.requires("libpng/1.6.40")
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_xmp == "bundled":
             self.requires("expat/2.5.0")
         if self.options.with_curl:

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -257,7 +257,7 @@ class FFMpegConan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:

--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -64,7 +64,7 @@ class FltkConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("libjpeg/9e")
         self.requires("libpng/1.6.40")
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -41,7 +41,7 @@ class GccConan(ConanFile):
         self.requires("mpc/1.2.0")
         self.requires("mpfr/4.1.0")
         self.requires("gmp/6.2.1")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("isl/0.24")
 
     def package_id(self):

--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -286,7 +286,7 @@ class GdalConan(ConanFile):
             self.requires("libxml2/2.10.3")
 
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")

--- a/recipes/gdal/pre_3.5.0/conanfile.py
+++ b/recipes/gdal/pre_3.5.0/conanfile.py
@@ -254,7 +254,7 @@ class GdalConan(ConanFile):
         if Version(self.version) >= "3.1.0":
             self.requires("flatbuffers/2.0.5")
         if self.options.get_safe("with_zlib", True):
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.get_safe("with_libdeflate"):
             self.requires("libdeflate/1.18")
         if self.options.with_libiconv:

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -62,7 +62,7 @@ class GDCMConan(ConanFile):
         if self.options.with_zlibng:
             self.requires("zlib-ng/2.0.7")
         else:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.settings.os != "Windows":
             self.requires("util-linux-libuuid/2.39")
             if Version(self.version) >= Version("3.0.20"):

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -65,7 +65,7 @@ class GLibConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("libffi/3.4.4")
         if Version(self.version) >= "2.73.2":
             self.requires("pcre2/10.42")

--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -145,7 +145,7 @@ class GoogleCloudCppConan(ConanFile):
         self.requires("abseil/20220623.0", transitive_headers=True)
         self.requires("libcurl/7.88.1")
         self.requires("openssl/[>=1.1 <4]")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def build_requirements(self):
         # For the grpc-cpp-plugin executable

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -95,7 +95,7 @@ class GrpcConan(ConanFile):
         self.requires("c-ares/1.19.1")
         self.requires("openssl/[>=1.1 <4]")
         self.requires("re2/20230301")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("protobuf/3.21.12", transitive_headers=True, transitive_libs=True, run=can_run(self))
 
     def package_id(self):

--- a/recipes/gzip-hpp/all/conanfile.py
+++ b/recipes/gzip-hpp/all/conanfile.py
@@ -27,7 +27,7 @@ class GzipHppConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13", transitive_headers=True)
+        self.requires("zlib/1.3", transitive_headers=True)
 
     def package_id(self):
         self.info.clear()

--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -70,7 +70,7 @@ class H5ppConan(ConanFile):
         if Version(self.version) < "1.10.0" or self.options.get_safe('with_spdlog'):
             self.requires("spdlog/1.11.0", transitive_headers=True, transitive_libs=True)
         if Version(self.version) >= "1.10.0" and self.options.with_zlib:
-            self.requires("zlib/1.2.13", transitive_headers=True, transitive_libs=True)
+            self.requires("zlib/1.3", transitive_headers=True, transitive_libs=True)
 
     def layout(self):
         basic_layout(self,src_folder="src")

--- a/recipes/hdf4/all/conanfile.py
+++ b/recipes/hdf4/all/conanfile.py
@@ -52,7 +52,7 @@ class Hdf4Conan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.jpegturbo:
             self.requires("libjpeg-turbo/3.0.0")
         else:

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -75,7 +75,7 @@ class Hdf5Conan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.szip_support == "with_libaec":
             self.requires("libaec/1.0.6")
         elif self.options.szip_support == "with_szip":

--- a/recipes/hdrhistogram-c/all/conanfile.py
+++ b/recipes/hdrhistogram-c/all/conanfile.py
@@ -42,7 +42,7 @@ class HdrhistogramcConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/itk/all/conanfile.py
+++ b/recipes/itk/all/conanfile.py
@@ -78,7 +78,7 @@ class ITKConan(ConanFile):
         self.requires("libtiff/4.5.1")
         self.requires("openjpeg/2.5.0")
         self.requires("onetbb/2021.9.0")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def validate(self):
         if self.options.shared and not self.dependencies["hdf5"].options.shared:

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -56,7 +56,7 @@ class IXWebSocketConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_zlib", True):
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.tls == "openssl":
             self.requires("openssl/1.1.1s")
         elif self.options.tls == "mbedtls":

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/conanfile.py
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/conanfile.py
@@ -31,7 +31,7 @@ class KaitaiStructCppStlRuntimeConan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_iconv:
             self.requires("libiconv/1.17")
 

--- a/recipes/kmod/all/conanfile.py
+++ b/recipes/kmod/all/conanfile.py
@@ -49,7 +49,7 @@ class KModConan(ConanFile):
         if self.options.with_xz:
             self.requires("xz_utils/5.4.2")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]")
 

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -66,7 +66,7 @@ class LeptonicaConan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_gif:
             self.requires("giflib/5.2.1")
         if self.options.with_jpeg == "libjpeg":

--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -81,7 +81,7 @@ class LibarchiveConan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_libxml2:

--- a/recipes/libbigwig/all/conanfile.py
+++ b/recipes/libbigwig/all/conanfile.py
@@ -49,7 +49,7 @@ class LibBigWigConan(ConanFile):
         if self.options.with_zlibng:
             self.requires("zlib-ng/2.1.3")
         else:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if self.info.settings.os == "Windows":

--- a/recipes/libbpf/all/conanfile.py
+++ b/recipes/libbpf/all/conanfile.py
@@ -40,7 +40,7 @@ class LibbpfConan(ConanFile):
     def requirements(self):
         self.requires("linux-headers-generic/5.14.9")
         self.requires("libelf/0.8.13")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def validate(self):
         if self.settings.os != "Linux":

--- a/recipes/libdwarf/all/conanfile.py
+++ b/recipes/libdwarf/all/conanfile.py
@@ -48,7 +48,7 @@ class LibdwarfConan(ConanFile):
 
     def requirements(self):
         self.requires("libelf/0.8.13")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -51,7 +51,7 @@ class LibgdConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.with_png:
             self.requires("libpng/1.6.39")
             if is_msvc(self):

--- a/recipes/libharu/all/conanfile.py
+++ b/recipes/libharu/all/conanfile.py
@@ -47,7 +47,7 @@ class LibharuConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("libpng/1.6.40")
 
     def source(self):

--- a/recipes/libkml/all/conanfile.py
+++ b/recipes/libkml/all/conanfile.py
@@ -46,7 +46,7 @@ class LibkmlConan(ConanFile):
         self.requires("expat/2.5.0")
         self.requires("minizip/1.2.13")
         self.requires("uriparser/0.9.7")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def validate(self):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):

--- a/recipes/libmediainfo/all/conanfile.py
+++ b/recipes/libmediainfo/all/conanfile.py
@@ -52,7 +52,7 @@ class LibmediainfoConan(ConanFile):
         self.requires("libcurl/8.0.1")
         self.requires("libzen/0.4.38", transitive_headers=True, transitive_libs=True)
         self.requires("tinyxml2/9.0.0")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def validate(self):
         if not self.dependencies["libzen"].options.enable_unicode:

--- a/recipes/libmicrohttpd/all/conanfile.py
+++ b/recipes/libmicrohttpd/all/conanfile.py
@@ -71,7 +71,7 @@ class LibmicrohttpdConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_zlib"):
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if is_msvc(self) and self.settings.arch not in ("x86", "x86_64"):

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -66,7 +66,7 @@ class LibMysqlClientCConan(ConanFile):
             self.requires("openssl/1.1.1u")
         else:
             self.requires("openssl/[>=1.1 <4]")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("zstd/1.5.5")
         self.requires("lz4/1.9.4")
         if self.settings.os == "FreeBSD":

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -67,7 +67,7 @@ class Nghttp2Conan(ConanFile):
             self.requires("libev/4.33")
             self.requires("libevent/2.1.12")
             self.requires("libxml2/2.11.4")
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
             if self.options.with_jemalloc:
                 self.requires("jemalloc/5.3.0")
         if self.options.with_hpack:

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -92,7 +92,7 @@ class LibpngConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def validate(self):
         if Version(self.version) < "1.6" and self.settings.arch == "armv8" and is_apple_os(self):

--- a/recipes/librasterlite2/all/conanfile.py
+++ b/recipes/librasterlite2/all/conanfile.py
@@ -79,7 +79,7 @@ class Librasterlite2Conan(ConanFile):
         self.requires("libtiff/4.5.1")
         self.requires("libxml2/2.11.4")
         self.requires("sqlite3/3.42.0")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.with_openjpeg:
             self.requires("openjpeg/2.5.0")
         if self.options.with_webp:

--- a/recipes/libspatialite/all/conanfile.py
+++ b/recipes/libspatialite/all/conanfile.py
@@ -86,7 +86,7 @@ class LibspatialiteConan(ConanFile):
 
     def requirements(self):
         self.requires("sqlite3/3.42.0")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.with_proj:
             self.requires("proj/9.1.1")
         if self.options.with_iconv:

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -80,7 +80,7 @@ class Libssh2Conan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.crypto_backend == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         elif self.options.crypto_backend == "mbedtls":

--- a/recipes/libtar/all/conanfile.py
+++ b/recipes/libtar/all/conanfile.py
@@ -46,7 +46,7 @@ class LibTarConan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if self.settings.os == "Windows":

--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -63,7 +63,7 @@ class LibtiffConan(ConanFile):
 
     def requirements(self):
         if self.options.zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.libdeflate:
             self.requires("libdeflate/1.18")
         if self.options.lzma:

--- a/recipes/libunwind/all/conanfile.py
+++ b/recipes/libunwind/all/conanfile.py
@@ -55,7 +55,7 @@ class LiunwindConan(ConanFile):
         if self.options.minidebuginfo:
             self.requires("xz_utils/5.4.2")
         if self.options.zlibdebuginfo:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:

--- a/recipes/libvips/all/conanfile.py
+++ b/recipes/libvips/all/conanfile.py
@@ -163,7 +163,7 @@ class LibvipsConan(ConanFile):
         if self.options.with_webp:
             self.requires("libwebp/1.3.0")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if self.options.vapi and not self.options.introspection:

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -212,7 +212,7 @@ class LibwebsocketsConan(ConanFile):
             self.requires("libev/4.33")
 
         if self.options.with_zlib == "zlib":
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         elif self.options.with_zlib == "miniz":
             self.requires("miniz/2.2.0")
 

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -95,7 +95,7 @@ class Libxml2Conan(ConanFile):
 
     def requirements(self):
         if self.options.zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.lzma:
             self.requires("xz_utils/5.4.2")
         if self.options.iconv:

--- a/recipes/libzip/all/conanfile.py
+++ b/recipes/libzip/all/conanfile.py
@@ -62,7 +62,7 @@ class LibZipConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")

--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -45,7 +45,7 @@ class LibZipppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if Version(self.version) == "4.0":
             self.requires("libzip/1.7.3")
         else:

--- a/recipes/mariadb-connector-c/all/conanfile.py
+++ b/recipes/mariadb-connector-c/all/conanfile.py
@@ -54,7 +54,7 @@ class MariadbConnectorcConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.get_safe("with_iconv"):
             self.requires("libiconv/1.17")
         if self.options.with_curl:

--- a/recipes/matio/all/conanfile.py
+++ b/recipes/matio/all/conanfile.py
@@ -56,7 +56,7 @@ class MatioConan(ConanFile):
         if self.options.with_hdf5:
             self.requires("hdf5/1.14.1")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if not self.options.with_hdf5 and self.options.mat73:

--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -52,7 +52,7 @@ class MBedTLSConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_zlib"):
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:

--- a/recipes/minisat/all/conanfile.py
+++ b/recipes/minisat/all/conanfile.py
@@ -41,7 +41,7 @@ class MiniSatConan(ConanFile):
 
     def requirements(self):
         # https://github.com/niklasso/minisat/blob/37dc6c67e2af26379d88ce349eb9c4c6160e8543/minisat/utils/ParseUtils.h#L27
-        self.requires("zlib/1.2.13", transitive_headers=True, transitive_libs=True)
+        self.requires("zlib/1.3", transitive_headers=True, transitive_libs=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -81,7 +81,7 @@ class MinizipNgConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_zlib"):
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:

--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -45,7 +45,7 @@ class MoldConan(ConanFile):
         del self.info.settings.compiler
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("openssl/1.1.1q")
         self.requires("xxhash/0.8.1")
         self.requires("onetbb/2021.3.0")

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -74,7 +74,7 @@ class MongoCDriverConan(ConanFile):
         if self.options.with_snappy:
             self.requires("snappy/1.1.10")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.with_icu:

--- a/recipes/nss/all/conanfile.py
+++ b/recipes/nss/all/conanfile.py
@@ -50,7 +50,7 @@ class NSSConan(ConanFile):
     def requirements(self):
         self.requires("nspr/4.35")
         self.requires("sqlite3/3.41.2")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def validate(self):
         if not self.options.shared:

--- a/recipes/opencv/2.x/conanfile.py
+++ b/recipes/opencv/2.x/conanfile.py
@@ -352,7 +352,7 @@ class OpenCVConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.with_eigen:
             self.requires("eigen/3.4.0")
         if self.options.with_tbb:

--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -76,7 +76,7 @@ class OpenCVConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_jpeg == "libjpeg-turbo":

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -1008,7 +1008,7 @@ class OpenCVConan(ConanFile):
 
     def requirements(self):
         # core module dependencies
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.with_eigen:
             self.requires("eigen/3.4.0")
         if self.options.parallel == "tbb":

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -91,7 +91,7 @@ class OpenImageIOConan(ConanFile):
 
     def requirements(self):
         # Required libraries
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         self.requires("boost/1.78.0")
         self.requires("libtiff/4.5.1")
         self.requires("openexr/2.5.7")

--- a/recipes/openscenegraph/all/conanfile.py
+++ b/recipes/openscenegraph/all/conanfile.py
@@ -154,7 +154,7 @@ class OpenSceneGraphConanFile(ConanFile):
         if self.options.with_tiff:
             self.requires("libtiff/4.5.1")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -71,7 +71,7 @@ class OpenTDFConan(ConanFile):
         self.requires("ms-gsl/2.1.0")
         self.requires("nlohmann_json/3.11.1")
         self.requires("jwt-cpp/0.4.0")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         # Use newer boost+libxml2 after 1.3.6
         if Version(self.version) <= "1.3.6":
             self.requires("boost/1.79.0")

--- a/recipes/pcl/all/conanfile.py
+++ b/recipes/pcl/all/conanfile.py
@@ -384,7 +384,7 @@ class PclConan(ConanFile):
         if self._is_enabled("opencv"):
             self.requires("opencv/4.5.5", transitive_headers=True)
         if self._is_enabled("zlib"):
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         # TODO:
         # self.requires("vtk/9.x.x", transitive_headers=True)
         # self.requires("openni/x.x.x", transitive_headers=True)

--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -68,7 +68,7 @@ class PrometheusCppConan(ConanFile):
         if self.options.with_push:
             self.requires("libcurl/8.0.1")
         if self.options.get_safe("with_compression"):
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if self.info.settings.compiler.cppstd:

--- a/recipes/ptex/all/conanfile.py
+++ b/recipes/ptex/all/conanfile.py
@@ -40,7 +40,7 @@ class PtexConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/qdbm/all/conanfile.py
+++ b/recipes/qdbm/all/conanfile.py
@@ -53,7 +53,7 @@ class QDBMConan(ConanFile):
         if self.options.with_iconv:
             self.requires("libiconv/1.17")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -339,7 +339,7 @@ class QtConan(ConanFile):
             raise ConanInvalidConfiguration("sqlite3 option enable_column_metadata must be enabled for qt")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.openssl:
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_pcre2:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -301,7 +301,7 @@ class QtConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.options.openssl:
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_pcre2:

--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -49,7 +49,7 @@ class QuaZIPConan(ConanFile):
 
     def requirements(self):
         self.requires("qt/5.15.9")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if Version(self.version) >= "1.4":
             self.requires("bzip2/1.0.8")
 

--- a/recipes/readosm/all/conanfile.py
+++ b/recipes/readosm/all/conanfile.py
@@ -55,7 +55,7 @@ class ReadosmConan(ConanFile):
 
     def requirements(self):
         self.requires("expat/2.5.0")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def build_requirements(self):
         if not is_msvc(self):

--- a/recipes/restinio/all/conanfile.py
+++ b/recipes/restinio/all/conanfile.py
@@ -53,7 +53,7 @@ class RestinioConan(ConanFile):
             self.requires("openssl/[>=1.1 <4]")
 
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
         if self.options.with_pcre == 1:
             self.requires("pcre/8.45")

--- a/recipes/rsync/all/conanfile.py
+++ b/recipes/rsync/all/conanfile.py
@@ -53,7 +53,7 @@ class RsyncConan(ConanFile):
             self.requires("openssl/[>=1.1 <4]")
 
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -80,7 +80,7 @@ class SCIPConan(ConanFile):
         if self.options.with_sym == "bliss":
             self.requires("bliss/0.77")
         self.requires("soplex/6.0.3")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def configure(self):
         self.options["soplex"].with_gmp = self.options.with_gmp

--- a/recipes/seasocks/all/conanfile.py
+++ b/recipes/seasocks/all/conanfile.py
@@ -57,7 +57,7 @@ class SeasocksConan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
 
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -60,7 +60,7 @@ class SentryCrashpadConan(ConanFile):
             self.tool_requires("jwasm/2.13")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.settings.os in ("Linux", "FreeBSD"):
             self.requires("libcurl/8.2.0")
         if self.options.get_safe("with_tls"):

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -77,7 +77,7 @@ class SoPlexConan(ConanFile):
 
     def requirements(self):
         # transitive libs as anything using soplex requires gzread, gzwrite, gzclose, gzopen
-        self.requires("zlib/1.2.13", transitive_headers=True, transitive_libs=True)
+        self.requires("zlib/1.3", transitive_headers=True, transitive_libs=True)
         if self.options.with_gmp:
             # transitive libs as anything using soplex requires __gmpz_init_set_si
             # see https://github.com/conan-io/conan-center-index/pull/16017#issuecomment-1495688452

--- a/recipes/taglib/all/conanfile.py
+++ b/recipes/taglib/all/conanfile.py
@@ -44,7 +44,7 @@ class TaglibConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -50,7 +50,7 @@ class TclConan(ConanFile):
         self.folders.generators = "conan"
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def validate(self):
         if self.settings.os not in ("FreeBSD", "Linux", "Macos", "Windows"):

--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -71,7 +71,7 @@ class ThriftConan(ConanFile):
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_libevent:
             self.requires("libevent/2.1.12")
         if self.options.with_qt5:

--- a/recipes/tinyexr/all/conanfile.py
+++ b/recipes/tinyexr/all/conanfile.py
@@ -40,7 +40,7 @@ class TinyExrConan(ConanFile):
         if self.options.with_z == "miniz":
             self.requires("miniz/3.0.2")
         else:
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_zfp:
             self.requires("zfp/1.0.0")
 

--- a/recipes/tng/all/conanfile.py
+++ b/recipes/tng/all/conanfile.py
@@ -41,7 +41,7 @@ class tngConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -37,7 +37,7 @@ class WebsocketPPConan(ConanFile):
             self.requires("openssl/[>=1.1 <4]", transitive_headers=True, transitive_libs=True)
 
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13", transitive_headers=True, transitive_libs=True)
+            self.requires("zlib/1.3", transitive_headers=True, transitive_libs=True)
 
         if self.options.asio == "standalone":
             self.requires("asio/1.28.1", transitive_headers=True)

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -54,7 +54,7 @@ class XapianCoreConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
         if self.settings.os != "Windows":
             self.requires("util-linux-libuuid/2.39")
 

--- a/recipes/zint/all/conanfile.py
+++ b/recipes/zint/all/conanfile.py
@@ -59,7 +59,7 @@ class ZintConan(ConanFile):
     def requirements(self):
         if self.options.with_libpng:
             self.requires("libpng/1.6.38")
-            self.requires("zlib/1.2.13")
+            self.requires("zlib/1.3")
         if self.options.with_qt:
             self.requires("qt/5.15.6")
 

--- a/recipes/zstr/all/conanfile.py
+++ b/recipes/zstr/all/conanfile.py
@@ -21,7 +21,7 @@ class ZstrConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/1.3")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Specify library name and version:  **MANY**

Downstream, we are having issues with the `pcre` package dependencies because the version regex it uses for zlib is now matching version 1.3.
Global search and replace zlib/1.2.13 with zlib/1.3 and this is the result.
I'm hoping we don't need 95 separate pull requests for this, but maybe zlib is an exceptional case, as it's used by many other projects.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
