### PR TITLE
rpclib: fix MinGW shared

### DIFF
--- a/recipes/rpclib/all/conandata.yml
+++ b/recipes/rpclib/all/conandata.yml
@@ -2,3 +2,9 @@ sources:
   "2.3.0":
     url: "https://github.com/rpclib/rpclib/archive/refs/tags/v2.3.0.tar.gz"
     sha256: "eb9e6fa65e1a79b37097397f60599b93cb443d304fbc0447c50851bc3452fdef"
+patches:
+  "2.3.0":
+    - patch_file: "patches/2.3.0-0001-win-link-winsock.patch"
+      patch_description: "Link to mswsock and ws2_32 if windows"
+      patch_type: "portability"
+      patch_source: "https://github.com/rpclib/rpclib/pull/287"

--- a/recipes/rpclib/all/patches/2.3.0-0001-win-link-winsock.patch
+++ b/recipes/rpclib/all/patches/2.3.0-0001-win-link-winsock.patch
@@ -1,0 +1,12 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -167,6 +167,9 @@ if(RPCLIB_COMPILE_DEFINITIONS)
+ endif()
+ 
+ target_link_libraries(${PROJECT_NAME} ${RPCLIB_DEP_LIBRARIES})
++if (WIN32)
++  target_link_libraries(${PROJECT_NAME} mswsock ws2_32)
++endif()
+ target_include_directories(
+   ${PROJECT_NAME} PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
backport https://github.com/rpclib/rpclib/pull/287 in order to fix build of shared lib with MinGW.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
