### PR TITLE
coost: use version range for libcurl

### DIFF
--- a/recipes/coost/all/conanfile.py
+++ b/recipes/coost/all/conanfile.py
@@ -44,7 +44,7 @@ class CoostConan(ConanFile):
 
     def requirements(self):
         if self.options.with_libcurl:
-            self.requires("libcurl/8.2.1")
+            self.requires("libcurl/[>=7.78.0 <9]")
         if self.options.with_libcurl or self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]")
         if self.settings.os == "Linux":


### PR DESCRIPTION
Specify library name and version:  **coost/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
