### PR TITLE
rotor: add version 0.26, several improvements

### DIFF
--- a/recipes/rotor/all/CMakeLists.txt
+++ b/recipes/rotor/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.8)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory(source_subfolder/)

--- a/recipes/rotor/all/conandata.yml
+++ b/recipes/rotor/all/conandata.yml
@@ -1,13 +1,16 @@
 sources:
-  "0.21":
-    url: "https://github.com/basiliscos/cpp-rotor/archive/refs/tags/v0.21.tar.gz"
-    sha256: "1a5bc1919fe1052c8ad148707708b19fad903ff3db33015710cfb4f89baab8fa"
-  "0.23":
-    url: "https://github.com/basiliscos/cpp-rotor/archive/refs/tags/v0.23.tar.gz"
-    sha256: "8f89f9d0a561ab7cc90253cc761d8b5a78887c99ef488e75ae4c49abb44ddac4"
-  "0.24":
-    url: "https://github.com/basiliscos/cpp-rotor/archive/refs/tags/v0.24.tar.gz"
-    sha256: "3a360d6ce7c743b740b9c6c4063493f67298690fc51e29efa19811bb3d11fa86"
+  "0.26":
+    url: "https://github.com/basiliscos/cpp-rotor/archive/refs/tags/v0.26.tar.gz"
+    sha256: "495e8556dad36e05452bf7b0463cc3bca122e15aa31ae2cb2d29a0ecb34ab4aa"
   "0.25":
     url: "https://github.com/basiliscos/cpp-rotor/archive/refs/tags/v0.25.tar.gz"
     sha256: "b1de95937adb8d7a9beb93bc4956d8e28ff64a6c0a898e7ce12b22a224bb8f6f"
+  "0.24":
+    url: "https://github.com/basiliscos/cpp-rotor/archive/refs/tags/v0.24.tar.gz"
+    sha256: "3a360d6ce7c743b740b9c6c4063493f67298690fc51e29efa19811bb3d11fa86"
+  "0.23":
+    url: "https://github.com/basiliscos/cpp-rotor/archive/refs/tags/v0.23.tar.gz"
+    sha256: "8f89f9d0a561ab7cc90253cc761d8b5a78887c99ef488e75ae4c49abb44ddac4"
+  "0.21":
+    url: "https://github.com/basiliscos/cpp-rotor/archive/refs/tags/v0.21.tar.gz"
+    sha256: "1a5bc1919fe1052c8ad148707708b19fad903ff3db33015710cfb4f89baab8fa"

--- a/recipes/rotor/all/conanfile.py
+++ b/recipes/rotor/all/conanfile.py
@@ -3,21 +3,19 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, rmdir, copy
+from conan.tools.files import get, rmdir, copy
 from conan.tools.cmake import CMakeToolchain, CMake, CMakeDeps, cmake_layout
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 class RotorConan(ConanFile):
     name = "rotor"
+    description = "Event loop friendly C++ actor micro-framework, supervisable"
     license = "MIT"
-    homepage = "https://github.com/basiliscos/cpp-rotor"
     url = "https://github.com/conan-io/conan-center-index"
-    description = (
-        "Event loop friendly C++ actor micro-framework, supervisable"
-    )
+    homepage = "https://github.com/basiliscos/cpp-rotor"
     topics = ("concurrency", "actor-framework", "actors", "actor-model", "erlang", "supervising", "supervisor")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
@@ -25,6 +23,7 @@ class RotorConan(ConanFile):
         "enable_asio": [True, False],
         "enable_thread": [True, False],
         "multithreading": [True, False],  # enables multithreading support
+        "enable_ev": [True, False],
     }
     default_options = {
         "fPIC": True,
@@ -32,27 +31,59 @@ class RotorConan(ConanFile):
         "enable_asio": False,
         "enable_thread": False,
         "multithreading": True,
+        "enable_ev": False,
     }
 
