### PR TITLE
b2: build universal binary with intel and arm

### DIFF
--- a/recipes/b2/config.yml
+++ b/recipes/b2/config.yml
@@ -1,49 +1,5 @@
 versions:
-  "4.0.0":
-    folder: standard
-  "4.0.1":
-    folder: standard
-  "4.1.0":
-    folder: standard
-  "4.2.0":
-    folder: standard
-  "4.3.0":
-    folder: portable
-  "4.4.0":
-    folder: portable
-  "4.4.1":
-    folder: portable
-  "4.4.2":
-    folder: portable
-  "4.5.0":
-    folder: portable
-  "4.6.0":
-    folder: portable
-  "4.6.1":
-    folder: portable
-  "4.7.0":
-    folder: portable
-  "4.7.1":
-    folder: portable
-  "4.7.2":
-    folder: portable
-  "4.8.0":
-    folder: portable
-  "4.8.1":
-    folder: portable
   "4.8.2":
-    folder: portable
-  "4.9.0":
-    folder: portable
-  "4.9.1":
-    folder: portable
-  "4.9.2":
-    folder: portable
-  "4.9.3":
-    folder: portable
-  "4.9.4":
-    folder: portable
-  "4.9.5":
     folder: portable
   "4.9.6":
     folder: portable

--- a/recipes/b2/portable/conandata.yml
+++ b/recipes/b2/portable/conandata.yml
@@ -1,61 +1,7 @@
 sources:
-  "4.3.0":
-    sha256: 138c90b66edb0a28e225705a2cbf897a8cef5f87e68befc748f8e6808e21628a
-    url: https://github.com/bfgroup/b2/archive/4.3.0.tar.gz
-  "4.4.0":
-    sha256: fa4079370644110604895ff08057fe2eff3289bcffdaec55fcdf43ea33ff25a8
-    url: https://github.com/bfgroup/b2/archive/4.4.0.tar.gz
-  "4.4.1":
-    sha256: 4fb15abd994968a24868c13502f080c4a28b20f59831acf9eabd64a3b257554f
-    url: https://github.com/bfgroup/b2/archive/4.4.1.tar.gz
-  "4.4.2":
-    sha256: 575e59b89191a6a6780d7165cae3222b8a7a1e7d5e8165b3524eefe32fc3de46
-    url: https://github.com/bfgroup/b2/archive/4.4.2.tar.gz
-  "4.5.0":
-    url: "https://github.com/bfgroup/b2/archive/4.5.0.tar.gz"
-    sha256: "39c3b51bf9c5f32b1c249d2d405274976b166e1bdca1fc5205b595f1cb5dbac3"
-  "4.6.0":
-    url: "https://github.com/bfgroup/b2/archive/4.6.0.tar.gz"
-    sha256: "3a308e0f79a039d8a9495b375f3292f5163000c19caa79c5687e4cb5b1938b49"
-  "4.6.1":
-    url: "https://github.com/bfgroup/b2/archive/4.6.1.tar.gz"
-    sha256: "a3f3323eaeb2c27d7a3ca86842665c6c3bc3d93cc626ba362ae6d0c5a7bfbe2c"
-  "4.7.0":
-    url: "https://github.com/bfgroup/b2/archive/4.7.0.tar.gz"
-    sha256: "82c2eb92d6ab2bd447646568ac8430c316cbd2a1819c108136224498c0abed84"
-  "4.7.1":
-    url: "https://github.com/bfgroup/b2/archive/4.7.1.tar.gz"
-    sha256: "30844184ded3217c090b76e6e051c3ac663ea63bd19e1b727b05c54411cac867"
-  "4.7.2":
-    url: "https://github.com/bfgroup/b2/archive/4.7.2.tar.gz"
-    sha256: "70883f8ed82efc49f425f1961a82e961cefdbca3a28581cb57b405bd7516677f"
-  "4.8.0":
-    url: "https://github.com/bfgroup/b2/archive/4.8.0.tar.gz"
-    sha256: "2f18951d4cc267a810e44fc483b747d489e30ed42ee6d9e7c5e19de750ee5cd2"
-  "4.8.1":
-    url: "https://github.com/bfgroup/b2/archive/4.8.1.tar.gz"
-    sha256: "8ecff1025df9473d91a0d116af3e32be6fba6e57d4ea962e033ff1678609d668"
   "4.8.2":
     url: "https://github.com/bfgroup/b2/archive/4.8.2.tar.gz"
     sha256: "220edfbd5022394c5dc264dfdd8bf6d3ec53b784db87461026bb23ea9d9ec4bd"
