### PR TITLE
(#22210) bazel: add version 5.4.1

### DIFF
--- a/recipes/bazel/all/conandata.yml
+++ b/recipes/bazel/all/conandata.yml
@@ -51,6 +51,32 @@ sources:
         url: "https://github.com/bazelbuild/bazel/releases/download/6.2.0/bazel-6.2.0-windows-arm64.exe"
         sha256: "3c23fccd3815933452c859e8482864598b6903d3143f9f18589915bf2c0dd2d4"
 
+  "5.4.1":
+    license:
+      url: "https://raw.githubusercontent.com/bazelbuild/bazel/5.4.1/LICENSE"
+      sha256: "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
+    Macos:
+      x86_64:
+        url: "https://github.com/bazelbuild/bazel/releases/download/5.4.1/bazel-5.4.1-darwin-x86_64"
+        sha256: "e8f796d67e9e4b54183c465443158dfb38bfe7df3626c1cfa0a6a3d9866047f9"
+      armv8:
+        url: "https://github.com/bazelbuild/bazel/releases/download/5.4.1/bazel-5.4.1-darwin-arm64"
+        sha256: "f2443a2131e832c2f12d448e673be7dad9cd2822066b4e2d4bd2d634bb2495e6"
+    Linux:
+      x86_64:
+        url: "https://github.com/bazelbuild/bazel/releases/download/5.4.1/bazel-5.4.1-linux-x86_64"
+        sha256: "5d90515f84b5ee1fd6ec22ee9e83103e77ed1a907ee5eec198fef3a5b45abf13"
+      armv8:
+        url: "https://github.com/bazelbuild/bazel/releases/download/5.4.1/bazel-5.4.1-linux-arm64"
+        sha256: "431dfaf5c0bd264b5753ae7a57f262137394c214c5e83651218887a9155dd010"
+    Windows:
+      x86_64:
+        url: "https://github.com/bazelbuild/bazel/releases/download/5.4.1/bazel-5.4.1-windows-x86_64.exe"
+        sha256: "f44329c91ee0ca2ea8526f9c0fecb65f1aa483e658f9b09831b16a0e70e16b51"
+      armv8:
+        url: "https://github.com/bazelbuild/bazel/releases/download/5.4.1/bazel-5.4.1-windows-arm64.exe"
+        sha256: "1e273c20dfa8493bf21b002614592a6cb3aa9eabe8b30eda96f8a517fca1a619"
+
   "4.0.0":
     license:
       url: "https://raw.githubusercontent.com/bazelbuild/bazel/4.0.0/LICENSE"

--- a/recipes/bazel/config.yml
+++ b/recipes/bazel/config.yml
@@ -3,5 +3,7 @@ versions:
     folder: all
   "6.2.0":
     folder: all
+  "5.4.1":
+    folder: all
   "4.0.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **bazel/5.4.1**
_fixes #22210_

Reason:
The tensorflow_cc package does not support current versions and requires versions >= 4.2.2 and <= 5.99.0
Version 5.4.1 is the latest in this required range (>= 4.2.2 and <= 5.99.0).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
