### PR TITLE
daw utf range header libraries 2.97.0

### DIFF
--- a/recipes/daw_utf_range/all/conanfile.py
+++ b/recipes/daw_utf_range/all/conanfile.py
@@ -38,7 +38,7 @@ class DawUtfRangeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("daw_header_libraries/2.96.1")
+        self.requires("daw_header_libraries/2.97.0", transitive_headers=True)
 
     def package_id(self):
         self.info.clear()

--- a/recipes/daw_utf_range/all/conanfile.py
+++ b/recipes/daw_utf_range/all/conanfile.py
@@ -38,7 +38,7 @@ class DawUtfRangeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("daw_header_libraries/2.97.0", transitive_headers=True)
+        self.requires("daw_header_libraries/2.97.0")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Specify library name and version:  **daw_utf_range/***

daw_header_libraries has changed API since 2.98.0.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
