### PR TITLE
chore(docs): fixed multiple typos

### DIFF
--- a/docs/adding_packages/build_and_package.md
+++ b/docs/adding_packages/build_and_package.md
@@ -67,7 +67,7 @@ Both methods often use build helpers to build binaries and install them into the
 
 * On Apple OS family:
   * shared libs: name field of `LC_ID_DYLIB` load command must be `@rpath/<libfilename>`.
-  * shared libs & executables: name field of each `LC_LOAD_DYLIB` load command should be `@rpath/<libdependencyfilename>` (except those refering to system libs or frameworks).
+  * shared libs & executables: name field of each `LC_LOAD_DYLIB` load command should be `@rpath/<libdependencyfilename>` (except those referring to system libs or frameworks).
 
 * Installed files must not contain absolute paths specific to build machine. Relative paths to other packages is also forbidden since relative paths of dependencies during build may not be the same for consumers. Hardcoded relative paths pointing to a location in the package itself are allowed.
 

--- a/docs/adding_packages/conanfile_attributes.md
+++ b/docs/adding_packages/conanfile_attributes.md
@@ -50,7 +50,7 @@ In order to create reproducible builds, we also "commit-lock" to the latest comm
 ### License Attribute
 
 The license attribute is a mandatory field which provides the legal information that summarizes the contents saved in the package. These follow the
