### PR TITLE
Bump librasterlite2's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/librasterlite2/all/conanfile.py
+++ b/recipes/librasterlite2/all/conanfile.py
@@ -79,7 +79,7 @@ class Librasterlite2Conan(ConanFile):
         self.requires("libtiff/4.5.1")
         self.requires("libxml2/2.11.4")
         self.requires("sqlite3/3.42.0")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_openjpeg:
             self.requires("openjpeg/2.5.0")
         if self.options.with_webp:


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1