### PR TITLE
libatomic_ops: update to 7.8.2

### DIFF
--- a/recipes/libatomic_ops/all/conandata.yml
+++ b/recipes/libatomic_ops/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "7.8.0":
-    url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.8.0/libatomic_ops-7.8.0.tar.gz"
-    sha256: "15676e7674e11bda5a7e50a73f4d9e7d60452271b8acf6fd39a71fefdf89fa31"
+  "7.8.2":
+    url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.8.2/libatomic_ops-7.8.2.tar.gz"
+    sha256: "d305207fe207f2b3fb5cb4c019da12b44ce3fcbc593dfd5080d867b1a2419b51"

--- a/recipes/libatomic_ops/config.yml
+++ b/recipes/libatomic_ops/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "7.8.0":
+  "7.8.2":
     folder: all


### PR DESCRIPTION
Specify library name and version: libatomic_ops/7.8.2

* update package version from 7.8.0 to 7.8.2

I'm maintainer of libatomic_ops upstream; v7.8.2 has been released recently - it contains a number of bug fixes.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
