### PR TITLE
xmlrpc-epi: add recipe

### DIFF
--- a/recipes/xmlrpc-epi/all/CMakeLists.txt
+++ b/recipes/xmlrpc-epi/all/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(xmlrpc-epi C)
+
+find_package(EXPAT REQUIRED)
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+file(GLOB HEADERS "src/*.h")
+file(GLOB SOURCES "src/*.c")
+
+add_library(xmlrpc-epi ${SOURCES} ${HEADERS})
+
+target_include_directories(xmlrpc-epi PUBLIC include)
+
+set(LINK_LIBRARIES expat::expat)
+if (WIN32 OR APPLE)
+    find_package(ICONV REQUIRED)
+    list(APPEND LINK_LIBRARIES Iconv::Iconv)
+endif (WIN32)
+
+target_link_libraries(xmlrpc-epi ${LINK_LIBRARIES})
+
+install(TARGETS xmlrpc-epi)
+install(FILES ${HEADERS} DESTINATION include)

--- a/recipes/xmlrpc-epi/all/CMakeLists.txt
+++ b/recipes/xmlrpc-epi/all/CMakeLists.txt
@@ -8,12 +8,22 @@ if(MSVC AND BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
-file(GLOB HEADERS "src/*.h")
 file(GLOB SOURCES "src/*.c")
+file(GLOB PRIVATE_HEADERS "src‌/*_private.h")
+set(PUBLIC_HEADERS
+    "src/base64.h"
+    "src/encodings.h"
+    "src/queue.h"
+    "src/simplestring.h"
+    "src/xml_element.h"
+    "src/xml_to_dandarpc.h"
+    "src/xml_to_soap.h"
+    "src/xmlrpc_introspection.h"
+    "src/xmlrpc.h"
+)
 
-add_library(xmlrpc-epi ${SOURCES} ${HEADERS})
-
-target_include_directories(xmlrpc-epi PUBLIC include)
+add_library(xmlrpc-epi)
+target_sources(xmlrpc-epi PUBLIC ${PUBLIC_HEADERS} PRIVATE ${SOURCES} ${PRIVATE_HEADER})
 
 set(LINK_LIBRARIES expat::expat)
 if (WIN32 OR APPLE)
@@ -24,4 +34,4 @@ endif (WIN32)
 target_link_libraries(xmlrpc-epi ${LINK_LIBRARIES})
 
 install(TARGETS xmlrpc-epi)
-install(FILES ${HEADERS} DESTINATION include)
+install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xmlrpc-epi)

--- a/recipes/xmlrpc-epi/all/conandata.yml
+++ b/recipes/xmlrpc-epi/all/conandata.yml
@@ -1,0 +1,13 @@
+sources:
+  "0.54.2":
+    url: "https://downloads.sourceforge.net/project/xmlrpc-epi/xmlrpc-epi-base/0.54.2/xmlrpc-epi-0.54.2.tar.bz2"
+    sha256: "c74ef8fb680b140890138a82f37619714b67f69025a775b9ba2009d62cded0b8"
+patches:
+  "0.54.2":
+    - patch_file: "patches/0001-debian.patch"
+      patch_type: "vulnerability"
+      patch_description: "CVE-2016-6296: Heap buffer overflow vulnerability in simplestring_addn"
+      patch_source: https://sources.debian.org/src/xmlrpc-epi/0.54.2-2/debian/patches/debian.patch/
+    - patch_file: "patches/0002-msvc.patch"
+      patch_type: "portability"
+      patch_description: "Fix strncasecmp and strcasecmp for MSVC"

--- a/recipes/xmlrpc-epi/all/conanfile.py
+++ b/recipes/xmlrpc-epi/all/conanfile.py
@@ -1,0 +1,79 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, replace_in_file
+
+
+required_conan_version = ">=1.53.0"
+
+
+class XMLRPCEPIRecipe(ConanFile):
+    name = "xmlrpc-epi"
+    description = "An implementation of the xmlrpc protocol in C"
+    license = "MIT"
+    homepage = "https://xmlrpc-epi.sourceforge.net/"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("xml-rpc", "http")
+    package_type = "library"
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    def requirements(self):
+        self.requires("expat/2.5.0")
+        if self.settings.os in ("Windows", "Macos"):
+            self.requires("libiconv/1.17")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        # This is a c-only library, remove C++ compiler settings
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def export_sources(self):
+        export_conandata_patches(self)
+        copy(self, "CMakeLists.txt",
+             src=self.recipe_folder,
+             dst=os.path.join(self.export_sources_folder, "src"))
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+        if self.settings.build_type == "Debug":
+            # Remove inlines from source files so that we can link the debug build
+            replace_in_file(self, os.path.join(self.source_folder, "src/xml_to_soap.c"), "inline", "")
+            replace_in_file(self, os.path.join(self.source_folder, "src/xmlrpc_introspection.c"), "inline", "")
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, pattern="AUTHORS", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["xmlrpc-epi"]

