### PR TITLE
[tz] Package the source database by default

### DIFF
--- a/recipes/tz/all/conandata.yml
+++ b/recipes/tz/all/conandata.yml
@@ -2,3 +2,5 @@ sources:
   "2023c":
     url: "https://github.com/eggert/tz/archive/refs/tags/2023c.tar.gz"
     sha256: "9aa20ef838183e58f09acca92098cf6aa6d8e229aecf24e098c3af2a38e596f8"
+    windows_zones_url: "https://raw.githubusercontent.com/unicode-org/cldr/fd8ca965e03ca3cf07a0487678e0a1e002646ec0/common/supplemental/windowsZones.xml"
+    windows_zones_sha256: "e5720d0d82a0a62687184bf0d9472f3cf0f7ef8b930ad40f3ae7386d8cb57213"

--- a/recipes/tz/all/conandata.yml
+++ b/recipes/tz/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "2023c":
-    url: "https://github.com/eggert/tz/archive/refs/tags/2023c.tar.gz"
-    sha256: "9aa20ef838183e58f09acca92098cf6aa6d8e229aecf24e098c3af2a38e596f8"
-    windows_zones_url: "https://raw.githubusercontent.com/unicode-org/cldr/fd8ca965e03ca3cf07a0487678e0a1e002646ec0/common/supplemental/windowsZones.xml"
-    windows_zones_sha256: "e5720d0d82a0a62687184bf0d9472f3cf0f7ef8b930ad40f3ae7386d8cb57213"
+    "sources":
+      url: "https://github.com/eggert/tz/archive/refs/tags/2023c.tar.gz"
+      sha256: "9aa20ef838183e58f09acca92098cf6aa6d8e229aecf24e098c3af2a38e596f8"
+    "windows_zones":
+      url: "https://raw.githubusercontent.com/unicode-org/cldr/fd8ca965e03ca3cf07a0487678e0a1e002646ec0/common/supplemental/windowsZones.xml"
+      sha256: "e5720d0d82a0a62687184bf0d9472f3cf0f7ef8b930ad40f3ae7386d8cb57213"

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -76,6 +76,10 @@ class TzConan(ConanFile):
             rmdir(self, os.path.join(self.package_folder, "usr", "lib"))
         else:
             tzdata = [
+                # This file listing is drawn from the source distribution of the tz database at
+                # https://data.iana.org/time-zones/releases/tzdata2023c.tar.gz. It includes only data
+                # files, and excludes project documentation such as CONTRIBUTING, NEWS, README,
+                # SECURITY, theory.html.
                 "africa",
                 "antarctica",
                 "asia",
@@ -92,7 +96,6 @@ class TzConan(ConanFile):
                 "leap-seconds.list",
                 "leapseconds",
                 "leapseconds.awk",
-                "NEWS",
                 "northamerica",
                 "southamerica",
                 "version",
@@ -100,6 +103,9 @@ class TzConan(ConanFile):
                 "zishrink.awk",
                 "zone.tab",
                 "zone1970.tab",
+                # This file is maintained by CLDR and is required to provide a conversion between
+                # windows time zone names and the IANA time zone names. This enables the IANA tzdb
+                # to be used on windows. For more information, see https://cldr.unicode.org/index
                 "windowsZones.xml",
             ]
             for data in tzdata:

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -60,10 +60,7 @@ class TzConan(ConanFile):
         if self.options.with_binary_db:
             self._patch_sources()
             autotools = Autotools(self)
