### PR TITLE
libucl/all: bump deps, use version range for OpenSSL

### DIFF
--- a/recipes/libucl/all/conanfile.py
+++ b/recipes/libucl/all/conanfile.py
@@ -46,11 +46,11 @@ class LibuclConan(ConanFile):
 
     def requirements(self):
         if self.options.enable_url_include:
-            self.requires("libcurl/7.86.0")
+            self.requires("libcurl/8.2.1")
         if self.options.enable_url_sign:
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/[>=1.1 <4]")
         if self.options.with_lua == "lua":
-            self.requires("lua/5.4.4")
+            self.requires("lua/5.4.6")
         elif self.options.with_lua == "luajit":
             self.requires("luajit/2.0.5")
 


### PR DESCRIPTION
Specify library name and version:  **libucl/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
