### PR TITLE
Bump dd-opentracing-cpp's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/dd-opentracing-cpp/all/conanfile.py
+++ b/recipes/dd-opentracing-cpp/all/conanfile.py
@@ -57,7 +57,7 @@ class DatadogOpenTracingConan(ConanFile):
 
     def requirements(self):
         self.requires("opentracing-cpp/1.6.0")
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/[>=1.2.11 <2]")
         self.requires("libcurl/7.80.0")
         self.requires("msgpack/3.3.0")
         self.requires("nlohmann_json/3.10.5")


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1