-            ldlibs = ""
-            if self.settings.os == "Macos":
-                ldlibs = "-lintl"
-            autotools.make(args=["-C", self.source_folder.replace("\\", "/"), f"LDLIBS={ldlibs}"])
+            autotools.make(args=["-C", self.source_folder.replace("\\", "/")])
 
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -44,18 +44,8 @@ class TzConan(ConanFile):
                     self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        get(
-            self,
-            url=self.conan_data["sources"][self.version]["url"],
-            sha256=self.conan_data["sources"][self.version]["sha256"],
-            strip_root=True
-        )
-        download(
-            self,
-            url=self.conan_data["sources"][self.version]["windows_zones_url"],
-            filename="windowsZones.xml",
-            sha256=self.conan_data["sources"][self.version]["windows_zones_sha256"],
-        )
+        get(self, **self.conan_data["sources"][self.version]["sources"], strip_root=True)
+        download(self, **self.conan_data["sources"][self.version]["windows_zones"], filename="windowsZones.xml")
 
     def generate(self):
         tc = AutotoolsToolchain(self)

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.gnu import Autotools, AutotoolsToolchain
-from conan.tools.files import get, copy, rmdir, replace_in_file
+from conan.tools.files import get, copy, rmdir, replace_in_file, download
 from conan.tools.layout import basic_layout
 
 required_conan_version = ">=1.53.0"
@@ -43,7 +43,19 @@ class TzConan(ConanFile):
                     self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        get(
+            self,
+            url=self.conan_data["sources"][self.version]["url"],
+            sha256=self.conan_data["sources"][self.version]["sha256"],
+            strip_root=True
+        )
+        if not self.options.with_binary_db:
+            download(
+                self,
+                url=self.conan_data["sources"][self.version]["windows_zones_url"],
+                filename="windowsZones.xml",
+                sha256=self.conan_data["sources"][self.version]["windows_zones_sha256"],
+            )
 
     def generate(self):
         tc = AutotoolsToolchain(self)
@@ -98,6 +110,7 @@ class TzConan(ConanFile):
                 "zishrink.awk",
                 "zone.tab",
                 "zone1970.tab",
+                "windowsZones.xml",
             ]
             for data in tzdata:
                 copy(self, data, dst=os.path.join(self.package_folder, "res", "tzdata"), src=self.source_folder)

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -50,13 +50,12 @@ class TzConan(ConanFile):
             sha256=self.conan_data["sources"][self.version]["sha256"],
             strip_root=True
         )
-        if not self.options.with_binary_db:
-            download(
-                self,
-                url=self.conan_data["sources"][self.version]["windows_zones_url"],
-                filename="windowsZones.xml",
-                sha256=self.conan_data["sources"][self.version]["windows_zones_sha256"],
-            )
+        download(
+            self,
+            url=self.conan_data["sources"][self.version]["windows_zones_url"],
+            filename="windowsZones.xml",
+            sha256=self.conan_data["sources"][self.version]["windows_zones_sha256"],
+        )
 
     def generate(self):
         tc = AutotoolsToolchain(self)

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -58,7 +58,10 @@ class TzConan(ConanFile):
         if self.options.with_binary_db:
             self._patch_sources()
             autotools = Autotools(self)
-            autotools.make(args=["-C", self.source_folder.replace("\\", "/")])
+            ldlibs = ""
+            if self.settings.os == "Macos":
+                ldlibs = "-lintl"
+            autotools.make(args=["-C", self.source_folder.replace("\\", "/"), f"LDLIBS={ldlibs}"])
 
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -17,6 +17,7 @@ class TzConan(ConanFile):
     settings = "os", "build_type", "arch", "compiler"
     options = {"with_binary_db": [True, False]}
     default_options = {"with_binary_db": False}
+    package_type = "application" # This is not an application, but application has the correct traits to provide a runtime dependency on data
 
     @property
     def _settings_build(self):

--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -15,6 +15,8 @@ class TzConan(ConanFile):
     description = "The Time Zone Database contains data that represent the history of local time for many representative locations around the globe."
     topics = ("tz", "tzdb", "time", "zone", "date")
     settings = "os", "build_type", "arch", "compiler"
+    options = {"with_binary_db": [True, False]}
+    default_options = {"with_binary_db": False}
 
     @property
     def _settings_build(self):
@@ -29,13 +31,16 @@ class TzConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
+        if not self.info.options.with_binary_db:
+            self.info.clear()
 
     def build_requirements(self):
