### PR TITLE
miniaudio: add version 0.11.18

### DIFF
--- a/recipes/miniaudio/all/conandata.yml
+++ b/recipes/miniaudio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.18":
+    url: "https://github.com/mackron/miniaudio/archive/0.11.18.tar.gz"
+    sha256: "85ca916266d809b39902e180a6d16f82caea9c2ea1cea6d374413641b7ba48c3"
   "0.11.17":
     url: "https://github.com/mackron/miniaudio/archive/0.11.17.tar.gz"
     sha256: "4b139065f7068588b73d507d24e865060e942eb731f988ee5a8f1828155b9480"

--- a/recipes/miniaudio/config.yml
+++ b/recipes/miniaudio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.18":
+    folder: all
   "0.11.17":
     folder: all
   "0.11.16":


### PR DESCRIPTION
Specify library name and version:  **miniaudio/0.11.18**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
