### PR TITLE
opentdf-client: add version 1.5.6

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.6":
+    url: "https://github.com/opentdf/client-cpp/archive/1.5.6.tar.gz"
+    sha256: "3f46d9a175ce67fc2814faf34a42bc6ff9519d9a80ae7dbdd8d34317231a404a"
   "1.5.4":
     url: "https://github.com/opentdf/client-cpp/archive/1.5.4.tar.gz"
     sha256: "7902d3f09b632ac3827f3c9c8fd1a1f7c8fdff82eeed2157385278b91a7f515f"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.6":
+    folder: all
   "1.5.4":
     folder: all
   "1.5.3":


### PR DESCRIPTION
Specify library name and version:  **opentdf-client/1.5.6**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

- Add support for non-encrypted TDF
- Changes to support SWIG

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
