### PR TITLE
arbiter: new recipe

### DIFF
--- a/recipes/arbiter/all/CMakeLists.txt
+++ b/recipes/arbiter/all/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Simplified version of https://github.com/connormanning/arbiter/blob/70b57eeddfaed426d8edc8a5f02c87defd3a0f22/CMakeLists.txt
+cmake_minimum_required(VERSION 3.15)
+project(arbiter)
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+
+find_package(Threads REQUIRED)
+find_package(CURL REQUIRED CONFIG)
+find_package(OpenSSL REQUIRED CONFIG)
+find_package(ZLIB REQUIRED CONFIG)
+find_package(nlohmann_json REQUIRED CONFIG)
+find_package(rapidxml REQUIRED CONFIG)
+
+set(CMAKE_CXX_STANDARD 11)
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU OR ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+    add_definitions(-DUNIX)
+    add_compile_options(-Wno-deprecated-declarations -Wall -pedantic -fexceptions)
+elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+    add_definitions(-DWINDOWS)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    if(BUILD_SHARED_LIBS)
+        add_definitions(-DARBITER_DLL_EXPORT)
+    endif()
+    link_libraries(Shlwapi)
+endif()
+
+file(GLOB_RECURSE ARBITER_SRC src/arbiter/*.cpp)
+add_library(arbiter ${ARBITER_SRC})
+
+target_include_directories(arbiter PRIVATE src)
+target_compile_definitions(arbiter PRIVATE
+    -DARBITER_OPENSSL
+    -DARBITER_CURL
+    -DARBITER_ZLIB
+)
+target_link_libraries(arbiter PRIVATE
+    ZLIB::ZLIB
+    CURL::libcurl
+    Threads::Threads
+    OpenSSL::SSL
+    OpenSSL::Crypto
+    nlohmann_json::nlohmann_json
+    rapidxml::rapidxml
+)
+
+install(TARGETS arbiter
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)

--- a/recipes/arbiter/all/conandata.yml
+++ b/recipes/arbiter/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "cci.20231005":
+    url: "https://github.com/connormanning/arbiter/archive/70b57eeddfaed426d8edc8a5f02c87defd3a0f22.tar.gz"
+    sha256: "5adab0b51bef87bc3fa1d100ad1c49a2a334f4f8c15ed8e62c68fb84181a4159"
+patches:
+  "cci.20231005":
+    - patch_file: "patches/001-fix-cbegin-cend.patch"
+      patch_type: "portability"
+      patch_description: "Replace std::cbegin and std::cend for C++11 compatibility"
+      patch_source: "https://github.com/connormanning/arbiter/pull/49"

--- a/recipes/arbiter/all/conanfile.py
+++ b/recipes/arbiter/all/conanfile.py
@@ -1,0 +1,105 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm, export_conandata_patches, apply_conandata_patches, rmdir, save
+
+required_conan_version = ">=1.53.0"
+
+
+class PackageConan(ConanFile):
+    name = "arbiter"
+    description = "Uniform access to the filesystem, HTTP, S3, GCS, Dropbox, etc."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/connormanning/arbiter"
+    topics = ("filesystem", "http", "s3", "gcs", "dropbox")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 11
+
+    def export_sources(self):
+        copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("libcurl/[>=7.78.0 <9]")
+        self.requires("openssl/[>=1.1 <4]")
+        self.requires("zlib/[>=1.2.11 <2]")
+        self.requires("nlohmann_json/3.11.2")
+        self.requires("rapidxml/1.13")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+        # Unvendor nlohmann_json
+        rmdir(self, os.path.join(self.source_folder, "arbiter", "third", "json"))
+        save(self, os.path.join(self.source_folder, "arbiter", "third", "json", "json.hpp"),
+             "#include <nlohmann/json.hpp>\n")
+        # Unvendor rapidxml
+        rmdir(self, os.path.join(self.source_folder, "arbiter", "third", "xml"))
+        save(self, os.path.join(self.source_folder, "arbiter", "third", "xml", "xml.hpp"),
+             "#include <rapidxml/rapidxml.hpp>\n"
+             "namespace Xml = rapidxml;\n")
+
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self.source_path.parent)
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        copy(self, "*.hpp",
+             os.path.join(self.source_folder, "arbiter"),
+             os.path.join(self.package_folder, "include", "arbiter"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["arbiter"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("Shlwapi")
+        if self.options.shared:
+            self.cpp_info.defines.append("ARBITER_DLL_IMPORT")

--- a/recipes/arbiter/all/patches/001-fix-cbegin-cend.patch
+++ b/recipes/arbiter/all/patches/001-fix-cbegin-cend.patch
@@ -1,0 +1,11 @@
+--- arbiter/drivers/az.cpp
++++ arbiter/drivers/az.cpp
+@@ -270,7 +270,7 @@
+     if (m_config->hasSasToken())
+     {
+         Query q = m_config->sasToken();
+-        q.insert(std::cbegin(query),std::cend(query));
++        q.insert(query.cbegin(), query.cend());
+         res.reset(new Response(http.internalHead(resource.url(), headers, q)));
+     }
+     else

--- a/recipes/arbiter/all/test_package/CMakeLists.txt
+++ b/recipes/arbiter/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(arbiter REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE arbiter::arbiter)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/arbiter/all/test_package/conanfile.py
+++ b/recipes/arbiter/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/arbiter/all/test_package/test_package.cpp
+++ b/recipes/arbiter/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <arbiter/arbiter.hpp>
+
+int main() {
+    arbiter::Arbiter a;
+    a.isHttpDerived("http://arbitercpp.com");
+    return EXIT_SUCCESS;
+}

--- a/recipes/arbiter/config.yml
+++ b/recipes/arbiter/config.yml
@@ -1,0 +1,4 @@
+versions:
+  "cci.20231005":
+    folder: all
+


### PR DESCRIPTION
Adds arbiter: https://github.com/connormanning/arbiter

Arbiter provides simple/fast/thread-safe C++ access to filesystem, HTTP, S3, and Dropbox resources in a uniform way. It is designed to be extendible, so other resource types may also be abstracted.

Adding it mostly to unvendor it in the PDAL recipe.
The CMake setup in the project was not great. I found it easier to rewrite it entirely instead of patching.

[![Packaging status](https://repology.org/badge/tiny-repos/arbiter.svg)](https://repology.org/project/arbiter/versions)
