### PR TITLE
uchardet: fix unnecessary copying of DLLs

### DIFF
--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file, rmdir, rename
+from conan.tools.files import copy, get, replace_in_file, rmdir
 
 required_conan_version = ">=1.53.0"
 
@@ -100,8 +100,6 @@ class UchardetConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
         fix_apple_shared_install_name(self)
-        for dll in (self.package_path / "lib").glob("*.dll"):
-            rename(self, dll, self.package_path / "bin" / dll.name)
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "libuchardet")


### PR DESCRIPTION
The copying of DLLs in `package()` can be avoided.

Related to #20331.