### PR TITLE
libmicrohttpd: fix pkg_config_name

### DIFF
--- a/recipes/libmicrohttpd/all/conanfile.py
+++ b/recipes/libmicrohttpd/all/conanfile.py
@@ -175,7 +175,7 @@ class LibmicrohttpdConan(ConanFile):
             fix_apple_shared_install_name(self)
 
     def package_info(self):
-        self.cpp_info.set_property("pkg_config_name", "libmicrohttps")
+        self.cpp_info.set_property("pkg_config_name", "libmicrohttpd")
         libname = "microhttpd"
         if is_msvc(self):
             libname = "libmicrohttpd"


### PR DESCRIPTION
Specify library name and version:  **libmicrohttpd/***

I think pkg_config_name is typo.

https://git.gnunet.org/libmicrohttpd.git/tree/libmicrohttpd.pc.in?h=v0.9.77&id=0c91379e116cd12644d908ca1743cdaab1906816#n6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
