### PR TITLE
soundtouch: fix missing glibc symbols on newer systems

### DIFF
--- a/recipes/soundtouch/all/conanfile.py
+++ b/recipes/soundtouch/all/conanfile.py
@@ -54,8 +54,10 @@ class SoundTouchConan(ConanFile):
         tc.cache_variables["OPENMP"] = self.options.with_openmp
         # The finite-math-only optimization has no effect and can cause linking errors
         # when linked against glibc >= 2.31
-        tc.variables["CMAKE_C_FLAGS"] = "-fno-finite-math-only"
-        tc.variables["CMAKE_CXX_FLAGS"] = "-fno-finite-math-only"
+        tc.blocks["generic_system"].template = tc.blocks["cmake_flags_init"].template + """
+               string(APPEND CMAKE_CXX_FLAGS_INIT " -fno-finite-math-only")
+               string(APPEND CMAKE_C_FLAGS_INIT " -fno-finite-math-only")
+           """
         tc.generate()
 
     def build(self):

--- a/recipes/soundtouch/all/conanfile.py
+++ b/recipes/soundtouch/all/conanfile.py
@@ -48,10 +48,14 @@ class SoundTouchConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["INTEGER_SAMPLES"] = self.options.integer_samples
-        tc.variables["SOUNDTOUCH_DLL"] = self.options.with_dll
-        tc.variables["SOUNDSTRETCH"] = self.options.with_util
-        tc.variables["OPENMP"] = self.options.with_openmp
+        tc.cache_variables["INTEGER_SAMPLES"] = self.options.integer_samples
+        tc.cache_variables["SOUNDTOUCH_DLL"] = self.options.with_dll
+        tc.cache_variables["SOUNDSTRETCH"] = self.options.with_util
+        tc.cache_variables["OPENMP"] = self.options.with_openmp
+        # The finite-math-only optimization has no effect and can cause linking errors
+        # when linked against glibc >= 2.31
+        tc.variables["CMAKE_C_FLAGS"] = "-fno-finite-math-only"
+        tc.variables["CMAKE_CXX_FLAGS"] = "-fno-finite-math-only"
         tc.generate()
 
     def build(self):

--- a/recipes/soundtouch/all/conanfile.py
+++ b/recipes/soundtouch/all/conanfile.py
@@ -54,7 +54,7 @@ class SoundTouchConan(ConanFile):
         tc.cache_variables["OPENMP"] = self.options.with_openmp
         # The finite-math-only optimization has no effect and can cause linking errors
         # when linked against glibc >= 2.31
-        tc.blocks["generic_system"].template = tc.blocks["cmake_flags_init"].template + """
+        tc.blocks["cmake_flags_init"].template = tc.blocks["cmake_flags_init"].template + """
                string(APPEND CMAKE_CXX_FLAGS_INIT " -fno-finite-math-only")
                string(APPEND CMAKE_C_FLAGS_INIT " -fno-finite-math-only")
            """


### PR DESCRIPTION
Related to https://github.com/conan-io/hooks/pull/508
Applying the hook temporarily as a part of the package to validate that the fix for the glibc issue works.

A full list of packages affected by removed glibc symbols can be found here:
https://gist.github.com/valgur/4fec44c680d3df6401495dc8be4642d2
