### PR TITLE
onetbb: remove shared option + fix tbbmaloc & tbbproxy logic

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -77,10 +77,6 @@ class OneTBBConan(ConanFile):
         if self._tbbbind_build:
             self.requires("hwloc/2.9.3")
 
-    def build_requirements(self):
-        if not self._tbbbind_explicit_hwloc and not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/1.9.5")
-
     def package_id(self):
         if Version(self.version) < "2021.5.0":
             self.info.options.tbbmalloc = True
@@ -93,6 +89,10 @@ class OneTBBConan(ConanFile):
 
         if self._tbbbind_explicit_hwloc and not self.dependencies["hwloc"].options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} requires hwloc:shared=True to be built.")
+
+    def build_requirements(self):
+        if not self._tbbbind_explicit_hwloc and not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
- regarding removal of shared option: see https://github.com/conan-io/conan/issues/15040#issuecomment-1790753531
- for tbbmaloc & tbbproxy, well current logic was super weird. It comes from https://github.com/conan-io/conan-center-index/pull/17311, but it doesn't really make sense. These options didn't exist before 2021.5.0 or 2021.6.0, so they have to be removed in config_option, that's all.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
