### PR TITLE
libblkid: Add recipe

### DIFF
--- a/recipes/libblkid/all/conandata.yml
+++ b/recipes/libblkid/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.39":
+    url: "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-2.39.tar.xz"
+    sha256: "32b30a336cda903182ed61feb3e9b908b762a5e66fe14e43efb88d37162075cb"

--- a/recipes/libblkid/all/conanfile.py
+++ b/recipes/libblkid/all/conanfile.py
@@ -1,0 +1,73 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class LibblkidConan(ConanFile):
+    name = "libblkid"
+    description = (
+        "The libblkid library is used to identify block devices (disks) as to their content (e.g.  filesystem type, partitions) as well as extracting additional information such as filesystem labels/volume names, partitions, unique identifiers/serial numbers, etc."
+    )
+    topics = ("block", "device", "linux", "util-linux")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"
+    license = "LGPL-2.1-or-later"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(f"{self.ref} only supports Linux")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.configure_args.extend([
+            "--disable-all-programs",
+            "--enable-libblkid",
+        ])
+        tc.generate()
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        copy(self, "COPYING", os.path.join(self.source_folder, "libblkid"), os.path.join(self.package_folder, "licenses"))
+        copy(self, "COPYING.LGPL-2.1-or-later", os.path.join(self.source_folder, "Documentation", "licenses"), os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+        rmdir(self, os.path.join(self.package_folder, "sbin"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "usr"))
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["blkid"]
+        self.cpp_info.set_property("pkg_config_name", "blkid")

--- a/recipes/libblkid/all/test_package/CMakeLists.txt
+++ b/recipes/libblkid/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(libblkid REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE libblkid::libblkid)

--- a/recipes/libblkid/all/test_package/conanfile.py
+++ b/recipes/libblkid/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libblkid/all/test_package/test_package.c
+++ b/recipes/libblkid/all/test_package/test_package.c
@@ -1,0 +1,12 @@
+#include <stddef.h>
+
+#include <blkid/blkid.h>
+#include <stdlib.h>
+
+int main()
+{
+  if (blkid_get_library_version(NULL, NULL) <= 0) {
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/recipes/libblkid/config.yml
+++ b/recipes/libblkid/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.39":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libblkid/2.39**

libblkid is part of the util-linux project.
It is currently packaged as part of the libmount package, but I need to depend on the libblkid library specifically in the eudev recipe, so I'm creating a separate package for it.
This will be the third Conan package broken out from the util-linux project.
I'm not sure if these could somehow be brought together in the future to reduce the maintenance overhead.
Anyways, the libmount recipe should be updated after this is merged to depend on this libblkid package instead of bundling the library itself.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
