### PR TITLE
aws-c-common: re-add 0.8.2

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
   "0.8.23":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.8.23.tar.gz"
     sha256: "67455d8149c74b1db3e4dd68db47dc7372de02dd78fbc620f9c7f0270d9d6018"
+  "0.8.2":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.8.2.tar.gz"
+    sha256: "36edc6e486c43bbb34059dde227e872c0d41ab54f0b3609d38f188cfbbc6d1f8"
   "0.7.5":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.7.5.tar.gz"
     sha256: "e34fd3d3d32e3597f572205aaabbe995e162f4015e14c7328987b596bd25812c"

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -7,6 +7,8 @@ versions:
     folder: all
   "0.8.23":
     folder: all
+  "0.8.2":
+    folder: all
   "0.7.5":
     folder: all
   "0.6.20":


### PR DESCRIPTION
it was removed in https://github.com/conan-io/conan-center-index/pull/19995 but is still referenced by several recipes:
https://github.com/search?q=repo%3Aconan-io%2Fconan-center-index%20aws-c-common%2F0.8.2&type=code

Specify library name and version:  **aws-c-common/0.8.2**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
