### PR TITLE
libmount: Make the libblkid and libmount libraries separate components

### DIFF
--- a/recipes/libmount/all/conanfile.py
+++ b/recipes/libmount/all/conanfile.py
@@ -72,7 +72,11 @@ class LibmountConan(ConanFile):
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
-        self.cpp_info.libs = ["mount", "blkid"]
-        self.cpp_info.system_libs = ["rt"]
-        self.cpp_info.includedirs.append(os.path.join("include", "libmount"))
-        self.cpp_info.set_property("pkg_config_name", "mount")
+        self.cpp_info.components["libblkid"].libs = ["blkid"]
+        self.cpp_info.components["libblkid"].set_property("pkg_config_name", "blkid")
+
+        self.cpp_info.components["libmount"].libs = ["mount"]
+        self.cpp_info.components["libmount"].system_libs = ["rt"]
+        self.cpp_info.components["libmount"].includedirs.append(os.path.join("include", "libmount"))
+        self.cpp_info.components["libmount"].set_property("pkg_config_name", "mount")
+        self.cpp_info.components["libmount"].requires = ["libblkid"]


### PR DESCRIPTION
Adding the eudev package, #20335, requires `libblkid` only. Adding a separate libblkid recipe, PR #20373, hasn't gotten anywhere yet. This PR uses an alternative approach and separates the libraries. Each library is split into its own component.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
