### PR TITLE
openjdk: add version 21.0.1, support Linux armv8

### DIFF
--- a/recipes/openjdk/all/conandata.yml
+++ b/recipes/openjdk/all/conandata.yml
@@ -1,11 +1,30 @@
 sources:
+  "21.0.1":
+    Windows:
+      url: "https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_windows-x64_bin.zip"
+      sha256: "77ea464f4fa7cbcbffe0124af44707e8e5ad8c1ce2373f1d94a64d9b20ba0c69"
+    Linux_x86_64:
+      url: "https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-x64_bin.tar.gz"
+      sha256: "7e80146b2c3f719bf7f56992eb268ad466f8854d5d6ae11805784608e458343f"
+    Linux_armv8:
+      url: "https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-aarch64_bin.tar.gz"
+      sha256: "f5e4e4622756fafe05ac0105a8efefa1152c8aad085a2bbb9466df0721bf2ba4"
+    Macos_x86_64:
+      url: "https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_macos-x64_bin.tar.gz"
+      sha256: "1ca6db9e6c09752f842eee6b86a2f7e51b76ae38e007e936b9382b4c3134e9ea"
+    Macos_armv8:
+      url: "https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_macos-aarch64_bin.tar.gz"
+      sha256: "9760eaa019b6d214a06bd44a304f3700ac057d025000bdfb9739b61080969a96"
   "19.0.2":
     Windows:
       url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_windows-x64_bin.zip"
       sha256: "9f70eba3f2631674a2d7d3aa01150d697f68be16ad76662ff948d7fe1b4985d8"
-    Linux:
+    Linux_x86_64:
       url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz"
       sha256: "34cf8d095cc071e9e10165f5c45023f96ec68397fdaabf6c64bfec1ffeee6198"
+    Linux_armv8:
+      url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-aarch64_bin.tar.gz"
+      sha256: "95728187b4b5607c49de751a209ecda6e04d9ed7cee603cf36f454239106527b"
     Macos_x86_64:
       url: "https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-x64_bin.tar.gz"
       sha256: "c57c7c511706738fff6540945e0159e97b8b328777e6460977dd64e00f4c2c0b"
@@ -16,7 +35,7 @@ sources:
     Windows:
       url: "https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_windows-x64_bin.zip"
       sha256: "733b45b09463c97133d70c2368f1b9505da58e88f2c8a84358dd4accfd06a7a4"
-    Linux:
+    Linux_x86_64:
       url: "https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz"
       sha256: "b1198ffffb7d26a3fdedc0fa599f60a0d12aa60da1714b56c1defbce95d8b235"
     Macos_x86_64:

--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -30,10 +30,9 @@ class OpenJDK(ConanFile):
 
     def build(self):
         key = self.settings.os
-        if self.settings.os == "Macos":
+        if self.settings.os in ["Macos", "Linux"]:
             key = f"{self.settings.os}_{self.settings.arch}"
-        get(self, **self.conan_data["sources"][self.version][str(key)],
-                  destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version][str(key)], strip_root=True)
 
     def package(self):
         if self.settings.os == "Macos":

--- a/recipes/openjdk/config.yml
+++ b/recipes/openjdk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "21.0.1":
+    folder: all
   "19.0.2":
     folder: all
   "16.0.1":


### PR DESCRIPTION
Specify library name and version:  **openjdk/***

openjdk 21 is LTS release.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
