### PR TITLE
libzippp: add version 7.0-1.10.1

### DIFF
--- a/recipes/libzippp/all/conandata.yml
+++ b/recipes/libzippp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.0-1.10.1":
+    url: "https://github.com/ctabin/libzippp/archive/libzippp-v7.0-1.10.1.tar.gz"
+    sha256: "67d6808406b4fc255016ede52c7b5105e2d0e43899a3331de9ed86da5dea07a1"
   "6.1-1.9.2":
     url: "https://github.com/ctabin/libzippp/archive/libzippp-v6.1-1.9.2.tar.gz"
     sha256: "3796f174780f23938749da493cf4cbc4c55f84a568ec395f2c256dfe10129305"

--- a/recipes/libzippp/config.yml
+++ b/recipes/libzippp/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "7.0.1-1.10.1":
+  "7.0-1.10.1":
     folder: all
   "6.1-1.9.2":
     folder: all

--- a/recipes/libzippp/config.yml
+++ b/recipes/libzippp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.0.1-1.10.1":
+    folder: all
   "6.1-1.9.2":
     folder: all
   "6.0-1.9.2":


### PR DESCRIPTION
Specify library name and version:  **libzippp/7.0-1.10-1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
