### PR TITLE
libsystemd/253.*: Fix cross-compilation

### DIFF
--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -34,6 +34,10 @@ patches:
     - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
+    - patch_file: "patches/253.3/0002-meson-use-c_args-in-generator-scripts.patch"
+      patch_source: "https://patch-diff.githubusercontent.com/raw/systemd/systemd/pull/29538"
+      patch_description: "fixes cross-compilation by passing necessary compiler arguments to generator scripts"
+      patch_type: "portability"
   "253.6":
     - patch_file: "patches/253.3/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
@@ -41,6 +45,10 @@ patches:
     - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
+    - patch_file: "patches/253.3/0002-meson-use-c_args-in-generator-scripts.patch"
+      patch_source: "https://patch-diff.githubusercontent.com/raw/systemd/systemd/pull/29538"
+      patch_description: "fixes cross-compilation by passing necessary compiler arguments to generator scripts"
+      patch_type: "portability"
   "253.3":
     - patch_file: "patches/253.3/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"
@@ -48,6 +56,10 @@ patches:
     - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
       patch_type: "conan"
+    - patch_file: "patches/253.3/0002-meson-use-c_args-in-generator-scripts.patch"
+      patch_source: "https://patch-diff.githubusercontent.com/raw/systemd/systemd/pull/29538"
+      patch_description: "fixes cross-compilation by passing necessary compiler arguments to generator scripts"
+      patch_type: "portability"
   "252.9":
     - patch_file: "patches/248.12/0001-missing_syscalls.py-Replace-unicode-with-ascii.patch"
       patch_description: "allow to use meson.build with older versions of Python by replacing utf8 message to ascii message in the helper script"

--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -70,7 +70,7 @@ class LibsystemdConan(ConanFile):
             raise ConanInvalidConfiguration("Only Linux supported")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.1")
+        self.tool_requires("meson/1.2.2")
         self.tool_requires("m4/1.4.19")
         self.tool_requires("gperf/3.1")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):

--- a/recipes/libsystemd/all/patches/253.3/0002-meson-use-c_args-in-generator-scripts.patch
+++ b/recipes/libsystemd/all/patches/253.3/0002-meson-use-c_args-in-generator-scripts.patch
@@ -1,0 +1,33 @@
+From 7b110183b2607d57d399e977a96cb453aed37265 Mon Sep 17 00:00:00 2001
+From: Jordan Williams <jordan@jwillikers.com>
+Date: Fri, 13 Oct 2023 09:41:00 -0500
+Subject: [PATCH] Revert "Revert "meson: use c_args in generator scripts
+ (#10289)""
+
+This reverts commit 0e3cc902faec4f18d5fa606396f602b08bc94e27.
+
+Fixes #10288.
+I have confirmed that this does now fix cross-compilation.
+It appears that changes upstream in Meson, probably mesonbuild/meson#5263, have made the original MR, #10289, work now.
+
+This needs to be tested to ensure that it doesn't break Travis CI like when it was reverted in #10361.
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index d79263ea8b..87b5a76082 100644
+--- a/meson.build
++++ b/meson.build
+@@ -498,7 +498,7 @@ if cxx_cmd != ''
+         add_project_arguments(cxx.get_supported_arguments(basic_disabled_warnings), language : 'cpp')
+ endif
+ 
+-cpp = ' '.join(cc.cmd_array()) + ' -E'
++cpp = ' '.join(cc.cmd_array() + get_option('c_args')) + ' -E'
+ 
+ has_wstringop_truncation = cc.has_argument('-Wstringop-truncation')
+ 
+-- 
+2.41.0
+

--- a/recipes/libsystemd/all/test_package/conanfile.py
+++ b/recipes/libsystemd/all/test_package/conanfile.py
@@ -18,7 +18,7 @@ class TestPackageConan(ConanFile):
 
     def build_requirements(self):
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/1.9.3")
+            self.tool_requires("pkgconf/2.0.3")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/libsystemd/all/test_v1_package/conanfile.py
+++ b/recipes/libsystemd/all/test_v1_package/conanfile.py
@@ -7,7 +7,7 @@ class TestPackageConan(ConanFile):
     generators = "cmake", "pkg_config"
 
     def build_requirements(self):
-        self.build_requires("pkgconf/1.9.3")
+        self.build_requires("pkgconf/2.0.3")
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **libsystemd/253.***

Bump versions of pkgconf and Meson.
Add  a patch to ensure that necessary compiler flags are passed through when the build system is invoking the compiler to generate files.
Without the proper compiler flags when cross-compiling, the system include directories and such are used which causes problems.
The patch has been applied upstream in systemd/systemd#29538.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
