### PR TITLE
fltk: Disable xft to fix compilation on Linux

### DIFF
--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -25,6 +25,7 @@ class FltkConan(ConanFile):
         "with_threads": [True, False],
         "with_gdiplus": [True, False],
         "abi_version": ["ANY"],
+        "with_xft": [True, False],
     }
     default_options = {
         "shared": False,
@@ -32,6 +33,7 @@ class FltkConan(ConanFile):
         "with_gl": True,
         "with_threads": True,
         "with_gdiplus": True,
+        "with_xft": False,
     }
 
     def export_sources(self):
@@ -72,6 +74,8 @@ class FltkConan(ConanFile):
             self.requires("glu/system")
             self.requires("fontconfig/2.14.2")
             self.requires("xorg/system")
+            if self.options.with_xft:
+                self.requires("libxft/2.3.6")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -85,7 +89,7 @@ class FltkConan(ConanFile):
         tc.variables["OPTION_USE_THREADS"] = self.options.with_threads
         tc.variables["OPTION_BUILD_HTML_DOCUMENTATION"] = False
         tc.variables["OPTION_BUILD_PDF_DOCUMENTATION"] = False
-        tc.variables["OPTION_USE_XFT"] = False
+        tc.variables["OPTION_USE_XFT"] = self.options.with_xft
         if self.options.abi_version:
             tc.variables["OPTION_ABI_VERSION"] = self.options.abi_version
         tc.generate()

--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -70,8 +70,9 @@ class FltkConan(ConanFile):
         self.requires("libjpeg/9e")
         self.requires("libpng/1.6.40")
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.requires("opengl/system")
-            self.requires("glu/system")
+            if self.options.with_gl:
+                self.requires("opengl/system")
+                self.requires("glu/system")
             self.requires("fontconfig/2.14.2")
             self.requires("xorg/system")
             if self.options.with_xft:
@@ -124,8 +125,10 @@ class FltkConan(ConanFile):
         elif is_apple_os(self):
             self.cpp_info.frameworks = [
                 "AppKit", "ApplicationServices", "Carbon", "Cocoa", "CoreFoundation", "CoreGraphics",
-                "CoreText", "CoreVideo", "Foundation", "IOKit", "OpenGL",
+                "CoreText", "CoreVideo", "Foundation", "IOKit",
             ]
+            if self.options.with_gl:
+                self.cpp_info.frameworks.append("OpenGL")
         elif self.settings.os == "Windows":
             if self.options.shared:
                 self.cpp_info.defines.append("FL_DLL")

--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -72,7 +72,6 @@ class FltkConan(ConanFile):
             self.requires("glu/system")
             self.requires("fontconfig/2.14.2")
             self.requires("xorg/system")
-            self.requires("libxft/2.3.6")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -86,6 +85,7 @@ class FltkConan(ConanFile):
         tc.variables["OPTION_USE_THREADS"] = self.options.with_threads
         tc.variables["OPTION_BUILD_HTML_DOCUMENTATION"] = False
         tc.variables["OPTION_BUILD_PDF_DOCUMENTATION"] = False
+        tc.variables["OPTION_USE_XFT"] = False
         if self.options.abi_version:
             tc.variables["OPTION_ABI_VERSION"] = self.options.abi_version
         tc.generate()

--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -72,6 +72,7 @@ class FltkConan(ConanFile):
             self.requires("glu/system")
             self.requires("fontconfig/2.14.2")
             self.requires("xorg/system")
+            self.requires("libxft/2.3.6")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
fltk/1.3.8

On Linux I got undefined references when using the `fltk` library.

~~~~
undefined reference to `XftFontMatch'
undefined reference to `XftFontOpenPattern'
undefined reference to `XftFontOpen'
undefined reference to `XftFontOpenXlfd'
undefined reference to `XftTextExtents32'
undefined reference to `XftDrawChange'
undefined reference to `XftDrawSetClip'
undefined reference to `XftDrawString32'
~~~~

Found a stale pull request #15277 and bug report  #15276.

--

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
