### PR TITLE
cpp-lazy: add package_type & explicit cmake names

### DIFF
--- a/recipes/cpp-lazy/all/conanfile.py
+++ b/recipes/cpp-lazy/all/conanfile.py
@@ -16,8 +16,8 @@ class CpplazyConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/MarcDirven/cpp-lazy"
     topics = ("lazy evaluation", "header-only")
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
-    no_copy_source = True
 
     @property
     def _min_cppstd(self):
@@ -55,5 +55,7 @@ class CpplazyConan(ConanFile):
         )
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "cpp-lazy")
+        self.cpp_info.set_property("cmake_target_name", "cpp-lazy::cpp-lazy")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []


### PR DESCRIPTION
explicit cmake names since there is a config file upstream: https://github.com/MarcDirven/cpp-lazy/blob/5ee8d81ba6ccaa808a97c0ac1c1eb9431d38a149/CMakeLists.txt#L122-L129

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
