### PR TITLE
Bump crashpad's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -54,7 +54,7 @@ class CrashpadConan(ConanFile):
 
     def requirements(self):
         # FIXME: use mini_chromium conan package instead of embedded package (if possible)
-        self.requires("zlib/1.2.12")
+        self.requires("zlib/[>=1.2.11 <2]")
         if self.settings.os in ("Linux", "FreeBSD"):
             self.requires("linux-syscall-support/cci.20200813")
         if self.options.http_transport != "socket":


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1