### PR TITLE
openvino: ported upstream patch for C++23 support

### DIFF
--- a/recipes/openvino/all/conandata.yml
+++ b/recipes/openvino/all/conandata.yml
@@ -49,3 +49,7 @@ patches:
       patch_description: "Support macos 14"
       patch_type: "portability"
       patch_source: "https://github.com/openvinotoolkit/openvino/pull/19946"
+    - patch_file: "patches/2023.1.0/0007-compilation-c++23.patch"
+      patch_description: "Compilation with C++23"
+      patch_type: "portability"
+      patch_source: "https://github.com/openvinotoolkit/openvino/pull/20724"

--- a/recipes/openvino/all/patches/2023.1.0/0007-compilation-c++23.patch
+++ b/recipes/openvino/all/patches/2023.1.0/0007-compilation-c++23.patch
@@ -1,0 +1,38 @@
+diff --git a/src/core/src/type.cpp b/src/core/src/type.cpp
+index 7d6aef2c46..c75d9a7476 100644
+--- a/src/core/src/type.cpp
++++ b/src/core/src/type.cpp
+@@ -37,7 +37,7 @@ std::string DiscreteTypeInfo::get_version() const {
+     if (version_id) {
+         return std::string(version_id);
+     }
+-    return nullptr;
++    return {};
+ }
+ 
+ DiscreteTypeInfo::operator std::string() const {
+diff --git a/src/frontends/onnx/frontend/src/ops_bridge.hpp b/src/frontends/onnx/frontend/src/ops_bridge.hpp
+index bbd6bfd129..4e2d2edb2b 100644
+--- a/src/frontends/onnx/frontend/src/ops_bridge.hpp
++++ b/src/frontends/onnx/frontend/src/ops_bridge.hpp
+@@ -5,6 +5,7 @@
+ #pragma once
+ 
+ #include <cstdint>
++#include <iterator>
+ #include <map>
+ #include <mutex>
+ #include <string>
+diff --git a/src/inference/src/dev/make_tensor.cpp b/src/inference/src/dev/make_tensor.cpp
+index 2e319c04c5..5e3fa241ea 100644
+--- a/src/inference/src/dev/make_tensor.cpp
++++ b/src/inference/src/dev/make_tensor.cpp
+@@ -520,7 +520,7 @@ public:
+     }
+ 
+     void allocate() noexcept override {
+-        if (ie::TBlob<T>::buffer() != tensor->data()) {
++        if ((void*)ie::TBlob<T>::buffer() != tensor->data()) {
+             ie::TBlob<T>::_allocator =
+                 ie::details::make_pre_allocator(static_cast<T*>(tensor->data()), tensor->get_byte_size());
+             ie::TBlob<T>::allocate();


### PR DESCRIPTION
Specify library name and version:  **openvino/2023.1.0**

**Changes:** Ported upstream patch for compilation with C++23 for better portability

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
