### PR TITLE
Bump libgit2's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/libgit2/all/conanfile.py
+++ b/recipes/libgit2/all/conanfile.py
@@ -72,7 +72,7 @@ class LibGit2Conan(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("zlib/1.2.12")
+        self.requires("zlib/[>=1.2.11 <2]")
         self.requires("http_parser/2.9.4")
         if self.options.with_libssh2:
             self.requires("libssh2/1.10.0")


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1