### PR TITLE
arsenalgear: restore shared option + allow msvc since 2.1.0 + fix CMakeLists of 2.1.0 to avoid building and packaging doctest

### DIFF
--- a/recipes/arsenalgear/all/conandata.yml
+++ b/recipes/arsenalgear/all/conandata.yml
@@ -11,5 +11,5 @@ sources:
 patches:
   "2.1.0":
     - patch_file: "patches/2.1.0-0001-fix-cmake.patch"
-      patch_description: "CMake: honor compiler.cppstd, and avoid to download and build doctest"
+      patch_description: "CMake: allow shared, honor compiler.cppstd, avoid to download and build doctest"
       patch_type: "conan"

--- a/recipes/arsenalgear/all/conandata.yml
+++ b/recipes/arsenalgear/all/conandata.yml
@@ -13,3 +13,4 @@ patches:
     - patch_file: "patches/2.1.0-0001-fix-cmake.patch"
       patch_description: "CMake: allow shared, honor compiler.cppstd, avoid to download and build doctest"
       patch_type: "conan"
+      patch_source: "https://github.com/JustWhit3/arsenalgear-cpp/pull/4"

--- a/recipes/arsenalgear/all/conandata.yml
+++ b/recipes/arsenalgear/all/conandata.yml
@@ -8,3 +8,8 @@ sources:
   "1.2.2":
     url: "https://github.com/JustWhit3/arsenalgear-cpp/archive/refs/tags/v1.2.2.tar.gz"
     sha256: "556155d0be0942bcdd5df02fcda258579915e76b5a70e7220de6ef38c8ca7779"
+patches:
+  "2.1.0":
+    - patch_file: "patches/2.1.0-0001-fix-cmake.patch"
+      patch_description: "CMake: honor compiler.cppstd, and avoid to download and build doctest"
+      patch_type: "conan"

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -17,12 +17,14 @@ class ArsenalgearConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/JustWhit3/arsenalgear-cpp"
     topics = ("constants", "math", "operators", "stream")
-    package_type = "static-library"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
+        "shared": [True, False],
         "fPIC": [True, False],
     }
     default_options = {
+        "shared": False,
         "fPIC": True,
     }
 
@@ -37,7 +39,7 @@ class ArsenalgearConan(ConanFile):
             "msvc": "192",
             "gcc": "8",
             "clang": "7",
-            "apple-clang": "12.0",
+            "apple-clang": "12",
         }
 
     def export_sources(self):
@@ -48,6 +50,10 @@ class ArsenalgearConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -60,7 +60,7 @@ class ArsenalgearConan(ConanFile):
                 self.requires("exprtk/0.0.2", transitive_headers=True)
 
     def validate(self):
-        if Version(self.version) < "2.0.0" and is_msvc(self):
+        if Version(self.version) < "2.1.0" and is_msvc(self):
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support Visual Studio.")
 
         if self.settings.compiler.cppstd:

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -104,6 +104,8 @@ class ArsenalgearConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "arsenalgear")
+        self.cpp_info.set_property("cmake_target_name", "arsenalgear::arsenalgear")
         self.cpp_info.libs = ["arsenalgear"]
 
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -64,9 +64,8 @@ class ArsenalgearConan(ConanFile):
                 self.requires("exprtk/0.0.2", transitive_headers=True)
 
     def validate(self):
-        # arsenalgear doesn't support Visual Studio(yet).
-        if is_msvc(self):
-            raise ConanInvalidConfiguration(f"{self.ref} doesn't support Visual Studio(yet)")
+        if Version(self.version) < "2.0.0" and is_msvc(self):
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support Visual Studio.")
 
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -48,10 +48,6 @@ class ArsenalgearConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
-    def configure(self):
-        if self.options.get_safe("shared"):
-            self.options.rm_safe("fPIC")
-
     def layout(self):
         cmake_layout(self, src_folder="src")
 

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -1,10 +1,10 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import is_msvc
-from conan.tools.files import get, copy, rmdir
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 
 import os
 
@@ -41,6 +41,7 @@ class ArsenalgearConan(ConanFile):
         }
 
     def export_sources(self):
+        export_conandata_patches(self)
         if Version(self.version) < "2.1.0":
             copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
 
