### PR TITLE
boost-wintls: Add new recipe

### DIFF
--- a/recipes/boost-wintls/all/conandata.yml
+++ b/recipes/boost-wintls/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "0.9.8":
+    url:
+      - "https://github.com/laudrup/boost-wintls/archive/refs/tags/v0.9.8.zip"
+    sha256: "fcdaec26cae39c9699d43e6d71920ccfcb1db6bee61262c8949fbe215a53380b"

--- a/recipes/boost-wintls/all/conanfile.py
+++ b/recipes/boost-wintls/all/conanfile.py
@@ -1,0 +1,111 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.layout import basic_layout
+from conan.tools.files import (
+    apply_conandata_patches,
+    copy,
+    export_conandata_patches,
+    get,
+)
+from conan.tools.scm import Version
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class BoostWinTLS(ConanFile):
+    name = "boost-wintls"
+    description = "Native Windows TLS stream wrapper for use with boost::asio"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://wintls.dev"
+    topics = (
+        "header-only",
+        "windows",
+        "tls",
+        "ssl",
+        "networking",
+        "boost",
+        "asio",
+        "sspi",
+        "schannel",
+    )
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {}
+    default_options = {}
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "clang": "12",
+            "gcc": "7",
+            "msvc": "192",
+            "Visual Studio": "16",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("boost/[>=1.75 <2.0]")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(
+            str(self.settings.compiler), False
+        )
+        if (
+            minimum_version
+            and Version(self.settings.compiler.version) < minimum_version
+        ):
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+        if self.settings.os != "Windows":
+            raise ConanInvalidConfiguration(f"{self.ref} can only be used on Windows.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        apply_conandata_patches(self)
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            self.source_folder,
+            os.path.join(self.package_folder, "licenses"),
+        )
+        copy(
+            self,
+            "*.hpp",
+            os.path.join(self.source_folder, "include"),
+            os.path.join(self.package_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.set_property("cmake_target_name", "boost-wintls")
+        self.cpp_info.filenames["cmake_find_package"] = "boost-wintls"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "boost-wintls"
+        self.cpp_info.names["cmake_find_package"] = "boost-wintls"
+        self.cpp_info.names["cmake_find_package_multi"] = "boost-wintls"

--- a/recipes/boost-wintls/all/test_package/CMakeLists.txt
+++ b/recipes/boost-wintls/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package LANGUAGES CXX)
+
+find_package(boost-wintls REQUIRED CONFIG)
+find_package(boost REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE boost-wintls Boost::headers)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/boost-wintls/all/test_package/conanfile.py
+++ b/recipes/boost-wintls/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/boost-wintls/all/test_package/test_package.cpp
+++ b/recipes/boost-wintls/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include <boost/asio.hpp>
+#include <boost/wintls.hpp>
+
+namespace net = boost::asio;
+namespace ssl = boost::wintls;
+
+int main(int argc, char **argv) {
+  net::io_context ioc;
+  ssl::context ctx{boost::wintls::method::system_default};
+  ctx.use_default_certificates(true);
+  ctx.verify_server_certificate(true);
+  ioc.run();
+
+  return 0;
+}

--- a/recipes/boost-wintls/config.yml
+++ b/recipes/boost-wintls/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.9.8":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **boost-wintls/0.9.8**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

I'm adding [boost-wintls](https://github.com/laudrup/boost-wintls) which is a native Windows TLS wrapper for `boost::asio`, similar to [certify](http://github.com/djarek/certify) (already on conan). In fact, `boost-wintls` is the preferred TLS wrapper as djarek, the author of certify, [explains here](https://github.com/microsoft/vcpkg/pull/16783#issuecomment-941705540).

I've overwritten the default CMake target name to ease compatibility with vcpkg and git-submodule setups, where the target is called `boost-wintls`. On vcpkg, the package is called `bext-wintls` since they provide each boost module as `boost-<module>` and this isn't an official boost module, but I think it's better to call it `boost-wintls` here.

It only makes sense to build the package on Windows, but I'm not sure how to encode that other than through the check in `validate`.

Technically, this package only depends on `Boost::headers` (for ASIO) should this be encoded in `requirements` and if so, how?

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
