### PR TITLE
[config] Enable merge labels for Conan 1.x

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -58,6 +58,7 @@ tasks:
       job_name: "prod-v2/cci"  # e.g. "cci-v2/cci" -> this means waiting for cci-v2/cci/PR-<number>
       timeout_seconds: 600  # Maximum time to wait for the multibranch job
       merge_messages: true  # Merge messages from the multibranch job waited for
+      merge_labels: true  # Merge labels from the multibranch job waited for
   scheduled_export_check:
     report_issue_url: https://github.com/conan-io/conan-center-index/issues/20516
     report_issue_append: false


### PR DESCRIPTION
When having a failure like missing dependencies or version conflict for Conan 2.x, it will be merged to Conan 1.x status and pushed to the PR labels.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
