### PR TITLE
trompeloell: add version 47

### DIFF
--- a/recipes/trompeloeil/all/conandata.yml
+++ b/recipes/trompeloeil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "47":
+    url: "https://github.com/rollbear/trompeloeil/archive/v47.tar.gz"
+    sha256: "4a1d79260c1e49e065efe0817c8b9646098ba27eed1802b0c3ba7d959e4e5e84"
   "46":
     url: "https://github.com/rollbear/trompeloeil/archive/v46.tar.gz"
     sha256: "dc2c856ab7716ef659f8df7fc5f6740a40e736089f05e0a8251d4ad3ad17ad83"

--- a/recipes/trompeloeil/config.yml
+++ b/recipes/trompeloeil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "47":
+    folder: all
   "46":
     folder: all
   "45":


### PR DESCRIPTION
Specify library name and version:  **trompeloell/47**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
