### PR TITLE
opencascade: add v7.8.0, bump deps

### DIFF
--- a/recipes/opencascade/all/conandata.yml
+++ b/recipes/opencascade/all/conandata.yml
@@ -1,24 +1,15 @@
 sources:
+  "7.8.0":
+    url: "https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_8_0.tar.gz"
+    sha256: "fc58eaae5813cd15ea2ead8afeb965a9dce791ec23f2a8f3af65b5788ee4efe8"
   "7.6.2":
     url: "https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_6_2.tar.gz"
     sha256: "dea04077d71507c666aaa7ccaeacc73ab580d6572d7f75e90a1984c4c0302a7a"
-  "7.6.0":
-    url: "https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_6_0.tar.gz"
-    sha256: "73f8f71be02c1d9a977e854bcc9202502184d339f1f212c19797a5f23baefabe"
   "7.5.0":
     url: "https://github.com/Open-Cascade-SAS/OCCT/archive/V7_5_0.tar.gz"
     sha256: "dbe1d62a9317ad1516bd4575293d9aab2dc20206ca7a60a7705c9a3b77dc59c9"
 patches:
   "7.6.2":
-    - patch_file: "patches/7.5.0-0001-fix-compile-error-cxx17.patch"
-      patch_description: "Fix compilation error with C++17"
-      patch_source: "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=7021de2fe7a69d4c788ccf43b8b096dbcc8597c8"
-      patch_type: "portability"
-    - patch_file: "patches/7.5.0-0002-fix-compile-error-cxx20.patch"
-      patch_description: "Fix compilation error with C++20"
-      patch_source: "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=73035770f6fced4ec7dc7e6a0276ee894daa479a"
-      patch_type: "portability"
-  "7.6.0":
     - patch_file: "patches/7.5.0-0001-fix-compile-error-cxx17.patch"
       patch_description: "Fix compilation error with C++17"
       patch_source: "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=commitdiff;h=7021de2fe7a69d4c788ccf43b8b096dbcc8597c8"

--- a/recipes/opencascade/all/conandata.yml
+++ b/recipes/opencascade/all/conandata.yml
@@ -9,6 +9,10 @@ sources:
     url: "https://github.com/Open-Cascade-SAS/OCCT/archive/V7_5_0.tar.gz"
     sha256: "dbe1d62a9317ad1516bd4575293d9aab2dc20206ca7a60a7705c9a3b77dc59c9"
 patches:
+  "7.8.0":
+    - patch_file: "patches/7.8.0-fix-tkexpress-linking.patch"
+      patch_description: "Fix linking of TKExpress module"
+      patch_type: "conan"
   "7.6.2":
     - patch_file: "patches/7.5.0-0001-fix-compile-error-cxx17.patch"
       patch_description: "Fix compilation error with C++17"

--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -76,6 +76,8 @@ class OpenCascadeConan(ConanFile):
 
     @property
     def _min_cppstd(self):
+        if Version(self.version) >= "7.8":
+            return "14"
         return "11"
 
     def export_sources(self):

--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -102,7 +102,7 @@ class OpenCascadeConan(ConanFile):
         self.requires("tcl/8.6.10")
         if self._link_tk:
             self.requires("tk/8.6.10")
-        self.requires("freetype/2.13.0")
+        self.requires("freetype/2.13.2")
         if self._link_opengl:
             self.requires("opengl/system")
         if self._is_linux:
@@ -110,13 +110,13 @@ class OpenCascadeConan(ConanFile):
             self.requires("xorg/system")
         # TODO: add vtk support?
         if self.options.with_ffmpeg:
-            self.requires("ffmpeg/6.0")
+            self.requires("ffmpeg/6.1")
         if self.options.with_freeimage:
             self.requires("freeimage/3.18.0")
         if self.options.with_openvr:
             self.requires("openvr/1.16.8")
         if self.options.with_rapidjson:
-            self.requires("rapidjson/1.1.0")
+            self.requires("rapidjson/cci.20230929")
         if self.options.get_safe("with_draco"):
             self.requires("draco/1.5.6")
         if self.options.with_tbb:
