### PR TITLE
cairomm: relocatable shared lib on macOS

### DIFF
--- a/recipes/cairomm/all/conanfile.py
+++ b/recipes/cairomm/all/conanfile.py
@@ -4,7 +4,7 @@ import shutil
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import is_apple_os
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.build import check_min_cppstd, cross_building
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rename, replace_in_file, rm, rmdir
@@ -139,6 +139,8 @@ class CairommConan(ConanFile):
 
         for dir_to_remove in ["pkgconfig", f"cairomm-{self._abi_version}"]:
             rmdir(self, os.path.join(self.package_folder, "lib", dir_to_remove))
+
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
         name = f"cairomm-{self._abi_version}"


### PR DESCRIPTION
cairomm is built with Meson, so fix_apple_shared_install_name() must be called after packaging.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
