### PR TITLE
stb: add package_type + fix package id

### DIFF
--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -14,9 +14,9 @@ class StbConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/nothings/stb"
     license = ("Unlicense", "MIT")
+    package_type = "header-only"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
-
     options = {
         "with_deprecated": [True, False],
     }
@@ -42,8 +42,7 @@ class StbConan(ConanFile):
         self.info.clear()
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         pass

--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -39,7 +39,14 @@ class StbConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def package_id(self):
-        self.info.clear()
+        # Can't call self.info.clear() because options contribute to package id
+        self.info.settings.clear()
+        self.info.requires.clear()
+        try:
+            # conan v2 specific
+            self.info.conf.clear()
+        except AttributeError:
+            pass
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -14,7 +14,7 @@ class StbConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/nothings/stb"
     license = ("Unlicense", "MIT")
-    package_type = "header-only"
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
     options = {


### PR DESCRIPTION
There is a `with_deprecated` option in stb recipe, and this option controls whether some headers are packaged or not, so stb recipe can't clear info.options in package_id().

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
