### PR TITLE
libarchive: patch to include getopt.h when required

### DIFF
--- a/recipes/libarchive/all/conandata.yml
+++ b/recipes/libarchive/all/conandata.yml
@@ -28,6 +28,7 @@ patches:
     - patch_file: "patches/0007-3.7.1-include-getopt.patch"
       patch_description: "include getopt.h if HAVE_GETOPT_OPTRESET is defined"
       patch_type: "portability"
+      patch_source: "https://github.com/libarchive/libarchive/pull/2007"
     - patch_file: "patches/0001-3.7.1-zlib-winapi.patch"
       patch_description: "Remove broken ZLIB WINAPI check"
       patch_type: "portability"

--- a/recipes/libarchive/all/conandata.yml
+++ b/recipes/libarchive/all/conandata.yml
@@ -25,6 +25,9 @@ sources:
     sha256: "8643d50ed40c759f5412a3af4e353cffbce4fdf3b5cf321cb72cacf06b2d825e"
 patches:
   "3.7.1":
+    - patch_file: "patches/0007-3.7.1-include-getopt.patch"
+      patch_description: "include getopt.h if HAVE_GETOPT_OPTRESET is defined"
+      patch_type: "portability"
     - patch_file: "patches/0001-3.7.1-zlib-winapi.patch"
       patch_description: "Remove broken ZLIB WINAPI check"
       patch_type: "portability"

--- a/recipes/libarchive/all/patches/0007-3.7.1-include-getopt.patch
+++ b/recipes/libarchive/all/patches/0007-3.7.1-include-getopt.patch
@@ -1,0 +1,13 @@
+--- unzip/bsdunzip.c	2023-07-29 19:27:43.000000000 +0200
++++ unzip/bsdunzip.c	2023-10-28 13:19:27.181106700 +0200
+@@ -78,6 +78,10 @@
+ #include <sys/time.h>
+ #endif
+ #endif
++#ifdef HAVE_GETOPT_OPTRESET
++#include <getopt.h>
++#endif
++
+ 
+ #include <archive.h>
+ #include <archive_entry.h>


### PR DESCRIPTION
libarchive 3.7.1

Including getopt.h when HAVE_GETOPT_OPTRESET is defined.
[Upstream PR](https://github.com/libarchive/libarchive/pull/2007)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
