### PR TITLE
[OneTBB] Deprecate support for shared option

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -84,7 +84,7 @@ class OneTBBConan(ConanFile):
         if self._tbbbind_explicit_hwloc:
             self.options["hwloc"].shared = True
         if self.options.shared != "deprecated":
-            self.output.warning("shared option is deprecated because is highly discourage: https://github.com/oneapi-src/oneTBB/issues/920")
+            self.output.warning(f"{self.ref}:shared option is deprecated because is highly discouraged: https://github.com/oneapi-src/oneTBB/issues/920")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **onetbb/2021.x**

The OneTBB package uses `shared=True` by default because the upstream does not encourage of using is as a static library. The recipe still offers the option, but add a big warning or an InvalidConfiguration.

This PR proposes deprecating it not only because to follow upstream recommendation and avoid unexpected errors with static library, but also to remedy current missing dependencies error when consuming OneTBB.

So only shared/dynamic libraries will be provided.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
