### PR TITLE
lksctp-tools: add libtool in build requirements

### DIFF
--- a/recipes/lksctp-tools/all/conanfile.py
+++ b/recipes/lksctp-tools/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import get, chdir, copy, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
@@ -34,17 +35,21 @@ class LKSCTPToolsConan(ConanFile):
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
 
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration(f"{self.ref} is only available on Linux")
 
-    def layout(self):
-        basic_layout(self, src_folder="src")
+    def build_requirements(self):
+        self.tool_requires("libtool/2.4.7")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        VirtualBuildEnv(self).generate()
         tc = AutotoolsToolchain(self)
         tc.configure_args.extend([
             "--disable-tests",


### PR DESCRIPTION
autoreconf is called in build(), therefore libtool is a build requirement. Indeed we can't assume that libtool is installed on users systems.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
