### PR TITLE
yaml-cpp: fix interface definition for windows + provide `yaml-cpp::yaml-cpp` imported target

### DIFF
--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -111,6 +111,7 @@ class YamlCppConan(ConanFile):
             self.cpp_info.system_libs.append("m")
         if is_msvc(self):
             self.cpp_info.defines.append("_NOEXCEPT=noexcept")
+        if self.settings.os == "Windows":
             if Version(self.version) < "0.8.0" and self.options.shared:
                 self.cpp_info.defines.append("YAML_CPP_DLL")
             if Version(self.version) >= "0.8.0" and not self.options.shared:

--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -111,10 +111,11 @@ class YamlCppConan(ConanFile):
             self.cpp_info.system_libs.append("m")
         if is_msvc(self):
             self.cpp_info.defines.append("_NOEXCEPT=noexcept")
-        if self.settings.os == "Windows":
-            if Version(self.version) < "0.8.0" and self.options.shared:
+        if Version(self.version) < "0.8.0":
+            if self.settings.os == "Windows" and self.options.shared:
                 self.cpp_info.defines.append("YAML_CPP_DLL")
-            if Version(self.version) >= "0.8.0" and not self.options.shared:
+        else:
+            if not self.options.shared:
                 self.cpp_info.defines.append("YAML_CPP_STATIC_DEFINE")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed

--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -104,7 +104,8 @@ class YamlCppConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "yaml-cpp")
-        self.cpp_info.set_property("cmake_target_name", "yaml-cpp")
+        self.cpp_info.set_property("cmake_target_name", "yaml-cpp::yaml-cpp")
+        self.cpp_info.set_property("cmake_target_aliases", ["yaml-cpp"]) # CMake imported target before 0.8.0
         self.cpp_info.set_property("pkg_config_name", "yaml-cpp")
         self.cpp_info.libs = collect_libs(self)
         if self.settings.os in ("Linux", "FreeBSD"):

--- a/recipes/yaml-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/yaml-cpp/all/test_package/CMakeLists.txt
@@ -4,5 +4,5 @@ project(test_package LANGUAGES CXX)
 find_package(yaml-cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE yaml-cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE yaml-cpp::yaml-cpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)


### PR DESCRIPTION
- Since 0.8.0, `YAML_CPP_STATIC_DEFINE` is an interface definition of static yaml-cpp, irrespective of compiler or OS (see https://github.com/jbeder/yaml-cpp/blob/0.8.0/CMakeLists.txt#L126). And looking at https://github.com/jbeder/yaml-cpp/blob/0.8.0/include/yaml-cpp/dll.h, you can quickly see that it's very important on windows (not only msvc), otherwise you have tones of `__declspec(dllimport)` in public headers of static lib, which is not good.
- Since 0.8.0 also, imported target is namespaced (https://github.com/jbeder/yaml-cpp/blob/0.8.0/CMakeLists.txt#L171), therefore `cmake_target_name` is updated with this new target. Non-namespaced target is still provided in `cmake_target_aliases` for compatibility.

closes https://github.com/conan-io/conan-center-index/issues/20825

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
