### PR TITLE
tensorflow-lite: Add v2.15.0

### DIFF
--- a/recipes/tensorflow-lite/all/conandata.yml
+++ b/recipes/tensorflow-lite/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.15.0":
+    url: "https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.15.0.tar.gz"
+    sha256: "9cec5acb0ecf2d47b16891f8bc5bc6fbfdffe1700bdadc0d9ebe27ea34f0c220"
   "2.12.0":
     url: "https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.12.0.tar.gz"
     sha256: "c030cb1905bff1d2446615992aad8d8d85cbe90c4fb625cee458c63bf466bc8e"
@@ -6,6 +9,17 @@ sources:
     url: "https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.10.0.tar.gz"
     sha256: "b5a1bb04c84b6fe1538377e5a1f649bb5d5f0b2e3625a3c526ff3a8af88633e8"
 patches:
+  "2.15.0":
+    - patch_file: "patches/2.15.0-0001-disable-fetch-content.patch"
+      patch_description: "Fail if the CMake build script tries to fetch external dependencies"
+      patch_type: "conan"
+    - patch_file: "patches/2.15.0-0002-windows-mmap.patch"
+      patch_description: "Disable mmap on Windows."
+      patch_type: "bugfix"
+      patch_source: "https://github.com/tensorflow/tensorflow/pull/62636"
+    - patch_file: "patches/2.15.0-0003-use-cci-dependencies.patch"
+      patch_description: "Dependency compatibility: Patch CMakeLists.txt, updating package names, target names, etc"
+      patch_type: "conan"
   "2.12.0":
     - patch_file: "patches/2.12.0-0001-remove_simple_memory_arena_debug_dump.patch"
       patch_description: "Shared build fails on Windows with error LNK2005. Resolve the conflict by removing the conflicting implementation for now."

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -82,9 +82,12 @@ class TensorflowLiteConan(ConanFile):
         self.requires("eigen/3.4.0")
         self.requires("farmhash/cci.20190513")
         self.requires("fft/cci.20061228")
-        self.requires("flatbuffers/23.3.3", transitive_headers=True)
+        if Version(self.version) < "2.15.0":
+            self.requires("flatbuffers/23.3.3", transitive_headers=True)
+        else:
+            self.requires("flatbuffers/23.5.26", transitive_headers=True)
         self.requires("gemmlowp/cci.20210928")
-        self.requires("ruy/cci.20220628")
+        self.requires("ruy/cci.20231129")
         if self.settings.arch in ("x86", "x86_64"):
             self.requires("intel-neon2sse/cci.20210225")
         if self.options.with_xnnpack:
@@ -124,6 +127,7 @@ class TensorflowLiteConan(ConanFile):
             "TFLITE_ENABLE_XNNPACK": self.options.with_xnnpack,
             "TFLITE_ENABLE_MMAP": self.options.get_safe("with_mmap", False),
             "FETCHCONTENT_FULLY_DISCONNECTED": True,
+            "SYSTEM_PTHREADPOOL": True,
             "clog_POPULATED": True,
         })
         if self.settings.arch == "armv8":
@@ -159,9 +163,9 @@ class TensorflowLiteConan(ConanFile):
         copy(self, "LICENSE", self.source_folder, join(self.package_folder, "licenses"))
         copy(self, "*.h", join(self.source_folder, "tensorflow", "lite"), join(self.package_folder, "include", "tensorflow", "lite"))
         copy(self, "version.h", join(self.source_folder, "tensorflow", "core", "public"), join(self.package_folder, "include", "tensorflow", "core", "public"))
-        copy(self, "*.a", self.build_folder, join(self.package_folder, "lib"))
-        copy(self, "*.so", self.build_folder, join(self.package_folder, "lib"))
-        copy(self, "*.dylib", self.build_folder, join(self.package_folder, "lib"))
+        copy(self, "*.a", self.build_folder, join(self.package_folder, "lib"), keep_path=False)
+        copy(self, "*.so", self.build_folder, join(self.package_folder, "lib"), keep_path=False)
+        copy(self, "*.dylib", self.build_folder, join(self.package_folder, "lib"), keep_path=False)
         copy(self, "*.lib", self.build_folder, join(self.package_folder, "lib"), keep_path=False)
         copy(self, "*.dll", self.build_folder, join(self.package_folder, "bin"), keep_path=False)
         self._create_cmake_module_alias_target(self, join(self.package_folder, self._module_file))

