### PR TITLE
nanodbc: no warnings as errors + bump deps + don't raise if apple-clang and nanodbc > 2.14.0

### DIFF
--- a/recipes/nanodbc/all/conandata.yml
+++ b/recipes/nanodbc/all/conandata.yml
@@ -5,9 +5,6 @@ sources:
   "2.13.0":
     url: "https://github.com/nanodbc/nanodbc/archive/v2.13.0.zip"
     sha256: "1287869b6ca82728cb6cc53c54f836c72cde15370c16f32d81c9ef6c257f7e43"
-  "cci.20200807":
-    url: "https://github.com/nanodbc/nanodbc/archive/ab8d176262f92d5f75aa2d441bfce27041032201.zip"
-    sha256: "9de057ae6e8d0b9192df1d16ccc70ce7525ca9fe52e56fa8d13cfae9206f8286"
 patches:
   "2.14.0":
     - patch_file: "patches/0001-odbc-from-cci.patch"
@@ -24,15 +21,5 @@ patches:
       patch_description: "Allow windows to compile shared libraries"
       patch_type: "portability"
     - patch_file: "patches/0003-add-missing-include.patch"
-      patch_description: "Add missing include to fix compilation for v2.13 and v20200807"
-      patch_type: "portability"
-  "cci.20200807":
-    - patch_file: "patches/0001-odbc-from-cci.patch"
-      patch_description: "Allow compilation on CI with ODBC library"
-      patch_type: "portability"
-    - patch_file: "patches/0002-allow-windows-shared.patch"
-      patch_description: "Allow windows to compile shared libraries"
-      patch_type: "portability"
-    - patch_file: "patches/0003-add-missing-include.patch"
-      patch_description: "Add missing include to fix compilation for v2.13 and v20200807"
+      patch_description: "Add missing include to fix compilation"
       patch_type: "portability"

--- a/recipes/nanodbc/all/conandata.yml
+++ b/recipes/nanodbc/all/conandata.yml
@@ -1,23 +1,20 @@
 sources:
-  "cci.20200807":
-    url: "https://github.com/nanodbc/nanodbc/archive/ab8d176262f92d5f75aa2d441bfce27041032201.zip"
-    sha256: "9de057ae6e8d0b9192df1d16ccc70ce7525ca9fe52e56fa8d13cfae9206f8286"
-  "2.13.0":
-    url: "https://github.com/nanodbc/nanodbc/archive/v2.13.0.zip"
-    sha256: "1287869b6ca82728cb6cc53c54f836c72cde15370c16f32d81c9ef6c257f7e43"
   "2.14.0":
     url: "https://github.com/nanodbc/nanodbc/archive/v2.14.0.tar.gz"
     sha256: "56228372042b689beccd96b0ac3476643ea85b3f57b3f23fb11ca4314e68b9a5"
-patches:
+  "2.13.0":
+    url: "https://github.com/nanodbc/nanodbc/archive/v2.13.0.zip"
+    sha256: "1287869b6ca82728cb6cc53c54f836c72cde15370c16f32d81c9ef6c257f7e43"
   "cci.20200807":
+    url: "https://github.com/nanodbc/nanodbc/archive/ab8d176262f92d5f75aa2d441bfce27041032201.zip"
+    sha256: "9de057ae6e8d0b9192df1d16ccc70ce7525ca9fe52e56fa8d13cfae9206f8286"
+patches:
+  "2.14.0":
     - patch_file: "patches/0001-odbc-from-cci.patch"
       patch_description: "Allow compilation on CI with ODBC library"
       patch_type: "portability"
     - patch_file: "patches/0002-allow-windows-shared.patch"
       patch_description: "Allow windows to compile shared libraries"
-      patch_type: "portability"
-    - patch_file: "patches/0003-add-missing-include.patch"
-      patch_description: "Add missing include to fix compilation for v2.13 and v20200807"
       patch_type: "portability"
   "2.13.0":
     - patch_file: "patches/0001-odbc-from-cci.patch"
@@ -29,10 +26,13 @@ patches:
     - patch_file: "patches/0003-add-missing-include.patch"
       patch_description: "Add missing include to fix compilation for v2.13 and v20200807"
       patch_type: "portability"
-  "2.14.0":
+  "cci.20200807":
     - patch_file: "patches/0001-odbc-from-cci.patch"
       patch_description: "Allow compilation on CI with ODBC library"
       patch_type: "portability"
     - patch_file: "patches/0002-allow-windows-shared.patch"
       patch_description: "Allow windows to compile shared libraries"
+      patch_type: "portability"
+    - patch_file: "patches/0003-add-missing-include.patch"
+      patch_description: "Add missing include to fix compilation for v2.13 and v20200807"
       patch_type: "portability"

--- a/recipes/nanodbc/all/test_package/CMakeLists.txt
+++ b/recipes/nanodbc/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(nanodbc REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE nanodbc::nanodbc)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/nanodbc/all/test_package/conanfile.py
+++ b/recipes/nanodbc/all/test_package/conanfile.py
@@ -6,6 +6,7 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/nanodbc/config.yml
+++ b/recipes/nanodbc/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "cci.20200807":
+  "2.14.0":
     folder: "all"
   "2.13.0":
     folder: "all"
-  "2.14.0":
+  "cci.20200807":
     folder: "all"

--- a/recipes/nanodbc/config.yml
+++ b/recipes/nanodbc/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: "all"
   "2.13.0":
     folder: "all"
-  "cci.20200807":
-    folder: "all"


### PR DESCRIPTION
- disable warnings as errors (otherwise it fails with apple-clang 15:
  ```
  /Users/spaceim/.conan2/p/b/nanodb0f0d557a98e9/b/src/nanodbc/nanodbc.cpp:263:25: error: 'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it. [-Werror,-Wdeprecated-declarations]
  ```
- add required_conan_version
- bump boost & odbc
- don't raise for version > 2.14.0 if apple-clang
- explicit CMake names since upstream export nanodbc::nanodbc target
- sort version by desc order

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
