### PR TITLE
nmslib: fix missing glibc symbols on newer systems

### DIFF
--- a/recipes/nmslib/all/conanfile.py
+++ b/recipes/nmslib/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file
 from conan.tools.microsoft import is_msvc, check_min_vs
 
 required_conan_version = ">=1.53.0"
@@ -62,8 +62,15 @@ class Nmslib(ConanFile):
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.generate()
 
-    def build(self):
+    def _patch_sources(self):
         apply_conandata_patches(self)
+        # The finite-math-only optimization has no effect and can cause linking errors
+        # when linked against glibc >= 2.31
+        replace_in_file(self, os.path.join(self.source_folder, "similarity_search", "CMakeLists.txt"),
+                        "-Ofast", "-Ofast -fno-finite-math-only")
+
+    def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join(self.source_folder, "similarity_search"))
         cmake.build()


### PR DESCRIPTION
Related to https://github.com/conan-io/hooks/pull/508
Applying the hook temporarily as a part of the package to validate that the fix for the glibc issue works.

A full list of packages affected by removed glibc symbols can be found here:
https://gist.github.com/valgur/4fec44c680d3df6401495dc8be4642d2
