### PR TITLE
Minor clean up of template packages

### DIFF
--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd, cross_building
 from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
-from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
+from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path
 from conan.tools.scm import Version

--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -42,6 +42,10 @@ class PackageConan(ConanFile):
     }
 
     @property
+    def _min_cppstd(self):
+        return 11
+
+    @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
@@ -74,7 +78,7 @@ class PackageConan(ConanFile):
     def validate(self):
         # validate the minimum cpp standard supported. Only for C++ projects
         if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, 11)
+            check_min_cppstd(self, self._min_cppstd)
         if self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
             raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
 

--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -58,8 +58,8 @@ class PackageConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
         # for plain C projects only
-        self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         # src_folder must use the same source folder name the project

--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -44,7 +44,7 @@ class PackageConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return 11
+        return 14
 
     # in case the project requires C++14/17/20/... the minimum compiler version should be listed
     @property

--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -155,7 +155,7 @@ class PackageConan(ConanFile):
         autotools.make()
 
     def package(self):
-        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         autotools = Autotools(self)
         autotools.install()
 

--- a/docs/package_templates/cmake_package/all/conanfile.py
+++ b/docs/package_templates/cmake_package/all/conanfile.py
@@ -1,11 +1,11 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
+from conan.tools.microsoft import check_min_vs, is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 import os
 
 

--- a/docs/package_templates/cmake_package/all/conanfile.py
+++ b/docs/package_templates/cmake_package/all/conanfile.py
@@ -46,9 +46,11 @@ class PackageConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "7",
-            "clang": "7",
             "apple-clang": "10",
+            "clang": "7",
+            "gcc": "7",
+            "msvc": "191",
+            "Visual Studio": "15",
         }
 
     # no exports_sources attribute, but export_sources(self) method instead
@@ -79,13 +81,11 @@ class PackageConan(ConanFile):
         # validate the minimum cpp standard supported. For C++ projects only
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)
-        check_min_vs(self, 191)
-        if not is_msvc(self):
-            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-            if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-                raise ConanInvalidConfiguration(
-                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-                )
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
         # in case it does not work in another configuration, it should validated here too
         if is_msvc(self) and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")

--- a/docs/package_templates/cmake_package/all/conanfile.py
+++ b/docs/package_templates/cmake_package/all/conanfile.py
@@ -64,8 +64,8 @@ class PackageConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
         # for plain C projects only
-        self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         # src_folder must use the same source folder name the project

--- a/docs/package_templates/cmake_package/all/conanfile.py
+++ b/docs/package_templates/cmake_package/all/conanfile.py
@@ -131,7 +131,7 @@ class PackageConan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
 

--- a/docs/package_templates/cmake_package/all/conanfile.py
+++ b/docs/package_templates/cmake_package/all/conanfile.py
@@ -40,7 +40,7 @@ class PackageConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return 17
+        return 14
 
     # in case the project requires C++14/17/20/... the minimum compiler version should be listed
     @property

--- a/docs/package_templates/cmake_package/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/cmake_package/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(test_package C) # if the project is pure C
-# project(test_package CXX) # if the project uses c++
+project(test_package LANGUAGES C) # if the project is pure C
+# project(test_package LANGUAGES CXX) # if the project uses c++
 
 find_package(package REQUIRED CONFIG)
 

--- a/docs/package_templates/header_only/all/conanfile.py
+++ b/docs/package_templates/header_only/all/conanfile.py
@@ -35,9 +35,9 @@ class PackageConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "apple-clang": "5.1",
-            "clang": "5",
-            "gcc": "5",
+            "apple-clang": "10",
+            "clang": "7",
+            "gcc": "7",
             "msvc": "191",
             "Visual Studio": "15",
         }

--- a/docs/package_templates/header_only/all/conanfile.py
+++ b/docs/package_templates/header_only/all/conanfile.py
@@ -35,11 +35,11 @@ class PackageConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "Visual Studio": "15",
-            "msvc": "191",
-            "gcc": "5",
-            "clang": "5",
             "apple-clang": "5.1",
+            "clang": "5",
+            "gcc": "5",
+            "msvc": "191",
+            "Visual Studio": "15",
         }
 
     # Use the export_sources(self) method instead of the exports_sources attribute.

--- a/docs/package_templates/header_only/all/conanfile.py
+++ b/docs/package_templates/header_only/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os

