### PR TITLE
gstreamer: Add version 1.22.6

### DIFF
--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.22.6":
+    url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.22.6.tar.xz"
+    sha256: "f500e6cfddff55908f937711fc26a0840de28a1e9ec49621c0b6f1adbd8f818e"
   "1.22.3":
     url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.22.3.tar.xz"
     sha256: "9ffeab95053f9f6995eb3b3da225e88f21c129cd60da002d3f795db70d6d5974"

--- a/recipes/gstreamer/all/conanfile.py
+++ b/recipes/gstreamer/all/conanfile.py
@@ -55,6 +55,7 @@ class GStreamerConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
+
         self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
 
     def validate(self):

--- a/recipes/gstreamer/all/conanfile.py
+++ b/recipes/gstreamer/all/conanfile.py
@@ -55,7 +55,6 @@ class GStreamerConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-
         self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
 
     def validate(self):

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.22.6":
+    folder: all
   "1.22.3":
     folder: all
   "1.20.6":


### PR DESCRIPTION
Specify library name and version: gstreamer/1.22.6

We request the update of the GStreamer version to have all the GStreamer modules aligned to version 1.22.6, the last version before the release of version 1.24

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
