### PR TITLE
mbits-mstch: Compile for GCC 10

### DIFF
--- a/recipes/mbits-mstch/all/conanfile.py
+++ b/recipes/mbits-mstch/all/conanfile.py
@@ -33,7 +33,7 @@ class MBitsMstchConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "11",
+            "gcc": "10",
             "clang": "12",
             "msvc": "192",
             "apple-clang": "11.0.3",


### PR DESCRIPTION
Specify library name and version:  **mbits-mstch/1.0.4**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This is a refinement of the recipe as it works also on GCC 10 (which is also a common baseline for embedded development). The README in [their repo](https://github.com/mbits-libs/libmstch) also specifies GCC 4.7 as minimum requirement.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
