### PR TITLE
libevdev: Add recipe

### DIFF
--- a/recipes/libevdev/all/conandata.yml
+++ b/recipes/libevdev/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.13.1":
+    url: "https://www.freedesktop.org/software/libevdev/libevdev-1.13.1.tar.xz"
+    sha256: "06a77bf2ac5c993305882bc1641017f5bec1592d6d1b64787bad492ab34f2f36"

--- a/recipes/libevdev/all/conanfile.py
+++ b/recipes/libevdev/all/conanfile.py
@@ -77,4 +77,3 @@ class LibEvdevConan(ConanFile):
         self.cpp_info.includedirs = [os.path.join("include", f"libevdev-{Version(self.version).major}.0")]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["m", "rt"])
-        self.runenv_info.prepend_path("PATH", os.path.join(self.package_folder, "bin"))

--- a/recipes/libevdev/all/conanfile.py
+++ b/recipes/libevdev/all/conanfile.py
@@ -1,0 +1,80 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rmdir
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.scm import Version
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+class LibEvdevConan(ConanFile):
+    name = "libevdev"
+    description = "libevdev is a wrapper library for evdev devices."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.freedesktop.org/wiki/Software/libevdev"
+    topics = ("device", "evdev", "freedesktop", "input")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if not self.settings.os in ["FreeBSD", "Linux"]:
+            raise ConanInvalidConfiguration(f"{self.name} Only supports FreeBSD and Linux")
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["tests"] = "disabled"
+        tc.project_options["documentation"] = "disabled"
+        tc.project_options["coverity"] = "false"
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate()
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["evdev"]
+        self.cpp_info.includedirs = [os.path.join("include", f"libevdev-{Version(self.version).major}.0")]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["m", "rt"])
+        self.runenv_info.prepend_path("PATH", os.path.join(self.package_folder, "bin"))

--- a/recipes/libevdev/all/test_package/conanfile.py
+++ b/recipes/libevdev/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libevdev/all/test_package/meson.build
+++ b/recipes/libevdev/all/test_package/meson.build
@@ -1,0 +1,5 @@
+project('test_package', 'c')
+libevdev_dep = dependency('libevdev')
+executable('test_package',
+            sources : ['test_package.c'],
+            dependencies : [libevdev_dep])

--- a/recipes/libevdev/all/test_package/test_package.c
+++ b/recipes/libevdev/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <stddef.h>
+
+#include <libevdev/libevdev.h>
+
+int main(void) {
+	libevdev_new_from_fd(0, NULL);
+    return 0;
+}

--- a/recipes/libevdev/config.yml
+++ b/recipes/libevdev/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.13.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libevdev/1.13.1**

The libevdev library is required to make a libinput package.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
