### PR TITLE
Remove prints from msys2 test recipes

### DIFF
--- a/recipes/msys2/all/test_package/conanfile.py
+++ b/recipes/msys2/all/test_package/conanfile.py
@@ -31,5 +31,4 @@ class TestPackageConan(ConanFile):
 
         output = StringIO()
         self.run('bash.exe -c "echo $PKG_CONFIG_PATH"', output)
-        print(output.getvalue())
         assert self._secret_value in output.getvalue()

--- a/recipes/msys2/all/test_v1_package/conanfile.py
+++ b/recipes/msys2/all/test_v1_package/conanfile.py
@@ -25,5 +25,4 @@ class TestPackageConan(ConanFile):
         with tools.environment_append({"PKG_CONFIG_PATH": secret_value}):
             output = StringIO()
             self.run('bash.exe -c "echo $PKG_CONFIG_PATH"', output=output)
-            print(output.getvalue())
             assert secret_value in output.getvalue()


### PR DESCRIPTION
Specify library name and version:  **msys2/cci.latest**

Test package recipes use `print()`, which breaks the json output of conan commands.
I think they are just leftovers from previous debugging sessions.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
