### PR TITLE
[libmysqlclient] Add include/mysql directory

### DIFF
--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -271,6 +271,7 @@ class LibMysqlClientCConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "mysqlclient")
         self.cpp_info.libs = ["libmysql" if self.settings.os == "Windows" and self.options.shared else "mysqlclient"]
+        self.cpp_info.includedirs.append(os.path.join("include", "mysql"))
         if not self.options.shared:
             stdcpplib = stdcpp_library(self)
             if stdcpplib:


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient/8.1.0**

There is no official CMake file for mysql client library, so each project consume mysql headers or using "mysql/mysql.h" or "mysql.h" directly.

This PR provides the option of including the header directly. The Poco project uses on that way and we need to use patches to fix it. 

Related to https://github.com/conan-io/conan-center-index/pull/21879/files#diff-359080320353606291963031f9c2e4ccc955802bd4ea9232fcbed7577843ba36

/cc @toge 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
