### PR TITLE
duckdb: do not remove import lib during packaging if mingw shared

### DIFF
--- a/recipes/duckdb/all/conandata.yml
+++ b/recipes/duckdb/all/conandata.yml
@@ -25,29 +25,17 @@ patches:
     - patch_file: "patches/0.9.0-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"
       patch_type: "portability"
-    - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
-      patch_description: "include stdlib for abort function"
-      patch_type: "portability"
   "0.8.1":
     - patch_file: "patches/0.8.1-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"
-      patch_type: "portability"
-    - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
-      patch_description: "include stdlib for abort function"
       patch_type: "portability"
   "0.8.0":
     - patch_file: "patches/0.8.0-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"
       patch_type: "portability"
-    - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
-      patch_description: "include stdlib for abort function"
-      patch_type: "portability"
   "0.7.1":
     - patch_file: "patches/0.7.0-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"
-      patch_type: "portability"
-    - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
-      patch_description: "include stdlib for abort function"
       patch_type: "portability"
   "0.6.1":
     - patch_file: "patches/0.6.0-0001-fix-cmake.patch"
@@ -56,6 +44,7 @@ patches:
     - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
       patch_description: "include stdlib for abort function"
       patch_type: "portability"
+      patch_source: "https://github.com/duckdb/duckdb/commit/50b0bd07a6c22d17c4453632fce3b3d3c872663e"
   "0.6.0":
     - patch_file: "patches/0.6.0-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"
@@ -63,6 +52,7 @@ patches:
     - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
       patch_description: "include stdlib for abort function"
       patch_type: "portability"
+      patch_source: "https://github.com/duckdb/duckdb/commit/50b0bd07a6c22d17c4453632fce3b3d3c872663e"
   "0.5.1":
     - patch_file: "patches/0.5.1-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
+import glob
 import os
 
 required_conan_version = ">=1.53.0"
@@ -147,8 +148,10 @@ class DuckdbConan(ConanFile):
         cmake.install()
 
         if self.options.shared:
-            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
             rm(self, "duckdb_*.lib", os.path.join(self.package_folder, "lib"))
+            for lib in glob.glob(os.path.join(self.package_folder, "lib", "*.a")):
+                if not lib.endswith(".dll.a"):
+                    os.remove(lib)
 
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "cmake"))

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -5,7 +5,6 @@ from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
-import glob
 import os
 
 required_conan_version = ">=1.53.0"
@@ -148,10 +147,8 @@ class DuckdbConan(ConanFile):
         cmake.install()
 
         if self.options.shared:
+            rm(self, "*[!.dll].a", os.path.join(self.package_folder, "lib"))
             rm(self, "duckdb_*.lib", os.path.join(self.package_folder, "lib"))
-            for lib in glob.glob(os.path.join(self.package_folder, "lib", "*.a")):
-                if not lib.endswith(".dll.a"):
-                    os.remove(lib)
 
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "cmake"))

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
+import glob
 import os
 
 required_conan_version = ">=1.53.0"
@@ -147,8 +148,10 @@ class DuckdbConan(ConanFile):
         cmake.install()
 
         if self.options.shared:
-            rm(self, "*[!.dll].a", os.path.join(self.package_folder, "lib"))
             rm(self, "duckdb_*.lib", os.path.join(self.package_folder, "lib"))
+            for lib in glob.glob(os.path.join(self.package_folder, "lib", "*.a")):
+                if not lib.endswith(".dll.a"):
+                    os.remove(lib)
 
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "cmake"))


### PR DESCRIPTION
Any logic which tries to naively remove  static lib with pattern `*.a` when we want to keep shared only is broken for MinGW, since import libs have extension `.dll.a`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
