### PR TITLE
Ninja: remove build_type setting

### DIFF
--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -22,6 +22,7 @@ class NinjaConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
+        del self.info.settings.build_type
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Ninja will fail to work if a build type is set to anything other than Release. This should fix the issue.

Specify library name and version:  **ninja/***

Allow ninja to be used with projects that want to be built using `build_type` other than `Release`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
