### PR TITLE
Add support for ICU version 74.1

### DIFF
--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "74.1":
+    url: "https://github.com/unicode-org/icu/releases/download/release-74-1/icu4c-74_1-src.tgz"
+    sha256: "86ce8e60681972e60e4dcb2490c697463fcec60dd400a5f9bffba26d0b52b8d0"
   "73.2":
     url: "https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-src.tgz"
     sha256: "818a80712ed3caacd9b652305e01afc7fa167e6f2e94996da44b90c2ab604ce1"
@@ -21,6 +24,8 @@ sources:
     url: "https://github.com/unicode-org/icu/releases/download/release-68-2/icu4c-68_2-src.tgz"
     sha256: "c79193dee3907a2199b8296a93b52c5cb74332c26f3d167269487680d479d625"
 patches:
+  "74.1":
+    - patch_file: "patches/0001-69.1-fix-mingw.patch"
   "73.2":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
   "73.1":

--- a/recipes/icu/config.yml
+++ b/recipes/icu/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "74.1":
+    folder: all
   "73.2":
     folder: all
   "73.1":


### PR DESCRIPTION
Specify library name and version:  **icu/74.1**

Add support for ICU version 74.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
