### PR TITLE
stb/cci.20230920

### DIFF
--- a/recipes/stb/all/conandata.yml
+++ b/recipes/stb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20230920":
+    url: "https://github.com/nothings/stb/archive/5736b15f7ea0ffb08dd38af21067c314d6a3aae9.zip"
+    sha256: "b6601f182fa4bc04dd0f135e38231e8a2c6c9e7901c66a942871f03285713b05"
   "cci.20220909":
     url: "https://github.com/nothings/stb/archive/8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55.zip"
     sha256: "93a16ee3e866e719feec459f6f132cce932c5ec751eb38e3ec1975f911353d2e"

--- a/recipes/stb/config.yml
+++ b/recipes/stb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20230920":
+    folder: all
   "cci.20220909":
     folder: all
   "cci.20210910":


### PR DESCRIPTION
Add latest version available of stb from commit [5736b15f7ea0ffb08dd38af21067c314d6a3aae9](https://github.com/nothings/stb/tree/5736b15f7ea0ffb08dd38af21067c314d6a3aae9)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
