### PR TITLE
opencv/3.x add version 3.4.20

### DIFF
--- a/recipes/opencv/3.x/conandata.yml
+++ b/recipes/opencv/3.x/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "3.4.20":
+    - url: "https://github.com/opencv/opencv/archive/refs/tags/3.4.20.tar.gz"
+      sha256: "b9eda448a08ba7b10bfd5bd45697056569ebdf7a02070947e1c1f3e8e69280cd"
+    - url: "https://github.com/opencv/opencv_contrib/archive/refs/tags/3.4.20.tar.gz"
+      sha256: "b0bb3fa7ae4ac00926b83d4d95c6500c2f7af542f8ec78d0f01b2961a690d5dc"
   "3.4.17":
     - url: "https://github.com/opencv/opencv/archive/refs/tags/3.4.17.tar.gz"
       sha256: "1353eec67849aadb20df71d8bae18b83708e18fc5da080fe5efeabb1e99b2ee8"

--- a/recipes/opencv/3.x/conandata.yml
+++ b/recipes/opencv/3.x/conandata.yml
@@ -10,6 +10,10 @@ sources:
     - url: "https://github.com/opencv/opencv_contrib/archive/refs/tags/3.4.17.tar.gz"
       sha256: "2b4d3e91a5767a1ae4f4e2a71b0a93c9ec744755763653a650e40ace8f7b9a1b"
 patches:
+  "3.4.20":
+    - patch_file: "patches/3.4.17-0001-find-openexr.patch"
+      patch_description: "Robust discovery & injection of OpenEXR"
+      patch_type: "conan"
   "3.4.17":
     - patch_file: "patches/3.4.17-0001-find-openexr.patch"
       patch_description: "Robust discovery & injection of OpenEXR"

--- a/recipes/opencv/config.yml
+++ b/recipes/opencv/config.yml
@@ -7,6 +7,8 @@ versions:
     folder: "4.x"
   "4.1.2":
     folder: "4.x"
+  "3.4.20":
+    folder: "3.x"
   "3.4.17":
     folder: "3.x"
   "2.4.13.7":


### PR DESCRIPTION
Specify library name and version:  **opencv/3.4.20**

the current 3.x version (3.4.17) doesn't compile with GCC12

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
