### PR TITLE
libmd: new recipe

### DIFF
--- a/recipes/libmd/all/conandata.yml
+++ b/recipes/libmd/all/conandata.yml
@@ -1,0 +1,6 @@
+sources:
+  "1.1.0":
+    url:
+      - "https://libbsd.freedesktop.org/releases/libmd-1.1.0.tar.xz"
+      - "https://archive.hadrons.org/software/libmd/libmd-1.1.0.tar.xz"
+    sha256: "1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332"

--- a/recipes/libmd/all/conanfile.py
+++ b/recipes/libmd/all/conanfile.py
@@ -1,0 +1,64 @@
+import os
+
+from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.files import copy, get, rmdir, rm
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.53.0"
+
+class LibMDConan(ConanFile):
+    name = "libmd"
+    description = "Message Digest functions from BSD systems"
+    license = "BSD-2-Clause AND BSD-3-Clause AND ISC AND Beerware AND DocumentRef-COPYING:LicenseRef-libmd-Public-Domain"
+    homepage = "https://gitlab.freedesktop.org/libbsd/libmd"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("message-digest", "hash", "bsd",
+              "md2", "md4", "md5", "ripemd", "rmd160",
+              "sha", "sha1", "sha2", "sha256", "sha512")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def configure(self):
+        if self.options.shared:
+           self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.generate()
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "libmd")
+        self.cpp_info.libs = ["md"]

--- a/recipes/libmd/all/conanfile.py
+++ b/recipes/libmd/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.files import copy, get, rmdir, rm
+from conan.tools.files import copy, get, rmdir, rm, chdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 
@@ -46,14 +46,16 @@ class LibMDConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build(self):
-        autotools = Autotools(self)
-        autotools.configure()
-        autotools.make()
+        with chdir(self, self.source_folder):
+            autotools = Autotools(self)
+            autotools.configure()
+            autotools.make()
 
     def package(self):
         copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        autotools = Autotools(self)
-        autotools.install()
+        with chdir(self, self.source_folder):
+            autotools = Autotools(self)
+            autotools.install()
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))

--- a/recipes/libmd/all/conanfile.py
+++ b/recipes/libmd/all/conanfile.py
@@ -2,11 +2,14 @@ import os
 
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.files import copy, get, rmdir, rm, chdir
+from conan.tools.env import Environment, VirtualBuildEnv
+from conan.tools.files import chdir, rename, copy, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, unix_path
 
 required_conan_version = ">=1.53.0"
+
 
 class LibMDConan(ConanFile):
     name = "libmd"
@@ -29,15 +32,49 @@ class LibMDConan(ConanFile):
         "fPIC": True,
     }
 
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
     def configure(self):
         if self.options.shared:
-           self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.libcxx")
+            self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def build_requirements(self):
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
+        if is_msvc(self):
+            self.tool_requires("automake/1.16.5")
 
     def generate(self):
+        venv = VirtualBuildEnv(self)
+        venv.generate()
+
         tc = AutotoolsToolchain(self)
         tc.generate()
+
+        if is_msvc(self):
+            env = Environment()
+            automake_conf = self.dependencies.build["automake"].conf_info
+            compile_wrapper = unix_path(self, automake_conf.get("user.automake:compile-wrapper", check_type=str))
+            ar_wrapper = unix_path(self, automake_conf.get("user.automake:lib-wrapper", check_type=str))
+            env.define("CC", f"{compile_wrapper} cl -nologo")
+            env.define("CXX", f"{compile_wrapper} cl -nologo")
+            env.define("LD", "link -nologo")
+            env.define("AR", f"{ar_wrapper} lib")
+            env.define("NM", "dumpbin -symbols")
+            env.define("OBJDUMP", ":")
+            env.define("RANLIB", ":")
+            env.define("STRIP", ":")
+            env.vars(self).save_script("conanbuild_msvc")
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -56,6 +93,9 @@ class LibMDConan(ConanFile):
         with chdir(self, self.source_folder):
             autotools = Autotools(self)
             autotools.install()
+        if self.settings.os == "Windows" and self.options.shared:
+            rename(self, os.path.join(self.package_folder, "lib", "md.dll.lib"),
+                         os.path.join(self.package_folder, "lib", "md-0.lib"))
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
@@ -63,4 +103,9 @@ class LibMDConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "libmd")
-        self.cpp_info.libs = ["md"]
+
+        if self.settings.os == "Windows" and self.options.shared:
+            lib = "md-0"
+        else:
+            lib = "md"
+        self.cpp_info.libs = [lib]

--- a/recipes/libmd/all/conanfile.py
+++ b/recipes/libmd/all/conanfile.py
@@ -59,6 +59,9 @@ class LibMDConan(ConanFile):
         venv.generate()
 
         tc = AutotoolsToolchain(self)
+        if is_msvc(self):
+            tc.extra_cflags.append("-FS")
+            tc.extra_cxxflags.append("-FS")
         tc.generate()
 
         if is_msvc(self):

--- a/recipes/libmd/all/test_package/CMakeLists.txt
+++ b/recipes/libmd/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package C)
+
+find_package(libmd REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE libmd::libmd)

--- a/recipes/libmd/all/test_package/conanfile.py
+++ b/recipes/libmd/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libmd/all/test_package/test_package.c
+++ b/recipes/libmd/all/test_package/test_package.c
@@ -1,0 +1,12 @@
+#include <md5.h>
+#include <string.h>
+
+int main() {
+    const char data[] = "12345";
+    uint8_t hash[MD5_DIGEST_LENGTH];
+    MD5_CTX md5_ctx;
+    MD5Init(&md5_ctx);
+    MD5Update(&md5_ctx, (const uint8_t *)data, strlen(data));
+    MD5Final(hash, &md5_ctx);
+    return 0;
+}

--- a/recipes/libmd/config.yml
+++ b/recipes/libmd/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.0":
+    folder: "all"


### PR DESCRIPTION
Adds `libmd`: a message digest library from BSD. Required for the latest versions of `libbsd`.

[![Packaging status](https://repology.org/badge/tiny-repos/libmd.svg)](https://repology.org/project/libmd/versions)
