### PR TITLE
(#21870) restinio/0.7: build with Visual Studio 2019 

### DIFF
--- a/recipes/restinio/v0.7/conanfile.py
+++ b/recipes/restinio/v0.7/conanfile.py
@@ -67,7 +67,7 @@ class RestinioConan(ConanFile):
             "gcc": "9",
             "clang": "10",
             "apple-clang": "11",
-            "Visual Studio": "17",
+            "Visual Studio": "15",
             "msvc": "191"
         }
 


### PR DESCRIPTION
Specify library name and version:  **restinio/0.7**

Enable compilation with Visual Studio 2019 which supports C++17.
---

- [ x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
