### PR TITLE
zxing-cpp: add version 2.2.1

### DIFF
--- a/recipes/zxing-cpp/all/conandata.yml
+++ b/recipes/zxing-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.1":
+    url: "https://github.com/zxing-cpp/zxing-cpp/archive/v2.2.1.tar.gz"
+    sha256: "02078ae15f19f9d423a441f205b1d1bee32349ddda7467e2c84e8f08876f8635"
   "2.1.0":
     url: "https://github.com/zxing-cpp/zxing-cpp/archive/v2.1.0.tar.gz"
     sha256: "6d54e403592ec7a143791c6526c1baafddf4c0897bb49b1af72b70a0f0c4a3fe"

--- a/recipes/zxing-cpp/config.yml
+++ b/recipes/zxing-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.1":
+    folder: all
   "2.1.0":
     folder: all
   "2.0.0":


### PR DESCRIPTION
Specify library name and version:  **zxing-cpp/2.2.1**

I'm the maintainer of this library and just released a new version. It includes bug fixes and new support for QRCode Model 1 and rMQRCode symbols.

I'm not a conan user myself and hence, I did not test anything related to this conan packaging.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
