### PR TITLE
Allow transitive headers for openssl on cpprestsdk

### DIFF
--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -1,10 +1,11 @@
-from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import (
     apply_conandata_patches, collect_libs, copy, export_conandata_patches, get,
     replace_in_file, rmdir
 )
 import os
+
+from conan import ConanFile
 
 required_conan_version = ">=1.53.0"
 
@@ -57,8 +58,8 @@ class CppRestSDKConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.83.0")
-        self.requires("openssl/[>=1.1 <4]")
+        self.requires("boost/[>=1.75.0 <2]")
+        self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
         if self.options.with_compression:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_websockets:


### PR DESCRIPTION
Specify library name and version:  cpprestsdk/*

Allow transitive headers for openssl. This is required when linking cpprestsdk to azure-storage-cpp.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
