### PR TITLE
openssl: add backport patch (make Windows build more robust)

### DIFF
--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -10,3 +10,7 @@ patches:
     - patch_file: patches/1.1.1-tvos-watchos.patch
       patch_description: "TVOS and WatchOS don't like fork()"
       patch_type: "portability"
+    - patch_file: patches/1.1.1w-Make-Windows-build-more-robust.patch
+      patch_description: "Make Windows build more robust"
+      patch_type: "backport"
+      patch_source: "https://github.com/openssl/openssl/pull/22754"

--- a/recipes/openssl/1.x.x/patches/1.1.1w-Make-Windows-build-more-robust.patch
+++ b/recipes/openssl/1.x.x/patches/1.1.1w-Make-Windows-build-more-robust.patch
@@ -1,0 +1,82 @@
+From a55f319f279a8101947392f3960af4285f83889d Mon Sep 17 00:00:00 2001
+From: Haohui Mai <ricetons@gmail.com>
+Date: Sat, 7 Dec 2019 00:44:16 -0800
+Subject: [PATCH] Make Windows build more robust
+
+(cherry picked from commit b5756085078f43c0a6c9a22ba6e87bc073515780)
+---
+ Configurations/windows-makefile.tmpl | 29 ++++++++++++++++------------
+ 1 file changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/Configurations/windows-makefile.tmpl b/Configurations/windows-makefile.tmpl
+index f7a6652996..78cb90efcf 100644
+--- a/Configurations/windows-makefile.tmpl
++++ b/Configurations/windows-makefile.tmpl
+@@ -165,29 +165,29 @@ libdir={- file_name_is_absolute($libdir)
+ 
+ ##### User defined commands and flags ################################
+ 
+-CC={- $config{CC} -}
+-CPP={- $config{CPP} -}
++CC="{- $config{CC} -}"
++CPP="{- $config{CPP} -}"
+ CPPFLAGS={- our $cppflags1 = join(" ",
+                                   (map { "-D".$_} @{$config{CPPDEFINES}}),
+                                   (map { " /I ".$_} @{$config{CPPINCLUDES}}),
+                                   @{$config{CPPFLAGS}}) -}
+ CFLAGS={- join(' ', @{$config{CFLAGS}}) -}
+-LD={- $config{LD} -}
++LD="{- $config{LD} -}"
+ LDFLAGS={- join(' ', @{$config{LDFLAGS}}) -}
+ EX_LIBS={- join(' ', @{$config{LDLIBS}}) -}
+ 
+ PERL={- $config{PERL} -}
+ 
+-AR={- $config{AR} -}
++AR="{- $config{AR} -}"
+ ARFLAGS= {- join(' ', @{$config{ARFLAGS}}) -}
+ 
+-MT={- $config{MT} -}
++MT="{- $config{MT} -}"
+ MTFLAGS= {- join(' ', @{$config{MTFLAGS}}) -}
+ 
+-AS={- $config{AS} -}
++AS="{- $config{AS} -}"
+ ASFLAGS={- join(' ', @{$config{ASFLAGS}}) -}
+ 
+-RC={- $config{RC} -}
++RC="{- $config{RC} -}"
+ RCFLAGS={- join(' ', @{$config{RCFLAGS}}) -}
+ 
+ ECHO="$(PERL)" "$(SRCDIR)\util\echo.pl"
+@@ -402,7 +402,8 @@ install_ssldirs:
+ 	@IF NOT EXIST "$(OPENSSLDIR)\openssl.cnf" \
+          "$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\apps\openssl.cnf" \
+                                         "$(OPENSSLDIR)\openssl.cnf"
+-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(MISC_SCRIPTS) \
++	@if not "$(MISC_SCRIPTS)"=="" \
++	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(MISC_SCRIPTS) \
+                                         "$(OPENSSLDIR)\misc"
+ 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(SRCDIR)\apps\ct_log_list.cnf" \
+                                         "$(OPENSSLDIR)\ct_log_list.cnf.dist"
+@@ -456,12 +457,16 @@ install_runtime_libs: build_libs
+ install_programs: install_runtime_libs build_programs
+ 	@if "$(INSTALLTOP)"=="" ( $(ECHO) "INSTALLTOP should not be empty" & exit 1 )
+ 	@$(ECHO) "*** Installing runtime programs"
+-	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\bin"
+-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_PROGRAMS) \
++	@if not "$(INSTALL_PROGRAMS)"=="" \
++	 "$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\bin"
++	@if not "$(INSTALL_PROGRAMS)"=="" \
++	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_PROGRAMS) \
+                                         "$(INSTALLTOP)\bin"
+-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_PROGRAMPDBS) \
++	@if not "$(INSTALL_PROGRAMS)"=="" \
++	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_PROGRAMPDBS) \
+                                         "$(INSTALLTOP)\bin"
+-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(BIN_SCRIPTS) \
++	@if not "$(INSTALL_PROGRAMS)"=="" \
++	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(BIN_SCRIPTS) \
+                                         "$(INSTALLTOP)\bin"
+ 
+ uninstall_runtime:


### PR DESCRIPTION
Specify library name and version:  **openssl/1.1.1w**

Add patch that fixes the problem with spaces in paths.
Fixes #21167

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
