### PR TITLE
openjpeg: fix missing glibc symbols on newer systems

### DIFF
--- a/recipes/openjpeg/all/conanfile.py
+++ b/recipes/openjpeg/all/conanfile.py
@@ -144,6 +144,7 @@ class OpenjpegConan(ConanFile):
         self.cpp_info.set_property("cmake_build_modules", [self._module_vars_rel_path])
         self.cpp_info.set_property("pkg_config_name", "libopenjp2")
         self.cpp_info.includedirs.append(os.path.join("include", self._openjpeg_subdir))
+        self.cpp_info.builddirs.append(os.path.join("lib", "cmake"))
         self.cpp_info.libs = ["openjp2"]
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.defines.append("OPJ_STATIC")

--- a/recipes/openjpeg/all/conanfile.py
+++ b/recipes/openjpeg/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save, replace_in_file
 from conan.tools.scm import Version
 import os
 import textwrap
@@ -71,8 +71,15 @@ class OpenjpegConan(ConanFile):
         tc.variables["OPJ_USE_THREAD"] = True
         tc.generate()
 
-    def build(self):
+    def _patch_sources(self):
         apply_conandata_patches(self)
+        # The finite-math-only optimization has no effect and can cause linking errors
+        # when linked against glibc >= 2.31
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        "-ffast-math", "-ffast-math;-fno-finite-math-only")
+
+    def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()


### PR DESCRIPTION
Related to https://github.com/conan-io/hooks/pull/508
Applying the hook temporarily as a part of the package to validate that the fix for the glibc issue works.

A full list of packages affected by removed glibc symbols can be found here:
https://gist.github.com/valgur/4fec44c680d3df6401495dc8be4642d2
