### PR TITLE
GNU gengetopt

### DIFF
--- a/recipes/gengetopt/all/conandata.yml
+++ b/recipes/gengetopt/all/conandata.yml
@@ -7,3 +7,4 @@ patches:
     - patch_file: "patches/remove_test_and_docs.patch"
       patch_type: conan
       patch_description: Prevent building of the tests and documentation
+      strip: 2

--- a/recipes/gengetopt/all/conandata.yml
+++ b/recipes/gengetopt/all/conandata.yml
@@ -7,4 +7,3 @@ patches:
     - patch_file: "patches/remove_test_and_docs.patch"
       patch_type: conan
       patch_description: Prevent building of the tests and documentation
-      strip: 2

--- a/recipes/gengetopt/all/conandata.yml
+++ b/recipes/gengetopt/all/conandata.yml
@@ -2,3 +2,8 @@ sources:
   "2.23":
     url: "http://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     sha256: "b941aec9011864978dd7fdeb052b1943535824169d2aa2b0e7eae9ab807584ac"
+patches:
+  "2.23":
+    - patch_file: "patches/remove_test_and_docs.patch"
+      patch_type: conan
+      patch_description: Prevent building of the tests and documentation

--- a/recipes/gengetopt/all/conandata.yml
+++ b/recipes/gengetopt/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.23":
+    url: "http://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    sha256: "b941aec9011864978dd7fdeb052b1943535824169d2aa2b0e7eae9ab807584ac"

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -21,10 +21,11 @@ class gengetoptConan(ConanFile):
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "patches/*.patch"
-    generators = "AutotoolsDeps", "AutotoolsToolchain"
+    generators = "AutotoolsDeps", "AutotoolsToolchain", "VirtualRunEnv"
 
     def build_requirements(self):
         if self.settings.os == "Windows":
+            self.tool_requires("msys2/cci.latest")
             self.tool_requires("winflexbison/2.5.25")
         else:
             self.tool_requires("flex/2.6.4")

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.gnu import AutotoolsToolchain, Autotools, AutotoolsDeps
 from conan.tools.layout import basic_layout
-from conan.tools.files import get, mkdir
+from conan.tools.files import get, mkdir, apply_conandata_patches
 
 import pathlib
 
@@ -39,11 +39,10 @@ class gengetoptConan(ConanFile):
         at_toolchain.generate()
 
     def build(self):
-
-        self.run("which gengen")
+        apply_conandata_patches(self)
 
         autotools = Autotools(self)
-#        autotools.autoreconf()
+        autotools.autoreconf()
         autotools.configure()
         autotools.make()
 

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -18,6 +18,7 @@ class gengetoptConan(ConanFile):
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
+    exports_sources = "patches/*.patch"
 
     def build_requirements(self):
         self.tool_requires("gengen/1.4.2")

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -4,7 +4,7 @@ import os
 from conan import ConanFile
 from conan.tools.gnu import AutotoolsToolchain, Autotools, AutotoolsDeps
 from conan.tools.layout import basic_layout
-from conan.tools.files import chdir
+from conan.tools.files import chdir, get
 
 
 class gengetoptConan(ConanFile):
@@ -21,13 +21,14 @@ class gengetoptConan(ConanFile):
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
 
-    # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "configure.ac", "Makefile.am", "src/*"
 
-    
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder,
+            strip_root=True)
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def generate(self):
         deps = AutotoolsDeps(self)

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -1,10 +1,9 @@
-
-import os
-
 from conan import ConanFile
 from conan.tools.gnu import AutotoolsToolchain, Autotools, AutotoolsDeps
 from conan.tools.layout import basic_layout
-from conan.tools.files import chdir, get
+from conan.tools.files import get, mkdir
+
+import pathlib
 
 
 class gengetoptConan(ConanFile):
@@ -12,15 +11,18 @@ class gengetoptConan(ConanFile):
     package_type = "application"
 
     # Optional metadata
-    license = "<Put the package license here>"
-    author = "<Put your name here> <And your email here>"
-    url = "<Package recipe repository url here, for issues about the package>"
-    description = "<Description of {package_name} here>"
-    topics = ("<Put some tag here>", "<here>", "<and here>")
+    license = "GPL-3.0-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "A tool to write command line option parsing code for C programs."
+    topics = ("gnu", "generator", "parsing", "command-line")
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
 
