### PR TITLE
qarchive: add version 2.2.8

### DIFF
--- a/recipes/qarchive/all/conandata.yml
+++ b/recipes/qarchive/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.8":
+    url: "https://github.com/antony-jr/QArchive/archive/v2.2.8.tar.gz"
+    sha256: "2f231b48b51de5d730f98bffbff34d7791b61ea766429230d81bce82c7ce1bf9"
   "2.2.6":
     url: "https://github.com/antony-jr/QArchive/archive/v2.2.6.tar.gz"
     sha256: "c0cad2bc79eeb4ab4180fd97822a967b8a0e3c594387ccf921733449ee5bd3e6"

--- a/recipes/qarchive/config.yml
+++ b/recipes/qarchive/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.8":
+    folder: all
   "2.2.6":
     folder: all
   "2.2.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **qarchive/2.2.8**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
