### PR TITLE
[docs] Update bump PR review rule

### DIFF
--- a/docs/review_process.md
+++ b/docs/review_process.md
@@ -82,8 +82,8 @@ At least 2 approving reviews are required, and at least one of them has to be fr
 So, it might be 1 official + 1 community, or 2 official, but it couldn't be just 2 community reviews.
 Approvals are only counted if they are associated with the latest commit in the PR, while "Change requested" ones (from the Conan team) will persist even if there are new commits. Don't hesitate to dismiss old reviews if the issues have already been addressed.
 
-There is a second rule for any pull request labelled as [`Bump version`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+version%22)
-or [`Bump dependencies`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+dependencies%22+). They require only 1 approving review from an official reviewer. This is because these PRs are usually very simple and don't require much review. Community reviewers are not required, but are still welcome to review these PRs.
+Pull requests labelled as [`Bump version`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+version%22)
+or [`Bump dependencies`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+dependencies%22+) require **just 1 approving review from an official reviewer**. Community reviewers are not required but are still welcome.
 
 ### Reviews from others
 

--- a/docs/review_process.md
+++ b/docs/review_process.md
@@ -82,9 +82,8 @@ At least 2 approving reviews are required, and at least one of them has to be fr
 So, it might be 1 official + 1 community, or 2 official, but it couldn't be just 2 community reviews.
 Approvals are only counted if they are associated with the latest commit in the PR, while "Change requested" ones (from the Conan team) will persist even if there are new commits. Don't hesitate to dismiss old reviews if the issues have already been addressed.
 
-> **Note** Pull requests labelled as [`Bump version`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+version%22)
-> or [`Bump dependencies`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+dependencies%22+) are merged by
-> the bot without requiring any approval.
+There is a second rule for any pull request labelled as [`Bump version`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+version%22)
+or [`Bump dependencies`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+dependencies%22+). They require only 1 approving review from an official reviewer. This is because these PRs are usually very simple and don't require much review. Community reviewers are not required, but are still welcome to review these PRs.
 
 ### Reviews from others
 


### PR DESCRIPTION
To avoid mistakes related to incompatible versions and mainly to dependencies graph that result in missing dependencies, the bump PR will require a maintainer review to be merged.

It may delay some PRs to be merged, but in other hand, the team will be able to check the dependencies graph and see what could be broken in terms of missing package ID after merging.

This PR will be in effect after updating C3I jenkins. 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
