### PR TITLE
asio-grpc: add version 2.7.0, update asio

### DIFF
--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.7.0":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v2.7.0.tar.gz"
+    sha256: "a4a3deeabbdef37a8e7238e25b6f26b63071151c4b49e1f2f86c528da54eed79"
   "2.6.0":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v2.6.0.tar.gz"
     sha256: "9f17f1dfe390667c71d8e0645937afa36f1a0e146f60f6036c7b4e12b09ed14e"

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -60,7 +60,7 @@ class AsioGrpcConan(ConanFile):
         if self._local_allocator_option == "boost_container" or self.options.backend == "boost":
             self.requires("boost/1.83.0")
         if self.options.backend == "asio":
-            self.requires("asio/1.28.1")
+            self.requires("asio/1.28.2")
         if self.options.backend == "unifex":
             self.requires("libunifex/cci.20220430")
 

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -85,6 +85,9 @@ class AsioGrpcConan(ConanFile):
                 f"{self.name} requires C++{self._min_cppstd}. Your compiler is unknown. Assuming it supports"
                 f" C++{self._min_cppstd}."
             )
+        if Version(self.version) == "2.7.0" and \
+            self.settings.compiler == "gcc" and Version(self.settings.compiler.version).major == "11":
+            raise ConanInvalidConfiguration(f"{self.ref} does not support gcc 11.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.7.0":
+    folder: all
   "2.6.0":
     folder: all
   "2.5.1":


### PR DESCRIPTION
Specify library name and version:  **asio-grpc/***

The version of grpc is kept at 1.50.1 because 1.54.3 causes compile errors.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
