### PR TITLE
modern-cpp-kafka: add package_type + reset cmake names to default value

### DIFF
--- a/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
+++ b/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
-find_package(ModernCppKafka REQUIRED CONFIG)
+find_package(modern-cpp-kafka REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE ModernCppKafka::ModernCppKafka)
+target_link_libraries(${PROJECT_NAME} PRIVATE modern-cpp-kafka::modern-cpp-kafka)
 target_compile_features(${PROJECT_NAME}  PRIVATE cxx_std_17)

--- a/recipes/modern-cpp-kafka/all/test_v1_package/CMakeLists.txt
+++ b/recipes/modern-cpp-kafka/all/test_v1_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
- add package_type
- do not invent unofficial target name (there is no config file upstream, and the target name representing interface lib in their CMakeLists is not even the same as suggested in this recipe)
- empty cpp_info.bindirs & libdirs
- bump librdkafka

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
