### PR TITLE
Add set_property for pkg_config_name

### DIFF
--- a/recipes/gst-plugins-base/all/conanfile.py
+++ b/recipes/gst-plugins-base/all/conanfile.py
@@ -551,6 +551,7 @@ class GStPluginsBaseConan(ConanFile):
 
         # Libraries
         self.cpp_info.components["gstreamer-plugins-base-1.0"].names["pkg_config"] = "gstreamer-plugins-base-1.0"
+        self.cpp_info.components["gstreamer-plugins-base-1.0"].set_property("pkg_config_name", "gstreamer-plugins-base-1.0")
         self.cpp_info.components["gstreamer-plugins-base-1.0"].requires = ["gstreamer::gstreamer-1.0"]
         self.cpp_info.components["gstreamer-plugins-base-1.0"].includedirs = [gst_include_path]
         if not self.options.shared:
@@ -561,18 +562,21 @@ class GStPluginsBaseConan(ConanFile):
         self.cpp_info.components["gstreamer-plugins-base-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-allocators-1.0"].names["pkg_config"] = "gstreamer-allocators-1.0"
+        self.cpp_info.components["gstreamer-allocators-1.0"].set_property("pkg_config_name", "gstreamer-allocators-1.0")
         self.cpp_info.components["gstreamer-allocators-1.0"].libs = ["gstallocators-1.0"]
         self.cpp_info.components["gstreamer-allocators-1.0"].requires = ["gstreamer::gstreamer-1.0"]
         self.cpp_info.components["gstreamer-allocators-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-allocators-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-app-1.0"].names["pkg_config"] = "gstreamer-app-1.0"
+        self.cpp_info.components["gstreamer-app-1.0"].set_property("pkg_config_name", "gstreamer-app-1.0")
         self.cpp_info.components["gstreamer-app-1.0"].libs = ["gstapp-1.0"]
         self.cpp_info.components["gstreamer-app-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0"]
         self.cpp_info.components["gstreamer-app-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-app-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-audio-1.0"].names["pkg_config"] = "gstreamer-audio-1.0"
+        self.cpp_info.components["gstreamer-audio-1.0"].set_property("pkg_config_name", "gstreamer-audio-1.0")
         self.cpp_info.components["gstreamer-audio-1.0"].libs = ["gstaudio-1.0"]
         self.cpp_info.components["gstreamer-audio-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-tag-1.0"] # TODO: orc
         self.cpp_info.components["gstreamer-audio-1.0"].includedirs = [gst_include_path]
@@ -581,6 +585,7 @@ class GStPluginsBaseConan(ConanFile):
         self.cpp_info.components["gstreamer-audio-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-fft-1.0"].names["pkg_config"] = "gstreamer-fft-1.0"
+        self.cpp_info.components["gstreamer-fft-1.0"].set_property("pkg_config_name", "gstreamer-fft-1.0")
         self.cpp_info.components["gstreamer-fft-1.0"].libs = ["gstfft-1.0"]
         self.cpp_info.components["gstreamer-fft-1.0"].requires = ["gstreamer::gstreamer-1.0"]
         self.cpp_info.components["gstreamer-fft-1.0"].includedirs = [gst_include_path]
@@ -599,6 +604,7 @@ class GStPluginsBaseConan(ConanFile):
             gl_custom_content = "\n".join("{}={}".format(key, value) for key, value in gl_variables.items())
 
             self.cpp_info.components["gstreamer-gl-1.0"].names["pkg_config"] = "gstreamer-gl-1.0"
