### PR TITLE
aws-c-sdkutils: add v0.1.13, use version range for dependencies

### DIFF
--- a/recipes/aws-c-sdkutils/all/conandata.yml
+++ b/recipes/aws-c-sdkutils/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.13":
+    url: "https://github.com/awslabs/aws-c-sdkutils/archive/v0.1.13.tar.gz"
+    sha256: "fb22b1d12172afa07214ba18ad3c3b71244cb3d31c81c439b0a6625745c1fef9"
   "0.1.12":
     url: "https://github.com/awslabs/aws-c-sdkutils/archive/v0.1.12.tar.gz"
     sha256: "c876c3ce2918f1181c24829f599c8f06e29733f0bd6556d4c4fb523390561316"

--- a/recipes/aws-c-sdkutils/all/conanfile.py
+++ b/recipes/aws-c-sdkutils/all/conanfile.py
@@ -40,10 +40,14 @@ class AwsCSDKUtils(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) <= "0.1.3":
+        if Version(self.version) < "0.1.12":
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
-        else:
+        elif Version(self.version) == "0.1.12":
+            # [>=0.9.4 <=0.9.10]
             self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
+        else:
+            # [>=0.9.10]
+            self.requires("aws-c-common/0.9.12", transitive_headers=True, transitive_libs=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/aws-c-sdkutils/config.yml
+++ b/recipes/aws-c-sdkutils/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.1.13":
+    folder: all
   "0.1.12":
     folder: all
   "0.1.3":


### PR DESCRIPTION
Specify library name and version:  **aws-c-sdkutils/0.1.13**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Update this dependency because I want to update `aws-crt-cpp` to the latest version. Here are related issues:
- https://github.com/conan-io/conan-center-index/issues/22404
- https://github.com/conan-io/conan-center-index/issues/2275

The version range is based on the submodules used in `aws-crt-cpp`. I wrote a script to collect the version mapping between `aws-c-sdkutils` and `aws-c-common`. In  the following mapping, keys are the versions of `aws-c-sdkutils` and values are the versions of `was-c-common`.

```
{
  'v0.1.10': {'v0.8.21'},
  'v0.1.11': {'v0.9.3', 'v0.9.0', 'v0.8.23'},
  'v0.1.12': {'v0.9.10', 'v0.9.4', 'v0.9.7', 'v0.9.9'},
  'v0.1.13': {'v0.9.12', 'v0.9.10'},
  'v0.1.7': {'v0.8.12'},
  'v0.1.8': {'v0.8.17', 'v0.8.15'},
  'v0.1.9': {'v0.8.19'},
}
```

The change of version range in this PR is based on it.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
