### PR TITLE
mtdev: Call autoreconf to allow cross-compiling for armv8

### DIFF
--- a/recipes/mtdev/all/conanfile.py
+++ b/recipes/mtdev/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
@@ -36,6 +37,9 @@ class MtdevConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
+    def build_requirements(self):
+        self.tool_requires("libtool/2.4.7")
+
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
@@ -46,9 +50,12 @@ class MtdevConan(ConanFile):
     def generate(self):
         tc = AutotoolsToolchain(self)
         tc.generate()
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
 
     def build(self):
         autotools = Autotools(self)
+        autotools.autoreconf()
         autotools.configure()
         autotools.make()
 


### PR DESCRIPTION
Specify library name and version:  **mtdev/***

Unless autoreconf is called when cross-compiling for armv8, the follow error occurs:

```
checking build system type... x86_64-pc-linux-gnu
checking host system type... Invalid configuration `aarch64-linux-gnu': machine `aarch64' not recognized
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
