### PR TITLE
Remove cuda-api-wrappers/0.7

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  "0.7":
+  "0.7-b1":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/0.7b1.tar.gz"
     sha256: "1ed5912d8f602ccd176865b824de17f462cb57142eb2a685d7cc034831e54a71"
   "0.6.3":

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.7":
+  "0.7-b1":
     folder: all
   "0.6.3":
     folder: all


### PR DESCRIPTION
See issue #22071 ; this removes the use of the beta as a regular version.

If it can, instead, be marked as a beta and kept, that would be better - please advise on how to do that.

FYI: I also plan to submit a PR with _actual_ newer non-beta releases, and an update of the package's meta-data in the recipe, independently of this one.

---

- [YES] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [N/A] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [N/A] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
