### PR TITLE
util-linux-libuuid/2.39: Remove usr directory from package folder

### DIFF
--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -105,6 +105,7 @@ class UtilLinuxLibuuidConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "bin"))
         rmdir(self, os.path.join(self.package_folder, "sbin"))
         rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "usr"))
         fix_apple_shared_install_name(self)
 
     def package_info(self):


### PR DESCRIPTION
For some reason, it tries to install a systemd directory and bash completions in the usr directory.

Specify library name and version:  **util-linux-libuuid/2.39**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
