### PR TITLE
detools: add version 0.53.0, suppport conan v2

### DIFF
--- a/recipes/detools/all/CMakeLists.txt
+++ b/recipes/detools/all/CMakeLists.txt
@@ -2,13 +2,11 @@ cmake_minimum_required(VERSION 3.1)
 project(detools LANGUAGES C)
 
 find_package(heatshrink REQUIRED CONFIG)
-find_package(lz4 REQUIRED CONFIG)
 find_package(LibLZMA REQUIRED CONFIG)
 
 add_library(detools ${DETOOLS_SRC_DIR}/c/detools.c)
 target_link_libraries(detools PRIVATE
     heatshrink::heatshrink
-    lz4::lz4
     LibLZMA::LibLZMA
 )
 

--- a/recipes/detools/all/CMakeLists.txt
+++ b/recipes/detools/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(detools LANGUAGES C)
 
 find_package(heatshrink REQUIRED CONFIG)
@@ -9,6 +9,8 @@ target_link_libraries(detools PRIVATE
     heatshrink::heatshrink
     LibLZMA::LibLZMA
 )
+
+include(GNUInstallDirs)
 
 install(
     TARGETS detools

--- a/recipes/detools/all/CMakeLists.txt
+++ b/recipes/detools/all/CMakeLists.txt
@@ -1,9 +1,22 @@
 cmake_minimum_required(VERSION 3.1)
-project(detools C)
+project(detools LANGUAGES C)
 
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
+find_package(heatshrink REQUIRED CONFIG)
+find_package(lz4 REQUIRED CONFIG)
+find_package(LibLZMA REQUIRED CONFIG)
 
-add_library(detools source_subfolder/c/detools.c)
-install(TARGETS detools DESTINATION lib)
-install(FILES source_subfolder/c/detools.h DESTINATION include)
+add_library(detools ${DETOOLS_SRC_DIR}/c/detools.c)
+target_link_libraries(detools PRIVATE
+    heatshrink::heatshrink
+    lz4::lz4
+    LibLZMA::LibLZMA
+)
+
+install(
+    TARGETS detools
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(
+    FILES ${DETOOLS_SRC_DIR}/c/detools.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/recipes/detools/all/conandata.yml
+++ b/recipes/detools/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.53.0":
+    url: "https://github.com/eerimoq/detools/archive/refs/tags/0.53.0.tar.gz"
+    sha256: "9ea3b547627f5d37756023d91c701ef18fb2748b801b985e55c74c7fe8247ac2"
   "0.51.0":
-    url: "https://github.com/eerimoq/detools/archive/refs/tags/0.51.0.zip"
-    sha256: 604175d493a9df5d19e78a55cd183e9c44789ee552f24d1a2b7466d58628c1ac
+    url: "https://github.com/eerimoq/detools/archive/refs/tags/0.51.0.tar.gz"
+    sha256: "18e5f08fbc3c09ec9d805fd859838940f57a3f064724bad4897461f9a3c8f87c"

--- a/recipes/detools/all/conanfile.py
+++ b/recipes/detools/all/conanfile.py
@@ -37,8 +37,7 @@ class DetoolsConan(ConanFile):
 
     def requirements(self):
         self.requires('heatshrink/0.4.1', transitive_headers=True)
-        self.requires('lz4/1.9.4')
-        self.requires('xz_utils/5.4.4')
+        self.requires('xz_utils/5.4.4', transitive_headers=True)
 
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:

--- a/recipes/detools/all/conanfile.py
+++ b/recipes/detools/all/conanfile.py
@@ -1,17 +1,20 @@
-import functools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import get, copy
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+import os
 
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
-
+required_conan_version = ">=1.53.0"
 
 class DetoolsConan(ConanFile):
     name = "detools"
     description = "Binary delta encoding"
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/eerimoq/detools"
-    license = "MIT"
     topics = ("delta-compression", "delta-update", "delta-encoding",
               "ota", "bsdiff", "hdiffpatch")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -22,43 +25,43 @@ class DetoolsConan(ConanFile):
         "fPIC": True,
     }
     exports_sources = "CMakeLists.txt"
-    generators = "cmake"
-    requires = ['heatshrink/0.4.1', 'lz4/1.9.3', 'xz_utils/5.2.5']
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
-    def validate(self):
-        if self.settings.os not in ["Linux", "FreeBSD"]:
-            raise ConanInvalidConfiguration("This library is only compatible with Linux and FreeBSD")
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires('heatshrink/0.4.1', transitive_headers=True)
+        self.requires('lz4/1.9.4')
+        self.requires('xz_utils/5.4.4')
+
+    def validate(self):
+        if self.settings.os not in ["Linux", "FreeBSD"]:
+            raise ConanInvalidConfiguration(f"{self.ref} is only compatible with Linux and FreeBSD")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["DETOOLS_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
 
     def package_info(self):

--- a/recipes/detools/all/test_package/CMakeLists.txt
+++ b/recipes/detools/all/test_package/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(PackageTest C)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(PackageTest LANGUAGES C)
 
 find_package(detools REQUIRED CONFIG)
 
 add_executable(test_package test_package.c)
-target_link_libraries(test_package detools::detools)
+target_link_libraries(test_package PRIVATE detools::detools)

--- a/recipes/detools/all/test_package/CMakeLists.txt
+++ b/recipes/detools/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(PackageTest LANGUAGES C)
 
 find_package(detools REQUIRED CONFIG)

--- a/recipes/detools/all/test_package/conanfile.py
+++ b/recipes/detools/all/test_package/conanfile.py
@@ -1,18 +1,19 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
-from conans import ConanFile, CMake, tools
 
-
-class DetoolsTestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
-    def build_requirements(self):
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            self.build_requires("cmake/3.20.1")
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -20,13 +21,6 @@ class DetoolsTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if tools.cross_building(self):
-            return
-
-        bin_path = os.path.join("bin", "test_package")
-        old_path = os.path.join(self.source_folder, "old")
-        patch_path = os.path.join(self.source_folder, "patch")
-        patched_path = os.path.join(self.build_folder, "patched")
-
-        self.run(f"{bin_path} {old_path} {patch_path} {patched_path}",
-                 run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/detools/all/test_package/test_package.c
+++ b/recipes/detools/all/test_package/test_package.c
@@ -1,23 +1,60 @@
 #include <stdlib.h>
 #include "detools.h"
 
-#define EXPECTED_PATCHED_FILE_SIZE 2780
-
-int main(int argc, const char *argv[])
+/* Helper functions. */
+static int flash_read(void *arg_p, void *dst_p, uintptr_t src, size_t size)
 {
+    return (0);
+}
+
+static int flash_write(void *arg_p, uintptr_t dst, void *src_p, size_t size)
+{
+    return (0);
+}
+
+static int flash_erase(void *arg_p, uintptr_t addr, size_t size)
+{
+    return (0);
+}
+
+static int step_set(void *arg_p, int step)
+{
+    return (0);
+}
+
+static int step_get(void *arg_p, int *step_p)
+{
+    return (0);
+}
+
+static int serial_read(uint8_t *buf_p, size_t size)
+{
+    return (0);
+}
+
+static int verify_written_data(int to_size, uint32_t to_crc)
+{
+    return (0);
+}
+
+int main()
+{
+    struct detools_apply_patch_in_place_t apply_patch;
+    uint8_t buf[256];
     int res;
+    size_t patch_size = 512;
 
-    if (argc != 4) {
-        printf("Wrong number of arguments.\n");
+    /* Initialize the in-place apply patch object. */
+    res = detools_apply_patch_in_place_init(&apply_patch,
+                                            flash_read,
+                                            flash_write,
+                                            flash_erase,
+                                            step_set,
+                                            step_get,
+                                            patch_size,
+                                            NULL);
 
-        return EXIT_FAILURE;
-    }
-
-    res = detools_apply_patch_filenames(argv[1], argv[2], argv[3]);
-
-    if (res == EXPECTED_PATCHED_FILE_SIZE) {
-        return EXIT_SUCCESS;
-    } else {
-        return EXIT_FAILURE;
+    if (res != 0) {
+        return (res);
     }
 }

--- a/recipes/detools/config.yml
+++ b/recipes/detools/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.53.0":
+    folder: "all"
   "0.51.0":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **detools/***

- support conan v2
- add package_type
- add version 0.53.0
- update dependencies
- replace zip to tar ball

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
