### PR TITLE
[docs] Update changelog 24 January 2024

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 24-January-2024 - 12:13 CET
+
+- [feature] Update Conan 1.x branch to version 1.62.0
+- [feature] Update Conan 2.x branch to version 2.0.16
+- [feature] Require review from maintainers for Bump version and Bump requirements
+- [fix] Show header-only option in the build CI summary table
+- [fix] Use build/host profile conf also in test package
+- [fix] Use only string to handle Github labels
+
 ### 05-December-2023 - 16:23 CET
 
 - [fix] Use the correct profile to test a tool_require.


### PR DESCRIPTION
- The ConanCenterIndex is now running both Conan 1.62.0 and 2.0.16
- Any bump PR will require a maintainer review to be merged. It has several reasons, including security and coordination to avoid missing dependencies. 
- Previously, header_only option values was now shown in Conan 2.x build results. Now it's fixed.
- Profile config (e.g tools.system.package_manager) is now propagated to test_package execution, fixing those cases where system package are needed
- Fixed internal usage for Github labels, to be treated as string only when parsing.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
