### PR TITLE
Bump diligent-tools's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/diligent-tools/all/conanfile.py
+++ b/recipes/diligent-tools/all/conanfile.py
@@ -91,7 +91,7 @@ class DiligentToolsConan(ConanFile):
             self.requires("libjpeg-turbo/2.1.4")
         self.requires("libpng/1.6.37")
         self.requires("libtiff/4.3.0")
-        self.requires("zlib/1.2.12")
+        self.requires("zlib/[>=1.2.11 <2]")
 
     @property
     def _diligent_platform(self):


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1