### PR TITLE
Bump mysql-connector-c's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/mysql-connector-c/all/conanfile.py
+++ b/recipes/mysql-connector-c/all/conanfile.py
@@ -29,7 +29,7 @@ class MysqlConnectorCConan(ConanFile):
             self.requires("openssl/1.0.2u")
 
         if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/[>=1.2.11 <2]")
 
     def validate(self):
         if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1