### PR TITLE
g3log: remove 1.3.2-86 version

### DIFF
--- a/recipes/g3log/all/conandata.yml
+++ b/recipes/g3log/all/conandata.yml
@@ -14,9 +14,6 @@ sources:
   "1.3.3":
     url: "https://github.com/KjellKod/g3log/archive/1.3.3.tar.gz"
     sha256: "d8cae14e1508490145d710f10178b2da9b86ce03fb2428a684fff35576fe5d5c"
-  "1.3.2-86":
-    url: "https://github.com/KjellKod/g3log/archive/4000c5c899c0ae58b8b851f9b66e1a2ac0fe2bff.tar.gz"
-    sha256: "4572b723458fbe2b3bf620e2bd47ecfab2975c16369dc6390ffa27e177b33c88"
   "1.3.2":
     url: "https://github.com/KjellKod/g3log/archive/1.3.2.tar.gz"
     sha256: "0ed1983654fdd8268e051274904128709c3d9df8234acf7916e9015199b0b247"

--- a/recipes/g3log/config.yml
+++ b/recipes/g3log/config.yml
@@ -9,7 +9,5 @@ versions:
     folder: all
   "1.3.3":
     folder: all
-  "1.3.2-86":
-    folder: all
   "1.3.2":
     folder: all


### PR DESCRIPTION
it never was an actual version, and newer version have been created since then.
also, this recipe has no dependants in CCI

Specify library name and version:  **g3log/1.3.2-86**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
