### PR TITLE
[config] Uses CCI Bot as ower of Conan 1.x scheduled export results

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -59,7 +59,7 @@ tasks:
       timeout_seconds: 600  # Maximum time to wait for the multibranch job
       merge_messages: true  # Merge messages from the multibranch job waited for
   scheduled_export_check:
-    report_issue_url: https://github.com/conan-io/conan-center-index/issues/2232
+    report_issue_url: https://github.com/conan-io/conan-center-index/issues/20516
     report_issue_append: false
   validate_infrastructure:
     macos_executors: 2


### PR DESCRIPTION
Replaces the issue #2232 in favor of #20516 that's owned by CCI bot, so no humans related in case leaving the team.

closes #2232

After merging, #2232 should be updated with a message that we moved to the new issue and check in case it's pinned in GH issues as well. 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
