### PR TITLE
onnx: make static-library only

### DIFF
--- a/recipes/onnx/all/conanfile.py
+++ b/recipes/onnx/all/conanfile.py
@@ -65,7 +65,10 @@ class OnnxConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.options.shared:
+        if is_msvc(self):
+            del self.options.shared
+            self.package_type = "static-library"
+        if self.options.get_safe("shared"):
             self.options.rm_safe("fPIC")
 
     def layout(self):
@@ -83,8 +86,6 @@ class OnnxConan(ConanFile):
                 raise ConanInvalidConfiguration(
                     f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
                 )
-        if is_msvc(self) and self.options.shared:
-            raise ConanInvalidConfiguration("onnx shared is broken with Visual Studio")
 
     def build_requirements(self):
         if not self._is_legacy_one_profile:


### PR DESCRIPTION
Specify library name and version:  **onnx/all**

Similar reason as https://github.com/conan-io/conan-center-index/pull/20976, because on Windows shared library for ONNX is not available and we don't have package available.

For OpenVINO Conan v2 case https://github.com/conan-io/conan-center-index/pull/20933 we have failed dynamic builds https://c3i.jfrog.io/c3i/misc-v2/summary.html?json=https://c3i.jfrog.io/c3i/misc-v2/logs/pr/20933/5/openvino/2023.2.0//summary.json

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
