### PR TITLE
glib/2.78.x: Add patch to support Python 3.12

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -30,6 +30,11 @@ sources:
     url: "https://download.gnome.org/sources/glib/2.75/glib-2.75.3.tar.xz"
     sha256: "7c517d0aff456c35a039bce8a8df7a08ce95a8285b09d1849f8865f633f7f871"
 patches:
+  "2.78.3":
+    - patch_file: "patches/0001-Switch-from-the-deprecated-distutils-module-to-the-p.patch"
+      patch_type: "portability"
+      patch_description: "Replace the distutils module to support Python 3.12"
+      patch_source: "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3740"
   "2.78.1":
     - patch_file: "patches/0001-Switch-from-the-deprecated-distutils-module-to-the-p.patch"
       patch_type: "portability"

--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.79.2":
+    url: "https://download.gnome.org/sources/glib/2.79/glib-2.79.2.tar.xz"
+    sha256: "a47f7ecf7bba0346e6cd562887b93ee4ee37a57d8dcae0755f0de8dc75ca5e8c"
   "2.78.3":
     url: "https://download.gnome.org/sources/glib/2.78/glib-2.78.3.tar.xz"
     sha256: "609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21"

--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -27,6 +27,16 @@ sources:
     url: "https://download.gnome.org/sources/glib/2.75/glib-2.75.3.tar.xz"
     sha256: "7c517d0aff456c35a039bce8a8df7a08ce95a8285b09d1849f8865f633f7f871"
 patches:
+  "2.78.1":
+    - patch_file: "patches/0001-Switch-from-the-deprecated-distutils-module-to-the-p.patch"
+      patch_type: "portability"
+      patch_description: "Replace the distutils module to support Python 3.12"
+      patch_source: "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3740"
+  "2.78.0":
+    - patch_file: "patches/0001-Switch-from-the-deprecated-distutils-module-to-the-p.patch"
+      patch_type: "portability"
+      patch_description: "Replace the distutils module to support Python 3.12"
+      patch_source: "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3740"
   "2.76.3":
     - patch_file: "patches/libintl-discovery.patch"
       patch_type: bugfix

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -81,7 +81,7 @@ class GLibConan(ConanFile):
             self.requires("libiconv/1.17")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.3.1")
+        self.tool_requires("meson/1.3.2")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/2.1.0")
 

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -81,7 +81,7 @@ class GLibConan(ConanFile):
             self.requires("libiconv/1.17")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.3.0")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/2.0.3")
 

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -81,9 +81,9 @@ class GLibConan(ConanFile):
             self.requires("libiconv/1.17")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.3.0")
+        self.tool_requires("meson/1.3.1")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/glib/all/patches/0001-Switch-from-the-deprecated-distutils-module-to-the-p.patch
+++ b/recipes/glib/all/patches/0001-Switch-from-the-deprecated-distutils-module-to-the-p.patch
@@ -1,0 +1,33 @@
+From 45edf065cb7d02b466761083a6860f3ef2b149fe Mon Sep 17 00:00:00 2001
+From: Jordan Williams <jordan@jwillikers.com>
+Date: Fri, 1 Dec 2023 09:55:02 -0600
+Subject: [PATCH] Switch from the deprecated distutils module to the packaging
+ module
+
+The distutils module was removed in Python 3.12.
+---
+ gio/gdbus-2.0/codegen/utils.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gio/gdbus-2.0/codegen/utils.py b/gio/gdbus-2.0/codegen/utils.py
+index 02046108d..08f1ba973 100644
+--- a/gio/gdbus-2.0/codegen/utils.py
++++ b/gio/gdbus-2.0/codegen/utils.py
+@@ -19,7 +19,7 @@
+ #
+ # Author: David Zeuthen <davidz@redhat.com>
+ 
+-import distutils.version
++import packaging.version
+ import os
+ import sys
+ 
+@@ -166,4 +166,4 @@ def version_cmp_key(key):
+         v = str(key[0])
+     else:
+         v = "0"
+-    return (distutils.version.LooseVersion(v), key[1])
++    return (packaging.version.Version(v), key[1])
+-- 
+2.43.0
+

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -18,7 +18,7 @@ class TestPackageConan(ConanFile):
 
     def build_requirements(self):
         if self.settings.os != "Windows" and not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/glib/all/test_v1_package/conanfile.py
+++ b/recipes/glib/all/test_v1_package/conanfile.py
@@ -8,7 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build_requirements(self):
         if self.settings.os != "Windows":
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
 
     def build(self):
         if self.settings.os != "Windows":

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.79.2":
+    folder: all
   "2.78.3":
     folder: all
   "2.78.1":


### PR DESCRIPTION
Specify library name and version:  **glib/2.78.x**

The distutils module was removed in Python 3.12, requiring at least Meson 1.2.3 and a patch for glib. See the upstream PR [here](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3740).

Requires conan-io/conan-docker-tools#554

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
