### PR TITLE
glaze: add version 1.6.0

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/stephenberry/glaze/archive/v1.6.0.tar.gz"
+    sha256: "1206421e4dfd259b9c3cd012adc35946cc27a19f10083040b353a78520ad1bee"
   "1.5.7":
     url: "https://github.com/stephenberry/glaze/archive/v1.5.7.tar.gz"
     sha256: "3bd40d0a2547fb9ee0fb94894dc13ba0bc37dac6d26ee292941e7a5203702c84"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.0":
+    folder: all
   "1.5.7":
     folder: all
   "1.5.6":


### PR DESCRIPTION
Specify library name and version:  **glaze/1.6.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
