### PR TITLE
fix exiv2 provides

### DIFF
--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -44,8 +44,6 @@ class Exiv2Conan(ConanFile):
         "win_unicode": False,
     }
 
-    provides = []
-
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -67,7 +65,7 @@ class Exiv2Conan(ConanFile):
         if self.options.with_xmp == "bundled":
             # recipe has bundled xmp-toolkit-sdk of old version
             # avoid conflict with a future xmp recipe
-            self.provides.append("xmp-toolkit-sdk")
+            self.provides = ["xmp-toolkit-sdk"]
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **exiv2**

Follow up from https://github.com/conan-io/conan/issues/15065, fixing ``provides`` definition

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
