### PR TITLE
Fix libdispatch for conan v2

### DIFF
--- a/recipes/libdispatch/all/CMakeLists.txt
+++ b/recipes/libdispatch/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/libdispatch/all/conandata.yml
+++ b/recipes/libdispatch/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "5.3.2":
-    sha256: d18ad8f24e3461108d8e2e0c838c8fca671f808ab8d06a2c32a7065f321995a1
-    url: https://github.com/apple/swift-corelibs-libdispatch/archive/swift-5.3.2-RELEASE.tar.gz
+  "5.9":
+    sha256: db30ccf6b20963112ab3aad256c2e49a18041a9806cf2f05854fe63a90d688c2
+    url: https://github.com/apple/swift-corelibs-libdispatch/archive/swift-5.9-RELEASE.tar.gz

--- a/recipes/libdispatch/all/conanfile.py
+++ b/recipes/libdispatch/all/conanfile.py
@@ -1,6 +1,7 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
-import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import get, copy
+from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.32.0"
 
@@ -11,48 +12,36 @@ class LibDispatchConan(ConanFile):
     topics = ("conan", "libdispatch", "apple", "GCD", "concurrency")
     url = "https://github.com/conan-io/conan-center-index"
     license = "Apache-2.0"
-    exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
     settings = "os", "compiler", "build_type", "arch"
 
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
 
-    _cmake = None
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def validate(self):
         if self.settings.compiler != "clang":
             raise ConanInvalidConfiguration("Clang compiler is required.")
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "swift-corelibs-{}-swift-{}-RELEASE".format(self.name, self.version)
-        os.rename(extracted_dir, self._source_subfolder)
-
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
+        cmake.install()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
-        cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        copy(self, "LICENSE" , self.source_folder, self.package_folder, keep_path=False)
 
     def package_info(self):
         if self.settings.os == "Macos":

--- a/recipes/libdispatch/all/test_package/CMakeLists.txt
+++ b/recipes/libdispatch/all/test_package/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.1.2)
 project(test_package CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
 find_package(libdispatch REQUIRED)
 
 # TEST_PACKAGE #################################################################

--- a/recipes/libdispatch/all/test_package/conanfile.py
+++ b/recipes/libdispatch/all/test_package/conanfile.py
@@ -1,16 +1,25 @@
 import os
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package", "cmake"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
+    def layout(self):
+        cmake_layout(self)
+
     def test(self):
-        if not tools.cross_building(self.settings):
-            self.run(os.path.join("bin","test_package"), run_environment=True)
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")


### PR DESCRIPTION
Specify library name and version:  **libdispatch/5.9**

Make conan2 work + bump version


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
