### PR TITLE
libx265: fix missing glibc symbols on newer systems

### DIFF
--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -108,6 +108,11 @@ class Libx265Conan(ConanFile):
         if self.settings.os == "Android":
             replace_in_file(self, cmakelists, "list(APPEND PLATFORM_LIBS pthread)", "")
             replace_in_file(self, cmakelists, "list(APPEND PLATFORM_LIBS rt)", "")
+        # The finite-math-only optimization has no effect and can cause linking errors
+        # when linked against glibc >= 2.31
+        replace_in_file(self, cmakelists,
+                        "add_definitions(-ffast-math)",
+                        "add_definitions(-ffast-math -fno-finite-math-only)")
 
     def build(self):
         self._patch_sources()

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -150,7 +150,7 @@ class Libx265Conan(ConanFile):
             if self.options.shared:
                 self.cpp_info.defines.append("X265_API_IMPORTS")
         elif self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.extend(["dl", "pthread", "m"])
+            self.cpp_info.system_libs.extend(["dl", "pthread", "m", "rt"])
             if not self.options.shared:
                 self.cpp_info.sharedlinkflags = ["-Wl,-Bsymbolic,-znoexecstack"]
         elif self.settings.os == "Android":


### PR DESCRIPTION
Related to https://github.com/conan-io/hooks/pull/508
Applying the hook temporarily as a part of the package to validate that the fix for the glibc issue works.

A full list of packages affected by removed glibc symbols can be found here:
https://gist.github.com/valgur/4fec44c680d3df6401495dc8be4642d2
