### PR TITLE
dcmtk: fix compilation error `ambiguous overload for operator==` with some compilers

### DIFF
--- a/recipes/dcmtk/all/conandata.yml
+++ b/recipes/dcmtk/all/conandata.yml
@@ -11,5 +11,6 @@ patches:
       patch_description: "CMake: fix OpenSSL compatibility checks"
       patch_type: "conan"
     - patch_file: "patches/3.6.7-0003-ambiguous-overload-operator-equal.patch"
-      patch_description: "Fix ambiguous overload for operator== between DB_SerializedTagKey and DcmTagKey"
+      patch_description: "C++20: Fix ambiguous overload for operator== between DB_SerializedTagKey and DcmTagKey"
       patch_type: "portability"
+      patch_source: "https://github.com/DCMTK/dcmtk/pull/88"

--- a/recipes/dcmtk/all/conandata.yml
+++ b/recipes/dcmtk/all/conandata.yml
@@ -6,7 +6,10 @@ patches:
   "3.6.7":
     - patch_file: "patches/3.6.7-0001-cmake-robust-deps-handling.patch"
       patch_description: "CMake: robust discovery with find_package() and use imported targets"
-      patch_type: conan
+      patch_type: "conan"
     - patch_file: "patches/3.6.7-0002-cmake-check-openssl-symbol.patch"
       patch_description: "CMake: fix OpenSSL compatibility checks"
-      patch_type: conan
+      patch_type: "conan"
+    - patch_file: "patches/3.6.7-0003-ambiguous-overload-operator-equal.patch"
+      patch_description: "Fix ambiguous overload for operator== between DB_SerializedTagKey and DcmTagKey"
+      patch_type: "portability"

--- a/recipes/dcmtk/all/patches/3.6.7-0003-ambiguous-overload-operator-equal.patch
+++ b/recipes/dcmtk/all/patches/3.6.7-0003-ambiguous-overload-operator-equal.patch
@@ -1,64 +1,26 @@
---- a/dcmqrdb/libsrc/dcmqrdbi.cc
-+++ b/dcmqrdb/libsrc/dcmqrdbi.cc
-@@ -1216,12 +1216,13 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare (
-          */
+--- a/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h
++++ b/dcmqrdb/include/dcmtk/dcmqrdb/dcmqridx.h
+@@ -122,10 +122,22 @@ struct DCMTK_DCMQRDB_EXPORT DB_SerializedTagKey
+     inline DB_SerializedTagKey(const DcmTagKey& rhs) { *this = rhs; }
+     inline DB_SerializedTagKey& operator=(const DcmTagKey& tk) { key[0] = tk.getGroup(); key[1] = tk.getElement(); return *this; }
+     inline operator DcmTagKey() const { return DcmTagKey( key[0], key[1] ); }
+-    inline bool operator==(const DB_SerializedTagKey& rhs) const { return key[0] == rhs.key[0] && key[1] == rhs.key[1]; }
+     Uint16 key[2];
+ };
  
-         DB_GetUIDTag (level, &XTag) ;
-+        const DB_SerializedTagKey XTagDBSerialized = XTag;
++inline bool operator==(const DB_SerializedTagKey& lhs, const DB_SerializedTagKey& rhs)
++{
++    return lhs.key[0] == rhs.key[0] && lhs.key[1] == rhs.key[1];
++}
++inline bool operator==(const DB_SerializedTagKey& lhs, const DcmTagKey& rhs)
++{
++    return lhs == DB_SerializedTagKey(rhs);
++}
++inline bool operator==(const DcmTagKey& lhs, const DB_SerializedTagKey& rhs)
++{
++    return rhs == lhs;
++}
++
+ /* ENSURE THAT DBVERSION IS INCREMENTED WHENEVER ONE OF THESE STRUCTS IS MODIFIED */
  
