### PR TITLE
cfitsio: more accurate license identifier

### DIFF
--- a/recipes/cfitsio/all/conanfile.py
+++ b/recipes/cfitsio/all/conanfile.py
@@ -12,7 +12,7 @@ class CfitsioConan(ConanFile):
     name = "cfitsio"
     description = "C library for reading and writing data files in FITS " \
                   "(Flexible Image Transport System) data format"
-    license = "ISC"
+    license = "CFITSIO"
     topics = ("fits", "image", "nasa", "astronomy", "astrophysics", "space")
     homepage = "https://heasarc.gsfc.nasa.gov/fitsio/"
     url = "https://github.com/conan-io/conan-center-index"


### PR DESCRIPTION
The project uses
https://spdx.org/licenses/CFITSIO.html
not the currently set
https://spdx.org/licenses/ISC.html
