### PR TITLE
duckdb: add version 0.9.0

### DIFF
--- a/recipes/duckdb/all/conandata.yml
+++ b/recipes/duckdb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.0":
+    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.9.0.tar.gz"
+    sha256: "3dbf3326a831bf0797591572440e81a3d6d668f8e33a25ce04efae19afc3a23d"
   "0.8.1":
     url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.8.1.tar.gz"
     sha256: "a0674f7e320dc7ebcf51990d7fc1c0e7f7b2c335c08f5953702b5285e6c30694"
@@ -18,6 +21,13 @@ sources:
     url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.5.1.tar.gz"
     sha256: "3dab7ba0d0f8d024d3c73fd3d4fb8834203c31d7b0ddb1e8539ee266e11b0e9b"
 patches:
+  "0.9.0":
+    - patch_file: "patches/0.9.0-0001-fix-cmake.patch"
+      patch_description: "install static of shared library, add installation for odbc extention"
+      patch_type: "portability"
+    - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
+      patch_description: "include stdlib for abort function"
+      patch_type: "portability"
   "0.8.1":
     - patch_file: "patches/0.8.1-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -68,6 +68,8 @@ class DuckdbConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) >= "0.9.0":
+            del self.options.with_parquet
 
     def configure(self):
         if self.options.shared:
@@ -97,7 +99,8 @@ class DuckdbConan(ConanFile):
         tc.variables["DUCKDB_PATCH_VERSION"] = Version(self.version).patch
         tc.variables["DUCKDB_DEV_ITERATION"] = 0
         tc.variables["BUILD_ICU_EXTENSION"] = self.options.with_icu
-        tc.variables["BUILD_PARQUET_EXTENSION"] = self.options.with_parquet
+        if "with_parquet" in self.options:
+            tc.variables["BUILD_PARQUET_EXTENSION"] = self.options.with_parquet
         tc.variables["BUILD_TPCH_EXTENSION"] = self.options.with_tpch
         tc.variables["BUILD_TPCDS_EXTENSION"] = self.options.with_tpcds
         tc.variables["BUILD_FTS_EXTENSION"] = self.options.with_fts
@@ -170,7 +173,7 @@ class DuckdbConan(ConanFile):
 
             if self.options.with_icu:
                 self.cpp_info.libs.append("icu_extension")
-            if self.options.with_parquet:
+            if self.options.get_safe("with_parquet", True):
                 self.cpp_info.libs.append("parquet_extension")
             if self.options.with_tpch:
                 self.cpp_info.libs.append("tpch_extension")

--- a/recipes/duckdb/all/patches/0.9.0-0001-fix-cmake.patch
+++ b/recipes/duckdb/all/patches/0.9.0-0001-fix-cmake.patch
@@ -1,0 +1,101 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index cda2d86..de25f6c 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -77,24 +77,26 @@ else()
+       duckdb_fastpforlib
+       duckdb_mbedtls)
+ 
++  if(BUILD_SHARED_LIBS)
+   add_library(duckdb SHARED ${ALL_OBJECT_FILES})
+   target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
+   link_threads(duckdb)
+   link_extension_libraries(duckdb)
+-
++  else()
+   add_library(duckdb_static STATIC ${ALL_OBJECT_FILES})
+   target_link_libraries(duckdb_static ${DUCKDB_LINK_LIBS})
+   link_threads(duckdb_static)
+   link_extension_libraries(duckdb_static)
+-
++  endif()
++  if(BUILD_SHARED_LIBS)
+   target_include_directories(
+     duckdb PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+-
++  else()
+   target_include_directories(
+     duckdb_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+-
++  endif()
+   install(
+     DIRECTORY "${PROJECT_SOURCE_DIR}/src/include/duckdb"
+     DESTINATION "${INSTALL_INCLUDE_DIR}"
+@@ -105,10 +107,18 @@ else()
+           DESTINATION "${INSTALL_INCLUDE_DIR}")
+ 
+ endif()
+-
++if(BUILD_SHARED_LIBS)
+ install(
+-  TARGETS duckdb duckdb_static
++  TARGETS duckdb
+   EXPORT "${DUCKDB_EXPORT_SET}"
+   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+   RUNTIME DESTINATION "${INSTALL_BIN_DIR}")
++else()
++install(
++  TARGETS duckdb_static
++  EXPORT "${DUCKDB_EXPORT_SET}"
++  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
++  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
++  RUNTIME DESTINATION "${INSTALL_BIN_DIR}")
++endif()
+diff --git a/tools/odbc/CMakeLists.txt b/tools/odbc/CMakeLists.txt
+index ffd0140..1901aa8 100644
+--- a/tools/odbc/CMakeLists.txt
++++ b/tools/odbc/CMakeLists.txt
+@@ -53,7 +53,15 @@ add_library(
+ 
+ set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")
+ target_link_libraries(duckdb_odbc ${LINK_LIB_LIST} duckdb_static)
++install(
++    TARGETS duckdb_odbc
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)
+ 
+ if(NOT WIN32 AND NOT CLANG_TIDY)
+   add_subdirectory(test)
+ endif()
++
+diff --git a/tools/sqlite3_api_wrapper/CMakeLists.txt b/tools/sqlite3_api_wrapper/CMakeLists.txt
+index 3fa4166..792d4e7 100644
+--- a/tools/sqlite3_api_wrapper/CMakeLists.txt
++++ b/tools/sqlite3_api_wrapper/CMakeLists.txt
+@@ -25,16 +25,16 @@ if(NOT AMALGAMATION_BUILD)
+ endif()
+ link_threads(sqlite3_api_wrapper_static)
+ 
+-if(NOT WIN32 AND NOT ZOS)
++if(BUILD_SHARED_LIBS AND NOT WIN32 AND NOT ZOS)
+   add_library(sqlite3_api_wrapper SHARED ${SQLITE_API_WRAPPER_FILES})
+   target_link_libraries(sqlite3_api_wrapper duckdb ${DUCKDB_EXTRA_LINK_FLAGS})
+   link_threads(sqlite3_api_wrapper)
+ endif()
+ 
+-include_directories(../../third_party/catch)
++# include_directories(../../third_party/catch)
+ 
+-include_directories(test/include)
+-add_subdirectory(test)
++# include_directories(test/include)
++# add_subdirectory(test)
+ 
+ add_executable(test_sqlite3_api_wrapper ${SQLITE_TEST_FILES})
+ if(WIN32 OR ZOS)

--- a/recipes/duckdb/config.yml
+++ b/recipes/duckdb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.0":
+    folder: "all"
   "0.8.1":
     folder: "all"
   "0.8.0":


### PR DESCRIPTION
Specify library name and version:  **duckdb/0.9.0**

duckdb/0.9.0 remove BUILD_PARQUET_EXTENSION option.
parquet becomes mandatory.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
