### PR TITLE
tinkerforge-bindings: fix MinGW shared

### DIFF
--- a/recipes/tinkerforge-bindings/all/CMakeLists.txt
+++ b/recipes/tinkerforge-bindings/all/CMakeLists.txt
@@ -1,23 +1,22 @@
-cmake_minimum_required(VERSION 3.4)
-project(tinkerforge_bindings)
+cmake_minimum_required(VERSION 3.15)
+project(tinkerforge_bindings LANGUAGES C)
 
-set(SOURCES_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
+file(GLOB TINK_SOURCES ${TINKERFORGE_BINDINGS_SRC_DIR}/source/*.c)
+file(GLOB TINK_HEADERS ${TINKERFORGE_BINDINGS_SRC_DIR}/source/*.h)
 
-file(GLOB SOURCES ${SOURCES_DIR}/source/*.c)
-file(GLOB HEADERS ${SOURCES_DIR}/source/*.h)
-
-if(WIN32 AND BUILD_SHARED_LIBS)
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif()
-
-add_library(${PROJECT_NAME} ${SOURCES})
-
-if(MSVC)
-        target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 advapi32)
+add_library(${PROJECT_NAME} ${TINK_SOURCES})
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    PUBLIC_HEADER "${TINK_HEADERS}"
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+if(WIN32)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 advapi32)
 endif()
 
 include(GNUInstallDirs)
-set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADERS}")
 install(TARGETS ${PROJECT_NAME}
-        PUBLIC_HEADER DESTINATION include
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/recipes/tinkerforge-bindings/all/conanfile.py
+++ b/recipes/tinkerforge-bindings/all/conanfile.py
@@ -53,6 +53,7 @@ class TinkerforgeBindingsConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["TINKERFORGE_BINDINGS_SRC_DIR"] = self.source_folder.replace("\\", "/")
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
There was an incorrect logic in custom CMakeLists shipped by recipe. Windows system libs must be linked if Windows, it's unrelated to compiler name (here there was a link only for msvc).

Without this fix, you get a link error with MinGW shared:

```
ld.exe: CMakeFiles/tinkerforge_bindings.dir/src/source/ip_connection.c.obj:ip_connection.:(.text+0x90): undefined reference to `__imp_closesocket'
```

I take also advantage of this PR to write a neater CMakeLists.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
