### PR TITLE
Update CI Conan 1.x configurations

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -85,7 +85,7 @@ configurations:
               compiler.version: ["5", "7", "9"]
               build_type: ["Release"]
   - id: linux-gcc11
-    hrname: "Linux, GCC-legacy"
+    hrname: "Linux, GCC11"
     content:
       - os: ["Linux"]
         arch: ["x86_64"]

--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -74,15 +74,25 @@ tasks:
 
 # Profile configurations to build packages
 configurations:
-  - id: linux-gcc
-    hrname: "Linux, GCC"
+  - id: linux-gcc-legacy
+    hrname: "Linux, GCC-legacy"
     content:
       - os: ["Linux"]
         arch: ["x86_64"]
         compiler:
           - "gcc":
               compiler.libcxx: [ "libstdc++11" ]
-              compiler.version: ["5", "7", "9", "10", "11"]
+              compiler.version: ["5", "7", "9"]
+              build_type: ["Release"]
+  - id: linux-gcc11
+    hrname: "Linux, GCC-legacy"
+    content:
+      - os: ["Linux"]
+        arch: ["x86_64"]
+        compiler:
+          - "gcc":
+              compiler.libcxx: [ "libstdc++11" ]
+              compiler.version: ["11"]
               build_type: ["Release", "Debug"]
   - id: linux-clang
     hrname: "Linux, Clang"
@@ -92,21 +102,8 @@ configurations:
         compiler:
           - "clang":
               compiler.libcxx: ["libstdc++", "libc++"]
-              compiler.version: ["12", "13"]
-              build_type: ["Release", "Debug"]
-  - id: macos-clang
-    hrname: "macOS, Clang"
-    build_profile:
-      os: "Macos"
-      arch: "armv8"
-    content:
-      - os: [ "Macos" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "apple-clang":
-              compiler.version: [ "13.0" ]
-              compiler.libcxx: [ "libc++" ]
-              build_type: [ "Release", "Debug" ]
+              compiler.version: ["13"]
+              build_type: ["Release"]
   - id: macos-m1-clang
     hrname: "macOS, Clang (M1/arm64)"
     content:


### PR DESCRIPTION
Drop:
- Debug builds for Linux gcc5, gcc7, gcc9 - these are less demanded than gcc11
- Builds for Linux gcc10 - these are a lot less requested than 11, 9 and 7. Not surprising, since 11,9,7 match the default gcc versions in the most recent Ubuntu LTS releases
- Builds for Linux clang12 - very few requests
- Debug builds for Linux clang13 - very few requests, but still valuable to test clang builds on Linux. In v2 pipeline we will add newer versions of clang in the future.
- macOS x86_64 builds - there is already enough testing going on with Conan 2.0 - users who want x86_64 are encouraged to use Conan 2.0. 
