### PR TITLE
qt/5.15.11: Expose QSvgPlugin and QSvgIconPlugin

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1253,6 +1253,8 @@ Examples = bin/datadir/examples""")
 
         if self.options.qtsvg and self.options.gui:
             _create_module("Svg", ["Gui"])
+            _create_plugin("QSvgIconPlugin", "qsvgicon", "iconengines", [])
+            _create_plugin("QSvgPlugin", "qsvg", "imageformats", [])
 
         if self.options.qtwayland and self.options.gui:
             _create_module("WaylandClient", ["Gui", "wayland::wayland-client"])


### PR DESCRIPTION
fixes #20816
Specify library name and version:  **qt/5.15.11**

I wrote a little proof of concept here:
https://github.com/fnadeau/qt-demo.git
A simple app that display 4 buttons with icons. Two use SVG and two use PNG as image source.

When build with ```qt/5.15.11``` in conanfile.txt, this is the result

![notworking](https://github.com/conan-io/conan-center-index/assets/1904563/48e5d25b-ca30-4875-9076-7e2b5af37a1b)

If locally building this PR with something like:
```
conan create .\recipes\qt\5.x.x\ --name qt --version 5.15.11 -pr:b default -pr:h default -o qt*:qtsvg=True --user fnadeau --channel github
```
and changing ```qt/5.15.11``` to ```qt/5.15.11@fnadeau/github``` in conanfile.txt, you'll get this

![working](https://github.com/conan-io/conan-center-index/assets/1904563/9721f411-5bd5-4eb8-9e81-05fa28df37cb)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
  I'm using conan 2.0, not yet supported as per documentation, but I did try at least one configuration.