### PR TITLE
(#22482) poco: add transitive_headers trait on expat dependency

### DIFF
--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -151,7 +151,7 @@ class PocoConan(ConanFile):
             self.requires("pcre2/10.42")
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.enable_xml:
-            self.requires("expat/2.5.0")
+            self.requires("expat/2.5.0", transitive_headers=True)
         if self.options.enable_data_sqlite:
             self.requires("sqlite3/3.45.0")
         if self.options.enable_apacheconnector:


### PR DESCRIPTION
Specify library name and version: poco/all

Add the transitive_headers=True trait on the expat dependency to reflect that poco headers transitively include expat headers

Fixes https://github.com/conan-io/conan-center-index/issues/22482

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
