### PR TITLE
opencv: define several official cmake vars of OpenCV in CMakeDeps + use `<host_version>` for protobuf in build requirements

### DIFF
--- a/recipes/opencv/2.x/conanfile.py
+++ b/recipes/opencv/2.x/conanfile.py
@@ -46,7 +46,7 @@ class OpenCVConan(ConanFile):
     description = "OpenCV (Open Source Computer Vision Library)"
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("computer-vision", "deep-learning", "image-processing")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/opencv/2.x/conanfile.py
+++ b/recipes/opencv/2.x/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.build import valid_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, save
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 import sys
 import os
 import textwrap
@@ -533,14 +534,38 @@ class OpenCVConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "staticlib"))
         rm(self, "*.cmake", self.package_folder, recursive=True)
 
+        self._create_cmake_module_variables(os.path.join(self.package_folder, self._module_vars_rel_path))
+
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         targets_mapping = {self._cmake_target(k): f"opencv::{self._cmake_target(k)}" for k in self._opencv_modules.keys()}
         if self.options.world:
             targets_mapping.update({"opencv_world": "opencv::opencv_world"})
         self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
+            os.path.join(self.package_folder, self._module_target_rel_path),
             targets_mapping,
         )
+
+    def _create_cmake_module_variables(self, module_file):
+        """
+        Define several CMake variables from upstream CMake config file not defined by default by CMakeDeps.
+        See https://github.com/opencv/opencv/blob/2.4.13.7/cmake/templates/OpenCVConfig.cmake.in
+        """
+        v = Version(self.version)
+        content = textwrap.dedent(f"""\
+            if(NOT DEFINED OpenCV_LIBS)
+                set(OpenCV_LIBS opencv::opencv)
+            endif()
+            if(NOT DEFINED OpenCV_VERSION_MAJOR)
+                set(OpenCV_VERSION_MAJOR {v.major})
+            endif()
+            if(NOT DEFINED OpenCV_VERSION_MINOR)
+                set(OpenCV_VERSION_MINOR {v.minor})
+            endif()
+            if(NOT DEFINED OpenCV_VERSION_PATCH)
+                set(OpenCV_VERSION_PATCH {v.patch})
+            endif()
+        """)
+        save(self, module_file, content)
 
     def _create_cmake_module_alias_targets(self, module_file, targets):
         content = ""
@@ -554,7 +579,11 @@ class OpenCVConan(ConanFile):
         save(self, module_file, content)
 
     @property
-    def _module_file_rel_path(self):
+    def _module_vars_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")
+
+    @property
+    def _module_target_rel_path(self):
         return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     @staticmethod
@@ -612,8 +641,8 @@ class OpenCVConan(ConanFile):
                 # TODO: to remove in conan v2 once cmake_find_package* generators removed
                 self.cpp_info.components[conan_component].names["cmake_find_package"] = cmake_target
                 self.cpp_info.components[conan_component].names["cmake_find_package_multi"] = cmake_target
-                self.cpp_info.components[conan_component].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-                self.cpp_info.components[conan_component].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+                self.cpp_info.components[conan_component].build_modules["cmake_find_package"] = [self._module_vars_rel_path, self._module_target_rel_path]
+                self.cpp_info.components[conan_component].build_modules["cmake_find_package_multi"] = [self._module_vars_rel_path, self._module_target_rel_path]
                 if module != cmake_target:
                     conan_component_alias = conan_component + "_alias"
                     self.cpp_info.components[conan_component_alias].names["cmake_find_package"] = module
@@ -629,10 +658,11 @@ class OpenCVConan(ConanFile):
                 self.cpp_info.components["opencv_world"].frameworks = list(world_frameworks)
 
                 # TODO: to remove in conan v2 once cmake_find_package* generators removed
