### PR TITLE
boost: add with_stacktrace_addr2line option

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -104,6 +104,7 @@ class BoostConan(ConanFile):
         "i18n_backend_icu": [True, False],
         "visibility": ["global", "protected", "hidden"],
         "addr2line_location": ["ANY"],
+        "with_stacktrace_addr2line" : [True, False],
         "with_stacktrace_backtrace": [True, False],
         "buildid": [None, "ANY"],
         "python_buildid": [None, "ANY"],
@@ -143,6 +144,7 @@ class BoostConan(ConanFile):
         "i18n_backend_icu": False,
         "visibility": "hidden",
         "addr2line_location": "/usr/bin/addr2line",
+        "with_stacktrace_addr2line": True,
         "with_stacktrace_backtrace": True,
         "buildid": None,
         "python_buildid": None,
@@ -419,6 +421,8 @@ class BoostConan(ConanFile):
 
     @property
     def _stacktrace_addr2line_available(self):
+        if not self.options.with_stacktrace_addr2line:
+            return False
         if (self._is_apple_embedded_platform or self.settings.get_safe("os.subsystem") == "catalyst"):
              # sandboxed environment - cannot launch external processes (like addr2line), system() function is forbidden
             return False


### PR DESCRIPTION
While attempting to cross-compile Boost for the x86 architecture using a multilib toolchain I have the following error: 

```bash
boost/1.84.0: WARN: Boost component 'stacktrace_addr2line' is missing libraries. Try building boost with '-o boost:without_stacktrace_addr2line'. (Option is not guaranteed to exist) boost/1.84.0: WARN: Boost component 'stacktrace_backtrace' is missing libraries. Try building boost with '-o boost:without_stacktrace_backtrace'. (Option is not guaranteed to exist) ERROR: boost/1.84.0: Error in package_info() method, line 1750
        raise ConanException(f"These libraries were expected to be built, but were not built: {non_built}")
        ConanException: These libraries were expected to be built, but were not built: {'boost_stacktrace_backtrace', 'boost_stacktrace_addr2line'}
```

To address this issue, I've introduced the 'with_stacktrace_addr2line' option.

This modification allows explicitly disable the inclusion of 'boost_stacktrace_addr2line' during the build process. By doing so, it allows Boost to be built with alternative stacktrace options, such as 'boost_stacktrace_noop' and 'boost_stacktrace_basic'.

Specify library name and version:  **boost/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
