### PR TITLE
Bump rocksdb's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -86,7 +86,7 @@ class RocksDB(ConanFile):
         if self.options.with_lz4:
             self.requires("lz4/1.9.3")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.12")
+            self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_zstd:
             self.requires("zstd/1.5.2")
         if self.options.get_safe("with_tbb"):


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1