### PR TITLE
nmslib: better way to create relocatable shared lib on macOS

### DIFF
--- a/recipes/nmslib/all/conanfile.py
+++ b/recipes/nmslib/all/conanfile.py
@@ -2,8 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.microsoft import is_msvc, check_min_vs
 
@@ -59,6 +58,8 @@ class Nmslib(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["WITHOUT_TESTS"] = True
+        # Relocatable shared libs on macOS
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.generate()
 
     def build(self):
@@ -73,7 +74,6 @@ class Nmslib(ConanFile):
              src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
-        fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.libs = ["NonMetricSpaceLib"]


### PR DESCRIPTION
It's a more efficient and faster way to set @rpath in shared lib on macOS (fix_apple_shared_install_name() should be the last ressort).

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
