### PR TITLE
hdf5: do not remove import lib during packaging if mingw shared

### DIFF
--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import textwrap
 
@@ -236,9 +235,7 @@ class Hdf5Conan(ConanFile):
 
         # remove extra libs... building 1.8.21 as shared also outputs static libs on Linux.
         if self.options.shared:
-            for lib in glob.glob(os.path.join(self.package_folder, "lib", "*.a")):
-                if not lib.endswith(".dll.a"):
-                    os.remove(lib)
+            rm(self, "*[!.dll].a", os.path.join(self.package_folder, "lib"))
 
         # Mimic the official CMake FindHDF5 targets. HDF5::HDF5 refers to the global target as per conan,
         # but component targets have a lower case namespace prefix. hdf5::hdf5 refers to the C library only

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import textwrap
 
@@ -235,7 +236,9 @@ class Hdf5Conan(ConanFile):
 
         # remove extra libs... building 1.8.21 as shared also outputs static libs on Linux.
         if self.options.shared:
-            rm(self, "*[!.dll].a", os.path.join(self.package_folder, "lib"))
+            for lib in glob.glob(os.path.join(self.package_folder, "lib", "*.a")):
+                if not lib.endswith(".dll.a"):
+                    os.remove(lib)
 
         # Mimic the official CMake FindHDF5 targets. HDF5::HDF5 refers to the global target as per conan,
         # but component targets have a lower case namespace prefix. hdf5::hdf5 refers to the C library only

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import textwrap
 
@@ -235,7 +236,9 @@ class Hdf5Conan(ConanFile):
 
         # remove extra libs... building 1.8.21 as shared also outputs static libs on Linux.
         if self.options.shared:
-            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
+            for lib in glob.glob(os.path.join(self.package_folder, "lib", "*.a")):
+                if not lib.endswith(".dll.a"):
+                    os.remove(lib)
 
         # Mimic the official CMake FindHDF5 targets. HDF5::HDF5 refers to the global target as per conan,
         # but component targets have a lower case namespace prefix. hdf5::hdf5 refers to the C library only


### PR DESCRIPTION
https://github.com/conan-io/conan-center-index/pull/15674 broke packaging of MinGW shared, by removing import lib (extension `.dll.a`). This PR fixes this issue.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