-        self.tool_requires("mawk/1.3.4-20230404")
-        if self._settings_build.os == "Windows":
-            self.win_bash = True
-            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
-                self.tool_requires("msys2/cci.latest")
+        if self.options.with_binary_db:
+            self.tool_requires("mawk/1.3.4-20230404")
+            if self._settings_build.os == "Windows":
+                self.win_bash = True
+                if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                    self.tool_requires("msys2/cci.latest")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -50,24 +55,59 @@ class TzConan(ConanFile):
         replace_in_file(self, os.path.join(self.source_folder, "Makefile"), "AWK=		awk", f"AWK={awk_path}")
 
     def build(self):
-        self._patch_sources()
-        autotools = Autotools(self)
-        autotools.make(args=["-C", self.source_folder.replace("\\", "/")])
+        if self.options.with_binary_db:
+            self._patch_sources()
+            autotools = Autotools(self)
+            autotools.make(args=["-C", self.source_folder.replace("\\", "/")])
 
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        autotools = Autotools(self)
-        destdir = self.package_folder.replace('\\', '/')
-        autotools.install(args=["-C", self.source_folder.replace("\\", "/"), f"DESTDIR={destdir}"])
-        rmdir(self, os.path.join(self.package_folder, "usr", "share", "man"))
-        # INFO: The library does not have a public API, it's used to build the zic and zdump tools
-        rmdir(self, os.path.join(self.package_folder, "usr", "lib"))
+        if self.options.with_binary_db:
+            autotools = Autotools(self)
+            destdir = self.package_folder.replace('\\', '/')
+            autotools.install(args=["-C", self.source_folder.replace("\\", "/"), f"DESTDIR={destdir}"])
+            rmdir(self, os.path.join(self.package_folder, "usr", "share", "man"))
+            # INFO: The library does not have a public API, it's used to build the zic and zdump tools
+            rmdir(self, os.path.join(self.package_folder, "usr", "lib"))
+        else:
+            tzdata = [
+                "africa",
+                "antarctica",
+                "asia",
+                "australasia",
+                "backward",
+                "backzone",
+                "calendars",
+                "checklinks.awk",
+                "checktab.awk",
+                "etcetera",
+                "europe",
+                "factory",
+                "iso3166.tab",
+                "leap-seconds.list",
+                "leapseconds",
+                "leapseconds.awk",
+                "NEWS",
+                "northamerica",
+                "southamerica",
+                "version",
+                "ziguard.awk",
+                "zishrink.awk",
+                "zone.tab",
+                "zone1970.tab",
+            ]
+            for data in tzdata:
+                copy(self, data, dst=os.path.join(self.package_folder, "res", "tzdata"), src=self.source_folder)
 
     def package_info(self):
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
         self.cpp_info.frameworkdirs = []
-        self.cpp_info.resdirs = [os.path.join("usr", "share")]
-        self.cpp_info.bindirs = [os.path.join("usr", "bin"), os.path.join("usr", "sbin")]
-        self.buildenv_info.define("TZDATA", os.path.join(self.package_folder, "usr", "share", "zoneinfo"))
-        self.runenv_info.define("TZDATA", os.path.join(self.package_folder, "usr", "share", "zoneinfo"))
+        self.cpp_info.resdirs = ["res"]
+        self.buildenv_info.define("TZDATA", os.path.join(self.package_folder, "res", "tzdata"))
+        self.runenv_info.define("TZDATA", os.path.join(self.package_folder, "res", "tzdata"))
+        if self.options.with_binary_db:
+            self.cpp_info.resdirs = [os.path.join("usr", "share")]
+            self.cpp_info.bindirs = [os.path.join("usr", "bin"), os.path.join("usr", "sbin")]
+            self.buildenv_info.define("TZDATA", os.path.join(self.package_folder, "usr", "share", "zoneinfo"))
+            self.runenv_info.define("TZDATA", os.path.join(self.package_folder, "usr", "share", "zoneinfo"))

--- a/recipes/tz/all/test_package/conanfile.py
+++ b/recipes/tz/all/test_package/conanfile.py
@@ -43,5 +43,5 @@ class TzTestConan(ConanFile):
                 self.run(f"zdump {os.path.join(self.tzdata, 'America', 'Los_Angeles')}", env="conanrun")
             else:
                 self.output.info("Test that source tzdb is readable")
