### PR TITLE
onetbb: don't require pkgconf when tbbbind is disabled

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, load, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.scm import Version
@@ -97,13 +98,17 @@ class OneTBBConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} requires hwloc:shared=True to be built.")
 
     def build_requirements(self):
-        if not self._tbbbind_explicit_hwloc and not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+        if self._tbbbind_build and not self._tbbbind_explicit_hwloc:
+            if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+                self.tool_requires("pkgconf/2.0.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
         toolchain = CMakeToolchain(self)
         toolchain.variables["TBB_TEST"] = False
         toolchain.variables["TBB_STRICT"] = False
@@ -126,7 +131,7 @@ class OneTBBConan(ConanFile):
                     os.path.join(hwloc_package_folder, "bin", "hwloc.dll").replace("\\", "/")
         toolchain.generate()
 
-        if self._tbbbind_build:
+        if self._tbbbind_build and not self._tbbbind_explicit_hwloc:
             deps = PkgConfigDeps(self)
             deps.generate()
 


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/21315

see https://github.com/oneapi-src/oneTBB/blob/a71747cd869882e51cec231d822c5f31ed70da71/cmake/hwloc_detection.cmake#L48-L64

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
