### PR TITLE
libtasn1: use winflexbison instead of bison if build machine is Windows

### DIFF
--- a/recipes/libtasn1/all/conanfile.py
+++ b/recipes/libtasn1/all/conanfile.py
@@ -55,7 +55,11 @@ class LibTasn1Conan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support Visual Studio")
 
     def build_requirements(self):
-        self.tool_requires("bison/3.8.2")
+        if self._settings_build.os == "Windows":
+            self.tool_requires("winflexbison/2.5.25")
+        else:
+            self.tool_requires("bison/3.8.2")
+
         if self._settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):


### PR DESCRIPTION
bison raises for Windows

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
