### PR TITLE
bzip2: fix project URL

### DIFF
--- a/recipes/bzip2/all/conanfile.py
+++ b/recipes/bzip2/all/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.53.0"
 class Bzip2Conan(ConanFile):
     name = "bzip2"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "http://www.bzip.org"
+    homepage = "https://sourceware.org/bzip2"
     license = "bzip2-1.0.8"
     description = "bzip2 is a free and open-source file compression program that uses the Burrows Wheeler algorithm."
     topics = ("data-compressor", "file-compression")


### PR DESCRIPTION
The current one (http://www.bzip.org) does not look legitimate. Replaced it with https://sourceware.org/bzip2