### PR TITLE
simple-websocket-server/all: bump deps, use OpenSSL version range

### DIFF
--- a/recipes/simple-websocket-server/all/conanfile.py
+++ b/recipes/simple-websocket-server/all/conanfile.py
@@ -31,7 +31,7 @@ class SimpleWebSocketServerConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("openssl/1.1.1q")
+        self.requires("openssl/[>=1.1 <4]")
         # only version 2.0.2 upwards is able to build against asio 1.18.0 or higher
         if Version(self.version) <= "2.0.1":
             if self.options.use_asio_standalone:
@@ -40,9 +40,9 @@ class SimpleWebSocketServerConan(ConanFile):
                 self.requires("boost/1.73.0")
         else:
             if self.options.use_asio_standalone:
-                self.requires("asio/1.28.0")
+                self.requires("asio/1.28.1")
             else:
-                self.requires("boost/1.82.0")
+                self.requires("boost/1.83.0")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Specify library name and version:  **simple-websocket-server/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
