### PR TITLE
Add package id to xorg

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -108,4 +108,5 @@ class XorgConan(ConanFile):
     def package_id(self):
         libraries = self._libraries(self.info.settings.os == "Linux")
         self.info.clear()
-        self.info.conf.define("user.xorg:libs", str(libraries))
+        if conan_version.major >= 2:
+            self.info.conf.define("user.xorg:libs", str(libraries))


### PR DESCRIPTION
Specify library name and version:  **xorg/system**

Since https://github.com/conan-io/conan-center-index/pull/22081 (which removed `xvmc`) was merged, there have been periodic build failures in a few PRs, for example https://github.com/conan-io/conan-center-index/pull/21387. I believe the issue is that the package pulls the latest `xorg` package revision, but because the package ID for `xorg` is cleared (and a shared library is not considered embedded), any dependencies that depend on `xorg` will not be rebuilt. When the main package is built, the dependency thinks it needs `xvmc`, but the main package pulls the latest recipe, which does not pull `xvmc`. So I think one or both of the following need to happen, hence this PR:
1. Encode which packages are part of `xorg` as part of the package ID.
2. Adjust the embed mode of `xorg` to always rebuild if the package ID changes.

So far this PR does (1). I'm mildly confident in the cause of the problem, but only half-sure on my implementation. Any input is welcome.

The goal is to fix this in `xorg` once and for all, and perhaps other `system` packages should follow suit to avoid potential issues like this.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
