### PR TITLE
icu/74.2 recipe, #21292 dat_package_file option improved.

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -33,6 +33,7 @@ class ICUConan(ConanFile):
         "data_packaging": ["files", "archive", "library", "static"],
         "with_dyload": [True, False],
         "dat_package_file": [None, "ANY"],
+        "custom_data_hash": [None, "ANY"],
         "with_icuio": [True, False],
         "with_extras": [True, False],
     }
@@ -42,6 +43,7 @@ class ICUConan(ConanFile):
         "data_packaging": "archive",
         "with_dyload": True,
         "dat_package_file": None,
+        "custom_data_hash": None,
         "with_icuio": True,
         "with_extras": False,
     }
@@ -88,7 +90,8 @@ class ICUConan(ConanFile):
 
     def package_id(self):
         if self.info.options.dat_package_file:
-            self.info.options.dat_package_file = self._sha256sum(str(self.info.options.dat_package_file))
+            self.info.options.custom_data_hash = self._sha256sum(str(self.info.options.dat_package_file))
+            del self.info.options.dat_package_file
 
     def build_requirements(self):
         if self._settings_build.os == "Windows":


### PR DESCRIPTION
dat_package_file option usage was impractical for consumer recipes. It required that the file specified for the dat_package_file option to exist on the consumer machine since the hash of the file is calculated in package_id method and existence of the file was verified by the validate method.

Introduced a new custom_data_hash option which is calculated from the hash of the file specified in dat_package_file option.
package_id method calculates the hash of the file and sets the custom_data_hash option accordingly and removes the dat_package_file option.

During package creation the dat_package_file option shall be set to the appropriate data file.
In consumer recipes the dat_package_file option cannot be used.

In this way the consumer recipe does not require the file specified in the dat_package_file option to exist but icu built from custom data file can still be used.

Specify library name and version: icu/74.2

fixes #21292