### PR TITLE
openjdk fix JAVA_HOME environment variable

### DIFF
--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -67,8 +67,8 @@ class OpenJDK(ConanFile):
     def package_info(self):
         self.output.info(f"Creating JAVA_HOME environment variable with : {self.package_folder}")
 
-        self.runenv_info.append("JAVA_HOME", self.package_folder)
-        self.buildenv_info.append("JAVA_HOME", self.package_folder)
+        self.runenv_info.define_path("JAVA_HOME", self.package_folder)
+        self.buildenv_info.define_path("JAVA_HOME", self.package_folder)
 
         # TODO: remove `env_info` once the recipe is only compatible with Conan >= 2.0
         self.env_info.JAVA_HOME = self.package_folder


### PR DESCRIPTION
Specify library name and version:  **openjdk/***

The current recipe sets JAVA_HOME using `*env_info.append`, but this results in a leading space, which breaks things that are really picky about it. For example, Gradle fails with the following error:

```
ERROR: JAVA_HOME is set to an invalid directory:  /home/aramallo/.conan2/p/b/openje4780c153b838/p /home/aramallo/.conan2/p/b/openje4780c153b838/p
```

It also gets added twice for some reason, but this fixes it regardless.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
