### PR TITLE
libtiff: use https for download

### DIFF
--- a/recipes/libtiff/all/conandata.yml
+++ b/recipes/libtiff/all/conandata.yml
@@ -1,18 +1,18 @@
 sources:
   "4.6.0":
-    url: "http://download.osgeo.org/libtiff/tiff-4.6.0.tar.gz"
+    url: "https://download.osgeo.org/libtiff/tiff-4.6.0.tar.gz"
     sha256: "88b3979e6d5c7e32b50d7ec72fb15af724f6ab2cbf7e10880c360a77e4b5d99a"
   "4.5.1":
-    url: "http://download.osgeo.org/libtiff/tiff-4.5.1.tar.gz"
+    url: "https://download.osgeo.org/libtiff/tiff-4.5.1.tar.gz"
     sha256: "d7f38b6788e4a8f5da7940c5ac9424f494d8a79eba53d555f4a507167dca5e2b"
   "4.5.0":
-    url: "http://download.osgeo.org/libtiff/tiff-4.5.0.tar.gz"
+    url: "https://download.osgeo.org/libtiff/tiff-4.5.0.tar.gz"
     sha256: "c7a1d9296649233979fa3eacffef3fa024d73d05d589cb622727b5b08c423464"
   "4.4.0":
-    url: "http://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz"
+    url: "https://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz"
     sha256: "917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed"
   "4.3.0":
-    url: "http://download.osgeo.org/libtiff/tiff-4.3.0.tar.gz"
+    url: "https://download.osgeo.org/libtiff/tiff-4.3.0.tar.gz"
     sha256: "0e46e5acb087ce7d1ac53cf4f56a09b221537fc86dfc5daaad1c2e89e1b37ac8"
 patches:
   "4.6.0":


### PR DESCRIPTION
The conandata.yml files in this git repo contains 6411 https:// uris and 109 http:// uris. There is no reason not to use https with the libtiff downloads from download.osgeo.org and some organizations block http:// file transfers for security reasons.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
