### PR TITLE
[armadillo] Use lapack provided by openblas by default

### DIFF
--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -58,7 +58,7 @@ class ArmadilloConan(ConanFile):
         "shared": False,
         "fPIC": True,
         "use_blas": "openblas",
-        "use_lapack": False,
+        "use_lapack": "openblas",
         "use_hdf5": True,
         "use_superlu": False,
         "use_extern_rng": False,
@@ -102,11 +102,6 @@ class ArmadilloConan(ConanFile):
             self.options.rm_safe("fPIC")
 
         if self.options.use_blas == "openblas":
-            # Note that if you're relying on this to build LAPACK, you _must_ have
-            # a fortran compiler installed. If you don't, OpenBLAS will build successfully but
-            # without LAPACK support, which isn't obvious.
-            # This can be achieved by setting the FC environment variable or the conf tools.build:compiler_executables={"fortran": "/path/to/fortran"}
-            # in your conan profile.
             self.options["openblas"].build_lapack = (
                 self.options.use_lapack == "openblas"
             )
@@ -190,11 +185,11 @@ class ArmadilloConan(ConanFile):
         if self.options.use_hdf5 and Version(self.version) < "12":
             # Use the conan dependency if the system lib isn't being used
             # Libraries not required to be propagated transitively when the armadillo run-time wrapper is used
-            self.requires("hdf5/1.14.1", transitive_headers=True, transitive_libs=not self.options.use_wrapper)
+            self.requires("hdf5/1.14.3", transitive_headers=True, transitive_libs=not self.options.use_wrapper)
 
         if self.options.use_blas == "openblas":
             # Libraries not required to be propagated transitively when the armadillo run-time wrapper is used
-            self.requires("openblas/0.3.20", transitive_libs=not self.options.use_wrapper)
+            self.requires("openblas/0.3.25", transitive_libs=not self.options.use_wrapper)
         if (
             self.options.use_blas == "intel_mkl"
             and self.options.use_lapack == "intel_mkl"


### PR DESCRIPTION
* The CCI OpenBLAS package is now built with lapack by default for versions >= 0.3.25 as of https://github.com/conan-io/conan-center-index/pull/20894. Change the armadillo default to use openblas as lapack provider to make armadillo useful for default build configurations.
* Bump openblas and hdf5 dependencies

Specify library name and version:  **armadillo/12.6.4**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
