### PR TITLE
Fix SFML linker error on Linux

### DIFF
--- a/recipes/sfml/all/conanfile.py
+++ b/recipes/sfml/all/conanfile.py
@@ -147,6 +147,9 @@ class SfmlConan(ConanFile):
         def ws2_32():
             return ["ws2_32"] if self.settings.os == "Windows" else []
 
+        def dl():
+            return ["dl"] if self.settings.os == "Linux" else []
+
         def libudev():
             return ["libudev::libudev"] if self.settings.os == "Linux" else []
 
@@ -235,7 +238,7 @@ class SfmlConan(ConanFile):
                     "target": "sfml-window",
                     "libs": [f"sfml-window{suffix}"],
                     "requires": ["system"] + opengl() + xorg() + libudev(),
-                    "system_libs": gdi32() + winmm() + usbhid() + android() + opengles_android(),
+                    "system_libs": dl() + gdi32() + winmm() + usbhid() + android() + opengles_android(),
                     "frameworks": foundation() + appkit() + iokit() + carbon() +
                                   uikit() + coregraphics() + quartzcore() +
                                   coreservices() + coremotion() + opengles_ios(),

--- a/recipes/sfml/all/conanfile.py
+++ b/recipes/sfml/all/conanfile.py
@@ -148,7 +148,7 @@ class SfmlConan(ConanFile):
             return ["ws2_32"] if self.settings.os == "Windows" else []
 
         def dl():
-            return ["dl"] if self.settings.os == "Linux" else []
+            return ["dl"] if self.settings.os in ["Linux", "FreeBSD"] and Version(self.version) >= "2.6.0" else []
 
         def libudev():
             return ["libudev::libudev"] if self.settings.os == "Linux" else []


### PR DESCRIPTION
Specify library name and version:  **sfml/2.6.1**

When I attempt to link a C++ program that uses Conan package sfml/2.6.1 on Linux, I get this error:
```
/home/runner/.conan2/p/b/sfml9a8b35e144b99/p/lib/libsfml-window-s-d.a(VulkanImplX11.cpp.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
```

whereas sfml/2.5.1 worked fine. The CMake code in the SFML repo links with `dl` on linux [as shown here](https://github.com/SFML/SFML/blob/39ba64cfc63866a868c94a41ca331c12235c190e/src/SFML/Window/CMakeLists.txt#L325) so I'm just propagating that to the Conan package.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
