### PR TITLE
clickhouse-cpp: add version 2.5.1

### DIFF
--- a/recipes/clickhouse-cpp/all/conandata.yml
+++ b/recipes/clickhouse-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.1":
+    url: "https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/v2.5.1.tar.gz"
+    sha256: "8942fc702eca1f656e59c680c7e464205bffea038b62c1a0ad1f794ee01e7266"
   "2.5.0":
     url: "https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/v2.5.0.tar.gz"
     sha256: "7eead6beb47a64be9b1f12f2435f0fb6304e8363823ed72178c76faf0d835801"

--- a/recipes/clickhouse-cpp/config.yml
+++ b/recipes/clickhouse-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.1":
+    folder: all
   "2.5.0":
     folder: all
   "2.4.0":


### PR DESCRIPTION
Specify library name and version:  **clickhouse-cpp/2.5.1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
