### PR TITLE
Add protobuf 3.15.8

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "3.17.1":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.17.1.tar.gz"
     sha256: "036d66d6eec216160dd898cfb162e9d82c1904627642667cc32b104d407bb411"
+  "3.15.8":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.15.8.tar.gz"
+    sha256: "0cbdc9adda01f6d2facc65a22a2be5cecefbefe5a09e5382ee8879b522c04441"
 patches:
   "3.21.12":
     - patch_file: "patches/protobuf-3.21.12-upstream-macos-macros.patch"

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "3.17.1":
     folder: all
+  "3.15.8":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **protobuf/3.15.8**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

It is not always easy to migrate to a newer protobuf library. Therefore, we would like to have it in conan center so that it is easily accessible as a dependency.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
