### PR TITLE
Sdl bugfix

### DIFF
--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -322,7 +322,7 @@ class SDLConan(ConanFile):
         # Add extra information collected from the deps
         tc.variables["EXTRA_LDFLAGS"] = ";".join(cmake_extra_ldflags)
         tc.variables["CMAKE_REQUIRED_INCLUDES"] = ";".join(cmake_required_includes)
-        cmake_extra_cflags = ["-I{}".format(path) for _, dep in self.dependencies.items() for path in dep.cpp_info.includedirs]
+        cmake_extra_cflags = ["-I{}".format(path.replace("\\", "/")) for _, dep in self.dependencies.items() for path in dep.cpp_info.includedirs]
         tc.variables["EXTRA_CFLAGS"] = ";".join(cmake_extra_cflags)
         tc.variables["EXTRA_LIBS"] = ";".join(cmake_extra_libs)
         tc.generate()


### PR DESCRIPTION
Specify library name and version:  **SDL/2.28.2**

This PR is simply to fix a build issue on Windows with MinGW that results in bad path formatting within CMake.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
