### PR TITLE
hwloc: added 2.9.3

### DIFF
--- a/recipes/hwloc/all/conandata.yml
+++ b/recipes/hwloc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.9.3":
+    sha256: "5985db3a30bbe51234c2cd26ebe4ae9b4c3352ab788b1a464c40c0483bf4de59"
+    url: https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.3.tar.gz
   "2.9.2":
     sha256: "ffb554d5735e0e0a19d1fd4b2b86e771d3b58b2d97f257eedacae67ade5054b3"
     url: https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.2.tar.gz

--- a/recipes/hwloc/config.yml
+++ b/recipes/hwloc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.9.3":
+    folder: all
   "2.9.2":
     folder: all
   "2.9.1":


### PR DESCRIPTION
Specify library name and version:  **hwloc/2.9.2**

Reason: this version resolves this CVE https://nvd.nist.gov/vuln/detail/CVE-2022-47022

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
