### PR TITLE
meson: add version 1.3.1

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.1":
+    url: "https://github.com/mesonbuild/meson/archive/1.3.1.tar.gz"
+    sha256: "274c121edb859602eb4589d31d8791e980748bb19950fc6f611a21d76dc22cc6"
   "1.3.0":
     url: "https://github.com/mesonbuild/meson/releases/download/1.3.0/meson-1.3.0.tar.gz"
     sha256: "4ba253ef60e454e23234696119cbafa082a0aead0bd3bbf6991295054795f5dc"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.1":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/1.3.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
