### PR TITLE
incbin: allow msvc + pack incbin_tool on msvc

### DIFF
--- a/recipes/homog2d/all/conanfile.py
+++ b/recipes/homog2d/all/conanfile.py
@@ -15,6 +15,7 @@ class Homog2dConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/skramm/homog2d"
     topics = ("computational-geometry", "homography", "2d-geometric", "header-only")
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
 
     @property

--- a/recipes/incbin/all/conanfile.py
+++ b/recipes/incbin/all/conanfile.py
@@ -39,7 +39,7 @@ class IncbinConan(ConanFile):
     def package(self):
         copy(self, "UNLICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(self, "incbin.h", dst=os.path.join(self.package_folder, "include"), src=self.source_folder)
-        copy(self, "**/incbin_tool.exe", dst=os.path.join(self.package_folder, "bin"), src=self.build_folder, keep_path=False)
+        copy(self, "incbin_tool.exe", dst=os.path.join(self.package_folder, "bin"), src=self.build_folder, keep_path=False)
 
     def package_id(self):
         if not is_msvc(self):

--- a/recipes/incbin/all/conanfile.py
+++ b/recipes/incbin/all/conanfile.py
@@ -1,8 +1,8 @@
 from conan import ConanFile
+from conans import CMake
 from conan.tools.files import get, copy
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
-from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.50.0"
@@ -22,20 +22,32 @@ class IncbinConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
-    def package_id(self):
-        self.info.clear()
-
-    def validate(self):
-        if is_msvc(self):
-            raise ConanInvalidConfiguration("Currently incbin recipe is not supported for Visual Studio because it requires external command 'incbin'.")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        if is_msvc(self):
+            with open("CMakeLists.txt", "w") as f:
+                f.write("cmake_minimum_required(VERSION 3.0)\n"
+                        "project(incbin_tool)\n"
+                        "add_executable(incbin_tool incbin.c)\n")
+
+    def build(self):
+        if is_msvc(self):
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
 
     def package(self):
         copy(self, "UNLICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(self, "incbin.h", dst=os.path.join(self.package_folder, "include"), src=self.source_folder)
+        copy(self, "**/incbin_tool.exe", dst=os.path.join(self.package_folder, "bin"), src=self.build_folder, keep_path=False)
+
+    def package_id(self):
+        if not is_msvc(self):
+            self.info.clear()
 
     def package_info(self):
-        self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        if is_msvc(self):
+            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+        else:
+            self.cpp_info.bindirs = []

--- a/recipes/incbin/all/test_package/CMakeLists.txt
+++ b/recipes/incbin/all/test_package/CMakeLists.txt
@@ -3,9 +3,11 @@ project(test_package LANGUAGES C)
 
 find_package(incbin CONFIG REQUIRED)
 
+configure_file(${CMAKE_SOURCE_DIR}/hello_world.txt ${CMAKE_BINARY_DIR}/hello_world.txt COPYONLY)
+
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} incbin::incbin)
-target_compile_definitions(${PROJECT_NAME} PUBLIC INCBIN_FILE="${CMAKE_SOURCE_DIR}/CMakeLists.txt")
+target_compile_definitions(${PROJECT_NAME} PUBLIC INCBIN_FILE="${CMAKE_BINARY_DIR}/hello_world.txt")
 
 if(MSVC)
     add_custom_command(OUTPUT data.c

--- a/recipes/incbin/all/test_package/CMakeLists.txt
+++ b/recipes/incbin/all/test_package/CMakeLists.txt
@@ -13,5 +13,5 @@ if(MSVC)
             ARGS ${CMAKE_CURRENT_LIST_DIR}/test_package.c -p g_ -Ssnakecase -o ${CMAKE_BINARY_DIR}/data.c
             WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
             COMMENT "Generating resources with incbin_tool")
-    target_sources(${PROJECT_NAME} ${CMAKE_BINARY_DIR}/data.c)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/data.c)
 endif()

--- a/recipes/incbin/all/test_package/CMakeLists.txt
+++ b/recipes/incbin/all/test_package/CMakeLists.txt
@@ -6,3 +6,12 @@ find_package(incbin CONFIG REQUIRED)
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} incbin::incbin)
 target_compile_definitions(${PROJECT_NAME} PUBLIC INCBIN_FILE="${CMAKE_SOURCE_DIR}/CMakeLists.txt")
+
+if(MSVC)
+    add_custom_command(OUTPUT data.c
+            COMMAND incbin_tool
+            ARGS ${CMAKE_CURRENT_LIST_DIR}/test_package.c -p g_ -Ssnakecase -o ${CMAKE_BINARY_DIR}/data.c
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            COMMENT "Generating resources with incbin_tool")
+    target_sources(${PROJECT_NAME} ${CMAKE_BINARY_DIR}/data.c)
+endif()

--- a/recipes/incbin/all/test_package/conanfile.py
+++ b/recipes/incbin/all/test_package/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.microsoft import is_msvc
 import os
 
 
@@ -11,6 +12,10 @@ class TestPackageConan(ConanFile):
 
     def layout(self):
         cmake_layout(self)
