### PR TITLE
re2c: Add RE2C_STDLIB_DIR variable with re2c stdlib

### DIFF
--- a/recipes/re2c/all/conanfile.py
+++ b/recipes/re2c/all/conanfile.py
@@ -91,6 +91,10 @@ class Re2CConan(ConanFile):
              src=self.source_folder,
              dst=os.path.join(self.package_folder, "licenses"),
              keep_path=False)
+        copy(self, "*.re",
+             src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"),
+             keep_path=False)
         with chdir(self, self.source_folder):
             autotools = Autotools(self)
             autotools.install()
@@ -102,6 +106,10 @@ class Re2CConan(ConanFile):
         self.cpp_info.resdirs = []
         self.cpp_info.includedirs = []
 
+        include_dir = os.path.join(self.package_folder, "include")
+        self.buildenv_info.define("RE2C_STDLIB_DIR", include_dir)
+
         # TODO: to remove in conan v2
         bin_path = os.path.join(self.package_folder, "bin")
         self.env_info.PATH.append(bin_path)
+        self.env_info.RE2C_STDLIB_DIR = include_dir

--- a/recipes/re2c/all/test_package/CMakeLists.txt
+++ b/recipes/re2c/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package C)
 
+find_program(RE2C NAMES re2c)
+
 add_custom_command(OUTPUT test_package.c
-    COMMAND re2c -W "${CMAKE_CURRENT_LIST_DIR}/syntax.re" -o test_package.c
+    COMMAND "${RE2C}" -W "${CMAKE_CURRENT_LIST_DIR}/syntax.re" -I "$ENV{RE2C_STDLIB_DIR}" -o test_package.c
 )
 
 add_executable(${PROJECT_NAME} test_package.c)

--- a/recipes/re2c/all/test_package/syntax.re
+++ b/recipes/re2c/all/test_package/syntax.re
@@ -1,16 +1,21 @@
 #include <stdio.h>
+#include <assert.h>
+
+/*!include:re2c "unicode_categories.re" */
 
 /*!max:re2c*/
 /*!re2c
     digit  = [0-9];
     number = digit+;
+    word = L+;
 */
 
 static int lex(const char *YYCURSOR)
 {
     const char *YYMARKER;
     /*!re2c
-    re2c:define:YYCTYPE = char;
+    re2c:flags:utf-8 = 1;
+    re2c:define:YYCTYPE = 'unsigned char';
     re2c:yyfill:enable  = 0;
 
     * { return 1; }
@@ -20,12 +25,18 @@ static int lex(const char *YYCURSOR)
         return 0;
     }
 
+    word {
+        printf("word\n");
+        return 0;
+    }
+
     */
 }
 
 int main()
 {
-    lex("1024");
-    lex(";]");
+    assert(lex("1024") == 0);
+    assert(lex(";]") == 1);
+    assert(lex("Слово") == 0);
     return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **re2c/***

Problem: Current recipe for re2c does not provide stdlib for this tool. 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
