### PR TITLE
shapelib: Fix RPATH on macOS

### DIFF
--- a/recipes/shapelib/all/conanfile.py
+++ b/recipes/shapelib/all/conanfile.py
@@ -47,7 +47,7 @@ class ShapelibConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_TESTING"] = False
-        tc.variables["USE_RPATH"] = False
+        tc.cache_variables["USE_RPATH"] = False
         tc.generate()
 
     def build(self):

--- a/recipes/shapelib/all/test_package/CMakeLists.txt
+++ b/recipes/shapelib/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(shapelib REQUIRED CONFIG)

--- a/recipes/shapelib/all/test_v1_package/CMakeLists.txt
+++ b/recipes/shapelib/all/test_v1_package/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)


### PR DESCRIPTION
Specify library name and version:  **shapelib/1.5.0**

Disabling the `USE_RPATH` CMake option in the conanfile.py currently has no effect on the shapelib build system.
This is because the `USE_RPATH` variable is set as a normal variable and not a cache variable and due to the fact that the minimum required version of CMake is 3.7.
As of CMake 3.13, policy CMP0077 fixes this behavior so that the `option()` function in CMake accepts normal variables for setting options.

For now, this PR sets `USE_RPATH` as a cache variable to workaround this issue.
Additionally, the CMake version required in the test packages is updated.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
