### PR TITLE
perfetto: Bump version: 41.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "41.0":
+    url: "https://github.com/google/perfetto/archive/refs/tags/v41.0.tar.gz"
+    sha256: "4c8fe8a609fcc77ca653ec85f387ab6c3a048fcd8df9275a1aa8087984b89db8"
   "40.0":
     url: "https://github.com/google/perfetto/archive/refs/tags/v40.0.tar.gz"
     sha256: "bd78f0165e66026c31c8c39221ed2863697a8bba5cd39b12e4b43d0b7f71626f"

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "41.0":
+    folder: all
   "40.0":
     folder: all
   "39.0":


### PR DESCRIPTION
Specify library name and version:  **perfetto/41.0**

```
v41.0 - 2023-01-02:
  Tracing service and probes:
    * Added support for ADB_SERVER_SOCKET in the websocket bridge.
    * Added support for reading Pressure Stall Information (PSI) from the kernel.
  Trace Processor:
    * Added capability to control trace processor using stdin/stdout when using
      shell binary. This acts as a simpler alternative to the existing HTTP
      control API.
    * Fixed multiple edge-case issues in RestoreInitialTables.
  SDK:
    * Fixed a long standing bug that caused the last TrackEvent event for each
      thread to be lost during scraping. The fix works with old versions of the
      tracing service.
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
