### PR TITLE
minizip-ng: Update xz_utils requirements

### DIFF
--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -83,7 +83,7 @@ class MinizipNgConan(ConanFile):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:
-            self.requires("xz_utils/5.4.4")
+            self.requires("xz_utils/5.4.5")
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.with_openssl:


### PR DESCRIPTION
Specify library name and version:  **minizip-ng**

Upgrading the xz_utils requirement to match the requirement of libtiff, as I can't build other recipes without a force version override, as both minizip-ng and libtiff are in the dependency graph

Would be curious why normally versions are fully defined for all dependencies on conan-center-index besides zlib which everywhere seems to use a version range now.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
