### PR TITLE
restinio: bump to `fmt/10.2.0`

### DIFF
--- a/recipes/restinio/v0.7/conanfile.py
+++ b/recipes/restinio/v0.7/conanfile.py
@@ -36,7 +36,7 @@ class RestinioConan(ConanFile):
 
     def requirements(self):
         self.requires("llhttp/9.1.3")
-        self.requires("fmt/10.1.1")
+        self.requires("fmt/10.2.0")
         self.requires("expected-lite/0.6.3")
 
         if self.options.asio == "standalone":


### PR DESCRIPTION
Specify library name and version:  **restinio/0.7.1**

This PR bumps `fmt` to `10.2.0` to match other deps in conan center (i.e. `spdlog`, etc..) so as to avoid needing an `override`.


<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
