### PR TITLE
pdfium: migrate to Conan v2

### DIFF
--- a/recipes/pdfium/all/CMakeLists.txt
+++ b/recipes/pdfium/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.0)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-add_subdirectory(pdfium-cmake/cmake)

--- a/recipes/pdfium/all/conandata.yml
+++ b/recipes/pdfium/all/conandata.yml
@@ -1,11 +1,11 @@
 sources:
-  "cci.20210730":
+  "95.0.4629":
     pdfium-cmake:
-      # FIXME: create release + use hash
-      url: "https://github.com/madebr/pdfium-cmake/archive/0abc6ac8b3ecd2faac45bf46ee79bf381b5b5890.zip"
-      sha256: "8bcbb1eb6ec171604d669585f289c609d3b6c95045525d0e510c3fee7851d44e"
+      # FIXME: create release
+      url: "https://github.com/madebr/pdfium-cmake/archive/9611e37f688e9881b50aef7e7775accdda6cd98f.zip"
+      sha256: "9085c22bd9d21acede4f5f26be0b6a0f82346e2ea53cc8bcddd785a4190d7a84"
     pdfium:
-      url: "https://pdfium.googlesource.com/pdfium/+archive/6c8cd905587809a0ff299d1edb34fc85bed4c976.tar.gz"
+      url: "https://pdfium.googlesource.com/pdfium/+archive/refs/heads/chromium/4629.tar.gz"
       # sha256 is volatile on googlesource, no up-to-date github fork
     trace_event:
       url: "https://chromium.googlesource.com/chromium/src/base/trace_event/common/+archive/ad56859ef8c85cc09a3d8e95dcedadb5109a0af8.tar.gz"

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -49,10 +49,11 @@ class PdfiumConan(ConanFile):
         self.requires("icu/74.1")
         self.requires("lcms/2.14")
         self.requires("openjpeg/2.5.0")
+        self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_libjpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_libjpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/3.0.0")
+            self.requires("libjpeg-turbo/3.0.1")
 
     def validate(self):
         if self.settings.compiler.cppstd:
@@ -86,6 +87,8 @@ class PdfiumConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["PDFIUM_ROOT"] = self.source_folder.replace("\\", "/")
         tc.variables["PDF_LIBJPEG_TURBO"] = self.options.with_libjpeg == "libjpeg-turbo"
+        tc.variables["PDF_ENABLE_XFA"] = False  # TODO: pdfium-cmake needs updating
+        tc.variables["PDF_ENABLE_V8"] = False  # TODO: requires v8
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -1,20 +1,26 @@
-from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import get
-from conan.tools.scm import Version
-from conans import CMake, tools
 import os
 
-required_conan_version = ">=1.33.0"
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.build import check_min_cppstd, stdcpp_library
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
 
 
 class PdfiumConan(ConanFile):
     name = "pdfium"
     description = "PDF generation and rendering library."
     license = "BSD-3-Clause"
-    topics = ("conan", "pdfium", "generate", "generation", "rendering", "pdf", "document", "print")
-    homepage = "https://opensource.google/projects/pdfium"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://opensource.google/projects/pdfium"
+    topics = ("generate", "generation", "rendering", "pdf", "document", "print")
+
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -27,84 +33,80 @@ class PdfiumConan(ConanFile):
         "with_libjpeg": "libjpeg",
     }
 
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake", "cmake_find_package", "pkg_config"
-    short_paths = True
-
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("freetype/2.13.0")
-        self.requires("icu/73.2")
+        self.requires("icu/74.1")
         self.requires("lcms/2.14")
         self.requires("openjpeg/2.5.0")
         if self.options.with_libjpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_libjpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.1.5")
-
-    def build_requirements(self):
-        self.build_requires("pkgconf/1.9.5")
+            self.requires("libjpeg-turbo/3.0.0")
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 14)
+            check_min_cppstd(self, 14)
         minimum_compiler_versions = {
-            "gcc": 8,
-            "Visual Studio": 15,
+            "gcc": "8",
+            "msvc": "191",
+            "Visual Studio": "15",
         }
         min_compiler_version = minimum_compiler_versions.get(str(self.settings.compiler))
