### PR TITLE
aws-c-cal: fix dependency version conflict

### DIFF
--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -50,8 +50,11 @@ class AwsCCal(ConanFile):
     def requirements(self):
         if Version(self.version) <= "0.5.20":
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
-        else:
+        elif Version(self.version) <= "0.6.1":
             self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
+        else:
+            # [>=0.9.7]
+            self.requires("aws-c-common/0.9.12", transitive_headers=True, transitive_libs=True)
         if self._needs_openssl:
             self.requires("openssl/[>=1.1 <4]")
 


### PR DESCRIPTION
Specify library name and version:  **aws-c-cal/0.6.9**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


After adding `was-c-common/0.9.12`, I tried to use this version in `aws-c-io` but got a build failure. It is because the dependency of `aws-c-io`: `aws-c-cal` is hard coded to use `aws-c-common/0.9.6`. So, I filed this PR to adjust the version range of the dependencies.

Related PR: https://github.com/conan-io/conan-center-index/pull/22421

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