@@ -84,6 +85,7 @@ class ArsenalgearConan(ConanFile):
         deps.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         if Version(self.version) < "2.1.0":
             cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))

--- a/recipes/arsenalgear/all/patches/2.1.0-0001-fix-cmake.patch
+++ b/recipes/arsenalgear/all/patches/2.1.0-0001-fix-cmake.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -16,12 +16,8 @@ if( EXISTS "${LOC_PATH}" )
+@@ -16,27 +16,26 @@ if( EXISTS "${LOC_PATH}" )
  endif()
  
  # Set c++ standard options
@@ -13,10 +13,15 @@
  
  # Include directories
  include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
-@@ -32,11 +28,13 @@ add_library( arsenalgear STATIC
+ 
+ # Create static library
+-add_library( arsenalgear STATIC
++add_library( arsenalgear
+     src/stream.cpp
      src/system.cpp
      src/utils.cpp
  )
++set_target_properties(arsenalgear PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 +target_compile_features(arsenalgear PUBLIC cxx_std_17)
  add_library( arsenalgear::arsenalgear ALIAS arsenalgear )
  
@@ -27,3 +32,14 @@
      add_subdirectory( test )
  else()
      message( STATUS "Skipping tests." )
+@@ -57,7 +56,9 @@ install(
+ install( 
+     TARGETS arsenalgear
+     EXPORT arsenalgearTargets
+-    DESTINATION lib
++    ARCHIVE DESTINATION lib
++    LIBRARY DESTINATION lib
++    RUNTIME DESTINATION bin
+ )
+ 
+ install(

--- a/recipes/arsenalgear/all/patches/2.1.0-0001-fix-cmake.patch
+++ b/recipes/arsenalgear/all/patches/2.1.0-0001-fix-cmake.patch
@@ -1,0 +1,29 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,12 +16,8 @@ if( EXISTS "${LOC_PATH}" )
+ endif()
+ 
+ # Set c++ standard options
+-set( CMAKE_CXX_STANDARD 17 )
+-set( CMAKE_CXX_STANDARD_REQUIRED ON )
+-set( CMAKE_CXX_EXTENSIONS OFF )
+ 
+ # Fetching dependencies
+-add_subdirectory( deps )
+ 
+ # Include directories
+ include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
+@@ -32,11 +28,13 @@ add_library( arsenalgear STATIC
+     src/system.cpp
+     src/utils.cpp
+ )
++target_compile_features(arsenalgear PUBLIC cxx_std_17)
+ add_library( arsenalgear::arsenalgear ALIAS arsenalgear )
+ 
+ # Compile tests
+ option( ARSENALGEAR_TESTS "Enable / disable tests." ON )
+ if( ARSENALGEAR_TESTS )
++    add_subdirectory( deps )
+     add_subdirectory( test )
+ else()
+     message( STATUS "Skipping tests." )


### PR DESCRIPTION
- Restore shared option, it has been removed by https://github.com/conan-io/conan-center-index/pull/16264, but I think it was a mistake. Moreover removing shared option leads to missing arsenalgear packages for osmanip (see https://github.com/conan-io/conan-center-index/pull/19882#issuecomment-1819891094 & https://github.com/conan-io/conan-center-index/issues/21283)
- Allow msvc since 2.1.0, it seems to build fine (I've tested with 2.0.1, and it didn't pass, so only since 2.1.0)
- We use upstream CMakeLists since 2.1.0, but it has several issues (build & download doctest, pollutes install dir with doctest headers, doesn't honor compiler.cppstd, don't allow to build shared while it works just fine). So I've added a patch and submitted a PR upstream: https://github.com/JustWhit3/arsenalgear-cpp/pull/4
- I've also added cmake names explicitly since a CMake config file is installed upstream since 2.1.0, see:
  https://github.com/JustWhit3/arsenalgear-cpp/blob/v2.1.0/CMakeLists.txt#L30
  https://github.com/JustWhit3/arsenalgear-cpp/blob/v2.1.0/CMakeLists.txt#L66
  https://github.com/JustWhit3/arsenalgear-cpp/blob/v2.1.0/CMakeLists.txt#L87-L91

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
