### PR TITLE
fix openssl 3.X for MinGW

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -481,7 +481,8 @@ class OpenSSLConan(ConanFile):
     def _run_make(self, targets=None, parallel=True, install=False):
         command = [self._make_program]
         if install:
-            command.append(f"DESTDIR={self.package_folder}")
+            package_folder = self.package_folder.replace("\\", "/")  # needed for MinGW build
+            command.append(f"DESTDIR={package_folder}")
         if targets:
             command.extend(targets)
         if not self._use_nmake:
@@ -517,7 +518,8 @@ class OpenSSLConan(ConanFile):
 
     def build(self):
         self._make()
-        self.run(f"{self._perl} {self.source_folder}/configdata.pm --dump")
+        source_folder = self.source_folder.replace("\\", "/")  # Necessary for MinGW build
+        self.run(f"{self._perl} {source_folder}/configdata.pm --dump")
 
     @property
     def _make_program(self):


### PR DESCRIPTION
Specify library name and version:  **openssl/3.X**

This was failing in Windows for MinGW builds. Managed to build with MSVC (to check not broken) and with the following profile:
```
[settings]
arch=x86_64
build_type=Debug
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Windows

[conf]
tools.cmake.cmaketoolchain:generator=Ninja
tools.build:compiler_executables={'c': 'C:/ws/msys64/mingw64/bin/gcc.exe','cpp': 'C:/ws/msys64/mingw64/bin/g++.exe'}

[tool_requires]
ninja/[*]

[buildenv]
PATH+=(path)C:/ws/msys64/mingw64/bin
```

