### PR TITLE
libglvnd: Fix incorrect license and update recipe

### DIFF
--- a/recipes/libglvnd/all/conanfile.py
+++ b/recipes/libglvnd/all/conanfile.py
@@ -16,6 +16,7 @@ class LibGlvndConan(ConanFile):
     homepage = "https://gitlab.freedesktop.org/glvnd/libglvnd"
     topics = ("dispatch", "egl", "gl", "glx", "opengl", "vendor-neutral")
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "library"
     options = {
         "asm": [True, False],
         "x11": [True, False],

--- a/recipes/libglvnd/all/conanfile.py
+++ b/recipes/libglvnd/all/conanfile.py
@@ -14,7 +14,7 @@ class LibGlvndConan(ConanFile):
     license = "LicenseRef-LICENSE"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.freedesktop.org/glvnd/libglvnd"
-    topics = ("gl", "vendor-neutral", "dispatch")
+    topics = ("dispatch", "egl", "gl", "glx", "opengl", "vendor-neutral")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "asm": [True, False],

--- a/recipes/libglvnd/all/conanfile.py
+++ b/recipes/libglvnd/all/conanfile.py
@@ -1,8 +1,10 @@
 from conan import ConanFile
-from conan.tools.meson import Meson, MesonToolchain
-from conan.tools.files import get, rmdir, save
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import get, rmdir, save
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
 import os
 import textwrap
 
@@ -14,9 +16,9 @@ class LibGlvndConan(ConanFile):
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.freedesktop.org/glvnd/libglvnd"
-    topics = ("dispatch", "egl", "gl", "glx", "opengl", "vendor-neutral")
+    topics = ("dispatch", "egl", "gl", "gles", "glx", "glvnd", "opengl", "vendor-neutral")
     settings = "os", "arch", "compiler", "build_type"
-    package_type = "library"
+    package_type = "shared-library"
     options = {
         "asm": [True, False],
         "x11": [True, False],
@@ -42,21 +44,9 @@ class LibGlvndConan(ConanFile):
         "entrypoint_patching": True,
     }
 
-    generators = "PkgConfigDeps"
-
-    # don't use self.settings_build
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
-    # don't use self.user_info_build
-    @property
-    def _user_info_build(self):
-        return getattr(self, "user_info_build", self.deps_user_info)
-
     def configure(self):
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def requirements(self):
         if self.options.x11:
@@ -66,11 +56,12 @@ class LibGlvndConan(ConanFile):
 
     def validate(self):
         if self.settings.os not in ['Linux', 'FreeBSD']:
-            raise ConanInvalidConfiguration("libglvnd is only compatible with Linux and FreeBSD")
+            raise ConanInvalidConfiguration(f"{self.name} is only compatible with Linux and FreeBSD")
 
     def build_requirements(self):
-        self.build_requires("meson/0.63.2")
-        self.build_requires("pkgconf/1.9.3")
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
 
     def layout(self):
         basic_layout(self)
@@ -80,6 +71,10 @@ class LibGlvndConan(ConanFile):
                   strip_root=True)
 
     def generate(self):
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+        pkg_config_deps = PkgConfigDeps(self)
+        pkg_config_deps.generate()
         tc = MesonToolchain(self)
         tc.project_options["asm"] = "enabled" if self.options.asm else "disabled"
         tc.project_options["x11"] = "enabled" if self.options.x11 else "disabled"

--- a/recipes/libglvnd/all/conanfile.py
+++ b/recipes/libglvnd/all/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 class LibGlvndConan(ConanFile):
     name = "libglvnd"
     description = "The GL Vendor-Neutral Dispatch library"
-    license = "LicenseRef-LICENSE"
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.freedesktop.org/glvnd/libglvnd"
     topics = ("dispatch", "egl", "gl", "glx", "opengl", "vendor-neutral")

--- a/recipes/libglvnd/all/conanfile.py
+++ b/recipes/libglvnd/all/conanfile.py
@@ -64,7 +64,7 @@ class LibGlvndConan(ConanFile):
             self.tool_requires("pkgconf/2.0.3")
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/libglvnd/all/test_package/CMakeLists.txt
+++ b/recipes/libglvnd/all/test_package/CMakeLists.txt
@@ -1,8 +1,9 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.15)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+project(test_package LANGUAGES C)
+
+find_package(libglvnd REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE libglvnd::libglvnd)
+

--- a/recipes/libglvnd/all/test_package/conanfile.py
+++ b/recipes/libglvnd/all/test_package/conanfile.py
@@ -1,12 +1,19 @@
 from conan import ConanFile
-from conan.tools.build import cross_building
-from conans import CMake
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -14,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")


### PR DESCRIPTION
Specify library name and version:  **libglvnd/***

The package's license has been updated from the meaningless `LicenseRef-LICENSE` to `MIT`.

Several updates to the outdated Conan recipe were also done.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
