### PR TITLE
frugally-deep: add v0.15.27, drop old versions, fix version naming

### DIFF
--- a/recipes/frugally-deep/all/conandata.yml
+++ b/recipes/frugally-deep/all/conandata.yml
@@ -1,25 +1,7 @@
 sources:
-  "0.15.27":
+  "0.15.27.0":
     url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.27-p0.tar.gz"
     sha256: "b2c8aba2b59865f6a6024982aebd7fca69ce0b8b24a74ce55be2dbceb34a54c8"
-  "0.15.25-p0":
+  "0.15.25.0":
     url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.25-p0.tar.gz"
     sha256: "d1204bc13ace603e97696aa7a1331d6af819c3a9b4952b4fd1e3d72dd8f524c3"
-  "0.15.24-p0":
-    url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.24-p0.tar.gz"
-    sha256: "118b0219a3f17c6d5a3535874acb145ee2079fd309e1fb83884facc684810baf"
-  "0.15.19-p0":
-    url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.19-p0.tar.gz"
-    sha256: "acaba428ae19ef8d57a53b3767373cd96770c190dd57909e52d2759be89ac942"
-  "0.15.18-p0":
-    url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.18-p0.tar.gz"
-    sha256: "b721bd7b2fa842a1a10f00008e079c057fab7a5cfc4c394d64238ee59ad7e189"
-  "0.15.16-p0":
-    url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.16-p0.tar.gz"
-    sha256: "778b8cf0da847239a2ad21c611331b231831c6c175154c68ca30dd87489336a5"
-  "0.15.13-p0":
-    url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.13-p0.tar.gz"
-    sha256: "ca18c7b8dc0df3a36dba3c2578df35592e61ff51e5bbaa1c1ed3e6c529e14075"
-  "0.15.1-p0":
-    url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.1-p0.tar.gz"
-    sha256: "ab15cb540a8ddeffa56cd8235bfdf709f5d6b3b2543d9ec83658c5d9bad02f18"

--- a/recipes/frugally-deep/all/conandata.yml
+++ b/recipes/frugally-deep/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.15.27":
+    url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.27-p0.tar.gz"
+    sha256: "b2c8aba2b59865f6a6024982aebd7fca69ce0b8b24a74ce55be2dbceb34a54c8"
   "0.15.25-p0":
     url: "https://github.com/Dobiasd/frugally-deep/archive/v0.15.25-p0.tar.gz"
     sha256: "d1204bc13ace603e97696aa7a1331d6af819c3a9b4952b4fd1e3d72dd8f524c3"

--- a/recipes/frugally-deep/config.yml
+++ b/recipes/frugally-deep/config.yml
@@ -1,17 +1,5 @@
 versions:
-  "0.15.27":
+  "0.15.27.0":
     folder: all
-  "0.15.25-p0":
-    folder: all
-  "0.15.24-p0":
-    folder: all
-  "0.15.19-p0":
-    folder: all
-  "0.15.18-p0":
-    folder: all
-  "0.15.16-p0":
-    folder: all
-  "0.15.13-p0":
-    folder: all
-  "0.15.1-p0":
+  "0.15.25.0":
     folder: all

--- a/recipes/frugally-deep/config.yml
+++ b/recipes/frugally-deep/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.15.27":
+    folder: all
   "0.15.25-p0":
     folder: all
   "0.15.24-p0":


### PR DESCRIPTION
Frugally deep uses `0.15.x-p0` for all of its version names. I assume the `-p0` suffix is meant to effectively be a patch version there, but afaik it gets interpreted as a pre-release version by Conan due to the hyphen. I converted the version names to a more standard semver format without the suffix.