### PR TITLE
numcpp: add version 2.12.1, support apple-clang again

### DIFF
--- a/recipes/numcpp/all/conandata.yml
+++ b/recipes/numcpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.12.1":
+    url: "https://github.com/dpilger26/NumCpp/archive/Version_2.12.1.tar.gz"
+    sha256: "f462ecd27126e6057b31fa38f1f72cef2c4223c9d848515412970714a5bb6d16"
   "2.12.0":
     url: "https://github.com/dpilger26/NumCpp/archive/Version_2.12.0.tar.gz"
     sha256: "4c7266d405c8058f87467732129362b5a5c810d36df91e8655defa4d93fc141b"

--- a/recipes/numcpp/config.yml
+++ b/recipes/numcpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.12.1":
+    folder: "all"
   "2.12.0":
     folder: "all"
   "2.11.0":


### PR DESCRIPTION
Specify library name and version:  **numcpp/2.12.1**

Since numcpp/2.12.1 fixed https://github.com/dpilger26/NumCpp/issues/204,
numcpp/2.12.1 supports apple-clang again.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hoox](https://github.com/conan-io/hooks.git) activated.
