### PR TITLE
structopt: update magic_enum/0.9.5

### DIFF
--- a/recipes/structopt/all/conanfile.py
+++ b/recipes/structopt/all/conanfile.py
@@ -45,7 +45,7 @@ class StructoptConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("magic_enum/0.9.2")
+        self.requires("magic_enum/0.9.5")
         self.requires("visit_struct/1.1.0")
 
     def package_id(self):

--- a/recipes/structopt/all/patches/0.1.0-0001-use-recipes.patch
+++ b/recipes/structopt/all/patches/0.1.0-0001-use-recipes.patch
@@ -21,7 +21,7 @@ index 5ef391c..a8f51e6 100644
  #include <structopt/sub_command.hpp>
 -#include <structopt/third_party/magic_enum/magic_enum.hpp>
 -#include <structopt/third_party/visit_struct/visit_struct.hpp>
-+#include <magic_enum.hpp>
++#include <magic_enum/magic_enum.hpp>
 +#include <visit_struct/visit_struct.hpp>
  #include <tuple>
  #include <type_traits>


### PR DESCRIPTION
Specify library name and version:  **structopt/***

magic_enum/0.9.5 changed include path from `"magic_enum.hpp"` to `magic_enum/magic_enum.hpp`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
