### PR TITLE
[pcl] Hotfix: export qhull define

### DIFF
--- a/recipes/pcl/all/conanfile.py
+++ b/recipes/pcl/all/conanfile.py
@@ -574,6 +574,13 @@ class PclConan(ConanFile):
         if self.settings.os == "Windows":
             common.system_libs.append("ws2_32")
 
+        if self.options.with_qhull:
+            self.cpp_info.defines.append('HAVE_QHULL=1')
+        if self.options.with_png:
+            self.cpp_info.defines.append('HAVE_PNG=1')
+        if self.options.with_cuda:
+            self.cpp_info.defines.append('HAVE_CUDA=1')
+
         # TODO: Legacy, to be removed on Conan 2.0
         self.cpp_info.names["cmake_find_package"] = "PCL"
         self.cpp_info.names["cmake_find_package_multi"] = "PCL"


### PR DESCRIPTION
Specify library name and version:  **qhull/1.13.1**

The exported `pcl_config.h` is not following the requested package options:

https://github.com/PointCloudLibrary/pcl/blob/pcl-1.13.1/pcl_config.h.in#L41

Let's export those defines directly. 

fixes #21290

/cc @DevlBert

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
