### PR TITLE
[changelog] New C3I Jenkins version: release 2023.10.26

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 26-Oct-2023 - 12:13 CEST
+
+- [feature] Allow X.Y semver for version bumps
+- [feature] Add assert message for parent commit checks on PR checkout
+- [feature] JobRelauncher restarts both Conan v1 and v2 pipelines.
+- [fix] Do not close the report issue of the recipe export check
+
 ### 11-Oct-2023 - 12:17 CEST
 
 - [feature] Update Conan 2.x to the version 2.0.12 in the CI


### PR DESCRIPTION
- Allow X.Y semver for version bumps

  So far, CCI has only accepting `<semver>` format to be automatically marked as `bump version`, but looking at some projects that only use `<major>.<minor>` format, they could be aggregated to the same rule without problem. However, in case adding a new version to a PR only, but mixing between `<semver>` and `<major>.<minor>`, this will not be considered an automatic bump version by the CI bot.

- Add assert message for parent commit checks on PR checkout

  Sometimes users can experience an internal CI error related to concurrency: 
  
  `parentCommits[1] == masterCommit`

  This error is a bit hard to track, so some logs were added to filter it better when failing in the CI.

- JobRelauncher restarts both Conan v1 and v2 pipelines

  When a build fails due an unexpected and internal error, or the CI build system is under maintenance, there is an internal CI build dedicated to re-trigger them. We added a new entry in `.c3i/config_vx.yml` to list which builds should be restarted.

- Do not close the report issue of the recipe export check

  The Conan export check, used to validate if a recipe is broken and hooks are passing, closes its dedicated issue in case all recipes are good and nothing fails, but opens again as soon as it runs again. It caused notification noise, where users received several e-mails about that issue being closed/opened everyday. Now it will be open always.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
