### PR TITLE
iconfontcppheaders: bump version to cci.20231102 with added Lucide font

### DIFF
--- a/recipes/iconfontcppheaders/all/conandata.yml
+++ b/recipes/iconfontcppheaders/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20231102":
+    sha256: 7618e844dcbfea2404c209e8b52158a37c2368a79cc77e94087375a8186442c4
+    url: https://github.com/juliettef/IconFontCppHeaders/archive/41b304750e83c0a89375cc1834f65c1204308b4a/main.zip
   "cci.20231026":
     sha256: b65a0256820ce24541247eeb22843968164acc40786c017392e53c5aa5a58996
     url: https://github.com/juliettef/IconFontCppHeaders/archive/b1700cdf6ca2f78f8d27321dfecdafd7c2d8ef08/main.zip

--- a/recipes/iconfontcppheaders/all/conanfile.py
+++ b/recipes/iconfontcppheaders/all/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.52.0"
 
 class FireHppConan(ConanFile):
     name = "iconfontcppheaders"
-    description = "Headers for icon fonts Font Awesome, Fork Awesome, Google Material Design, Kenney game icons, Fontaudio, Codicons, Pictogrammers Material Design icons."
+    description = "Headers for icon fonts Font Awesome, Fork Awesome, Google Material Design, Pictogrammers Material Design icons, Kenney game icons, Fontaudio, Codicons and Lucide."
     license = "Zlib"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/juliettef/IconFontCppHeaders"

--- a/recipes/iconfontcppheaders/config.yml
+++ b/recipes/iconfontcppheaders/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20231102":
+    folder: all
   "cci.20231026":
     folder: all


### PR DESCRIPTION
Bumping iconfontcppheaders to latest version (cci.20231102) which adds the Lucide font. Package description also updated to include the new font.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
