### PR TITLE
readline: fix build with shared ncurses

### DIFF
--- a/recipes/readline/all/conanfile.py
+++ b/recipes/readline/all/conanfile.py
@@ -38,7 +38,7 @@ class ReadLineConan(ConanFile):
         if self.options.with_library == "termcap":
             self.requires("termcap/1.3.1")
         elif self.options.with_library == "curses":
-            self.requires("ncurses/6.4")
+            self.requires("ncurses/6.4", transitive_headers=True, transitive_libs=True)
 
     def configure(self):
         if self.options.shared:
@@ -74,9 +74,10 @@ class ReadLineConan(ConanFile):
         deps.generate()
 
     def _patch_sources(self):
-        replace_in_file(self, os.path.join(self.source_folder, "shlib", "Makefile.in"), "-o $@ $(SHARED_OBJ) $(SHLIB_LIBS)",
+        if self.options.with_library == "termcap":
+            replace_in_file(self, os.path.join(self.source_folder, "shlib", "Makefile.in"), "-o $@ $(SHARED_OBJ) $(SHLIB_LIBS)",
                               "-o $@ $(SHARED_OBJ) $(SHLIB_LIBS) -ltermcap")
-        replace_in_file(self, os.path.join(self.source_folder, "Makefile.in"), "@TERMCAP_LIB@", "-ltermcap")
+            replace_in_file(self, os.path.join(self.source_folder, "Makefile.in"), "@TERMCAP_LIB@", "-ltermcap")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
Specify library name and version:  **readline/all**

The issue could be reproduced with the following build options:

```
conan create . --version 8.1.2 -o with_library=curses -o shared=True
```

Fixes the following build error:

```
gcc -shared -Wl,-soname,libreadline.so.8.1 -m64 -L/opt/conan/p/ncursd4659b2179361/p/lib -Wl,-rpath,//lib -Wl,-soname,`basename libreadline.so.8.1 .1` -o libreadline.so.8.1 readline.so vi_mode.so funmap.so keymaps.so parens.so search.so rltty.so complete.so bind.so isearch.so display.so signals.so util.so kill.so undo.so macro.so input.so callback.so terminal.so text.so nls.so misc.so history.so histexpand.so histfile.so histsearch.so shell.so mbutil.so tilde.so colors.so parse-colors.so xmalloc.so xfree.so compat.so  -ltermcap
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: cannot find -ltermcap: No such file or directory
```
Also, add missing transitive dependency declaration:
```
FAILED: test_package 
: && /opt/toolchain/bin/gcc -m64 -O3 -DNDEBUG -m64   -rdynamic CMakeFiles/test_package.dir/test_package.c.o -o test_package -L/opt/conan/p/b/readl5e22c45be609a/p/lib -Wl,-rpath,/opt/conan/p/b/readl5e22c45be609a/p/lib  /opt/conan/p/b/readl5e22c45be609a/p/lib/libhistory.so  /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so && :
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `tputs'
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `tgoto'
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `tgetflag'
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `UP'
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `tgetent'
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `tgetnum'
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `PC'
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `tgetstr'
/opt/toolchain/bin/../lib/gcc/x86_64-multilib-linux-gnu/11.3.0/../../../../x86_64-multilib-linux-gnu/bin/ld.bfd: /opt/conan/p/b/readl5e22c45be609a/p/lib/libreadline.so: undefined reference to `BC'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```



<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
