### PR TITLE
directx-headers: Add recipe

### DIFF
--- a/recipes/directx-headers/all/conandata.yml
+++ b/recipes/directx-headers/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.711.3-preview":
+    url: "https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.711.3-preview.tar.gz"
+    sha256: "fad57451096836ef38c3c6c4fe4f3ca77c2e77d9c788a0a680ef6a42f88a5f25"
+  "1.610.2":
+    url: "https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.610.2.tar.gz"
+    sha256: "59492497e99bd3c23f8f8aa8a709f4d7b5bc5bd5057efa8c568bbad40015a8b2"

--- a/recipes/directx-headers/all/conandata.yml
+++ b/recipes/directx-headers/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.711.3-preview":
-    url: "https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.711.3-preview.tar.gz"
-    sha256: "fad57451096836ef38c3c6c4fe4f3ca77c2e77d9c788a0a680ef6a42f88a5f25"
   "1.610.2":
     url: "https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.610.2.tar.gz"
     sha256: "59492497e99bd3c23f8f8aa8a709f4d7b5bc5bd5057efa8c568bbad40015a8b2"

--- a/recipes/directx-headers/all/conanfile.py
+++ b/recipes/directx-headers/all/conanfile.py
@@ -1,0 +1,64 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rmdir
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+import os
+
+
+required_conan_version = ">=1.52.0"
+
+
+class DirectXHeadersConan(ConanFile):
+    name = "directx-headers"
+    description = "Headers for using D3D12"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/microsoft/DirectX-Headers"
+    topics = ("3d", "d3d", "d3d12", "direct", "direct3d", "directx", "graphics", "header-only")
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if not self.settings.os in ["Linux", "Windows"]:
+            raise ConanInvalidConfiguration(f"{self.name} is not supported on {self.settings.os}")
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["build-test"] = False
+        tc.generate()
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        if self.settings.os == "Linux" or self.settings.get_safe("os.subsystem") == "wsl":
+            self.cpp_info.includedirs.append(os.path.join("include", "wsl", "stubs"))
+        self.cpp_info.libs = ["d3dx12-format-properties", "DirectX-Guids"]
+        self.cpp_info.set_property("cmake_file_name", "DirectX-Headers")
+        self.cpp_info.set_property("cmake_target_name", "Microsoft::DirectX-Headers")
+        self.cpp_info.set_property("pkg_config_name", "DirectX-Headers")
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("d3d12")
+        if self.settings.compiler == "msvc":
+            self.cpp_info.system_libs.append("dxcore")

--- a/recipes/directx-headers/all/conanfile.py
+++ b/recipes/directx-headers/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
@@ -20,12 +21,18 @@ class DirectXHeadersConan(ConanFile):
     package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
 
+    @property
+    def _min_cppstd(self):
+        return 11
+
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def validate(self):
         if not self.settings.os in ["Linux", "Windows"]:
             raise ConanInvalidConfiguration(f"{self.name} is not supported on {self.settings.os}")
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
 
     def build_requirements(self):
         self.tool_requires("meson/1.2.2")

--- a/recipes/directx-headers/all/conanfile.py
+++ b/recipes/directx-headers/all/conanfile.py
@@ -26,6 +26,16 @@ class DirectXHeadersConan(ConanFile):
     def _min_cppstd(self):
         return 11
 
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "10",
+            "clang": "5",
+            "gcc": "6",
+            "msvc": "191",
+            "Visual Studio": "15",
+        }
+
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -34,6 +44,11 @@ class DirectXHeadersConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.name} is not supported on {self.settings.os}")
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def build_requirements(self):
         self.tool_requires("meson/1.2.2")

--- a/recipes/directx-headers/all/conanfile.py
+++ b/recipes/directx-headers/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.scm import Version
 import os
 
 
@@ -31,7 +32,7 @@ class DirectXHeadersConan(ConanFile):
     def validate(self):
         if not self.settings.os in ["Linux", "Windows"]:
             raise ConanInvalidConfiguration(f"{self.name} is not supported on {self.settings.os}")
-        if self.settings.compiler.get_safe("cppstd"):
+        if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)
 
     def build_requirements(self):

--- a/recipes/directx-headers/all/conanfile.py
+++ b/recipes/directx-headers/all/conanfile.py
@@ -16,7 +16,7 @@ class DirectXHeadersConan(ConanFile):
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/microsoft/DirectX-Headers"
-    topics = ("3d", "d3d", "d3d12", "direct", "direct3d", "directx", "graphics", "header-only")
+    topics = ("3d", "d3d", "d3d12", "direct", "direct3d", "directx", "graphics")
     package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
 

--- a/recipes/directx-headers/all/test_package/conanfile.py
+++ b/recipes/directx-headers/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.2.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/directx-headers/all/test_package/meson.build
+++ b/recipes/directx-headers/all/test_package/meson.build
@@ -1,0 +1,5 @@
+project('test_package', 'cpp')
+package_dep = dependency('DirectX-Headers')
+executable('test_package',
+            sources : ['test_package.cpp'],
+            dependencies : [package_dep])

--- a/recipes/directx-headers/all/test_package/test_package.cpp
+++ b/recipes/directx-headers/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <wsl/winadapter.h>
+#include <dxguids/dxguids.h>
+
+int main()
+{
+    return sizeof(IID_IUnknown) == 0;
+}

--- a/recipes/directx-headers/config.yml
+++ b/recipes/directx-headers/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "1.711.3-preview":
+    folder: all
+  "1.610.2":
+    folder: all

--- a/recipes/directx-headers/config.yml
+++ b/recipes/directx-headers/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "1.711.3-preview":
-    folder: all
   "1.610.2":
     folder: all


### PR DESCRIPTION
This recipe is for the [DirectX-Headers](https://github.com/microsoft/DirectX-Headers/) library. These are the official Direct3D 12 headers.
Add versions 1.610.2 and 1.711.3-preview.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
