### PR TITLE
add check for opensuse tumbleweed

### DIFF
--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.system import package_manager
 from conan.tools.gnu import PkgConfig
+import platform
 
 required_conan_version = ">=1.50.0"
 
@@ -35,8 +36,15 @@ class SysConfigOpenGLConan(ConanFile):
         pacman = package_manager.PacMan(self)
         pacman.install(["libglvnd"], update=True, check=True)
 
+        is_opensuse_tumbleweed: bool = False
+        if self.settings.os == "Linux":
+            is_opensuse_tumbleweed: bool = "tumbleweed" in platform.freedesktop_os_release()["ID"]
+
         zypper = package_manager.Zypper(self)
-        zypper.install(["Mesa-libGL-devel", "glproto-devel"], update=True, check=True)
+        if is_opensuse_tumbleweed:
+            zypper.install(["Mesa-libGL-devel"], update=True, check=True)
+        else:
+            zypper.install(["Mesa-libGL-devel", "glproto-devel"], update=True, check=True)
 
         pkg = package_manager.Pkg(self)
         pkg.install(["libglvnd"], update=True, check=True)


### PR DESCRIPTION
Specify library name and version:  **opengl/system**

opensuse tumbleweed no longer provides openGL protocols in glproto-devel package, which no longer exists. 
This patch checks if the platform is specifically opensuse tumbleweed and does not install that library from system if so.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
