### PR TITLE
Add transitive_headers=True for oatpp-xxx requirements

### DIFF
--- a/recipes/oatpp-libressl/all/conanfile.py
+++ b/recipes/oatpp-libressl/all/conanfile.py
@@ -43,8 +43,8 @@ class OatppLibresslConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires(f"oatpp/{self.version}")
-        self.requires("libressl/3.5.3")
+        self.requires(f"oatpp/{self.version}", transitive_headers=True)
+        self.requires("libressl/3.5.3", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/oatpp-openssl/all/conanfile.py
+++ b/recipes/oatpp-openssl/all/conanfile.py
@@ -43,8 +43,8 @@ class OatppOpenSSLConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires(f"oatpp/{self.version}")
-        self.requires("openssl/[>=1.1 <4]")
+        self.requires(f"oatpp/{self.version}", transitive_headers=True)
+        self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/oatpp-sqlite/all/conanfile.py
+++ b/recipes/oatpp-sqlite/all/conanfile.py
@@ -43,7 +43,7 @@ class OatppsqliteConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires(f"oatpp/{self.version}")
+        self.requires(f"oatpp/{self.version}", transitive_headers=True)
         self.requires("sqlite3/3.39.4")
 
     def validate(self):

--- a/recipes/oatpp-swagger/all/conanfile.py
+++ b/recipes/oatpp-swagger/all/conanfile.py
@@ -43,7 +43,7 @@ class OatppSwaggerConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires(f"oatpp/{self.version}")
+        self.requires(f"oatpp/{self.version}", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/oatpp-websocket/all/conanfile.py
+++ b/recipes/oatpp-websocket/all/conanfile.py
@@ -43,7 +43,7 @@ class OatppWebSocketConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires(f"oatpp/{self.version}")
+        self.requires(f"oatpp/{self.version}", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Fixes #22205

oatpp satellite libraries need to depend on oatpp with transitive_headers=True.

Changed for oatpp-libressl, oatpp-openssl, oatpp-sqlite, oatpp-swagger and oatpp-websocket.

For oatpp-openssl and oatpp-libressl, I also added transitive_headers for the underlying ssl library.

Test packages for these libraries now all pass on my machine.

Specify library name and version:  **oatpp-swagger/1.3.0** (and others)

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
