### PR TITLE
fftw: fix typo in quad precision CMake option

### DIFF
--- a/recipes/fftw/all/conanfile.py
+++ b/recipes/fftw/all/conanfile.py
@@ -112,7 +112,7 @@ class FFTWConan(ConanFile):
             variables = {
                 "ENABLE_FLOAT": on_off(self._current_precision == SINGLE),
                 "ENABLE_LONG_DOUBLE": on_off(self._current_precision == LONGDOUBLE),
-                "EENABLE_QUAD_PRECISION": on_off(self._current_precision == QUAD)
+                "ENABLE_QUAD_PRECISION": on_off(self._current_precision == QUAD)
             }
             cmake.configure(variables=variables)
             cmake.build()


### PR DESCRIPTION
It's `ENABLE_QUAD_PRECISION` (https://github.com/FFTW/fftw3/blob/38ea230e25e69e7a3f35b957b815bac4f9aa22b0/CMakeLists.txt#L22) instead of `EENABLE_QUAD_PRECISION`

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
