### PR TITLE
ulfius: use version range for libcurl

### DIFF
--- a/recipes/ulfius/all/conanfile.py
+++ b/recipes/ulfius/all/conanfile.py
@@ -63,7 +63,7 @@ class UlfiusConan(ConanFile):
         if self.options.with_jansson:
             self.requires("jansson/2.14", transitive_headers=True)
         if self.options.with_libcurl:
-            self.requires("libcurl/8.2.1")
+            self.requires("libcurl/[>=7.78.0 <9]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **ulfius/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
