### PR TITLE
abseil: fix build in environments without CMake

### DIFF
--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -50,7 +50,7 @@ class AbseilConan(ConanFile):
         }.get(self._min_cppstd, {})
 
     def build_requirements(self):
-        self.tool_requires("cmake/3.27.9")
+        self.tool_requires("cmake/[>=3.16 <4]")
 
     def export_sources(self):
         copy(self, "abi_trick/*", self.recipe_folder, self.export_sources_folder)

--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -49,6 +49,9 @@ class AbseilConan(ConanFile):
             },
         }.get(self._min_cppstd, {})
 
+    def build_requirements(self):
+        self.tool_requires("cmake/3.27.9")
+
     def export_sources(self):
         copy(self, "abi_trick/*", self.recipe_folder, self.export_sources_folder)
         export_conandata_patches(self)


### PR DESCRIPTION
Specify library name and version:  **abseil/X**

`abseil` requires CMake to be built, but does it without respect 🙂 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
