### PR TITLE
json-schema-validator: add version 2.3.0, downgrade nolhmann_json in older versions

### DIFF
--- a/recipes/json-schema-validator/all/conandata.yml
+++ b/recipes/json-schema-validator/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3.0":
+    url: "https://github.com/pboettch/json-schema-validator/archive/refs/tags/2.3.0.tar.gz"
+    sha256: "2c00b50023c7d557cdaa71c0777f5bcff996c4efd7a539e58beaa4219fa2a5e1"
   "2.2.0":
     url: "https://github.com/pboettch/json-schema-validator/archive/refs/tags/2.2.0.tar.gz"
     sha256: "03897867bd757ecac1db7545babf0c6c128859655b496582a9cea4809c2260aa"

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -95,6 +95,8 @@ class JsonSchemaValidatorConan(ConanFile):
         else:
             tc.variables["JSON_VALIDATOR_BUILD_TESTS"] = False
             tc.variables["JSON_VALIDATOR_BUILD_EXAMPLES"] = False
+            tc.variables["JSON_VALIDATOR_INSTALL"] = True
+            tc.variables["JSON_VALIDATOR_SHARED_LIBS"] = self.options.shared
         if self.options.json_diagnostics:
             tc.preprocessor_definitions["JSON_DIAGNOSTICS"] = '1'
         if Version(self.version) < "2.1.0":
@@ -150,6 +152,8 @@ class JsonSchemaValidatorConan(ConanFile):
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
+        elif self.settings.os == "Windows" and self.options.shared:
+            self.cpp_info.defines.append("JSON_SCHEMA_VALIDATOR_EXPORTS=1")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "nlohmann_json_schema_validator"

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -97,6 +97,7 @@ class JsonSchemaValidatorConan(ConanFile):
             tc.variables["JSON_VALIDATOR_BUILD_EXAMPLES"] = False
             tc.variables["JSON_VALIDATOR_INSTALL"] = True
             tc.variables["JSON_VALIDATOR_SHARED_LIBS"] = self.options.shared
+            tc.variables["CMAKE_INSTALL_RUNTIMEDIR"] = "bin"
         if self.options.json_diagnostics:
             tc.preprocessor_definitions["JSON_DIAGNOSTICS"] = '1'
         if Version(self.version) < "2.1.0":

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -13,10 +13,10 @@ required_conan_version = ">=1.53.0"
 
 class JsonSchemaValidatorConan(ConanFile):
     name = "json-schema-validator"
+    description = "JSON schema validator for JSON for Modern C++ "
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/pboettch/json-schema-validator"
-    description = "JSON schema validator for JSON for Modern C++ "
     topics = ("modern-json", "schema-validation", "json")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
@@ -37,7 +37,6 @@ class JsonSchemaValidatorConan(ConanFile):
         "fPIC": True,
         "json_diagnostics": False,
     }
-
     short_paths = True
 
     @property
@@ -69,12 +68,16 @@ class JsonSchemaValidatorConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("nlohmann_json/3.11.2", transitive_headers=True)
+        # to support latest compilers, we have to downgrade nlohmann_json.
+        # https://github.com/pboettch/json-schema-validator/pull/276
+        if Version(self.version) < "2.3.0":
+            self.requires("nlohmann_json/3.10.5", transitive_headers=True)
+        else:
+            self.requires("nlohmann_json/3.11.3", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -13,7 +13,7 @@ required_conan_version = ">=1.53.0"
 
 class JsonSchemaValidatorConan(ConanFile):
     name = "json-schema-validator"
-    description = "JSON schema validator for JSON for Modern C++ "
+    description = "JSON schema validator for JSON for Modern C++"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/pboettch/json-schema-validator"

--- a/recipes/json-schema-validator/all/test_package/CMakeLists.txt
+++ b/recipes/json-schema-validator/all/test_package/CMakeLists.txt
@@ -4,5 +4,5 @@ project(test_package LANGUAGES CXX)
 find_package(nlohmann_json_schema_validator CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} nlohmann_json_schema_validator)
+target_link_libraries(${PROJECT_NAME} PRIVATE nlohmann_json_schema_validator)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/json-schema-validator/config.yml
+++ b/recipes/json-schema-validator/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3.0":
+    folder: all
   "2.2.0":
     folder: all
   "2.1.0":


### PR DESCRIPTION
Specify library name and version:  **json-schema-validator/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
