### PR TITLE
aeron: fix missing glibc symbols on newer systems

### DIFF
--- a/recipes/aeron/all/conanfile.py
+++ b/recipes/aeron/all/conanfile.py
@@ -90,10 +90,12 @@ class AeronConan(ConanFile):
         tc.cache_variables["AERON_BUILD_DOCUMENTATION"] = False
         tc.cache_variables["AERON_INSTALL_TARGETS"] = True
         tc.cache_variables["AERON_ENABLE_NONSTANDARD_OPTIMIZATIONS"] = True
-        # The finite-math-only optimization has no effect and will cause linking errors
+        # The finite-math-only optimization has no effect and can cause linking errors
         # when linked against glibc >= 2.31
-        tc.variables["CMAKE_C_FLAGS"] = "-fno-finite-math-only"
-        tc.variables["CMAKE_CXX_FLAGS"] = "-fno-finite-math-only"
+        tc.blocks["cmake_flags_init"].template += (
+            'string(APPEND CMAKE_CXX_FLAGS_INIT " -fno-finite-math-only")\n'
+            'string(APPEND CMAKE_C_FLAGS_INIT " -fno-finite-math-only")\n'
+        )
         tc.generate()
 
     def _patch_sources(self):

--- a/recipes/aeron/all/conanfile.py
+++ b/recipes/aeron/all/conanfile.py
@@ -90,6 +90,10 @@ class AeronConan(ConanFile):
         tc.cache_variables["AERON_BUILD_DOCUMENTATION"] = False
         tc.cache_variables["AERON_INSTALL_TARGETS"] = True
         tc.cache_variables["AERON_ENABLE_NONSTANDARD_OPTIMIZATIONS"] = True
+        # The finite-math-only optimization has no effect and will cause linking errors
+        # when linked against glibc >= 2.31
+        tc.variables["CMAKE_C_FLAGS"] = "-fno-finite-math-only"
+        tc.variables["CMAKE_CXX_FLAGS"] = "-fno-finite-math-only"
         tc.generate()
 
     def _patch_sources(self):

--- a/recipes/aeron/all/conanfile.py
+++ b/recipes/aeron/all/conanfile.py
@@ -17,7 +17,7 @@ class AeronConan(ConanFile):
     description = "Efficient reliable UDP unicast, UDP multicast, and IPC message transport"
     topics = ("udp", "messaging", "low-latency")
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/real-logic/aeron/wiki"
+    homepage = "https://github.com/real-logic/aeron"
     license = "Apache-2.0"
 
     package_type = "library"
@@ -72,7 +72,7 @@ class AeronConan(ConanFile):
             raise ConanInvalidConfiguration("This platform (os=Macos arch=armv8) is not yet supported by this recipe")
 
     def build_requirements(self):
-        self.tool_requires("zulu-openjdk/11.0.15")
+        self.tool_requires("zulu-openjdk/11.0.19")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Related to https://github.com/conan-io/hooks/pull/508
Applying the hook temporarily as a part of the package to validate that the fix for the glibc issue works.

A full list of packages affected by removed glibc symbols can be found here:
https://gist.github.com/valgur/4fec44c680d3df6401495dc8be4642d2