### PR TITLE
zstd: do not package both static & shared on windows

### DIFF
--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -86,24 +86,25 @@ class ZstdConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
         if self.options.shared and self.options.build_programs:
-            #If we built programs we always build static libs,
-            #but if we only want shared libs in the package then remove the static libs
+            # If we built programs we always build static libs,
+            # but if we only want shared libs in the package then remove the static libs
             rm(self, "*.a", os.path.join(self.package_folder, "lib"))
+            rm(self, "*_static.*", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         zstd_cmake = "libzstd_shared" if self.options.shared else "libzstd_static"
         self.cpp_info.set_property("cmake_file_name", "zstd")
         self.cpp_info.set_property("cmake_target_name", f"zstd::{zstd_cmake}")
         self.cpp_info.set_property("pkg_config_name", "libzstd")
-        self.cpp_info.components["zstdlib"].set_property("pkg_config_name", "libzstd")
-        self.cpp_info.components["zstdlib"].names["cmake_find_package"] = zstd_cmake
-        self.cpp_info.components["zstdlib"].names["cmake_find_package_multi"] = zstd_cmake
-        self.cpp_info.components["zstdlib"].set_property("cmake_target_name", f"zstd::{zstd_cmake}")
         self.cpp_info.components["zstdlib"].libs = collect_libs(self)
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["zstdlib"].system_libs.append("pthread")
 
+        # TODO: Remove after dropping Conan 1.x from ConanCenterIndex
+        self.cpp_info.components["zstdlib"].names["cmake_find_package"] = zstd_cmake
+        self.cpp_info.components["zstdlib"].names["cmake_find_package_multi"] = zstd_cmake
+        self.cpp_info.components["zstdlib"].set_property("cmake_target_name", f"zstd::{zstd_cmake}")
+        self.cpp_info.components["zstdlib"].set_property("pkg_config_name", "libzstd")
         if self.options.build_programs:
-            # TODO: Remove after dropping Conan 1.x from ConanCenterIndex
             bindir = os.path.join(self.package_folder, "bin")
             self.env_info.PATH.append(bindir)

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -86,8 +86,8 @@ class ZstdConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
         if self.options.shared and self.options.build_programs:
-            # If we built programs we always build static libs,
-            # but if we only want shared libs in the package then remove the static libs
+            # If we build programs we have to build static libs (see logic in generate()),
+            # but if shared is True, we only want shared lib in package folder.
             rm(self, "*.a", os.path.join(self.package_folder, "lib"))
             rm(self, "*_static.*", os.path.join(self.package_folder, "lib"))
 


### PR DESCRIPTION
fix regression from https://github.com/conan-io/conan-center-index/pull/18826 where both shared & static were packaged on Windows if shared=True (see https://github.com/conan-io/conan-center-index/pull/18826#issuecomment-1769360351)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
