### PR TITLE
Bump imagemagick's zlib requirement to [>=1.2.11 <2] range (v1 only)

### DIFF
--- a/recipes/imagemagick/all/conanfile.py
+++ b/recipes/imagemagick/all/conanfile.py
@@ -102,7 +102,7 @@ class ImageMagicConan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_bzlib:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:


### PR DESCRIPTION
Part of the zlib range migration, this PR only supports Conan v1