### PR TITLE
commata: create patch file for 0.2.7

### DIFF
--- a/recipes/commata/all/conandata.yml
+++ b/recipes/commata/all/conandata.yml
@@ -14,3 +14,9 @@ sources:
   "0.2.5":
     url: "https://github.com/furfurylic/commata/archive/refs/tags/v0.2.5.tar.gz"
     sha256: "d1be1f366267af6c466c29f846f5968f57626a8a6635a2ea9a3de3f6fb88e53b"
+patches:
+  "0.2.7":
+    - patch_file: "patches/0.2.7-0001-include-optional.patch"
+      patch_description: "include <optional> header"
+      patch_type: "portability"
+      patch_source: "https://github.com/furfurylic/commata/pull/2"

--- a/recipes/commata/all/conanfile.py
+++ b/recipes/commata/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import get, copy, replace_in_file
+from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
@@ -19,7 +19,6 @@ class CommataConan(ConanFile):
     topics = ("csv", "parser", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
-    no_copy_source = True
 
     @property
     def _min_cppstd(self):
@@ -34,6 +33,9 @@ class CommataConan(ConanFile):
             "clang": "7",
             "apple-clang": "12",
         }
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -54,12 +56,7 @@ class CommataConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
-        # waiting for merge PR and release newer version. https://github.com/furfurylic/commata/pull/2
-        if Version(self.version) >= "0.2.7":
-            replace_in_file(self, os.path.join(self.source_folder, "include", "commata", "typing_aid.hpp"),
-                "#include <type_traits>",
-                """#include <type_traits>
-#include <optional>""")
+        apply_conandata_patches(self)
 
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)

--- a/recipes/commata/all/patches/0.2.7-0001-include-optional.patch
+++ b/recipes/commata/all/patches/0.2.7-0001-include-optional.patch
@@ -1,0 +1,12 @@
+diff --git a/include/commata/typing_aid.hpp b/include/commata/typing_aid.hpp
+index adf9c6e..c1365d4 100644
+--- a/include/commata/typing_aid.hpp
++++ b/include/commata/typing_aid.hpp
+@@ -10,6 +10,7 @@
+ #include <iterator>
+ #include <string>
+ #include <type_traits>
++#include <optional>
+ 
+ namespace commata::detail {
+ 


### PR DESCRIPTION
Specify library name and version:  **commata/0.2.7**

This PR is to create a patch file instead of using `replace_in_file`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
