### PR TITLE
foxglove-websocket: Add version 1.2.0

### DIFF
--- a/recipes/foxglove-websocket/all/conandata.yml
+++ b/recipes/foxglove-websocket/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  1.2.0:
+    url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v1.2.0.tar.gz
+    sha256: 0471d3932500ed6acd87a99cd76e048366c82f2527c1631afcee4f8ab71c4ab7
   1.1.0:
     url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v1.1.0.tar.gz
     sha256: 3ad1f639e340e878dd638d542e57185b8c7c08fdfcb03d8c43d054957078a81f

--- a/recipes/foxglove-websocket/config.yml
+++ b/recipes/foxglove-websocket/config.yml
@@ -1,4 +1,6 @@
 versions:
+  1.2.0:
+    folder: all
   1.1.0:
     folder: all
   1.0.0:


### PR DESCRIPTION
Specify library name and version:  **foxglove-websocket/1.2.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
