### PR TITLE
quill: add version 3.6.0

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.0":
+    url: "https://github.com/odygrd/quill/archive/v3.6.0.tar.gz"
+    sha256: "ba9dc3df262f2e65c57904580cc8407eba9a462001340c17bab7ae1dccddb4bd"
   "3.5.1":
     url: "https://github.com/odygrd/quill/archive/v3.5.1.tar.gz"
     sha256: "9fa4ebe594c66ce2a409630c304724fa7a2ada0d842ba9c9aaf05f0a90b461f9"

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.0":
+    folder: "all"
   "3.5.1":
     folder: "all"
   "3.5.0":


### PR DESCRIPTION
Specify library name and version:  **quill/3.6.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
