### PR TITLE
[hwloc] Build shared library only

### DIFF
--- a/recipes/hwloc/all/conanfile.py
+++ b/recipes/hwloc/all/conanfile.py
@@ -98,7 +98,5 @@ class HwlocConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "hwloc")
         self.cpp_info.libs = ["hwloc"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs = ["m"]
         if is_apple_os(self):
             self.cpp_info.frameworks = ['IOKit', 'Foundation', 'CoreFoundation']

--- a/recipes/hwloc/all/conanfile.py
+++ b/recipes/hwloc/all/conanfile.py
@@ -64,6 +64,7 @@ class HwlocConan(ConanFile):
             if not self.options.with_libxml2:
                 tc.configure_args.extend(["--disable-libxml2"])
             tc.configure_args.extend(["--disable-io", "--disable-cairo"])
+            tc.configure_args.extend(["--enable-shared", "--disable-static"])
             tc.generate()
 
     def build(self):

--- a/recipes/hwloc/all/conanfile.py
+++ b/recipes/hwloc/all/conanfile.py
@@ -8,6 +8,7 @@ import os
 
 required_conan_version = ">=1.53.0"
 
+# INFO: In order to prevent OneTBB missing package error, we build only shared library for hwloc.
 
 class HwlocConan(ConanFile):
     name = "hwloc"
@@ -16,26 +17,16 @@ class HwlocConan(ConanFile):
     license = "BSD-3-Clause"
     homepage = "https://www.open-mpi.org/projects/hwloc/"
     url = "https://github.com/conan-io/conan-center-index"
-    package_type = "library"
+    package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
-        "shared": [True, False],
-        "fPIC": [True, False],
         "with_libxml2": [True, False]
     }
     default_options = {
-        "shared": False,
-        "fPIC": True,
         "with_libxml2": False
     }
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
     def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
 
@@ -63,7 +54,7 @@ class HwlocConan(ConanFile):
             tc.cache_variables["HWLOC_SKIP_INCLUDES"] = 'OFF'
             tc.cache_variables["HWLOC_WITH_OPENCL"] = 'OFF'
             tc.cache_variables["HWLOC_WITH_CUDA"] = 'OFF'
-            tc.cache_variables["HWLOC_BUILD_SHARED_LIBS"] = self.options.shared
+            tc.cache_variables["HWLOC_BUILD_SHARED_LIBS"] = True
             tc.cache_variables["HWLOC_WITH_LIBXML2"] = self.options.with_libxml2
             tc.generate()
         else:
@@ -106,9 +97,7 @@ class HwlocConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "hwloc")
         self.cpp_info.libs = ["hwloc"]
-
-        if not self.options.shared:
-            if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.system_libs = ["m"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m"]
         if is_apple_os(self):
             self.cpp_info.frameworks = ['IOKit', 'Foundation', 'CoreFoundation']


### PR DESCRIPTION
Specify library name and version:  **hwloc/all**

Related to #20897

Removing shared option for OneTBB will not be enough to fix our current error with missing packages, because it uses hwloc as dependency.

The `hwloc` supports both static and shared, but when running CCI, it will be consumed by OneTBB without `shared`, resulting in a single configuration.

The problem occurs because when CCI builds with Conan 2.x, it will use `*/*:shared=True/False`, resulting in `hwloc/*:shared=True` with OneTBB, a configuration not available in Conan Center, because only the default configuration is available (the static one).

This PR sacrifices `hwloc`, by removing its support for static library, but provide only shared, so it should be kept aligned with OneTBB. Also, only OneTBB uses `hwloc` in CCI, so it should be safe.

Checking some Linux package repositories, like AUR, only .so are available to hwloc.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