@@ -412,26 +412,27 @@ class OpenCascadeConan(ConanFile):
 
         # Honor fPIC option, compiler.cppstd and compiler.libcxx
         replace_in_file(self, occt_defs_flags_cmake, "-fPIC", "")
-        replace_in_file(self, occt_defs_flags_cmake, "-std=c++0x", "")
-        replace_in_file(self, occt_defs_flags_cmake, "-std=gnu++0x", "")
+        if Version(self.version) < "7.8.0":
+            replace_in_file(self, occt_defs_flags_cmake, "-std=c++0x", "")
+            replace_in_file(self, occt_defs_flags_cmake, "-std=gnu++0x", "")
         replace_in_file(self, occt_defs_flags_cmake, "-stdlib=libc++", "")
         replace_in_file(self, occt_csf_cmake,
-                              "set (CSF_ThreadLibs  \"pthread rt stdc++\")",
-                              "set (CSF_ThreadLibs  \"pthread rt\")")
+                              'set (CSF_ThreadLibs  "pthread rt stdc++")',
+                              'set (CSF_ThreadLibs  "pthread rt")')
 
         # No hardcoded link through #pragma
         if Version(self.version) < "7.6.0":
             replace_in_file(
                 self,
                 os.path.join(self.source_folder, "src", "Font", "Font_FontMgr.cxx"),
-                "#pragma comment (lib, \"freetype.lib\")",
+                '#pragma comment (lib, "freetype.lib")',
                 "",
             )
             replace_in_file(
                 self,
                 os.path.join(self.source_folder, "src", "Draw", "Draw.cxx"),
-                """#pragma comment (lib, "tcl" STRINGIZE2(TCL_MAJOR_VERSION) STRINGIZE2(TCL_MINOR_VERSION) ".lib")
-#pragma comment (lib, "tk"  STRINGIZE2(TCL_MAJOR_VERSION) STRINGIZE2(TCL_MINOR_VERSION) ".lib")""",
+                '#pragma comment (lib, "tcl" STRINGIZE2(TCL_MAJOR_VERSION) STRINGIZE2(TCL_MINOR_VERSION) ".lib")\n'
+                '#pragma comment (lib, "tk"  STRINGIZE2(TCL_MAJOR_VERSION) STRINGIZE2(TCL_MINOR_VERSION) ".lib")',
                 ""
             )
 

--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -80,6 +80,18 @@ class OpenCascadeConan(ConanFile):
             return "14"
         return "11"
 
+    @property
+    def _compilers_minimum_version(self):
+        if Version(self.version) >= "7.8":
+            return {
+                "gcc": "7",
+                "clang": "7",
+                "apple-clang": "10",
+                "Visual Studio": "15",
+                "msvc": "191",
+            }
+        return {}
+
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -130,6 +142,12 @@ class OpenCascadeConan(ConanFile):
         if self.settings.compiler == "clang" and self.settings.compiler.version == "6.0" and \
            self.settings.build_type == "Release":
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support Clang 6.0 if Release build type")
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -134,10 +134,15 @@ class OpenCascadeConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-
-        # Inject C++ standard from profile since we have removed hardcoded C++ standard from upstream build files
-        if not valid_min_cppstd(self, self._min_cppstd):
-            tc.variables["CMAKE_CXX_STANDARD"] = self._min_cppstd
+        if Version(self.version) < "7.7.0":
+            # Inject C++ standard from profile since we have removed hardcoded C++ standard from upstream build files
+            if not valid_min_cppstd(self, self._min_cppstd):
+                tc.variables["CMAKE_CXX_STANDARD"] = self._min_cppstd
+        else:
+            if not valid_min_cppstd(self, self._min_cppstd):
+                tc.cache_variables["BUILD_CPP_STANDARD"] = self._min_cppstd
+            else:
+                tc.cache_variables["BUILD_CPP_STANDARD"] = self.settings.compiler.cppstd
 
         tc.cache_variables["BUILD_LIBRARY_TYPE"] = "Shared" if self.options.shared else "Static"
         tc.cache_variables["INSTALL_TEST_CASES"] = False