-[SPDX license](https://spdx.org/licenses/) as a standard. This is for consummers, in particular in the enterprise sector, that do rely on SDPX compliant identifiers so that they can flag this as a custom license text.
+[SPDX license](https://spdx.org/licenses/) as a standard. This is for consumers, in particular in the enterprise sector, that do rely on SDPX compliant identifiers so that they can flag this as a custom license text.
 
 * If the library has a license that has a SPDX identifier, use the [short Identifiers](https://spdx.dev/ids/).
 * If the library has a license text that does not match a SPDX identifier, including custom wording disclaiming copyright or dedicating the words to the ["public domain"](https://fairuse.stanford.edu/overview/public-domain/welcome/), use the [SPDX License Expressions](https://spdx.github.io/spdx-spec/v2-draft/SPDX-license-expressions/), this can follow:

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -54,7 +54,7 @@ class ExampleConan(ConanFile):
 ```
 
 If a dependency was added (or removed) with a release, then the `if` condition could check [`self.version`](https://docs.conan.io/1/reference/conanfile/attributes.html#version). Another common case is
-`self.settings.os` dependant requirements which need to be added for certain plaforms.
+`self.settings.os` dependant requirements which need to be added for certain platforms.
 
 ### Build Requirements
 
@@ -82,7 +82,7 @@ this is not guaranteed and not a common practice.
 
 Forcing options of dependencies inside a ConanCenter should be avoided, except if it is mandatory for the library to build.
 Our general belief is the users input should be the most important; it's unexpected for command line arguments to be over ruled
-by specifc recipes.
+by specific recipes.
 
 You need to use the [`validate()`](https://docs.conan.io/1/reference/conanfile/methods.html#validate) method in order to ensure they check after the Conan graph is completely built.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -70,7 +70,7 @@
 
 ### 12-April-2023 - 16:18 CEST
 
-- [feature] Add ListPackages job the posibility to update a list via PR
+- [feature] Add ListPackages job the possibility to update a list via PR
 - [feature] Add c3i-conan2-ready label when modifying .c3i/conan_v2_ready_references.yml
 - [hotfix] Use Conan helpers to update Conan Center page
 - [hotfix] Automatic Merge reduces the number of requests for each execution
@@ -171,7 +171,7 @@
 
 ### 15-December-2022 - 11:12 CET
 
-- [feature] Set github feeback title via config file (`feedback_title`).
+- [feature] Set github feedback title via config file (`feedback_title`).
 - [fix] Fix log summary html table for shared option with Conan v2.
 - [fix] ValidateInfra: Remove same OS version check for Macos nodes.
 
@@ -729,7 +729,7 @@
 
 - Raise error if zero packages are generated
 - Remove "No beta user" label if corresponding check pass
-- [engineering] Unify catchs and simplify slackSend function
+- [engineering] Unify catches and simplify slackSend function
 - [engineering] Pipeline step to create all packages in stages
 - [engineering] Pipeline step to compute and reduce 'packageID'
 - [engineering] Simplify 'ComputePackageIDs' command

--- a/docs/error_knowledge_base.md
+++ b/docs/error_knowledge_base.md
@@ -96,7 +96,7 @@ class SomeRecipe(ConanFile):
 
 #### **<a name="KB-H011">#KB-H011</a>: "LIBCXX MANAGEMENT"**
 
-If the library is detected as a pure C library (sources doesn't conatain any file with the following extensions: ["cc", "cpp", "cxx", "c++m", "cppm", "cxxm", "h++", "hh", "hxx", "hpp"]) then it has to remove the [compiler.libcxx](https://docs.conan.io/1/reference/config_files/settings.yml.html#c-standard-libraries-aka-compiler-libcxx) subsetting, because the cpp standard library shouldn't affect the binary ID:
+If the library is detected as a pure C library (sources doesn't contain any file with the following extensions: ["cc", "cpp", "cxx", "c++m", "cppm", "cxxm", "h++", "hh", "hxx", "hpp"]) then it has to remove the [compiler.libcxx](https://docs.conan.io/1/reference/config_files/settings.yml.html#c-standard-libraries-aka-compiler-libcxx) subsetting, because the cpp standard library shouldn't affect the binary ID:
 
 ```python
 class SomeRecipe(ConanFile):
@@ -139,7 +139,7 @@ See also: [Why are CMake find/config files and pkg-config files not packaged?](f
 
 #### **<a name="KB-H017">#KB-H017</a>: "PDB FILES NOT ALLOWED"**
 
-Because of the big size of the [PDB](https://github.com/Microsoft/microsoft-pdb) files (Program Databse, a debug information format) and the issues using them changing the original folders, the PDB files are not allowed to be packaged.
+Because of the big size of the [PDB](https://github.com/Microsoft/microsoft-pdb) files (Program Database, a debug information format) and the issues using them changing the original folders, the PDB files are not allowed to be packaged.
 
 See also: [Why PDB files are not allowed?](faqs.md#why-pdb-files-are-not-allowed).
 
@@ -164,7 +164,7 @@ For the legal reasons, and in order to reduce the size of packages, it's not all
 
 #### **<a name="KB-H022">#KB-H022</a>: "CPPSTD MANAGEMENT"**
 
-If the library is detected as a pure C library (sources doesn't conatain any file with the following extensions: ["cc", "cpp", "cxx", "c++m", "cppm", "cxxm", "h++", "hh", "hxx", "hpp"]) then it has to remove the [compiler.cppstd](https://docs.conan.io/1/howtos/manage_cpp_standard.html) subsetting, because the cpp standard library shouldn't affect the binary ID:
+If the library is detected as a pure C library (sources doesn't contain any file with the following extensions: ["cc", "cpp", "cxx", "c++m", "cppm", "cxxm", "h++", "hh", "hxx", "hpp"]) then it has to remove the [compiler.cppstd](https://docs.conan.io/1/howtos/manage_cpp_standard.html) subsetting, because the cpp standard library shouldn't affect the binary ID:
 
 ```python
 class SomeRecipe(ConanFile):
@@ -199,7 +199,7 @@ The [test_package](https://docs.conan.io/1/creating_packages/getting_started.htm
 
 #### **<a name="KB-H025">#KB-H025</a>: "META LINES"**
 
-The following metadata lines (and similiar) are not allowed in recipes:
+The following metadata lines (and similar) are not allowed in recipes:
 
 - [Shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) to specify Python version:
 
@@ -325,7 +325,7 @@ By default, all packages should be built as static library (the option ``shared`
 
 #### **<a name="KB-H051">#KB-H051</a>: "DEFAULT OPTIONS AS DICTIONARY"**
 
-The attribue [default_options](https://docs.conan.io/1/reference/conanfile/attributes.html#default-options) should be a dictionary, for example `default_options = {'shared': False, 'fPIC': True}`.
+The attribute [default_options](https://docs.conan.io/1/reference/conanfile/attributes.html#default-options) should be a dictionary, for example `default_options = {'shared': False, 'fPIC': True}`.
 
 #### **<a name="KB-H052">#KB-H052</a>: "CONFIG.YML HAS NEW VERSION"**
 

--- a/docs/v2_migration.md
+++ b/docs/v2_migration.md
@@ -77,12 +77,12 @@ as there are a few cases to look out for:
   set(USE_JPEG ON CACHE BOOL "include jpeg support?")
   ```
 
-For more information refere to the [CMakeToolchain docs](https://docs.conan.io/1/reference/conanfile/tools/cmake/cmaketoolchain.html)
-or check out the converstaion in conan-io/conan#11937 for the brave.
+For more information refer to the [CMakeToolchain docs](https://docs.conan.io/1/reference/conanfile/tools/cmake/cmaketoolchain.html)
+or check out the conversation in conan-io/conan#11937 for the brave.
 
 ## New conf_info properties
 
-As described in the documentation `self.user_info` has been depreated and you are now required to use
+As described in the documentation `self.user_info` has been deprecated and you are now required to use
 `self.conf_info` to define individual properties to expose to downstream recipes.
 The [2.0 migrations docs](https://docs.conan.io/1/migrating_to_2.0/recipes.html#removed-self-user-info)
 should cover the technical details, however for ConanCenterIndex we need to make sure there are no collisions


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Fixed multiple typos form docs:
refering -> referring 
consummers -> consumers
plaforms -> platforms
specifc -> specific 
posibility -> possibility 
feeback -> feedback 
catchs -> catches 
conatain -> contain 
Databse ->Database
similiar -> similar
attribue -> attribute
refere -> refer 
converstaion -> conversation 
depreated -> deprecated 
