### PR TITLE
libmodplug: add libcxx dependency for both shared and static builds

### DIFF
--- a/recipes/libmodplug/all/conanfile.py
+++ b/recipes/libmodplug/all/conanfile.py
@@ -70,6 +70,6 @@ class LibmodplugConan(ConanFile):
             self.cpp_info.system_libs.extend(["m"])
         if not self.options.shared:
             self.cpp_info.defines.append("MODPLUG_STATIC")
-            libcxx = stdcpp_library(self)
-            if libcxx:
-                self.cpp_info.system_libs.append(libcxx)
+        libcxx = stdcpp_library(self)
+        if libcxx:
+            self.cpp_info.system_libs.append(libcxx)

--- a/recipes/libmodplug/all/conanfile.py
+++ b/recipes/libmodplug/all/conanfile.py
@@ -70,6 +70,6 @@ class LibmodplugConan(ConanFile):
             self.cpp_info.system_libs.extend(["m"])
         if not self.options.shared:
             self.cpp_info.defines.append("MODPLUG_STATIC")
-        libcxx = stdcpp_library(self)
-        if libcxx:
-            self.cpp_info.system_libs.append(libcxx)
+            libcxx = stdcpp_library(self)
+            if libcxx:
+                self.cpp_info.system_libs.append(libcxx)

--- a/recipes/libmodplug/all/test_package/conanfile.py
+++ b/recipes/libmodplug/all/test_package/conanfile.py
@@ -9,6 +9,10 @@ class TestPackageConan(ConanFile):
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
     def layout(self):
         cmake_layout(self)
 

--- a/recipes/libmodplug/all/test_v1_package/conanfile.py
+++ b/recipes/libmodplug/all/test_v1_package/conanfile.py
@@ -6,6 +6,10 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
The macOS build in #21782 appears to be failing due to a missing libcxx dependency in this repo: https://c3i.jfrog.io/c3i/misc/summary.html?json=https://c3i.jfrog.io/c3i/misc/logs/pr/21782/5-macos-clang/sdl_mixer/2.6.3//summary.json

It only happens for shared builds, which correlates with the libcxx being only exported as a dependency for static builds in this recipe.

@SSE4 or @SpaceIm Can you maybe share your reasoning for only adding libcxx on static builds? This is frequently applied that way in other recipes as well.