+
+    def build_requirements(self):
+        if is_msvc(self):
+            self.build_requires(self.tested_reference_str) # incbin_tool
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/incbin/all/test_package/hello_world.txt
+++ b/recipes/incbin/all/test_package/hello_world.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/recipes/incbin/all/test_package/test_package.c
+++ b/recipes/incbin/all/test_package/test_package.c
@@ -2,11 +2,7 @@
 #define INCBIN_STYLE INCBIN_STYLE_SNAKE
 #include "incbin.h"
 
-#ifdef _MSC_VER
 INCBIN(cmake, "CMakeLists.txt");
-#else
-INCBIN(cmake, INCBIN_FILE);
-#endif
 
 #include <stdio.h>
 

--- a/recipes/incbin/all/test_package/test_package.c
+++ b/recipes/incbin/all/test_package/test_package.c
@@ -1,15 +1,12 @@
 #define INCBIN_PREFIX g_
 #define INCBIN_STYLE INCBIN_STYLE_SNAKE
-#include "incbin.h"
-
-INCBIN(cmake, "CMakeLists.txt");
+#include <incbin.h>
 
 #include <stdio.h>
 
-int main(int argc, char* argv[]) {
-    (void)g_cmake_data[0];
-    (void)*g_cmake_end;
-    printf(INCBIN_FILE" size is %d\n", g_cmake_size);
+INCBIN(hello_world, "hello_world.txt");
 
+int main(int argc, char* argv[]) {
+    fwrite(g_hello_world_data, 1, g_hello_world_size, stdout);
     return 0;
 }

--- a/recipes/incbin/all/test_package/test_package.c
+++ b/recipes/incbin/all/test_package/test_package.c
@@ -2,7 +2,11 @@
 #define INCBIN_STYLE INCBIN_STYLE_SNAKE
 #include "incbin.h"
 
+#ifdef _MSC_VER
+INCBIN(cmake, "CMakeLists.txt");
+#else
 INCBIN(cmake, INCBIN_FILE);
+#endif
 
 #include <stdio.h>
 

--- a/recipes/indicators/all/conanfile.py
+++ b/recipes/indicators/all/conanfile.py
@@ -7,7 +7,8 @@ from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.50.0"
+
 
 class IndicatorsConan(ConanFile):
     name = "indicators"
@@ -16,6 +17,7 @@ class IndicatorsConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/p-ranav/indicators"
     topics = ("activity", "indicator", "loading", "spinner", "animation", "progress", "header-only")
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -47,6 +49,8 @@ class IndicatorsConan(ConanFile):
         copy(self, pattern="*.hpp", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "indicators")
+        self.cpp_info.set_property("cmake_target_name", "indicators::indicators")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
 

--- a/recipes/itlib/all/conandata.yml
+++ b/recipes/itlib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.10.3":
+    url: "https://github.com/iboB/itlib/archive/v1.10.3.tar.gz"
+    sha256: "e533c44354d48b2251ca57f1502778033b38170d9d6aba6bb2bbad90f2bf9d27"
   "1.10.0":
     url: "https://github.com/iboB/itlib/archive/v1.10.0.tar.gz"
     sha256: "a97b98514aa7194241383b537c368a01d4a56e05316a94551cd183a986caa9c7"

--- a/recipes/itlib/config.yml
+++ b/recipes/itlib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.10.3":
+    folder: all
   "1.10.0":
     folder: all
   "1.9.2":

--- a/recipes/platform.interfaces/all/test_package/test_package.cpp
+++ b/recipes/platform.interfaces/all/test_package/test_package.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <ranges>
+#include <iterator>
 #include <vector>
 #include <set>
 
@@ -11,7 +11,7 @@ using namespace Platform::Interfaces;
 
 void print(IEnumerable auto&& enumerable)
 {
-    auto size = std::ranges::size(enumerable);
+    auto size = std::size(enumerable);
 
     std::cout << '[';
     for (int i = 0; auto&& item : enumerable)
@@ -48,7 +48,7 @@ void add(Collection& collection, const std::same_as<Item> auto& item)
 
 void print(CEnumerable auto&& enumerable)
 {
-    auto size = std::ranges::size(enumerable);
+  auto size = enumerable.size();
 
     std::cout << '[';
     for (int i = 0; auto&& item : enumerable)

--- a/recipes/rangesnext/all/test_package/test_package.cpp
+++ b/recipes/rangesnext/all/test_package/test_package.cpp
@@ -9,7 +9,7 @@ bool test_enumerate_with(RangeT &&range) {
     auto enumerated_range = rangesnext::enumerate(range);
 
     std::size_t idx_ref = 0;
-    auto it_ref = std::ranges::begin(range);
+    auto it_ref = std::begin(range);
 
     bool success = true;
     for (auto &&[i, v] : enumerated_range) {


### PR DESCRIPTION
Specify library name and version:  **incbin/cci.20211107**

- enabled MSVC target
- building and packing incbin_tool which is necessary to generate "included" binaries on MSVC build system
- test_package serves also as example of using the poor-documented incbin_tool

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [y ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [y ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ y] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
