### PR TITLE
replxx: fix MinGW shared + remove old version + fix cpp_info.libs for RelWithDebInfo

### DIFF
--- a/recipes/replxx/all/conandata.yml
+++ b/recipes/replxx/all/conandata.yml
@@ -5,6 +5,14 @@ sources:
   "0.0.3":
     url: "https://github.com/AmokHuginnsson/replxx/archive/release-0.0.3.tar.gz"
     sha256: "72ad0655eead16544645b1724b27a988543fcefd14d46df6e8dfef17d9ba50ac"
-  "0.0.2":
-    url: "https://github.com/AmokHuginnsson/replxx/archive/release-0.0.2.tar.gz"
-    sha256: "6f5c58b4cd23550d5a589d134727296438793cb818ce7158fbd5e1b0db1548ba"
+patches:
+  "0.0.4":
+    - patch_file: "patches/0.0.4-0001-fix-export-symbols-windows.patch"
+      patch_description: "Fix export of symbols for Windows"
+      patch_type: "portability"
+      patch_source: "https://github.com/AmokHuginnsson/replxx/pull/151"
+  "0.0.3":
+    - patch_file: "patches/0.0.3-0001-fix-export-symbols-windows.patch"
+      patch_description: "Fix export of symbols for Windows"
+      patch_type: "portability"
+      patch_source: "https://github.com/AmokHuginnsson/replxx/pull/151"

