### PR TITLE
libhal: Correct 2.0.1 dependency on conan center

### DIFF
--- a/recipes/libhal/all/conandata.yml
+++ b/recipes/libhal/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.0.1":
     url: "https://github.com/libhal/libhal/archive/refs/tags/2.0.1.tar.gz"
-    sha256: "TBD"
+    sha256: "b3667b8333f18ff61c394a846c7220d5d692097db4b2e1ca02b0cfb392be8469"

--- a/recipes/libhal/all/conandata.yml
+++ b/recipes/libhal/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.0.1":
     url: "https://github.com/libhal/libhal/archive/refs/tags/2.0.1.tar.gz"
-    sha256: "ba05f9d2172f7afbf816ab18f2dcd7c8cc4452df2b268a832e995a0321c1d2f9"
+    sha256: "TBD"

--- a/recipes/libhal/all/conandata.yml
+++ b/recipes/libhal/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
   "2.0.1":
     url: "https://github.com/libhal/libhal/archive/refs/tags/2.0.1.tar.gz"
-    sha256: "b3667b8333f18ff61c394a846c7220d5d692097db4b2e1ca02b0cfb392be8469"
+    sha256: "ba05f9d2172f7afbf816ab18f2dcd7c8cc4452df2b268a832e995a0321c1d2f9"
+  "2.0.2":
+    url: "https://github.com/libhal/libhal/archive/refs/tags/2.0.2.tar.gz"
+    sha256: "bb69fffbff58ac9a91f71636422d81a4426fe70c3b47ca9b07c87fb074c989dc"

--- a/recipes/libhal/all/conandata.yml
+++ b/recipes/libhal/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.0.1":
-    url: "https://github.com/libhal/libhal/archive/refs/tags/2.0.1.tar.gz"
-    sha256: "ba05f9d2172f7afbf816ab18f2dcd7c8cc4452df2b268a832e995a0321c1d2f9"
   "2.0.2":
     url: "https://github.com/libhal/libhal/archive/refs/tags/2.0.2.tar.gz"
     sha256: "bb69fffbff58ac9a91f71636422d81a4426fe70c3b47ca9b07c87fb074c989dc"
+  "2.0.1":
+    url: "https://github.com/libhal/libhal/archive/refs/tags/2.0.1.tar.gz"
+    sha256: "ba05f9d2172f7afbf816ab18f2dcd7c8cc4452df2b268a832e995a0321c1d2f9"

--- a/recipes/libhal/all/conanfile.py
+++ b/recipes/libhal/all/conanfile.py
@@ -77,9 +77,9 @@ class LibHALConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler ({compiler}-{version}) does not support")
 
-        uses_boost_leaf = self._bare_metal and version < "3.0.0"
-        if (not self.dependencies["boost"].options.header_only and
-            uses_boost_leaf):
+        if (Version(self.version) == "2.0.2" and
+            not self.dependencies["boost"].options.header_only and
+            self._bare_metal):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires boost/*:header_only=True due boost::leaf")
 

--- a/recipes/libhal/all/conanfile.py
+++ b/recipes/libhal/all/conanfile.py
@@ -43,7 +43,17 @@ class LibHALConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.83.0", transitive_headers=True)
+        # NOTE: from the author, kammce, to the conan team. although boost-leaf
+        # is marked as deprecated, it is required for libhal to work with bare
+        # metal cross compilers such as the Arm GNU Toolchain. The main issue
+        # with boost is its dependency on things such as bzip that cannot
+        # compile on freestanding environments. boost-leaf has no dependencies
+        # and can work in freestanding environments.
+        version = Version(self.version)
+        if "2.0.0" <= version and version < "3.0.0":
+            self.requires("boost/1.83.0",
+                          transitive_headers=True,
+                          options={ "header_only": True })
 
     def package_id(self):
         self.info.clear()
@@ -74,15 +84,15 @@ class LibHALConan(ConanFile):
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(
-            self, 
-            "*.h", 
-            dst=os.path.join(self.package_folder, "include"), 
+            self,
+            "*.h",
+            dst=os.path.join(self.package_folder, "include"),
             src=os.path.join(self.source_folder, "include")
         )
         copy(
-            self, 
-            "*.hpp", 
-            dst=os.path.join(self.package_folder, "include"), 
+            self,
+            "*.hpp",
+            dst=os.path.join(self.package_folder, "include"),
             src=os.path.join(self.source_folder, "include")
         )
 

--- a/recipes/libhal/all/conanfile.py
+++ b/recipes/libhal/all/conanfile.py
@@ -77,6 +77,10 @@ class LibHALConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler ({compiler}-{version}) does not support")
 
+        if not self.dependencies["boost"].options.header_only:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires boost/*:header_only=True due boost::leaf")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/libhal/all/conanfile.py
+++ b/recipes/libhal/all/conanfile.py
@@ -77,7 +77,9 @@ class LibHALConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler ({compiler}-{version}) does not support")
 
-        if not self.dependencies["boost"].options.header_only:
+        uses_boost_leaf = self._bare_metal and version < "3.0.0"
+        if (not self.dependencies["boost"].options.header_only and
+            uses_boost_leaf):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires boost/*:header_only=True due boost::leaf")
 

--- a/recipes/libhal/config.yml
+++ b/recipes/libhal/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.0.1":
-    folder: "all"
   "2.0.2":
+    folder: "all"
+  "2.0.1":
     folder: "all"

--- a/recipes/libhal/config.yml
+++ b/recipes/libhal/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.0.1":
     folder: "all"
+  "2.0.2":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **libhal/2.0.0**

Boost does not work as a dependency for baremetal platforms. Boost-leaf must be used for `libhal/[^2.0.0]` 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
