### PR TITLE
xmlsec-1.2.38: Fix OpenSSL engine headers install on Windows

### DIFF
--- a/recipes/xmlsec/all/conandata.yml
+++ b/recipes/xmlsec/all/conandata.yml
@@ -17,3 +17,9 @@ sources:
   "1.2.30":
     url: "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.30.tar.gz"
     sha256: "2d84360b03042178def1d9ff538acacaed2b3a27411db7b2874f1612ed71abc8"
+patches:
+  "1.2.38":
+    - patch_file: "patches/1.2.38-fix-openssl-engine-headers-install-on-windows.patch"
+      patch_description: "Fix OpenSSL engine headers install on Windows"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/lsh123/xmlsec/pull/736/files"

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
-from conan.tools.files import chdir, copy, get, replace_in_file, rm, rmdir
+from conan.tools.files import chdir, copy, get, replace_in_file, rm, rmdir, apply_conandata_patches, export_conandata_patches
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, msvc_runtime_flag, NMakeDeps, NMakeToolchain
@@ -45,6 +45,9 @@ class XmlSecConan(ConanFile):
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -130,6 +133,7 @@ class XmlSecConan(ConanFile):
             deps.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         if is_msvc(self):
             # Configure step to generate Makefile.msvc
             deps_includedirs = []

--- a/recipes/xmlsec/all/patches/1.2.38-fix-openssl-engine-headers-install-on-windows.patch
+++ b/recipes/xmlsec/all/patches/1.2.38-fix-openssl-engine-headers-install-on-windows.patch
@@ -1,0 +1,28 @@
+From 980fb52b63a4d5d3968f01df15e4cb0dcfc6e4d2 Mon Sep 17 00:00:00 2001
+From: Alexey Katargin <gureedo@gmail.com>
+Date: Wed, 20 Dec 2023 17:38:40 +0100
+Subject: [PATCH] fix openssl engine headers install on windows
+
+---
+ win32/Makefile.msvc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/win32/Makefile.msvc b/win32/Makefile.msvc
+index 7eeb4ce0..27c62602 100755
+--- a/win32/Makefile.msvc
++++ b/win32/Makefile.msvc
+@@ -642,9 +642,9 @@ install : all
+ 	if not exist $(LIBPREFIX) mkdir $(LIBPREFIX)
+ 
+ 	:: include files
+-	if exist $(BASEDIR)\include\$(XMLSEC_NAME) copy $(BASEDIR)\include\$(XMLSEC_NAME)\*.h $(INCPREFIX)\$(XMLSEC_NAME)	
++	if exist $(BASEDIR)\include\$(XMLSEC_NAME) copy $(BASEDIR)\include\$(XMLSEC_NAME)\*.h $(INCPREFIX)\$(XMLSEC_NAME)
+ 	if exist $(BINDIR)\$(XMLSEC_OPENSSL_SO) if not exist $(INCPREFIX)\$(XMLSEC_NAME)\openssl mkdir $(INCPREFIX)\$(XMLSEC_NAME)\openssl
+-	if exist $(BINDIR)\$(XMLSEC_OPENSSL_A) if not exist $(INCPREFIX)\$(XMLSEC_NAME)\openssl mkdir $(INCPREFIX)\$(XMLSEC_NAME)\opensslmsvc if exists
++	if exist $(BINDIR)\$(XMLSEC_OPENSSL_A) if not exist $(INCPREFIX)\$(XMLSEC_NAME)\openssl mkdir $(INCPREFIX)\$(XMLSEC_NAME)\openssl
+ 	if exist $(BINDIR)\$(XMLSEC_OPENSSL_SO) copy $(BASEDIR)\include\$(XMLSEC_NAME)\openssl\*.h $(INCPREFIX)\$(XMLSEC_NAME)\openssl
+     if exist $(BINDIR)\$(XMLSEC_OPENSSL_A) copy $(BASEDIR)\include\$(XMLSEC_NAME)\openssl\*.h $(INCPREFIX)\$(XMLSEC_NAME)\openssl
+ 	if exist $(BINDIR)\$(XMLSEC_NSS_SO) if not exist $(INCPREFIX)\$(XMLSEC_NAME)\nss mkdir $(INCPREFIX)\$(XMLSEC_NAME)\nss
+-- 
+2.43.0.windows.1
+

--- a/recipes/xmlsec/all/test_package/main.c
+++ b/recipes/xmlsec/all/test_package/main.c
@@ -2,6 +2,7 @@
 
 
 #include <xmlsec/xmlsec.h>
+#include <xmlsec/crypto.h>
 
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Specify library name and version:  **xmlsec/1.2.38**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
