### PR TITLE
yaml linter: remove warning about base_path

### DIFF
--- a/linter/conandata_yaml_linter.py
+++ b/linter/conandata_yaml_linter.py
@@ -92,17 +92,6 @@ def main():
                         " reviewing and consumers to evaluate patches"
                     )
 
-                # v2 migrations suggestion
-                if "base_path" in parsed["patches"][version][i]:
-                    base_path = parsed["patches"][version][i]["base_path"]
-                    print(
-                        f"::notice file={args.path},line={base_path.start_line},endline={base_path.end_line},"
-                        f"title=conandata.yml v2 migration suggestion"
-                        "::'base_path' should not be required once a recipe has been upgraded to take advantage of"
-                        " layouts (see https://docs.conan.io/en/latest/reference/conanfile/tools/layout.html) and"
-                        " the new helper (see https://docs.conan.io/en/latest/reference/conanfile/tools/files/patches.html#conan-tools-files-apply-conandata-patches)"
-                    )
-
 
 def pretty_print_yaml_validate_error(args, error):
     snippet = error.context_mark.get_snippet().replace("\n", "%0A")


### PR DESCRIPTION
base_path is necessary in some cases (eg qt) where upstream patches apply to only a sub-directory of the sources. This happens when the sources are an aggregation of several repositories. cf https://github.com/conan-io/conan-center-index/pull/18376/files

the presence of base_path is an indirect consequence of explicitly setting the `destination` argument  of the `get` function,  so a better diagnostic would be to detect these.



<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