+            self.cpp_info.components["gstreamer-gl-1.0"].set_property("pkg_config_name", "gstreamer-gl-1.0")
             self.cpp_info.components["gstreamer-gl-1.0"].libs = ["gstgl-1.0"]
             self.cpp_info.components["gstreamer-gl-1.0"].requires = [
                 "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
@@ -625,23 +631,28 @@ class GStPluginsBaseConan(ConanFile):
             self.cpp_info.components["gstreamer-gl-1.0"].set_property("pkg_config_custom_content", gl_custom_content)
 
             self.cpp_info.components["gstreamer-gl-prototypes-1.0"].names["pkg_config"] = "gstreamer-gl-prototypes-1.0"
+            self.cpp_info.components["gstreamer-gl-prototypes-1.0"].set_property("pkg_config_name", "gstreamer-gl-prototypes-1.0")
             self.cpp_info.components["gstreamer-gl-prototypes-1.0"].requires = ["gstreamer-gl-1.0", "opengl::opengl"]
 
             if self.options.get_safe("with_egl"):
                 self.cpp_info.components["gstreamer-gl-egl-1.0"].names["pkg_config"] = "gstreamer-gl-egl-1.0"
+                self.cpp_info.components["gstreamer-gl-egl-1.0"].set_property("pkg_config_name", "gstreamer-gl-egl-1.0")
                 self.cpp_info.components["gstreamer-gl-egl-1.0"].requires = ["gstreamer-gl-1.0", "egl::egl"]
 
             if self.options.get_safe("with_wayland"):
                 self.cpp_info.components["gstreamer-gl-wayland-1.0"].names["pkg_config"] = "gstreamer-gl-wayland-1.0"
+                self.cpp_info.components["gstreamer-gl-wayland-1.0"].set_property("pkg_config_name", "gstreamer-gl-wayland-1.0")
                 self.cpp_info.components["gstreamer-gl-wayland-1.0"].requires = [
                     "gstreamer-gl-1.0", "wayland::wayland-client", "wayland::wayland-egl",
                     "wayland-protocols::wayland-protocols"]
 
             if self.options.get_safe("with_xorg"):
                 self.cpp_info.components["gstreamer-gl-x11-1.0"].names["pkg_config"] = "gstreamer-gl-x11-1.0"
+                self.cpp_info.components["gstreamer-gl-x11-1.0"].set_property("pkg_config_name", "gstreamer-gl-x11-1.0")
                 self.cpp_info.components["gstreamer-gl-x11-1.0"].requires = ["gstreamer-gl-1.0", "xorg::x11-xcb"]
 
         self.cpp_info.components["gstreamer-pbutils-1.0"].names["pkg_config"] = "gstreamer-pbutils-1.0"
+        self.cpp_info.components["gstreamer-pbutils-1.0"].set_property("pkg_config_name", "gstreamer-pbutils-1.0")
         self.cpp_info.components["gstreamer-pbutils-1.0"].libs = ["gstpbutils-1.0"]
         self.cpp_info.components["gstreamer-pbutils-1.0"].requires = [
             "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
@@ -650,18 +661,21 @@ class GStPluginsBaseConan(ConanFile):
         self.cpp_info.components["gstreamer-pbutils-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-riff-1.0"].names["pkg_config"] = "gstreamer-riff-1.0"
+        self.cpp_info.components["gstreamer-riff-1.0"].set_property("pkg_config_name", "gstreamer-riff-1.0")
         self.cpp_info.components["gstreamer-riff-1.0"].libs = ["gstriff-1.0"]
         self.cpp_info.components["gstreamer-riff-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer-audio-1.0", "gstreamer-tag-1.0"]
         self.cpp_info.components["gstreamer-riff-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-riff-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-rtp-1.0"].names["pkg_config"] = "gstreamer-rtp-1.0"
+        self.cpp_info.components["gstreamer-rtp-1.0"].set_property("pkg_config_name", "gstreamer-rtp-1.0")
         self.cpp_info.components["gstreamer-rtp-1.0"].libs = ["gstrtp-1.0"]
         self.cpp_info.components["gstreamer-rtp-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
         self.cpp_info.components["gstreamer-rtp-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-rtp-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-rtsp-1.0"].names["pkg_config"] = "gstreamer-rtsp-1.0"
+        self.cpp_info.components["gstreamer-rtsp-1.0"].set_property("pkg_config_name", "gstreamer-rtsp-1.0")
         self.cpp_info.components["gstreamer-rtsp-1.0"].libs = ["gstrtsp-1.0"]
         self.cpp_info.components["gstreamer-rtsp-1.0"].requires = [
             "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
@@ -674,12 +688,14 @@ class GStPluginsBaseConan(ConanFile):
         self.cpp_info.components["gstreamer-rtsp-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-sdp-1.0"].names["pkg_config"] = "gstreamer-sdp-1.0"
+        self.cpp_info.components["gstreamer-sdp-1.0"].set_property("pkg_config_name", "gstreamer-sdp-1.0")
         self.cpp_info.components["gstreamer-sdp-1.0"].libs = ["gstsdp-1.0"]
         self.cpp_info.components["gstreamer-sdp-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer-rtp-1.0", "glib::glib-2.0", "glib::gio-2.0"]
         self.cpp_info.components["gstreamer-sdp-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-sdp-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-tag-1.0"].names["pkg_config"] = "gstreamer-tag-1.0"
+        self.cpp_info.components["gstreamer-tag-1.0"].set_property("pkg_config_name", "gstreamer-tag-1.0")
         self.cpp_info.components["gstreamer-tag-1.0"].libs = ["gsttag-1.0"]
         self.cpp_info.components["gstreamer-tag-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "zlib::zlib"]
         if self.settings.os == "Linux":
@@ -688,6 +704,7 @@ class GStPluginsBaseConan(ConanFile):
         self.cpp_info.components["gstreamer-tag-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
         self.cpp_info.components["gstreamer-video-1.0"].names["pkg_config"] = "gstreamer-video-1.0"
+        self.cpp_info.components["gstreamer-video-1.0"].set_property("pkg_config_name", "gstreamer-video-1.0")
         self.cpp_info.components["gstreamer-video-1.0"].libs = ["gstvideo-1.0"]
         self.cpp_info.components["gstreamer-video-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0"] # TODO: orc
         if self.settings.os == "Linux":


### PR DESCRIPTION
**gst-plugins-base/all**

qt/5.x.x cannot currently be built with the with_gstreamer=True option. This PR sets the correct names for PkgConfigDeps generator and thus fixes the qt build.
