### PR TITLE
rapidjson/*: Fix incorrect `package_id_embed_mode` value.

### DIFF
--- a/recipes/rapidjson/all/conanfile.py
+++ b/recipes/rapidjson/all/conanfile.py
@@ -22,26 +22,12 @@ class RapidjsonConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def source(self):
-        get(
-            self,
-            **self.conan_data["sources"][self.version],
-            strip_root=True,
-            destination=self.source_folder
-        )
+        get(self, **self.conan_data["sources"][self.version], strip_root=True,
+                    destination=self.source_folder)
 
     def package(self):
-        copy(
-            self,
-            pattern="license.txt",
-            src=self.source_folder,
-            dst=os.path.join(self.package_folder, "licenses"),
-        )
-        copy(
-            self,
-            pattern="*",
-            src=os.path.join(self.source_folder, "include"),
-            dst=os.path.join(self.package_folder, "include"),
-        )
+        copy(self, pattern="license.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, pattern="*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
 
     def package_id(self):
         self.info.clear()

--- a/recipes/rapidjson/all/conanfile.py
+++ b/recipes/rapidjson/all/conanfile.py
@@ -14,7 +14,7 @@ class RapidjsonConan(ConanFile):
     homepage = "http://rapidjson.org"
     license = "MIT"
     package_type = "header-library"
-    package_id_embed_mode = "minor"
+    package_id_embed_mode = "minor_mode"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -22,12 +22,26 @@ class RapidjsonConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True,
-                    destination=self.source_folder)
+        get(
+            self,
+            **self.conan_data["sources"][self.version],
+            strip_root=True,
+            destination=self.source_folder
+        )
 
     def package(self):
-        copy(self, pattern="license.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        copy(self, pattern="*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+        copy(
+            self,
+            pattern="license.txt",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        copy(
+            self,
+            pattern="*",
+            src=os.path.join(self.source_folder, "include"),
+            dst=os.path.join(self.package_folder, "include"),
+        )
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Specify library name and version:  **rapidjson/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The last update to the rapidjson recipe included a `package_id_embed_mode` value of `minor` instead of `minor_mode` which caused build errors such as `AttributeError: 'RequirementInfo' object has no attribute 'minor'` and `'minor' is not a known package_id_mode`.

Problem found in conjunction with @matthewkandiah-sonocent

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
