### PR TITLE
yaclib: fix `YACLIB_CXX_STANDARD` + add package_type

### DIFF
--- a/recipes/yaclib/all/conanfile.py
+++ b/recipes/yaclib/all/conanfile.py
@@ -62,27 +62,12 @@ class YACLibConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
-    def layout(self):
-        cmake_layout(self, src_folder="src")
-
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.variables['YACLIB_INSTALL'] = True
-        if self.settings.compiler.get_safe("cppstd"):
-            tc.variables["YACLIB_CXX_STANDARD"] = self.settings.compiler.cppstd
-
-        flags = []
-        for flag in self._yaclib_flags:
-            if self.options.get_safe(flag):
-                flags.append(flag.upper())
-        if flags:
-            tc.variables["YACLIB_FLAGS"] = ";".join(flags)
-
-        tc.generate()
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -102,6 +87,22 @@ class YACLibConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["YACLIB_INSTALL"] = True
+        cppstd = self.settings.compiler.get_safe("cppstd")
+        if cppstd:
+            tc.variables["YACLIB_CXX_STANDARD"] = str(cppstd).replace("gnu", "")
+
+        flags = []
+        for flag in self._yaclib_flags:
+            if self.options.get_safe(flag):
+                flags.append(flag.upper())
+        if flags:
+            tc.variables["YACLIB_FLAGS"] = ";".join(flags)
+
+        tc.generate()
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/yaclib/all/conanfile.py
+++ b/recipes/yaclib/all/conanfile.py
@@ -16,6 +16,7 @@ class YACLibConan(ConanFile):
     homepage = "https://github.com/YACLib/YACLib"
     license = "MIT"
     topics = ("async", "parallel", "concurrency")
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
 
     _yaclib_flags = {


### PR DESCRIPTION
- Definition of `YACLIB_CXX_STANDARD` in CMakeToolchain was broken with `compiler.cppstd` set to something like `gnu*`:

  ```
  CMake Error in src/CMakeLists.txt:
    The CXX_STANDARD property on target "yaclib" contained an invalid value:
    "gnu20".
  ```
- add package_type (yaclib is always static: https://github.com/YACLib/YACLib/blob/v2022.12.10/src/CMakeLists.txt#L36)


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
