### PR TITLE
yajl: fix MinGW + package either static or shared lib

### DIFF
--- a/recipes/yajl/all/conandata.yml
+++ b/recipes/yajl/all/conandata.yml
@@ -2,3 +2,8 @@ sources:
   "2.1.0":
     url: "https://github.com/lloyd/yajl/archive/refs/tags/2.1.0.tar.gz"
     sha256: "3fb73364a5a30efe615046d07e6db9d09fd2b41c763c5f7d3bfb121cd5c5ac5a"
+patches:
+  "2.1.0":
+    - patch_file: "patches/2.1.0-0001-fix-cmake.patch"
+      patch_description: "CMake: fix mingw, disable build of doc/test/perf/example, relocatable shared lib for macos, install DLL into bin folder"
+      patch_type: "conan"

--- a/recipes/yajl/all/patches/2.1.0-0001-fix-cmake.patch
+++ b/recipes/yajl/all/patches/2.1.0-0001-fix-cmake.patch
@@ -1,0 +1,83 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ 
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
+ 
+ PROJECT(YetAnotherJSONParser C)
+ 
+@@ -26,6 +26,7 @@ IF (NOT CMAKE_BUILD_TYPE)
+   SET(CMAKE_BUILD_TYPE "Release")
+ ENDIF (NOT CMAKE_BUILD_TYPE)
+ 
++if(0)
+ SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+ 
+ IF (WIN32)
+@@ -61,16 +62,13 @@ ELSE (WIN32)
+   SET(CMAKE_C_FLAGS_DEBUG "-DDEBUG -g")
+   SET(CMAKE_C_FLAGS_RELEASE "-DNDEBUG -O2 -Wuninitialized")
+ ENDIF (WIN32)
++endif()
+ 
+ 
+ ADD_SUBDIRECTORY(src)
+-ADD_SUBDIRECTORY(test)
+ ADD_SUBDIRECTORY(reformatter)
+ ADD_SUBDIRECTORY(verify)
+-ADD_SUBDIRECTORY(example)
+-ADD_SUBDIRECTORY(perf)
+ 
+-INCLUDE(YAJLDoc.cmake)
+ 
+ # a test target
+ ADD_CUSTOM_TARGET(test
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -25,7 +25,6 @@ SET (PUB_HDRS api/yajl_parse.h api/yajl_gen.h api/yajl_common.h api/yajl_tree.h)
+ # Ensure defined when building YAJL (as opposed to using it from
+ # another project).  Used to ensure correct function export when
+ # building win32 DLL.
+-ADD_DEFINITIONS(-DYAJL_BUILD)
+ 
+ # set up some paths
+ SET (libDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
+@@ -36,21 +35,19 @@ SET (shareDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/share/pkgconfig)
+ SET(LIBRARY_OUTPUT_PATH ${libDir})
+ 
+ ADD_LIBRARY(yajl_s STATIC ${SRCS} ${HDRS} ${PUB_HDRS})
+-
++target_compile_features(yajl_s PRIVATE c_std_99)
+ ADD_LIBRARY(yajl SHARED ${SRCS} ${HDRS} ${PUB_HDRS})
++target_compile_features(yajl PRIVATE c_std_99)
++target_compile_definitions(yajl PUBLIC YAJL_SHARED)
+ 
+ #### setup shared library version number
+ SET_TARGET_PROPERTIES(yajl PROPERTIES
+-                      DEFINE_SYMBOL YAJL_SHARED
++                      DEFINE_SYMBOL YAJL_BUILD
++                      C_VISIBILITY_PRESET hidden
+                       SOVERSION ${YAJL_MAJOR}
+                       VERSION ${YAJL_MAJOR}.${YAJL_MINOR}.${YAJL_MICRO})
+ 
+ #### ensure a .dylib has correct absolute installation paths upon installation
+-IF(APPLE)
+-  MESSAGE("INSTALL_NAME_DIR: ${CMAKE_INSTALL_PREFIX}/lib")
+-  SET_TARGET_PROPERTIES(yajl PROPERTIES
+-                        INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+-ENDIF(APPLE)
+ 
+ #### build up an sdk as a post build step
+ 
+@@ -78,7 +75,7 @@ INCLUDE_DIRECTORIES(${incDir}/..)
+ # at build time you may specify the cmake variable LIB_SUFFIX to handle
+ # 64-bit systems which use 'lib64'
+ INSTALL(TARGETS yajl
+-        RUNTIME DESTINATION lib${LIB_SUFFIX}
++        RUNTIME DESTINATION bin
+         LIBRARY DESTINATION lib${LIB_SUFFIX}
+         ARCHIVE DESTINATION lib${LIB_SUFFIX})
+ INSTALL(TARGETS yajl_s ARCHIVE DESTINATION lib${LIB_SUFFIX})

--- a/recipes/yajl/all/patches/2.1.0-0001-fix-cmake.patch
+++ b/recipes/yajl/all/patches/2.1.0-0001-fix-cmake.patch
@@ -1,15 +1,18 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -12,7 +12,7 @@
+@@ -12,7 +12,10 @@
  # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  
 -CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 +CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
++if(POLICY CMP0026)
++    cmake_policy(SET CMP0026 OLD)
++endif()
  
  PROJECT(YetAnotherJSONParser C)
  
-@@ -26,6 +26,7 @@ IF (NOT CMAKE_BUILD_TYPE)
+@@ -26,6 +29,7 @@ IF (NOT CMAKE_BUILD_TYPE)
    SET(CMAKE_BUILD_TYPE "Release")
  ENDIF (NOT CMAKE_BUILD_TYPE)
  
@@ -17,7 +20,7 @@
  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
  
  IF (WIN32)
-@@ -61,16 +62,13 @@ ELSE (WIN32)
+@@ -61,16 +65,13 @@ ELSE (WIN32)
    SET(CMAKE_C_FLAGS_DEBUG "-DDEBUG -g")
    SET(CMAKE_C_FLAGS_RELEASE "-DNDEBUG -O2 -Wuninitialized")
  ENDIF (WIN32)
@@ -45,11 +48,10 @@
  
  # set up some paths
  SET (libDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/lib)
-@@ -36,21 +35,19 @@ SET (shareDir ${CMAKE_CURRENT_BINARY_DIR}/../${YAJL_DIST_NAME}/share/pkgconfig)
- SET(LIBRARY_OUTPUT_PATH ${libDir})
+@@ -37,20 +36,19 @@ SET(LIBRARY_OUTPUT_PATH ${libDir})
  
  ADD_LIBRARY(yajl_s STATIC ${SRCS} ${HDRS} ${PUB_HDRS})
--
+ 
 +target_compile_features(yajl_s PRIVATE c_std_99)
  ADD_LIBRARY(yajl SHARED ${SRCS} ${HDRS} ${PUB_HDRS})
 +target_compile_features(yajl PRIVATE c_std_99)
@@ -72,7 +74,7 @@
  
  #### build up an sdk as a post build step
  
-@@ -78,7 +75,7 @@ INCLUDE_DIRECTORIES(${incDir}/..)
+@@ -78,7 +76,7 @@ INCLUDE_DIRECTORIES(${incDir}/..)
  # at build time you may specify the cmake variable LIB_SUFFIX to handle
  # 64-bit systems which use 'lib64'
  INSTALL(TARGETS yajl


### PR DESCRIPTION
- Fix build with MinGW (cleanup bloated CMakeLists which was injecting unnecessary msvc warning flags if windows regardless of compiler, leading to `gcc.exe: error: /W4: linker input file not found: No such file or directory` with MinGW).
- Package either static or shared, not both. Indeed yajl builds and installs both flavors, and cci hook didn't catch this issue because static and shared lib names are different. I've preferred removing unwanted flavor afterwards instead of patching CMakeLists, because several executables are always link to static flavor.
- Disable build of doc, example, test, perf
- Better way to install relocatable shared lib for macOS (by removing hardcoded `INSTALL_NAME_DIR` in CMakeLists, and bumping cmake_minimum_required which was very very old and deprecated).
- Better way to install dll into bin folder (fix `RUNTIME DESTINATION` in CMakeLists instead of moving files afterwards).
- Add `YAJL_SHARED` interface definition if shared in `package_info()`.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
