### PR TITLE
fastgltf: Update to 0.6.1

### DIFF
--- a/recipes/fastgltf/all/conandata.yml
+++ b/recipes/fastgltf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.0":
+    url: "https://github.com/spnda/fastgltf/archive/refs/tags/v0.6.0.tar.gz"
+    sha256: "c7245f37c264fee47353b4501284d2329d5fc5e40fb4b8a9bbc418cd449ca35e"
   "0.5.0":
     url: "https://github.com/spnda/fastgltf/archive/refs/tags/v0.5.0.tar.gz"
     sha256: "f67558da009bfd1174b3f32606c41c20fe6fbcb70fc516e9f7bf0f63c06e87ff"
@@ -6,6 +9,11 @@ sources:
     url: "https://github.com/spnda/fastgltf/archive/refs/tags/v0.4.0.tar.gz"
     sha256: "77debe12acb6b498ea77306ce64277cedb14ad803b461ea677a61bc604bb59b5"
 patches:
+  "0.6.0":
+    - patch_file: "patches/0.6.0-0001-find_package-simdjson.patch"
+      patch_description: "find_package simdjson"
+      patch_type: "conan"
+      patch_source: "https://github.com/spnda/fastgltf/issues/22"
   "0.5.0":
     - patch_file: "patches/0.5.0-0001-find_package-simdjson.patch"
       patch_description: "find_package simdjson"

--- a/recipes/fastgltf/all/conandata.yml
+++ b/recipes/fastgltf/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.6.0":
-    url: "https://github.com/spnda/fastgltf/archive/refs/tags/v0.6.0.tar.gz"
-    sha256: "c7245f37c264fee47353b4501284d2329d5fc5e40fb4b8a9bbc418cd449ca35e"
+  "0.6.1":
+    url: "https://github.com/spnda/fastgltf/archive/refs/tags/v0.6.1.tar.gz"
+    sha256: "5f10b153ec941f5e6465425f542d3864f586aca040b0b659cb9ae70d42369390"
   "0.5.0":
     url: "https://github.com/spnda/fastgltf/archive/refs/tags/v0.5.0.tar.gz"
     sha256: "f67558da009bfd1174b3f32606c41c20fe6fbcb70fc516e9f7bf0f63c06e87ff"
@@ -9,8 +9,8 @@ sources:
     url: "https://github.com/spnda/fastgltf/archive/refs/tags/v0.4.0.tar.gz"
     sha256: "77debe12acb6b498ea77306ce64277cedb14ad803b461ea677a61bc604bb59b5"
 patches:
-  "0.6.0":
-    - patch_file: "patches/0.6.0-0001-find_package-simdjson.patch"
+  "0.6.1":
+    - patch_file: "patches/0.6.1-0001-find_package-simdjson.patch"
       patch_description: "find_package simdjson"
       patch_type: "conan"
       patch_source: "https://github.com/spnda/fastgltf/issues/22"

--- a/recipes/fastgltf/all/conanfile.py
+++ b/recipes/fastgltf/all/conanfile.py
@@ -55,6 +55,10 @@ class fastgltf(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+        if Version(self.version) <= "0.6.0":
+            del self.options.disable_custom_memory_pool
+            del self.options.use_64bit_float
+
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
@@ -82,9 +86,9 @@ class fastgltf(ConanFile):
         tc.variables["FASTGLTF_DOWNLOAD_SIMDJSON"] = False
         if self.options.enable_small_vector:
             tc.variables["FASTGLTF_USE_SMALL_VECTOR"] = True
-        if self.options.disable_custom_memory_pool:
+        if self.options.get_safe("disable_custom_memory_pool"):
             tc.variables["FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL"] = True
-        if self.options.use_64bit_float:
+        if self.options.get_safe("use_64bit_float"):
             tc.variables["FASTGLTF_USE_64BIT_FLOAT"] = True
         tc.generate()
         deps = CMakeDeps(self)

--- a/recipes/fastgltf/all/conanfile.py
+++ b/recipes/fastgltf/all/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.59.0"
 
 class fastgltf(ConanFile):
     name = "fastgltf"
-    description = "A blazing fast C++17 glTF 2.0 library powered by SIMD."
+    description = "A modern C++17 glTF 2.0 library focused on speed, correctness, and usability"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/spnda/fastgltf"
@@ -23,11 +23,15 @@ class fastgltf(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "enable_small_vector": [True, False],
+        "disable_custom_memory_pool": [True, False],
+        "use_64bit_float": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_small_vector": False,
+        "disable_custom_memory_pool": False,
+        "use_64bit_float": False,
     }
 
     @property
@@ -78,6 +82,10 @@ class fastgltf(ConanFile):
         tc.variables["FASTGLTF_DOWNLOAD_SIMDJSON"] = False
         if self.options.enable_small_vector:
             tc.variables["FASTGLTF_USE_SMALL_VECTOR"] = True
+        if self.options.disable_custom_memory_pool:
+            tc.variables["FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL"] = True
+        if self.options.use_64bit_float:
+            tc.variables["FASTGLTF_USE_64BIT_FLOAT"] = True
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/fastgltf/all/patches/0.6.0-0001-find_package-simdjson.patch
+++ b/recipes/fastgltf/all/patches/0.6.0-0001-find_package-simdjson.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8091f60..674e474 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -77,6 +77,8 @@ if (FASTGLTF_DOWNLOAD_SIMDJSON)
+         NAMESPACE fastgltf::
+         DESTINATION lib/cmake/fastgltf
+     )
++else()
++    find_package(simdjson CONFIG REQUIRED)
+ endif()
+
+ # Create the library target

--- a/recipes/fastgltf/all/patches/0.6.1-0001-find_package-simdjson.patch
+++ b/recipes/fastgltf/all/patches/0.6.1-0001-find_package-simdjson.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8091f60..674e474 100644
+index 250ee84..1877f54 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -77,6 +77,8 @@ if (FASTGLTF_DOWNLOAD_SIMDJSON)
+@@ -79,6 +79,8 @@ if (FASTGLTF_DOWNLOAD_SIMDJSON)
          NAMESPACE fastgltf::
          DESTINATION lib/cmake/fastgltf
      )

--- a/recipes/fastgltf/config.yml
+++ b/recipes/fastgltf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.0":
+    folder: all
   "0.5.0":
     folder: all
   "0.4.0":

--- a/recipes/fastgltf/config.yml
+++ b/recipes/fastgltf/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.6.0":
+  "0.6.1":
     folder: all
   "0.5.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **fastgltf/0.6.0**

Updates fastgltf to 0.6.0. Also I've seen spnda/fastgltf#22. Would adding an option like `FASTGLTF_FIND_SIMDJSON` be appropriate, which if set calls `find_package` so that these patches can be avoided? That would be for the next release, though I think.