### PR TITLE
[wt] Unblock Linux and Mac for 4.10.1 + cppstd=17

### DIFF
--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -121,8 +121,11 @@ class WtConan(ConanFile):
                 f"{self.ref} requires non header-only boost with these components: "
                 f"{', '.join(self._required_boost_components)}"
             )
-        # FIXME: check_max_cppstd is only available for Conan 2.x. Remove it after dropping support for Conan 1.x
-        if conan_version.major == 2 and Version(self.version) >= "4.10.1":
+
+        # FIXME: https://redmine.emweb.be/issues/12073w
+        if conan_version.major == 2 and Version(self.version) >= "4.10.1" and is_msvc(self):
+
+            # FIXME: check_max_cppstd is only available for Conan 2.x. Remove it after dropping support for Conan 1.x
             # FIXME: linter complains, but function is there
             # https://docs.conan.io/2.0/reference/tools/build.html?highlight=check_min_cppstd#conan-tools-build-check-max-cppstd
             check_max_cppstd = getattr(sys.modules['conan.tools.build'], 'check_max_cppstd')

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -123,7 +123,7 @@ class WtConan(ConanFile):
             )
 
         # FIXME: https://redmine.emweb.be/issues/12073w
-        if conan_version.major == 2 and Version(self.version) >= "4.10.1" and is_msvc(self):
+        if conan_version.major == 2 and Version(self.version) == "4.10.1" and is_msvc(self):
 
             # FIXME: check_max_cppstd is only available for Conan 2.x. Remove it after dropping support for Conan 1.x
             # FIXME: linter complains, but function is there


### PR DESCRIPTION
Specify library name and version:  **wt/4.10.1**

Related to https://github.com/conan-io/conan-center-index/pull/19989#issuecomment-1775331230

Doing more builds locally, only MSVC and with the version 4.10.1 the error occurs.
Testing with LInux and Mac, but also with the version 4.10.0, everything works.

It could be related to https://github.com/emweb/wt/commit/7956a40c736aae9c5be87ed68d19e2b00bb81bc2

I opened an issue to Wt asking about: https://redmine.emweb.be/issues/12073

/cc @SpaceIm 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
