### PR TITLE
cgif: bump meson

### DIFF
--- a/recipes/cgif/all/conanfile.py
+++ b/recipes/cgif/all/conanfile.py
@@ -47,7 +47,7 @@ class CgifConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support shared build with Visual Studio")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
+        self.tool_requires("meson/1.2.1")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Without this bump, it fails during configuration with apple-clang 15:

```
../src/meson.build:1:0: ERROR: Unable to detect linker for compiler `clang -Wl,--version -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -arch x86_64`
stdout:
stderr: ld: unknown options: --version
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I guess that all meson based recipes are affected and will need a bump (version range for meson would help).

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
