### PR TITLE
Bump osgearth's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/osgearth/all/conanfile.py
+++ b/recipes/osgearth/all/conanfile.py
@@ -109,7 +109,7 @@ class OsgearthConan(ConanFile):
         self.requires("lerc/2.2")
         self.requires("rapidjson/1.1.0")
 
-        self.requires("zlib/1.2.13")  # override
+        self.requires("zlib/[>=1.2.11 <2]")  # override
         self.requires("libtiff/4.5.1")  # override
         self.requires("libpng/1.6.40")  # override
 


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1