### PR TITLE
aws-c-common: add version 0.9.12

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.12":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.9.12.tar.gz"
+    sha256: "10ef8f5629fb6ac24aa4893f3bb9a8480997e96a58c81043e019bf6b149f4332"
   "0.9.6":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.9.6.tar.gz"
     sha256: "5c30cc066a7f05fb8e4728f93aeed0e0e2698197a6df76237ac4e1200977d090"

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.12":
+    folder: all
   "0.9.6":
     folder: all
   "0.9.3":


### PR DESCRIPTION
Specify library name and version:  **aws-c-common/0.9.12**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Import the latest version of this library because I am working on this issue: https://github.com/conan-io/conan-center-index/issues/2275

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
