### PR TITLE
poly2tri: fix MinGW by injecting `_USE_MATH_DEFINES` to avoid `M_PI` not defined

### DIFF
--- a/recipes/poly2tri/all/CMakeLists.txt
+++ b/recipes/poly2tri/all/CMakeLists.txt
@@ -11,6 +11,11 @@ add_library(poly2tri
     ${POLY2TRI_SRC_DIR}/sweep/sweep_context.cc
 )
 
+# _USE_MATH_DEFINES is defined in utils.h where M_PI is used, but it can break because math.h or cmath
+# may have already been included indirectly by other headers included by sweep.cc before inclusion of utils.h
+# Therefore we ensure that _USE_MATH_DEFINES is defined before any inclusion of headers.
+target_compile_definitions(poly2tri PRIVATE _USE_MATH_DEFINES)
+
 if(MSVC AND BUILD_SHARED_LIBS)
     set_property(TARGET poly2tri PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()

--- a/recipes/poly2tri/all/conanfile.py
+++ b/recipes/poly2tri/all/conanfile.py
@@ -58,3 +58,5 @@ class Poly2triConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["poly2tri"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/17054
closes https://github.com/conan-io/conan-center-index/issues/20471

@StellaSmith @algarcia-ujaen please test this PR with your compiler and report whether it fixes your issue.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