-         /** Find Element with this XTag in Identifier list
-          */
- 
-         for (plist = phandle->findRequestList ; plist ; plist = plist->next)
--            if (plist->elem. XTag == XTag)
-+            if (plist->elem. XTag == XTagDBSerialized)
-                 break ;
- 
-         /** Element not found
-@@ -1237,7 +1238,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare (
-          */
- 
-         for (i = 0 ; i < NBPARAMETERS ; i++)
--            if (idxRec->param [i]. XTag == XTag)
-+            if (idxRec->param [i]. XTag == XTagDBSerialized)
-                 break ;
- 
-         /** Compare with Single value matching
-@@ -1370,7 +1371,8 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(
-         DcmElement* dcelem = findRequestIdentifiers->getElement(elemIndex);
- 
-         elem.XTag = dcelem->getTag().getXTag();
--        if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
-+        const DB_SerializedTagKey DCM_QueryRetrieveLevelDBSerialized = DCM_QueryRetrieveLevel;
-+        if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized || DB_TagSupported(elem.XTag)) {
-             elem.ValueLength = dcelem->getLength();
-             if (elem.ValueLength == 0) {
-                 elem.PValueField = NULL ;
-@@ -1387,7 +1389,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(
-             /** If element is the Query Level, store it in handle
-              */
- 
--            if (elem.XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
-+            if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized && elem.PValueField) {
-                 char *pc ;
-                 char level [50] ;
- 
-@@ -2055,7 +2057,8 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(
-         DcmElement* dcelem = moveRequestIdentifiers->getElement(elemIndex);
- 
-         elem.XTag = dcelem->getTag().getXTag();
--        if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
-+        const DB_SerializedTagKey DCM_QueryRetrieveLevelDBSerialized = DCM_QueryRetrieveLevel;
-+        if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized || DB_TagSupported(elem.XTag)) {
-             elem.ValueLength = dcelem->getLength();
-             if (elem.ValueLength == 0) {
-                 elem.PValueField = NULL ;
-@@ -2073,7 +2076,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(
-             /** If element is the Query Level, store it in handle
-              */
- 
--            if (elem. XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
-+            if (elem. XTag == DCM_QueryRetrieveLevelDBSerialized && elem.PValueField) {
-                 char *pc ;
-                 char level [50] ;
- 
+ struct DCMTK_DCMQRDB_EXPORT DB_SerializedCharPtr

--- a/recipes/dcmtk/all/patches/3.6.7-0003-ambiguous-overload-operator-equal.patch
+++ b/recipes/dcmtk/all/patches/3.6.7-0003-ambiguous-overload-operator-equal.patch
@@ -1,0 +1,64 @@
+--- a/dcmqrdb/libsrc/dcmqrdbi.cc
++++ b/dcmqrdb/libsrc/dcmqrdbi.cc
+@@ -1216,12 +1216,13 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare (
+          */
+ 
+         DB_GetUIDTag (level, &XTag) ;
++        const DB_SerializedTagKey XTagDBSerialized = XTag;
+ 
+         /** Find Element with this XTag in Identifier list
+          */
+ 
+         for (plist = phandle->findRequestList ; plist ; plist = plist->next)
+-            if (plist->elem. XTag == XTag)
++            if (plist->elem. XTag == XTagDBSerialized)
+                 break ;
+ 
+         /** Element not found
+@@ -1237,7 +1238,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::hierarchicalCompare (
+          */
+ 
+         for (i = 0 ; i < NBPARAMETERS ; i++)
+-            if (idxRec->param [i]. XTag == XTag)
++            if (idxRec->param [i]. XTag == XTagDBSerialized)
+                 break ;
+ 
+         /** Compare with Single value matching
+@@ -1370,7 +1371,8 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(
+         DcmElement* dcelem = findRequestIdentifiers->getElement(elemIndex);
+ 
+         elem.XTag = dcelem->getTag().getXTag();
+-        if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
++        const DB_SerializedTagKey DCM_QueryRetrieveLevelDBSerialized = DCM_QueryRetrieveLevel;
++        if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized || DB_TagSupported(elem.XTag)) {
+             elem.ValueLength = dcelem->getLength();
+             if (elem.ValueLength == 0) {
+                 elem.PValueField = NULL ;
+@@ -1387,7 +1389,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startFindRequest(
+             /** If element is the Query Level, store it in handle
+              */
+ 
+-            if (elem.XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
++            if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized && elem.PValueField) {
+                 char *pc ;
+                 char level [50] ;
+ 
+@@ -2055,7 +2057,8 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(
+         DcmElement* dcelem = moveRequestIdentifiers->getElement(elemIndex);
+ 
+         elem.XTag = dcelem->getTag().getXTag();
+-        if (elem.XTag == DCM_QueryRetrieveLevel || DB_TagSupported(elem.XTag)) {
++        const DB_SerializedTagKey DCM_QueryRetrieveLevelDBSerialized = DCM_QueryRetrieveLevel;
++        if (elem.XTag == DCM_QueryRetrieveLevelDBSerialized || DB_TagSupported(elem.XTag)) {
+             elem.ValueLength = dcelem->getLength();
+             if (elem.ValueLength == 0) {
+                 elem.PValueField = NULL ;
+@@ -2073,7 +2076,7 @@ OFCondition DcmQueryRetrieveIndexDatabaseHandle::startMoveRequest(
+             /** If element is the Query Level, store it in handle
+              */
+ 
+-            if (elem. XTag == DCM_QueryRetrieveLevel && elem.PValueField) {
++            if (elem. XTag == DCM_QueryRetrieveLevelDBSerialized && elem.PValueField) {
+                 char *pc ;
+                 char level [50] ;
+ 


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/20332
closes https://github.com/conan-io/conan-center-index/issues/20444

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
