### PR TITLE
cyclonedds: Add properties to ddsc target

### DIFF
--- a/recipes/cyclonedds/all/conanfile.py
+++ b/recipes/cyclonedds/all/conanfile.py
@@ -134,6 +134,11 @@ class CycloneDDSConan(ConanFile):
         copy(self, "CycloneDDS_idlc.cmake",
                    src=os.path.join(self.source_folder, os.pardir, "cmake"),
                    dst=os.path.join(self.package_folder, "lib", "cmake", "CycloneDDS"))
+        with open(os.path.join(self.package_folder, "lib", "cmake", "CycloneDDS", "CycloneDDS_ddsc.cmake"), "w") as f:
+            f.write("set_target_properties(CycloneDDS::ddsc" + \
+                    "\n  PROPERTIES SHM_SUPPORT_IS_AVAILABLE {}".format(self.options.with_shm) + \
+                    "\n             TYPE_DISCOVERY_IS_AVAILABLE {}".format(self.options.enable_discovery) + \
+                    "\n             TOPIC_DISCOVERY_IS_AVAILABLE {})".format(self.options.enable_discovery))
         if self.settings.os == "Windows":
             for p in ("*.pdb", "concrt*.dll", "msvcp*.dll", "vcruntime*.dll"):
                 rm(self, p, os.path.join(self.package_folder, "bin"))
@@ -161,6 +166,7 @@ class CycloneDDSConan(ConanFile):
             ]
 
         build_modules = [
+            os.path.join("lib", "cmake", "CycloneDDS", "CycloneDDS_ddsc.cmake"),
             os.path.join("lib", "cmake", "CycloneDDS", "CycloneDDS_idlc.cmake"),
             os.path.join("lib", "cmake", "CycloneDDS", "idlc", "Generate.cmake"),
         ]


### PR DESCRIPTION
**cyclonedds/0.10.4**

Add properties to the `CycloneDDS::ddsc` target that are required by downstream consumers of the target.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
