### PR TITLE
coin-utils: expose bzip2 and zlib

### DIFF
--- a/recipes/coin-utils/all/conanfile.py
+++ b/recipes/coin-utils/all/conanfile.py
@@ -53,8 +53,8 @@ class CoinUtilsConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("bzip2/1.0.8")
-        self.requires("zlib/[>=1.2.11 <2]")
+        self.requires("bzip2/1.0.8", transitive_libs=True)
+        self.requires("zlib/[>=1.2.11 <2]", transitive_libs=True)
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:

--- a/recipes/coin-utils/all/test_package/conanfile.py
+++ b/recipes/coin-utils/all/test_package/conanfile.py
@@ -17,7 +17,7 @@ class TestPackageConan(ConanFile):
 
     def build_requirements(self):
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/1.9.3")
+            self.tool_requires("pkgconf/2.0.3")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/coin-utils/all/test_v1_package/conanfile.py
+++ b/recipes/coin-utils/all/test_v1_package/conanfile.py
@@ -7,7 +7,7 @@ class TestPackageConan(ConanFile):
     generators = "cmake", "pkg_config"
 
     def build_requirements(self):
-        self.build_requires("pkgconf/1.9.3")
+        self.build_requires("pkgconf/2.0.3")
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **coin-utils/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This should fix coin-clp test package when all reqs are static:
```
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinGzipFileInput::CoinGzipFileInput(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:216: undefined reference to `gzopen'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinGzipFileInput::~CoinGzipFileInput()':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:226: undefined reference to `gzclose'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinGzipFileInput::readRaw(void*, int)':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:232: undefined reference to `gzread'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinBzip2FileInput::CoinBzip2FileInput(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:262: undefined reference to `BZ2_bzReadOpen'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinBzip2FileInput::~CoinBzip2FileInput()':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:274: undefined reference to `BZ2_bzReadClose'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinBzip2FileInput::readRaw(void*, int)':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:284: undefined reference to `BZ2_bzRead'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinGzipFileOutput::CoinGzipFileOutput(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:436: undefined reference to `gzopen'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinGzipFileOutput::~CoinGzipFileOutput()':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:446: undefined reference to `gzclose'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinGzipFileOutput::write(void const*, int)':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:451: undefined reference to `gzwrite'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinBzip2FileOutput::CoinBzip2FileOutput(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:482: undefined reference to `BZ2_bzWriteOpen'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinBzip2FileOutput::~CoinBzip2FileOutput()':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:500: undefined reference to `BZ2_bzWriteClose'
/usr/bin/ld: /home/conan/w/prod-v1/bsr/31991/bbaae/.conan/data/coin-utils/2.11.9/_/_/package/3b9d7f53ee87171712dda22121c4e799f69fdcf7/lib/libCoinUtils.a(CoinFileIO.o): in function `CoinBzip2FileOutput::write(void const*, int)':
/home/conan/w/prod-v1/bsr/7966/eddba/.conan/data/coin-utils/2.11.9/_/_/build/3b9d7f53ee87171712dda22121c4e799f69fdcf7/src/CoinUtils/src/CoinFileIO.cpp:509: undefined reference to `BZ2_bzWrite'
collect2: error: ld returned 1 exit status
```


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