--- a/docs/package_templates/header_only/all/conanfile.py
+++ b/docs/package_templates/header_only/all/conanfile.py
@@ -85,12 +85,12 @@ class PackageConan(ConanFile):
 
     # Copy all files to the package folder
     def package(self):
-        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         copy(
             self,
-            pattern="*.h",
-            dst=os.path.join(self.package_folder, "include"),
-            src=os.path.join(self.source_folder, "include"),
+            "*.h",
+            os.path.join(self.source_folder, "include"),
+            os.path.join(self.package_folder, "include"),
         )
 
     def package_info(self):

--- a/docs/package_templates/meson_package/all/conanfile.py
+++ b/docs/package_templates/meson_package/all/conanfile.py
@@ -98,7 +98,7 @@ class PackageConan(ConanFile):
     # if another tool than the compiler or Meson is required to build the project (pkgconf, bison, flex etc)
     def build_requirements(self):
         # CCI policy assumes that Meson may not be installed on consumers machine
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.2.3")
         # pkgconf is largely used by Meson, it should be added in build requirement when there are dependencies
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.0.3")

--- a/docs/package_templates/meson_package/all/conanfile.py
+++ b/docs/package_templates/meson_package/all/conanfile.py
@@ -45,7 +45,7 @@ class PackageConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return 17
+        return 14
 
     # in case the project requires C++14/17/20/... the minimum compiler version should be listed
     @property

--- a/docs/package_templates/meson_package/all/test_package/conanfile.py
+++ b/docs/package_templates/meson_package/all/test_package/conanfile.py
@@ -18,7 +18,7 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.2.3")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.0.3")
 

--- a/docs/package_templates/msbuild_package/all/conanfile.py
+++ b/docs/package_templates/msbuild_package/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, MSBuild, MSBuildDeps, MSBuildToolchain
+from conan.tools.microsoft import MSBuild, MSBuildDeps, MSBuildToolchain, is_msvc
 import os
 
 

--- a/docs/package_templates/msbuild_package/all/conanfile.py
+++ b/docs/package_templates/msbuild_package/all/conanfile.py
@@ -44,8 +44,8 @@ class PackageConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
         # for plain C projects only
-        self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/docs/package_templates/msbuild_package/all/conanfile.py
+++ b/docs/package_templates/msbuild_package/all/conanfile.py
@@ -125,10 +125,10 @@ class PackageConan(ConanFile):
         msbuild.build(sln="project_2017.sln")
 
     def package(self):
-        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        copy(self, "*.lib", src=self.source_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
-        copy(self, "*.dll", src=self.source_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
-        copy(self, "*.h", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.lib", self.source_folder, os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, "*.dll", self.source_folder, os.path.join(self.package_folder, "bin"), keep_path=False)
+        copy(self, "*.h", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
 
     def package_info(self):
         self.cpp_info.libs = ["package_lib"]

--- a/docs/package_templates/msbuild_package/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/msbuild_package/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(test_package C) # if the project is pure C
-project(test_package CXX) # if the project uses c++
+project(test_package LANGUAGES C) # if the project is pure C
+# project(test_package LANGUAGES CXX) # if the project uses C++
 
 find_package(package REQUIRED CONFIG)
 

--- a/docs/package_templates/prebuilt_tool_package/all/conanfile.py
+++ b/docs/package_templates/prebuilt_tool_package/all/conanfile.py
@@ -48,9 +48,9 @@ class PackageConan(ConanFile):
     # copy all needed files to the package folder
     def package(self):
         # a license file is always mandatory
-        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        copy(self, pattern="*.exe", dst=os.path.join(self.package_folder, "bin"), src=self.source_folder)
-        copy(self, pattern="foo", dst=os.path.join(self.package_folder, "bin"), src=self.source_folder)
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.exe", self.source_folder, os.path.join(self.package_folder, "bin"))
+        copy(self, "foo", self.source_folder, os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         # folders not used for pre-built binaries

--- a/docs/package_templates/prebuilt_tool_package/all/conanfile.py
+++ b/docs/package_templates/prebuilt_tool_package/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
-from conan.tools.files import get, copy
-from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get
+from conan.tools.scm import Version
 import os
 
 


### PR DESCRIPTION
Alphabetize things.
Use `_min_cppstd` and `_compilers_minimum_version` consistently.
Omit keywords from the `copy` command and use the same order of the arguments across all calls.
Use the `LANGUAGES` keyword in CMake project commands.
Bump the Meson version in the Meson test package.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
