### PR TITLE
jasper: add version 4.1.2

### DIFF
--- a/recipes/jasper/all/conandata.yml
+++ b/recipes/jasper/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.1.2":
+    url: "https://github.com/jasper-software/jasper/releases/download/version-4.1.2/jasper-4.1.2.tar.gz"
+    sha256: "22392e439b87c79aaf8689ec79a286a7147e811c4bee34edf3d0b239798d672b"
   "4.1.1":
     url: "https://github.com/jasper-software/jasper/releases/download/version-4.1.1/jasper-4.1.1.tar.gz"
     sha256: "03ba86823f8798f3f60a5a34e36f3eff9e9cbd76175643a33d4aac7c0390240a"
@@ -15,6 +18,14 @@ sources:
     url: "https://github.com/jasper-software/jasper/releases/download/version-2.0.33/jasper-2.0.33.tar.gz"
     sha256: "28d28290cc2eaf70c8756d391ed8bcc8ab809a895b9a67ea6e89da23a611801a"
 patches:
+  "4.1.2":
+    - patch_file: "patches/4.1.1-0001-skip-rpath.patch"
+      patch_description: "Do not enforce rpath configuration"
+      patch_source: "https://github.com/jasper-software/jasper/pull/347"
+      patch_type: "conan"
+    - patch_file: "patches/4.1.1-0003-deterministic-libname.patch"
+      patch_description: "No generator dependent libname"
+      patch_type: "conan"
   "4.1.1":
     - patch_file: "patches/4.1.1-0001-skip-rpath.patch"
       patch_description: "Do not enforce rpath configuration"

--- a/recipes/jasper/config.yml
+++ b/recipes/jasper/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.1.2":
+    folder: all
   "4.1.1":
     folder: all
   "4.1.0":


### PR DESCRIPTION
Specify library name and version:  **jasper/4.1.2**

This version fixed [CVE-2023-51257](https://github.com/advisories/GHSA-c74w-77jp-9c48).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
