### PR TITLE
rapidjson/* Specify that rapidjson is a header-only library.

### DIFF
--- a/recipes/rapidjson/all/conanfile.py
+++ b/recipes/rapidjson/all/conanfile.py
@@ -13,6 +13,8 @@ class RapidjsonConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://rapidjson.org"
     license = "MIT"
+    package_type = "header-library"
+    package_id_embed_mode = "minor"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 

--- a/recipes/rapidjson/all/conanfile.py
+++ b/recipes/rapidjson/all/conanfile.py
@@ -17,7 +17,7 @@ class RapidjsonConan(ConanFile):
     no_copy_source = True
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True,
@@ -33,6 +33,8 @@ class RapidjsonConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "RapidJSON")
         self.cpp_info.set_property("cmake_target_name", "rapidjson")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "RapidJSON"


### PR DESCRIPTION
rapidjson/*

Specify that the library is a header-only library to get rid of a warning.
```
ld64.lld: warning: directory not found for option -L/Users/me/.conan2/p/rapidf6bdd1718c30a/p/lib
```

Feature documentation.
https://docs.conan.io/2/tutorial/creating_packages/other_types_of_packages/header_only_packages.html?highlight=libdirs

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
