### PR TITLE
Updated Opene57 to 1.6.5

### DIFF
--- a/recipes/opene57/all/conandata.yml
+++ b/recipes/opene57/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.5":
+    url: "https://github.com/openE57/openE57/archive/1.6.5.tar.gz"
+    sha256: "23f3c159550a70b6a1c2330f0f03ed816cbc27ff5656410bfee527bae31eb186"
   "1.6.4":
     url: "https://github.com/openE57/openE57/archive/1.6.4.tar.gz"
     sha256: "97accc32ae294113a97b8d3f0ecf0d608057a6f0fcdfee17db0c5db4ab28ce69"

--- a/recipes/opene57/all/conandata.yml
+++ b/recipes/opene57/all/conandata.yml
@@ -8,6 +8,3 @@ sources:
   "1.6.3":
     url: "https://github.com/openE57/openE57/archive/refs/tags/1.6.3.tar.gz"
     sha256: "e335afdda98a2707d05ec4bce99f362a6f7f0eb2e8bbf2d7346eae292046f827"
-  "1.6.2":
-    url: "https://github.com/openE57/openE57/archive/refs/tags/1.6.2.tar.gz"
-    sha256: "2d487e663cf43105b19653d34250fd45f947af839e327336b6878464a99d5423"

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -66,7 +66,7 @@ class Opene57Conan(ConanFile):
 
     def requirements(self):
         if self.options.with_tools:
-            self.requires("boost/1.83.0")
+            self.requires("boost/1.84.0")
 
         if self.options.with_docs:
             self.requires("doxygen/1.9.4")

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -41,9 +41,10 @@ class Opene57Conan(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
+            "Visual Studio": "15",
             "msvc": "191",
-            "gcc": "8",
-            "clang": "8",
+            "gcc": "7",
+            "clang": "6",
             "apple-clang": "10",
         }
 
@@ -94,6 +95,8 @@ class Opene57Conan(ConanFile):
         tc.variables["BUILD_EXAMPLES"] = False
         tc.variables["BUILD_TOOLS"] = self.options.with_tools
         tc.variables["BUILD_TESTS"] = False
+        tc.variables["BUILD_DOCS"] = self.options.with_docs
+
         if is_msvc(self):
             tc.variables["BUILD_WITH_MT"] = is_msvc_static_runtime(self)
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = self.options.shared

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.files import copy, export_conandata_patches, get, replace_in_fi
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 
-required_conan_version = ">=2.0.5"
+required_conan_version = ">=1.54.0"
 
 
 class Opene57Conan(ConanFile):

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.files import copy, export_conandata_patches, get, replace_in_fi
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0.5"
 
 
 class Opene57Conan(ConanFile):
@@ -25,11 +25,13 @@ class Opene57Conan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_tools": [True, False],
+        "with_docs":  [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_tools": False,
+        "with_docs":  False
     }
 
     @property
@@ -39,10 +41,9 @@ class Opene57Conan(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
-            "Visual Studio": "15",
             "msvc": "191",
-            "gcc": "7",
-            "clang": "6",
+            "gcc": "8",
+            "clang": "8",
             "apple-clang": "10",
         }
 
@@ -65,8 +66,13 @@ class Opene57Conan(ConanFile):
     def requirements(self):
         if self.options.with_tools:
             self.requires("boost/1.83.0")
+
+        if self.options.with_docs:
+            self.requires("doxygen/1.9.4")
+
         if self.settings.os != "Windows":
-            self.requires("icu/73.2")
+            self.requires("icu/74.1")
+
         self.requires("xerces-c/3.2.4")
 
     def validate(self):
@@ -127,6 +133,8 @@ class Opene57Conan(ConanFile):
 
         self.cpp_info.defines.append(f"E57_REFIMPL_REVISION_ID={self.name}-{self.version}")
         self.cpp_info.defines.append("XERCES_STATIC_LIBRARY")
+        self.cpp_info.defines.append("CRCPP_INCLUDE_ESOTERIC_CRC_DEFINITIONS")
+        self.cpp_info.defines.append("CRCPP_USE_CPP11")
 
         # TODO: to remove in conan v2
         if self.options.with_tools:

--- a/recipes/opene57/config.yml
+++ b/recipes/opene57/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.5":
+    folder: all
   "1.6.4":
     folder: all
   "1.6.3":

--- a/recipes/opene57/config.yml
+++ b/recipes/opene57/config.yml
@@ -5,5 +5,3 @@ versions:
     folder: all
   "1.6.3":
     folder: all
-  "1.6.2":
-    folder: all


### PR DESCRIPTION
Specify library name and version:  **opene57/1.6.5**

A new release of opene57 is available (1.6.5), therefore the recipe has been updated.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
