### PR TITLE
libepoxy: bump meson

### DIFF
--- a/recipes/libepoxy/all/conanfile.py
+++ b/recipes/libepoxy/all/conanfile.py
@@ -70,7 +70,7 @@ class EpoxyConan(ConanFile):
             raise ConanInvalidConfiguration("Static builds on Windows are not supported")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
+        self.tool_requires("meson/1.2.1")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
same problem than https://github.com/conan-io/conan-center-index/pull/19968#issue-1903862552 with apple-clang 15. Upgrading meson helps.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
