### PR TITLE
boost-ext-ut: Add version 2.0.1

### DIFF
--- a/recipes/boost-ext-ut/all/conandata.yml
+++ b/recipes/boost-ext-ut/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.1":
+    url: "https://github.com/boost-ext/ut/archive/v2.0.1.tar.gz"
+    sha256: "1e43be17045a881c95cedc843d72fe9c1e53239b02ed179c1e39e041ebcd7dad"
   "2.0.0":
     url: "https://github.com/boost-ext/ut/archive/v2.0.0.tar.gz"
     sha256: "8b5b11197d1308dfc1fe20efd6a656e0c833dbec2807e2292967f6e2f7c0420f"

--- a/recipes/boost-ext-ut/config.yml
+++ b/recipes/boost-ext-ut/config.yml
@@ -1,7 +1,9 @@
 versions:
+  "2.0.1":
+    folder: "all"
   "2.0.0":
     folder: "all"
-  "1.1.8":
-    folder: "all"
   "1.1.9":
+    folder: "all"
+  "1.1.8":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **boost-ext-ut/2.0.1**

Add version 2.0.1.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
