### PR TITLE
gtlab-logging: Initial support for the gtlab-logging library (4.4.1)

### DIFF
--- a/recipes/gtlab-logging/all/conandata.yml
+++ b/recipes/gtlab-logging/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "4.4.1":
+    sha256: "3f905b36de130e32a3b2230b78fee8dfc2747775a6171c7a81d3d02843093e72"
+    url: "https://github.com/dlr-gtlab/gt-logging/archive/refs/tags/4-4-1.tar.gz"

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -2,20 +2,19 @@ from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools import files
 from conan import ConanFile
 import os
-import textwrap
 
 required_conan_version = ">=1.59.0"
 
 class GTLabLoggingConan(ConanFile):
     name = "gtlab-logging"
     license = "BSD-3-Clause"
-    author = "Martin Siggel <martin.siggel@dlr.de>"
-    url = "https://github.com/dlr-gtlab/gt-logging"
+    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/dlr-gtlab/gt-logging"
-    toppics = "logging", "qt"
+    topics = ("logging", "qt")
     description = "Simple logging interface with qt support"
 
     settings = "os", "arch", "compiler", "build_type"
+    
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -29,9 +28,8 @@ class GTLabLoggingConan(ConanFile):
         CMakeToolchain(self).generate()
         CMakeDeps(self).generate()
 
-
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder="src")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -41,9 +39,9 @@ class GTLabLoggingConan(ConanFile):
         files.get(self, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self.source_folder)
 
-    def build(self):    
+    def build(self):
         cmake = CMake(self)
-        cmake.configure(build_script_folder="src")
+        cmake.configure()
         cmake.build()
 
 

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -1,0 +1,71 @@
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools import files
+from conan import ConanFile
+import os
+import textwrap
+
+required_conan_version = ">=1.59.0"
+
+class GTLabLoggingConan(ConanFile):
+    name = "gtlab-logging"
+    license = "BSD-3-Clause"
+    author = "Martin Siggel <martin.siggel@dlr.de>"
+    url = "https://github.com/dlr-gtlab/gt-logging"
+    homepage = "https://github.com/dlr-gtlab/gt-logging"
+    toppics = "logging", "qt"
+    description = "Simple logging interface with qt support"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def generate(self):
+        CMakeToolchain(self).generate()
+        CMakeDeps(self).generate()
+
+
+    def layout(self):
+        cmake_layout(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def source(self):
+        files.get(self, **self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self.source_folder)
+
+    def build(self):    
+        cmake = CMake(self)
+        cmake.configure(build_script_folder="src")
+        cmake.build()
+
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        files.copy(self, "README.md", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        files.copy(self, os.path.join("LICENSES", "BSD-3-Clause.txt"), dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+
+    def package_info(self):
+        self.cpp_info.libs = ["GTlabLogging"]
+        
+        self.cpp_info.includedirs.append(os.path.join("include", "logging"))
+
+        self.cpp_info.libdirs = ['lib', 'lib/logging']
+
+        if self.settings.build_type != "Debug":
+            self.cpp_info.libs = ['GTlabLogging']
+        else:
+            self.cpp_info.libs = ['GTlabLogging-d']
+
+        self.cpp_info.set_property("cmake_file_name", "GTlabLogging")
+        self.cpp_info.set_property("cmake_target_name", "GTlab::Logging")

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -54,16 +54,11 @@ class GTLabLoggingConan(ConanFile):
         files.copy(self, os.path.join("LICENSES", "BSD-3-Clause.txt"), dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
 
     def package_info(self):
-        self.cpp_info.libs = ["GTlabLogging"]
+        self.cpp_info.libs = ["GTlabLogging"] if self.settings.build_type != "Debug" else ["GTlabLogging-d"]
         
         self.cpp_info.includedirs.append(os.path.join("include", "logging"))
 
-        self.cpp_info.libdirs = ['lib', 'lib/logging']
-
-        if self.settings.build_type != "Debug":
-            self.cpp_info.libs = ['GTlabLogging']
-        else:
-            self.cpp_info.libs = ['GTlabLogging-d']
+        self.cpp_info.libdirs = [os.path.join("lib", "logging")]
 
         self.cpp_info.set_property("cmake_file_name", "GTlabLogging")
         self.cpp_info.set_property("cmake_target_name", "GTlab::Logging")

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools import files
+from conan.tools.build import check_min_cppstd
 from conan import ConanFile
 import os
 
@@ -18,11 +19,21 @@ class GTLabLoggingConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_qt": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_qt": False
     }
+
+    def requirements(self):
+        if self.options.with_qt:
+            self.requires("qt/[>=5.0.0]")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, "14")
 
     def generate(self):
         CMakeToolchain(self).generate()
@@ -62,3 +73,6 @@ class GTLabLoggingConan(ConanFile):
 
         self.cpp_info.set_property("cmake_file_name", "GTlabLogging")
         self.cpp_info.set_property("cmake_target_name", "GTlab::Logging")
+
+        if self.options.with_qt:
+            self.cpp_info.defines = ['GT_LOG_USE_QT_BINDINGS']

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -60,10 +60,7 @@ class GTLabLoggingConan(ConanFile):
             check_min_cppstd(self, self._min_cppstd)
 
         def loose_lt_semver(v1, v2):
-            lv1 = [int(v) for v in v1.split(".")]
-            lv2 = [int(v) for v in v2.split(".")]
-            min_length = min(len(lv1), len(lv2))
-            return lv1[:min_length] < lv2[:min_length]
+            return all(int(p1) < int(p2) for p1, p2 in zip(str(v1).split("."), str(v2).split(".")))
 
         compiler = self.settings.compiler
         min_version = self._minimum_compilers_version.get(str(compiler))

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -45,7 +45,7 @@ class GTLabLoggingConan(ConanFile):
                 "msvc": "191",
                 "gcc": "7.3.1",
                 "clang": "6",
-                "apple-clang": "12",
+                "apple-clang": "14",
             },
         }.get(self._min_cppstd, {})
 

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -83,6 +83,10 @@ class GTLabLoggingConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
     def source(self):
         files.get(self, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self.source_folder)

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -50,12 +50,6 @@ class GTLabLoggingConan(ConanFile):
         }.get(self._min_cppstd, {})
 
     def validate(self):
