### PR TITLE
libwacom: Add recipe

### DIFF
--- a/recipes/libwacom/all/conandata.yml
+++ b/recipes/libwacom/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.8.0":
+    url: "https://github.com/linuxwacom/libwacom/releases/download/libwacom-2.8.0/libwacom-2.8.0.tar.xz"
+    sha256: "bb04b12c8688d0ff6a108d47a38d2057d572c4d7227d78138abd5fd0ba59f215"

--- a/recipes/libwacom/all/conanfile.py
+++ b/recipes/libwacom/all/conanfile.py
@@ -1,0 +1,72 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rmdir
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class LibwacomConan(ConanFile):
+    name = "libwacom"
+    description = "libwacom is a library to identify graphics tablets and their model-specific features."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/linuxwacom/libwacom"
+    topics = ("device", "graphics", "input", "tablet", "wacom")
+    package_type = "shared-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("glib/2.78.0")
+        self.requires("libgudev/238")
+
+    def validate(self):
+        if not self.settings.os in ["FreeBSD", "Linux"]:
+            raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["datadir"] = "res"
+        tc.project_options["documentation"] = "disabled"
+        tc.project_options["tests"] = "disabled"
+        tc.generate()
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate()
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["wacom"]
+        self.cpp_info.includedirs = [os.path.join(self.package_folder, "include", "libwacom-1.0")]

--- a/recipes/libwacom/all/test_package/conanfile.py
+++ b/recipes/libwacom/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libwacom/all/test_package/meson.build
+++ b/recipes/libwacom/all/test_package/meson.build
@@ -1,0 +1,5 @@
+project('test_package', 'c')
+package_dep = dependency('libwacom')
+executable('test_package',
+            sources : ['test_package.c'],
+            dependencies : [package_dep])

--- a/recipes/libwacom/all/test_package/test_package.c
+++ b/recipes/libwacom/all/test_package/test_package.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+
+#include <libwacom/libwacom.h>
+
+
+int main(void) {
+    WacomDeviceDatabase *db = libwacom_database_new();
+    if (!db) {
+      return EXIT_FAILURE;
+    }
+    libwacom_database_destroy(db);
+    return EXIT_SUCCESS;
+}

--- a/recipes/libwacom/config.yml
+++ b/recipes/libwacom/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.8.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libwacom/2.8.0**

[libwacom](https://github.com/linuxwacom/libwacom) is a library to identify graphics tablets and their model-specific features.

It is an optional library for libinput.

Requires #20358.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
