### PR TITLE
(#21795) copypp: add version 0.2.0

### DIFF
--- a/recipes/copypp/all/conandata.yml
+++ b/recipes/copypp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.2.0":
+    url: "https://github.com/i-curve/copypp/archive/v0.2.0.tar.gz"
+    sha256: "beb4ece5b8ce12b252f363e6213e8016a5370898428478e38d095c3242b3c0b1"

--- a/recipes/copypp/all/conanfile.py
+++ b/recipes/copypp/all/conanfile.py
@@ -41,7 +41,7 @@ class BasicConanfile(ConanFile):
 
     def package(self):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        copy(self, "*.h", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+        copy(self, "*.hh", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
 
     def package_info(self):
         self.cpp_info.bindirs = []

--- a/recipes/copypp/all/conanfile.py
+++ b/recipes/copypp/all/conanfile.py
@@ -1,0 +1,51 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=1.52.0"
+
+
+class BasicConanfile(ConanFile):
+    name = "copypp"
+    homepage = "https://github.com/i-curve/copypp"
+    description = "support field copy in different c++ struct."
+    topics = ("copy", "struct", "header-only")
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "MIT"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.h", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "copypp")
+        self.cpp_info.set_property("cmake_target_name", "icurve::copypp")
+        self.cpp_info.set_property("pkg_config_name", "copypp")

--- a/recipes/copypp/all/test_package/CMakeLists.txt
+++ b/recipes/copypp/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(copypp REQUIRED CONFIG)
+find_package(copypp CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE icurve::copypp)

--- a/recipes/copypp/all/test_package/CMakeLists.txt
+++ b/recipes/copypp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(copypp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE icurve::copypp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/copypp/all/test_package/conanfile.py
+++ b/recipes/copypp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/copypp/all/test_package/test_package.cpp
+++ b/recipes/copypp/all/test_package/test_package.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <cassert>
+#include "icurve/copypp"
+
+class A {
+public:
+    int id;
+    std::string name;
+    bool sex;
+
+public:
+    A() = default;
+    A(int id, std::string name, bool sex) : id(id), name(name), sex(sex) {}
+};
+
+class B {
+public:
+    int id;
+    std::string name;
+    bool sex;
+
+public:
+    B() = default;
+    B(int id, std::string name, bool sex) : id(id), name(name), sex(sex) {}
+};
+
+COPYPP_FIELDS_NON_INTRUSIVE(B, A, id, name, sex)
+
+int main(void) {
+    A a(1, "curve", true);
+    B b;
+    icurve::copy(b, a);
+    assert(a.id == b.id);
+    assert(a.name == b.name);
+    assert(a.sex == b.sex);
+    return EXIT_SUCCESS;
+}

--- a/recipes/copypp/all/test_package/test_package.cpp
+++ b/recipes/copypp/all/test_package/test_package.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <cassert>
-#include "icurve/copypp"
+#include "icurve/copypp.hh"
 
 class A {
 public:
@@ -33,5 +33,6 @@ int main(void) {
     assert(a.id == b.id);
     assert(a.name == b.name);
     assert(a.sex == b.sex);
+    std::cout << "copypp ok" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/recipes/copypp/config.yml
+++ b/recipes/copypp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.2.0":
+    folder: all


### PR DESCRIPTION
copypp/0.2.0

support field copy in different c++ struct/class.

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
