### PR TITLE
glaze: add version 1.9.5, remove older versions, relax gcc version check

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.9.1":
-    url: "https://github.com/stephenberry/glaze/archive/v1.9.1.tar.gz"
-    sha256: "2c928508efb0398ed2fdc8a90e8e27eff5418420ff336d859f3ed659d11a1fc2"
+  "1.9.4.1":
+    url: "https://github.com/stephenberry/glaze/archive/v1.9.4.1.tar.gz"
+    sha256: "0d4ce582a397580ceaa9311db80af44d060bbc74f6684fc6a85886574fb4b907"
   "1.8.5":
     url: "https://github.com/stephenberry/glaze/archive/v1.8.5.tar.gz"
     sha256: "5d876eed5689f1947ea4eafd9f13a4e0b527611a6b1857c79a5d598a856287b4"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.0":
+    url: "https://github.com/stephenberry/glaze/archive/v1.9.0.tar.gz"
+    sha256: "7745bda3383e0a78602b5359b5c455381561e96e35f22a21ee913b1bc3f22da2"
   "1.8.5":
     url: "https://github.com/stephenberry/glaze/archive/v1.8.5.tar.gz"
     sha256: "5d876eed5689f1947ea4eafd9f13a4e0b527611a6b1857c79a5d598a856287b4"
@@ -20,33 +23,3 @@ sources:
   "1.6.1":
     url: "https://github.com/stephenberry/glaze/archive/v1.6.1.tar.gz"
     sha256: "c52c0f66d98d829ae1f2b859abddc84132ad49aea4c76f3286970fbab1489c10"
-  "1.6.0":
-    url: "https://github.com/stephenberry/glaze/archive/v1.6.0.tar.gz"
-    sha256: "1206421e4dfd259b9c3cd012adc35946cc27a19f10083040b353a78520ad1bee"
-  "1.5.7":
-    url: "https://github.com/stephenberry/glaze/archive/v1.5.7.tar.gz"
-    sha256: "3bd40d0a2547fb9ee0fb94894dc13ba0bc37dac6d26ee292941e7a5203702c84"
-  "1.5.6":
-    url: "https://github.com/stephenberry/glaze/archive/v1.5.6.tar.gz"
-    sha256: "11910435f078a2be66c451413203097197991a4c2d0e5ec5b3e81f5568bfe64d"
-  "1.5.3":
-    url: "https://github.com/stephenberry/glaze/archive/v1.5.3.tar.gz"
-    sha256: "dc0fcd447f9edb65521033466aca820c9a955c696bd51709e12048e0a12291d8"
-  "1.5.2":
-    url: "https://github.com/stephenberry/glaze/archive/v1.5.2.tar.gz"
-    sha256: "d9dff3570ae479123b8eadb890db41255c6c0c74c4cdb1b9ca3d1eb73f8ca5eb"
-  "1.5.1":
-    url: "https://github.com/stephenberry/glaze/archive/v1.5.1.tar.gz"
-    sha256: "b119b0375d13ab34ebc156e1c12eacc65e7f4c8b0cfcf6ae93e8fe18744d1ad5"
-  "1.5.0":
-    url: "https://github.com/stephenberry/glaze/archive/v1.5.0.tar.gz"
-    sha256: "9ab1cc5faa3a1a46b478c884207e6c364e4b6ae9c09f96cbf9f2ef620b3bb3b5"
-  "1.4.1":
-    url: "https://github.com/stephenberry/glaze/archive/v1.4.1.tar.gz"
-    sha256: "fae4188004d383f79225db26e41060aaae9a3eff92da7637aa467749e9590ee6"
-  "1.4.0":
-    url: "https://github.com/stephenberry/glaze/archive/v1.4.0.tar.gz"
-    sha256: "301c831e2476529bfa1ea24d87011186da91644830bdf57e1ed99bc7f6326989"
-  "1.3.6":
-    url: "https://github.com/stephenberry/glaze/archive/v1.3.6.tar.gz"
-    sha256: "c339f036a96fef72f9b8542d6a1e2ecb4bd3fa5d3d09a206da5e844765d2b6c3"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.9.4.1":
-    url: "https://github.com/stephenberry/glaze/archive/v1.9.4.1.tar.gz"
-    sha256: "0d4ce582a397580ceaa9311db80af44d060bbc74f6684fc6a85886574fb4b907"
+  "1.9.5":
+    url: "https://github.com/stephenberry/glaze/archive/v1.9.5.tar.gz"
+    sha256: "3800fa7283a1d4e5bd2c746fe9e268d2f8af76d3a75be7318b2084f38f529c7f"
   "1.8.5":
     url: "https://github.com/stephenberry/glaze/archive/v1.8.5.tar.gz"
     sha256: "5d876eed5689f1947ea4eafd9f13a4e0b527611a6b1857c79a5d598a856287b4"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.9.0":
