### PR TITLE
harfbuzz: fix frameworks used in package_info

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -197,8 +197,11 @@ class HarfbuzzConan(ConanFile):
                 self.cpp_info.system_libs.append("usp10")
             if self.options.with_directwrite:
                 self.cpp_info.system_libs.append("dwrite")
-        if is_apple_os(self):
-            self.cpp_info.frameworks.extend(["CoreFoundation", "CoreGraphics", "CoreText", "ApplicationServices"])
+        if is_apple_os(self) and self.options.get_safe("with_coretext", False):
+            if self.settings.os == "Macos":
+                self.cpp_info.frameworks.append("ApplicationServices")
+            else:
+                self.cpp_info.frameworks.extend(["CoreFoundation", "CoreGraphics", "CoreText"])
         if not self.options.shared:
             libcxx = stdcpp_library(self)
             if libcxx:


### PR DESCRIPTION
Specify library name and version:  **harfbuzz/all**

This addresses the comment https://github.com/conan-io/conan-center-index/pull/20870#issuecomment-1836088235 by @SpaceIm 

Apple frameworks are only used when `with_coretext=True`.

On macOS, harfbuzz links against the ApplicationServices framework.
For other Apple OS, it links against CoreFoundation, CoreGraphics & CoreText frameworks.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
