### PR TITLE
boost 1.83.0: fix windows without NOMINMAX

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -67,6 +67,10 @@ patches:
     - patch_file: "patches/1.82.0-locale-iconv-library-option.patch"
       patch_description: "Optional flag to specify iconv from either libc of libiconv"
       patch_type: "conan"
+    - patch_file: "patches/1.83.0-locale-msvc.patch"
+      patch_description: "Fix compilation on windows when NOMINMAX is not defined"
+      patch_type: "official"
+      patch_source: "https://github.com/boostorg/locale/pull/189"
   "1.82.0":
     - patch_file: "patches/1.82.0-locale-iconv-library-option.patch"
       patch_description: "Optional flag to specify iconv from either libc of libiconv"

--- a/recipes/boost/all/patches/1.83.0-locale-msvc.patch
+++ b/recipes/boost/all/patches/1.83.0-locale-msvc.patch
@@ -1,0 +1,22 @@
+From 0552ffc29ff11e4fe130b7143ea6ac2bee7b15c6 Mon Sep 17 00:00:00 2001
+From: wevsty <ty@wevs.org>
+Date: Sat, 12 Aug 2023 22:13:48 +0800
+Subject: [PATCH] fix build error on MSVC
+
+---
+ boost/locale/util/string.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/boost/locale/util/string.hpp b/boost/locale/util/string.hpp
+index 9ab9521c..ba066bd4 100644
+--- a/boost/locale/util/string.hpp
++++ b/boost/locale/util/string.hpp
+@@ -38,7 +38,7 @@ namespace boost { namespace locale { namespace util {
+     /// Cast an unsigned char to a (possibly signed) char avoiding implementation defined behavior
+     constexpr char to_char(unsigned char c)
+     {
+-        return static_cast<char>((c - std::numeric_limits<char>::min()) + std::numeric_limits<char>::min());
++        return static_cast<char>((c - (std::numeric_limits<char>::min)()) + (std::numeric_limits<char>::min)());
+     }
+ 
+ }}} // namespace boost::locale::util


### PR DESCRIPTION
Specify library name and version:  **boost/1.83.0**

unblocks:
- https://github.com/conan-io/conan-center-index/pull/22239
- https://github.com/conan-io/conan-center-index/pull/21536
- https://github.com/conan-io/conan-center-index/pull/21334
- https://github.com/conan-io/conan-center-index/pull/19506

And probably most windows consumers of boost 1.83.0

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
