### PR TITLE
[changelog] New C3I Release: 2023-Oct-06

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 06-Oct-2023 - 10:15 CEST
+
+- [feature] Label PRs with version conflict properly
+- [feature] Add motivation message when under maintenance
+- [feature] Wait for sibling job in master right before promote
+- [fix] No longer run Conan v2 export step
+- [fix] Ensure build order follows only static first
+- [fix] Disable quiet period for all jobs except CCI multibranch
+
 ### 25-Sep-2023 - 14:33 CEST
 
 - [feature] Label PRs that have missing dependencies.


### PR DESCRIPTION
1) When a having a version conflict as error in a PR, it will be labeled by CCI. This feature enables a better way to filter those PRs that are blocked due a conflict and need more attention.

2) When C3I Jenkins service is under maintenance, the CI bot shows a default message warning about the current state. This new feature enables Conan team to improve the message with a short section about the motivation of the out-of-service. It does not replace status.conan.io

3) Improved the code that promotes merged packages to Conan Center, right after be in the master branch. It reduced the execution to only few minutes, about 60%.

4) When Conan 2. was introduced in CCI, there was an internal step to check if the recipe could be exported with Conan 2.x, validating if was Conan 2.x compatible. Now, Conan 2.x is mandatory, so this check is no longer needed.

5) To keep stability between builds, like tools and static library only, the CI build order is now sorted to runs all static (shared=False) first.

6) Fixed the waiting time before executing a CI build in Jenkins. There was a specific delay that is now zero seconds.

Please, open an issue in case you note something working bad and you think is related to this release.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