+    def build_requirements(self):
+        self.tool_requires("gengen/1.4.2")
+        self.tool_requires("flex/2.6.4")
+        self.tool_requires("bison/3.8.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -37,11 +39,19 @@ class gengetoptConan(ConanFile):
         at_toolchain.generate()
 
     def build(self):
+
+        self.run("which gengen")
+
         autotools = Autotools(self)
-        autotools.autoreconf()
+#        autotools.autoreconf()
         autotools.configure()
         autotools.make()
 
     def package(self):
         autotools = Autotools(self)
         autotools.install()
+
+        lic_path = pathlib.Path(self.package_folder) / "licenses"
+        mkdir(lic_path)
+        copy(self, "COPYING", self.source_folder, lic_path)
+        copy(self, "LICENSE", self.source_folder, lic_path)

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -13,6 +13,7 @@ class gengetoptConan(ConanFile):
     # Optional metadata
     license = "GPL-3.0-or-later"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.gnu.org/software/gengetopt/gengetopt.html"
     description = "A tool to write command line option parsing code for C programs."
     topics = ("gnu", "generator", "parsing", "command-line")
 

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -1,0 +1,46 @@
+
+import os
+
+from conan import ConanFile
+from conan.tools.gnu import AutotoolsToolchain, Autotools, AutotoolsDeps
+from conan.tools.layout import basic_layout
+from conan.tools.files import chdir
+
+
+class gengetoptConan(ConanFile):
+    name = "gengetopt"
+    package_type = "application"
+
+    # Optional metadata
+    license = "<Put the package license here>"
+    author = "<Put your name here> <And your email here>"
+    url = "<Package recipe repository url here, for issues about the package>"
+    description = "<Description of {package_name} here>"
+    topics = ("<Put some tag here>", "<here>", "<and here>")
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+
+    # Sources are located in the same place as this recipe, copy them to the recipe
+    exports_sources = "configure.ac", "Makefile.am", "src/*"
+
+    
+
+    def layout(self):
+        basic_layout(self)
+
+    def generate(self):
+        deps = AutotoolsDeps(self)
+        deps.generate()
+        at_toolchain = AutotoolsToolchain(self)
+        at_toolchain.generate()
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        autotools = Autotools(self)
+        autotools.install()

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -28,6 +28,7 @@ class gengetoptConan(ConanFile):
         self.tool_requires("bison/3.8.2")
         self.tool_requires("automake/1.16.5")
         self.tool_requires("autoconf/2.71")
+        self.tool_requires("libtool/2.4.7")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -24,8 +24,11 @@ class gengetoptConan(ConanFile):
     generators = "AutotoolsDeps", "AutotoolsToolchain"
 
     def build_requirements(self):
-        self.tool_requires("flex/2.6.4")
-        self.tool_requires("bison/3.8.2")
+        if self.settings.os == "Windows":
+            self.tool_requires("winflexbison/2.5.25")
+        else:
+            self.tool_requires("flex/2.6.4")
+            self.tool_requires("bison/3.8.2")
         self.tool_requires("automake/1.16.5")
         self.tool_requires("autoconf/2.71")
         self.tool_requires("libtool/2.4.7")

--- a/recipes/gengetopt/all/conanfile.py
+++ b/recipes/gengetopt/all/conanfile.py
@@ -1,7 +1,8 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.tools.gnu import Autotools
 from conan.tools.layout import basic_layout
 from conan.tools.files import get, mkdir, apply_conandata_patches, rmdir, copy
+from conan.tools.scm import Version
 
 import pathlib
 
@@ -60,6 +61,11 @@ class gengetoptConan(ConanFile):
     def package_info(self):
         self.cpp_info.includedirs.clear()
         self.cpp_info.libdirs.clear()
+
+        if Version(conan_version).major < 2:
+            binpath = pathlib.Path(self.package_folder) / "bin"
+            self.env_info.PATH.append(str(binpath))
+
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/gengetopt/all/patches/remove_test_and_docs.patch
+++ b/recipes/gengetopt/all/patches/remove_test_and_docs.patch
@@ -1,0 +1,72 @@
+Index: src/Makefile.am
+===================================================================
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -18,7 +18,7 @@
+ ACLOCAL_AMFLAGS = -I m4 -I gl/m4
+ 
+ EXTRA_DIST = configure TODO LICENSE gl/m4/gnulib-cache.m4
+-SUBDIRS = gl src doc tests
++SUBDIRS = gl src
+ 
+ gengetoptdoc_DATA = ChangeLog COPYING NEWS THANKS INSTALL README LICENSE
+ 
+Index: src/configure.ac
+===================================================================
+--- a/configure.ac
++++ b/configure.ac
+@@ -115,54 +115,10 @@ AH_TEMPLATE(HAVE_LONG_LONG)
+ 
+ AC_CONFIG_FILES([
+ 	Makefile
+-	doc/Makefile
+ 	gl/Makefile
+ 	src/Makefile
+ 	src/skels/Makefile
+-	src/tests/Makefile
+-	tests/Makefile
+-	tests/test_conf.conf
+-	tests/test_conf_inc.conf
+-	tests/test_conf_parser_ov2.c
+-	tests/test_conf_parser_ov3.c
+-	tests/test_conf_parser_ov4.c
+ ])
+ 
+-AC_DEFUN([AC_CONFIG_TEST_SH], [AC_CONFIG_FILES([$1], [chmod -- +x $1])])
+-
+-AC_CONFIG_TEST_SH([tests/more_than_once.sh])
+-AC_CONFIG_TEST_SH([tests/no_optgiven.sh])
+-AC_CONFIG_TEST_SH([tests/test_all_opts.sh])
+-AC_CONFIG_TEST_SH([tests/test_all_opts_file_save.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser_err.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser_err_string.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser_grp.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser_ov.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser_ov2.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser_ov3.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser_ov4.sh])
+-AC_CONFIG_TEST_SH([tests/test_conf_parser_save.sh])
+-AC_CONFIG_TEST_SH([tests/test_default_values.sh])
+-AC_CONFIG_TEST_SH([tests/test_dep.sh])
+-AC_CONFIG_TEST_SH([tests/test_groups.sh])
+-AC_CONFIG_TEST_SH([tests/test_manual_help.sh])
+-AC_CONFIG_TEST_SH([tests/test_manual_help_args.sh])
+-AC_CONFIG_TEST_SH([tests/test_modes.sh])
+-AC_CONFIG_TEST_SH([tests/test_multiple.sh])
+-AC_CONFIG_TEST_SH([tests/test_multiple_err.sh])
+-AC_CONFIG_TEST_SH([tests/test_multiple_parsers.sh])
+-AC_CONFIG_TEST_SH([tests/test_output_dir.sh])
+-AC_CONFIG_TEST_SH([tests/test_output_dirs.sh])
+-AC_CONFIG_TEST_SH([tests/test_sections.sh])
+-AC_CONFIG_TEST_SH([tests/test_show_help.sh])
+-AC_CONFIG_TEST_SH([tests/test_simple_multiple.sh])
+-AC_CONFIG_TEST_SH([tests/test_simple_multiple_default.sh])
+-AC_CONFIG_TEST_SH([tests/test_unamed.sh])
+-AC_CONFIG_TEST_SH([tests/test_unnamed.sh])
+-AC_CONFIG_TEST_SH([tests/test_values.sh])
+-AC_CONFIG_TEST_SH([tests/test_values_err.sh])
+-AC_CONFIG_TEST_SH([tests/test_wrong_ggo.sh])
+-AC_CONFIG_TEST_SH([tests/valgrind_tests.sh])
+ 
+ AC_OUTPUT

--- a/recipes/gengetopt/all/patches/remove_test_and_docs.patch
+++ b/recipes/gengetopt/all/patches/remove_test_and_docs.patch
@@ -1,7 +1,7 @@
 Index: all/src/configure.ac
 ===================================================================
---- all.orig/src/configure.ac
-+++ all/src/configure.ac
+--- a/configure.ac
++++ b/configure.ac
 @@ -119,50 +119,8 @@ AC_CONFIG_FILES([
  	gl/Makefile
  	src/Makefile
@@ -56,8 +56,8 @@ Index: all/src/configure.ac
  AC_OUTPUT
 Index: all/src/Makefile.am
 ===================================================================
---- all.orig/src/Makefile.am
-+++ all/src/Makefile.am
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -18,7 +18,7 @@
  ACLOCAL_AMFLAGS = -I m4 -I gl/m4
  
@@ -69,8 +69,8 @@ Index: all/src/Makefile.am
  
 Index: all/src/src/Makefile.am
 ===================================================================
---- all.orig/src/src/Makefile.am
-+++ all/src/src/Makefile.am
+--- a/src/Makefile.am
++++ b/src/Makefile.am
 @@ -16,7 +16,7 @@
  # with gengetopt; see the file COPYING. If not, write to the Free Software 
  # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. 

--- a/recipes/gengetopt/all/patches/remove_test_and_docs.patch
+++ b/recipes/gengetopt/all/patches/remove_test_and_docs.patch
@@ -1,25 +1,8 @@
-Index: src/Makefile.am
+Index: all/src/configure.ac
 ===================================================================
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -18,7 +18,7 @@
- ACLOCAL_AMFLAGS = -I m4 -I gl/m4
- 
- EXTRA_DIST = configure TODO LICENSE gl/m4/gnulib-cache.m4
--SUBDIRS = gl src doc tests
-+SUBDIRS = gl src
- 
- gengetoptdoc_DATA = ChangeLog COPYING NEWS THANKS INSTALL README LICENSE
- 
-Index: src/configure.ac
-===================================================================
---- a/configure.ac
-+++ b/configure.ac
-@@ -115,54 +115,10 @@ AH_TEMPLATE(HAVE_LONG_LONG)
- 
- AC_CONFIG_FILES([
- 	Makefile
--	doc/Makefile
+--- all.orig/src/configure.ac
++++ all/src/configure.ac
+@@ -119,50 +119,8 @@ AC_CONFIG_FILES([
  	gl/Makefile
  	src/Makefile
  	src/skels/Makefile
@@ -30,10 +13,11 @@ Index: src/configure.ac
 -	tests/test_conf_parser_ov2.c
 -	tests/test_conf_parser_ov3.c
 -	tests/test_conf_parser_ov4.c
- ])
+-])
  
 -AC_DEFUN([AC_CONFIG_TEST_SH], [AC_CONFIG_FILES([$1], [chmod -- +x $1])])
--
++])
+ 
 -AC_CONFIG_TEST_SH([tests/more_than_once.sh])
 -AC_CONFIG_TEST_SH([tests/no_optgiven.sh])
 -AC_CONFIG_TEST_SH([tests/test_all_opts.sh])
@@ -70,3 +54,29 @@ Index: src/configure.ac
 -AC_CONFIG_TEST_SH([tests/valgrind_tests.sh])
  
  AC_OUTPUT
+Index: all/src/Makefile.am
+===================================================================
+--- all.orig/src/Makefile.am
++++ all/src/Makefile.am
+@@ -18,7 +18,7 @@
+ ACLOCAL_AMFLAGS = -I m4 -I gl/m4
+ 
+ EXTRA_DIST = configure TODO LICENSE gl/m4/gnulib-cache.m4
+-SUBDIRS = gl src doc tests
++SUBDIRS = gl src
+ 
+ gengetoptdoc_DATA = ChangeLog COPYING NEWS THANKS INSTALL README LICENSE
+ 
+Index: all/src/src/Makefile.am
+===================================================================
+--- all.orig/src/src/Makefile.am
++++ all/src/src/Makefile.am
+@@ -16,7 +16,7 @@
+ # with gengetopt; see the file COPYING. If not, write to the Free Software 
+ # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. 
+ 
+-SUBDIRS = skels tests
++SUBDIRS = skels
+ 
+ bin_PROGRAMS = gengetopt
+ 

--- a/recipes/gengetopt/all/patches/series
+++ b/recipes/gengetopt/all/patches/series
@@ -1,0 +1,1 @@
+remove_test_and_docs.patch

--- a/recipes/gengetopt/all/test_package/conanfile.py
+++ b/recipes/gengetopt/all/test_package/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.layout import basic_layout
 class gengetoptTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     test_type = "explicit"
+    generators = "VirtualRunEnv"
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)

--- a/recipes/gengetopt/all/test_package/conanfile.py
+++ b/recipes/gengetopt/all/test_package/conanfile.py
@@ -10,6 +10,9 @@ class gengetoptTestConan(ConanFile):
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
 
+    def build(self):
+        self.output.info("no need to build another executable!")
+        
     def layout(self):
         basic_layout(self)
 

--- a/recipes/gengetopt/all/test_package/conanfile.py
+++ b/recipes/gengetopt/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+
+class gengetoptTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def layout(self):
+        basic_layout(self)
+
+    def test(self):
+        if can_run(self):
+            self.run("gengetopt --version", env="conanbuild")

--- a/recipes/gengetopt/config.yml
+++ b/recipes/gengetopt/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.23":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **gengetopt/2.23**

packaging for the getopt automatic generator tool from GNU gnugenopt. Used by quite a few C libraries to generate getopt code since the dark ages.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
