### PR TITLE
qdbm: fix install() in CMakeLists.txt

### DIFF
--- a/recipes/qdbm/all/CMakeLists.txt
+++ b/recipes/qdbm/all/CMakeLists.txt
@@ -60,8 +60,11 @@ set_target_properties(
 # ---- Install ----
 
 include(GNUInstallDirs)
-
-install(TARGETS qdbm)
+install(TARGETS qdbm
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)
 
 install(
     FILES

--- a/recipes/qdbm/all/conanfile.py
+++ b/recipes/qdbm/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rename
+from conan.tools.files import copy, get
 
 required_conan_version = ">=1.53.0"
 
@@ -77,8 +77,6 @@ class QDBMConan(ConanFile):
         copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
-        for dll in (self.package_path / "lib").glob("*.dll"):
-            rename(self, dll, self.package_path / "bin" / dll.name)
 
     def package_info(self):
         self.cpp_info.libs = ["qdbm"]


### PR DESCRIPTION
The copying of DLLs in `package()` can be avoided.

Related to #20331.