-    url: "https://github.com/stephenberry/glaze/archive/v1.9.0.tar.gz"
-    sha256: "7745bda3383e0a78602b5359b5c455381561e96e35f22a21ee913b1bc3f22da2"
+  "1.9.1":
+    url: "https://github.com/stephenberry/glaze/archive/v1.9.1.tar.gz"
+    sha256: "2c928508efb0398ed2fdc8a90e8e27eff5418420ff336d859f3ed659d11a1fc2"
   "1.8.5":
     url: "https://github.com/stephenberry/glaze/archive/v1.8.5.tar.gz"
     sha256: "5d876eed5689f1947ea4eafd9f13a4e0b527611a6b1857c79a5d598a856287b4"

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -28,7 +28,7 @@ class GlazeConan(ConanFile):
         return {
             "Visual Studio": "17",
             "msvc": "193",
-            "gcc": "12",
+            "gcc": "10" if Version(self.version) < "1.9.0" else "11",
             "clang": "12",
             "apple-clang": "13.1",
         }
@@ -42,7 +42,6 @@ class GlazeConan(ConanFile):
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -40,16 +40,6 @@ class GlazeConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        # there is a compilation error on cci's gcc 11.
-        # https://c3i.jfrog.io/c3i/misc/logs/pr/21629/1-linux-gcc/glaze/1.9.0//5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9-test.txt
-        if os.getenv('NOT_ON_C3I', '0') == '0':
-            if Version(self.version) >= "1.9.0" and \
-                self.info.settings.compiler == "gcc" and \
-                Version(self.info.settings.compiler.version) == "11":
-                raise ConanInvalidConfiguration(f"gcc 11 doesn't compile {self.ref} in C3I due to internal compiler error.\n" \
-                                                "However, it works fine with gcc11 in several environments.\n"
-                                                f"If you want to try {self.ref} with gcc11, set environment variable NOT_ON_C3I=1.")
-
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -28,7 +28,9 @@ class GlazeConan(ConanFile):
         return {
             "Visual Studio": "17",
             "msvc": "193",
-            "gcc": "10" if Version(self.version) < "1.9.0" else "11",
+            # there is compilation error on cci's gcc 11.
+            # https://c3i.jfrog.io/c3i/misc/logs/pr/21629/1-linux-gcc/glaze/1.9.0//5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9-test.txt
+            "gcc": "10" if Version(self.version) < "1.9.0" else "12",
             "clang": "12",
             "apple-clang": "13.1",
         }

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -28,9 +28,7 @@ class GlazeConan(ConanFile):
         return {
             "Visual Studio": "17",
             "msvc": "193",
-            # there is compilation error on cci's gcc 11.
-            # https://c3i.jfrog.io/c3i/misc/logs/pr/21629/1-linux-gcc/glaze/1.9.0//5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9-test.txt
-            "gcc": "10" if Version(self.version) < "1.9.0" else "12",
+            "gcc": "10" if Version(self.version) < "1.9.0" else "11",
             "clang": "12",
             "apple-clang": "13.1",
         }
@@ -42,6 +40,16 @@ class GlazeConan(ConanFile):
         self.info.clear()
 
     def validate(self):
+        # there is a compilation error on cci's gcc 11.
+        # https://c3i.jfrog.io/c3i/misc/logs/pr/21629/1-linux-gcc/glaze/1.9.0//5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9-test.txt
+        if os.getenv('NOT_ON_C3I', '0') == '0':
+            if Version(self.version) >= "1.9.0" and \
+                self.info.settings.compiler == "gcc" and \
+                Version(self.info.settings.compiler.version) == "11":
+                raise ConanInvalidConfiguration(f"gcc 11 doesn't compile {self.ref} in C3I due to internal compiler error.\n" \
+                                                "However, it works fine with gcc11 in several environments.\n"
+                                                f"If you want to try {self.ref} with gcc11, set environment variable NOT_ON_C3I=1.")
+
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.9.1":
+  "1.9.4.1":
     folder: all
   "1.8.5":
     folder: all

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.9.4.1":
+  "1.9.5":
     folder: all
   "1.8.5":
     folder: all

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.0":
+    folder: all
   "1.8.5":
     folder: all
   "1.8.4":
@@ -12,24 +14,4 @@ versions:
   "1.7.0":
     folder: all
   "1.6.1":
-    folder: all
-  "1.6.0":
-    folder: all
-  "1.5.7":
-    folder: all
-  "1.5.6":
-    folder: all
-  "1.5.3":
-    folder: all
-  "1.5.2":
-    folder: all
-  "1.5.1":
-    folder: all
-  "1.5.0":
-    folder: all
-  "1.4.1":
-    folder: all
-  "1.4.0":
-    folder: all
-  "1.3.6":
     folder: all

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.9.0":
+  "1.9.1":
     folder: all
   "1.8.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **glaze/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
