### PR TITLE
coin-mumps: add recipe

### DIFF
--- a/recipes/coin-mumps/all/conandata.yml
+++ b/recipes/coin-mumps/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "3.0.5":
+    source:
+      url:
+        - "https://coin-or-tools.github.io/ThirdParty-Mumps/MUMPS_5.6.2.tar.gz"
+        - "http://mumps-solver.org/MUMPS_5.6.2.tar.gz"
+      sha256: "13a2c1aff2bd1aa92fe84b7b35d88f43434019963ca09ef7e8c90821a8f1d59a"
+    build_scripts:
+      url: "https://github.com/coin-or-tools/ThirdParty-Mumps/archive/refs/tags/releases/3.0.5.tar.gz"
+      sha256: "7010384ae705939d8e8bb784e96eb117f91e572f29fab14b72a1d86765cfde01"

--- a/recipes/coin-mumps/all/conanfile.py
+++ b/recipes/coin-mumps/all/conanfile.py
@@ -1,0 +1,165 @@
+import os
+import shutil
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import cross_building
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import get, rm, rmdir, patch, mkdir
+from conan.tools.gnu import Autotools, AutotoolsToolchain, PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc
+
+required_conan_version = ">=1.56.0 <2 || >=2.0.6"
+
+
+class PackageConan(ConanFile):
+    name = "coin-mumps"
+    description = "MUltifrontal Massively Parallel sparse direct Solver (MUMPS)"
+    license = "CECILL-C", "BSD 3-Clause", "EPL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/coin-or-tools/ThirdParty-Mumps"
+    topics = ("solver", "sparse", "direct", "parallel", "linear-algebra")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "intsize": [32, 64],
+        "precision": ["single", "double", "all"],
+        "with_lapack": [True, False],
+        "with_metis": [True, False],
+        "with_openmp": [True, False],
+        "with_pthread": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "intsize": 32,
+        "precision": "double",
+        "with_lapack": True,
+        "with_metis": True,
+        "with_openmp": False,
+        "with_pthread": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("openmpi/4.1.6")
+        if self.options.with_lapack:
+            self.requires("openblas/0.3.25")
+        if self.options.with_metis:
+            self.requires("metis/5.2.1")
+        if self.options.with_openmp and self.settings.compiler in ["clang", "apple-clang"]:
+            self.requires("llvm-openmp/17.0.4")
+        self.requires("gcc/13.2.0", headers=False, libs=True)
+
+    def validate(self):
+        if self.options.with_lapack and not self.dependencies["openblas"].options.build_lapack:
+            raise ConanInvalidConfiguration("MUMPS requires openblas with build_lapack=True")
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/2.1.0")
+        # Require GCC for gfortran
+        self.build_requires("gcc/<host_version>")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version]["build_scripts"], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version]["source"], destination="MUMPS", strip_root=True)
+
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
+        if not cross_building(self):
+            env = VirtualRunEnv(self)
+            env.generate(scope="build")
+
+        tc = AutotoolsToolchain(self)
+        yes_no = lambda v: "yes" if v else "no"
+        tc.configure_args.extend([
+            f"--enable-pthread-mumps={yes_no(self.options.with_pthread)}",
+            f"--enable-openmp={yes_no(self.options.with_openmp)}",
+            f"--with-lapack={yes_no(self.options.with_lapack)}",
+            f"--with-metis={yes_no(self.options.with_metis)}",
+            f"--with-precision={self.options.precision}",
+            f"--with-intsize={self.options.intsize}",
+        ])
+        if self.options.with_lapack:
+            dep_info = self.dependencies["openblas"].cpp_info.aggregated_components()
+            lib_flags = " ".join([f"-l{lib}" for lib in dep_info.libs + dep_info.system_libs])
+            tc.configure_args.append(f"--with-lapack-lflags=-L{dep_info.libdir} {lib_flags}")
+        tc.generate()
+
+        deps = PkgConfigDeps(self)
+        deps.generate()
+
+    def _patch_sources(self):
+        # https://github.com/coin-or-tools/ThirdParty-Mumps/blob/releases/3.0.5/get.Mumps#L63-L67
+        patch(self, self.source_folder, os.path.join(self.source_folder, "mumps_mpi.patch"))
+        os.rename(os.path.join(self.source_folder, "MUMPS", "libseq", "mpi.h"),
+                  os.path.join(self.source_folder, "MUMPS", "libseq", "mumps_mpi.h"))
+
+    def build(self):
+        self._patch_sources()
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        mkdir(self, os.path.join(self.package_folder, "licenses"))
+        shutil.copy(os.path.join(self.source_folder, "LICENSE"),
+                    os.path.join(self.package_folder, "licenses", "LICENSE-ThirdParty-Mumps"))
+        shutil.copy(os.path.join(self.source_folder, "MUMPS", "LICENSE"),
+                    os.path.join(self.package_folder, "licenses", "LICENSE-MUMPS"))
+        autotools = Autotools(self)
+        autotools.install()
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "coinmumps")
+        self.cpp_info.libs = ["coinmumps"]
+        self.cpp_info.includedirs.append(os.path.join("include", "coin-or"))
+        self.cpp_info.includedirs.append(os.path.join("include", "coin-or", "mumps"))
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["m"])
+            if self.options.with_pthread:
+                self.cpp_info.system_libs.extend(["pthread"])
+
+        if self.options.with_openmp:
+            if is_msvc(self):
+                openmp_flags = ["-openmp"]
+            elif self.settings.compiler in ("gcc", "clang"):
+                openmp_flags = ["-fopenmp"]
+            elif self.settings.compiler == "apple-clang":
+                openmp_flags = ["-Xpreprocessor", "-fopenmp"]
+            else:
+                openmp_flags = []
+            self.cpp_info.exelinkflags = openmp_flags
+            self.cpp_info.sharedlinkflags = openmp_flags
+
+        self.cpp_info.requires = ["openmpi::ompi-c"]
+        if self.options.with_lapack:
+            self.cpp_info.requires.append("openblas::openblas")
+        if self.options.with_metis:
+            self.cpp_info.requires.append("metis::metis")
+        if self.options.with_openmp and self.settings.compiler in ["clang", "apple-clang"]:
+            self.cpp_info.requires.append("llvm-openmp::llvm-openmp")
+        self.cpp_info.requires.extend(["gcc::gfortran", "gcc::quadmath"])