-        """
-        Adapted from the gtest recipe
-
-        Make sure that C++ 14 is available
-        """
-
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
 

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -93,7 +93,6 @@ class GTLabLoggingConan(ConanFile):
         cmake.install()
 
         files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
-        files.copy(self, "README.md", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         files.copy(self, os.path.join("LICENSES", "BSD-3-Clause.txt"), dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
 
     def package_info(self):

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -16,6 +16,7 @@ class GTLabLoggingConan(ConanFile):
     description = "Simple logging interface with qt support"
 
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "library"
     
     options = {
         "shared": [True, False],

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -30,7 +30,7 @@ class GTLabLoggingConan(ConanFile):
 
     def requirements(self):
         if self.options.with_qt:
-            self.requires("qt/6.7.0")
+            self.requires("qt/[>=5.15 <7]", transitive_headers=True)
 
 
     @property

--- a/recipes/gtlab-logging/all/conanfile.py
+++ b/recipes/gtlab-logging/all/conanfile.py
@@ -30,7 +30,7 @@ class GTLabLoggingConan(ConanFile):
 
     def requirements(self):
         if self.options.with_qt:
-            self.requires("qt/[>=5.0.0]")
+            self.requires("qt/6.7.0")
 
 
     @property

--- a/recipes/gtlab-logging/all/test_package/CMakeLists.txt
+++ b/recipes/gtlab-logging/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+project(PackageTest CXX)
+
+find_package(GTlabLogging REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(example GTlab::Logging)

--- a/recipes/gtlab-logging/all/test_package/conanfile.py
+++ b/recipes/gtlab-logging/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+import os
+
+
+class GTlabLoggingTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+
+    def layout(self):
+        cmake_layout(self)
+        
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gtlab-logging/all/test_package/example.cpp
+++ b/recipes/gtlab-logging/all/test_package/example.cpp
@@ -1,0 +1,6 @@
+#include <gt_logging.h>
+
+int main() {
+    gtError() << "Hello World";
+    return 0;
+}

--- a/recipes/gtlab-logging/config.yml
+++ b/recipes/gtlab-logging/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.4.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **gtlab-logging/4.4.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

We are the developers of the gtlab-logging  library. We just open sourced our gtlab ecosystem with libraries etc and now want to support a smooth build experience for the users. 
Therefore, we want to use conan for our builds and we need to provide all libraries as conan packages.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
(Conan 1.59.0, Conan 2.0.14)
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
(Shared, Static, debug, release, Windows only)

Closes #21739 
