### PR TITLE
coin-utils: explicitly disable blas and lapack, add CMakeDeps test

### DIFF
--- a/recipes/coin-utils/all/conanfile.py
+++ b/recipes/coin-utils/all/conanfile.py
@@ -55,6 +55,7 @@ class CoinUtilsConan(ConanFile):
     def requirements(self):
         self.requires("bzip2/1.0.8")
         self.requires("zlib/[>=1.2.11 <2]")
+        # TODO: add blas and lapack support
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:
@@ -86,6 +87,8 @@ class CoinUtilsConan(ConanFile):
             env.generate(scope="build")
 
         tc = AutotoolsToolchain(self)
+        tc.configure_args.append("--without-blas")
+        tc.configure_args.append("--without-lapack")
         if is_msvc(self):
             tc.configure_args.append(f"--enable-msvc={self.settings.compiler.runtime}")
             tc.extra_cxxflags.append("-EHsc")

--- a/recipes/coin-utils/all/test_package/CMakeLists.txt
+++ b/recipes/coin-utils/all/test_package/CMakeLists.txt
@@ -3,6 +3,9 @@ project(test_package LANGUAGES CXX)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(CoinUtils REQUIRED IMPORTED_TARGET coinutils)
+add_executable(${PROJECT_NAME}_pkgconfig test_package.cpp)
+target_link_libraries(${PROJECT_NAME}_pkgconfig PRIVATE PkgConfig::CoinUtils)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::CoinUtils)
+find_package(coin-utils REQUIRED CONFIG)
+add_executable(${PROJECT_NAME}_cmake test_package.cpp)
+target_link_libraries(${PROJECT_NAME}_cmake PRIVATE coin-utils::coin-utils)

--- a/recipes/coin-utils/all/test_package/conanfile.py
+++ b/recipes/coin-utils/all/test_package/conanfile.py
@@ -6,7 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
@@ -26,5 +26,7 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package_pkgconfig")
+            self.run(bin_path, env="conanrun")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package_cmake")
             self.run(bin_path, env="conanrun")

--- a/recipes/coin-utils/all/test_v1_package/conanfile.py
+++ b/recipes/coin-utils/all/test_v1_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "pkg_config"
+    generators = "cmake", "cmake_find_package_multi", "pkg_config"
 
     def build_requirements(self):
         self.build_requires("pkgconf/2.0.3")
@@ -16,5 +16,7 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
+            bin_path = os.path.join("bin", "test_package_pkgconfig")
+            self.run(bin_path, run_environment=True)
+            bin_path = os.path.join("bin", "test_package_cmake")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
BLAS and LAPACK were getting picked up from the system automatically otherwise. This breaks downstream package builds.

Also added a separate test_package test against CMakeDeps. Not that important here, but the `coin-cbc` package is having severe issues with `PkgConfigDeps` (#18864), but not `CMakeDeps`, so I thought it would not hurt to include it for all COIN packages.