### PR TITLE
DCMTK: Add `dcmect` submodule

### DIFF
--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -301,6 +301,7 @@ class DCMTKConan(ConanFile):
             "dcmjpls" : ["ofstd", "oflog", "dcmdata", "dcmimgle", "dcmimage", "dcmtkcharls"],
             "dcmtkcharls": ["ofstd", "oflog"],
             "dcmtls"  : ["ofstd", "dcmdata", "dcmnet"] + openssl(),
+            "dcmect"  : ["ofstd", "dcmdata", "dcmfg", "dcmiod", "oflog"],
             "dcmnet"  : ["ofstd", "oflog", "dcmdata"] + tcpwrappers(),
             "dcmsr"   : ["ofstd", "oflog", "dcmdata", "dcmimgle", "dcmimage"] + xml2(),
             "cmr"     : ["dcmsr"],


### PR DESCRIPTION
Specify library name and version:  **dcmtk/3.6.7**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
I've got link error while tring to compile this code:
```cpp
EctEnhancedCT* concat = NULL;
EctEnhancedCT::loadDataset(*dataset, concat);
size_t numFrames;
numFrames = concat->getNumberOfFrames();
EctEnhancedCT::FramesType frames = concat->getFrames();
Uint16* frame                    = OFget<EctEnhancedCT::Frames<Uint16> >(&frames)->getFrame(0);
assert(frame != nullptr);
```


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
