### PR TITLE
Fix NuRaft Homepage metadata.

### DIFF
--- a/recipes/nuraft/all/conanfile.py
+++ b/recipes/nuraft/all/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.53.0"
 
 class NuRaftConan(ConanFile):
     name = "nuraft"
-    homepage = "https://github.corp.ebay.com/sds/NuRaft"
+    homepage = "https://github.com/eBay/NuRaft"
     description = """Cornerstone based RAFT library."""
     topics = ("raft",)
     url = "https://github.com/conan-io/conan-center-index"


### PR DESCRIPTION
**nuraft/\***

The `homepage` metadata is pointing to an internal github service at eBay. Correct this to the upstream OSS site in github.com

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
