### PR TITLE
[docs] Allow boost namespace for non official projects

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -444,6 +444,8 @@ and does not install libraries with the boost prefix.
 
 Yes, but make sure it does not have Boost in the name. Use the [`author-name` convention](https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-is-the-policy-on-recipe-name-collisions) so there are no conflicts. In addition to follow the rules outlined above.
 
+**NOTE**: In case you have no intention to submit to Boost, then you can use the project name as is (e.g `boost-foobar`).
+
 ## Can I add options that do not affect `package_id` or the package contents
 
 Generally no, these sorts of options can most likely be set from a profile or downstream recipes. However if the project supports this option from its build script


### PR DESCRIPTION
After talking to Conan team about a non official boost library, having no intention to be integrated to official boost, and finding that even cmake targets and headers are using the name boost, it would be better allow these specific cases to use the project name, including the boost prefix as package name. Otherwise, it would require more changes, like the cmake target and cmake name.

In case the project changes, and want to be part to boost, then, it should be marked as `deprecated` as soon as becomes official in Boost. 

Related to https://github.com/conan-io/conan-center-index/pull/21303


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
