### PR TITLE
rapidfuzz: add version 2.2.3

### DIFF
--- a/recipes/rapidfuzz/all/conandata.yml
+++ b/recipes/rapidfuzz/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.3":
+    url: "https://github.com/maxbachmann/rapidfuzz-cpp/archive/refs/tags/v2.2.3.tar.gz"
+    sha256: "df4412e9593945782de2212095bd4b70a8f8e63ae8f313976c616809be124d2c"
   "2.2.0":
     url: "https://github.com/maxbachmann/rapidfuzz-cpp/archive/refs/tags/v2.2.0.tar.gz"
     sha256: "8fe2d2792ee8b32598f4aa3aad5db7d449fb3c4a32387080f650335cf4faef81"

--- a/recipes/rapidfuzz/config.yml
+++ b/recipes/rapidfuzz/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.3":
+    folder: "all"
   "2.2.0":
     folder: "all"
   "2.1.1":


### PR DESCRIPTION
Specify library name and version:  **rapidfuzz/2.2.3**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
