### PR TITLE
mpg123: fix missing glibc symbols on newer systems

### DIFF
--- a/recipes/mpg123/all/conanfile.py
+++ b/recipes/mpg123/all/conanfile.py
@@ -153,7 +153,10 @@ class Mpg123Conan(ConanFile):
             ])
             if is_apple_os(self):
                 # Needed for fix_apple_shared_install_name invocation in package method
-                tc.extra_cflags = ["-headerpad_max_install_names"]
+                tc.extra_cflags += ["-headerpad_max_install_names"]
+            # The finite-math-only optimization has no effect and will cause linking errors
+            # when linked against glibc >= 2.31
+            tc.extra_cflags += ["-fno-finite-math-only"]
             tc.generate()
             tc = AutotoolsDeps(self)
             tc.generate()


### PR DESCRIPTION
Related to https://github.com/conan-io/hooks/pull/508
Applying the hook temporarily as a part of the package to validate that the fix for the glibc issue works.

A full list of packages affected by removed glibc symbols can be found here:
https://gist.github.com/valgur/4fec44c680d3df6401495dc8be4642d2