### PR TITLE
android-ndk: add r26

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,4 +1,17 @@
 sources:
+  "r26":
+    "Windows":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26-windows.zip"
+        sha256: "a748c6634b96991e15cb8902ffa4a498bba2ec6aa8028526de3c4c9dfcf00663"
+    "Linux":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26-linux.zip"
+        sha256: "1505c2297a5b7a04ed20b5d44da5665e91bac2b7c0fbcd3ae99b6ccc3a61289a"
+    "Macos":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26-darwin.zip"
+        sha256: "b2ab2fd17f71e2d2994c8c0ba2e48e99377806e05bf7477093344c26ab71dec0"
   "r25c":
     "Windows":
       "x86_64":

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "r26":
+    folder: all
   "r25c":
     folder: all
   "r25b":


### PR DESCRIPTION
Specify library name and version:  **android-ndk/r26**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This adds the new r26 LTS.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
