### PR TITLE
cairo: Fix cross-compilation when using Meson

### DIFF
--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -4,6 +4,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
+from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, replace_in_file, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
@@ -188,6 +189,9 @@ class CairoConan(ConanFile):
 
         meson = MesonToolchain(self)
         meson.project_options.update(options)
+
+        if cross_building(self):
+            meson.properties["ipc_rmid_deferred_release"] = self.settings.os == "Linux"
 
         if is_apple_os(self) and Version(self.version) < "1.17.6":
             # This was fixed in the meson build from 1.17.6


### PR DESCRIPTION
Set `ipc_rmid_deferred_release` property when cross building. Setting this according to runtime behavior is impossible when cross-compiling. Refer to https://gitlab.freedesktop.org/cairo/cairo/-/issues/408. To fix this, set the property `ipc_rmid_deferred_release`. According to the discussion in the issue, this should at least be enabled on Linux. Since other systems may behave differently, this is disabled otherwise.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
