### PR TITLE
gperftools: set pkg_config_name for components

### DIFF
--- a/recipes/gperftools/all/conanfile.py
+++ b/recipes/gperftools/all/conanfile.py
@@ -184,12 +184,7 @@ class GperftoolsConan(ConanFile):
         autotools.make()
 
     def package(self):
-        copy(
-            self,
-            pattern="COPYING",
-            dst=os.path.join(self.package_folder, "licenses"),
-            src=self.source_folder,
-        )
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
         autotools = Autotools(self)
         autotools.install()
 
@@ -200,6 +195,7 @@ class GperftoolsConan(ConanFile):
 
     def _add_component(self, lib):
         self.cpp_info.components[lib].libs = [lib]
+        self.cpp_info.components[lib].set_property("pkg_config_name", f"lib{lib}")
 
     def package_info(self):
         self._add_component("tcmalloc_minimal")
@@ -217,6 +213,8 @@ class GperftoolsConan(ConanFile):
         for component in self.cpp_info.components.values():
             if self.settings.os in ["Linux", "FreeBSD"]:
                 component.system_libs.extend(["pthread", "m"])
+                component.cflags.append("-pthread")
+                component.cxxflags.append("-pthread")
             if self.options.get_safe("enable_libunwind"):
                 component.requires.append("libunwind::libunwind")
 


### PR DESCRIPTION
The gperftools project exports a .pc file for each of the libraries and also sets `-pthread` in addition to `-lpthread`.
https://github.com/gperftools/gperftools/blob/gperftools-2.15/CMakeLists.txt#L1468-L1484

Required for `jxl`: https://github.com/libjxl/libjxl/blob/v0.9.1/lib/jxl.cmake#L176-L177