--- a/recipes/opencascade/all/patches/7.8.0-fix-tkexpress-linking.patch
+++ b/recipes/opencascade/all/patches/7.8.0-fix-tkexpress-linking.patch
@@ -1,0 +1,33 @@
+To fix the following linking errors during package build:
+
+ld: ../../lin64/gcc/lib/libTKExpress.a(Express.cxx.o): in function `Express::WriteFileStamp(std::ostream&)':
+Express.cxx:(.text+0x9d): undefined reference to `OSD_Process::OSD_Process()'
+ld: Express.cxx:(.text+0xa5): undefined reference to `OSD_Process::SystemDate()'
+ld: Express.cxx:(.text+0xce): undefined reference to `OSD_Environment::OSD_Environment(TCollection_AsciiString const&)'
+ld: Express.cxx:(.text+0xe6): undefined reference to `OSD_Environment::Value()'
+ld: Express.cxx:(.text+0x188): undefined reference to `OSD_Process::UserName()'
+ld: ../../lin64/gcc/lib/libTKExpress.a(Express_Entity.cxx.o): in function `Express_Entity::writeIncludes(std::ostream&) const':
+Express_Entity.cxx:(.text+0x23a2): undefined reference to `OSD_Directory::OSD_Directory(OSD_Path const&)'
+ld: Express_Entity.cxx:(.text+0x23ad): undefined reference to `OSD_Directory::Build(OSD_Protection const&)'
+ld: ../../lin64/gcc/lib/libTKExpress.a(Express_Entity.cxx.o): in function `Express_Entity::GenerateClass() const':
+Express_Entity.cxx:(.text+0x9509): undefined reference to `OSD_Directory::OSD_Directory(OSD_Path const&)'
+ld: Express_Entity.cxx:(.text+0x9516): undefined reference to `OSD_Directory::Build(OSD_Protection const&)'
+ld: Express_Entity.cxx:(.text+0xafc8): undefined reference to `OSD_Directory::OSD_Directory(OSD_Path const&)'
+ld: Express_Entity.cxx:(.text+0xafd5): undefined reference to `OSD_Directory::Build(OSD_Protection const&)'
+ld: Express_Entity.cxx:(.text+0xbaff): undefined reference to `OSD_Directory::OSD_Directory(OSD_Path const&)'
+ld: Express_Entity.cxx:(.text+0xbb19): undefined reference to `OSD_Directory::Build(OSD_Protection const&)'
+ld: ../../lin64/gcc/lib/libTKExpress.a(Express_Enum.cxx.o): in function `Express_Enum::GenerateClass() const':
+Express_Enum.cxx:(.text+0x4d3): undefined reference to `OSD_Directory::OSD_Directory(OSD_Path const&)'
+ld: Express_Enum.cxx:(.text+0x4de): undefined reference to `OSD_Directory::Build(OSD_Protection const&)'
+ld: ../../lin64/gcc/lib/libTKExpress.a(Express_Select.cxx.o): in function `Express_Select::generateSelectMember(opencascade::handle<TColStd_HSequenceOfInteger> const&) const':
+Express_Select.cxx:(.text+0x345): undefined reference to `OSD_Directory::OSD_Directory(OSD_Path const&)'
+ld: Express_Select.cxx:(.text+0x350): undefined reference to `OSD_Directory::Build(OSD_Protection const&)'
+ld: ../../lin64/gcc/lib/libTKExpress.a(Express_Select.cxx.o): in function `Express_Select::GenerateClass() const':
+Express_Select.cxx:(.text+0x1923): undefined reference to `OSD_Directory::OSD_Directory(OSD_Path const&)'
+ld: Express_Select.cxx:(.text+0x192e): undefined reference to `OSD_Directory::Build(OSD_Protection const&)'
+
+--- src/TKExpress/EXTERNLIB
++++ src/TKExpress/EXTERNLIB
+@@ -1,1 +1,2 @@
+ TKernel
++OSD

--- a/recipes/opencascade/config.yml
+++ b/recipes/opencascade/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "7.6.2":
+  "7.8.0":
     folder: all
-  "7.6.0":
+  "7.6.2":
     folder: all
   "7.5.0":
     folder: all


### PR DESCRIPTION
The patches used in previous versions have been merged into the codebase.
