### PR TITLE
netcdf: fix libm not found in cross build

### DIFF
--- a/recipes/netcdf/all/conandata.yml
+++ b/recipes/netcdf/all/conandata.yml
@@ -10,7 +10,13 @@ patches:
     - patch_file: "patches/4.7.4-0001-fix-cmake.patch"
       patch_description: "fixes for cmake target_link_libraries and using deps"
       patch_type: "conan"
+    - patch_file: "patches/4.7.4-0002-fix-cross-compile.patch"
+      patch_description: "fixes 'Unable to find the math library' when cross compiling"
+      patch_type: "conan"
   "4.8.1":
     - patch_file: "patches/4.8.1-0001-fix-cmake.patch"
       patch_description: "fixes for cmake target_link_libraries and using deps"
+      patch_type: "conan"
+    - patch_file: "patches/4.8.1-0002-fix-cross-compile.patch"
+      patch_description: "fixes 'Unable to find the math library' when cross compiling"
       patch_type: "conan"

--- a/recipes/netcdf/all/conanfile.py
+++ b/recipes/netcdf/all/conanfile.py
@@ -75,6 +75,7 @@ class NetcdfConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -95,7 +96,6 @@ class NetcdfConan(ConanFile):
         tc.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/netcdf/all/patches/4.7.4-0002-fix-cross-compile.patch
+++ b/recipes/netcdf/all/patches/4.7.4-0002-fix-cross-compile.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 80a986f6..5d887a34 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -864,7 +864,8 @@ ENDIF()
+ 
+ # Check for the math library so it can be explicitly linked.
+ IF(NOT WIN32)
+-  FIND_LIBRARY(HAVE_LIBM NAMES math m libm)
++  INCLUDE(CheckLibraryExists)
++  CHECK_LIBRARY_EXISTS(m log "" HAVE_LIBM)
+   MESSAGE(STATUS "Found Math library: ${HAVE_LIBM}")
+   IF(NOT HAVE_LIBM)
+     MESSAGE(FATAL_ERROR "Unable to find the math library.")

--- a/recipes/netcdf/all/patches/4.7.4-0002-fix-cross-compile.patch
+++ b/recipes/netcdf/all/patches/4.7.4-0002-fix-cross-compile.patch
@@ -1,14 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 80a986f6..5d887a34 100644
+index 80a986f..7e398ba 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -864,7 +864,8 @@ ENDIF()
+@@ -864,7 +864,11 @@ ENDIF()
  
  # Check for the math library so it can be explicitly linked.
  IF(NOT WIN32)
 -  FIND_LIBRARY(HAVE_LIBM NAMES math m libm)
 +  INCLUDE(CheckLibraryExists)
-+  CHECK_LIBRARY_EXISTS(m log "" HAVE_LIBM)
++  CHECK_LIBRARY_EXISTS(m log "" CAN_LINK_LIBM)
++  IF(CAN_LINK_LIBM)
++      SET(HAVE_LIBM m)
++  ENDIF()
    MESSAGE(STATUS "Found Math library: ${HAVE_LIBM}")
    IF(NOT HAVE_LIBM)
      MESSAGE(FATAL_ERROR "Unable to find the math library.")

--- a/recipes/netcdf/all/patches/4.8.1-0002-fix-cross-compile.patch
+++ b/recipes/netcdf/all/patches/4.8.1-0002-fix-cross-compile.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fd6713d4..3eceb66c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -938,7 +938,8 @@ OPTION(ENABLE_BYTERANGE "Enable byte-range access to remote datasets.." OFF)
+
+ # Check for the math library so it can be explicitly linked.
+ IF(NOT WIN32)
+-  FIND_LIBRARY(HAVE_LIBM NAMES math m libm)
++  INCLUDE(CheckLibraryExists)
++  CHECK_LIBRARY_EXISTS(m log "" HAVE_LIBM)
+   MESSAGE(STATUS "Found Math library: ${HAVE_LIBM}")
+   IF(NOT HAVE_LIBM)
+     MESSAGE(FATAL_ERROR "Unable to find the math library.")

--- a/recipes/netcdf/all/patches/4.8.1-0002-fix-cross-compile.patch
+++ b/recipes/netcdf/all/patches/4.8.1-0002-fix-cross-compile.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6b39f0e..3816772 100644
+index fd6713d..c6312b2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -940,7 +940,11 @@ OPTION(ENABLE_BYTERANGE "Enable byte-range access to remote datasets.." OFF)
+@@ -938,7 +938,11 @@ OPTION(ENABLE_BYTERANGE "Enable byte-range access to remote datasets.." OFF)
  
  # Check for the math library so it can be explicitly linked.
  IF(NOT WIN32)

--- a/recipes/netcdf/all/patches/4.8.1-0002-fix-cross-compile.patch
+++ b/recipes/netcdf/all/patches/4.8.1-0002-fix-cross-compile.patch
@@ -1,14 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fd6713d4..3eceb66c 100644
+index 6b39f0e..3816772 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -938,7 +938,8 @@ OPTION(ENABLE_BYTERANGE "Enable byte-range access to remote datasets.." OFF)
-
+@@ -940,7 +940,11 @@ OPTION(ENABLE_BYTERANGE "Enable byte-range access to remote datasets.." OFF)
+ 
  # Check for the math library so it can be explicitly linked.
  IF(NOT WIN32)
 -  FIND_LIBRARY(HAVE_LIBM NAMES math m libm)
 +  INCLUDE(CheckLibraryExists)
-+  CHECK_LIBRARY_EXISTS(m log "" HAVE_LIBM)
++  CHECK_LIBRARY_EXISTS(m log "" CAN_LINK_LIBM)
++  IF(CAN_LINK_LIBM)
++      SET(HAVE_LIBM m)
++  ENDIF()
    MESSAGE(STATUS "Found Math library: ${HAVE_LIBM}")
    IF(NOT HAVE_LIBM)
      MESSAGE(FATAL_ERROR "Unable to find the math library.")


### PR DESCRIPTION
netcdf is unable to find the math library when cross building, similar to #13418. Ran into this issue when cross building from Linux:x86_64 to Linux:armv8. This PR adds a patch that fixes the issue.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
