### PR TITLE
libpsl: bump icu, meson & pkgconf

### DIFF
--- a/recipes/libpsl/all/conanfile.py
+++ b/recipes/libpsl/all/conanfile.py
@@ -48,7 +48,7 @@ class LibPslConan(ConanFile):
 
     def requirements(self):
         if self.options.with_idna == "icu":
-            self.requires("icu/72.1")
+            self.requires("icu/73.2")
         elif self.options.with_idna == "libidn":
             self.requires("libidn/1.36")
         elif self.options.with_idna == "libidn2":
@@ -57,9 +57,9 @@ class LibPslConan(ConanFile):
             self.requires("libunistring/0.9.10")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.0.0")
+        self.tool_requires("meson/1.2.1")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/1.9.3")
+            self.tool_requires("pkgconf/2.0.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Same issue than https://github.com/conan-io/conan-center-index/pull/19968#issue-1903862552 with apple-clang 15. Upgrading meson helps.

And I take advantage of this PR to bump icu & pkgconf.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
