### PR TITLE
imgui: add version 1.90, 1.90-docking

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.90":
+    url: "https://github.com/ocornut/imgui/archive/v1.90.tar.gz"
+    sha256: "170986e6a4b83d165bfc1d33c2c5a5bc2d67e5b97176287485c51a2299249296"
+  "1.90-docking":
+    url: "https://github.com/ocornut/imgui/archive/v1.90-docking.tar.gz"
+    sha256: "d4b7fd185443111a3a892d4625c85ab9666c6c9cb5484e3a447de6af419f8d2f"
   "1.89.9":
     url: "https://github.com/ocornut/imgui/archive/v1.89.9.tar.gz"
     sha256: "1acc27a778b71d859878121a3f7b287cd81c29d720893d2b2bf74455bf9d52d6"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.90":
+    folder: all
+  "1.90-docking":
+    folder: all
   "1.89.9":
     folder: all
   "1.89.9-docking":


### PR DESCRIPTION
Specify library name and version:  **imgui/1.90,1.90-docking**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