-                self.cpp_info.components["opencv_world"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-                self.cpp_info.components["opencv_world"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+                self.cpp_info.components["opencv_world"].build_modules["cmake_find_package"] = [self._module_vars_rel_path, self._module_target_rel_path]
+                self.cpp_info.components["opencv_world"].build_modules["cmake_find_package_multi"] = [self._module_vars_rel_path, self._module_target_rel_path]
 
         self.cpp_info.set_property("cmake_file_name", "OpenCV")
+        self.cpp_info.set_property("cmake_build_modules", [self._module_vars_rel_path])
 
         add_components(self._opencv_modules)
 

--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -80,9 +80,9 @@ class OpenCVConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.1.5")
+            self.requires("libjpeg-turbo/3.0.0")
         elif self.options.with_jpeg == "mozjpeg":
-            self.requires("mozjpeg/4.1.1")
+            self.requires("mozjpeg/4.1.3")
         if self.options.with_png:
             self.requires("libpng/1.6.40")
         if self.options.with_jasper:
@@ -91,17 +91,17 @@ class OpenCVConan(ConanFile):
             # opencv 3.x doesn't support openexr >= 3
             self.requires("openexr/2.5.7")
         if self.options.with_tiff:
-            self.requires("libtiff/4.5.1")
+            self.requires("libtiff/4.6.0")
         if self.options.with_eigen:
             self.requires("eigen/3.4.0")
         if self.options.parallel == "tbb":
             # opencv 3.x doesn't support onetbb >= 2021
-            self.requires("onetbb/2020.3")
+            self.requires("onetbb/2020.3.3")
         if self.options.with_webp:
             self.requires("libwebp/1.3.2")
         if self.options.contrib:
             self.requires("freetype/2.13.0")
-            self.requires("harfbuzz/6.0.0")
+            self.requires("harfbuzz/8.2.2")
             self.requires("gflags/2.2.2")
             self.requires("glog/0.6.0")
         if self.options.get_safe("with_gtk"):

--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -287,11 +287,35 @@ class OpenCVConan(ConanFile):
             rename(self, os.path.join(self.package_folder, "setup_vars_opencv3.cmd"),
                          os.path.join(self.package_folder, "res", "setup_vars_opencv3.cmd"))
 
+        self._create_cmake_module_variables(os.path.join(self.package_folder, self._module_vars_rel_path))
+
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
+            os.path.join(self.package_folder, self._module_target_rel_path),
             {component["target"]:"opencv::{}".format(component["target"]) for component in self._opencv_components}
         )
+
+    def _create_cmake_module_variables(self, module_file):
+        """
+        Define several CMake variables from upstream CMake config file not defined by default by CMakeDeps.
+        See https://github.com/opencv/opencv/blob/3.4.20/cmake/templates/OpenCVConfig.cmake.in
+        """
+        v = Version(self.version)
+        content = textwrap.dedent(f"""\
+            if(NOT DEFINED OpenCV_LIBS)
+                set(OpenCV_LIBS opencv::opencv)
+            endif()
+            if(NOT DEFINED OpenCV_VERSION_MAJOR)
+                set(OpenCV_VERSION_MAJOR {v.major})
+            endif()
+            if(NOT DEFINED OpenCV_VERSION_MINOR)
+                set(OpenCV_VERSION_MINOR {v.minor})
+            endif()
+            if(NOT DEFINED OpenCV_VERSION_PATCH)
+                set(OpenCV_VERSION_PATCH {v.patch})
+            endif()
+        """)
+        save(self, module_file, content)
 
     def _create_cmake_module_alias_targets(self, module_file, targets):
         content = ""
@@ -305,7 +329,11 @@ class OpenCVConan(ConanFile):
         save(self, module_file, content)
 
     @property
-    def _module_file_rel_path(self):
+    def _module_vars_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")
+
+    @property
+    def _module_target_rel_path(self):
         return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     @property
@@ -431,8 +459,8 @@ class OpenCVConan(ConanFile):
                 # TODO: to remove in conan v2 once cmake_find_package* generators removed
                 self.cpp_info.components[conan_component].names["cmake_find_package"] = cmake_target
                 self.cpp_info.components[conan_component].names["cmake_find_package_multi"] = cmake_target
-                self.cpp_info.components[conan_component].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-                self.cpp_info.components[conan_component].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+                self.cpp_info.components[conan_component].build_modules["cmake_find_package"] = [self._module_vars_rel_path, self._module_target_rel_path]
+                self.cpp_info.components[conan_component].build_modules["cmake_find_package_multi"] = [self._module_vars_rel_path, self._module_target_rel_path]
                 if cmake_component != cmake_target:
                     conan_component_alias = conan_component + "_alias"
                     self.cpp_info.components[conan_component_alias].names["cmake_find_package"] = cmake_component
@@ -443,6 +471,7 @@ class OpenCVConan(ConanFile):
                     self.cpp_info.components[conan_component_alias].libdirs = []
 
         self.cpp_info.set_property("cmake_file_name", "OpenCV")
+        self.cpp_info.set_property("cmake_build_modules", [self._module_vars_rel_path])
 
         add_components(self._opencv_components)
 

--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -17,7 +17,7 @@ class OpenCVConan(ConanFile):
     description = "OpenCV (Open Source Computer Vision Library)"
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("computer-vision", "deep-learning", "image-processing")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -1023,7 +1023,7 @@ class OpenCVConan(ConanFile):
             self.requires("vulkan-headers/1.3.250.0")
         # gapi module dependencies
         if self.options.gapi:
-            self.requires("ade/0.1.2c")
+            self.requires("ade/0.1.2d")
         # highgui module dependencies
         if self.options.get_safe("with_gtk"):
             self.requires("gtk/system")
@@ -1062,7 +1062,7 @@ class OpenCVConan(ConanFile):
         # freetype module dependencies
         if self.options.freetype:
             self.requires("freetype/2.13.0")
-            self.requires("harfbuzz/8.2.1")
+            self.requires("harfbuzz/8.2.2")
         # hdf module dependencies
         if self.options.hdf:
             self.requires("hdf5/1.14.1")


### PR DESCRIPTION
- Define several CMake variables of upstream config file (see https://github.com/opencv/opencv/blob/4.8.1/cmake/templates/OpenCVConfig.cmake.in):
  - `OpenCV_LIBS`
  - `OpenCV_VERSION_MAJOR`
  - `OpenCV_VERSION_MINOR`
  - `OpenCV_VERSION_PATCH`
- Bump dependencies
- opencv 4.x: Use `<host_version>` for protobuf in build requirements (and update `required_conan_version` accordingly).

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
