### PR TITLE
xlsxio: relocatable shared libs on macOS + cleanup recipe a little bit

### DIFF
--- a/recipes/xlsxio/all/conanfile.py
+++ b/recipes/xlsxio/all/conanfile.py
@@ -106,10 +106,7 @@ class XlsxioConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "xlsxio")
-        self.cpp_info.set_property("cmake_module_file_name", "xlsxio")
-        self.cpp_info.set_property("pkg_config_name", "xlsxio")
 
         ziplib = "minizip::minizip"
         if self.options.with_libzip:
@@ -120,7 +117,6 @@ class XlsxioConan(ConanFile):
         xlsxio_macro = "BUILD_XLSXIO_SHARED" if self.options.shared else "BUILD_XLSXIO_STATIC"
 
         self.cpp_info.components["xlsxio_read"].set_property("cmake_target_name", "xlsxio::xlsxio_read")
-        self.cpp_info.components["xlsxio_read"].set_property("cmake_module_target_name", "xlsxio::xlsxio_read")
         self.cpp_info.components["xlsxio_read"].set_property("pkg_config_name", "libxlsxio_read")
         self.cpp_info.components["xlsxio_read"].libs = ["xlsxio_read"]
         self.cpp_info.components["xlsxio_read"].requires = ["expat::expat", ziplib]
@@ -129,7 +125,6 @@ class XlsxioConan(ConanFile):
         self.cpp_info.components["xlsxio_read"].defines.append(xlsxio_macro)
 
         self.cpp_info.components["xlsxio_write"].set_property("cmake_target_name", "xlsxio::xlsxio_write")
-        self.cpp_info.components["xlsxio_write"].set_property("cmake_module_target_name", "xlsxio::xlsxio_write")
         self.cpp_info.components["xlsxio_write"].set_property("pkg_config_name", "libxlsxio_write")
         self.cpp_info.components["xlsxio_write"].libs = ["xlsxio_write"]
         self.cpp_info.components["xlsxio_write"].requires = ["expat::expat", ziplib]
@@ -139,7 +134,6 @@ class XlsxioConan(ConanFile):
 
         if self.options.with_wide:
             self.cpp_info.components["xlsxio_readw"].set_property("cmake_target_name", "xlsxio::xlsxio_readw")
-            self.cpp_info.components["xlsxio_readw"].set_property("cmake_module_target_name", "xlsxio::xlsxio_readw")
             self.cpp_info.components["xlsxio_readw"].set_property("pkg_config_name", "libxlsxio_readw")
             self.cpp_info.components["xlsxio_readw"].libs = ["xlsxio_readw"]
             self.cpp_info.components["xlsxio_readw"].requires = ["expat::expat", ziplib]

--- a/recipes/xlsxio/all/conanfile.py
+++ b/recipes/xlsxio/all/conanfile.py
@@ -84,6 +84,8 @@ class XlsxioConan(ConanFile):
         if Version(self.version) >= "0.2.34":
             tc.variables["WITH_MINIZIP_NG"] = self.options.with_minizip_ng
         tc.variables["WITH_WIDE"] = self.options.with_wide
+        # Relocatable shared lib on Macos
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.generate()
 
         tc = CMakeDeps(self)

--- a/recipes/xlsxio/all/conanfile.py
+++ b/recipes/xlsxio/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
-from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.scm import Version
 import os
@@ -74,9 +73,6 @@ class XlsxioConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        tc = VirtualBuildEnv(self)
-        tc.generate()
-
         tc = CMakeToolchain(self)
         tc.variables["BUILD_STATIC"] = not self.options.shared
         tc.variables["BUILD_SHARED"] = self.options.shared


### PR DESCRIPTION
- relocatable shared lib on macOS by injecting CMAKE_POLICY_DEFAULT_CMP0042 NEW (cmake_minimum_required of upstream is super old: 2.6 !)
- remove VirtualBuildEnv, it's useless here, there is no build requirements
- no cmake_find_mode both, there is no Find module file upstream, only a CMake config file
- no explicit global pc file, there is none upstream, only pc files per component

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
