### PR TITLE
Update authorized users list: Remove old username after username change.

### DIFF
--- a/.c3i/authorized_users.yml
+++ b/.c3i/authorized_users.yml
@@ -809,7 +809,6 @@ authorized_users:
 - luizgabriel
 - kshehata
 - dietssa
-- simoncent
 - staskau
 - Iswenzz
 - DAP-IT-Aachen


### PR DESCRIPTION
In reference to this PR https://github.com/conan-io/conan-center-index/pull/21162, @sizeak is my username after I merged my personal and professional Github accounts. This PR removes my old username from the authorized users list. 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
