### PR TITLE
signals-light: add recipe

### DIFF
--- a/recipes/signals-light/all/conandata.yml
+++ b/recipes/signals-light/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20210616":
+    url: "https://github.com/a-n-t-h-o-n-y/signals-light/archive/1070e931d20e6d0bf6dacfdca7c2b6094975fb16.tar.gz"
+    sha256: "b1dfcd5dced5b8e6aef066bc8f5d541f1122a4b807911bfb77b3ed0f4b2d4fec"

--- a/recipes/signals-light/all/conanfile.py
+++ b/recipes/signals-light/all/conanfile.py
@@ -1,0 +1,65 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.52.0"
+
+class SignalsLightConan(ConanFile):
+    name = "signals-light"
+    description = "Lightweight Signals & Slots Library"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/a-n-t-h-o-n-y/signals-light/"
+    topics = ("signals", "slot", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12",
+            "Visual Studio": "16",
+            "msvc": "192",
+        }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.hpp",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/signals-light/all/test_package/CMakeLists.txt
+++ b/recipes/signals-light/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(signals-light REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE signals-light::signals-light)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/signals-light/all/test_package/conanfile.py
+++ b/recipes/signals-light/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/signals-light/all/test_package/test_package.cpp
+++ b/recipes/signals-light/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include "signals_light/signal.hpp"
+
+int main(void) {
+    auto signal = sl::Signal<void(int)>{};
+    signal.connect([](int i){ std::cout << i << '\n'; });
+    signal.connect([](int i){ std::cout << i * 2 << '\n'; });
+
+    signal(4);  // prints "4\n8\n" to standard output.
+}

--- a/recipes/signals-light/config.yml
+++ b/recipes/signals-light/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210616":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **signals-light/***

signals-light is one of the termox(https://github.com/a-n-t-h-o-n-y/TermOx)'s dependency libraries.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
