### PR TITLE
catch2: add version 3.5.1

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.1":
+    url: "https://github.com/catchorg/Catch2/archive/v3.5.1.tar.gz"
+    sha256: "49c3ca7a68f1c8ec71307736bc6ed14fec21631707e1be9af45daf4037e75a08"
   "3.5.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.5.0.tar.gz"
     sha256: "f6d4f8d78a9b59ec72a81d49f58d18eb317372ac07f8d9432710a079e69fd66a"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5.1":
+    folder: 3.x.x
   "3.5.0":
     folder: 3.x.x
   "3.4.0":


### PR DESCRIPTION
Specify library name and version:  **catch2/3.5.1**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
