### PR TITLE
npcap 1.70: migrate to Conan 2.0

### DIFF
--- a/recipes/npcap/all/test_package/conanfile.py
+++ b/recipes/npcap/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile, conan_version
+from conan import ConanFile
 from conan.tools import files
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake
@@ -23,6 +23,9 @@ class TestPackageConan(ConanFile):
     def layout(self):
         cmake_layout(self)
 
+    def generate(self):
+        files.save(self, os.path.join(self.build_folder, "libpcap_bin_path"), self.dependencies["libpcap"].cpp_info.bindirs[0])
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()
@@ -35,7 +38,7 @@ class TestPackageConan(ConanFile):
             # It will not provide all the functions
             # but it will cover enough to check that what we compiled is correct
             files.rm(self, "wpcap.dll", bindir)
-            libpcap_bin_path = self.deps_cpp_info["libpcap"].bin_paths[0] if conan_version < "2" else self.dependencies["libpcap"].cpp_info.bindirs[0]
+            libpcap_bin_path = files.load(self, os.path.join(self.build_folder, "libpcap_bin_path"))
             files.copy(self, "pcap.dll", src=libpcap_bin_path, dst=os.path.join(str(self.build_path), bindir))
             files.rename(self, os.path.join(bindir, "pcap.dll"), os.path.join(bindir, "wpcap.dll"))
 

--- a/recipes/npcap/all/test_package/conanfile.py
+++ b/recipes/npcap/all/test_package/conanfile.py
@@ -31,17 +31,17 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bindir = self.cpp.build.bindirs[0]
+            bindir = self.cpp.build.bindir
             # Use libpcap DLL as a replacement for npcap DLL
             # It will not provide all the functions
             # but it will cover enough to check that what we compiled is correct
             files.rm(self, "wpcap.dll", bindir)
-            files.copy(self, "pcap.dll", src=self.deps_cpp_info['libpcap'].bin_paths[0], dst=bindir)
+            files.copy(self, "pcap.dll", src=self.dependencies['libpcap'].cpp_info.bindirs[0], dst=os.path.join(str(self.build_path), bindir))
             files.rename(self, os.path.join(bindir, "pcap.dll"), os.path.join(bindir, "wpcap.dll"))
 
             bin_path = os.path.join(bindir, "test_package")
             output = StringIO()
-            self.run(bin_path, env="conanrun", output=output)
+            self.run(bin_path, env="conanrun", stdout=output)
             test_output = output.getvalue()
             print(test_output)
             assert "libpcap version 1.10.1" in test_output

--- a/recipes/npcap/all/test_package/conanfile.py
+++ b/recipes/npcap/all/test_package/conanfile.py
@@ -2,7 +2,6 @@ from conan import ConanFile
 from conan.tools import files
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake
-from io import StringIO
 import os
 
 

--- a/recipes/npcap/all/test_package/conanfile.py
+++ b/recipes/npcap/all/test_package/conanfile.py
@@ -39,9 +39,4 @@ class TestPackageConan(ConanFile):
             files.copy(self, "pcap.dll", src=self.dependencies['libpcap'].cpp_info.bindirs[0], dst=os.path.join(str(self.build_path), bindir))
             files.rename(self, os.path.join(bindir, "pcap.dll"), os.path.join(bindir, "wpcap.dll"))
 
-            bin_path = os.path.join(bindir, "test_package")
-            output = StringIO()
-            self.run(bin_path, env="conanrun", stdout=output)
-            test_output = output.getvalue()
-            print(test_output)
-            assert "libpcap version 1.10.1" in test_output
+            self.run(os.path.join(bindir, "test_package"), env="conanrun")

--- a/recipes/npcap/all/test_package/conanfile.py
+++ b/recipes/npcap/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.tools import files
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake
@@ -35,7 +35,8 @@ class TestPackageConan(ConanFile):
             # It will not provide all the functions
             # but it will cover enough to check that what we compiled is correct
             files.rm(self, "wpcap.dll", bindir)
-            files.copy(self, "pcap.dll", src=self.dependencies['libpcap'].cpp_info.bindirs[0], dst=os.path.join(str(self.build_path), bindir))
+            libpcap_bin_path = self.deps_cpp_info["libpcap"].bin_paths[0] if conan_version < "2" else self.dependencies["libpcap"].cpp_info.bindirs[0]
+            files.copy(self, "pcap.dll", src=libpcap_bin_path, dst=os.path.join(str(self.build_path), bindir))
             files.rename(self, os.path.join(bindir, "pcap.dll"), os.path.join(bindir, "wpcap.dll"))
 
             self.run(os.path.join(bindir, "test_package"), env="conanrun")


### PR DESCRIPTION
Specify library name and version:  **npcap/1.70**

This recipe and version already exist in ConanCenter, but probably not in the Conan 2.0 repo. That's probably why the PcapPlusPlus PR fails: https://github.com/conan-io/conan-center-index/pull/20296

This PR mostly fixes the test to be compatible with Conan 2.0.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
