### PR TITLE
very-simple-smtps: use version range for libcurl

### DIFF
--- a/recipes/very-simple-smtps/all/conanfile.py
+++ b/recipes/very-simple-smtps/all/conanfile.py
@@ -55,13 +55,8 @@ class VerySimpleSmtpsConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        required_packages = [
-            "libcurl/8.0.1",
-            "doctest/2.4.11",
-        ]
-
-        for package in required_packages:
-            self.requires(package)
+        self.requires("doctest/2.4.11")
+        self.requires("libcurl/[>=7.78.0 <9]")
 
     def validate(self):
         if self.settings.os != "Linux":
@@ -108,7 +103,7 @@ class VerySimpleSmtpsConan(ConanFile):
         copy(self, pattern="include/*.hpp", dst=os.path.join(self.package_folder, ""), src=self.source_folder)
         meson = Meson(self)
         meson.install()
-        
+
         rmdir(self, os.path.join(self.package_folder, "share"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
Specify library name and version:  **very-simple-smtps/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
