### PR TITLE
timsort: add version 3.0.0

### DIFF
--- a/recipes/timsort/all/conandata.yml
+++ b/recipes/timsort/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.0":
+    url: "https://github.com/timsort/cpp-TimSort/archive/v3.0.0.tar.gz"
+    sha256: "d61b92850996305e5248d1621c8ac437c31b474f74907e223019739e2e556b1f"
   "2.1.0":
     url: "https://github.com/timsort/cpp-TimSort/archive/v2.1.0.tar.gz"
     sha256: "b16606f85316d9a3cfde638c02dd9ce23324b0a904bb020e4ad2497cb8cf9ebd"

--- a/recipes/timsort/all/conanfile.py
+++ b/recipes/timsort/all/conanfile.py
@@ -3,6 +3,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.50.0"
@@ -11,13 +12,29 @@ required_conan_version = ">=1.50.0"
 class TimsortConan(ConanFile):
     name = "timsort"
     description = "A C++ implementation of timsort"
-    topics = ("sorting", "algorithms")
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/timsort/cpp-TimSort"
-    license = "MIT"
+    topics = ("sorting", "algorithms", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return "11" if Version(self.version) < "3.0.0" else "20"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "20": {
+                "gcc": "11",
+                "clang": "12",
+                "apple-clang": "13",
+                "Visual Studio": "16",
+                "msvc": "192",
+            }
+        }.get(self._min_cppstd, {})
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -28,7 +45,12 @@ class TimsortConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             if Version(self.version) >= "2.0.0":
-                check_min_cppstd(self, 11)
+                check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/timsort/all/test_package/CMakeLists.txt
+++ b/recipes/timsort/all/test_package/CMakeLists.txt
@@ -5,4 +5,11 @@ find_package(gfx-timsort REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE gfx::timsort)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+
+if(gfx-timesort_VERSION VERSION_LESS "2.0.0")
+  target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_98)
+elseif(gfx-timesort_VERSION VERSION_LESS "3.0.0")
+  target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+else()
+  target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+endif()

--- a/recipes/timsort/config.yml
+++ b/recipes/timsort/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.0":
+    folder: all
   "2.1.0":
     folder: all
   "2.0.2":


### PR DESCRIPTION
Specify library name and version:  **timsort/***

timsort/3.x.x requires C++20

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