-    def export_sources(self):
-        export_conandata_patches(self)
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "clang": "6",
+            "apple-clang": "10",
+            "Visual Studio": "15",
+            "msvc": "191",
+        }
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "0.26":
+            del self.options.enable_ev
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-
-    def requirements(self):
-        self.requires("boost/1.81.0")
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("boost/1.83.0", transitive_headers=True)
+        if self.options.get_safe("enable_ev", False):
+            self.requires("libev/4.33")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+        if self.options.shared and Version(self.version) < "0.23":
+            raise ConanInvalidConfiguration("shared option is available from v0.23")
+
+    def build_requirements(self):
+        if Version(self.version) >= "0.26":
+            self.tool_requires("cmake/[>=3.23 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -60,45 +91,16 @@ class RotorConan(ConanFile):
         tc.variables["BUILD_THREAD"] = self.options.enable_thread
         tc.variables["BUILD_THREAD_UNSAFE"] = not self.options.multithreading
         tc.variables["BUILD_TESTING"] = False
+        if Version(self.version) >= "0.26":
+            tc.variables["BUILD_EV"] = self.options.enable_ev
         tc.generate()
-        tc = CMakeDeps(self)
-        tc.generate()
-
-    def validate(self):
-        minimal_cpp_standard = "17"
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, minimal_cpp_standard)
-        minimal_version = {
-            "gcc": "7",
-            "clang": "6",
-            "apple-clang": "10",
-            "Visual Studio": "15"
-        }
-        compiler = str(self.settings.compiler)
-        if compiler not in minimal_version:
-            self.output.warn(
-                f"{self.ref} recipe lacks information about the {compiler} compiler standard version support")
-            self.output.warn(
-                f"{self.ref} requires a compiler that supports at least C++{minimal_cpp_standard}")
-            return
-
-        compiler_version = Version(self.settings.compiler.version)
-        if compiler_version < minimal_version[compiler]:
-            raise ConanInvalidConfiguration(f"{self.ref} requires a compiler that supports at least C++{minimal_cpp_standard}")
-
-        if self.options.shared and Version(self.version) < "0.23":
-            raise ConanInvalidConfiguration("shared option is available from v0.23")
-
+        dpes = CMakeDeps(self)
+        dpes.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
-
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
 
     def package(self):
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
@@ -121,5 +123,6 @@ class RotorConan(ConanFile):
             self.cpp_info.components["thread"].libs = ["rotor_thread"]
             self.cpp_info.components["thread"].requires = ["core"]
 
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.names["cmake_find_package"] = "rotor"
+        if self.options.get_safe("enable_ev", False):
+            self.cpp_info.components["ev"].libs = ["rotor_ev"]
+            self.cpp_info.components["ev"].requires = ["core", "libev::libev"]

--- a/recipes/rotor/all/conanfile.py
+++ b/recipes/rotor/all/conanfile.py
@@ -111,6 +111,8 @@ class RotorConan(ConanFile):
     def package_info(self):
         self.cpp_info.components["core"].libs = ["rotor"]
         self.cpp_info.components["core"].requires = ["boost::date_time", "boost::system", "boost::regex"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["core"].system_libs.append("m")
 
         if not self.options.multithreading:
             self.cpp_info.components["core"].defines.append("BUILD_THREAD_UNSAFE")

--- a/recipes/rotor/all/test_package/CMakeLists.txt
+++ b/recipes/rotor/all/test_package/CMakeLists.txt
@@ -1,12 +1,10 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-find_package("rotor" REQUIRED)
+find_package(rotor REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE rotor::core)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-target_link_libraries(${PROJECT_NAME} rotor::core)
 
 

--- a/recipes/rotor/all/test_package/conanfile.py
+++ b/recipes/rotor/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,7 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
-
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/rotor/config.yml
+++ b/recipes/rotor/config.yml
@@ -1,9 +1,11 @@
 versions:
-  "0.21":
+  "0.26":
     folder: all
-  "0.23":
+  "0.25":
     folder: all
   "0.24":
     folder: all
-  "0.25":
+  "0.23":
+    folder: all
+  "0.21":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **rotor/***

- add version 0.26 which introduces new option `enable_ev` with libev
- require cmake since 0.26
- update boost
- sort descending by version
- remove v1 features
- remove patch functions
- add package_type
- use `rm_safe`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
