### PR TITLE
ffmpeg: Update xz_utils requirements

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -261,7 +261,7 @@ class FFMpegConan(ConanFile):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:
-            self.requires("xz_utils/5.4.4")
+            self.requires("xz_utils/5.4.5")
         if self.options.with_libiconv:
             self.requires("libiconv/1.17")
         if self.options.with_freetype:


### PR DESCRIPTION
Specify library name and version:  **ffmpeg**

Upgrading the xz_utils requirement to match the requirement of libtiff, as I can't build other recipes without a force version override, as both ffmpeg and libtiff are in the dependency graph

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
