### PR TITLE
s2geometry: do not suggest unofficial CMake imported target + cleanup a little bit recipe

### DIFF
--- a/recipes/s2geometry/all/conandata.yml
+++ b/recipes/s2geometry/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  0.10.0:
-    url: https://github.com/google/s2geometry/archive/refs/tags/v0.10.0.zip
-    sha256: d03ae5566e9957c5b3bc6e0e62603370d1450feaf093d204d27b7af9e4d14909
+  "0.10.0":
+    url: "https://github.com/google/s2geometry/archive/refs/tags/v0.10.0.tar.gz"
+    sha256: "1c17b04f1ea20ed09a67a83151ddd5d8529716f509dde49a8190618d70532a3d"
 patches:
-  0.10.0:
+  "0.10.0":
     - patch_description: "Bump CMAKE_CXX_STANDARD to 14"
       patch_file: "patches/bump_cmake_cxx_standard.patch"
       patch_source: "https://github.com/google/s2geometry/issues/317"

--- a/recipes/s2geometry/all/patches/bump_cmake_cxx_standard.patch
+++ b/recipes/s2geometry/all/patches/bump_cmake_cxx_standard.patch
@@ -7,7 +7,7 @@ index f080b4b..b2699ee 100644
  # end up defined differently.  There is probably a better way to achieve
  # this than assuming what absl used.
 -set(CMAKE_CXX_STANDARD 11)
-+set(CMAKE_CXX_STANDARD 14)
++set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to build with")
  set(CMAKE_CXX_STANDARD_REQUIRED ON)
  # No compiler-specific extensions, i.e. -std=c++11, not -std=gnu++11.
  set(CMAKE_CXX_EXTENSIONS OFF)

--- a/recipes/s2geometry/all/test_package/CMakeLists.txt
+++ b/recipes/s2geometry/all/test_package/CMakeLists.txt
@@ -1,20 +1,18 @@
 cmake_minimum_required(VERSION 3.15)
-
-project(test_package CXX)
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(test_package LANGUAGES CXX)
 
 find_package(s2geometry REQUIRED CONFIG)
 
-if (MSVC)
-    # Use unsigned characters
-    add_definitions(-J)
-    # Make sure cmath header defines things like M_PI
-    add_definitions(-D_USE_MATH_DEFINES)
-    # Make sure Windows doesn't define min/max macros that interfere with STL
-    add_definitions(-DNOMINMAX)
-endif ()
-
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE s2)
+target_link_libraries(${PROJECT_NAME} PRIVATE s2geometry::s2geometry)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+if(MSVC)
+    # Use unsigned characters
+    target_compile_options(${PROJECT_NAME} PRIVATE "-J")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE
+        # Make sure cmath header defines things like M_PI
+        "_USE_MATH_DEFINES"
+        # Make sure Windows doesn't define min/max macros that interfere with STL
+        "NOMINMAX"
+    )
+endif()

--- a/recipes/s2geometry/all/test_package/conanfile.py
+++ b/recipes/s2geometry/all/test_package/conanfile.py
@@ -4,17 +4,16 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
-    def requirements(self):
-        self.requires(self.tested_reference_str)
-
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
follow up of https://github.com/conan-io/conan-center-index/pull/20187#discussion_r1346311080

- honor C++ standard from profile
- do not define custom CMake target since upstream doesn't install a CMake config file
- cleanup topics
- bump required_conan_version to 1.54.0 because upstream defines BUILD_SHARED_LIBS as an option in its CMakeLists
- prefer to not scatter min compiler version logic
- prefer tar.gz tarball

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
