### PR TITLE
tcsbank-uconfig: robust to "unknow compilers" in validate()

### DIFF
--- a/recipes/tcsbank-uconfig/all/conanfile.py
+++ b/recipes/tcsbank-uconfig/all/conanfile.py
@@ -53,16 +53,13 @@ class TCSBankUconfigConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        compiler = str(self.settings.compiler)
-        compiler_version = Version(self.settings.compiler.version)
-
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)
 
-        if compiler_version < self._compilers_minimum_version[compiler]:
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
-                f"{self.name} requires a compiler that supports at least C++{self._min_cppstd}. "
-                f"{compiler} {compiler_version} is not supported."
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
     def source(self):


### PR DESCRIPTION
follow up https://github.com/conan-io/conan-center-index/pull/18353

validate() was fragile, there is a python error if compiler is not in `_compilers_minimum_version`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
