### PR TITLE
onnxruntime: More compatibility patches for 1.16

### DIFF
--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -25,6 +25,10 @@ patches:
     - patch_file: "patches/1.14.1-0004-abseil-no-string-view.patch"
       patch_description: "allow to build with abseil built without c++17 support"
       patch_type: "portability"
+    - patch_file: "patches/1.16.0-0002-vs2019.patch"
+      patch_description: "Do not include C++23 header if it is not present"
+      patch_type: "portability"
+      patch_source: "https://github.com/microsoft/onnxruntime/pull/17716"
   "1.16.2":
     - patch_file: "patches/1.16.0-0001-cmake-dependencies.patch"
       patch_description: "CMake: ensure conan dependencies are used"
@@ -32,6 +36,10 @@ patches:
     - patch_file: "patches/1.14.1-0004-abseil-no-string-view.patch"
       patch_description: "allow to build with abseil built without c++17 support"
       patch_type: "portability"
+    - patch_file: "patches/1.16.0-0002-vs2019.patch"
+      patch_description: "Do not include C++23 header if it is not present"
+      patch_type: "portability"
+      patch_source: "https://github.com/microsoft/onnxruntime/pull/17716"
   "1.16.1":
     - patch_file: "patches/1.16.0-0001-cmake-dependencies.patch"
       patch_description: "CMake: ensure conan dependencies are used"
@@ -39,6 +47,10 @@ patches:
     - patch_file: "patches/1.14.1-0004-abseil-no-string-view.patch"
       patch_description: "allow to build with abseil built without c++17 support"
       patch_type: "portability"
+    - patch_file: "patches/1.16.0-0002-vs2019.patch"
+      patch_description: "Do not include C++23 header if it is not present"
+      patch_type: "portability"
+      patch_source: "https://github.com/microsoft/onnxruntime/pull/17716"
   "1.16.0":
     - patch_file: "patches/1.16.0-0001-cmake-dependencies.patch"
       patch_description: "CMake: ensure conan dependencies are used"
@@ -46,6 +58,10 @@ patches:
     - patch_file: "patches/1.14.1-0004-abseil-no-string-view.patch"
       patch_description: "allow to build with abseil built without c++17 support"
       patch_type: "portability"
+    - patch_file: "patches/1.16.0-0002-vs2019.patch"
+      patch_description: "Do not include C++23 header if it is not present"
+      patch_type: "portability"
+      patch_source: "https://github.com/microsoft/onnxruntime/pull/17716"
   "1.15.1":
     - patch_file: "patches/1.15.1-0001-cmake-dependencies.patch"
       patch_description: "CMake: ensure conan dependencies are used"

--- a/recipes/onnxruntime/all/patches/1.16.0-0001-cmake-dependencies.patch
+++ b/recipes/onnxruntime/all/patches/1.16.0-0001-cmake-dependencies.patch
@@ -10,6 +10,15 @@ Subject: [PATCH] CMake: ensure conan dependencies are used
  cmake/onnxruntime_mlas.cmake                   |  2 +-
  4 files changed, 19 insertions(+), 14 deletions(-)
 
+diff --git a/cmake/external/abseil-cpp.cmake b/cmake/external/abseil-cpp.cmake
+index 54d2f9c5c1..3195ef15a0 100644
+--- a/cmake/external/abseil-cpp.cmake
++++ b/cmake/external/abseil-cpp.cmake
+@@ -22,6 +22,7 @@ FetchContent_Declare(
+     URL ${DEP_URL_abseil_cpp}
+     URL_HASH SHA1=${DEP_SHA1_abseil_cpp}
+     PATCH_COMMAND ${ABSL_PATCH_COMMAND}
++    FIND_PACKAGE_ARGS REQUIRED CONFIG NAMES absl
 diff --git a/cmake/external/eigen.cmake b/cmake/external/eigen.cmake
 index c0f7ddc50e..a47de64cbd 100644
 --- a/cmake/external/eigen.cmake

--- a/recipes/onnxruntime/all/patches/1.16.0-0002-vs2019.patch
+++ b/recipes/onnxruntime/all/patches/1.16.0-0002-vs2019.patch
@@ -1,0 +1,12 @@
+diff --git a/onnxruntime/core/platform/windows/stacktrace.cc b/onnxruntime/core/platform/windows/stacktrace.cc
+index cac6f4f290..d7d423e4a4 100644
+--- a/onnxruntime/core/platform/windows/stacktrace.cc
++++ b/onnxruntime/core/platform/windows/stacktrace.cc
+@@ -10,7 +10,6 @@
+ #include <stacktrace>
+ #endif
+ #endif
+-#include <stacktrace>
+ 
+ #include "core/common/logging/logging.h"
+ #include "core/common/gsl.h"


### PR DESCRIPTION
Specify library name and version:  **onnxruntime/1.16.X**

We have a custom `onnxruntime` recipe with CUDA support for internal use, and while adapting upstream changes to support 1.16 I noticed some weirdness in the patches.
- Comparing `1.16.0-0001-cmake-dependencies.patch` to the predecessor `1.15.1-0001-cmake-dependencies.patch`, it lost the hunk about Abseil. Because of this our CMake configuration logs were lacking a bunch of `Conan: Component target declared 'absl::something'` and we were getting weird `target_link_libraries: target absl::something not found`. Not sure why it doesn't happen in C3I, maybe because we use older version of Abseil.
- In https://github.com/microsoft/onnxruntime/pull/17173 MS started to use `<stacktrace>` header from C++23; then in https://github.com/microsoft/onnxruntime/pull/17209 they made it optional - but left a bug for VS2019 and below. The bug got a fix in https://github.com/microsoft/onnxruntime/pull/17716 but 1.16.0-3 were already released. I backported the fix to enable VS2019 builds in 1.16.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
