### PR TITLE
libliftoff: Add recipe

### DIFF
--- a/recipes/libliftoff/all/conandata.yml
+++ b/recipes/libliftoff/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.4.1":
+    url: "https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/v0.4.1/libliftoff-v0.4.1.tar.bz2"
+    sha256: "2ec4a6b467dda20476acb4d6bd864538ccdaa946e8666f96efa98156bf25cfb5"

--- a/recipes/libliftoff/all/conanfile.py
+++ b/recipes/libliftoff/all/conanfile.py
@@ -1,0 +1,82 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class LibliftoffConan(ConanFile):
+    name = "libliftoff"
+    description = "Lightweight KMS plane library."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/project/package"
+    topics = ("drm", "KMS", "plane")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("libdrm/2.4.114")
+
+    def validate(self):
+        if self.settings.os not in ["Linux", "FreeBSD"]:
+            raise ConanInvalidConfiguration(f"{self.name} only supports FreeBSD and Linux")
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.generate()
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate()
+
+    def _patch_sources(self):
+        replace_in_file(self, os.path.join(self.source_folder, "meson.build"), "subdir('test')", "#subdir('test')")
+
+    def build(self):
+        self._patch_sources()
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["liftoff"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["m", "pthread", "dl"])

--- a/recipes/libliftoff/all/conanfile.py
+++ b/recipes/libliftoff/all/conanfile.py
@@ -55,6 +55,7 @@ class LibliftoffConan(ConanFile):
 
     def generate(self):
         tc = MesonToolchain(self)
+        tc.project_options["werror"] = False
         tc.generate()
         tc = PkgConfigDeps(self)
         tc.generate()

--- a/recipes/libliftoff/all/test_package/conanfile.py
+++ b/recipes/libliftoff/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libliftoff/all/test_package/meson.build
+++ b/recipes/libliftoff/all/test_package/meson.build
@@ -1,0 +1,5 @@
+project('test_package', 'c')
+package_dep = dependency('libliftoff')
+executable('test_package',
+            sources : ['test_package.c'],
+            dependencies : [package_dep])

--- a/recipes/libliftoff/all/test_package/test_package.c
+++ b/recipes/libliftoff/all/test_package/test_package.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+#include <libliftoff.h>
+
+int main(void) {
+    liftoff_log_set_priority(LIFTOFF_DEBUG);
+    return EXIT_SUCCESS;
+}

--- a/recipes/libliftoff/config.yml
+++ b/recipes/libliftoff/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.4.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libliftoff/0.4.1**

libliftoff is a lightweight KMS plane library.
It is required to create a `wlroots` Conan package.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
