### PR TITLE
abseil: fix build of 20230802.1 with MinGW

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -29,6 +29,10 @@ patches:
       patch_description: "link libm to absl string"
       patch_type: "portability"
       patch_source: "https://github.com/abseil/abseil-cpp/issues/1100"
+    - patch_file: "patches/20230802.1-0001-fix-mingw.patch"
+      patch_description: "Fix build with MinGW"
+      patch_type: "portability"
+      patch_source: "https://github.com/abseil/abseil-cpp/commit/2f77684e8dc473a48dbc19167ffe69c40ce8ada4"
   "20230125.3":
     - patch_file: "patches/0003-absl-string-libm.patch"
       patch_description: "link libm to absl string"

--- a/recipes/abseil/all/patches/20230802.1-0001-fix-mingw.patch
+++ b/recipes/abseil/all/patches/20230802.1-0001-fix-mingw.patch
@@ -1,0 +1,40 @@
+--- a/absl/synchronization/internal/pthread_waiter.h
++++ b/absl/synchronization/internal/pthread_waiter.h
+@@ -16,7 +16,7 @@
+ #ifndef ABSL_SYNCHRONIZATION_INTERNAL_PTHREAD_WAITER_H_
+ #define ABSL_SYNCHRONIZATION_INTERNAL_PTHREAD_WAITER_H_
+ 
+-#ifndef _WIN32
++#if !defined(_WIN32) && !defined(__MINGW32__)
+ #include <pthread.h>
+ 
+ #include "absl/base/config.h"
+@@ -55,6 +55,6 @@ class PthreadWaiter : public WaiterCrtp<PthreadWaiter> {
+ ABSL_NAMESPACE_END
+ }  // namespace absl
+ 
+-#endif  // ndef _WIN32
++#endif  // !defined(_WIN32) && !defined(__MINGW32__)
+ 
+ #endif  // ABSL_SYNCHRONIZATION_INTERNAL_PTHREAD_WAITER_H_
+--- a/absl/synchronization/internal/win32_waiter.h
++++ b/absl/synchronization/internal/win32_waiter.h
+@@ -20,7 +20,8 @@
+ #include <sdkddkver.h>
+ #endif
+ 
+-#if defined(_WIN32) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
++#if defined(_WIN32) && !defined(__MINGW32__) && \
++    _WIN32_WINNT >= _WIN32_WINNT_VISTA
+ 
+ #include "absl/base/config.h"
+ #include "absl/synchronization/internal/kernel_timeout.h"
+@@ -65,6 +66,7 @@ class Win32Waiter : public WaiterCrtp<Win32Waiter> {
+ ABSL_NAMESPACE_END
+ }  // namespace absl
+ 
+-#endif  // defined(_WIN32) && _WIN32_WINNT >= _WIN32_WINNT_VISTA
++#endif  // defined(_WIN32) && !defined(__MINGW32__) &&
++        // _WIN32_WINNT >= _WIN32_WINNT_VISTA
+ 
+ #endif  // ABSL_SYNCHRONIZATION_INTERNAL_WIN32_WAITER_H_


### PR DESCRIPTION
Build erros of 20230802.1 with MinGW:

```
[213/236] Linking CXX shared library bin\libabsl_synchronization.dll
FAILED: bin/libabsl_synchronization.dll absl/synchronization/libabsl_synchronization.dll.a
cmd.exe /C "cd . && D:\Prog\winlibs64-13.1.0msvcrt\mingw64\bin\x86_64-w64-mingw32-g++.exe -std=c++17 -O3 -DNDEBUG   -shared -o bin\libabsl_synchronization.dll -Wl,--out-implib,absl\synchronization\libabsl_synchronization.dll.a -Wl,--major-image-version,0,--minor-image-version,0 absl/synchronization/CMakeFiles/synchronization.dir/barrier.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/blocking_counter.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/internal/create_thread_identity.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/internal/futex_waiter.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/internal/per_thread_sem.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/internal/pthread_waiter.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/internal/sem_waiter.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/internal/stdcpp_waiter.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/internal/waiter_base.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/internal/win32_waiter.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/notification.cc.obj absl/synchronization/CMakeFiles/synchronization.dir/mutex.cc.obj  absl/synchronization/libabsl_graphcycles_internal.dll.a  absl/synchronization/libabsl_kernel_timeout_internal.dll.a  absl/debugging/libabsl_stacktrace.dll.a  absl/debugging/libabsl_symbolize.dll.a  absl/time/libabsl_time.dll.a  absl/time/libabsl_civil_time.dll.a  absl/time/libabsl_time_zone.dll.a  absl/base/libabsl_malloc_internal.dll.a  absl/debugging/libabsl_debugging_internal.dll.a  absl/debugging/libabsl_demangle_internal.dll.a  absl/strings/libabsl_strings.dll.a  absl/numeric/libabsl_int128.dll.a  absl/strings/libabsl_string_view.dll.a  absl/strings/libabsl_strings_internal.dll.a  absl/base/libabsl_base.dll.a  -lpthread  absl/base/libabsl_spinlock_wait.dll.a  absl/base/libabsl_throw_delegate.dll.a  absl/base/libabsl_raw_logging_internal.dll.a  absl/base/libabsl_log_severity.dll.a  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -pthread && cd ."
D:/Prog/winlibs64-13.1.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: absl/synchronization/CMakeFiles/synchronization.dir/internal/per_thread_sem.cc.obj:per_thread_sem:(.text+0x14b): undefined reference to `absl::lts_20230802::synchronization_internal::Win32Waiter::Wait(absl::lts_20230802::synchronization_internal::KernelTimeout)'
D:/Prog/winlibs64-13.1.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: absl/synchronization/CMakeFiles/synchronization.dir/internal/per_thread_sem.cc.obj:per_thread_sem:(.text+0xb5): undefined reference to `absl::lts_20230802::synchronization_internal::Win32Waiter::Poke()'
D:/Prog/winlibs64-13.1.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: absl/synchronization/CMakeFiles/synchronization.dir/internal/per_thread_sem.cc.obj:per_thread_sem:(.text+0xc5): undefined reference to `absl::lts_20230802::synchronization_internal::Win32Waiter::Win32Waiter()'
D:/Prog/winlibs64-13.1.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: absl/synchronization/CMakeFiles/synchronization.dir/internal/per_thread_sem.cc.obj:per_thread_sem:(.text+0xd5): undefined reference to `absl::lts_20230802::synchronization_internal::Win32Waiter::Post()'
D:/Prog/winlibs64-13.1.0msvcrt/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: absl/synchronization/CMakeFiles/synchronization.dir/internal/per_thread_sem.cc.obj:per_thread_sem:(.text+0xe5): undefined reference to `absl::lts_20230802::synchronization_internal::Win32Waiter::Poke()'
collect2.exe: error: ld returned 1 exit status
[214/236] Building CXX object absl/strings/CMakeFiles/cord.dir/cord.cc.obj
ninja: build stopped: subcommand failed.
```

see https://github.com/abseil/abseil-cpp/issues/1510

Fix: backport https://github.com/abseil/abseil-cpp/commit/2f77684e8dc473a48dbc19167ffe69c40ce8ada4

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