-                cmd = "python -c 'import os; tzdata = os.environ[\"TZDATA\"]; f=open(os.path.join(tzdata, \"factory\"), \"r\"); s = f.read(); f.close(); print(s)'"
+                cmd = "python -c \"import os; tzdata = os.environ['TZDATA']; f=open(os.path.join(tzdata, 'factory'), 'r'); s = f.read(); f.close(); print(s)\""
                 self.run(cmd, env="conanrun")

--- a/recipes/tz/all/test_package/conanfile.py
+++ b/recipes/tz/all/test_package/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
 from conan.errors import ConanException
 import os
 
@@ -14,14 +15,19 @@ class TzTestConan(ConanFile):
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
     def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
         if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
             self.tool_requires("msys2/cci.latest")
 
     def generate(self):
         # INFO: zdump does not consume TZDATA, need to pass absolute path of the zoneinfo directory
-        self.tzdata = self.dependencies.build['tz'].buildenv_info.vars(self).get('TZDATA')
+        self.tzdata = self.dependencies['tz'].runenv_info.vars(self).get('TZDATA')
         with open("tzdata.info", "w") as fd:
             fd.write(self.tzdata)
 
@@ -30,6 +36,12 @@ class TzTestConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            with open("tzdata.info", "r") as fd:
-                self.tzdata = fd.read()
-            self.run(f"zdump {os.path.join(self.tzdata, 'America', 'Los_Angeles')}")
+            if self.dependencies['tz'].options.with_binary_db:
+                self.output.info("Test that binary tzdb is readable")
+                with open("tzdata.info", "r") as fd:
+                    self.tzdata = fd.read()
+                self.run(f"zdump {os.path.join(self.tzdata, 'America', 'Los_Angeles')}", env="conanrun")
+            else:
+                self.output.info("Test that source tzdb is readable")
+                cmd = "python -c 'import os; tzdata = os.environ[\"TZDATA\"]; f=open(os.path.join(tzdata, \"factory\"), \"r\"); s = f.read(); f.close(); print(s)'"
+                self.run(cmd, env="conanrun")

--- a/recipes/tz/all/test_package/conanfile.py
+++ b/recipes/tz/all/test_package/conanfile.py
@@ -38,7 +38,7 @@ class TzTestConan(ConanFile):
         if can_run(self):
             if self.dependencies['tz'].options.with_binary_db:
                 self.output.info("Test that binary tzdb is readable")
-                with open("tzdata.info", "r") as fd:
+                with open(os.path.join(self.generators_folder, "tzdata.info"), "r") as fd:
                     self.tzdata = fd.read()
                 self.run(f"zdump {os.path.join(self.tzdata, 'America', 'Los_Angeles')}", env="conanrun")
             else:


### PR DESCRIPTION
This replaces the iana binary tzdb with the source tzdb as the default. This is because this is what's supported most comprehensively by the date package. This still retains the option to build the binary database if required.

For additional context: 
* https://github.com/HowardHinnant/date/issues/1
* https://github.com/HowardHinnant/date/pull/611
* https://github.com/conan-io/conan-center-index/issues/21670

particularly https://github.com/HowardHinnant/date/pull/611#issuecomment-1596313038:

> For Windows platforms I strongly encourage people to migrate to C++20 <chrono>.

Indicating that the upstream project has no desire to support parsing a binary database on windows.

This PR is an initial step to adding support to the `date` recipe to use the IANA TZDB as a conan package. This is not a feature currently supported by the `date` recipe, but I've raised https://github.com/HowardHinnant/date/issues/788 upstream detailing the requirement. My plan is to submit a patch upstream (which I don't anticipate will be accepted, details are in the linked issue), and use this as the basis for a patch to the `date` recipe to allow the path to the source IANA TZDB to be specified as an environment variable to facilitate conan compatibility.

Closes #21670

Specify library name and version:  **tz/2023c**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
