### PR TITLE
qt6: do not define default_options for modules

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -117,7 +117,6 @@ class QtConan(ConanFile):
         "multiconfiguration": False,
         "disabled_features": "",
     }
-    default_options.update({module: False for module in _submodules})
 
     short_paths = True
 
@@ -140,15 +139,16 @@ class QtConan(ConanFile):
             assert section.startswith("submodule ")
             assert section.count('"') == 2
             modulename = section[section.find('"') + 1: section.rfind('"')]
+            if modulename in ["qtbase", "qtqa", "qtrepotools"]:
+                continue
             status = str(config.get(section, "status"))
             if status not in ["obsolete", "ignore", "additionalLibrary"]:
+                assert modulename in self._submodules, f"module {modulename} not in self._submodules"
                 self._submodules_tree[modulename] = {"status": status,
                                 "path": str(config.get(section, "path")), "depends": []}
                 if config.has_option(section, "depends"):
                     self._submodules_tree[modulename]["depends"] = [str(i) for i in config.get(section, "depends").split()]
 
-        for m in self._submodules_tree:
-            assert m in ["qtbase", "qtqa", "qtrepotools"] or m in self._submodules, f"module {m} not in self._submodules"
 
         return self._submodules_tree
 
@@ -214,12 +214,21 @@ class QtConan(ConanFile):
         def _enablemodule(mod):
             if mod != "qtbase":
                 setattr(self.options, mod, True)
-            for req in self._get_module_tree[mod]["depends"]:
-                _enablemodule(req)
+                for req in self._get_module_tree[mod]["depends"]:
+                    _enablemodule(req)
 
+        # enable all modules which are
+        # - required by a module explicitely enabled by the consumer
         for module in self._get_module_tree:
-            if self.options.get_safe(module):
+            if getattr(self.options, module):
                 _enablemodule(module)
+        
+        # disable all modules which are:
+        # - not explicitely enabled by the consumer and
+        # - not required by a module explicitely enabled by the consumer
+        for module in self._get_module_tree:
+            if getattr(self.options, module).value is None:
+                setattr(self.options, module, False)
 
     def validate(self):
         if os.getenv('NOT_ON_C3I', '0') == '0':
@@ -461,8 +470,9 @@ class QtConan(ConanFile):
         tc.variables["FEATURE_optimize_size"] = ("ON" if self.settings.build_type == "MinSizeRel" else "OFF")
 
         for module in self._get_module_tree:
-            if module != 'qtbase':
-                tc.variables[f"BUILD_{module}"] = ("ON" if self.options.get_safe(module) else "OFF")
+            tc.variables[f"BUILD_{module}"] = ("ON" if getattr(self.options, module) else "OFF")
+        tc.variables["BUILD_qtqa"] = "OFF"
+        tc.variables["BUILD_qtrepotools"] = "OFF"
 
         tc.variables["FEATURE_system_zlib"] = "ON"
 
@@ -764,7 +774,7 @@ class QtConan(ConanFile):
         cmake.install()
         copy(self, "*LICENSE*", self.source_folder, os.path.join(self.package_folder, "licenses"))
         for module in self._get_module_tree:
-            if module != "qtbase" and not self.options.get_safe(module):
+            if not getattr(self.options, module):
                 rmdir(self, os.path.join(self.package_folder, "licenses", module))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         for mask in ["Find*.cmake", "*Config.cmake", "*-config.cmake"]:


### PR DESCRIPTION
closes conan-io/conan-center-index#20565
fixes conan-io/conan-center-index#20383

Specify library name and version:  **qt/6.***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
