### PR TITLE
stlab: several fixes

### DIFF
--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -62,7 +62,7 @@ class Stlab(ConanFile):
 
     def requirements(self):
         if self.options.with_boost:
-            self.requires("boost/1.82.0")
+            self.requires("boost/1.83.0")
 
         # On macOS, it is not necessary to use the libdispatch conan package, because the library is
         # included in the OS.

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -158,8 +158,10 @@ class Stlab(ConanFile):
         rm(self, "vcruntime*.dll", os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
-        future_coroutines_value = 1 if self.options.future_coroutines else 0
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
 
+        future_coroutines_value = 1 if self.options.future_coroutines else 0
         self.cpp_info.defines = [
             'STLAB_FUTURE_COROUTINES={}'.format(future_coroutines_value)
         ]

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -28,7 +28,7 @@ class Stlab(ConanFile):
     default_options = {
         "with_boost": False,
         "no_std_coroutines": True,
-        "future_coroutines": False
+        "future_coroutines": False,
         # Handle default value for `thread_system` in `config_options` method
         # Handle default value for `task_system` in `config_options` method
     }
@@ -74,9 +74,6 @@ class Stlab(ConanFile):
         # (and also threading model which might depend on compiler).
         # Just remove build_type from package id for the moment
         del self.info.settings.build_type
-
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def _validate_task_system(self):
         if self.options.task_system == "libdispatch":
@@ -127,6 +124,9 @@ class Stlab(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.23.3 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -74,7 +74,7 @@ class Stlab(ConanFile):
         # (and also threading model which might depend on compiler).
         # Just remove build_type and requires from package id for the moment
         del self.info.settings.build_type
-        self.requires.clear()
+        self.info.requires.clear()
         # Hack to force KB-H014 to consider stlab as header-only
         # self.info.header_only()
 

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -75,7 +75,11 @@ class Stlab(ConanFile):
         # Just remove build_type, requires and conf from package id for the moment
         del self.info.settings.build_type
         self.info.requires.clear()
-        self.info.conf.clear()
+        try:
+            # Only conan v2
+            self.info.conf.clear()
+        except AttributeError:
+            pass
         # Hack to force KB-H014 to consider stlab as header-only
         # self.info.header_only()
 

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -60,9 +60,6 @@ class Stlab(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
-    def build_requirements(self):
-        self.tool_requires("cmake/[>=3.23.3]")
-
     def requirements(self):
         if self.options.with_boost:
             self.requires("boost/1.82.0")
@@ -121,6 +118,9 @@ class Stlab(ConanFile):
         self._validate_task_system()
         self._validate_thread_system()
         self._validate_boost_components()
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.23.3 <4]")
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -72,8 +72,9 @@ class Stlab(ConanFile):
     def package_id(self):
         # TODO: stlab is header only but needs a header modified by cmake based on OS and options
         # (and also threading model which might depend on compiler).
-        # Just remove build_type from package id for the moment
+        # Just remove build_type and requires from package id for the moment
         del self.info.settings.build_type
+        self.requires.clear()
         # Hack to force KB-H014 to consider stlab as header-only
         # self.info.header_only()
 

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -74,6 +74,8 @@ class Stlab(ConanFile):
         # (and also threading model which might depend on compiler).
         # Just remove build_type from package id for the moment
         del self.info.settings.build_type
+        # Hack to force KB-H014 to consider stlab as header-only
+        # self.info.header_only()
 
     def _validate_task_system(self):
         if self.options.task_system == "libdispatch":

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -72,9 +72,10 @@ class Stlab(ConanFile):
     def package_id(self):
         # TODO: stlab is header only but needs a header modified by cmake based on OS and options
         # (and also threading model which might depend on compiler).
-        # Just remove build_type and requires from package id for the moment
+        # Just remove build_type, requires and conf from package id for the moment
         del self.info.settings.build_type
         self.info.requires.clear()
+        self.info.conf.clear()
         # Hack to force KB-H014 to consider stlab as header-only
         # self.info.header_only()
 

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -122,13 +122,6 @@ class Stlab(ConanFile):
         self._validate_thread_system()
         self._validate_boost_components()
 
-    def configure(self):
-        self.output.info("STLab With Boost: {}.".format(self.options.with_boost))
-        self.output.info("STLab Future Coroutines: {}.".format(self.options.future_coroutines))
-        self.output.info("STLab No Standard Coroutines: {}.".format(self.options.no_std_coroutines))
-        self.output.info("STLab Task System: {}.".format(self.options.task_system))
-        self.output.info("STLab Thread System: {}.".format(self.options.thread_system))
-
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables['BUILD_TESTING'] = not self.conf.get("tools.build:skip_test", default=True, check_type=bool)

--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -69,6 +69,12 @@ class Stlab(ConanFile):
         if self.options.task_system == "libdispatch" and self.settings.os != "Macos":
             self.requires("libdispatch/5.3.2")
 
+    def package_id(self):
+        # TODO: stlab is header only but needs a header modified by cmake based on OS and options
+        # (and also threading model which might depend on compiler).
+        # Just remove build_type from package id for the moment
+        del self.info.settings.build_type
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
@@ -150,12 +156,6 @@ class Stlab(ConanFile):
         rm(self, "msvcp*.dll", os.path.join(self.package_folder, "bin"))
         rm(self, "concrt*.dll", os.path.join(self.package_folder, "bin"))
         rm(self, "vcruntime*.dll", os.path.join(self.package_folder, "bin"))
-
-    def package_id(self):
-        # TODO: is header only but needs a header modified by cmake
-        # self.info.settings.clear()
-        # self.info.header_only()
-        pass
 
     def package_info(self):
         future_coroutines_value = 1 if self.options.future_coroutines else 0


### PR DESCRIPTION
- Remove legacy conan v1 `self.output.warn`, otherwise it fails for "unknown compilers
- Remove noisy messages in `configure()` (these messages are already displayed by CMake during build, and messages in `configure()` are really noisy in a `conan install`)
- Add upper bound to cmake version range in build requirements
- Remove `settings.build_type` from package id. I think `settings.arch` could also be removed by I'm not sure.
- Set `cpp_info.bindirs` & `cpp_info.libdirs` to empty list

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