--- a/recipes/replxx/all/patches/0.0.3-0001-fix-export-symbols-windows.patch
+++ b/recipes/replxx/all/patches/0.0.3-0001-fix-export-symbols-windows.patch
@@ -1,0 +1,51 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,7 +15,6 @@ if (NOT DEFINED CMAKE_C_STANDARD)
+ 	set(CMAKE_C_STANDARD 99)
+ endif()
+ 
+-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS ON)
+ 
+@@ -77,8 +76,8 @@ target_compile_definitions(
+ 	replxx
+ 	PUBLIC
+ 		$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:REPLXX_STATIC>
+-		$<$<BOOL:${BUILD_SHARED_LIBS}>:REPLXX_BUILDING_DLL>
+ 	PRIVATE
++		$<$<BOOL:${BUILD_SHARED_LIBS}>:REPLXX_BUILDING_DLL>
+ 		$<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1 /ignore:4503>
+ )
+ target_compile_options(
+--- a/include/replxx.h
++++ b/include/replxx.h
+@@ -435,7 +435,7 @@ REPLXX_IMPEXP void replxx_bind_key( Replxx*, int code, key_press_handler_t handl
+  * \param actionName - name of internal action to be invoked on key press.
+  * \return -1 if invalid action name was used, 0 otherwise.
+  */
+-int replxx_bind_key_internal( Replxx*, int code, char const* actionName );
++REPLXX_IMPEXP int replxx_bind_key_internal( Replxx*, int code, char const* actionName );
+ 
+ REPLXX_IMPEXP void replxx_set_preload_buffer( Replxx*, const char* preloadText );
+ 
+@@ -552,7 +552,7 @@ REPLXX_IMPEXP int replxx_history_load( Replxx*, const char* filename );
+ REPLXX_IMPEXP void replxx_history_clear( Replxx* );
+ REPLXX_IMPEXP void replxx_clear_screen( Replxx* );
+ #ifdef __REPLXX_DEBUG__
+-void replxx_debug_dump_print_codes(void);
++REPLXX_IMPEXP void replxx_debug_dump_print_codes(void);
+ #endif
+ /* the following is extension to the original linenoise API */
+ REPLXX_IMPEXP int replxx_install_window_change_handler( Replxx* );
+--- a/include/replxx.hxx
++++ b/include/replxx.hxx
+@@ -242,7 +242,7 @@ public:
+ 		}
+ 	};
+ 	class HistoryScanImpl;
+-	class HistoryScan {
++	class REPLXX_IMPEXP HistoryScan {
+ 	public:
+ 		typedef std::unique_ptr<HistoryScanImpl, void (*)( HistoryScanImpl* )> impl_t;
+ 	private:

--- a/recipes/replxx/all/patches/0.0.4-0001-fix-export-symbols-windows.patch
+++ b/recipes/replxx/all/patches/0.0.4-0001-fix-export-symbols-windows.patch
@@ -1,0 +1,151 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,7 +15,6 @@ if (NOT DEFINED CMAKE_C_STANDARD)
+ 	set(CMAKE_C_STANDARD 99)
+ endif()
+ 
+-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS ON)
+ 
+@@ -77,8 +76,8 @@ target_compile_definitions(
+ 	replxx
+ 	PUBLIC
+ 		$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:REPLXX_STATIC>
+-		$<$<BOOL:${BUILD_SHARED_LIBS}>:REPLXX_BUILDING_DLL>
+ 	PRIVATE
++		$<$<BOOL:${BUILD_SHARED_LIBS}>:REPLXX_BUILDING_DLL>
+ 		$<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1 /ignore:4503>
+ )
+ target_compile_options(
+--- a/include/replxx.h
++++ b/include/replxx.h
+@@ -449,7 +449,7 @@ REPLXX_IMPEXP void replxx_bind_key( Replxx*, int code, key_press_handler_t handl
+  * \param actionName - name of internal action to be invoked on key press.
+  * \return -1 if invalid action name was used, 0 otherwise.
+  */
+-int replxx_bind_key_internal( Replxx*, int code, char const* actionName );
++REPLXX_IMPEXP int replxx_bind_key_internal( Replxx*, int code, char const* actionName );
+ 
+ REPLXX_IMPEXP void replxx_set_preload_buffer( Replxx*, const char* preloadText );
+ 
+@@ -572,7 +572,7 @@ REPLXX_IMPEXP int replxx_history_load( Replxx*, const char* filename );
+ REPLXX_IMPEXP void replxx_history_clear( Replxx* );
+ REPLXX_IMPEXP void replxx_clear_screen( Replxx* );
+ #ifdef __REPLXX_DEBUG__
+-void replxx_debug_dump_print_codes(void);
++REPLXX_IMPEXP void replxx_debug_dump_print_codes(void);
+ #endif
+ /* the following is extension to the original linenoise API */
+ REPLXX_IMPEXP int replxx_install_window_change_handler( Replxx* );
+@@ -587,35 +587,35 @@ REPLXX_IMPEXP void replxx_disable_bracketed_paste( Replxx* );
+  * \param color2 - second input color.
+  * \return A new color definition that represent combined input colors.
+  */
+-ReplxxColor replxx_color_combine( ReplxxColor color1, ReplxxColor color2 );
++REPLXX_IMPEXP ReplxxColor replxx_color_combine( ReplxxColor color1, ReplxxColor color2 );
+ 
+ /*! \brief Transform foreground color definition into a background color definition.
+  *
+  * \param color - an input foreground color definition.
+  * \return A background color definition that is a transformed input \e color.
+  */
+-ReplxxColor replxx_color_bg( ReplxxColor color );
++REPLXX_IMPEXP ReplxxColor replxx_color_bg( ReplxxColor color );
+ 
+ /*! \brief Add `bold` attribute to color definition.
+  *
+  * \param color - an input color definition.
+  * \return A new color definition with bold attribute set.
+  */
+-ReplxxColor replxx_color_bold( ReplxxColor color );
++REPLXX_IMPEXP ReplxxColor replxx_color_bold( ReplxxColor color );
+ 
+ /*! \brief Add `underline` attribute to color definition.
+  *
+  * \param color - an input color definition.
+  * \return A new color definition with underline attribute set.
+  */
+-ReplxxColor replxx_color_underline( ReplxxColor color );
++REPLXX_IMPEXP ReplxxColor replxx_color_underline( ReplxxColor color );
+ 
+ /*! \brief Create a new grayscale color of given brightness level.
+  *
+  * \param level - a brightness level for new color, must be between 0 (darkest) and 23 (brightest).
+  * \return A new grayscale color of a given brightest \e level.
+  */
+-ReplxxColor replxx_color_grayscale( int level );
++REPLXX_IMPEXP ReplxxColor replxx_color_grayscale( int level );
+ 
+ /*! \brief Create a new color in 6×6×6 RGB color space from base component levels.
+  *
+@@ -624,7 +624,7 @@ ReplxxColor replxx_color_grayscale( int level );
+  * \param blue - a blue (of RGB) component level, must be 0 and 5.
+  * \return A new color in 6×6×6 RGB color space.
+  */
+-ReplxxColor replxx_color_rgb666( int red, int green, int blue );
++REPLXX_IMPEXP ReplxxColor replxx_color_rgb666( int red, int green, int blue );
+ 
+ #ifdef __cplusplus
+ }
+--- a/include/replxx.hxx
++++ b/include/replxx.hxx
+@@ -249,7 +249,7 @@ public:
+ 		}
+ 	};
+ 	class HistoryScanImpl;
+-	class HistoryScan {
++	class REPLXX_IMPEXP HistoryScan {
+ 	public:
+ 		typedef std::unique_ptr<HistoryScanImpl, void (*)( HistoryScanImpl* )> impl_t;
+ 	private:
+@@ -646,35 +646,35 @@ namespace color {
+  * \param color2 - second input color.
+  * \return A new color definition that represent combined input colors.
+  */
+-Replxx::Color operator | ( Replxx::Color color1, Replxx::Color color2 );
++REPLXX_IMPEXP Replxx::Color operator | ( Replxx::Color color1, Replxx::Color color2 );
+ 
+ /*! \brief Transform foreground color definition into a background color definition.
+  *
+  * \param color - an input foreground color definition.
+  * \return A background color definition that is a transformed input \e color.
+  */
+-Replxx::Color bg( Replxx::Color color );
++REPLXX_IMPEXP Replxx::Color bg( Replxx::Color color );
+ 
+ /*! \brief Add `bold` attribute to color definition.
+  *
+  * \param color - an input color definition.
+  * \return A new color definition with bold attribute set.
+  */
+-Replxx::Color bold( Replxx::Color color );
++REPLXX_IMPEXP Replxx::Color bold( Replxx::Color color );
+ 
+ /*! \brief Add `underline` attribute to color definition.
+  *
+  * \param color - an input color definition.
+  * \return A new color definition with underline attribute set.
+  */
+-Replxx::Color underline( Replxx::Color color );
++REPLXX_IMPEXP Replxx::Color underline( Replxx::Color color );
+ 
+ /*! \brief Create a new grayscale color of given brightness level.
+  *
+  * \param level - a brightness level for new color, must be between 0 (darkest) and 23 (brightest).
+  * \return A new grayscale color of a given brightest \e level.
+  */
+-Replxx::Color grayscale( int level );
++REPLXX_IMPEXP Replxx::Color grayscale( int level );
+ 
+ /*! \brief Create a new color in 6×6×6 RGB color space from base component levels.
+  *
+@@ -683,7 +683,7 @@ Replxx::Color grayscale( int level );
+  * \param blue - a blue (of RGB) component level, must be 0 and 5.
+  * \return A new color in 6×6×6 RGB color space.
+  */
+-Replxx::Color rgb666( int red, int green, int blue );
++REPLXX_IMPEXP Replxx::Color rgb666( int red, int green, int blue );
+ 
+ }
+ 

--- a/recipes/replxx/config.yml
+++ b/recipes/replxx/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: "all"
   "0.0.3":
     folder: "all"
-  "0.0.2":
-    folder: "all"


### PR DESCRIPTION
- Fix MinGW shared. There were link errors in examples (they were not disabled in 0.0.3 & 0.0.4) due to bad export of symbols: `ld.exe: CMakeFiles/replxx-example-cxx-api.dir/examples/cxx-api.cxx.obj:cxx-api.cxx:(.text+0x17e1): undefined reference to 'replxx::color::bold(replxx::Replxx::Color)'`. Actually all the export logic for Windows was a little bit messy.
  **I still need to test these patches (submitted upstream https://github.com/AmokHuginnsson/replxx/pull/151), but I'm not on Windows currently.**
- remove maintenance of 0.0.2
- disable build of examples in versions >= 0.0.3
- fix lib name in `cpp_info.libs` if build_type `RelWithDebInfo`, there is a `-rd` suffix: https://github.com/AmokHuginnsson/replxx/blob/release-0.0.4/CMakeLists.txt#L117
- explicit cmake names: https://github.com/AmokHuginnsson/replxx/blob/release-0.0.4/CMakeLists.txt#L145-L157

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
