### PR TITLE
fltk: use a more accurate license identifier

### DIFF
--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.53.0"
 class FltkConan(ConanFile):
     name = "fltk"
     description = "Fast Light Toolkit is a cross-platform C++ GUI toolkit"
-    license = "LGPL-2.1+ WITH FLTK-exception"
+    license = "LGPL-2.1-or-later WITH FLTK-exception"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.fltk.org"
     topics = ("gui",)

--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.53.0"
 class FltkConan(ConanFile):
     name = "fltk"
     description = "Fast Light Toolkit is a cross-platform C++ GUI toolkit"
-    license = "LGPL-2.0-custom"
+    license = "LGPL-2.1+ WITH FLTK-exception"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.fltk.org"
     topics = ("gui",)


### PR DESCRIPTION
Adds FLTK-exceptio: https://spdx.org/licenses/FLTK-exception.html

See https://github.com/fltk/fltk/blob/master/COPYING#L1-L45