### PR TITLE
llvm-openmp: add v17.0.6, relax OS/compiler checks

### DIFF
--- a/recipes/llvm-openmp/all/conandata.yml
+++ b/recipes/llvm-openmp/all/conandata.yml
@@ -1,4 +1,11 @@
 sources:
+  "17.0.6":
+    openmp:
+      url: "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/openmp-17.0.6.src.tar.xz"
+      sha256: "74334cbb4dc8b73a768448a7561d5a3540404940b2267b1fb9813a6464b320de"
+    cmake:
+      url: "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/cmake-17.0.6.src.tar.xz"
+      sha256: "807f069c54dc20cb47b21c1f6acafdd9c649f3ae015609040d6182cab01140f4"
   "17.0.4":
     openmp:
       url: "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.4/openmp-17.0.4.src.tar.xz"

--- a/recipes/llvm-openmp/all/conanfile.py
+++ b/recipes/llvm-openmp/all/conanfile.py
@@ -8,6 +8,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, save, move_folder_contents, rmdir
+from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
@@ -45,15 +46,6 @@ class LLVMOpenMpConan(ConanFile):
         )
     }
 
-    def _supports_compiler(self):
-        supported_compilers_by_os = {
-            "Linux": ["clang", "gcc", "intel-cc"],
-            "Macos": ["apple-clang", "clang", "gcc", "intel-cc"],
-            "Windows": ["intel-cc"],
-        }
-        the_compiler, the_os = self.settings.compiler.value, self.settings.os.value
-        return the_compiler in supported_compilers_by_os.get(the_os, [])
-
     @property
     def _compilers_minimum_version(self):
         return {
@@ -85,9 +77,12 @@ class LLVMOpenMpConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if not self._supports_compiler():
-            raise ConanInvalidConfiguration("llvm-openmp doesn't support compiler: "
-                                            f"{self.settings.compiler} on OS: {self.settings.os}.")
+        if is_msvc(self):
+            raise ConanInvalidConfiguration("llvm-openmp is not compatible with MSVC")
+        if self.settings.compiler not in ["apple-clang", "clang", "gcc", "intel-cc"]:
+            raise ConanInvalidConfiguration(
+                f"{self.settings.compiler} is not supported by this recipe. Contributions are welcome!"
+            )
         if self._version_major >= 17:
             if self.settings.compiler.cppstd:
                 check_min_cppstd(self, 17)

--- a/recipes/llvm-openmp/config.yml
+++ b/recipes/llvm-openmp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "17.0.6":
+    folder: all
   "17.0.4":
     folder: all
   "16.0.6":


### PR DESCRIPTION
* Fixes #22104

This enables the package for non-macOS apple-clang builds and for MinGW (which should be compatible: https://packages.msys2.org/package/mingw-w64-clang-x86_64-openmp).