--- a/recipes/coin-mumps/all/conanfile.py
+++ b/recipes/coin-mumps/all/conanfile.py
@@ -9,7 +9,6 @@ from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import get, rm, rmdir, patch, mkdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc
 
 required_conan_version = ">=1.56.0 <2 || >=2.0.6"
 
@@ -64,8 +63,8 @@ class PackageConan(ConanFile):
             self.requires("openblas/0.3.25")
         if self.options.with_metis:
             self.requires("metis/5.2.1")
-        if self.options.with_openmp and self.settings.compiler in ["clang", "apple-clang"]:
-            self.requires("llvm-openmp/17.0.4")
+        if self.options.with_openmp:
+            self.requires("llvm-openmp/18.1.8")
         self.requires("gcc/13.2.0", headers=False, libs=True)
 
     def validate(self):
@@ -143,23 +142,11 @@ class PackageConan(ConanFile):
             if self.options.with_pthread:
                 self.cpp_info.system_libs.extend(["pthread"])
 
-        if self.options.with_openmp:
-            if is_msvc(self):
-                openmp_flags = ["-openmp"]
-            elif self.settings.compiler in ("gcc", "clang"):
-                openmp_flags = ["-fopenmp"]
-            elif self.settings.compiler == "apple-clang":
-                openmp_flags = ["-Xpreprocessor", "-fopenmp"]
-            else:
-                openmp_flags = []
-            self.cpp_info.exelinkflags = openmp_flags
-            self.cpp_info.sharedlinkflags = openmp_flags
-
         self.cpp_info.requires = ["openmpi::ompi-c"]
         if self.options.with_lapack:
             self.cpp_info.requires.append("openblas::openblas")
         if self.options.with_metis:
             self.cpp_info.requires.append("metis::metis")
-        if self.options.with_openmp and self.settings.compiler in ["clang", "apple-clang"]:
+        if self.options.with_openmp:
             self.cpp_info.requires.append("llvm-openmp::llvm-openmp")
         self.cpp_info.requires.extend(["gcc::gfortran", "gcc::quadmath"])

--- a/recipes/coin-mumps/all/test_package/CMakeLists.txt
+++ b/recipes/coin-mumps/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(coinmumps REQUIRED IMPORTED_TARGET coinmumps)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::coinmumps)

