### PR TITLE
openssl: add 3.2.1

### DIFF
--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  3.2.1:
+    url:
+      - "https://www.openssl.org/source/openssl-3.2.1.tar.gz"
+      - "https://github.com/openssl/openssl/releases/download/openssl-3.2.1/openssl-3.2.1.tar.gz"
+    sha256: 83C7329FE52C850677D75E5D0B0CA245309B97E8ECBCFDC1DFDC4AB9FAC35B39
   3.2.0:
     url:
       - "https://www.openssl.org/source/openssl-3.2.0.tar.gz"

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,5 +1,7 @@
 versions:
   # 3.2.x releases
+  3.2.1:
+    folder: "3.x.x"
   3.2.0:
     folder: "3.x.x"
   # 3.1.x releases


### PR DESCRIPTION
Specify library name and version:  **openssl/3.2.1**

Just adding v3.2.1 for OpenSSL

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
