### PR TITLE
feat(yaml-cpp): Allow to remove debug build suffix

### DIFF
--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -64,6 +64,8 @@ class YamlCppConan(ConanFile):
         if is_msvc(self):
             tc.variables["YAML_MSVC_SHARED_RT"] = not is_msvc_static_runtime(self)
             tc.preprocessor_definitions["_NOEXCEPT"] = "noexcept"
+        if self.conf.get("user.library.no_debug_suffix", default=False, check_type=bool):
+            tc.variables['CMAKE_DEBUG_POSTFIX'] = ''
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Specify library name and version:  **yaml-cpp/0.8.0**

Allows the user to remove the debug suffix, which is not necessary to exist in a conan environment, which never has different builds in the same directory.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