--- a/recipes/coin-mumps/all/test_package/conanfile.py
+++ b/recipes/coin-mumps/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "PkgConfigDeps", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/2.1.0")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/coin-mumps/all/test_package/test_package.c
+++ b/recipes/coin-mumps/all/test_package/test_package.c
@@ -1,0 +1,101 @@
+/*
+ *
+ *  This file is part of MUMPS 5.6.2, released
+ *  on Wed Oct 11 09:36:25 UTC 2023
+ *
+ */
+/* Example program using the C interface to the
+ * double real arithmetic version of MUMPS, dmumps_c.
+ * We solve the system A x = RHS with
+ *   A = diag(1 2) and RHS = [1 4]^T
+ * Solution is [1 2]^T */
+#include <stdio.h>
+#include <string.h>
+#include "mpi.h"
+#include "dmumps_c.h"
+#define JOB_INIT -1
+#define JOB_END -2
+#define USE_COMM_WORLD -987654
+
+#if defined(MAIN_COMP)
+/*
+ * Some Fortran compilers (COMPAQ fort) define "main" in
+ * their runtime library while a Fortran program translates
+ * to MAIN_ or MAIN__ which is then called from "main".
+ * We defined argc/argv arbitrarily in that case.
+ */
+int MAIN__();
+int MAIN_()
+  {
+    return MAIN__();
+  }
+
+int MAIN__()
+{
+  int argc=1;
+  char * name = "c_example";
+  char ** argv ;
+#else
+int main(int argc, char ** argv)
+{
+#endif
+  DMUMPS_STRUC_C id;
+  MUMPS_INT n = 2;
+  MUMPS_INT8 nnz = 2;
+  MUMPS_INT irn[] = {1,2};
+  MUMPS_INT jcn[] = {1,2};
+  double a[2];
+  double rhs[2];
+
+/* When compiling with -DINTSIZE64, MUMPS_INT is 64-bit but MPI
+   ilp64 versions may still require standard int for C interface. */
+/* MUMPS_INT myid, ierr; */
+  int myid, ierr;
+
+  int error = 0;
+#if defined(MAIN_COMP)
+  argv = &name;
+#endif
+  ierr = MPI_Init(&argc, &argv);
+  ierr = MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+  /* Define A and rhs */
+  rhs[0]=1.0;rhs[1]=4.0;
+  a[0]=1.0;a[1]=2.0;
+
+  /* Initialize a MUMPS instance. Use MPI_COMM_WORLD */
+  id.comm_fortran=USE_COMM_WORLD;
+  id.par=1; id.sym=0;
+  id.job=JOB_INIT;
+  dmumps_c(&id);
+
+  /* Define the problem on the host */
+  if (myid == 0) {
+    id.n = n; id.nnz =nnz; id.irn=irn; id.jcn=jcn;
+    id.a = a; id.rhs = rhs;
+  }
+#define ICNTL(I) icntl[(I)-1] /* macro s.t. indices match documentation */
+  /* No outputs */
+  id.ICNTL(1)=-1; id.ICNTL(2)=-1; id.ICNTL(3)=-1; id.ICNTL(4)=0;
+
+  /* Call the MUMPS package (analyse, factorization and solve). */
+  id.job=6;
+  dmumps_c(&id);
+  if (id.infog[0]<0) {
+    printf(" (PROC %d) ERROR RETURN: \tINFOG(1)= %d\n\t\t\t\tINFOG(2)= %d\n",
+        myid, id.infog[0], id.infog[1]);
+    error = 1;
+  }
+
+  /* Terminate instance. */
+  id.job=JOB_END;
+  dmumps_c(&id);
+  if (myid == 0) {
+    if (!error) {
+      printf("Solution is : (%8.2f  %8.2f)\n", rhs[0],rhs[1]);
+    } else {
+      printf("An error has occured, please check error code returned by MUMPS.\n");
+    }
+  }
+  ierr = MPI_Finalize();
+  return 0;
+}

--- a/recipes/coin-mumps/config.yml
+++ b/recipes/coin-mumps/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.0.5":
+    folder: all


### PR DESCRIPTION
Adds MUMPS, packaged by COIN-OR: 
* https://mumps-solver.org/index.php
* https://github.com/coin-or-tools/ThirdParty-Mumps

MUltifrontal Massively Parallel sparse direct Solver (MUMPS)

Required for COIN-OR IPOPT.

Requires GFortran with properly exported runtime libraries and updated OpenMPI:
* #23334
* #18980

[![Packaging status](https://repology.org/badge/tiny-repos/mumps-solver.svg)](https://repology.org/project/mumps-solver/versions)
[![Packaging status](https://repology.org/badge/tiny-repos/coin-or-mumps.svg)](https://repology.org/project/coin-or-mumps/versions)