### PR TITLE
minizip-ng: add version 4.0.4

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.4":
+    url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.4.tar.gz"
+    sha256: "955800fe39f9d830fcb84e60746952f6a48e41093ec7a233c63ad611b5fcfe9f"
   "4.0.3":
     url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.3.tar.gz"
     sha256: "e39a736d4f55c22fa548e68225b2e92bc22aedd9ab90d002b0c5851e3a7bdace"

--- a/recipes/minizip-ng/config.yml
+++ b/recipes/minizip-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.4":
+    folder: all
   "4.0.3":
     folder: all
   "4.0.2":


### PR DESCRIPTION
Specify library name and version:  **minizip-ng/4.0.4**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
