### PR TITLE
[config] Add reviews required bump entry in config.yml

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -29,6 +29,7 @@ tasks:
   automatic_merge:
     reviews_required_total: 2  # Reviews that a PR needs so it can be merged
     reviews_required_team: 1  # Reviews from the Conan team that a PR needs so it can be merged
+    reviews_required_bump: 1  # Total reviews required for a bump PR to be merged
     branches:  # PRs from automations that have these as base-branches will be merged automatically
       - "conan-io:action-doc-toc"
     # Requirements to merge a given pull-request:

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -29,6 +29,7 @@ tasks:
   automatic_merge:
     reviews_required_total: 1000  # AutomaticMerge shouldn't run with this file, but just in case
     reviews_required_team: 1000  # AutomaticMerge shouldn't run with this file, but just in case
+    reviews_required_bump: 1000  # AutomaticMerge shouldn't run with this file, but just in case
   access_request:
       request_issue_url: https://github.com/conan-io/conan-center-index/issues/4
       max_inactivity_days: 0


### PR DESCRIPTION
Add entry to list the number of maintainers reviewers required to merge a bump pull request (bump version or bump requirements)

This entry has no effect right now, only will have affect after next C3I Jenkins release (24-jan-2024)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
