### PR TITLE
opengl-registry: add package_type and set cpp_info.resdirs

### DIFF
--- a/recipes/opengl-registry/all/conanfile.py
+++ b/recipes/opengl-registry/all/conanfile.py
@@ -13,6 +13,7 @@ class OpenGLRegistryConan(ConanFile):
     topics = ("opengl-registry", "opengl")
     homepage = "https://github.com/KhronosGroup/OpenGL-Registry"
     url = "https://github.com/conan-io/conan-center-index"
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -26,8 +27,7 @@ class OpenGLRegistryConan(ConanFile):
         self.info.clear()
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
         pass
@@ -46,3 +46,4 @@ class OpenGLRegistryConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = ["res"]


### PR DESCRIPTION
We package xml files in res dir, so set cpp_info.resdirs accordingly.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
