### PR TITLE
[config] Remove old profile configurations

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -68,17 +68,6 @@ tasks:
 # Profile configurations to build packages
 configurations:
   - id: linux-gcc
-    epochs: [0]
-    hrname: "Linux, GCC"
-    content:
-      - os: [ "Linux" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "gcc":
-              compiler.libcxx: [ "libstdc++11" ]
-              compiler.version: [ "5", "7", "9", "10" ]
-              build_type: [ "Release", "Debug" ]
-  - id: linux-gcc
     epochs: [20211221, 20220120, 20230606]
     hrname: "Linux, GCC"
     content:
@@ -101,17 +90,6 @@ configurations:
               compiler.version: ["12", "13"]
               build_type: ["Release", "Debug"]
   - id: macos-clang
-    epochs: [0, 20211221]
-    hrname: "macOS, Clang"
-    content:
-      - os: [ "Macos" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "apple-clang":
-              compiler.version: [ "11.0", "12.0" ]
-              compiler.libcxx: [ "libc++" ]
-              build_type: [ "Release", "Debug" ]
-  - id: macos-clang
     epochs: [20220120, 20230606]
     hrname: "macOS, Clang"
     content:
@@ -120,20 +98,6 @@ configurations:
         compiler:
           - "apple-clang":
               compiler.version: [ "13.0" ]
-              compiler.libcxx: [ "libc++" ]
-              build_type: [ "Release", "Debug" ]
-  - id: macos-m1-clang
-    epochs: [0, 20211221]
-    hrname: "macOS, Clang (M1/arm64)"
-    build_profile:
-      os: "Macos"
-      arch: "x86_64"
-    content:
-      - os: [ "Macos" ]
-        arch: [ "armv8" ]
-        compiler:
-          - "apple-clang":
-              compiler.version: [ "12.0" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release", "Debug" ]
   - id: macos-m1-clang

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -104,21 +104,6 @@ configurations:
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
   - id: windows-msvc
-    epochs: [0, 20211221, 20220120, 20220628]
-    hrname: "Windows, MSVC"
-    build_profile:
-      os: "Windows"
-    content:
-      - os: [ "Windows" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "msvc":
-              compiler.version: [ "192" ]
-              build_type:
-                - "Release":
-                    compiler.runtime: ["dynamic"]
-                    compiler.runtime_type: [ "Release" ]
-  - id: windows-msvc
     epochs: [20230606]
     hrname: "Windows, MSVC"
     build_profile:


### PR DESCRIPTION
As we are deprecating the usage of epochs, in the latest deployment we introduced the change to only use the configuration of the latest epoch, so we can remove the other ones at this point.
