### PR TITLE
libnghttp2: add version 1.59.0

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.59.0":
+    url: "https://github.com/nghttp2/nghttp2/archive/v1.59.0.tar.gz"
+    sha256: "0dd5c980f1262ff5f03676fd99f46f250b66c842f7d864fa1ca9f8453e5f8868"
   "1.58.0":
     url: "https://github.com/nghttp2/nghttp2/archive/v1.58.0.tar.gz"
     sha256: "7da19947b33a07ddcf97b9791331bfee8a8545e6b394275a9971f43cae9d636b"

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.59.0":
+    folder: all
   "1.58.0":
     folder: all
   "1.57.0":


### PR DESCRIPTION
Specify library name and version:  **libnghttp2/1.59.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
