### PR TITLE
trompeloeil: add version 46

### DIFF
--- a/recipes/trompeloeil/all/conandata.yml
+++ b/recipes/trompeloeil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "46":
+    url: "https://github.com/rollbear/trompeloeil/archive/v46.tar.gz"
+    sha256: "dc2c856ab7716ef659f8df7fc5f6740a40e736089f05e0a8251d4ad3ad17ad83"
   "45":
     url: "https://github.com/rollbear/trompeloeil/archive/v45.tar.gz"
     sha256: "124b0aa45d84415193719376b6557fc1f1180cbfebf4dc4f7ca247cb404d6bd8"

--- a/recipes/trompeloeil/config.yml
+++ b/recipes/trompeloeil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "46":
+    folder: all
   "45":
     folder: all
   "43":


### PR DESCRIPTION
Specify library name and version:  **trompeloeil/46**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
