### PR TITLE
libdisplay-info: Add recipe

### DIFF
--- a/recipes/libdisplay-info/all/conandata.yml
+++ b/recipes/libdisplay-info/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.1":
+    url: "https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/0.1.1/libdisplay-info-0.1.1.tar.bz2"
+    sha256: "51cdb0362882ca2af62532ab4d95e60d81e9890b339264719fd55f8e3945d695"

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -18,7 +18,7 @@ class LibdisplayInfoConan(ConanFile):
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.freedesktop.org/emersion/libdisplay-info"
-    topics = ("display", "DisplayID", "EDID", "topic2", "topic3")
+    topics = ("display", "DisplayID", "EDID")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -1,6 +1,5 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import is_apple_os
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir
@@ -53,7 +52,7 @@ class LibdisplayInfoConan(ConanFile):
             self.requires("hwdata/0.374")
 
     def validate(self):
-        if is_apple_os(self):
+        if not self.settings.os in ["FreeBSD", "Linux"]
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}")
 
     def build_requirements(self):

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -1,0 +1,91 @@
+from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import cross_building
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, replace_in_file, rm, rmdir
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class LibdisplayInfoConan(ConanFile):
+    name = "libdisplay-info"
+    description = "EDID and DisplayID library."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://gitlab.freedesktop.org/emersion/libdisplay-info"
+    topics = ("display", "DisplayID", "EDID", "topic2", "topic3")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def build_requirements(self):
+        self.tool_requires("hwdata/0.374")
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        if cross_building(self):
+            tc.project_options["build.pkg_config_path"] = self.generators_folder
+        tc.generate()
+        pkg_config_deps = PkgConfigDeps(self)
+        if cross_building(self):
+            pkg_config_deps.build_context_activated = ["hwdata"]
+        pkg_config_deps.generate()
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+
+    def _patch_sources(self):
+        replace_in_file(self, os.path.join(self.source_folder, "meson.build"), "subdir('test')", "# subdir('test')")
+
+    def build(self):
+        self._patch_sources()
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.libs = ["display-info"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["m"])
+        self.runenv_info.prepend_path("PATH", os.path.join(self.package_folder, "bin"))

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -32,7 +32,7 @@ class LibdisplayInfoConan(ConanFile):
 
     @property
     def _has_build_profile(self):
-        return getattr(self, "settings_build")
+        return getattr(self, "settings_build", None)
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -45,7 +45,7 @@ class LibdisplayInfoConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("hwdata/0.374")
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.2.3")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.0.3")
 

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -30,6 +30,10 @@ class LibdisplayInfoConan(ConanFile):
         "fPIC": True,
     }
 
+    @property
+    def _has_build_profile(self):
+        return getattr(self, "settings_build")
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -43,8 +47,13 @@ class LibdisplayInfoConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
+    def requirements(self):
+        if not self._has_build_profile:
+            self.requires("hwdata/0.374")
+
     def build_requirements(self):
-        self.tool_requires("hwdata/0.374")
+        if self._has_build_profile:
+            self.tool_requires("hwdata/0.374")
         self.tool_requires("meson/1.2.3")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.0.3")
@@ -58,7 +67,8 @@ class LibdisplayInfoConan(ConanFile):
             tc.project_options["build.pkg_config_path"] = self.generators_folder
         tc.generate()
         pkg_config_deps = PkgConfigDeps(self)
-        pkg_config_deps.build_context_activated = ["hwdata"]
+        if self._has_build_profile:
+            pkg_config_deps.build_context_activated = ["hwdata"]
         pkg_config_deps.generate()
         virtual_build_env = VirtualBuildEnv(self)
         virtual_build_env.generate()

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
-from conan.tools.apple import fix_apple_shared_install_name
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir
@@ -51,6 +52,10 @@ class LibdisplayInfoConan(ConanFile):
         if not self._has_build_profile:
             self.requires("hwdata/0.374")
 
+    def validate(self):
+        if is_apple_os(self):
+            raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}")
+
     def build_requirements(self):
         if self._has_build_profile:
             self.tool_requires("hwdata/0.374")
@@ -90,8 +95,6 @@ class LibdisplayInfoConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
-
-        fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.libs = ["display-info"]

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -37,8 +37,8 @@ class LibdisplayInfoConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -58,8 +58,7 @@ class LibdisplayInfoConan(ConanFile):
             tc.project_options["build.pkg_config_path"] = self.generators_folder
         tc.generate()
         pkg_config_deps = PkgConfigDeps(self)
-        if cross_building(self):
-            pkg_config_deps.build_context_activated = ["hwdata"]
+        pkg_config_deps.build_context_activated = ["hwdata"]
         pkg_config_deps.generate()
         virtual_build_env = VirtualBuildEnv(self)
         virtual_build_env.generate()

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -52,7 +52,7 @@ class LibdisplayInfoConan(ConanFile):
             self.requires("hwdata/0.374")
 
     def validate(self):
-        if not self.settings.os in ["FreeBSD", "Linux"]
+        if not self.settings.os in ["FreeBSD", "Linux"]:
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}")
 
     def build_requirements(self):

--- a/recipes/libdisplay-info/all/conanfile.py
+++ b/recipes/libdisplay-info/all/conanfile.py
@@ -88,4 +88,3 @@ class LibdisplayInfoConan(ConanFile):
         self.cpp_info.libs = ["display-info"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["m"])
-        self.runenv_info.prepend_path("PATH", os.path.join(self.package_folder, "bin"))

--- a/recipes/libdisplay-info/all/test_package/conanfile.py
+++ b/recipes/libdisplay-info/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libdisplay-info/all/test_package/conanfile.py
+++ b/recipes/libdisplay-info/all/test_package/conanfile.py
@@ -17,7 +17,7 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.2.3")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.0.3")
 

--- a/recipes/libdisplay-info/all/test_package/meson.build
+++ b/recipes/libdisplay-info/all/test_package/meson.build
@@ -1,0 +1,5 @@
+project('test_package', 'c')
+package_dep = dependency('libdisplay-info')
+executable('test_package',
+            sources : ['test_package.c'],
+            dependencies : [package_dep])

--- a/recipes/libdisplay-info/all/test_package/test_package.c
+++ b/recipes/libdisplay-info/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <stddef.h>
+
+#include <libdisplay-info/info.h>
+
+int main()
+{
+    return di_info_parse_edid("", 0) != 0;
+}

--- a/recipes/libdisplay-info/config.yml
+++ b/recipes/libdisplay-info/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libdisplay-info/0.1.1**

`libdisplay-info` is required to create a `wlroots` Conan package.

Requires #20278.

Note that I might need to disable Windows / macOS builds if they don't work. I didn't see anything that wouldn't allow them to build there, so I left them enabled at first.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
