### PR TITLE
Bump version for vulkan-validationlayers/1.3.243.0

### DIFF
--- a/recipes/vulkan-validationlayers/all/conandata.yml
+++ b/recipes/vulkan-validationlayers/all/conandata.yml
@@ -22,7 +22,7 @@ sources:
     sha256: "927c1cb98c81fe8a1a529cf2d977d701dcda49c495a19583dc00e178b6757203"
 patches:
   "1.3.243.0":
-    - patch_file: "patches/1.3.239.0-0001-fix-cmake.patch"
+    - patch_file: "patches/1.3.243.0-0001-fix-cmake.patch"
       patch_description: "CMake: Adapt to conan"
       patch_type: "conan"
   "1.3.239.0":

--- a/recipes/vulkan-validationlayers/all/conandata.yml
+++ b/recipes/vulkan-validationlayers/all/conandata.yml
@@ -21,6 +21,10 @@ sources:
     url: "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/sdk-1.3.211.0.tar.gz"
     sha256: "927c1cb98c81fe8a1a529cf2d977d701dcda49c495a19583dc00e178b6757203"
 patches:
+  "1.3.243.0":
+    - patch_file: "patches/1.3.239.0-0001-fix-cmake.patch"
+      patch_description: "CMake: Adapt to conan"
+      patch_type: "conan"
   "1.3.239.0":
     - patch_file: "patches/1.3.239.0-0001-fix-cmake.patch"
       patch_description: "CMake: Adapt to conan"

--- a/recipes/vulkan-validationlayers/all/conandata.yml
+++ b/recipes/vulkan-validationlayers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.243.0":
+    url: "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/sdk-1.3.243.0.tar.gz"
+    sha256: "fd9f6c24027de177b2fb0eb6385542d62f4c21665a8d4cc7e1c118688e0836de"
   "1.3.239.0":
     url: "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/sdk-1.3.239.0.tar.gz"
     sha256: "7aa7fb46e25e5ef0144d29c92122b631dc7c7c6804a6339f195b368ad53328e4"

--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -55,7 +55,8 @@ class VulkanValidationLayersConan(ConanFile):
 
     @property
     def _needs_wayland_for_build(self):
-        return self.options.get_safe("with_wsi_wayland") and Version(self.version) < "1.3.231"
+        return (self.options.get_safe("with_wsi_wayland") and
+                (Version(self.version) < "1.3.231" or Version(self.version) >= "1.3.243.0"))
 
     @property
     def _needs_pkg_config(self):

--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -182,9 +182,10 @@ class VulkanValidationLayersConan(ConanFile):
         apply_conandata_patches(self)
 
         cmake_lists_path = os.path.join(self.source_folder, "layers", "CMakeLists.txt")
-        # This error is not correct, it only occurs because a generator expression isn't evaluated
-        # in an if statement. It has been disabled to allow the build to complete.
         if Version(self.version) >= "1.3.239":
+            # Without this an incorrect error is issued due to the above CMakeLists.txt
+            #  using generator expressions in an if statement.
+            # It has been disabled to allow the build to complete.
             replace_in_file(
                 self, cmake_lists_path,
                 "message(FATAL_ERROR \"Unable to find spirv/unified1\")",

--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -180,17 +180,29 @@ class VulkanValidationLayersConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
+
+        cmake_lists_path = os.path.join(self.source_folder, "layers", "CMakeLists.txt")
+        # This error is not correct, it only occurs because a generator expression isn't evaluated
+        # in an if statement. It has been disabled to allow the build to complete.
+        if Version(self.version) >= "1.3.239":
+            replace_in_file(
+                self, cmake_lists_path,
+                "message(FATAL_ERROR \"Unable to find spirv/unified1\")",
+                "message(STATUS \"Unable to find spirv/unified1\")",
+            )
         # Vulkan-ValidationLayers relies on Vulkan-Headers version from CMake config file
         # to set api_version in its manifest file, but this value MUST have format x.y.z (no extra number).
         # FIXME: find a way to force correct version in CMakeDeps of vulkan-headers recipe?
-        if Version(self.version) >= "1.3.235":
+        # NOTE: At version 1.3.239, the JSON_API_VERSION was removed from the cmakelists file, 
+        if Version(self.version) >= "1.3.235" and Version(self.version) < "1.3.239":
             vk_version = Version(self.dependencies["vulkan-headers"].ref.version)
             sanitized_vk_version = f"{vk_version.major}.{vk_version.minor}.{vk_version.patch}"
             replace_in_file(
-                self, os.path.join(self.source_folder, "layers", "CMakeLists.txt"),
+                self, cmake_lists_path,
                 "set(JSON_API_VERSION ${VulkanHeaders_VERSION})",
                 f"set(JSON_API_VERSION \"{sanitized_vk_version}\")",
             )
+            
         # FIXME: two CMake module/config files should be generated (SPIRV-ToolsConfig.cmake and SPIRV-Tools-optConfig.cmake),
         # but it can't be modeled right now in spirv-tools recipe
         if not os.path.exists(os.path.join(self.generators_folder, "SPIRV-Tools-optConfig.cmake")):

--- a/recipes/vulkan-validationlayers/all/dependencies/dependencies-1.3.243.0.yml
+++ b/recipes/vulkan-validationlayers/all/dependencies/dependencies-1.3.243.0.yml
@@ -1,0 +1,3 @@
+spirv-headers: "1.3.243.0"
+spirv-tools: "1.3.243.0"
+vulkan-headers: "1.3.243.0"

--- a/recipes/vulkan-validationlayers/all/dependencies/dependencies-1.4.309.0.yml
+++ b/recipes/vulkan-validationlayers/all/dependencies/dependencies-1.4.309.0.yml
@@ -1,0 +1,3 @@
+spirv-headers: "1.4.309.0"
+spirv-tools: "1.4.309.0"
+vulkan-headers: "1.4.309.0"

--- a/recipes/vulkan-validationlayers/all/dependencies/dependencies-1.4.309.0.yml
+++ b/recipes/vulkan-validationlayers/all/dependencies/dependencies-1.4.309.0.yml
@@ -1,3 +1,0 @@
-spirv-headers: "1.4.309.0"
-spirv-tools: "1.4.309.0"
-vulkan-headers: "1.4.309.0"

--- a/recipes/vulkan-validationlayers/all/patches/1.3.243.0-0001-fix-cmake.patch
+++ b/recipes/vulkan-validationlayers/all/patches/1.3.243.0-0001-fix-cmake.patch
@@ -1,0 +1,11 @@
+--- a/layers/CMakeLists.txt
++++ b/layers/CMakeLists.txt
+@@ -115,7 +115,7 @@ endif()
+ 
+ find_package(PythonInterp 3 QUIET)
+ 
+-if (PYTHONINTERP_FOUND)
++if (0)
+     # Get the include directory of the SPIRV-Headers
+     get_target_property(SPIRV_HEADERS_INCLUDE_DIR SPIRV-Headers::SPIRV-Headers INTERFACE_INCLUDE_DIRECTORIES)
+ 

--- a/recipes/vulkan-validationlayers/config.yml
+++ b/recipes/vulkan-validationlayers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.243.0":
+    folder: all
   "1.3.239.0":
     folder: all
   "1.3.236.0":


### PR DESCRIPTION
Specify library name and version:  **vulkan-validationlayers/1.3.243.0**

This library was out of sync with the other Vulkan libraries on Conan Center, specifically vulkan-headers and, vulkan-loader. This patch adds support for the same version of validation layer, so that validation layers can be used with the headers and libraries packages.
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
