### PR TITLE
libvpx: add 1.13.1 + remove shared option and set package_type to static-library if Windows instead of raising for shared=True

### DIFF
--- a/recipes/libvpx/all/conandata.yml
+++ b/recipes/libvpx/all/conandata.yml
@@ -26,6 +26,7 @@ patches:
     - patch_file: "patches/0001-extended-support-1.9.0.patch"
       patch_type: "portability"
       patch_description: "Add support for more compilers"
+      patch_source: "https://github.com/webmproject/libvpx/commit/cafe7cc1f10cfea74edb2ded7c3df2d69fcf1eee"
     - patch_file: "patches/0002-msvc_conan_build.patch"
       patch_type: "portability"
       patch_description: "Add support for more compilers"

--- a/recipes/libvpx/all/conandata.yml
+++ b/recipes/libvpx/all/conandata.yml
@@ -13,10 +13,12 @@ patches:
     - patch_file: "patches/0001-extended-support-1.10.0.patch"
       patch_type: "portability"
       patch_description: "Add support for more compilers"
+      patch_source: "https://github.com/webmproject/libvpx/commit/cafe7cc1f10cfea74edb2ded7c3df2d69fcf1eee"
   "1.10.0":
     - patch_file: "patches/0001-extended-support-1.10.0.patch"
       patch_type: "portability"
       patch_description: "Add support for more compilers"
+      patch_source: "https://github.com/webmproject/libvpx/commit/cafe7cc1f10cfea74edb2ded7c3df2d69fcf1eee"
   "1.9.0":
     - patch_file: "patches/0001-extended-support-1.9.0.patch"
       patch_type: "portability"
@@ -24,3 +26,4 @@ patches:
     - patch_file: "patches/0002-msvc_conan_build.patch"
       patch_type: "portability"
       patch_description: "Add support for more compilers"
+      patch_source: "https://github.com/webmproject/libvpx/commit/04086a30664d2a3e89d6a6e4e1c18f1a82c8f958"

--- a/recipes/libvpx/all/conandata.yml
+++ b/recipes/libvpx/all/conandata.yml
@@ -1,12 +1,15 @@
 sources:
+  "1.13.1":
+    url: "https://github.com/webmproject/libvpx/archive/refs/tags/v1.13.1.tar.gz"
+    sha256: "00dae80465567272abd077f59355f95ac91d7809a2d3006f9ace2637dd429d14"
   "1.11.0":
-    url: "https://github.com/webmproject/libvpx/archive/v1.11.0.tar.gz"
+    url: "https://github.com/webmproject/libvpx/archive/refs/tags/v1.11.0.tar.gz"
     sha256: "965e51c91ad9851e2337aebcc0f517440c637c506f3a03948062e3d5ea129a83"
   "1.10.0":
-    url: "https://github.com/webmproject/libvpx/archive/v1.10.0.tar.gz"
+    url: "https://github.com/webmproject/libvpx/archive/refs/tags/v1.10.0.tar.gz"
     sha256: "85803ccbdbdd7a3b03d930187cb055f1353596969c1f92ebec2db839fa4f834a"
   "1.9.0":
-    url: "https://github.com/webmproject/libvpx/archive/v1.9.0.tar.gz"
+    url: "https://github.com/webmproject/libvpx/archive/refs/tags/v1.9.0.tar.gz"
     sha256: "d279c10e4b9316bf11a570ba16c3d55791e1ad6faa4404c67422eb631782c80a"
 patches:
   "1.11.0":

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -53,15 +53,16 @@ class LibVPXConan(ConanFile):
                 delattr(self.options, name)
 
     def configure(self):
-        if self.options.shared:
+        if self.settings.os == "Windows":
+            del self.options.shared
+            self.package_type = "static-library"
+        if self.options.get_safe("shared"):
             self.options.rm_safe("fPIC")
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def validate(self):
-        if self.settings.os == "Windows" and self.options.shared:
-            raise ConanInvalidConfiguration("Windows shared builds are not supported")
         if str(self.settings.compiler) not in ["Visual Studio", "msvc", "gcc", "clang", "apple-clang"]:
             raise ConanInvalidConfiguration(f"Unsupported compiler {self.settings.compiler}")
         if self.settings.os == "Macos" and self.settings.arch == "armv8" and Version(self.version) < "1.10.0":
@@ -255,7 +256,7 @@ class LibVPXConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "vpx")
         self.cpp_info.libs = [self._lib_name]
-        if not self.options.shared:
+        if not self.options.get_safe("shared"):
             libcxx = stdcpp_library(self)
             if libcxx:
                 self.cpp_info.system_libs.append(libcxx)

--- a/recipes/libvpx/config.yml
+++ b/recipes/libvpx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.13.1":
+    folder: all
   "1.11.0":
     folder: all
   "1.10.0":


### PR DESCRIPTION
`libvpx` is a dependency of `ffmpeg` (optional but enabled by default), therefore v2 pipeline can't build `ffmpeg` shared for msvc because `libvpx` with `shared=True` raises for Windows. And as a consequence, it also prevents v2 pipeline to build shared flavor of downstream packages of `ffmpeg`, like `opencv`.
Therefore this PR removes shared option of `libvpx` if Windows, so that v2 pipeline can build downstream packages with `-o *:shared=True`.

It's the same rational as https://github.com/conan-io/conan-center-index/pull/17228 or https://github.com/conan-io/conan-center-index/pull/21144

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
