### PR TITLE
libinput: Add recipe

### DIFF
--- a/recipes/libinput/all/conandata.yml
+++ b/recipes/libinput/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.24.0":
+    url: "https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.24.0/libinput-1.24.0.tar.bz2"
+    sha256: "c07cd0f3f464e8d2e07dc9479fd5b9340e637408517b77e7e96b2245f37f6fe6"

--- a/recipes/libinput/all/conandata.yml
+++ b/recipes/libinput/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.24.0":
-    url: "https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.24.0/libinput-1.24.0.tar.bz2"
-    sha256: "c07cd0f3f464e8d2e07dc9479fd5b9340e637408517b77e7e96b2245f37f6fe6"
+  "1.25.0":
+    url: "https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.25.0/libinput-1.25.0.tar.bz2"
+    sha256: "193bd592298bd9e369c0ef3e5d83a6a9d68ddc4cd3dfc84bbe77920a8d0d57df"

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -1,0 +1,133 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rmdir
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class LibinputConan(ConanFile):
+    name = "libinput"
+    description = "libinput is a library that handles input devices for display servers and other applications that need to directly deal with input devices."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.freedesktop.org/wiki/Software/libinput/"
+    topics = ("device", "display", "event", "input")
+    package_type = "shared-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "epoll_dir": [None, "ANY"],
+        "debug_gui": [True, False],
+        "with_libudev": ["eudev", "systemd"],
+        "with_libwacom": [True, False],
+        "with_wayland": [True, False],
+        "with_x11": [True, False],
+    }
+    default_options = {
+        "epoll_dir": None,
+        "debug_gui": True,
+        "with_libudev": "systemd",
+        # todo Package libwacom and enable this option by default.
+        "with_libwacom": False,
+        "with_wayland": True,
+        "with_x11": True,
+    }
+
+    def configure(self):
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+        if not self.options.debug_gui:
+            self.options.rm_safe("with_wayland")
+            self.options.rm_safe("with_x11")
+        if self.options.get_safe("with_wayland"):
+            self.options["gtk"].with_wayland = True
+        if self.options.get_safe("with_x11"):
+            self.options["gtk"].with_x11 = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("mtdev/1.1.6")
+        self.requires("libevdev/1.13.1")
+
+        if self.options.debug_gui:
+            self.requires("cairo/1.17.6")
+            self.requires("glib/2.78.0")
+            self.requires("gtk/4.7.0")
+            if self.options.with_wayland:
+                self.requires("wayland/1.22.0")
+                self.requires("wayland-protocols/1.31")
+            if self.options.with_x11:
+                self.requires("xorg/system")
+
+        if self.options.with_libudev == "systemd":
+            # todo Use libudev from the libsystemd package.
+            # self.requires("libsystemd/253.10", transitive_libs=True)
+            self.requires("libudev/system", transitive_libs=True)
+        elif self.options.with_libudev == "eudev":
+            self.requires("eudev/3.2.12", transitive_libs=True)
+
+    def validate(self):
+        if not self.settings.os in ["FreeBSD", "Linux"]:
+            raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
+        # if self.options.debug_gui and not (self.options.with_wayland or self.options.with_x11):
+        #     raise ConanInvalidConfiguration(f"The debug_gui option for {self.ref} is not yet supported. Contributions welcome.")
+        if self.options.with_libwacom:
+            raise ConanInvalidConfiguration(f"The with_libwacom option for {self.ref} is not yet supported. Contributions welcome.")
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+        if self.options.get_safe("with_wayland"):
+            self.tool_requires("wayland/<host_version>")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["coverity"] = False
+        tc.project_options["datadir"] = "res"
+        tc.project_options["documentation"] = False
+        tc.project_options["epoll-dir"] = '' if self.options.epoll_dir is None else str(self.options.epoll_dir)
+        tc.project_options["debug-gui"] = self.options.debug_gui
+        tc.project_options["install-tests"] = False
+        # Change libexecdir so that the libinput subdirectory in the bin directory doesn't conflict with the libinput executable.
+        tc.project_options["libexecdir"] = "libexec"
+        tc.project_options["libwacom"] = self.options.with_libwacom
+        tc.project_options["tests"] = False
+        tc.generate()
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate()
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+
+        copy(self, f"{self.name}-*", os.path.join(self.package_folder, "libexec", self.name), os.path.join(self.package_folder, "bin"))
+        rmdir(self, os.path.join(self.package_folder, "libexec"))
+
+        rmdir(self, os.path.join(self.package_folder, "etc"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "res", "zsh"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["input"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["m", "rt"])

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -44,10 +44,6 @@ class LibinputConan(ConanFile):
         if not self.options.debug_gui:
             self.options.rm_safe("with_wayland")
             self.options.rm_safe("with_x11")
-        if self.options.get_safe("with_wayland"):
-            self.options["gtk"].with_wayland = True
-        if self.options.get_safe("with_x11"):
-            self.options["gtk"].with_x11 = True
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -57,12 +53,12 @@ class LibinputConan(ConanFile):
         self.requires("libevdev/1.13.1")
 
         if self.options.debug_gui:
-            self.requires("cairo/1.17.6")
-            self.requires("glib/2.78.0")
-            self.requires("gtk/4.7.0")
+            self.requires("cairo/1.18.0")
+            self.requires("glib/2.78.3")
+            self.requires("gtk/system")
             if self.options.with_wayland:
                 self.requires("wayland/1.22.0")
-                self.requires("wayland-protocols/1.31")
+                self.requires("wayland-protocols/1.33")
             if self.options.with_x11:
                 self.requires("xorg/system")
 
@@ -74,15 +70,15 @@ class LibinputConan(ConanFile):
             self.requires("eudev/3.2.12", transitive_libs=True)
 
     def validate(self):
-        if not self.settings.os in ["FreeBSD", "Linux"]:
+        if self.settings.os not in ["FreeBSD", "Linux"]:
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
         if self.options.with_libwacom:
             raise ConanInvalidConfiguration(f"The with_libwacom option for {self.ref} is not yet supported. Contributions welcome.")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.3.2")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
         if self.options.get_safe("with_wayland"):
             self.tool_requires("wayland/<host_version>")
 

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -76,8 +76,6 @@ class LibinputConan(ConanFile):
     def validate(self):
         if not self.settings.os in ["FreeBSD", "Linux"]:
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
-        # if self.options.debug_gui and not (self.options.with_wayland or self.options.with_x11):
-        #     raise ConanInvalidConfiguration(f"The debug_gui option for {self.ref} is not yet supported. Contributions welcome.")
         if self.options.with_libwacom:
             raise ConanInvalidConfiguration(f"The with_libwacom option for {self.ref} is not yet supported. Contributions welcome.")
 

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -63,8 +63,6 @@ class LibinputConan(ConanFile):
                 self.requires("xorg/system")
 
         if self.options.with_libudev == "systemd":
-            # todo Use libudev from the libsystemd package.
-            # self.requires("libsystemd/255.2", transitive_libs=True)
             self.requires("libudev/system", transitive_libs=True)
         elif self.options.with_libudev == "eudev":
             self.requires("eudev/3.2.14", transitive_libs=True)
@@ -79,7 +77,7 @@ class LibinputConan(ConanFile):
         self.tool_requires("meson/1.3.2")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.1.0")
-        if self.options.get_safe("with_wayland"):
+        if self.options.debug_gui and self.options.get_safe("with_wayland"):
             self.tool_requires("wayland/<host_version>")
 
     def source(self):

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -53,8 +53,8 @@ class LibinputConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("mtdev/1.1.6")
-        self.requires("libevdev/1.13.1")
+        self.requires("mtdev/1.1.6", transitive_libs=True)
+        self.requires("libevdev/1.13.1", transitive_libs=True)
 
         if self.options.debug_gui:
             self.requires("cairo/1.17.6")

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -64,10 +64,10 @@ class LibinputConan(ConanFile):
 
         if self.options.with_libudev == "systemd":
             # todo Use libudev from the libsystemd package.
-            # self.requires("libsystemd/253.10", transitive_libs=True)
+            # self.requires("libsystemd/255.2", transitive_libs=True)
             self.requires("libudev/system", transitive_libs=True)
         elif self.options.with_libudev == "eudev":
-            self.requires("eudev/3.2.12", transitive_libs=True)
+            self.requires("eudev/3.2.14", transitive_libs=True)
 
     def validate(self):
         if self.settings.os not in ["FreeBSD", "Linux"]:

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -39,8 +39,8 @@ class LibinputConan(ConanFile):
     }
 
     def configure(self):
-        self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
         if not self.options.debug_gui:
             self.options.rm_safe("with_wayland")
             self.options.rm_safe("with_x11")

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -53,8 +53,8 @@ class LibinputConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("mtdev/1.1.6", transitive_libs=True)
-        self.requires("libevdev/1.13.1", transitive_libs=True)
+        self.requires("mtdev/1.1.6")
+        self.requires("libevdev/1.13.1")
 
         if self.options.debug_gui:
             self.requires("cairo/1.17.6")

--- a/recipes/libinput/all/conanfile.py
+++ b/recipes/libinput/all/conanfile.py
@@ -30,7 +30,7 @@ class LibinputConan(ConanFile):
     }
     default_options = {
         "epoll_dir": None,
-        "debug_gui": True,
+        "debug_gui": False,
         "with_libudev": "systemd",
         # todo Package libwacom and enable this option by default.
         "with_libwacom": False,

--- a/recipes/libinput/all/test_package/conanfile.py
+++ b/recipes/libinput/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libinput/all/test_package/conanfile.py
+++ b/recipes/libinput/all/test_package/conanfile.py
@@ -17,9 +17,9 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.3.2")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
 
     def build(self):
         meson = Meson(self)

--- a/recipes/libinput/all/test_package/meson.build
+++ b/recipes/libinput/all/test_package/meson.build
@@ -1,0 +1,5 @@
+project('test_package', 'c')
+package_dep = dependency('libinput')
+executable('test_package',
+            sources : ['test_package.c'],
+            dependencies : [package_dep])

--- a/recipes/libinput/all/test_package/test_package.c
+++ b/recipes/libinput/all/test_package/test_package.c
@@ -8,7 +8,7 @@
 #include <libinput.h>
 
 static int
-open_restricted(const char *path, int flags, void */*user_data*/)
+open_restricted(const char *path, int flags, void *user_data)
 {
 	int fd = open(path, flags);
 	return fd < 0 ? -1 : fd;

--- a/recipes/libinput/all/test_package/test_package.c
+++ b/recipes/libinput/all/test_package/test_package.c
@@ -1,0 +1,54 @@
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <libudev.h>
+#include <libinput.h>
+
+static int
+open_restricted(const char *path, int flags, void */*user_data*/)
+{
+	int fd = open(path, flags);
+	return fd < 0 ? -1 : fd;
+}
+
+static void
+close_restricted(int fd, void *user_data)
+{
+	close(fd);
+}
+
+static const struct libinput_interface interface = {
+	.open_restricted = open_restricted,
+	.close_restricted = close_restricted,
+};
+
+int main(void) {
+	bool grab = false;
+    struct libinput *li;
+	struct udev *udev = udev_new();
+	if (!udev) {
+		fprintf(stderr, "Failed to initialize udev\n");
+		return EXIT_FAILURE;
+	}
+
+	li = libinput_udev_create_context(&interface, &grab, udev);
+	if (!li) {
+		fprintf(stderr, "Failed to initialize libinput context from udev\n");
+        udev_unref(udev);
+        return EXIT_FAILURE;
+	}
+
+	if (libinput_udev_assign_seat(li, "seat0")) {
+		fprintf(stderr, "Failed to set seat\n");
+		libinput_unref(li);
+		li = NULL;
+        udev_unref(udev);
+        return EXIT_FAILURE;
+	}
+
+    udev_unref(udev);
+	return EXIT_SUCCESS;
+}

--- a/recipes/libinput/config.yml
+++ b/recipes/libinput/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.24.0":
+    folder: all

--- a/recipes/libinput/config.yml
+++ b/recipes/libinput/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.24.0":
+  "1.25.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libinput/1.25.0**

[libinput](https://www.freedesktop.org/wiki/Software/libinput/) is a library that handles input devices for display servers and other applications that need to directly deal with input devices.

libinput is required to enable the libinput backend in wlroots.

The following PRs are required first:

- [x] #20335
- [x] #20320
- [x] #20318

Optionally, a libwacom package could be added to enable libwacom support.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
