### PR TITLE
android-ndk: add r26b

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,4 +1,17 @@
 sources:
+  "r26b":
+    "Windows":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26b-windows.zip"
+        sha256: "a478d43d4a45d0d345cda6be50d79642b92fb175868d9dc0dfc86181d80f691e"
+    "Linux":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26b-linux.zip"
+        sha256: "ad73c0370f0b0a87d1671ed2fd5a9ac9acfd1eb5c43a7fbfbd330f85d19dd632"
+    "Macos":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26b-darwin.zip"
+        sha256: "4b0ea6148a9a2337e62a0c0c7ac59ff1edc38d69b81d9c58251897d23f7fa321"
   "r26":
     "Windows":
       "x86_64":

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "r26b":
+    folder: all
   "r26":
     folder: all
   "r25c":


### PR DESCRIPTION
Specify library name and version:  **android-ndk/r26b**

This adds Android NDK r26b released two days ago: https://github.com/android/ndk/wiki/Changelog-r26#r26b

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
