### PR TITLE
libsystemd: correct required_conan_version, add v255.2

### DIFF
--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -33,6 +33,10 @@ sources:
     url: "https://github.com/systemd/systemd-stable/archive/v246.16.tar.gz"
     sha256: "b69f9940d65870f090269a28f1047a633d4b80d0001e091d53a031dd40a822d2"
 patches:
+  "255.2":
+    - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
+      patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"
+      patch_type: "conan"
   "255":
     - patch_file: "patches/251.15/0001-Remove-dependency-from-coreutils.patch"
       patch_description: "allow to build in environments without 'realpath --relative-to' by replacing it with conan-specific build variable"

--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "255.2":
+    url: "https://github.com/systemd/systemd-stable/archive/v255.2.tar.gz"
+    sha256: "ba7354a742dc9a8bb7dbeaa40cbf7cf2ca84f506d5b7ae5ab8d14c8eecb7aca0"
   "255":
     url: "https://github.com/systemd/systemd-stable/archive/v255.tar.gz"
     sha256: "a3eb766ee96eb9f4cc25c2a6c933f3299e1b7ae22e72507dade0a5c86d92534f"

--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -11,7 +11,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.60.0"
 
 
 class LibsystemdConan(ConanFile):

--- a/recipes/libsystemd/config.yml
+++ b/recipes/libsystemd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "255.2":
+    folder: all
   "255":
     folder: all
   "253.14":


### PR DESCRIPTION
Fixes the outdated `required_conan_version` value, as mentioned at https://github.com/conan-io/conan-center-index/pull/22436#issuecomment-1900995086 by @bhutch29