### PR TITLE
Bump folly's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -82,7 +82,7 @@ class FollyConan(ConanFile):
         self.requires("openssl/1.1.1q")
         self.requires("lz4/1.9.3")
         self.requires("snappy/1.1.9")
-        self.requires("zlib/1.2.12")
+        self.requires("zlib/[>=1.2.11 <2]")
         self.requires("zstd/1.5.2")
         if not is_msvc(self):
             self.requires("libdwarf/20191104")


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1