### PR TITLE
libcurl/all: Add CoreServices framework on macOS 14 Sonoma

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -680,6 +680,8 @@ class LibcurlConan(ConanFile):
                 self.cpp_info.components["curl"].system_libs.append("crypt32")
         elif is_apple_os(self):
             self.cpp_info.components["curl"].frameworks.append("CoreFoundation")
+            if Version(self.settings.os.version) >= 14:
+                self.cpp_info.components["curl"].frameworks.append("CoreServices")
             self.cpp_info.components["curl"].frameworks.append("SystemConfiguration")
             if self.options.with_ldap:
                 self.cpp_info.components["curl"].system_libs.append("ldap")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -680,8 +680,7 @@ class LibcurlConan(ConanFile):
                 self.cpp_info.components["curl"].system_libs.append("crypt32")
         elif is_apple_os(self):
             self.cpp_info.components["curl"].frameworks.append("CoreFoundation")
-            if Version(self.settings.os.version) >= 14:
-                self.cpp_info.components["curl"].frameworks.append("CoreServices")
+            self.cpp_info.components["curl"].frameworks.append("CoreServices")
             self.cpp_info.components["curl"].frameworks.append("SystemConfiguration")
             if self.options.with_ldap:
                 self.cpp_info.components["curl"].system_libs.append("ldap")


### PR DESCRIPTION
Specify library name and version:  **libcurl/all** on macOS (14 and up)

macOS 14 Sonoma has new framework CoreServices, to which libcurl stated linking in https://github.com/curl/curl/commit/6ab7e1990bd548059f08c471d20537bca13c67b6

This PR adds the `CoreServices` to the list of system frameworks only when building on macOS 14.

Absence of that framework caused a runtime crash earlier today to one of the apps as described in [here](https://github.com/curl/curl/issues/11893), however, I couldn't reproduce it with a provided test_package (or FWIW a tweaked one).


```
# conan --version
Conan version 2.0.14
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
