### PR TITLE
gperftools: fix missing libcxx dependency

### DIFF
--- a/recipes/gperftools/all/conanfile.py
+++ b/recipes/gperftools/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name, is_apple_os, XCRun
-from conan.tools.build import cross_building, check_min_cppstd
+from conan.tools.build import cross_building, check_min_cppstd, stdcpp_library
 from conan.tools.cmake import cmake_layout
 from conan.tools.env import VirtualRunEnv
 from conan.tools.files import get, copy, rm, rmdir, replace_in_file
@@ -196,6 +196,8 @@ class GperftoolsConan(ConanFile):
     def _add_component(self, lib):
         self.cpp_info.components[lib].libs = [lib]
         self.cpp_info.components[lib].set_property("pkg_config_name", f"lib{lib}")
+        if stdcpp_library(self):
+            self.cpp_info.components[lib].system_libs.append(stdcpp_library(self))
 
     def package_info(self):
         self._add_component("tcmalloc_minimal")

--- a/recipes/gperftools/all/test_package/CMakeLists.txt
+++ b/recipes/gperftools/all/test_package/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package LANGUAGES CXX)
+project(test_package LANGUAGES C)
 
 find_package(gperftools REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE gperftools::gperftools)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 
-add_executable(${PROJECT_NAME}_minimal test_package.cpp)
+add_executable(${PROJECT_NAME}_minimal test_package.c)
 target_link_libraries(${PROJECT_NAME}_minimal PRIVATE gperftools::tcmalloc_minimal)
-target_compile_features(${PROJECT_NAME}_minimal PRIVATE cxx_std_11)
+

--- a/recipes/gperftools/all/test_package/test_package.c
+++ b/recipes/gperftools/all/test_package/test_package.c
@@ -1,12 +1,12 @@
 #include <gperftools/tcmalloc.h>
 
-#include <cassert>
-#include <cstdlib>
-#include <iostream>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 int main() {
     void *p = tc_malloc(100);
     tc_free(p);
-    std::cout << TC_VERSION_STRING << std::endl;
+    puts(TC_VERSION_STRING);
     return p == 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/recipes/gperftools/all/test_package/test_package.c
+++ b/recipes/gperftools/all/test_package/test_package.c
@@ -7,6 +7,6 @@
 int main() {
     void *p = tc_malloc(100);
     tc_free(p);
-    puts(TC_VERSION_STRING);
+    puts(tc_version(NULL, NULL, NULL));
     return p == 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
Fixes the build failure in the jxl recipe (#18812):
```
/usr/bin/ld: /home/conan/w/prod-v1/bsr/90439/bedfd/.conan/data/gperftools/2.13.0/_/_/package/b911f48570f9bb2902d9e83b2b9ebf9d376c8c56/lib/libtcmalloc_minimal.a(libtcmalloc_minimal_la-tcmalloc.o): undefined reference to symbol '_ZSt20__throw_length_errorPKc@@GLIBCXX_3.4'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/libstdc++.so: error adding symbols: DSO missing from command line
```

I can reproduce it in this recipe as well after switching test_package to pure C and building statically without the libcxx dependency added.
