### PR TITLE
[docs] Add changelog for new conan versions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 11-Oct-2023 - 12:17 CEST
+
+- [feature] Update Conan 2.x to the version 2.0.12 in the CI
+- [feature] Update Conan 1.x to the version 1.61.0 in the CI
+
 ### 06-Oct-2023 - 10:15 CEST
 
 - [feature] Label PRs with version conflict properly


### PR DESCRIPTION
Related to the PR https://github.com/conan-io/conan-center-index/pull/20498

New Conan client versions are now running in CCI.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
