### PR TITLE
libpq: fix 15.x for mingw by adding missing patch

### DIFF
--- a/recipes/libpq/all/conandata.yml
+++ b/recipes/libpq/all/conandata.yml
@@ -24,6 +24,14 @@ sources:
     url: "https://ftp.postgresql.org/pub/source/v9.6.24/postgresql-9.6.24.tar.gz"
     sha256: "52947ecc119846eace5164399d173576c0d4a47ec116ae58a46a8fd0c576c7c3"
 patches:
+  "15.4":
+    - patch_file: "patches/15/001-mingw-build-static-libraries.patch"
+      patch_description: "port MinGW: Enable building static libraries in MinGW."
+      patch_type: "portability"
+  "15.3":
+    - patch_file: "patches/15/001-mingw-build-static-libraries.patch"
+      patch_description: "port MinGW: Enable building static libraries in MinGW."
+      patch_type: "portability"
   "14.9":
     - patch_file: "patches/13/002-mingw-build-static-libraries.patch"
       patch_description: "port MinGW: Enable building static libraries in MinGW."

--- a/recipes/libpq/all/patches/15/001-mingw-build-static-libraries.patch
+++ b/recipes/libpq/all/patches/15/001-mingw-build-static-libraries.patch
@@ -1,0 +1,39 @@
+--- a/src/Makefile.shlib
++++ b/src/Makefile.shlib
+@@ -322,7 +322,10 @@ else # PORTNAME == aix
+ # AIX case
+ 
+ # See notes in src/backend/parser/Makefile about the following two rules
+-$(stlib): $(shlib)
++$(stlib): $(OBJS) | $(SHLIB_PREREQS)
++	rm -f $@
++	$(LINK.static) $@ $^
++	$(RANLIB) $@
+ 	touch $@
+ 
+ $(shlib): $(OBJS) | $(SHLIB_PREREQS)
+@@ -371,12 +374,12 @@ $(stlib): $(shlib)
+ # Else we just use --export-all-symbols.
+ ifeq (,$(SHLIB_EXPORTS))
+ $(shlib): $(OBJS) | $(SHLIB_PREREQS)
+-	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--export-all-symbols -Wl,--out-implib=$(stlib)
++	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--export-all-symbols -Wl,--out-implib=lib$(NAME).dll.a
+ else
+ DLL_DEFFILE = lib$(NAME)dll.def
+ 
+ $(shlib): $(OBJS) $(DLL_DEFFILE) | $(SHLIB_PREREQS)
+-	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(DLL_DEFFILE) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--out-implib=$(stlib)
++	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(DLL_DEFFILE) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--out-implib=lib$(NAME).dll.a
+ 
+ UC_NAME = $(shell echo $(NAME) | tr 'abcdefghijklmnopqrstuvwxyz' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+ 
+@@ -457,6 +460,9 @@ endif # not aix
+ ifneq (,$(findstring $(PORTNAME),win32 cygwin))
+ 	$(INSTALL_SHLIB) $< '$(DESTDIR)$(bindir)/$(shlib)'
+ endif
++ifneq (,$(findstring $(PORTNAME),win32))
++	$(INSTALL_SHLIB) $< '$(DESTDIR)$(libdir)/lib$(NAME).dll.a'
++endif
+ else # no soname
+ 	$(INSTALL_SHLIB) $< '$(DESTDIR)$(pkglibdir)/$(shlib)'
+ endif


### PR DESCRIPTION
mingw patch has been forgotten while adding 15.x versions in https://github.com/conan-io/conan-center-index/pull/18317 & https://github.com/conan-io/conan-center-index/pull/19201

14.8 was also broken but it has been removed (very quickly!) in https://github.com/conan-io/conan-center-index/pull/19653...

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
