### PR TITLE
qt: fix minor issues in 6.x

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -181,6 +181,7 @@ class QtConan(ConanFile):
         # Qt6 requires C++17
         return {
             "Visual Studio": "16",
+            "msvc": "192",
             "gcc": "8",
             "clang": "9",
             "apple-clang": "12" if Version(self.version) >= "6.5.0" else "11"
@@ -1035,7 +1036,7 @@ class QtConan(ConanFile):
 
             if self.settings.os == "Windows":
                 self.cpp_info.components["qtGui"].system_libs = ["advapi32", "gdi32", "ole32", "shell32", "user32", "d3d11",
-                    "dxgi", "dxguid", "d2d1", "dwrite"]
+                    "dxgi", "dxguid", "d2d1", "dwrite", "d3d9", "setupapi", "SHCore"]
                 if self.settings.compiler == "gcc":
                     self.cpp_info.components["qtGui"].system_libs.append("uuid")
                 _create_plugin("QWindowsIntegrationPlugin", "qwindows", "platforms", ["Core", "Gui"])
@@ -1147,6 +1148,8 @@ class QtConan(ConanFile):
 
         if self.options.qtsvg and self.options.gui:
             _create_module("Svg", ["Gui"])
+            _create_plugin("QSvgIconPlugin", "qsvgicon", "iconengines", [])
+            _create_plugin("QSvgPlugin", "qsvg", "imageformats", [])
             if self.options.widgets:
                 _create_module("SvgWidgets", ["Gui", "Svg", "Widgets"])
 


### PR DESCRIPTION
Specify library name and version:  **qt/6.5.3**

Fix issue #20924.

Note to reviewers:
- See #20817 for Svg
- Technically, some version of msvc 191 support c++17. Is there a better way to detect cpp standard?
- Qt6 support DirectX 9,11 and 12. Shoud we add d3d12?

Tested with
```
#include <QApplication>
#include <QPushButton>
#include <QtPlugin>
Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);

//#pragma comment(lib, "d3d9")
//#pragma comment(lib, "setupapi")
//#pragma comment(lib, "SHCore")

int main(int argc, char *argv[])
{
    QApplication a(argc, argv);

    QPushButton button ("Hello world!");
    button.show();

    return a.exec(); 
}
```
Pragmas are needed without patch
```
set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES cmake/conan_provider.cmake)
cmake_minimum_required(VERSION 3.9)
project(FormatOutput CXX)

list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})

set(CMAKE_BUILD_TYPE Release)

if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
  message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/0.18.1/conan.cmake"
                "${CMAKE_BINARY_DIR}/conan.cmake"
                TLS_VERIFY ON)
endif()

find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets QWindowsIntegrationPlugin)
set(CMAKE_AUTOMOC ON)
set(CMAKE_AUTORCC ON)
set(CMAKE_AUTOUIC ON)

add_executable(main main.cpp)
target_link_libraries(main Qt6::Core Qt6::Gui Qt6::Widgets Qt6::QWindowsIntegrationPlugin)

target_compile_features(main PRIVATE cxx_std_17)
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
I'm using Conan 2.0, hooks don't work as per documentation.
