### PR TITLE
drogon: add version 1.8.7

### DIFF
--- a/recipes/drogon/all/conandata.yml
+++ b/recipes/drogon/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.7":
+    url: "https://github.com/drogonframework/drogon/archive/v1.8.7.tar.gz"
+    sha256: "d2d80d35becd69bf80d74bf09b69425193f1b7be3926bd44f3ac7b951e54465d"
   "1.8.6":
     url: "https://github.com/drogonframework/drogon/archive/v1.8.6.tar.gz"
     sha256: "ff02979f28047e97e19e36d1f363b3052b8122975fa8a379305d746dfe5fb004"
@@ -21,6 +24,13 @@ sources:
     url: "https://github.com/drogonframework/drogon/archive/refs/tags/v1.7.5.tar.gz"
     sha256: "e2af7c55dcabafef16f26f5b3242692f5a2b54c19b7b626840bf9132d24766f6"
 patches:
+  "1.8.7":
+    - patch_file: "patches/1.8.5-0001-remove-shared-libs.patch"
+      patch_description: "remove shared libs option"
+      patch_type: "conan"
+    - patch_file: "patches/1.8.6-0002-find-cci-packages.patch"
+      patch_description: "Fix jsoncpp cmake target name"
+      patch_type: "conan"
   "1.8.6":
     - patch_file: "patches/1.8.5-0001-remove-shared-libs.patch"
       patch_description: "remove shared libs option"

--- a/recipes/drogon/config.yml
+++ b/recipes/drogon/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.7":
+    folder: "all"
   "1.8.6":
     folder: "all"
   "1.8.5":


### PR DESCRIPTION
Specify library name and version:  **drogon/1.8.7**

1.8.7 is the last release supporting C++14.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
