### PR TITLE
octo-logger-cpp: add version 1.5.0

### DIFF
--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.0":
+    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.5.0.tar.gz"
+    sha256: "e62e4a54700f7c235111fd2b75c51d96f0b4deaf2c24ce7bc9ef1751ce31ea20"
   "1.4.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.4.0.tar.gz"
     sha256: "6aacbab0e57917a935e0f9741e52a57ecac21785ba49aaafec5775030208a153"

--- a/recipes/octo-logger-cpp/config.yml
+++ b/recipes/octo-logger-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.0":
+    folder: "all"
   "1.4.0":
     folder: "all"
   "1.2.0":


### PR DESCRIPTION
Specify library name and version:  **octo-logger-cpp/1.5.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
