### PR TITLE
Bump libid3tag's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/libid3tag/all/conanfile.py
+++ b/recipes/libid3tag/all/conanfile.py
@@ -35,7 +35,7 @@ class LibId3TagConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/[>=1.2.11 <2]")
 
     @property
     def _is_msvc(self):


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1