### PR TITLE
libcurl: add version 8.6.0

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "8.6.0":
+    url:
+      - "https://curl.se/download/curl-8.6.0.tar.xz"
+      - "https://github.com/curl/curl/releases/download/curl-8_6_0/curl-8.6.0.tar.xz"
+    sha256: "3ccd55d91af9516539df80625f818c734dc6f2ecf9bada33c76765e99121db15"
   "8.5.0":
     url:
       - "https://curl.se/download/curl-8.5.0.tar.xz"

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.6.0":
+    folder: all
   "8.5.0":
     folder: all
   "8.4.0":


### PR DESCRIPTION
Specify library name and version:  **libcurl/8.6.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
