### PR TITLE
[scippp] bump version to 1.1.0

### DIFF
--- a/recipes/scippp/all/conandata.yml
+++ b/recipes/scippp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/scipopt/SCIPpp/archive/refs/tags/1.1.0.tar.gz"
+    sha256: "808b58e8ddd873ec403c021f9255004120e58d7ec6fb4b7d99ff6f21950ff8fb"
   "1.0.2":
     url: "https://github.com/scipopt/SCIPpp/archive/refs/tags/1.0.2.tar.gz"
     sha256: "d51dfd0f1ca1b57619f7c82e32d5390d99d5cdaee98ae1ace99ec05a394dcee3"

--- a/recipes/scippp/all/conanfile.py
+++ b/recipes/scippp/all/conanfile.py
@@ -33,12 +33,21 @@ class ScipPlusPlus(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
-        return {
-            "gcc": "8",
-            "clang": "7",
-            "apple-clang": "11",
-            "msvc": "192"
-        }
+        # see https://github.com/scipopt/SCIPpp/commit/faa80e753f96094004467c1daa98a7ab4d86f279
+        if Version(self.version) >= "1.1.0":
+            return {
+                "gcc": "8",
+                "clang": "7",
+                "apple-clang": "11",
+                "msvc": "192"
+            }
+        else:
+            return {
+                "gcc": "7",
+                "clang": "7",
+                "apple-clang": "10",
+                "msvc": "192"
+            }
 
     def validate(self):
         if self.settings.compiler.cppstd:

--- a/recipes/scippp/all/conanfile.py
+++ b/recipes/scippp/all/conanfile.py
@@ -67,7 +67,7 @@ class ScipPlusPlus(ConanFile):
 
     def requirements(self):
         # see https://github.com/scipopt/SCIPpp/blob/1.0.0/conanfile.py#L25
-        self.requires("scip/8.0.3", transitive_headers=True)
+        self.requires("scip/8.0.4", transitive_headers=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/scippp/all/conanfile.py
+++ b/recipes/scippp/all/conanfile.py
@@ -34,9 +34,9 @@ class ScipPlusPlus(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "7",
+            "gcc": "8",
             "clang": "7",
-            "apple-clang": "10",
+            "apple-clang": "11",
             "msvc": "192"
         }
 

--- a/recipes/scippp/config.yml
+++ b/recipes/scippp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.2":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **scippp/1.1.0**

I am the author of the library. I just released v1.1.0

One dependency was also bumped in upstream: SCIP to 8.0.4: https://github.com/scipopt/SCIPpp/commit/236dec8b700e281cef5d89744ce587cb5fb3cbfd

Minimum compiler version updated, see upstream https://github.com/scipopt/SCIPpp/pull/15

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
