### PR TITLE
Fix onetbb compilation issue

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -80,8 +80,6 @@ class OneTBBConan(ConanFile):
     def configure(self):
         if Version(self.version) >= "2021.6.0" and not self.options.tbbmalloc:
             self.options.rm_safe("tbbproxy")
-        if self._tbbbind_explicit_hwloc:
-            self.options["hwloc"].shared = True
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **onetbb/2021.6.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Because hwloc package is published only as a shared-library package_type there is no shared option in hwloc conanfile which caused onetbb compilation issue. 
Comment from hwloc conanfile:
`# INFO: In order to prevent OneTBB missing package error, we build only shared library for hwloc.`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
