### PR TITLE
easylzma: better way to create relocatable shared lib on macOS

### DIFF
--- a/recipes/easylzma/all/conanfile.py
+++ b/recipes/easylzma/all/conanfile.py
@@ -1,7 +1,6 @@
 import os
 
 from conan import ConanFile
-from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, load, save
 from conan.tools.microsoft import is_msvc, msvc_runtime_flag
@@ -52,6 +51,10 @@ class EazylzmaConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        # Relocatable shared libs on macOS
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        # Silence CMake warning about LOCATION property
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0026"] = "OLD"
         tc.generate()
 
     def build(self):
@@ -80,7 +83,6 @@ class EazylzmaConan(ConanFile):
         copy(self, "easylzma/*",
              dst=os.path.join(self.package_folder, "include"),
              src=os.path.join(self.source_folder, "src"))
-        fix_apple_shared_install_name(self)
 
     @property
     def _libname(self):


### PR DESCRIPTION
It's a more efficient and faster way to set `@rpath` in shared lib on macOS (`fix_apple_shared_install_name()` should be the last ressort)

Moroever it avoids these warnings during CMake configuration:

```
CMake Warning (dev) at elzma/CMakeLists.txt:36 (GET_TARGET_PROPERTY):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target "elzma".  Use the
  target name directly with add_custom_command, or use the generator
  expression $<TARGET_FILE>, as appropriate.

This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at test/CMakeLists.txt:24 (GET_TARGET_PROPERTY):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target "easylzma_test".  Use
  the target name directly with add_custom_command, or use the generator
  expression $<TARGET_FILE>, as appropriate.

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   easylzma

This warning is for project developers.  Use -Wno-dev to suppress it.
```

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
