### PR TITLE
[google-cloud-cpp] bump requirements and other fixes

### DIFF
--- a/recipes/google-cloud-cpp/2.x/conandata.yml
+++ b/recipes/google-cloud-cpp/2.x/conandata.yml
@@ -22,6 +22,10 @@ patches:
       patch_source: https://github.com/googleapis/google-cloud-cpp/pull/10636
       patch_description: "Fix problems with INTERFACE proto libraries"
       patch_type: backport
+    - patch_file: "patches/2.5.0/006-cannot-use-or-with-windows.patch"
+      patch_source: https://github.com/googleapis/google-cloud-cpp/pull/10612
+      patch_description: "MSVC does not like `or` spelling for `||`"
+      patch_type: backport
   "2.12.0":
     - patch_file: "patches/2.12.0/001-use-conan-msvc-runtime.patch"
       patch_description: "Let Conan select the MSVC runtime"

--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -138,19 +138,16 @@ class GoogleCloudCppConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def requirements(self):
-        # Updating Protobuf requires updates to the generated code, even within
-        # a minor version.
+        # These must remain pinned in conan index.
         self.requires("protobuf/3.21.12", transitive_headers=True)
-        # Each release of Abseil is a new major version, not guaranteed to be
-        # compatible with previous verssions.
-        self.requires("abseil/[>=20230125.3.0 <20230126]", transitive_headers=True)
-        # The rest are more semver-like and require less pinning.
-        self.requires("grpc/[>=1.50]", transitive_headers=True)
-        self.requires("nlohmann_json/[>=3.10 <4]")
-        self.requires("crc32c/[>=1.1 <2]")
-        self.requires("libcurl/[>=7.47 <9]")
+        self.requires("abseil/20230125.3", transitive_headers=True)
+        self.requires("grpc/1.54.3", transitive_headers=True)
+        self.requires("nlohmann_json/3.11.2")
+        self.requires("crc32c/1.1.2")
+        # The rest require less pinning.
+        self.requires("libcurl/[>=7.78 <9]")
         self.requires("openssl/[>=1.1 <4]")
-        self.requires("zlib/[>=1.2 <2]")
+        self.requires("zlib/[>=1.2.11 <2]")
 
     def build_requirements(self):
         # For the `grpc-cpp-plugin` executable, and indirectly `protoc`

--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -176,9 +176,14 @@ class GoogleCloudCppConan(ConanFile):
         #     https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/RuntimeProtections/RuntimeProtections.html
         settings_build = getattr(self, "settings_build", self.settings)
         if settings_build.os == "Macos":
-            replace_in_file(self, os.path.join(self.source_folder, "cmake/CompileProtos.cmake"),
-                            "$<TARGET_FILE:protobuf::protoc>",
-                            '${CMAKE_COMMAND} -E env "DYLD_LIBRARY_PATH=$ENV{DYLD_LIBRARY_PATH}" $<TARGET_FILE:protobuf::protoc>')
+            if Version(self.version) < '2.12.0':
+                replace_in_file(self, os.path.join(self.source_folder, "cmake/CompileProtos.cmake"),
+                                "$<TARGET_FILE:protobuf::protoc>",
+                                '${CMAKE_COMMAND} -E env "DYLD_LIBRARY_PATH=$ENV{DYLD_LIBRARY_PATH}" $<TARGET_FILE:protobuf::protoc>')
+            else:
+                replace_in_file(self, os.path.join(self.source_folder, "cmake/CompileProtos.cmake"),
+                                "${Protobuf_PROTOC_EXECUTABLE} ARGS",
+                                '${CMAKE_COMMAND} -E env "DYLD_LIBRARY_PATH=$ENV{DYLD_LIBRARY_PATH}" ${Protobuf_PROTOC_EXECUTABLE}')
 
     def build(self):
         self._patch_sources()

--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -153,8 +153,8 @@ class GoogleCloudCppConan(ConanFile):
         self.requires("zlib/[>=1.2 <2]")
 
     def build_requirements(self):
