### PR TITLE
perfetto: Bump version: 39.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "39.0":
+    url: "https://github.com/google/perfetto/archive/refs/tags/v39.0.tar.gz"
+    sha256: "241cbaddc9ff4e5d1de2d28497fef40b5510e9ca60808815bf4944d0d2f026db"
   "38.0":
     url: "https://github.com/google/perfetto/archive/refs/tags/v38.0.tar.gz"
     sha256: "92160b0fbeb8c4992cc0690d832dd923cee1dda466f3364ef4ed26a835e55e40"

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "39.0":
+    folder: all
   "38.0":
     folder: all
   "37.0":


### PR DESCRIPTION
Specify library name and version:  **perfetto/39.0**

```
v39.0 - 2023-11-15:
  Tracing service and probes:
    * Added reporting of TZ offset under system_info.timezone_off_mins .
    * Added no_flush option to DataSourceDescriptor to avoid unnecessary IPC
      roundtrips to flush data sources like track_event that rely uniquely on
      server-side scraping.
    * Added support for running on Linux & Android systems configured with 16K
      pagetables.
  Trace Processor:
    * New android_boot metric.
    * Added new PerfettoSQL syntax (CREATE PERFETTO VIEW) for adding schemas to views.
    * Support perf.data import format.
    * Add dvfs and cpu_idle to stdlib.
  UI:
    * Add a new type of debug tracks: counter.
    * Improved visualization of timestamps for durations.```

---

- [ x ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ x ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
