### PR TITLE
Bump pdal's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -82,7 +82,7 @@ class PdalConan(ConanFile):
         if self.options.with_laszip:
             self.requires("laszip/3.4.3")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.12")
+            self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_lzma:
             self.requires("xz_utils/5.2.5")
         if self.options.get_safe("with_unwind"):


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1