### PR TITLE
shapelib: relocatable shared lib on macOS + add package_type

### DIFF
--- a/recipes/shapelib/all/conandata.yml
+++ b/recipes/shapelib/all/conandata.yml
@@ -12,3 +12,6 @@ patches:
       patch_description: "Use the standard BUILD_TESTING variable to control building tests"
       patch_source: "https://github.com/OSGeo/shapelib/pull/46"
       patch_type: "portability"
+    - patch_file: "patches/0003-relocatable-shared-macos.patch"
+      patch_description: "Relocatable shared lib on macOS"
+      patch_type: "conan"

--- a/recipes/shapelib/all/conanfile.py
+++ b/recipes/shapelib/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
 
 
 class ShapelibConan(ConanFile):
@@ -14,6 +14,7 @@ class ShapelibConan(ConanFile):
     topics = ("osgeo", "shapefile", "esri", "geospatial")
     homepage = "https://github.com/OSGeo/shapelib"
     url = "https://github.com/conan-io/conan-center-index"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -45,7 +46,6 @@ class ShapelibConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.variables["BUILD_TESTING"] = False
         tc.variables["USE_RPATH"] = False
         tc.generate()

--- a/recipes/shapelib/all/patches/0003-relocatable-shared-macos.patch
+++ b/recipes/shapelib/all/patches/0003-relocatable-shared-macos.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -117,7 +117,6 @@ set_target_properties(shp
+   PROPERTIES 
+   SOVERSION ${shp_SOVERSION}
+   VERSION ${shp_VERSION}
+-  INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}"
+   )
+ 
+ if(USE_RPATH)


### PR DESCRIPTION
also remove `CMAKE_POLICY_DEFAULT_CMP0077` trick (and increase `required_conan_version` to 1.54.0 since it's a workaround for a bug fixed in 1.54.0)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
