### PR TITLE
[fix][ceres-solver] Added IOS_DEPLOYMENT_TARGET variable

### DIFF
--- a/recipes/ceres-solver/all/conanfile.py
+++ b/recipes/ceres-solver/all/conanfile.py
@@ -1,3 +1,6 @@
+import os
+import textwrap
+
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
@@ -6,8 +9,6 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
-import os
-import textwrap
 
 required_conan_version = ">=1.54.0"
 
@@ -160,6 +161,9 @@ class CeressolverConan(ConanFile):
             tc.variables["OPENMP"] = False
             tc.variables["TBB"] = self.options.use_TBB
             tc.variables["CXX11_THREADS"] = self.options.use_CXX11_threads
+        # IOS_DEPLOYMENT_TARGET variable was added to iOS.cmake file in 1.12.0 version
+        if self.settings.os == "iOS":
+            tc.variables["IOS_DEPLOYMENT_TARGET"] = self.settings.os.version
         tc.generate()
 
         CMakeDeps(self).generate()


### PR DESCRIPTION
Specify library name and version:  **ceres-solver/***
Closes: https://github.com/conan-io/conan-center-index/issues/21715

`ceres-solver` uses the `IOS_DEPLOYMENT_TARGET` cmake variable to verify that the iOS version is higher than 7.
Indeed, the CMakeLists.txt does not include the iOS.cmake toolchain so it's up to the consumer to include that one as the official documentation reads http://ceres-solver.org/installation.html#ios