### PR TITLE
graphene: fix missing glibc symbols on newer systems

### DIFF
--- a/recipes/graphene/all/conanfile.py
+++ b/recipes/graphene/all/conanfile.py
@@ -51,7 +51,7 @@ class GrapheneConan(ConanFile):
 
     def requirements(self):
         if self.options.with_glib:
-            self.requires("glib/2.77.0")
+            self.requires("glib/2.78.0")
 
     def validate(self):
         if self.settings.compiler == "gcc":
@@ -70,9 +70,9 @@ class GrapheneConan(ConanFile):
                 )
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.1")
+        self.tool_requires("meson/1.2.2")
         if not self.conf.get("tools.gnu:pkg_config", default=False):
-            self.tool_requires("pkgconf/1.9.5")
+            self.tool_requires("pkgconf/2.0.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Related to https://github.com/conan-io/hooks/pull/508
Applying the hook temporarily as a part of the package to validate that the fix for the glibc issue works.

A full list of packages affected by removed glibc symbols can be found here:
https://gist.github.com/valgur/4fec44c680d3df6401495dc8be4642d2