### PR TITLE
[onetbb] Use validate method for package compatibility

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -102,7 +102,7 @@ class OneTBBConan(ConanFile):
         if Version(self.version) < "2021.6.0" and self.info.options.get_safe("tbbproxy"):
             self.info.options.tbbproxy = True
 
-    def validate_build(self):
+    def validate(self):
         if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "11.0":
             raise ConanInvalidConfiguration(f"{self.ref} couldn't be built by apple-clang < 11.0")
         if not self.options.get_safe("shared", True):
@@ -114,7 +114,6 @@ class OneTBBConan(ConanFile):
                 )
             self.output.warning("oneTBB strongly discourages usage of static linkage")
 
-    def validate(self):
         if self._tbbbind_explicit_hwloc and not self.dependencies["hwloc"].options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} requires hwloc:shared=True to be built.")
 


### PR DESCRIPTION
Specify library name and version:  **onetbb/2021.3.0**

The PR https://github.com/conan-io/conan-center-index/pull/19152 is blocked because OneTBB is missing. The explanation is simple: We raise an invalid configuration when building OneTBB, but not when consuming, so there is no package, and will not be available ever. 

That condition should be moved to `validate()` instead. 

/cc @fschoenm

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
