### PR TITLE
netcdf: version range for libcurl + add package_type

### DIFF
--- a/recipes/netcdf/all/conanfile.py
+++ b/recipes/netcdf/all/conanfile.py
@@ -17,7 +17,7 @@ class NetcdfConan(ConanFile):
     license = "BSD-3-Clause"
     homepage = "https://github.com/Unidata/netcdf-c"
     url = "https://github.com/conan-io/conan-center-index"
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/netcdf/all/conanfile.py
+++ b/recipes/netcdf/all/conanfile.py
@@ -71,7 +71,7 @@ class NetcdfConan(ConanFile):
                 self.requires("hdf5/1.14.1")
 
         if self.options.dap or self.options.byterange:
-            self.requires("libcurl/8.2.1")
+            self.requires("libcurl/[>=7.78.0 <9]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/netcdf/all/conanfile.py
+++ b/recipes/netcdf/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
 
 
 class NetcdfConan(ConanFile):
@@ -89,10 +89,6 @@ class NetcdfConan(ConanFile):
         tc.variables["ENABLE_BYTERANGE"] = self.options.byterange
         tc.variables["USE_HDF5"] = self.options.with_hdf5
         tc.variables["NC_FIND_SHARED_LIBS"] = self.options.with_hdf5 and self.dependencies["hdf5"].options.shared
-
-        # Honor BUILD_SHARED_LIBS from conan_toolchain (see https://github.com/conan-io/conan/issues/11840)
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
-
         tc.generate()
 
         tc = CMakeDeps(self)

--- a/recipes/netcdf/all/conanfile.py
+++ b/recipes/netcdf/all/conanfile.py
@@ -74,7 +74,7 @@ class NetcdfConan(ConanFile):
             self.requires("libcurl/[>=7.78.0 <9]")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/netcdf/all/conanfile.py
+++ b/recipes/netcdf/all/conanfile.py
@@ -123,8 +123,6 @@ class NetcdfConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "netcdf")
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["libnetcdf"].libs = ["netcdf"]
-        self.cpp_info.components["libnetcdf"].libdirs       = ["lib"]
-        self.cpp_info.components["libnetcdf"].includedirs   = ["include"]
         if self._with_hdf5:
             self.cpp_info.components["libnetcdf"].requires.append("hdf5::hdf5")
         if self.options.dap or self.options.byterange:


### PR DESCRIPTION
Also remove several workarounds (CMAKE_POLICY_DEFAULT_CMP0077 and explicit libdirs & includedirs in components) for old conan clients (not required anymore with conan >=1.54.0)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
