### PR TITLE
glfw: fix regressions introduced by #20913

### DIFF
--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -139,7 +139,9 @@ class GlfwConan(ConanFile):
                 "pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.15)",
                 "",
             )
-            pkgdatadir = os.path.join(self.dependencies["wayland-protocols"].package_folder, "res", "wayland-protocols")
+            # We must use legacy conan v1 deps_cpp_info because self.dependencies doesn't
+            # contain build requirements when using 1 profile.
+            pkgdatadir = os.path.join(self.deps_cpp_info["wayland-protocols"].rootpath, "res", "wayland-protocols")
             replace_in_file(
                 self,
                 cmakelists_src,

--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -50,7 +50,7 @@ class GlfwConan(ConanFile):
             self.options.rm_safe("fPIC")
         if self.settings.os != "Linux":
             self.options.rm_safe("with_wayland")
-        if not self.settings.os in ["Linux", "FreeBSD"] or self.version <= Version("3.3.8"):
+        if self.settings.os not in ["Linux", "FreeBSD"] or Version(self.version) <= "3.3.8":
             self.options.rm_safe("with_x11")
 
     def configure(self):
@@ -69,8 +69,9 @@ class GlfwConan(ConanFile):
         self.requires("opengl/system")
         if self.options.vulkan_static:
             self.requires("vulkan-loader/1.3.243.0")
-        if self.options.get_safe("with_x11") or self.version <= Version("3.3.8"):
-            self.requires("xorg/system")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            if self.options.get_safe("with_x11", True):
+                self.requires("xorg/system")
         if self.options.get_safe("with_wayland"):
             self.requires("wayland/1.22.0")
             self.requires("wayland-protocols/1.32")

--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -140,12 +140,12 @@ class GlfwConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-
-        cmakelists_src = os.path.join(self.source_folder, "src", "CMakeLists.txt")
         # don't force PIC
-        replace_in_file(self, cmakelists_src, "POSITION_INDEPENDENT_CODE ON", "")
+        replace_in_file(self, os.path.join(self.source_folder, "src", "CMakeLists.txt"),
+                              "POSITION_INDEPENDENT_CODE ON", "")
         # don't force static link to libgcc if MinGW
-        replace_in_file(self, cmakelists_src, "target_link_libraries(glfw PRIVATE \"-static-libgcc\")", "")
+        replace_in_file(self, os.path.join(self.source_folder, "src", "CMakeLists.txt"),
+                              "target_link_libraries(glfw PRIVATE \"-static-libgcc\")", "")
 
         # Allow to link vulkan-loader into shared glfw
         if self.options.vulkan_static:

--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.scm import Version
 import os
 import textwrap
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.60.0 <2 || >=2.0.5"
 
 
 class GlfwConan(ConanFile):

--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -93,9 +93,12 @@ class GlfwConan(ConanFile):
         tc.cache_variables["GLFW_BUILD_DOCS"] = False
         tc.cache_variables["GLFW_BUILD_EXAMPLES"] = False
         tc.cache_variables["GLFW_BUILD_TESTS"] = False
-        tc.cache_variables["GLFW_BUILD_X11"] = self.options.get_safe("with_x11")
         tc.cache_variables["GLFW_INSTALL"] = True
-        tc.variables["GLFW_USE_WAYLAND" if self.version <= "3.3.8" else "GLFW_BUILD_WAYLAND"] = self.options.get_safe("with_wayland")
+        if Version(self.version) > "3.3.8":
+            tc.cache_variables["GLFW_BUILD_X11"] = self.options.get_safe("with_x11", False)
+            tc.cache_variables["GLFW_BUILD_WAYLAND"] = self.options.get_safe("with_wayland", False)
+        else:
+            tc.cache_variables["GLFW_USE_WAYLAND"] = self.options.get_safe("with_wayland", False)
         tc.variables["GLFW_VULKAN_STATIC"] = self.options.vulkan_static
         if is_msvc(self):
             tc.cache_variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)


### PR DESCRIPTION
- do not required xorg if not Linux or FreeBSD (regression of https://github.com/conan-io/conan-center-index/pull/20913)
- update required_conan_version due to host_version in build requirements
- fix version comparison in CMake variables logic
- do not add wayland in build requirements if 1 profile

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
