### PR TITLE
boost: remove `b2-default` value of `layout` option

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -81,7 +81,7 @@ class BoostConan(ConanFile):
         "filesystem_no_deprecated": [True, False],
         "filesystem_use_std_fs": [True, False],
         "filesystem_version": [None, "3", "4"],
-        "layout": ["system", "versioned", "tagged", "b2-default"],
+        "layout": ["system", "versioned", "tagged"],
         "magic_autolink": [True, False],  # enables BOOST_ALL_NO_LIB
         "diagnostic_definitions": [True, False],  # enables BOOST_LIB_DIAGNOSTIC
         "python_executable": [None, "ANY"],  # system default python installation is used, if None
@@ -422,9 +422,6 @@ class BoostConan(ConanFile):
 
         if self.options.get_safe("without_stacktrace", True):
             self.options.rm_safe("with_stacktrace_backtrace")
-
-        if self.options.layout == "b2-default":
-            self.options.layout = "versioned" if self.settings.os == "Windows" else "system"
 
         if self.options.without_fiber:
             self.options.rm_safe("numa")


### PR DESCRIPTION
logic of this value in configure() can't work in conan v2, it raises a ConanException (see https://cpplang.slack.com/archives/C41CWV9HA/p1696374024080289)

If folks want default layout for Windows, they can set layout to versioned instead of this removed b2-layout, so this value was more or less useless.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
