### PR TITLE
wolfssl: add with_curl option

### DIFF
--- a/recipes/wolfssl/all/conanfile.py
+++ b/recipes/wolfssl/all/conanfile.py
@@ -39,6 +39,7 @@ class WolfSSLConan(ConanFile):
         "sessioncerts": [True, False],
         "sni": [True, False],
         "testcert": [True, False],
+        "with_curl": [True, False],
     }
     default_options = {
         "shared": False,
@@ -55,6 +56,7 @@ class WolfSSLConan(ConanFile):
         "sessioncerts": False,
         "sni": False,
         "testcert": False,
+        "with_curl": False,
     }
 
     @property
@@ -64,6 +66,8 @@ class WolfSSLConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "5.2.0":
+            del self.options.with_curl
 
     def configure(self):
         if self.options.shared:
@@ -114,6 +118,8 @@ class WolfSSLConan(ConanFile):
             "--enable-shared={}".format(yes_no(self.options.shared)),
             "--enable-static={}".format(yes_no(not self.options.shared)),
         ])
+        if self.options.get_safe("with_curl"):
+            tc.configure_args.append("--enable-curl")
         if is_msvc(self):
             tc.extra_ldflags.append("-ladvapi32")
             if check_min_vs(self, "180", raise_invalid=False):


### PR DESCRIPTION
Specify library name and version:  **wolfssl/***

I met compilation errors on executing `conan install --requires=libcurl/8.5.0@ --build=missing -o libcurl/\*:with_ssl=wolfssl`.

```
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c: In function 'sha256_to_hex':
  CC       libcurl_la-if2ip.lo
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c:67:23: error: 'SHA256_DIGEST_LENGTH' undeclared (first use in this function); did you mean 'SHA256_HEX_LENGTH'?
   67 |   Curl_hexencode(sha, SHA256_DIGEST_LENGTH,
      |                       ^~~~~~~~~~~~~~~~~~~~
      |                       SHA256_HEX_LENGTH
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c:67:23: note: each undeclared identifier is reported only once for each function it appears in
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c: In function 'calc_s3_payload_hash':
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c:63:32: error: 'SHA256_DIGEST_LENGTH' undeclared (first use in this function); did you mean 'SHA256_HEX_LENGTH'?
   63 | #define SHA256_HEX_LENGTH (2 * SHA256_DIGEST_LENGTH + 1)
      |                                ^~~~~~~~~~~~~~~~~~~~
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c:310:33: note: in expansion of macro 'SHA256_HEX_LENGTH'
  310 |                                 SHA256_HEX_LENGTH)
      |                                 ^~~~~~~~~~~~~~~~~
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c:393:21: note: in expansion of macro 'CONTENT_SHA256_HDR_LEN'
  393 |   msnprintf(header, CONTENT_SHA256_HDR_LEN,
      |                     ^~~~~~~~~~~~~~~~~~~~~~
  CC       libcurl_la-imap.lo
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c: In function 'Curl_output_aws_sigv4':
libcu091943b01efd5/b/src/lib/http_aws_sigv4.c:542:26: error: 'SHA256_DIGEST_LENGTH' undeclared (first use in this function); did you mean 'SHA256_HEX_LENGTH'?
  542 |   unsigned char sha_hash[SHA256_DIGEST_LENGTH];
      |                          ^~~~~~~~~~~~~~~~~~~~
      |                          SHA256_HEX_LENGTH
```

To solve it, I have to build wolfssl with `--enable-curl` arg which has been introduced since 5.2.0.
https://www.wolfssl.com/using-curl-with-wolfssl-and-tls-1-3/

This PR is adding the option to set `--enable-curl`.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
