### PR TITLE
serial: better way to set install_name to `@rpath` in shared lib macOS

### DIFF
--- a/recipes/serial/all/conanfile.py
+++ b/recipes/serial/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
 from conan import ConanFile
-from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
+from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 
@@ -47,6 +47,8 @@ class ConanRecipe(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        # Relocatable shared lib on Macos
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.generate()
 
     def build(self):
@@ -60,7 +62,6 @@ class ConanRecipe(ConanFile):
              src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
-        fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.libs = ["serial"]


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
