### PR TITLE
harfbuzz: add with_coretext option

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -34,6 +34,7 @@ class HarfbuzzConan(ConanFile):
         "with_uniscribe": [True, False],
         "with_directwrite": [True, False],
         "with_subset": [True, False],
+        "with_coretext": [True, False],
     }
     default_options = {
         "shared": False,
@@ -45,6 +46,7 @@ class HarfbuzzConan(ConanFile):
         "with_uniscribe": True,
         "with_directwrite": False,
         "with_subset": False,
+        "with_coretext": True,
     }
 
     short_paths = True
@@ -63,6 +65,8 @@ class HarfbuzzConan(ConanFile):
             del self.options.with_gdi
             del self.options.with_uniscribe
             del self.options.with_directwrite
+        if not is_apple_os(self):
+            del self.options.with_coretext
 
     def configure(self):
         if self.options.shared:
@@ -142,6 +146,7 @@ class HarfbuzzConan(ConanFile):
             "icu": is_enabled(self.options.with_icu),
             "freetype": is_enabled(self.options.with_freetype),
             "gdi": is_enabled(self.options.get_safe("with_gdi")),
+            "coretext": is_enabled(self.options.get_safe("with_coretext")),
             "directwrite": is_enabled(self.options.get_safe("with_directwrite")),
             "gobject": is_enabled(can_run(self) and self.options.with_glib),
             "introspection": is_enabled(False),


### PR DESCRIPTION
Specify library name and version:  **harfbuzz/all**

Before #13942 (switch from cmake to meson), CoreText was always enabled on macOS.
Meson is the official way to build and has CoreText disabled by default. The CMake build had a default of enabling CoreText on macOS.

This PR adds the option to enable/disable CoreText with the default being to enable it (which differs from the official default).

Why enabled by default: the pango recipe being ported to v2 in multiple PRs requires harfbuzz to be built with CoreText enabled (c.f. the v2 build logs in https://github.com/conan-io/conan-center-index/pull/20795#issuecomment-1788139568).
I couldn't get pango to build on macOS by disabling CoreText (by patching pango). While this might be doable, I won't have the time to investigate this option and I'm thus proposing to re-enable CoreText as a default on macOS.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
