### PR TITLE
wavelet_buffer/all: bump deps

### DIFF
--- a/recipes/wavelet_buffer/all/conanfile.py
+++ b/recipes/wavelet_buffer/all/conanfile.py
@@ -62,7 +62,7 @@ class WaveletBufferConan(ConanFile):
         self.requires("blaze/3.8", transitive_headers=True)
         self.requires("cimg/3.3.0")
         if self.options.jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/3.0.0")
+            self.requires("libjpeg-turbo/3.0.1")
         else:
             self.requires("libjpeg/9e")
         # FIXME: unvendor SfCompressor which is currently downloaded at build time :s

--- a/recipes/wavelet_buffer/all/conanfile.py
+++ b/recipes/wavelet_buffer/all/conanfile.py
@@ -60,7 +60,7 @@ class WaveletBufferConan(ConanFile):
 
     def requirements(self):
         self.requires("blaze/3.8", transitive_headers=True)
-        self.requires("cimg/3.2.6")
+        self.requires("cimg/3.3.0")
         if self.options.jpeg == "libjpeg-turbo":
             self.requires("libjpeg-turbo/3.0.0")
         else:

--- a/recipes/wavelet_buffer/all/conanfile.py
+++ b/recipes/wavelet_buffer/all/conanfile.py
@@ -60,7 +60,7 @@ class WaveletBufferConan(ConanFile):
 
     def requirements(self):
         self.requires("blaze/3.8", transitive_headers=True)
-        self.requires("cimg/3.2.5")
+        self.requires("cimg/3.2.6")
         if self.options.jpeg == "libjpeg-turbo":
             self.requires("libjpeg-turbo/3.0.0")
         else:


### PR DESCRIPTION
Specify library name and version:  **wavelet_buffer/***

migrates to a cimg version which is compatible with conan 2


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
