### PR TITLE
openjdk: use a more specific license identifier

### DIFF
--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -13,7 +13,7 @@ class OpenJDK(ConanFile):
     url = "https://github.com/conan-io/conan-center-index/"
     description = "Java Development Kit builds, from Oracle"
     homepage = "https://jdk.java.net"
-    license = "GPL-2.0-with-classpath-exception"
+    license = "GPL-2.0-only WITH Classpath-exception-2.0", "GPL-2.0-only WITH OpenJDK-assembly-exception-1.0"
     topics = ("java", "jdk", "openjdk")
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True


### PR DESCRIPTION
Adds
https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.html
https://spdx.org/licenses/Classpath-exception-2.0.html

See also https://openjdk.org/legal/

Sorry about the clunky license ID. There is no valid way to strictly specify more than one exception using a SPDX license expression.