### PR TITLE
qt: fix include path too long for msvc on windows

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -74,6 +74,10 @@ patches:
       "patch_file": "patches/32fa63f.patch"
       "patch_type": "bugfix"
       "patch_source": "https://bugreports.qt.io/browse/QTBUG-112920"
+    - "base_path": "qtbase"
+      "patch_description": "Use absolute path in the generated header files to avoid relative path longer than 250 characters (not supported on by msvc compiler)"
+      "patch_file": "patches/fix-long-path-on-windows_6.6.1.patch"
+      "patch_type": "bugfix"
   "6.6.0":
     - "base_path": "qtwebengine"
       "patch_description": "Workaround for too long .rps file name"
@@ -85,6 +89,10 @@ patches:
       "patch_file": "patches/32fa63f.patch"
       "patch_type": "bugfix"
       "patch_source": "https://bugreports.qt.io/browse/QTBUG-112920"
+    - "base_path": "qtbase"
+      "patch_description": "Use absolute path in the generated header files to avoid relative path longer than 250 characters (not supported on by msvc compiler)"
+      "patch_file": "patches/fix-long-path-on-windows_6.6.0.patch"
+      "patch_type": "bugfix"
   "6.5.3":
     - "base_path": "qtwebengine"
       "patch_description": "Workaround for too long .rps file name"
@@ -96,6 +104,10 @@ patches:
       "patch_file": "patches/32fa63f_6.5.0.patch"
       "patch_type": "bugfix"
       "patch_source": "https://bugreports.qt.io/browse/QTBUG-112920"
+    - "base_path": "qtbase"
+      "patch_description": "Use absolute path in the generated header files to avoid relative path longer than 250 characters (not supported on by msvc compiler)"
+      "patch_file": "patches/fix-long-path-on-windows_6.5.3.patch"
+      "patch_type": "bugfix"
   "6.4.2":
     - base_path: "qtbase/cmake"
       patch_description: "Fix pri helpers"

--- a/recipes/qt/6.x.x/patches/fix-long-path-on-windows_6.5.3.patch
+++ b/recipes/qt/6.x.x/patches/fix-long-path-on-windows_6.5.3.patch
@@ -1,0 +1,16 @@
+--- a/src/tools/syncqt/main.cpp
++++ b/src/tools/syncqt/main.cpp
+@@ -851,12 +851,7 @@
+
+         bool headerFileExists = std::filesystem::exists(headerFile);
+
+-        std::filesystem::path headerFileRootName =
+-                std::filesystem::weakly_canonical(headerFile, ec).root_name();
+-        std::string aliasedFilepath = !ec && headerFileRootName == m_outputRootName
+-                ? std::filesystem::relative(headerFile, outputDir).generic_string()
+-                : headerFile.generic_string();
+-        ec.clear();
++        std::string aliasedFilepath = headerFile.generic_string();
+
+         std::string aliasPath = outputDir + '/' + m_currentFilename;
+ 

--- a/recipes/qt/6.x.x/patches/fix-long-path-on-windows_6.6.0.patch
+++ b/recipes/qt/6.x.x/patches/fix-long-path-on-windows_6.6.0.patch
@@ -1,0 +1,16 @@
+--- a/src/tools/syncqt/main.cpp
++++ b/src/tools/syncqt/main.cpp
+@@ -875,12 +875,7 @@
+
+         bool headerFileExists = std::filesystem::exists(headerFile);
+
+-        std::filesystem::path headerFileRootName =
+-                std::filesystem::weakly_canonical(headerFile, ec).root_name();
+-        std::string aliasedFilepath = !ec && headerFileRootName == m_outputRootName
+-                ? std::filesystem::relative(headerFile, outputDir).generic_string()
+-                : headerFile.generic_string();
+-        ec.clear();
++        std::string aliasedFilepath = headerFile.generic_string();
+
+         std::string aliasPath = outputDir + '/' + m_currentFilename;
+ 

--- a/recipes/qt/6.x.x/patches/fix-long-path-on-windows_6.6.1.patch
+++ b/recipes/qt/6.x.x/patches/fix-long-path-on-windows_6.6.1.patch
@@ -1,0 +1,16 @@
+--- a/src/tools/syncqt/main.cpp
++++ b/src/tools/syncqt/main.cpp
+@@ -866,12 +866,7 @@
+
+         bool headerFileExists = std::filesystem::exists(headerFile);
+
+-        std::filesystem::path headerFileRootName =
+-                std::filesystem::weakly_canonical(headerFile, ec).root_name();
+-        std::string aliasedFilepath = !ec && headerFileRootName == m_outputRootName
+-                ? std::filesystem::relative(headerFile, outputDir).generic_string()
+-                : headerFile.generic_string();
+-        ec.clear();
++        std::string aliasedFilepath = headerFile.generic_string();
+
+         std::string aliasPath = outputDir + '/' + m_currentFilename;
+ 


### PR DESCRIPTION
Fix #21652

Qt generates header files in the build folder that include a header file to another relative location in the source folder.
However since the build and the source folder are very distant with conan 2, the concatenated root path + relative path is longer than 260, which is not supported by cl compiler (yes that's very sad to hear in 2024 😢 ).
The issue can only be reproduced with qt/*:qtdeclarative=True (which is not set in the conan center CI).
Even if the conan home is very short (like C:\.c) the issue appears.

The fix consists of patching the script used by qt to generate the header, so that the header to the source folder is written with absolute path instead of relative path.
It should not impact the build since it was already their fallback mechanism when the source and the build folder were on different disk (relative path is then impossible).
We could also suggest this fix in the upstream qt repo for the future versions of qt.

Note: I fix only qt>6.5.3, the previous versions were using a perl script instead and I am not planning to fix it for now.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
