### PR TITLE
cpp-jwt/all: use OpenSSL version range

### DIFF
--- a/recipes/cpp-jwt/all/conanfile.py
+++ b/recipes/cpp-jwt/all/conanfile.py
@@ -40,7 +40,7 @@ class CppJwtConan(ConanFile):
 
     def requirements(self):
         self.requires("nlohmann_json/3.11.2")
-        self.requires("openssl/1.1.1s")
+        self.requires("openssl/[>=1.1 <4]")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Specify library name and version:  **cpp-jwt/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
