### PR TITLE
aws-c-cal: remove 0.5.11

### DIFF
--- a/recipes/aws-c-cal/all/conandata.yml
+++ b/recipes/aws-c-cal/all/conandata.yml
@@ -20,9 +20,6 @@ sources:
   "0.5.12":
     url: "https://github.com/awslabs/aws-c-cal/archive/v0.5.12.tar.gz"
     sha256: "350c29a288d5d498bd6574fca659cffc9453bf62691fbde5788399716c2bd132"
-  "0.5.11":
-    url: "https://github.com/awslabs/aws-c-cal/archive/v0.5.11.tar.gz"
-    sha256: "ef46e121b2231a0b19afce8af4b32d77501df4d470e926990918456636cd83c0"
 patches:
   "0.6.9":
     - patch_file: "patches/0002-apple-corefoundation-0.6.9.patch"
@@ -55,12 +52,6 @@ patches:
       patch_type: "backport"
       patch_source: "https://github.com/awslabs/aws-c-cal/pull/126"
   "0.5.12":
-    - patch_file: "patches/0001-use-openssl-cmake-imported-target.patch"
-    - patch_file: "patches/0002-apple-corefoundation-0.5.11.patch"
-      patch_description: "Link to CoreFoundation on Apple"
-      patch_type: "backport"
-      patch_source: "https://github.com/awslabs/aws-c-cal/pull/126"
-  "0.5.11":
     - patch_file: "patches/0001-use-openssl-cmake-imported-target.patch"
     - patch_file: "patches/0002-apple-corefoundation-0.5.11.patch"
       patch_description: "Link to CoreFoundation on Apple"

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -48,12 +48,7 @@ class AwsCCal(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) <= "0.5.11":
-            # transitive_libs probably not strictly required, but it's impossible to write a robust test package
-            # without it for conan v2 (we would have to required aws-c-common in test package, but we can't know
-            # which version to require in test package)
-            self.requires("aws-c-common/0.6.11", transitive_headers=True, transitive_libs=True)
-        elif Version(self.version) <= "0.5.20":
+        if Version(self.version) <= "0.5.20":
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)

--- a/recipes/aws-c-cal/config.yml
+++ b/recipes/aws-c-cal/config.yml
@@ -13,5 +13,3 @@ versions:
     folder: all
   "0.5.12":
     folder: all
-  "0.5.11":
-    folder: all


### PR DESCRIPTION
the only dependents are aws-c-io 0.10.9 and 0.10.5 which are removed in https://github.com/conan-io/conan-center-index/pull/21022

Specify library name and version:  **aws-c-cal/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