-  "4.9.0":
-    url: "https://github.com/bfgroup/b2/archive/4.9.0.tar.gz"
-    sha256: "7c614e41f10e004c7539c75c60f7b2df26a61fe35058e9021f8fd5049c97a255"
-  "4.9.1":
-    url: "https://github.com/bfgroup/b2/archive/4.9.1.tar.gz"
-    sha256: "81e49dc85e956c3e708bdd02fcfe0b9f406fca8edca54c75c94ebd6c322ed587"
-  "4.9.2":
-    url: "https://github.com/bfgroup/b2/archive/4.9.2.tar.gz"
-    sha256: "7e1a135b308999d2a65fce3eba8f4ffb41ca82ae133f8494cc42cbca63c890de"
-  "4.9.3":
-    url: "https://github.com/bfgroup/b2/archive/4.9.3.tar.gz"
-    sha256: "4524b8ecf138a9087aa24b8889c44ea7ae9f2d373acc9535d72fb048c213e1b9"
-  "4.9.4":
-    url: "https://github.com/bfgroup/b2/releases/download/4.9.4/b2-4.9.4.tar.bz2"
-    sha256: "1996d8098955ad3fdecab242d784afaef0fba80dd5d2ef0b3a41592e26772312"
-  "4.9.5":
-    url: "https://github.com/bfgroup/b2/releases/download/4.9.5/b2-4.9.5.tar.bz2"
-    sha256: "f81bea44601613f633d3311341f3f63594608537bf38d7073b877ec1edb2760a"
   "4.9.6":
     url: "https://github.com/bfgroup/b2/releases/download/4.9.6/b2-4.9.6.tar.bz2"
     sha256: "10c1344c751fcf5a1f9ec6f52c02626cfbf78a4806f7817949b115e107bbbc5f"

--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -63,10 +63,14 @@ class B2Conan(ConanFile):
         del self.info.options.use_cxx_env
         del self.info.options.toolset
 
-    def validate(self):
-        if hasattr(self, "settings_build") and cross_building(self):
+        if self._is_macos_intel_or_arm(self.info.settings):
+            self.info.settings.arch = "x86_64,armv8"
+
+    def validate_build(self):
+        if hasattr(self, "settings_build") and cross_building(self) and not self._is_macos_intel_or_arm(self.settings):
             raise ConanInvalidConfiguration(f"{self.ref} recipe doesn't support cross-build yet")
 
+    def validate(self):
         if (self.options.toolset == 'cxx' or self.options.toolset == 'cross-cxx') and not self.options.use_cxx_env:
             raise ConanInvalidConfiguration(
                 "Option toolset 'cxx' and 'cross-cxx' requires 'use_cxx_env=True'")
@@ -89,6 +93,9 @@ class B2Conan(ConanFile):
     @property
     def _pkg_bin_dir(self):
         return os.path.join(self.package_folder, "bin")
+
+    def _is_macos_intel_or_arm(self, settings):
+        return settings.os == "Macos" and settings.arch in ["x86_64", "armv8"]
 
     @contextmanager
     def _bootstrap_env(self):
@@ -145,6 +152,10 @@ class B2Conan(ConanFile):
                                     command += '"'+b2_vcvars+'" && '
         command += "build" if use_windows_commands else "./build.sh"
 
+        cxxflags = ""
+        if self._is_macos_intel_or_arm(self.settings):
+            cxxflags += " -arch arm64 -arch x86_64"
+
         if self.options.use_cxx_env:
             envvars = VirtualBuildEnv(self).vars()
 
@@ -153,9 +164,11 @@ class B2Conan(ConanFile):
                 command += f" --cxx={cxx}"
                 self._write_project_config(cxx)
 
-            cxxflags = envvars.get("CXXFLAGS")
-            if cxxflags:
-                command += f" --cxxflags={cxxflags}"
+            cxxflags_env = envvars.get("CXXFLAGS")
+            cxxflags = f"{cxxflags} {cxxflags_env}"
+
+        if cxxflags:
+            command += f' --cxxflags="{cxxflags}"'
 
         if b2_toolset != 'auto':
             command += " "+str(b2_toolset)


### PR DESCRIPTION
The `b2` recipe cannot be currently cross-built because `b2 install` is called immediately after building it - thus, it needs to be able to run it. We are working towards upgrading all mac CI build agents to Apple Silicon - and we don't want to lose the ability to generate the x86_64 binaries for this package.

This PR tweaks the recipe such that on macOS the binary is built targeting both architectures (`x86_64` and `armv8`) - which would give us working binaries for armv8 (which we don't currently have), and will continue being able to produce them after the CI agents are upgraded.

There are more possible solutions:
* require a compatible version of the b2 executable only when crossbuilding (a tool requires on  itself) 
* re-implement the logic of `b2 install`, but in python - looks doable as it appears to copy a file structure, but this may be fragile over time


Also in this PR:
* Remove older versions - keep the latest patch version for every minor released since 2022.