--- a/recipes/tensorflow-lite/all/patches/2.15.0-0001-disable-fetch-content.patch
+++ b/recipes/tensorflow-lite/all/patches/2.15.0-0001-disable-fetch-content.patch
@@ -1,0 +1,12 @@
+diff --git a/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake b/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake
+index 9ed95109ba9..4ddf322b95f 100644
+--- a/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake
++++ b/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake
+@@ -244,6 +244,7 @@ endfunction()
+ # All content names passed to this method are added to the global property
+ # OVERRIDABLE_FETCH_CONTENT_LIST.
+ function(OverridableFetchContent_Declare CONTENT_NAME)
++  message(FATAL_ERROR "OverridableFetchContent_Declare called by ${CONTENT_NAME}! Failing build.")
+   set(OVERRIDABLE_ARGS
+     GIT_REPOSITORY
+     GIT_TAG

--- a/recipes/tensorflow-lite/all/patches/2.15.0-0002-windows-mmap.patch
+++ b/recipes/tensorflow-lite/all/patches/2.15.0-0002-windows-mmap.patch
@@ -1,0 +1,20 @@
+commit 77056b1ab930c36c8066446615577be4d121e3ea
+Author: talyz <kim.lindberger@gmail.com>
+Date:   Thu Dec 14 11:43:16 2023 +0100
+
+    cmake: Disable the use of mmap on Windows
+
+diff --git a/tensorflow/lite/CMakeLists.txt b/tensorflow/lite/CMakeLists.txt
+index 83bc7629004..0958ed1b9ce 100644
+--- a/tensorflow/lite/CMakeLists.txt
++++ b/tensorflow/lite/CMakeLists.txt
+@@ -202,7 +202,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+   # Use NOMINMAX to disable the min / max macros in windows.h as they break
+   # use of std::min std::max.
+   # Use NOGDI to ERROR macro which breaks TensorFlow logging.
+-  list(APPEND TFLITE_TARGET_PRIVATE_OPTIONS "-DNOMINMAX" "-DNOGDI")
++  # Disable mmap, which is not available on Windows.
++  list(APPEND TFLITE_TARGET_PRIVATE_OPTIONS "-DNOMINMAX" "-DNOGDI" "-DTFLITE_MMAP_DISABLED")
+   # lite/kernels/conv.cc has more than 64k sections so enable /bigobj to
+   # support compilation with MSVC2015.
+   if(MSVC)

--- a/recipes/tensorflow-lite/all/patches/2.15.0-0003-use-cci-dependencies.patch
+++ b/recipes/tensorflow-lite/all/patches/2.15.0-0003-use-cci-dependencies.patch
@@ -1,0 +1,68 @@
+diff --git a/tensorflow/lite/CMakeLists.txt b/tensorflow/lite/CMakeLists.txt
+index 0958ed1b9ce..13d06f12ca6 100644
+--- a/tensorflow/lite/CMakeLists.txt
++++ b/tensorflow/lite/CMakeLists.txt
+@@ -147,7 +147,7 @@ set(TFLITE_TARGET_DEPENDENCIES "")
+ find_package(absl REQUIRED)
+ find_package(Eigen3 REQUIRED)
+ find_package(farmhash REQUIRED)
+-find_package(fft2d REQUIRED)
++find_package(fft REQUIRED)
+ find_package(FlatBuffers REQUIRED)
+ find_package(gemmlowp REQUIRED)
+ if (NOT CMAKE_SYSTEM_PROCESSOR OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86")
+@@ -155,7 +155,6 @@ if (NOT CMAKE_SYSTEM_PROCESSOR OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86")
+   list(APPEND TFLITE_TARGET_DEPENDENCIES NEON_2_SSE::NEON_2_SSE)
+ endif()
+ find_package(cpuinfo REQUIRED)  #CPUINFO is used by XNNPACK and RUY library
+-find_package(ml_dtypes REQUIRED)
+ find_package(ruy REQUIRED)
+ # Include TSL, which is in tensorflow/third_party
+ include_directories(
+@@ -183,6 +182,11 @@ if(NOT SYSTEM_PTHREADPOOL AND NOT TARGET pthreadpool)
+     "${PTHREADPOOL_SOURCE_DIR}"
+     "${CMAKE_BINARY_DIR}/pthreadpool")
+ endif()
++if(TARGET flatbuffers::flatbuffers_shared)
++    set(FLATBUFFERS_TARGET flatbuffers::flatbuffers_shared)
++else()
++    set(FLATBUFFERS_TARGET flatbuffers::flatbuffers)
++endif()
+ set(TF_TARGET_PRIVATE_OPTIONS "")
+ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+   # TensorFlow uses a heap of deprecated proto fields so surpress these
+@@ -483,13 +487,13 @@ else()
+ endif()
+ if(TFLITE_ENABLE_XNNPACK)
+   find_package(fp16_headers REQUIRED)
+-  find_package(XNNPACK REQUIRED)
++  find_package(xnnpack REQUIRED)
+   populate_tflite_source_vars("delegates/xnnpack"
+     TFLITE_DELEGATES_XNNPACK_SRCS
+     FILTER ".*(_test|_tester)\\.(cc|h)"
+   )
+   list(APPEND TFLITE_TARGET_DEPENDENCIES
+-    XNNPACK
++    xnnpack::xnnpack
+   )
+   list(APPEND TFLITE_TARGET_PUBLIC_OPTIONS "-DTFLITE_BUILD_WITH_XNNPACK_DELEGATE")
+ endif()
+@@ -633,13 +637,12 @@ target_link_libraries(tensorflow-lite
+     absl::strings
+     absl::synchronization
+     absl::variant
+-    farmhash
+-    fft2d_fftsg2d
+-    flatbuffers::flatbuffers
+-    gemmlowp::gemmlowp
+-    ml_dtypes
++    farmhash::farmhash
++    fft::fft
++    ${FLATBUFFERS_TARGET}
++    gemmlowp::eight_bit_int_gemm
+     ruy::ruy
+-    pthreadpool
++    pthreadpool::pthreadpool
+     ${CMAKE_DL_LIBS}
+     ${TFLITE_TARGET_DEPENDENCIES}
+ )

--- a/recipes/tensorflow-lite/config.yml
+++ b/recipes/tensorflow-lite/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.15.0":
+    folder: all
   "2.12.0":
     folder: all
   "2.10.0":


### PR DESCRIPTION
Specify library name and version:  **tensorflow-lite/v2.15.0**

Add 2.15.0 and update a few dependencies which were causing crashes when running on M1 macs under rosetta. Also, remove 2.12.0, which was just a copy of 2.10.0.

Depends on #21762, #21761, #21760 and #21759, which should be merged before this.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
