### PR TITLE
[highs] bump version to 1.6.0

### DIFF
--- a/recipes/highs/all/conandata.yml
+++ b/recipes/highs/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/ERGO-Code/HiGHS/archive/refs/tags/v1.6.0.tar.gz"
+    sha256: "71962981566477c72c51b8b722c5df053d857b05b4f0e6869f455f657b3aa193"
   "1.5.3":
     url: "https://github.com/ERGO-Code/HiGHS/archive/refs/tags/v1.5.3.tar.gz"
     sha256: "ce1a7d2f008e60cc69ab06f8b16831bd0fcd5f6002d3bbebae9d7a3513a1d01d"

--- a/recipes/highs/config.yml
+++ b/recipes/highs/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.0":
+    folder: all
   "1.5.3":
     folder: all
   "1.4.2":


### PR DESCRIPTION
Specify library name and version:  **highs/1.6.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
