### PR TITLE
assimp: fix cmake configuration when zlib is not a direct dependency but minizip is

### DIFF
--- a/recipes/assimp/5.x/patches/0001-unvendor-deps-5.0.x.patch
+++ b/recipes/assimp/5.x/patches/0001-unvendor-deps-5.0.x.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -437,7 +437,12 @@ IF(HUNTER_ENABLED)
+@@ -437,10 +437,14 @@ IF(HUNTER_ENABLED)
    set(ASSIMP_BUILD_MINIZIP TRUE)
  ELSE(HUNTER_ENABLED)
    IF ( NOT ASSIMP_BUILD_ZLIB )
@@ -10,11 +10,25 @@
 +       ASSIMP_BUILD_X_IMPORTER OR ASSIMP_BUILD_XGL_IMPORTER)
 +        find_package(ZLIB REQUIRED)
 +    endif()
-+    set(ZLIB_FOUND TRUE)
    ENDIF( NOT ASSIMP_BUILD_ZLIB )
  
-   IF( NOT ZLIB_FOUND )
-@@ -470,14 +475,14 @@ ENDIF(HUNTER_ENABLED)
+-  IF( NOT ZLIB_FOUND )
++  IF(0)
+     MESSAGE(STATUS "compiling zlib from sources")
+     INCLUDE(CheckIncludeFile)
+     INCLUDE(CheckTypeSize)
+@@ -461,23 +465,23 @@ ELSE(HUNTER_ENABLED)
+     SET(ZLIB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/zlib ${CMAKE_CURRENT_BINARY_DIR}/contrib/zlib)
+     # need to ensure we don't link with system zlib or minizip as well.
+     SET(ASSIMP_BUILD_MINIZIP 1)
+-  ELSE(NOT ZLIB_FOUND)
++  ELSE()
+     ADD_DEFINITIONS(-DASSIMP_BUILD_NO_OWN_ZLIB)
+     SET(ZLIB_LIBRARIES_LINKED -lz)
+-  ENDIF(NOT ZLIB_FOUND)
++  ENDIF()
+   INCLUDE_DIRECTORIES(${ZLIB_INCLUDE_DIR})
+ ENDIF(HUNTER_ENABLED)
  
  IF( NOT IOS )
    IF( NOT ASSIMP_BUILD_MINIZIP )

--- a/recipes/assimp/5.x/patches/0003-unvendor-deps-5.1.x.patch
+++ b/recipes/assimp/5.x/patches/0003-unvendor-deps-5.1.x.patch
@@ -1,6 +1,13 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -465,7 +465,12 @@ ELSE()
+@@ -459,16 +459,20 @@ IF(ASSIMP_HUNTER_ENABLED)
+   set(ASSIMP_BUILD_MINIZIP TRUE)
+ ELSE()
+   # If the zlib is already found outside, add an export in case assimpTargets can't find it.
+-  IF( ZLIB_FOUND )
++  IF(0)
+     INSTALL( TARGETS zlib zlibstatic
+         EXPORT "${TARGETS_EXPORT_NAME}")
    ENDIF()
  
    IF ( NOT ASSIMP_BUILD_ZLIB )
@@ -10,11 +17,14 @@
 +       ASSIMP_BUILD_X_IMPORTER OR ASSIMP_BUILD_XGL_IMPORTER)
 +        find_package(ZLIB REQUIRED)
 +    endif()
-+    set(ZLIB_FOUND TRUE)
    ENDIF()
  
-   IF( NOT ZLIB_FOUND )
-@@ -498,12 +503,14 @@ ENDIF()
+-  IF( NOT ZLIB_FOUND )
++  IF(0)
+     MESSAGE(STATUS "compiling zlib from sources")
+     INCLUDE(CheckIncludeFile)
+     INCLUDE(CheckTypeSize)
+@@ -498,12 +502,14 @@ ENDIF()
  
  IF( NOT IOS )
    IF( NOT ASSIMP_BUILD_MINIZIP )

--- a/recipes/assimp/5.x/patches/0004-unvendor-deps-5.1.6.patch
+++ b/recipes/assimp/5.x/patches/0004-unvendor-deps-5.1.6.patch
@@ -1,6 +1,13 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -466,7 +466,12 @@ ELSE()
+@@ -460,16 +460,20 @@ IF(ASSIMP_HUNTER_ENABLED)
+   set(ASSIMP_BUILD_MINIZIP TRUE)
+ ELSE()
+   # If the zlib is already found outside, add an export in case assimpTargets can't find it.
+-  IF( ZLIB_FOUND )
++  IF(0)
+     INSTALL( TARGETS zlib zlibstatic
+         EXPORT "${TARGETS_EXPORT_NAME}")
    ENDIF()
  
    IF ( NOT ASSIMP_BUILD_ZLIB )
@@ -10,11 +17,14 @@
 +       ASSIMP_BUILD_X_IMPORTER OR ASSIMP_BUILD_XGL_IMPORTER)
 +        find_package(ZLIB REQUIRED)
 +    endif()
-+    set(ZLIB_FOUND TRUE)
    ENDIF()
  
-   IF( NOT ZLIB_FOUND )
-@@ -499,12 +504,14 @@ ENDIF()
+-  IF( NOT ZLIB_FOUND )
++  IF(0)
+     MESSAGE(STATUS "compiling zlib from sources")
+     INCLUDE(CheckIncludeFile)
+     INCLUDE(CheckTypeSize)
+@@ -499,12 +503,14 @@ ENDIF()
  
  IF( NOT IOS )
    IF( NOT ASSIMP_BUILD_MINIZIP )

--- a/recipes/assimp/5.x/patches/0006-unvendor-deps-5.2.x.patch
+++ b/recipes/assimp/5.x/patches/0006-unvendor-deps-5.2.x.patch
@@ -1,6 +1,13 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -488,7 +488,12 @@ ELSE()
+@@ -482,16 +482,20 @@ IF(ASSIMP_HUNTER_ENABLED)
+   set(ASSIMP_BUILD_MINIZIP TRUE)
+ ELSE()
+   # If the zlib is already found outside, add an export in case assimpTargets can't find it.
+-  IF( ZLIB_FOUND )
++  IF(0)
+     INSTALL( TARGETS zlib zlibstatic
+         EXPORT "${TARGETS_EXPORT_NAME}")
    ENDIF()
  
    IF ( NOT ASSIMP_BUILD_ZLIB )
@@ -10,11 +17,14 @@
 +       ASSIMP_BUILD_X_IMPORTER OR ASSIMP_BUILD_XGL_IMPORTER)
 +        find_package(ZLIB REQUIRED)
 +    endif()
-+    set(ZLIB_FOUND TRUE)
    ENDIF()
  
-   IF( NOT ZLIB_FOUND )
-@@ -521,12 +526,14 @@ ENDIF()
+-  IF( NOT ZLIB_FOUND )
++  IF(0)
+     MESSAGE(STATUS "compiling zlib from sources")
+     INCLUDE(CheckIncludeFile)
+     INCLUDE(CheckTypeSize)
+@@ -521,12 +525,14 @@ ENDIF()
  
  IF( NOT IOS )
    IF( NOT ASSIMP_BUILD_MINIZIP )


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/20553

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
