### PR TITLE
commata: add version 0.2.6-bug1

### DIFF
--- a/recipes/commata/all/conandata.yml
+++ b/recipes/commata/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.6-bug1":
+    url: "https://github.com/furfurylic/commata/archive/refs/tags/v0.2.6-bug1.tar.gz"
+    sha256: "141eb86f9033a808b6ead22a9367fc4d18a3047f55255ddf67d60e90f46b8f60"
   "0.2.6":
     url: "https://github.com/furfurylic/commata/archive/refs/tags/v0.2.6.tar.gz"
     sha256: "bc91f496cb261e5627fb39d8e79d1aaa924975332d9957de4cb4097db6957815"

--- a/recipes/commata/config.yml
+++ b/recipes/commata/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.6-bug1":
+    folder: all
   "0.2.6":
     folder: all
   "0.2.5":


### PR DESCRIPTION
Specify library name and version:  **commata/0.2.6-bug1**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
