### PR TITLE
whisper-cpp: add version 1.4.3

### DIFF
--- a/recipes/whisper-cpp/all/conandata.yml
+++ b/recipes/whisper-cpp/all/conandata.yml
@@ -5,6 +5,9 @@ sources:
   "1.4.2":
     url: "https://github.com/ggerganov/whisper.cpp/archive/a5defbc1b98bea0f070331ce1e8b62d947b0443d.tar.gz"
     sha256: "6dd0690b084269b22b1b749103b047e6d45d7b910d7bc9587085ce057dca5431"
+  "1.4.3":
+    url: "https://github.com/ggerganov/whisper.cpp/archive/6a5d195109994b865e1c92a88258ac182399eb64.tar.gz"
+    sha256: "5b6693c314ae6fb362c13d02357a18099ab0ba03abc07c21f2e8c32b42b7b07e"
 patches:
   "1.4.2":
     - patch_file: "patches/1.4.2-0001-find_package_openblas.patch"

--- a/recipes/whisper-cpp/all/conanfile.py
+++ b/recipes/whisper-cpp/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, apply_conandata_patches, export_conandata_patches
 from conan.tools.scm import Version
 
@@ -22,13 +22,13 @@ class WhisperCppConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False], "sanitize_thread": [True, False],
                "sanitize_address": [True, False], "sanitize_undefined": [True, False],
                "no_avx": [True, False], "no_avx2": [True, False], "no_fma": [True, False], "no_f16c": [True, False],
-               "no_accelerate": [True, False], "with_coreml": [True, False], "coreml_allow_fallback": [True, False],
-               "with_blas": [True, False]}
+               "no_accelerate": [True, False], "metal": [True, False], "metal_ndebug": [True, False], 
+               "with_coreml": [True, False], "coreml_allow_fallback": [True, False], "with_blas": [True, False]}
     default_options = {"shared": False, "fPIC": True, "sanitize_thread": False,
                        "sanitize_address": False, "sanitize_undefined": False,
                        "no_avx": False, "no_avx2": False, "no_fma": False, "no_f16c": False,
-                       "no_accelerate": False, "with_coreml": False, "coreml_allow_fallback": False,
-                       "with_blas": False}
+                       "no_accelerate": False, "metal": False, "metal_ndebug": False, 
+                       "with_coreml": False, "coreml_allow_fallback": False, "with_blas": False}
     package_type = "library"
 
     @property
@@ -117,6 +117,10 @@ class WhisperCppConan(ConanFile):
         if is_apple_os(self):
             if self.options.no_accelerate:
                 tc.variables["WHISPER_NO_ACCELERATE"] = True
+            if not self.options.metal:
+                tc.variables["WHISPER_METAL"] = False
+            if self.options.metal_ndebug:
+                tc.variables["WHISPER_METAL_NDEBUG"] = True
             if self.options.with_coreml:
                 tc.variables["WHISPER_COREML"] = True
                 if self.options.coreml_allow_fallback:

--- a/recipes/whisper-cpp/all/conanfile.py
+++ b/recipes/whisper-cpp/all/conanfile.py
@@ -58,6 +58,10 @@ class WhisperCppConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+        if Version(self.version) < "1.4.3":
+            del self.options.metal
+            del self.options.metal_ndebug
+
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
@@ -117,9 +121,9 @@ class WhisperCppConan(ConanFile):
         if is_apple_os(self):
             if self.options.no_accelerate:
                 tc.variables["WHISPER_NO_ACCELERATE"] = True
-            if not self.options.metal:
+            if not self.options.get_safe("metal"):
                 tc.variables["WHISPER_METAL"] = False
-            if self.options.metal_ndebug:
+            if self.options.get_safe("metal_ndebug"):
                 tc.variables["WHISPER_METAL_NDEBUG"] = True
             if self.options.with_coreml:
                 tc.variables["WHISPER_COREML"] = True

--- a/recipes/whisper-cpp/config.yml
+++ b/recipes/whisper-cpp/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "all"
   "1.4.2":
     folder: "all"
+  "1.4.3":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **whisper-cpp/1.4.3**

Will add the new patch version for whisper-cpp: https://github.com/ggerganov/whisper.cpp/releases/tag/v1.4.3

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
