### PR TITLE
magic_enum: add version 0.9.4, remove older versions

### DIFF
--- a/recipes/magic_enum/all/conandata.yml
+++ b/recipes/magic_enum/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.4":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.9.4.tar.gz"
+    sha256: "0ffc840d881a377a520e999b79ec2823b3b8ffadccad5d94084cc37fcf6fe2c9"
   "0.9.3":
     url: "https://github.com/Neargye/magic_enum/archive/v0.9.3.tar.gz"
     sha256: "3cadd6a05f1bffc5141e5e731c46b2b73c2dbff025e723c8abaa659e0a24f072"
@@ -20,21 +23,3 @@ sources:
   "0.8.0":
     url: "https://github.com/Neargye/magic_enum/archive/v0.8.0.tar.gz"
     sha256: "5e7680e877dd4cf68d9d0c0e3c2a683b432a9ba84fc1993c4da3de70db894c3c"
-  "0.7.3":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.7.3.tar.gz"
-    sha256: "b8d0cd848546fee136dc1fa4bb021a1e4dc8fe98e44d8c119faa3ef387636bf7"
-  "0.7.2":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.7.2.tar.gz"
-    sha256: "a77895ebc684f7a4dd2e4e06529b22e9ae694037f6dee0753d3ce0bbcd5b3e38"
-  "0.7.1":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.7.1.tar.gz"
-    sha256: "11bb590dd055194e92936fa4d0652084c14bd23ac8e4b5a02271b6259a05cec9"
-  "0.7.0":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.7.0.tar.gz"
-    sha256: "4fe6627407a656d0d73879c0346b251ccdcfb718c37bef5410ba172c7c7d5f9a"
-  "0.6.6":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.6.6.tar.gz"
-    sha256: "1033f9a9315023feebb48f20d5a572149ec72c1e95a52bcf7042a412ff9d2e28"
-  "0.6.5":
-    url: "https://github.com/Neargye/magic_enum/archive/v0.6.5.tar.gz"
-    sha256: "37A69482517C8976CB48CD271DA8C6BA92E07EE2AB2BDD7CAEF4C8158AF77359"

--- a/recipes/magic_enum/all/test_package/CMakeLists.txt
+++ b/recipes/magic_enum/all/test_package/CMakeLists.txt
@@ -6,3 +6,7 @@ find_package(magic_enum REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE magic_enum::magic_enum)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+if(magic_enum_VERSION VERSION_GREATER_EQUAL "0.9.4")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE MAGIC_ENUM_INCLUDE_WITH_FOLDER)
+endif()

--- a/recipes/magic_enum/all/test_package/test_package.cpp
+++ b/recipes/magic_enum/all/test_package/test_package.cpp
@@ -1,4 +1,8 @@
-#include <magic_enum.hpp>
+#ifdef MAGIC_ENUM_INCLUDE_WITH_FOLDER
+#  include <magic_enum/magic_enum.hpp>
+#else
+#  include <magic_enum.hpp>
+#endif
 #include <cstdlib>
 #include <string>
 

--- a/recipes/magic_enum/config.yml
+++ b/recipes/magic_enum/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.4":
+    folder: all
   "0.9.3":
     folder: all
   "0.9.2":
@@ -12,16 +14,4 @@ versions:
   "0.8.1":
     folder: all
   "0.8.0":
-    folder: all
-  "0.7.3":
-    folder: all
-  "0.7.2":
-    folder: all
-  "0.7.1":
-    folder: all
-  "0.7.0":
-    folder: all
-  "0.6.6":
-    folder: all
-  "0.6.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **magic_enum/***

Since 0.9.4, magic_enum places `magic_enum.hpp` to `include/magic_enum/` folder.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
