### PR TITLE
libyuv: add 1880 + remove shared option if msvc instead of raising

### DIFF
--- a/recipes/libyuv/all/conandata.yml
+++ b/recipes/libyuv/all/conandata.yml
@@ -1,6 +1,8 @@
 # Versions from LIBYUV_VERSION definition in include/libyuv/version.h
 # Pay attention to package commits incrementing this definition
 sources:
+  "1880":
+    url: "https://chromium.googlesource.com/libyuv/libyuv/+archive/fb6341d326846fbbe669ad5173e520f66b339621.tar.gz"
   "1854":
     url: "https://chromium.googlesource.com/libyuv/libyuv/+archive/3abd6f36b6e4f5a2e0ce236580a8bc1da3c7cf7e.tar.gz"
   "1845":
@@ -10,6 +12,10 @@ sources:
   "1768":
     url: "https://chromium.googlesource.com/libyuv/libyuv/+archive/dfaf7534e0e536f7e5ef8ddd7326797bd09b8622.tar.gz"
 patches:
+  "1880":
+    - patch_file: "patches/1880-0001-fix-cmake.patch"
+      patch_description: "Fix CMake to be more robust & predictable"
+      patch_type: "conan"
   "1854":
     - patch_file: "patches/1854-0001-fix-cmake.patch"
       patch_description: "Fix CMake to be more robust & predictable"

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -1,5 +1,4 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.microsoft import is_msvc
@@ -15,7 +14,7 @@ class LibyuvConan(ConanFile):
     description = "libyuv is an open source project that includes YUV scaling and conversion functionality."
     topics = ["YUV", "libyuv", "google", "chromium"]
     license = "BSD-3-Clause"
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -36,7 +35,12 @@ class LibyuvConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.options.shared:
+        if is_msvc(self):
+            # Only static for msvc
+            # Injecting CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS is not sufficient since there are global symbols
+            del self.options.shared
+            self.package_type = "static-library"
+        if self.options.get_safe("shared"):
             self.options.rm_safe("fPIC")
 
     def layout(self):
@@ -50,13 +54,8 @@ class LibyuvConan(ConanFile):
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.1")
 
-    def validate(self):
-        if is_msvc(self) and self.options.shared:
-            # Injecting CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS is not sufficient since there are global symbols
-            raise ConanInvalidConfiguration(f"{self.ref} shared not supported for msvc.")
-
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder)
+        get(self, **self.conan_data["sources"][self.version])
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -50,9 +50,9 @@ class LibyuvConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/3.0.0")
+            self.requires("libjpeg-turbo/3.0.1")
         elif self.options.with_jpeg == "mozjpeg":
-            self.requires("mozjpeg/4.1.1")
+            self.requires("mozjpeg/4.1.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version])

--- a/recipes/libyuv/all/patches/1880-0001-fix-cmake.patch
+++ b/recipes/libyuv/all/patches/1880-0001-fix-cmake.patch
@@ -1,0 +1,68 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,8 +2,8 @@
+ # Originally created for "roxlu build system" to compile libyuv on windows
+ # Run with -DTEST=ON to build unit tests
+ 
++CMAKE_MINIMUM_REQUIRED( VERSION 3.8 )
+ PROJECT ( YUV C CXX )	# "C" is required even for C++ projects
+-CMAKE_MINIMUM_REQUIRED( VERSION 2.8.12 )
+ OPTION( UNIT_TEST "Built unit tests" OFF )
+ 
+ SET ( ly_base_dir	${PROJECT_SOURCE_DIR} )
+@@ -27,15 +27,10 @@ if(MSVC)
+ endif()
+ 
+ # this creates the static library (.a)
+-ADD_LIBRARY				( ${ly_lib_static} STATIC ${ly_source_files} )
++ADD_LIBRARY				( ${ly_lib_static} ${ly_source_files} )
++target_compile_features(${ly_lib_static} PUBLIC cxx_std_11)
+ 
+ # this creates the shared library (.so)
+-ADD_LIBRARY				( ${ly_lib_shared} SHARED ${ly_source_files} )
+-SET_TARGET_PROPERTIES	( ${ly_lib_shared} PROPERTIES OUTPUT_NAME "${ly_lib_name}" )
+-SET_TARGET_PROPERTIES	( ${ly_lib_shared} PROPERTIES PREFIX "lib" )
+-if(WIN32)
+-  SET_TARGET_PROPERTIES	( ${ly_lib_shared} PROPERTIES IMPORT_PREFIX "lib" )
+-endif()
+ 
+ # this creates the conversion tool
+ ADD_EXECUTABLE			( yuvconvert ${ly_base_dir}/util/yuvconvert.cc )
+@@ -44,12 +39,18 @@ TARGET_LINK_LIBRARIES	( yuvconvert ${ly_lib_static} )
+ # this creates the yuvconstants tool
+ ADD_EXECUTABLE      ( yuvconstants ${ly_base_dir}/util/yuvconstants.c )
+ TARGET_LINK_LIBRARIES  ( yuvconstants ${ly_lib_static} )
++include(CheckFunctionExists)
++check_function_exists(round HAVE_MATH_SYSTEM)
++if(NOT HAVE_MATH_SYSTEM)
++  target_link_libraries(yuvconstants m)
++endif()
+ 
+-find_package ( JPEG )
+-if (JPEG_FOUND)
+-  include_directories( ${JPEG_INCLUDE_DIR} )
+-  target_link_libraries( ${ly_lib_shared} ${JPEG_LIBRARY} )
+-  add_definitions( -DHAVE_JPEG )
++option(LIBYUV_WITH_JPEG "Build libyuv with jpeg" ON)
++if (LIBYUV_WITH_JPEG)
++  find_package(JPEG REQUIRED)
++  target_link_libraries(${ly_lib_static} JPEG::JPEG )
++  target_compile_definitions(${ly_lib_static} PRIVATE HAVE_JPEG)
++  target_compile_definitions(yuvconvert PRIVATE HAVE_JPEG)
+ endif()
+ 
+ if(UNIT_TEST)
+@@ -94,11 +95,9 @@ endif()
+ 
+ 
+ # install the conversion tool, .so, .a, and all the header files
+-INSTALL ( PROGRAMS ${CMAKE_BINARY_DIR}/yuvconvert			DESTINATION bin )
+-INSTALL ( TARGETS ${ly_lib_static}						DESTINATION lib )
+-INSTALL ( TARGETS ${ly_lib_shared} LIBRARY				DESTINATION lib RUNTIME DESTINATION bin )
++INSTALL ( TARGETS yuvconvert yuvconstants DESTINATION bin)
++INSTALL ( TARGETS ${ly_lib_static} RUNTIME DESTINATION bin ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
+ INSTALL ( DIRECTORY ${PROJECT_SOURCE_DIR}/include/		DESTINATION include )
+ 
+ # create the .deb and .rpm packages using cpack
+-INCLUDE ( CM_linux_packages.cmake )
+ 

--- a/recipes/libyuv/config.yml
+++ b/recipes/libyuv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1880":
+    folder: all
   "1854":
     folder: all
   "1845":


### PR DESCRIPTION
Same rational as https://github.com/conan-io/conan-center-index/pull/17228, https://github.com/conan-io/conan-center-index/pull/21144 & https://github.com/conan-io/conan-center-index/pull/21202

libyuv is a dependency of libavif, so without this change libavif shared is never built for msvc in v2 pipeline.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
