### PR TITLE
wayland-protocols: add version 1.32

### DIFF
--- a/recipes/wayland-protocols/all/conandata.yml
+++ b/recipes/wayland-protocols/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.32":
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.32/downloads/wayland-protocols-1.32.tar.xz"
+    sha256: "7459799d340c8296b695ef857c07ddef24c5a09b09ab6a74f7b92640d2b1ba11"
   "1.31":
     url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.31/downloads/wayland-protocols-1.31.tar.xz"
     sha256: "a07fa722ed87676ec020d867714bc9a2f24c464da73912f39706eeef5219e238"

--- a/recipes/wayland-protocols/config.yml
+++ b/recipes/wayland-protocols/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.32":
+    folder: all
   "1.31":
     folder: all
   "1.27":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **wayland-protocols/1.32**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
