### PR TITLE
add 7bitconf 1.1.0 version

### DIFF
--- a/recipes/7bitconf/all/conandata.yml
+++ b/recipes/7bitconf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/7bitCoder/7bitConf/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "07e5bff366d66c276032021c9a9ca5cdb1d8f097b29c032d07ee6ae1a10885a2"
   "1.0.0":
     url: "https://github.com/7bitCoder/7bitConf/archive/refs/tags/v1.0.0.tar.gz"
     sha256: "48a02d331f4281c8ff691d55c54abe744228637e9ad3af500daf526f4c77696d"

--- a/recipes/7bitconf/all/conanfile.py
+++ b/recipes/7bitconf/all/conanfile.py
@@ -57,7 +57,7 @@ class SevenBitConfConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("taocpp-json/1.0.0-beta.13", transitive_headers=True)
+        self.requires("taocpp-json/1.0.0-beta.14", transitive_headers=True)
 
     def package_id(self):
         if self.info.options.header_only:
@@ -137,4 +137,3 @@ class SevenBitConfConan(ConanFile):
 
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.system_libs.append("m")
-

--- a/recipes/7bitconf/config.yml
+++ b/recipes/7bitconf/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  7bitconf /1.1.0

7bitconf add new 1.1.0 version and bump tapcpp json lib to 1.0.0-beta.14

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
