### PR TITLE
platform.converters: improve compiler versions checks for msvc and cleanup a little bit

### DIFF
--- a/recipes/platform.converters/all/conanfile.py
+++ b/recipes/platform.converters/all/conanfile.py
@@ -7,12 +7,15 @@ from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.50.0"
 
 
 class PlatformConvertersConan(ConanFile):
     name = "platform.converters"
-    description = "platform.converters is one of the libraries of the LinksPlatform modular framework, to provide conversions between different types"
+    description = (
+        "platform.converters is one of the libraries of the LinksPlatform "
+        "modular framework, to provide conversions between different types"
+    )
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/linksplatform/Converters"
@@ -23,7 +26,7 @@ class PlatformConvertersConan(ConanFile):
     no_copy_source = True
 
     @property
-    def _minimum_cpp_standard(self):
+    def _min_cppstd(self):
         return 20
 
     @property
@@ -31,6 +34,7 @@ class PlatformConvertersConan(ConanFile):
         return {
             "gcc": "10",
             "Visual Studio": "16",
+            "msvc": "192",
             "clang": "14",
             "apple-clang": "14",
         }
@@ -42,19 +46,14 @@ class PlatformConvertersConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
-
-        if not minimum_version:
-            self.output.warning(f"{self.name} recipe lacks information about the {self.settings.compiler} compiler support.")
-
-        elif Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.name}/{self.version} requires c++{self._minimum_cpp_standard}, "
-                f"which is not supported by {self.settings.compiler} {self.settings.compiler.version}."
-            )
-
         if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._minimum_cpp_standard)
+            check_min_cppstd(self, self._min_cppstd)
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
- Avoid to display these noisy warnings in case of "unknown" compilers, can't image someone with hundreds recipes like this
- Add min version of "msvc"
- fix required_conan_version, 1.50.0 is sufficient

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
