### PR TITLE
[avahi] Expose both root include folder and module name

### DIFF
--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -107,6 +107,7 @@ class AvahiConan(ConanFile):
             self.cpp_info.components[lib].names["cmake_find_package"] = lib
             self.cpp_info.components[lib].names["cmake_find_package_multi"] = lib
             self.cpp_info.components[lib].libs = [avahi_lib]
+            self.cpp_info.components[lib].includedirs = ["include", os.path.join("include", avahi_lib)]
         self.cpp_info.components["compat-libdns_sd"].libs = ["dns_sd"]
 
         self.cpp_info.components["client"].requires = ["common", "dbus::dbus"]
@@ -131,6 +132,7 @@ class AvahiConan(ConanFile):
         self.cpp_info.components["resolve"].requires = ["client"]
         self.cpp_info.components["set-host-name"].requires = ["client"]
 
+        # TODO: Remove after dropping Conan 1.x support
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info(f"Appending PATH environment variable: {bin_path}")
         self.env_info.PATH.append(bin_path)

--- a/recipes/avahi/all/test_package/test_package.c
+++ b/recipes/avahi/all/test_package/test_package.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include "avahi-compat-libdns_sd/dns_sd.h"
+#include "dns_sd.h"
 #include "avahi-core/log.h"
 
 


### PR DESCRIPTION
Specify library name and version:  **avahi/0.8**

The avahi package also provides `mdnsresponder`,  and when doing it, the consumer does not expect avahi, but the true include header, like `#include <dns.h>`. 

This reverts part of the commit https://github.com/conan-io/conan-center-index/pull/20706/commits/88c85c9b2c5cc25e2a1574fcc937695bdc7cadc3, but keep both root and module name as include folder.

Required by https://github.com/conan-io/conan-center-index/pull/20287


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
