### PR TITLE
exiv2: bump deps, use version range for libcurl

### DIFF
--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -78,9 +78,9 @@ class Exiv2Conan(ConanFile):
         if self.options.with_xmp == "bundled":
             self.requires("expat/2.5.0")
         if self.options.with_curl:
-            self.requires("libcurl/8.2.1")
+            self.requires("libcurl/[>=7.78.0 <9]")
         if self.options.get_safe("with_brotli"):
-            self.requires("brotli/1.0.9")
+            self.requires("brotli/1.1.0")
         if self.options.get_safe("with_inih"):
             self.requires("inih/57")
 


### PR DESCRIPTION
Specify library name and version:  **exiv2/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
