### PR TITLE
libxml2: remove unused versions

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -11,15 +11,9 @@ sources:
   "2.11.6":
     url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.6.tar.xz"
     sha256: "c90eee7506764abbe07bb616b82da452529609815aefef423d66ef080eb0c300"
-  "2.11.5":
-    url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.5.tar.xz"
-    sha256: "3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6"
   "2.11.4":
     url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.4.tar.xz"
     sha256: "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7"
-  "2.11.3":
-    url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.3.tar.xz"
-    sha256: "f1acae1664bda006cd81bfc238238217043d586d06659d5c0e3d1bcebe040870"
   "2.10.4":
     url: "https://download.gnome.org/sources/libxml2/2.10/libxml2-2.10.4.tar.xz"
     sha256: "ed0c91c5845008f1936739e4eee2035531c1c94742c6541f44ee66d885948d45"
@@ -38,6 +32,3 @@ sources:
   "2.9.10":
     url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.10.tar.xz"
     sha256: "593b7b751dd18c2d6abcd0c4bcb29efc203d0b4373a6df98e3a455ea74ae2813"
-  "2.9.9":
-    url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.9.tar.xz"
-    sha256: "58a5c05a2951f8b47656b676ce1017921a29f6b1419c45e3baed0d6435ba03f5"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -7,11 +7,7 @@ versions:
     folder: all
   "2.11.6":
     folder: all
-  "2.11.5":
-    folder: all
   "2.11.4":
-    folder: all
-  "2.11.3":
     folder: all
   "2.10.4":
     folder: all
@@ -24,6 +20,4 @@ versions:
   "2.9.12":
     folder: all
   "2.9.10":
-    folder: all
-  "2.9.9":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libxml2/all**

search all recipe usage with:
`find recipes -name 'conanfile.py' -exec grep 'libxml2/' {} +`

Can't remove more versions for now (especially old ones), it will have to wait for #20992 to be completed.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
