### PR TITLE
teemo: make deprecate

### DIFF
--- a/recipes/teemo/all/conandata.yml
+++ b/recipes/teemo/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.7":
     url: "https://github.com/winsoft666/teemo/archive/refs/tags/v2.7.tar.gz"
-    sha256: "97be8ae62cd3e2e92ed0ff405dfaf5e6cb6e323b21c53e798adfa5872a2f7084"
+    sha256: "0cf4f90d22b1c19845db08ff1addc5872327b33f020e8d5409f3819391afaf79"
 
 patches:
   "2.7":

--- a/recipes/teemo/all/conanfile.py
+++ b/recipes/teemo/all/conanfile.py
@@ -27,6 +27,7 @@ class TeemoConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
+    deprecated = "zoe"
 
     @property
     def _min_cppstd(self):

--- a/recipes/teemo/all/conanfile.py
+++ b/recipes/teemo/all/conanfile.py
@@ -48,13 +48,13 @@ class TeemoConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libcurl/7.86.0")
+        self.requires("libcurl/7.86.0", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)
         if self.info.settings.compiler == "apple-clang" and Version(self.info.settings.compiler.version) < "12.0":
-            raise ConanInvalidConfiguration(f"{self.ref} can not build on apple-clang < 12.0.") 
+            raise ConanInvalidConfiguration(f"{self.ref} can not build on apple-clang < 12.0.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
@@ -97,6 +97,6 @@ class TeemoConan(ConanFile):
             self.cpp_info.defines.append("TEEMO_EXPORTS")
         else:
             self.cpp_info.defines.append("TEEMO_STATIC")
-            
+
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/teemo/all/conanfile.py
+++ b/recipes/teemo/all/conanfile.py
@@ -48,7 +48,8 @@ class TeemoConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libcurl/7.86.0", transitive_headers=True)
+        self.requires("libcurl/7.86.0")
+        self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.cppstd:


### PR DESCRIPTION
Specify library name and version:  **teemo/***

teemo has been renamed to zoe.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
