### PR TITLE
cityhash: add version 1.0.1

### DIFF
--- a/recipes/cityhash/all/conandata.yml
+++ b/recipes/cityhash/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.1":
+    url: "https://github.com/google/cityhash/archive/8eded14d8e7cabfcdb10d4be35d521683edc0407.zip"
+    sha256: "e49f5bdb0f93d303bf18cb72f2f18e10ac3b4f2734da7cc1d708f7f2d2674c7c"
   "cci.20130801":
     url: "https://github.com/google/cityhash/archive/8af9b8c2b889d80c22d6bc26ba0df1afb79a30db.zip"
     sha256: "3524f5ed43143974a29fddeeece29c8b6348f05db08dd180452da01a2837ddce"

--- a/recipes/cityhash/config.yml
+++ b/recipes/cityhash/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.1":
+    folder: all
   "cci.20130801":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **cityhash/1.0.1**

Corresponding issue: #21173 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
