### PR TITLE
cpp-sort: remove legacy conan v1 output.warn which breaks conan v2 with "unknown compilers"

### DIFF
--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -54,22 +54,11 @@ class CppSortConan(ConanFile):
             min_length = min(len(lv1), len(lv2))
             return lv1[:min_length] < lv2[:min_length]
 
-        compiler = str(self.settings.compiler)
-        version = str(self.settings.compiler.version)
-        try:
-            minimum_version = self._compilers_minimum_version[str(compiler)]
-            if minimum_version and loose_lt_semver(version, minimum_version):
-                msg = (
-                    f"{self.ref} requires C++{self._min_cppstd} features "
-                    f"which are not supported by compiler {compiler} {version}."
-                )
-                raise ConanInvalidConfiguration(msg)
-        except KeyError:
-            msg = (
-                f"{self.ref} recipe lacks information about the {compiler} compiler, "
-                f"support for the required C++{self._min_cppstd} features is assumed"
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
+        if minimum_version and loose_lt_semver(self.settings.compiler.version, minimum_version):
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
-            self.output.warn(msg)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -55,7 +55,7 @@ class CppSortConan(ConanFile):
             return lv1[:min_length] < lv2[:min_length]
 
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
-        if minimum_version and loose_lt_semver(self.settings.compiler.version, minimum_version):
+        if minimum_version and loose_lt_semver(str(self.settings.compiler.version), minimum_version):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
