### PR TITLE
[ogdf] bump version to 2023.09

### DIFF
--- a/recipes/ogdf/all/conandata.yml
+++ b/recipes/ogdf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2023.09":
+    url: "https://github.com/ogdf/ogdf/archive/refs/tags/elderberry-202309.tar.gz"
+    sha256: "3438205d3a6ff69d24c3a6db748d2a5a78688605baf3092456073901a2b623f3"
   "2022.02":
     url: "https://github.com/ogdf/ogdf/archive/refs/tags/dogwood-202202.tar.gz"
     sha256: "308cc2749c6a63520f7979bac86a04066dfea2fb9d3a5e89831318db404bfbf5"

--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -37,7 +37,7 @@ class OGDFConan(ConanFile):
 
     def requirements(self):
         self.requires("coin-clp/1.17.7")
-        self.requires("pugixml/1.13")
+        self.requires("pugixml/1.14")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/ogdf/config.yml
+++ b/recipes/ogdf/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2023.09":
+    folder: all
   "2022.02":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **ogdf/2023.09**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