--- a/recipes/xmlrpc-epi/all/patches/0001-debian.patch
+++ b/recipes/xmlrpc-epi/all/patches/0001-debian.patch
@@ -1,0 +1,60 @@
+--- a/src/simplestring.c
++++ b/src/simplestring.c
+@@ -167,6 +167,10 @@ void simplestring_free(simplestring* str
+ }
+ /******/
+
++#ifndef SIZE_MAX
++#define SIZE_MAX ((size_t)-1)
++#endif
++
+ /****f* FUNC/simplestring_addn
+  * NAME
+  *   simplestring_addn
+@@ -185,18 +189,31 @@ void simplestring_free(simplestring* str
+  *   simplestring_add ()
+  * SOURCE
+  */
+-void simplestring_addn(simplestring* target, const char* source, int add_len) {
++void simplestring_addn(simplestring* target, const char* source, size_t add_len) {
++   size_t newsize = target->size, incr = 0;
+    if(target && source) {
+       if(!target->str) {
+          simplestring_init_str(target);
+       }
++
++      if((SIZE_MAX - add_len) < target->len || (SIZE_MAX - add_len - 1) < target->len) {
++    	  /* check for overflows, if there's a potential overflow do nothing */
++    	  return;
++      }
++
+       if(target->len + add_len + 1 > target->size) {
+          /* newsize is current length + new length */
+-         int newsize = target->len + add_len + 1;
+-         int incr = target->size * 2;
++         newsize = target->len + add_len + 1;
++         incr = target->size * 2;
+
+          /* align to SIMPLESTRING_INCR increments */
+-         newsize = newsize - (newsize % incr) + incr;
++         if (incr) {
++            newsize = newsize - (newsize % incr) + incr;
++         }
++         if(newsize < (target->len + add_len + 1)) {
++        	 /* some kind of overflow happened */
++        	 return;
++         }
+          target->str = (char*)realloc(target->str, newsize);
+
+          target->size = target->str ? newsize : 0;
+--- a/src/simplestring.h
++++ b/src/simplestring.h
+@@ -63,7 +63,7 @@ void simplestring_init(simplestring* str
+ void simplestring_clear(simplestring* string);
+ void simplestring_free(simplestring* string);
+ void simplestring_add(simplestring* string, const char* add);
+-void simplestring_addn(simplestring* string, const char* add, int add_len);
++void simplestring_addn(simplestring* string, const char* add, size_t add_len);
+
+ #ifdef __cplusplus
+ }

--- a/recipes/xmlrpc-epi/all/patches/0002-msvc.patch
+++ b/recipes/xmlrpc-epi/all/patches/0002-msvc.patch
@@ -1,15 +1,15 @@
-diff -ur a/src/xmlrpc.h b/src/xmlrpc.h
---- a/src/xmlrpc.h	2023-11-26 09:30:53.358486300 -0800
-+++ b/src/xmlrpc.h	2023-11-26 09:31:34.147842700 -0800
-@@ -55,6 +55,11 @@
- /* where to find more info. shouldn't need to change much */
- #define XMLRPC_HOME_PAGE_STR "http://xmlprc-epi.sourceforge.net/"
+diff -ruN a/src/xmlrpc_private.h b/src/xmlrpc_private.h
+--- a/src/xmlrpc_private.h	2023-11-28 23:38:00.109172126 -0800
++++ b/src/xmlrpc_private.h	2023-11-28 23:46:00.040837064 -0800
+@@ -42,6 +42,11 @@
+  */
+ #define XMLRPC_PRIVATE_ALREADY_INCLUDED
  
 +#ifdef _MSC_VER 
 +#define strncasecmp _strnicmp
 +#define strcasecmp _stricmp
 +#endif
 +
- 
- /****d* VALUE/XMLRPC_VALUE_TYPE
-  * NAME
+ #ifdef __cplusplus
+ extern "C" {
+ #endif

--- a/recipes/xmlrpc-epi/all/patches/0002-msvc.patch
+++ b/recipes/xmlrpc-epi/all/patches/0002-msvc.patch
@@ -1,0 +1,15 @@
+diff -ur a/src/xmlrpc.h b/src/xmlrpc.h
+--- a/src/xmlrpc.h	2023-11-26 09:30:53.358486300 -0800
++++ b/src/xmlrpc.h	2023-11-26 09:31:34.147842700 -0800
+@@ -55,6 +55,11 @@
+ /* where to find more info. shouldn't need to change much */
+ #define XMLRPC_HOME_PAGE_STR "http://xmlprc-epi.sourceforge.net/"
+ 
++#ifdef _MSC_VER 
++#define strncasecmp _strnicmp
++#define strcasecmp _stricmp
++#endif
++
+ 
+ /****d* VALUE/XMLRPC_VALUE_TYPE
+  * NAME

--- a/recipes/xmlrpc-epi/all/test_package/CMakeLists.txt
+++ b/recipes/xmlrpc-epi/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package C)
+
+find_package(xmlrpc-epi CONFIG REQUIRED)
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE xmlrpc-epi::xmlrpc-epi)

--- a/recipes/xmlrpc-epi/all/test_package/conanfile.py
+++ b/recipes/xmlrpc-epi/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/xmlrpc-epi/all/test_package/test_package.c
+++ b/recipes/xmlrpc-epi/all/test_package/test_package.c
@@ -1,0 +1,9 @@
+#include "xmlrpc.h"
+
+int main(int argc, char **argv)
+{
+  XMLRPC_SERVER server;
+  server = XMLRPC_ServerCreate();
+  XMLRPC_ServerDestroy(server);
+  return 0;
+}

--- a/recipes/xmlrpc-epi/all/test_package/test_package.c
+++ b/recipes/xmlrpc-epi/all/test_package/test_package.c
@@ -1,4 +1,4 @@
-#include "xmlrpc.h"
+#include <xmlrpc-epi/xmlrpc.h>
 
 int main(int argc, char **argv)
 {

--- a/recipes/xmlrpc-epi/config.yml
+++ b/recipes/xmlrpc-epi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.54.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **xmlrpc-epi/0.54.2**

This changeset adds a Conan recipe for the [xmlrpc-epi](https://xmlrpc-epi.sourceforge.net/) C library. While its upstream has not been updated since 2011 it still receives security patches from linux distros such as Debian.

The library is used by the [Second Life client](https://github.com/secondlife/viewer) and other software maintained by [Linden Lab](https://lindenlab.com/).

Thank you for the consideration, please let me know if anything needs to change!

Closes #21388


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] ~I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.~ _Skipped: Not compatible with conan2?_
