### PR TITLE
perfetto: Bump version: 40.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "40.0":
+    url: "https://github.com/google/perfetto/archive/refs/tags/v40.0.tar.gz"
+    sha256: "bd78f0165e66026c31c8c39221ed2863697a8bba5cd39b12e4b43d0b7f71626f"
   "39.0":
     url: "https://github.com/google/perfetto/archive/refs/tags/v39.0.tar.gz"
     sha256: "241cbaddc9ff4e5d1de2d28497fef40b5510e9ca60808815bf4944d0d2f026db"

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "40.0":
+    folder: all
   "39.0":
     folder: all
   "38.0":


### PR DESCRIPTION
Specify library name and version:  **perfetto/40.0**

```
v40.0 - 2023-12-04:
  Tracing service and probes:
    * Added support for collecting battery voltage from the Android Power HAL.
    * Added support for emitting machine id from producers on remote hosts.
  Trace Processor:
    * Added of flow id from trace as a column in the flow table.
    * Fixed computation of trace_bounds table when using UI native acceleration.
  UI:
    * Switched to use "v2" querying and rendering system for tracks by default.
 ```


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
