### PR TITLE
nodejs: fix glibc version check on Fedora, RHEL and probably more

### DIFF
--- a/recipes/nodejs/all/conanfile.py
+++ b/recipes/nodejs/all/conanfile.py
@@ -1,7 +1,6 @@
 import os
-import re
-from six import StringIO
-from conan import ConanFile, conan_version
+import platform
+from conan import ConanFile
 from conan.tools.scm import Version
 from conan.tools.files import copy, get
 from conan.errors import ConanInvalidConfiguration
@@ -17,7 +16,7 @@ class NodejsConan(ConanFile):
     homepage = "https://nodejs.org"
     license = "MIT"
     package_type = "application"
-    settings = "os", "arch", "compiler"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
     short_paths = True
 
@@ -34,13 +33,6 @@ class NodejsConan(ConanFile):
                 return "armv8"
         return str(self.settings.arch)
 
-    @property
-    def _glibc_version(self):
-        cmd = ['ldd', '--version'] if conan_version.major == "1" else ['ldd --version']
-        buff = StringIO()
-        self.run(cmd, buff)
-        return str(re.search(r'GLIBC (\d{1,3}.\d{1,3})', buff.getvalue()).group(1))
-
     def package_id(self):
         del self.info.settings.compiler
 
@@ -52,7 +44,7 @@ class NodejsConan(ConanFile):
 
         if Version(self.version) >= "18.0.0":
             if str(self.settings.os) == "Linux":
-                if Version(self._glibc_version) < '2.27':
+                if Version(platform.libc_ver()[1]) < '2.27':
                     raise ConanInvalidConfiguration("Binaries for this combination of architecture/version/os not available")
 
     def build(self):


### PR DESCRIPTION
The glibc version check implemented in commit 89fa4810f031 wont work on many distributions. The implemented check finds the version number by scanning the output of `ldd --version` with the regex /GLIBC (\d{1,3}.\d{1,3})/ - this works for debian and ubuntu, but not for Fedora, and RHEL/CentOS:

    $ podman run debian:latest ldd --version |head -1
    ldd (Debian GLIBC 2.36-9+deb12u3) 2.36

    $ podman run ubuntu:latest ldd --version |head -1
    ldd (Ubuntu GLIBC 2.35-0ubuntu3.5) 2.35

    $ podman run centos:7 ldd --version |head -1
    ldd (GNU libc) 2.17

    $ podman run fedora:latest ldd --version |head -1
    ldd (GNU libc) 2.38

Note that the output format "ldd (GNU libc) <version>" is the default for the ldd tool from binutils. Replacing "GNU libc" with a different string is done by defining PKGVERSION when building binutils which means the presence of GLIBC in this text is entirely dependent on the Linux distribution.

The problem can be fixed by parsing the version number at the end of the string, but I think it is better to use Python's platform.libc_ver() function.

Specify library name and version:  **nodejs**

Alternative to #17914.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
