### PR TITLE
[websocketpp] Bump zlib requirement to [>=1.2.11 <2] range

### DIFF
--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -37,7 +37,7 @@ class WebsocketPPConan(ConanFile):
             self.requires("openssl/[>=1.1 <4]", transitive_headers=True, transitive_libs=True)
 
         if self.options.with_zlib:
-            self.requires("zlib/1.2.13", transitive_headers=True, transitive_libs=True)
+            self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True, transitive_libs=True)
 
         if self.options.asio == "standalone":
             self.requires("asio/1.28.1", transitive_headers=True)


### PR DESCRIPTION
Specify library name and version:  **websocketpp/any**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

- Replace zlib specific version by ranged version.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
