### PR TITLE
ffmpeg: bump dependencies + disable with_vulkan by default

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -140,7 +140,7 @@ class FFMpegConan(ConanFile):
         "with_pulse": True,
         "with_vaapi": True,
         "with_vdpau": True,
-        "with_vulkan": True,
+        "with_vulkan": False,
         "with_xcb": True,
         "with_appkit": True,
         "with_avfoundation": True,

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -275,9 +275,9 @@ class FFMpegConan(ConanFile):
         if self.options.with_opus:
             self.requires("opus/1.4")
         if self.options.with_zeromq:
-            self.requires("zeromq/4.3.4")
+            self.requires("zeromq/4.3.5")
         if self.options.with_sdl:
-            self.requires("sdl/2.28.2")
+            self.requires("sdl/2.28.5")
         if self.options.with_libx264:
             self.requires("libx264/cci.20220602")
         if self.options.with_libx265:
@@ -303,7 +303,7 @@ class FFMpegConan(ConanFile):
         if self.options.get_safe("with_vdpau"):
             self.requires("vdpau/system")
         if self._version_supports_vulkan and self.options.get_safe("with_vulkan"):
-            self.requires("vulkan-loader/1.3.239.0")
+            self.requires("vulkan-loader/1.3.243.0")
 
     def validate(self):
         if self.options.with_ssl == "securetransport" and not is_apple_os(self):


### PR DESCRIPTION
I'm blocked by missing packages of ffmpeg for https://github.com/conan-io/conan-center-index/pull/19194

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
