### PR TITLE
clickhouse-cpp: use correct cityhash version

### DIFF
--- a/recipes/clickhouse-cpp/all/conanfile.py
+++ b/recipes/clickhouse-cpp/all/conanfile.py
@@ -61,7 +61,7 @@ class ClickHouseCppConan(ConanFile):
     def requirements(self):
         self.requires("lz4/1.9.4")
         self.requires("abseil/20230125.3", transitive_headers=True)
-        self.requires("cityhash/cci.20130801")
+        self.requires("cityhash/1.0.1")
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]")
 


### PR DESCRIPTION
Specify library name and version:  **clickhouse-cpp/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
