### PR TITLE
serf: Fix url for serf-1.3.9.tar.bz2 

### DIFF
--- a/recipes/serf/all/conandata.yml
+++ b/recipes/serf/all/conandata.yml
@@ -1,9 +1,6 @@
 sources:
   "1.3.9":
-    url: [
-            "https://archive.apache.org/dist/serf/serf-1.3.9.tar.bz2",
-            "https://github.com/apache/serf/archive/1.3.9.tar.gz",
-    ]
+    url: "https://archive.apache.org/dist/serf/serf-1.3.9.tar.bz2"
     sha256: "549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc"
 patches:
   "1.3.9":

--- a/recipes/serf/all/conandata.yml
+++ b/recipes/serf/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.3.9":
     url: [
-            "https://www.apache.org/dist/serf/serf-1.3.9.tar.bz2",
+            "https://archive.apache.org/dist/serf/serf-1.3.9.tar.bz2",
             "https://github.com/apache/serf/archive/1.3.9.tar.gz",
     ]
     sha256: "549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc"


### PR DESCRIPTION
Specify library name and version:  **serf/1.3.9**

Fix build failure of serf package (due to download linkrot) similar to apr (e.g. #15737)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
