### PR TITLE
libwebm: Update to 1.0.0.31 to fix C++20 builds.

### DIFF
--- a/recipes/libwebm/all/conandata.yml
+++ b/recipes/libwebm/all/conandata.yml
@@ -1,3 +1,5 @@
 sources:
+  '1.0.0.31':
+    url: 'https://chromium.googlesource.com/webm/libwebm/+archive/libwebm-1.0.0.31.tar.gz'
   '1.0.0.30':
     url: 'https://chromium.googlesource.com/webm/libwebm/+archive/libwebm-1.0.0.30.tar.gz'

--- a/recipes/libwebm/all/test_package/conanfile.py
+++ b/recipes/libwebm/all/test_package/conanfile.py
@@ -1,12 +1,11 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
@@ -14,6 +13,15 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Later versions of the library use prefixed headers, 1.0.0.30 is the only
+        # version supported by this recipe that does not.
+        if self.dependencies[self.tested_reference_str].ref.version == "1.0.0.30":
+            tc.preprocessor_definitions["UNPREFIXED_HEADERS"] = "1"
+        
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/libwebm/all/test_package/test_package.cpp
+++ b/recipes/libwebm/all/test_package/test_package.cpp
@@ -1,7 +1,13 @@
 #include <cstdint>
 #include <cstdio>
+
+#ifdef UNPREFIXED_HEADERS
 #include <webm/mkvmuxerutil.h>
 #include <webm/mkvparser.h>
+#else
+#include <webm/mkvmuxer/mkvmuxerutil.h>
+#include <webm/mkvparser/mkvparser.h>
+#endif // UNPREFIXED_HEADERS
 
 int main(void) {
   int32_t major, minor, build, revision;

--- a/recipes/libwebm/config.yml
+++ b/recipes/libwebm/config.yml
@@ -1,3 +1,5 @@
 versions:
+  '1.0.0.31':
+    folder: all
   '1.0.0.30':
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libwebm/1.0.0.31**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The library makes use of some deprecated features which were removed in the C++20 spec. Some compilers are now getting around to removing these, for example older versions of this library no longer build with XCode 15 when targeting C++20. 

This update fixes the build when targeting C++20, without breaking it when targeting older spec versions.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
