### PR TITLE
faac: fix build with mingw

### DIFF
--- a/recipes/faac/all/conanfile.py
+++ b/recipes/faac/all/conanfile.py
@@ -151,11 +151,11 @@ class FaacConan(ConanFile):
         else:
             autotools = Autotools(self)
             autotools.autoreconf()
+            autotools.configure()
             if self._is_mingw and self.options.shared:
                 replace_in_file(self, os.path.join(self.build_folder, "libfaac", "Makefile"),
                                 "\nlibfaac_la_LIBADD = ",
                                 "\nlibfaac_la_LIBADD = -no-undefined ")
-            autotools.configure()
             autotools.make()
 
     def package(self):


### PR DESCRIPTION
There is incorrect logic in recipe for mingw. It tries to patch Makefile after autoreconf, not configure, leading to:

```
faac/1.30: ERROR:
Package '50706d5c263b28ec09259a73ef46fa9f215f442d' build failed
faac/1.30: WARN: Build folder C:\Users\spaceim\.conan2\p\b\faacf76c1fb6f02e0\b\build-release
*********************************************************
Recipe 'faac/1.30' cannot build its binary
It is possible that this recipe is not Conan 2.0 ready
If the recipe comes from ConanCenter, report it at https://github.com/conan-io/conan-center-index/issues
If it is your recipe, check if it is updated to 2.0
*********************************************************

ERROR: faac/1.30: Error in build() method, line 155
        replace_in_file(self, os.path.join(self.build_folder, "libfaac", "Makefile"),
        FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\spaceim\\.conan2\\p\\b\\faacf76c1fb6f02e0\\b\\build-release\\libfaac\\Makefile'
```

So patch is moved after configure. It works fine for me locally.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
