### PR TITLE
cryptopp: add patch for CVE-2023-50980

### DIFF
--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -49,6 +49,11 @@ sources:
       url: "https://github.com/noloader/cryptopp-cmake/archive/CRYPTOPP_8_2_0.tar.gz"
       sha256: "f41f6a32b1177c094c3ef97423916713c902d0ac26cbee30ec70b1e8ab0e6fba"
 patches:
+  "8.9.0":
+    - patch_file: "patches/8.9.0-0001-cve-2023-50980.patch"
+      patch_description: "Validate PolynomialMod2 coefficients (CVE-2023-50980)"
+      patch_type: "vulnerability"
+      patch_source: "https://github.com/weidai11/cryptopp/issues/1248"
   "8.7.0":
     - patch_file: "patches/8.7.0-0001-fix-msvc-arm64.patch"
   "8.6.0":

--- a/recipes/cryptopp/all/patches/8.9.0-0001-cve-2023-50980.patch
+++ b/recipes/cryptopp/all/patches/8.9.0-0001-cve-2023-50980.patch
@@ -1,0 +1,78 @@
+https://github.com/weidai11/cryptopp/issues/1248
+https://github.com/weidai11/cryptopp/commit/eb383b8e1622
+https://github.com/weidai11/cryptopp/commit/641ae35258de
+https://github.com/weidai11/cryptopp/commit/93208e83937a
+--- a/gf2n.cpp
++++ b/gf2n.cpp
+@@ -135,6 +135,14 @@ PolynomialMod2 PolynomialMod2::Monomial(size_t i)
+ 
+ PolynomialMod2 PolynomialMod2::Trinomial(size_t t0, size_t t1, size_t t2)
+ {
++	// Asserts and checks due to Bing Shi
++	CRYPTOPP_ASSERT(t0 > t1);
++	CRYPTOPP_ASSERT(t1 > t2);
++
++	// The test is relaxed because of ECIES<EC2N>. The high order exponent is t0, but the other exponents are not in descending order.
++	if (t1 > t0 || t2 > t0)
++		throw InvalidArgument("PolynomialMod2: exponents must be in descending order");
++
+ 	PolynomialMod2 r((word)0, t0+1);
+ 	r.SetBit(t0);
+ 	r.SetBit(t1);
+@@ -144,6 +152,16 @@ PolynomialMod2 PolynomialMod2::Trinomial(size_t t0, size_t t1, size_t t2)
+ 
+ PolynomialMod2 PolynomialMod2::Pentanomial(size_t t0, size_t t1, size_t t2, size_t t3, size_t t4)
+ {
++	// Asserts and checks due to Bing Shi
++	CRYPTOPP_ASSERT(t0 > t1);
++	CRYPTOPP_ASSERT(t1 > t2);
++	CRYPTOPP_ASSERT(t2 > t3);
++	CRYPTOPP_ASSERT(t3 > t4);
++
++	// The test is relaxed because of ECIES<EC2N>. The high order exponent is t0, but the other exponents are not in descending order.
++	if (t1 > t0 || t2 > t0 || t3 > t0 || t4 > t0)
++		throw InvalidArgument("PolynomialMod2: exponents must be in descending order");
++
+ 	PolynomialMod2 r((word)0, t0+1);
+ 	r.SetBit(t0);
+ 	r.SetBit(t1);
+@@ -655,7 +673,12 @@ GF2NT::GF2NT(unsigned int c0, unsigned int c1, unsigned int c2)
+ 	, t0(c0), t1(c1)
+ 	, result((word)0, m)
+ {
++	// Asserts and checks due to Bing Shi
+ 	CRYPTOPP_ASSERT(c0 > c1 && c1 > c2 && c2==0);
++
++	// The test is relaxed because of ECIES<EC2N>. The high order exponent is t0, but the other exponents are not in descending order.
++	if (c1 > c0 || c2 > c0)
++		throw InvalidArgument("GF2NT: exponents must be in descending order");
+ }
+ 
+ const GF2NT::Element& GF2NT::MultiplicativeInverse(const Element &a) const
+@@ -964,7 +987,12 @@ GF2NP * BERDecodeGF2NP(BufferedTransformation &bt)
+ GF2NT233::GF2NT233(unsigned int c0, unsigned int c1, unsigned int c2)
+ 	: GF2NT(c0, c1, c2)
+ {
++	// Asserts and checks due to Bing Shi
+ 	CRYPTOPP_ASSERT(c0 > c1 && c1 > c2 && c2==0);
++
++	// The test is relaxed because of ECIES<EC2N>. The high order exponent is t0, but the other exponents are not in descending order.
++	if (c1 > c0 || c2 > c0)
++		throw InvalidArgument("GF2NT233: exponents must be in descending order");
+ }
+ 
+ const GF2NT::Element& GF2NT233::Multiply(const Element &a, const Element &b) const
+--- a/gf2n.h
++++ b/gf2n.h
+@@ -69,9 +69,11 @@ public:
+ 		static PolynomialMod2 CRYPTOPP_API Monomial(size_t i);
+ 		/// \brief Provides x^t0 + x^t1 + x^t2
+ 		/// \return x^t0 + x^t1 + x^t2
++		/// \pre The coefficients should be provided in descending order. That is, <pre>t0 > t1 > t2<pre>.
+ 		static PolynomialMod2 CRYPTOPP_API Trinomial(size_t t0, size_t t1, size_t t2);
+ 		/// \brief Provides x^t0 + x^t1 + x^t2 + x^t3 + x^t4
+ 		/// \return x^t0 + x^t1 + x^t2 + x^t3 + x^t4
++		/// \pre The coefficients should be provided in descending order. That is, <pre>t0 > t1 > t2 > t3 > t4<pre>.
+ 		static PolynomialMod2 CRYPTOPP_API Pentanomial(size_t t0, size_t t1, size_t t2, size_t t3, size_t t4);
+ 		/// \brief Provides x^(n-1) + ... + x + 1
+ 		/// \return x^(n-1) + ... + x + 1


### PR DESCRIPTION
Specify library name and version:  **cryptopp/8.9.0**

Add patch for CVE-2023-50980 that is based on 3 commits:
https://github.com/weidai11/cryptopp/commit/eb383b8e1622
https://github.com/weidai11/cryptopp/commit/641ae35258de
https://github.com/weidai11/cryptopp/commit/93208e83937a

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
