### PR TITLE
caf: add version 0.19.5

### DIFF
--- a/recipes/caf/all/conandata.yml
+++ b/recipes/caf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.19.5":
+    url: "https://github.com/actor-framework/actor-framework/archive/0.19.5.tar.gz"
+    sha256: "7eedfa9bc4d508185de12417f552f360812103a279ce9def568bffa8c512cbb4"
   "0.19.4":
     url: "https://github.com/actor-framework/actor-framework/archive/0.19.4.tar.gz"
     sha256: "114d43e3a7a2305ca1d2106cd0daeff471564f62b90db1e453ba9eb5c47c02f6"

--- a/recipes/caf/config.yml
+++ b/recipes/caf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.19.5":
+    folder: all
   "0.19.4":
     folder: all
   "0.19.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)

Specify library name and version:  **caf/0.19.5**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
