### PR TITLE
fixed libvault recipe for 2.0

### DIFF
--- a/recipes/libvault/all/conanfile.py
+++ b/recipes/libvault/all/conanfile.py
@@ -1,6 +1,6 @@
 import os
 
-from conan import ConanFile, Version
+from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd
@@ -8,6 +8,8 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, get, rmdir
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
+
 
 required_conan_version = ">=1.53.0"
 

--- a/recipes/libvault/all/conanfile.py
+++ b/recipes/libvault/all/conanfile.py
@@ -23,6 +23,7 @@ class LibvaultConan(ConanFile):
     topics = ("vault", "libvault", "secrets", "passwords")
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = ["CMakeLists.txt", "patches/**"]
+    package_type = "library"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
 
@@ -39,7 +40,7 @@ class LibvaultConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("libcurl/7.86.0")
+        self.requires("libcurl/7.86.0", transitive_headers=True)
         self.requires("catch2/3.2.0")
 
     def validate(self):


### PR DESCRIPTION
Specify library name and version:  **libvault/all**

The recipe is broken in 2.0 due to a wrong import to ``Version``