-        if min_compiler_version:
-            if Version(self.settings.compiler.version) < min_compiler_version:
-                raise ConanInvalidConfiguration("pdfium needs at least compiler version {}".format(min_compiler_version))
+        if min_compiler_version and Version(self.settings.compiler.version) < min_compiler_version:
+            raise ConanInvalidConfiguration(
+                f"pdfium needs at least compiler version {min_compiler_version}"
+            )
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.0.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version]["pdfium-cmake"],
-                  destination="pdfium-cmake", strip_root=True)
+            destination=os.path.join(self.source_folder, "pdfium-cmake"), strip_root=True)
         get(self, **self.conan_data["sources"][self.version]["pdfium"],
-                  destination=self._source_subfolder)
+            destination=self.source_folder)
         get(self, **self.conan_data["sources"][self.version]["trace_event"],
-                  destination=os.path.join(self._source_subfolder, "base", "trace_event", "common"))
+            destination=os.path.join(self.source_folder, "base", "trace_event", "common"))
         get(self, **self.conan_data["sources"][self.version]["chromium_build"],
-                  destination=os.path.join(self._source_subfolder, "build"))
+            destination=os.path.join(self.source_folder, "build"))
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["PDFIUM_ROOT"] = os.path.join(self.source_folder, self._source_subfolder).replace("\\", "/")
-        self._cmake.definitions["PDF_LIBJPEG_TURBO"] = self.options.with_libjpeg == "libjpeg-turbo"
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["PDFIUM_ROOT"] = self.source_folder.replace("\\", "/")
+        tc.variables["PDF_LIBJPEG_TURBO"] = self.options.with_libjpeg == "libjpeg-turbo"
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+        deps = PkgConfigDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
-        cmake.build()
-        cmake.configure()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join("pdfium-cmake", "cmake"))
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
 
     def package_info(self):
         self.cpp_info.libs = ["pdfium"]
-        if tools.is_apple_os(self.settings.os):
+        if is_apple_os(self):
             self.cpp_info.frameworks.extend(["Appkit", "CoreFoundation", "CoreGraphics"])
 
-        stdcpp_library = tools.stdcpp_library(self)
-        if stdcpp_library:
-            self.cpp_info.system_libs.append(stdcpp_library)
+        stdcpp = stdcpp_library(self)
+        if stdcpp:
+            self.cpp_info.system_libs.append(stdcpp)

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -105,7 +105,7 @@ class PdfiumConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["pdfium"]
         if is_apple_os(self):
-            self.cpp_info.frameworks.extend(["Appkit", "CoreFoundation", "CoreGraphics"])
+            self.cpp_info.frameworks.extend(["AppKit", "CoreFoundation", "CoreGraphics"])
 
         stdcpp = stdcpp_library(self)
         if stdcpp:

--- a/recipes/pdfium/all/test_package/CMakeLists.txt
+++ b/recipes/pdfium/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(pdfium REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE pdfium::pdfium)

--- a/recipes/pdfium/all/test_package/conanfile.py
+++ b/recipes/pdfium/all/test_package/conanfile.py
@@ -1,11 +1,19 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
-from conans import ConanFile, CMake, tools
-from conan.tools.build import cross_building
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -13,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/pdfium/all/test_v1_package/CMakeLists.txt
+++ b/recipes/pdfium/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/pdfium/all/test_v1_package/conanfile.py
+++ b/recipes/pdfium/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+from conan.tools.build import cross_building
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/pdfium/config.yml
+++ b/recipes/pdfium/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20210730":
+  "95.0.4629":  # released 2021-08-28
     folder: all


### PR DESCRIPTION
Bumped the version to the newest one supported by `pdfium-cmake`.
The existing version had compilation issues in its C++17 compatibility library.