### PR TITLE
doxygen: Drop compiler and build type from package ID

### DIFF
--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -111,3 +111,7 @@ class DoxygenConan(ConanFile):
 
         # TODO: to remove in conan v2
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type


### PR DESCRIPTION
Specify library name and version:  **doxygen/\***

Doxygen is a documentation generator. The compiler and build type used for building client code should be irrelevant.


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
