### PR TITLE
libpng: add version 1.6.42

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.42":
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.42/libpng-1.6.42.tar.xz"
+    sha256: "c919dbc11f4c03b05aba3f8884d8eb7adfe3572ad228af972bb60057bdb48450"
   "1.6.41":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.41/libpng-1.6.41.tar.xz"
     sha256: "d6a49a7a4abca7e44f72542030e53319c081fea508daccf4ecc7c6d9958d190f"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.42":
+    folder: all
   "1.6.41":
     folder: all
   "1.6.40":


### PR DESCRIPTION
Specify library name and version:  **libpng/1.6.42**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
