### PR TITLE
libzen: fix build of shared lib with MinGW

### DIFF
--- a/recipes/libzen/all/patches/0002-export-data-in-windows-dlls.patch
+++ b/recipes/libzen/all/patches/0002-export-data-in-windows-dlls.patch
@@ -1,18 +1,3 @@
---- Source/ZenLib/Conf.cpp
-+++ Source/ZenLib/Conf.cpp
-@@ -24,8 +24,8 @@
- 
- //End of line
- #ifdef WINDOWS
--    const Char* EOL=__T("\r\n");
--    const Char  PathSeparator=__T('\\');
-+    ZEN_IMPEXP const Char* EOL=__T("\r\n");
-+    ZEN_IMPEXP const Char  PathSeparator=__T('\\');
- #endif
- #ifdef UNIX
-     const Char* EOL=__T("\n");
-diff --git a/source_subfolder/Source/ZenLib/Conf.h b/source_subfolder/Source/ZenLib/Conf.h
-index 18264cf..d989fdb 100644
 --- Source/ZenLib/Conf.h
 +++ Source/ZenLib/Conf.h
 @@ -234,9 +234,22 @@


### PR DESCRIPTION
Patch `0002-export-data-in-windows-dlls.patch` was broken. msvc didn't complain, but MinGW did.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
