### PR TITLE
pcl: properly configure pcl_configure.h regarding qhull

### DIFF
--- a/recipes/pcl/all/conanfile.py
+++ b/recipes/pcl/all/conanfile.py
@@ -543,7 +543,6 @@ class PclConan(ConanFile):
                     component.requires.append(opt_dep)
             for dep in self._external_deps.get(name, []) + self._external_optional_deps.get(name, []):
                 component.requires += self._ext_dep_to_conan_target(dep)
-            self.output.info(f"Component {name} requires: {component.requires}")
 
         if self.options.apps:
             component = self.cpp_info.components["apps"]

--- a/recipes/pcl/all/conanfile.py
+++ b/recipes/pcl/all/conanfile.py
@@ -440,6 +440,10 @@ class PclConan(ConanFile):
         tc.cache_variables["WITH_PCAP"] = self._is_enabled("pcap")
         tc.cache_variables["WITH_PNG"] = self._is_enabled("png")
         tc.cache_variables["WITH_QHULL"] = self._is_enabled("qhull")
+        if self._is_enabled("qhull"):
+            # Upstream FindQhull.cmake defines HAVE_QHULL which changes content of pcl_config.h
+            # Since we use CMakeDeps instead of this file, we have to manually inject HAVE_QHULL
+            tc.cache_variables["HAVE_QHULL"] = True
         tc.cache_variables["WITH_QT"] = self._is_enabled("qt")
         tc.cache_variables["WITH_VTK"] = self._is_enabled("vtk")
         tc.cache_variables["WITH_CUDA"] = self._is_enabled("cuda")
@@ -573,13 +577,6 @@ class PclConan(ConanFile):
                         common.system_libs.append("gomp")
         if self.settings.os == "Windows":
             common.system_libs.append("ws2_32")
-
-        if self.options.with_qhull:
-            self.cpp_info.defines.append('HAVE_QHULL=1')
-        if self.options.with_png:
-            self.cpp_info.defines.append('HAVE_PNG=1')
-        if self.options.with_cuda:
-            self.cpp_info.defines.append('HAVE_CUDA=1')
 
         # TODO: Legacy, to be removed on Conan 2.0
         self.cpp_info.names["cmake_find_package"] = "PCL"


### PR DESCRIPTION
properly address https://github.com/conan-io/conan-center-index/issues/21290

see https://github.com/conan-io/conan-center-index/pull/21325#issuecomment-1825853655

And regarding HAVE_PNG and HAVE_CUDA, they were already properly defined when needed in pcl_configure.h, so no fix is needed at all for those dependencies.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
