### PR TITLE
nettle: fix patch logic when build machine is windows

### DIFF
--- a/recipes/nettle/all/conanfile.py
+++ b/recipes/nettle/all/conanfile.py
@@ -113,12 +113,15 @@ class NettleConan(ConanFile):
         self._patch_sources()
         autotools = Autotools(self)
         autotools.autoreconf()
+        autotools.configure()
         # srcdir in unix path causes some troubles in asm files on Windows
         if self._settings_build.os == "Windows":
-            replace_in_file(self, os.path.join(self.build_folder, "config.m4"),
-                                  unix_path(self, os.path.join(self.build_folder, self.source_folder)),
-                                  os.path.join(self.build_folder, self.source_folder).replace("\\", "/"))
-        autotools.configure()
+            replace_in_file(
+                self,
+                os.path.join(self.build_folder, "config.m4"),
+                unix_path(self, self.source_folder),
+                self.source_folder.replace("\\", "/"),
+            )
         autotools.make()
 
     def package(self):


### PR DESCRIPTION
Patch `config.m4` if build machine is Windows after configure() (instead of autreconf()), otherwise file doesn't exist yet and therefore replace_in_file fails.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
