### PR TITLE
sentry-crashpad: use version range for libcurl

### DIFF
--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -62,7 +62,7 @@ class SentryCrashpadConan(ConanFile):
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
         if self.settings.os in ("Linux", "FreeBSD"):
-            self.requires("libcurl/8.2.1")
+            self.requires("libcurl/[>=7.78.0 <9]")
         if self.options.get_safe("with_tls"):
             self.requires("openssl/[>=1.1 <4]")
 


### PR DESCRIPTION
Specify library name and version:  **sentry-crashpad/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
