### PR TITLE
base64: add version 0.5.2

### DIFF
--- a/recipes/base64/all/conandata.yml
+++ b/recipes/base64/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.5.2":
+    url: "https://github.com/aklomp/base64/archive/v0.5.2.tar.gz"
+    sha256: "723a0f9f4cf44cf79e97bcc315ec8f85e52eb104c8882942c3f2fba95acc080d"
   "0.5.1":
     url: "https://github.com/aklomp/base64/archive/v0.5.1.tar.gz"
     sha256: "35fd9400ce85ba5fc5455b3f1c8d0078d084ad246bd808315fd01ea8f2876dbf"

--- a/recipes/base64/config.yml
+++ b/recipes/base64/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.5.2":
+    folder: all
   "0.5.1":
     folder: all
   "0.5.0":


### PR DESCRIPTION
Specify library name and version:  **base64/0.5.2**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
