### PR TITLE
libnghttp2: add version 1.57.0 (fix CVE-2023-44487)

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.57.0":
+    url: "https://github.com/nghttp2/nghttp2/archive/v1.57.0.tar.gz"
+    sha256: "3c0b4e023dddf2afa087aa4409f7dbe03c099b4c63655e7545a607035085848a"
   "1.56.0":
     url: "https://github.com/nghttp2/nghttp2/archive/v1.56.0.tar.gz"
     sha256: "63dd705b524eec3c843b8e4e24914600a30c2804a113e8e5baeeb9695d09590a"

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.57.0":
+    folder: all
   "1.56.0":
     folder: all
   "1.55.1":


### PR DESCRIPTION
Specify library name and version:  **libnghttp2/1.57.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
