### PR TITLE
[grpc] Build versions 1.50.x

### DIFF
--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -2,10 +2,20 @@ sources:
   "1.54.3":
     url: "https://github.com/grpc/grpc/archive/v1.54.3.tar.gz"
     sha256: "17e4e1b100657b88027721220cbfb694d86c4b807e9257eaf2fb2d273b41b1b1"
+  "1.50.1":
+    url: "https://github.com/grpc/grpc/archive/v1.50.1.tar.gz"
+    sha256: "fb1ed98eb3555877d55eb2b948caca44bc8601c6704896594de81558639709ef"
+  "1.50.0":
+    url: "https://github.com/grpc/grpc/archive/v1.50.0.tar.gz"
+    sha256: "76900ab068da86378395a8e125b5cc43dfae671e09ff6462ddfef18676e2165a"
   "1.48.4":
     url: "https://github.com/grpc/grpc/archive/v1.48.4.tar.gz"
     sha256: "0c3faa83e39d4f1ab55fe1476362b9ac3b81632a46dce7fd4d50271bce816b53"
 patches:
+  "1.50.1":
+    - patch_file: "patches/v1.50.x/001-disable-cppstd-override.patch"
+  "1.50.0":
+    - patch_file: "patches/v1.50.x/001-disable-cppstd-override.patch"
   "1.48.4":
     - patch_file: "patches/v1.48.x/001-disable-cppstd-override.patch"
       patch_description: "disable cpp std override"

--- a/recipes/grpc/all/patches/v1.50.x/001-disable-cppstd-override.patch
+++ b/recipes/grpc/all/patches/v1.50.x/001-disable-cppstd-override.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7052846..259fa93 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -227,21 +227,6 @@ if (NOT DEFINED CMAKE_C_STANDARD)
+   set(CMAKE_C_STANDARD 11)
+ endif()
+
+-# Add c++14 flags
+-if (NOT DEFINED CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 14)
+-else()
+-  if (CMAKE_CXX_STANDARD LESS 14)
+-    message(FATAL_ERROR "CMAKE_CXX_STANDARD is less than 14, please specify at least SET(CMAKE_CXX_STANDARD 14)")
+-  endif()
+-endif()
+-if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+-endif()
+-if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
+-  set(CMAKE_CXX_EXTENSIONS OFF)
+-endif()
+-
+ if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
+   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+ endif()

--- a/recipes/grpc/config.yml
+++ b/recipes/grpc/config.yml
@@ -1,5 +1,9 @@
 versions:
   "1.54.3":
     folder: "all"
+  "1.50.1":
+    folder: "all"
+  "1.50.0":
+    folder: "all"
   "1.48.4":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **grpc/1.50.1**

The PR #18544 sanitized old versions for gRPC, but true is the version `1.50.1` is still largely used in CCI:

```
$ find .. -name conanfile.py -exec grep grpc/1.50. {} +  
../recipes/microservice-essentials/all/conanfile.py:            self.requires("grpc/1.50.1")
../recipes/arrow/all/conanfile.py:            self.requires("grpc/1.50.0")
../recipes/bear/all/conanfile.py:        self.requires("grpc/1.50.1")
../recipes/bear/all/conanfile.py:        self.tool_requires("grpc/1.50.1")
../recipes/asio-grpc/all/conanfile.py:        self.requires("grpc/1.50.1")
../recipes/google-cloud-cpp/2.x/conanfile.py:        self.requires("grpc/1.50.1", transitive_headers=True)
../recipes/google-cloud-cpp/2.x/conanfile.py:        self.tool_requires("grpc/1.50.1")
../recipes/opentelemetry-cpp/all/conanfile.py:                self.requires("grpc/1.50.1")
../recipes/opentelemetry-cpp/all/conanfile.py:                self.tool_requires("grpc/1.50.1")
```


Thank you @SpaceIm for spotting it.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
