### PR TITLE
[openblas] Make build_lapack=True default for >= 0.3.21

### DIFF
--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -46,12 +46,12 @@ class OpenblasConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) >= "0.3.21":
+            self.options.build_lapack = True
 
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        if Version(self.version) >= "0.3.21":
-            self.options.build_lapack = True
 
     def validate(self):
         if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -50,6 +50,8 @@ class OpenblasConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        if Version(self.version) >= "0.3.21":
+            self.options.build_lapack = True
 
     def validate(self):
         if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
@@ -87,7 +89,7 @@ class OpenblasConan(ConanFile):
         # This checks explicit user-specified fortran compiler
         if self.options.build_lapack:
             if not self._fortran_compiler:
-                if Version(self.version) < "0.3.24":
+                if Version(self.version) < "0.3.21":
                     self.output.warning(
                         "Building with LAPACK support requires a Fortran compiler.")
                 else:

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -171,7 +171,7 @@ endif()"""
             self.cpp_info.components["openblas_component"].system_libs.append("m")
             if self.options.use_thread:
                 self.cpp_info.components["openblas_component"].system_libs.append("pthread")
-            if self.options.build_lapack:
+            if self.options.build_lapack and self._fortran_compiler:
                 self.cpp_info.components["openblas_component"].system_libs.append("gfortran")
 
         self.output.info(

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -46,7 +46,7 @@ class OpenblasConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if Version(self.version) >= "0.3.21":
+        # INFO: When no Fortran compiler is available, OpenBLAS builds LAPACK from an f2c-converted copy of LAPACK unless the NO_LAPACK option is specified
             self.options.build_lapack = True
 
     def configure(self):

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -54,6 +54,12 @@ class OpenblasConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def validate(self):
+        if Version(self.version) < "0.3.24" and self.settings.arch == "armv8":
+            # OpenBLAS fails to detect the appropriate target architecture for armv8 for versions < 0.3.24, as it matches the 32 bit variant instead of 64.
+            # This was fixed in https://github.com/OpenMathLib/OpenBLAS/pull/4142, which was introduced in 0.3.24.
+            # This would be a reasonably trivial hotfix to backport.
+            raise ConanInvalidConfiguration("armv8 builds are not currently supported for versions lower than 0.3.24. Contributions to support this are welcome.")
+
         if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")
 

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -112,6 +112,9 @@ class OpenblasConan(ConanFile):
         # which is required to successfully compile on older gcc versions.
         tc.cache_variables["ANDROID"] = self.settings.os in ["Linux", "Android"]
 
+        if self.settings.arch == "armv8":
+            # OpenBLAS fails to detect the appropriate architecture for armv8, so help it out
+            tc.variables["TARGET"] = "ARMV8"
         tc.generate()
 
     def build(self):

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -111,9 +111,10 @@ class OpenblasConan(ConanFile):
         # This is a workaround to add the libm dependency on linux,
         # which is required to successfully compile on older gcc versions.
         tc.cache_variables["ANDROID"] = self.settings.os in ["Linux", "Android"]
+
         tc.generate()
 
-    def _patch_sources(self):
+    def build(self):
         if Version(self.version) < "0.3.21":
             if Version(self.version) >= "0.3.12":
                 search = """message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")"""
@@ -138,20 +139,6 @@ endif()"""
                 search,
                 replace,
             )
-
-        if Version(self.version) < "0.3.24":
-            # OpenBLAS fails to detect the appropriate target architecture for armv8, so help it out.
-            # This will ensure ARM64 is set, which will set TARGET=ARMV8 appropriately.
-            # This is a portability hotfix of https://github.com/OpenMathLib/OpenBLAS/pull/4142
-            replace_in_file(
-                self,
-                os.path.join(self.source_folder, "cmake", "system_check.cmake"),
-                'elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")',
-                'elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*|armv8.*)")'
-            )
-
-    def build(self):
-        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -46,7 +46,8 @@ class OpenblasConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        # INFO: When no Fortran compiler is available, OpenBLAS builds LAPACK from an f2c-converted copy of LAPACK unless the NO_LAPACK option is specified
+        if Version(self.version) >= "0.3.21":
+            # INFO: When no Fortran compiler is available, OpenBLAS builds LAPACK from an f2c-converted copy of LAPACK unless the NO_LAPACK option is specified
             self.options.build_lapack = True
 
     def configure(self):


### PR DESCRIPTION
Version 0.3.21 of openblas introduced the ability to build lapack from C. Make this default to enable CCI recipes to use lapack when depending on openblas.

Additionally, fix an inconsistency in version constraint. Review was provided in https://github.com/conan-io/conan-center-index/pull/19808 to constrain it to 0.3.24 as this was the latest version available in CCI. However, functionality to build lapack was added in 0.3.21, so it doesn't really make sense to exclude versions between 0.3.21 and 0.3.24 from building lapack should they be added at a later date.

Closes #7361

Specify library name and version:  **openblas/0.3.24**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
