### PR TITLE
fontconfig/meson: bump deps 

### DIFF
--- a/recipes/fontconfig/meson/conanfile.py
+++ b/recipes/fontconfig/meson/conanfile.py
@@ -56,7 +56,7 @@ class FontconfigConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("gperf/3.1")
-        self.tool_requires("meson/1.2.1")
+        self.tool_requires("meson/1.2.2")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.0.3")
 

--- a/recipes/fontconfig/meson/conanfile.py
+++ b/recipes/fontconfig/meson/conanfile.py
@@ -58,7 +58,7 @@ class FontconfigConan(ConanFile):
         self.tool_requires("gperf/3.1")
         self.tool_requires("meson/1.2.1")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.2")
+            self.tool_requires("pkgconf/2.0.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **fontconfig/***

Generated and committed by [Conan Center Bump Deps](https://github.com/ericLemanissier/conan-center-index-bump-deps)
Find more updatable recipes in the [GitHub Pages](https://ericlemanissier.github.io/conan-center-index-bump-deps/)


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
