### PR TITLE
Bump openmpi's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -40,7 +40,7 @@ class OpenMPIConan(ConanFile):
 
     def requirements(self):
         # FIXME : self.requires("libevent/2.1.12") - try to use libevent from conan
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/[>=1.2.11 <2]")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1