### PR TITLE
Fixing Qt6 Multimedia Dependency Issue With ShaderTools 

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -118,6 +118,7 @@ class QtConan(ConanFile):
         "disabled_features": "",
     }
     default_options.update({module: False for module in _submodules})
+    del default_options["qtshadertools"]
 
     short_paths = True
 
@@ -1200,7 +1201,7 @@ class QtConan(ConanFile):
             _create_plugin("QUACppPlugin", "uacpp_backend", "opcua", ["Network", "OpcUa"])
 
         if self.options.get_safe("qtmultimedia"):
-            multimedia_reqs = ["Network", "Gui"]
+            multimedia_reqs = ["Network", "Gui", "ShaderTools"]
             if self.options.get_safe("with_libalsa", False):
                 multimedia_reqs.append("libalsa::libalsa")
             if self.options.with_openal:


### PR DESCRIPTION
Specify library name and version:  **qt/6.5.2**

I've noticed that my statically built Qt6 on Windows failed when I set the `qtmultimedia` option.

From a quick glance at the code, I noticed that the `default_options` are frozen inside the `configure(...)` method, where the function that is supposed to be setting the module dependency options (like `qtmultimedia` should set `qtshadertools`) runs. This option setting fails with the error `  ConanException: Incorrect attempt to modify option 'qtshadertools' from 'False' to 'True'`. This is documented [in this issue](https://github.com/conan-io/conan-center-index/issues/20383#issuecomment-1762088147).

As a quick fix, we can remove the default value of `qtshadertools` so it does not get frozen, allowing the `_enablemodule` calls in the recipe to succeed setting the dependencies from the `qtmodules6.5.2.conf` file as expected.

I also suspect that other module dependencies may be broken, as the freezing behaviour seems to be a breaking change from Conan 1.x as documented [here](https://github.com/conan-io/conan/issues/10104). I haven't had time to build other optional Qt6 modules yet.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
