### PR TITLE
onnxruntime: don't bring link dependency to boost on conanv1

### DIFF
--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -271,6 +271,28 @@ class OnnxRuntimeConan(ConanFile):
         if self.settings.os == "Windows":
             self.cpp_info.system_libs.append("shlwapi")
 
+        # conanv1 doesn't support traits and we only need headers from boost
+        self.cpp_info.requires = [
+            "abseil::abseil",
+            "protobuf::protobuf",
+            "date::date",
+            "re2::re2",
+            "onnx::onnx",
+            "flatbuffers::flatbuffers",
+            "boost::headers",
+            "safeint::safeint",
+            "nlohmann_json::nlohmann_json",
+            "eigen::eigen",
+            "ms-gsl::ms-gsl",
+            "cpuinfo::cpuinfo"
+        ]
+        if self.settings.os != "Windows":
+            self.cpp_info.requires.append("nsync::nsync")
+        else:
+            self.cpp_info.requires.append("wil::wil")
+        if self.options.with_xnnpack:
+            self.cpp_info.requires.append("xnnpack::xnnpack")
+
         # https://github.com/microsoft/onnxruntime/blob/v1.16.0/cmake/CMakeLists.txt#L1759-L1763
         self.cpp_info.set_property("cmake_file_name", "onnxruntime")
         self.cpp_info.set_property("cmake_target_name", "onnxruntime::onnxruntime")


### PR DESCRIPTION
Specify library name and version:  **onnxruntime/all**

conan v1 completely ignores traits in self.requires(...) so without custom self.cpp_info.requires list onnxruntime was linking to all components of boost.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
