### PR TITLE
aws-c-event-stream: add version 0.3.2

### DIFF
--- a/recipes/aws-c-event-stream/all/conandata.yml
+++ b/recipes/aws-c-event-stream/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.3.2":
+    url: "https://github.com/awslabs/aws-c-event-stream/archive/v0.3.2.tar.gz"
+    sha256: "3134b35a45e9f9d974c2b78ee44fd2ea0aebc04df80236b80692aa63bee2092e"
   "0.3.1":
     url: "https://github.com/awslabs/aws-c-event-stream/archive/v0.3.1.tar.gz"
     sha256: "bdbc420efc2572689fb167ac288e982a01224876eb79d80e2411fad4c43e9dc0"

--- a/recipes/aws-c-event-stream/config.yml
+++ b/recipes/aws-c-event-stream/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.3.2":
+    folder: all
   "0.3.1":
     folder: all
   "0.2.15":


### PR DESCRIPTION
Specify library name and version:  **aws-c-event-stream/0.3.2**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
