### PR TITLE
arsenalgear: add version 2.1.1

### DIFF
--- a/recipes/arsenalgear/all/conandata.yml
+++ b/recipes/arsenalgear/all/conandata.yml
@@ -20,4 +20,4 @@ patches:
     - patch_file: "patches/2.1.0-0001-fix-cmake.patch"
       patch_description: "CMake: allow shared, honor compiler.cppstd, avoid to download and build doctest"
       patch_type: "conan"
-      patch_source: "https://github.com/JustWhit3/_gear-cpp/pull/4"
+      patch_source: "https://github.com/JustWhit3/arsenalgear-cpp/pull/4"

--- a/recipes/arsenalgear/all/conandata.yml
+++ b/recipes/arsenalgear/all/conandata.yml
@@ -12,6 +12,10 @@ sources:
     url: "https://github.com/JustWhit3/arsenalgear-cpp/archive/refs/tags/v1.2.2.tar.gz"
     sha256: "556155d0be0942bcdd5df02fcda258579915e76b5a70e7220de6ef38c8ca7779"
 patches:
+  "2.1.1":
+    - patch_file: "patches/2.1.1-0001-fix-cmake.patch"
+      patch_description: "disable cppcheck"
+      patch_type: "conan"
   "2.1.0":
     - patch_file: "patches/2.1.0-0001-fix-cmake.patch"
       patch_description: "CMake: allow shared, honor compiler.cppstd, avoid to download and build doctest"

--- a/recipes/arsenalgear/all/conandata.yml
+++ b/recipes/arsenalgear/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.1":
+    url: "https://github.com/JustWhit3/arsenalgear-cpp/archive/refs/tags/v2.1.1.tar.gz"
+    sha256: "5bcad6f0a2dfa3c271a532d60bfd7e45dd150fdd3c12503354718ff2b62ce967"
   "2.1.0":
     url: "https://github.com/JustWhit3/arsenalgear-cpp/archive/refs/tags/v2.1.0.tar.gz"
     sha256: "2548a0452f3c290f4912ccc3511ae70be62ef4cd8e5d372e27423184d72785f9"
@@ -13,4 +16,4 @@ patches:
     - patch_file: "patches/2.1.0-0001-fix-cmake.patch"
       patch_description: "CMake: allow shared, honor compiler.cppstd, avoid to download and build doctest"
       patch_type: "conan"
-      patch_source: "https://github.com/JustWhit3/arsenalgear-cpp/pull/4"
+      patch_source: "https://github.com/JustWhit3/_gear-cpp/pull/4"

--- a/recipes/arsenalgear/all/patches/2.1.1-0001-fix-cmake.patch
+++ b/recipes/arsenalgear/all/patches/2.1.1-0001-fix-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e5a01e7..17fb0e5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,7 +47,7 @@ endif()
+ set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILE_FLAGS}" )
+ 
+ # Adding cppcheck properties
+-if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
++if(0)
+     set( cppcheck cppcheck "--enable=warning" "--inconclusive" "--force" "--inline-suppr" )
+     set_target_properties( arsenalgear PROPERTIES CXX_CPPCHECK ${cppcheck})
+ endif()

--- a/recipes/arsenalgear/config.yml
+++ b/recipes/arsenalgear/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.1":
+    folder: all
   "2.1.0":
     folder: all
   "2.0.1":


### PR DESCRIPTION
Specify library name and version:  **arsenalgear/2.1.1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
