### PR TITLE
json-schema-validator: be less choosy regarding nlohmann/json

### DIFF
--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -69,7 +69,7 @@ class JsonSchemaValidatorConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("nlohmann_json/3.11.2", transitive_headers=True)
+        self.requires("nlohmann_json/[>=3.11.2 <4]", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Specify library name and version:  **json-schema-validator/all**

Lib depends on nlohmann_json/3.11.2 - be less specific and allow versions above, as i faced an error after updating nlohmann_json to 3.11.3.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
