### PR TITLE
libsndfile: fix missing glibc symbols on newer systems

### DIFF
--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -52,6 +52,8 @@ class LibsndfileConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -64,7 +66,7 @@ class LibsndfileConan(ConanFile):
             self.requires("vorbis/1.3.7")
             self.requires("flac/1.4.2")
             self.requires("opus/1.4")
-        if self.options.get_safe("with_mpeg", False):
+        if self.options.get_safe("with_mpeg"):
             self.requires("mpg123/1.31.2")
             self.requires("libmp3lame/3.100")
 

--- a/recipes/libsndfile/all/test_package/CMakeLists.txt
+++ b/recipes/libsndfile/all/test_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES CXX)
+project(test_package LANGUAGES C CXX)
 
 find_package(SndFile REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE SndFile::sndfile)
+add_executable(${PROJECT_NAME}_c test_package.c)
+target_link_libraries(${PROJECT_NAME}_c PRIVATE SndFile::sndfile)
+
+add_executable(${PROJECT_NAME}_cxx test_package.cpp)
+target_link_libraries(${PROJECT_NAME}_cxx PRIVATE SndFile::sndfile)

--- a/recipes/libsndfile/all/test_package/conanfile.py
+++ b/recipes/libsndfile/all/test_package/conanfile.py
@@ -22,5 +22,7 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package_c")
+            self.run(bin_path, env="conanrun")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package_cxx")
             self.run(bin_path, env="conanrun")

--- a/recipes/libsndfile/all/test_package/test_package.c
+++ b/recipes/libsndfile/all/test_package/test_package.c
@@ -1,0 +1,14 @@
+#include "sndfile.h"
+
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+	if (argc < 2) {
+		puts("Usage: example <file.wav>\n");
+		return 0;
+	}
+	SF_INFO sfinfo;
+    SNDFILE *infile = sf_open (argv[1], SFM_READ, &sfinfo);
+    printf("Sample rate: %d\n", sfinfo.samplerate);
+	return 0;
+}

--- a/recipes/libsndfile/all/test_package/test_package.cpp
+++ b/recipes/libsndfile/all/test_package/test_package.cpp
@@ -9,9 +9,9 @@
 int main(int argc, char *argv[]) {
 	if (argc < 2) {
 		std::cout << "Usage: example <file.wav>\n";
-	} else {
-		SndfileHandle handle(argv[1]);
-		std::cout << "Sample rate: " << handle.samplerate() << "\n";
+		return 0;
 	}
+    SndfileHandle handle(argv[1]);
+    std::cout << "Sample rate: " << handle.samplerate() << "\n";
 	return 0;
 }

--- a/recipes/libsndfile/all/test_v1_package/conanfile.py
+++ b/recipes/libsndfile/all/test_v1_package/conanfile.py
@@ -13,5 +13,7 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
+            bin_path = os.path.join("bin", "test_package_c")
+            self.run(bin_path, run_environment=True)
+            bin_path = os.path.join("bin", "test_package_cxx")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Related to https://github.com/conan-io/hooks/pull/508
Applying the hook temporarily as a part of the package to validate that the fix for the glibc issue works.

A full list of packages affected by removed glibc symbols can be found here:
https://gist.github.com/valgur/4fec44c680d3df6401495dc8be4642d2

Depends on:
- #20266