-        # For the grpc-cpp-plugin executable
-        self.tool_requires("grpc/1.50.1")
+        # For the `grpc-cpp-plugin` executable, and indirectly `protoc`
+        self.tool_requires("grpc/<host_version>")
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -138,14 +138,19 @@ class GoogleCloudCppConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def requirements(self):
-        self.requires("protobuf/3.21.9", transitive_headers=True)
-        self.requires("grpc/1.50.1", transitive_headers=True)
-        self.requires("nlohmann_json/3.10.0")
-        self.requires("crc32c/1.1.1")
-        self.requires("abseil/20220623.0", transitive_headers=True)
-        self.requires("libcurl/7.88.1")
+        # Updating Protobuf requires updates to the generated code, even within
+        # a minor version.
+        self.requires("protobuf/3.21.12", transitive_headers=True)
+        # Each release of Abseil is a new major version, not guaranteed to be
+        # compatible with previous verssions.
+        self.requires("abseil/[>=20230125.3.0 <20230126]", transitive_headers=True)
+        # The rest are more semver-like and require less pinning.
+        self.requires("grpc/[>=1.50]", transitive_headers=True)
+        self.requires("nlohmann_json/[>=3.10 <4]")
+        self.requires("crc32c/[>=1.1 <2]")
+        self.requires("libcurl/[>=7.47 <9]")
         self.requires("openssl/[>=1.1 <4]")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/[>=1.2 <2]")
 
     def build_requirements(self):
         # For the grpc-cpp-plugin executable
@@ -155,6 +160,7 @@ class GoogleCloudCppConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_TESTING"] = False
         tc.variables["GOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK"] = False
+        tc.variables["GOOGLE_CLOUD_CPP_ENABLE_WERROR"] = False
         tc.variables["GOOGLE_CLOUD_CPP_ENABLE"] = ",".join(self._components())
         tc.generate()
         VirtualRunEnv(self).generate(scope="build")

--- a/recipes/google-cloud-cpp/2.x/patches/2.5.0/006-cannot-use-or-with-windows.patch
+++ b/recipes/google-cloud-cpp/2.x/patches/2.5.0/006-cannot-use-or-with-windows.patch
@@ -1,0 +1,45 @@
+diff --git a/google/cloud/internal/oauth2_compute_engine_credentials.cc b/google/cloud/internal/oauth2_compute_engine_credentials.cc
+index 9cb45a6..5c6b45d 100644
+--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
++++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
+@@ -68,8 +68,8 @@ StatusOr<internal::AccessToken> ParseComputeEngineRefreshResponse(
+   auto payload = rest_internal::ReadAll(std::move(response).ExtractPayload());
+   if (!payload.ok()) return payload.status();
+   auto access_token = nlohmann::json::parse(*payload, nullptr, false);
+-  if (access_token.is_discarded() || access_token.count("access_token") == 0 or
+-      access_token.count("expires_in") == 0 or
++  if (access_token.is_discarded() || access_token.count("access_token") == 0 ||
++      access_token.count("expires_in") == 0 ||
+       access_token.count("token_type") == 0) {
+     auto error_payload =
+         *payload +
+diff --git a/google/cloud/storage/oauth2/compute_engine_credentials.cc b/google/cloud/storage/oauth2/compute_engine_credentials.cc
+index 365273a..92e631c 100644
+--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
++++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
+@@ -36,8 +36,8 @@ ParseComputeEngineRefreshResponse(
+   // Response should have the attributes "access_token", "expires_in", and
+   // "token_type".
+   auto access_token = nlohmann::json::parse(response.payload, nullptr, false);
+-  if (!access_token.is_object() || access_token.count("access_token") == 0 or
+-      access_token.count("expires_in") == 0 or
++  if (!access_token.is_object() || access_token.count("access_token") == 0 ||
++      access_token.count("expires_in") == 0 ||
+       access_token.count("token_type") == 0) {
+     auto payload =
+         response.payload +
+diff --git a/google/cloud/storage/oauth2/service_account_credentials.cc b/google/cloud/storage/oauth2/service_account_credentials.cc
+index 4c600db..34c4e72 100644
+--- a/google/cloud/storage/oauth2/service_account_credentials.cc
++++ b/google/cloud/storage/oauth2/service_account_credentials.cc
+@@ -85,8 +85,8 @@ ParseServiceAccountRefreshResponse(
+     storage::internal::HttpResponse const& response,
+     std::chrono::system_clock::time_point now) {
+   auto access_token = nlohmann::json::parse(response.payload, nullptr, false);
+-  if (access_token.is_discarded() || access_token.count("access_token") == 0 or
+-      access_token.count("expires_in") == 0 or
++  if (access_token.is_discarded() || access_token.count("access_token") == 0 ||
++      access_token.count("expires_in") == 0 ||
+       access_token.count("token_type") == 0) {
+     auto payload =
+         response.payload +


### PR DESCRIPTION
Specify library name and version:  **google-cloud-cpp/v2.5.0** and **google-cloud-cpp/v2.12.0**.

Several requirements need version bumps. Where possible I chose version ranges over pinning specific versions.

I had to backport fixes for MSVC. I am only guessing, but it seems the toolchain changed in the CI system and now spelling `||` as `or` results in build errors.

I also disabled `-Werror` because the code in `v2.5.0` has warnings with newer toolchains. This is to be expected, and that is why the project no longer enables `-Werror` by default.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
