### PR TITLE
usockets: fix mistake in _minimum_compilers_version logic

### DIFF
--- a/recipes/usockets/all/conanfile.py
+++ b/recipes/usockets/all/conanfile.py
@@ -44,7 +44,7 @@ class UsocketsConan(ConanFile):
         return False
 
     @property
-    def _minimum_compilers_version(self, cppstd):
+    def _minimum_compilers_version(self):
         return {
             "14": {
                 "Visual Studio": "15",
@@ -122,7 +122,7 @@ class UsocketsConan(ConanFile):
             if self.settings.compiler.get_safe("cppstd"):
                 check_min_cppstd(self, self._min_cppstd)
 
-            minimum_version = self._minimum_compilers_version(self._min_cppstd)
+            minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler))
             if minimum_version and Version(self.settings.compiler.version) < minimum_version:
                 raise ConanInvalidConfiguration(
                     f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/20896

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
