### PR TITLE
libarchive: fix mingw shared

### DIFF
--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, cmake_layout, CMakeDeps, CMakeToolchain
-from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, rm, rmdir
+from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
@@ -149,6 +149,7 @@ class LibarchiveConan(ConanFile):
         tc.variables["ENABLE_CPIO"] = False
         tc.variables["ENABLE_CAT"] = False
         tc.variables["ENABLE_TEST"] = False
+        tc.variables["ENABLE_UNZIP"] = False
         # too strict check
         tc.variables["ENABLE_WERROR"] = False
         if Version(self.version) >= "3.4.2":
@@ -171,9 +172,6 @@ class LibarchiveConan(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-
-        if self.options.shared:
-            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/recipes/libarchive/all/patches/0003-3.7.1-cmake.patch
+++ b/recipes/libarchive/all/patches/0003-3.7.1-cmake.patch
@@ -56,3 +56,36 @@ index 6849ce40..8d5b6018 100644
    FIND_PACKAGE(OpenSSL)
    IF(OPENSSL_FOUND)
      SET(HAVE_LIBCRYPTO 1)
+diff --git a/libarchive/CMakeLists.txt b/libarchive/CMakeLists.txt
+index f7fdfb68..9d2915ac 100644
+--- a/libarchive/CMakeLists.txt
++++ b/libarchive/CMakeLists.txt
+@@ -251,6 +251,7 @@ IF(BUILD_SHARED_LIBS)
+ ENDIF(BUILD_SHARED_LIBS)
+ 
+ # archive_static is a static library
++if(NOT BUILD_SHARED_LIBS)
+ ADD_LIBRARY(archive_static STATIC ${libarchive_SOURCES} ${include_HEADERS})
+ TARGET_LINK_LIBRARIES(archive_static ${ADDITIONAL_LIBS})
+ SET_TARGET_PROPERTIES(archive_static PROPERTIES COMPILE_DEFINITIONS
+@@ -259,6 +260,7 @@ SET_TARGET_PROPERTIES(archive_static PROPERTIES COMPILE_DEFINITIONS
+ IF(NOT WIN32 OR CYGWIN OR NOT BUILD_SHARED_LIBS)
+   SET_TARGET_PROPERTIES(archive_static PROPERTIES OUTPUT_NAME archive)
+ ENDIF(NOT WIN32 OR CYGWIN OR NOT BUILD_SHARED_LIBS)
++endif()
+ 
+ IF(ENABLE_INSTALL)
+   # How to install the libraries
+@@ -268,10 +270,12 @@ IF(ENABLE_INSTALL)
+             LIBRARY DESTINATION lib
+             ARCHIVE DESTINATION lib)
+   ENDIF(BUILD_SHARED_LIBS)
++  if(NOT BUILD_SHARED_LIBS)
+   INSTALL(TARGETS archive_static
+           RUNTIME DESTINATION bin
+           LIBRARY DESTINATION lib
+           ARCHIVE DESTINATION lib)
++  endif()
+   INSTALL_MAN(${libarchive_MANS})
+   INSTALL(FILES ${include_HEADERS} DESTINATION include)
+ ENDIF()


### PR DESCRIPTION
Fix regression of https://github.com/conan-io/conan-center-index/pull/19718

So we build either shared or static in 3.7.1 like all other previous versions, and avoid this removal of .a files if shared which breaks mingw shared since import lib is .dll.a

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
