### PR TITLE
libe57format: disable warnings as errors

### DIFF
--- a/recipes/libe57format/all/conanfile.py
+++ b/recipes/libe57format/all/conanfile.py
@@ -69,10 +69,12 @@ class LibE57FormatConan(ConanFile):
     def _patch_sources(self):
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                         "POSITION_INDEPENDENT_CODE ON", "")
-        # Disable compiler warnings, which cause older versions of GCC to fail due to unrecognized flags
         if Version(self.version) >= "3.0":
+            # Disable compiler warnings, which cause older versions of GCC to fail due to unrecognized flags
             replace_in_file(self, os.path.join(self.source_folder, "cmake", "CompilerWarnings.cmake"),
                             " -W", " # -W")
+            # Disable warnings as errors
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "set_warning_as_error()", "")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
I've asked upstream to remove this hardcoded warning as errors. There is an option, but it's no-op when you build from project tree directly...

Without this fix, it doesn't build with C++20 (errors with msvc 2022 and gcc 12).

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
