### PR TITLE
Add version libbpf v1.1.0, replace libelf dependency, bump linux-headers-generic, and add UAPI headers installation option

### DIFF
--- a/recipes/libbpf/all/conandata.yml
+++ b/recipes/libbpf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/libbpf/libbpf/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "5da826c968fdb8a2f714701cfef7a4b7078be030cf58b56143b245816301cbb8"
   "0.7.0":
     url: "https://github.com/libbpf/libbpf/archive/refs/tags/v0.7.0.tar.gz"
     sha256: "5083588ce5a3a620e395ee1e596af77b4ec5771ffc71cff2af49dfee38c06361"

--- a/recipes/libbpf/all/conanfile.py
+++ b/recipes/libbpf/all/conanfile.py
@@ -19,11 +19,13 @@ class LibbpfConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
-        "fPIC": [True, False]
+        "fPIC": [True, False],
+        "with_uapi_headers": [True, False]
     }
     default_options = {
         "shared": False,
-        "fPIC": True
+        "fPIC": True,
+        "with_uapi_headers": False
     }
 
     def config_options(self):
@@ -75,6 +77,8 @@ class LibbpfConan(ConanFile):
         with chdir(self, os.path.join(self.source_folder, "src")):
             autotools = Autotools(self)
             autotools.make()
+            if self.options.with_uapi_headers:
+                autotools.make('install_uapi_headers')
 
     def package(self):
         copy(self, pattern="LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/libbpf/all/conanfile.py
+++ b/recipes/libbpf/all/conanfile.py
@@ -43,7 +43,7 @@ class LibbpfConan(ConanFile):
 
     def requirements(self):
         self.requires("linux-headers-generic/5.15.128", transitive_headers=True)
-        self.requires("libelf/0.8.13")
+        self.requires("elfutils/0.180", transitive_headers=True, transitive_libs=True)
         self.requires("zlib/[>=1.2.11 <2]")
 
     def validate(self):

--- a/recipes/libbpf/all/conanfile.py
+++ b/recipes/libbpf/all/conanfile.py
@@ -42,7 +42,7 @@ class LibbpfConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("linux-headers-generic/5.14.9", transitive_headers=True)
+        self.requires("linux-headers-generic/5.15.128", transitive_headers=True)
         self.requires("libelf/0.8.13")
         self.requires("zlib/[>=1.2.11 <2]")
 

--- a/recipes/libbpf/config.yml
+++ b/recipes/libbpf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.0":
+    folder: all
   "0.7.0":
     folder: all
   "0.5.0":


### PR DESCRIPTION
**libbpf/1.1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

- The dependency on libelf has been replaced with elfutils v0.180, improving compatibility and ensuring a more streamlined build process.
- The linux-headers-generic version has been bumped to v5.15.128 LTS version.
- Add option to install UAPI headers, providing greater flexibility for users who require bpf UAPI headers.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
