### PR TITLE
opentelemetry-cpp: add 1.13.0

### DIFF
--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.13.0":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.13.0.tar.gz"
+    sha256: "7735cc56507149686e6019e06f588317099d4522480be5f38a2a09ec69af1706"
   "1.12.0":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.12.0.tar.gz"
     sha256: "09c208a21fb1159d114a3ea15dc1bcc5dee28eb39907ba72a6012d2c7b7564a0"
@@ -11,3 +14,9 @@ sources:
   "1.7.0":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.7.0.tar.gz"
     sha256: "2ad0911cdc94fe84a93334773bef4789a38bd1f01e39560cabd4a5c267e823c3"
+patches:
+  "1.13.0":
+    - patch_file: "patches/2475.patch"
+      patch_description: "Fix build w/ MSVC"
+      patch_type: "backport"
+      patch_source: "https://github.com/open-telemetry/opentelemetry-cpp/pull/2475"

--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -16,7 +16,11 @@ sources:
     sha256: "2ad0911cdc94fe84a93334773bef4789a38bd1f01e39560cabd4a5c267e823c3"
 patches:
   "1.13.0":
+    - patch_file: "patches/0b9371dcc5d26b2721482a7c0f89eb154dbe364f.patch"
+      patch_description: "Fix build w/ MSVC and cppstd=20"
+      patch_type: "backport"
+      patch_source: "https://github.com/open-telemetry/opentelemetry-cpp/commit/0b9371dcc5d26b2721482a7c0f89eb154dbe364f.patch"
     - patch_file: "patches/2475.patch"
-      patch_description: "Fix build w/ MSVC"
+      patch_description: "Fix build w/ MSVC and cppstd=20"
       patch_type: "backport"
       patch_source: "https://github.com/open-telemetry/opentelemetry-cpp/pull/2475"

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -273,7 +273,7 @@ class OpenTelemetryCppConan(ConanFile):
 
         protos_cmake_path = os.path.join(self.source_folder, "cmake", "opentelemetry-proto.cmake")
         if (self.options.with_otlp_http or self.options.with_otlp_grpc) and Version(self.version) < "1.8":
-            protos_path = self.dependencies.build["opentelemetry-proto"].conf_info.get("user.opentelemetry-proto:proto_root").replace("\\", "/")
+            protos_path = self._proto_root
             replace_in_file(self, protos_cmake_path,
                             "if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto/.git)",
                             "if(1)")
@@ -515,3 +515,4 @@ class OpenTelemetryCppConan(ConanFile):
                 "nlohmann_json::nlohmann_json",
             )
 
+        self.conf_info.define("user.opentelemetry-cpp:min_cpp", self._min_cppstd)

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -117,6 +117,8 @@ class OpenTelemetryCppConan(ConanFile):
             self.options.rm_safe("fPIC")
         if Version(self.version) >= "1.10":
             del self.options.with_jaeger
+        if Version(self.version) >= "1.11.0":
+            self.options.rm_safe("with_logs_preview")
 
     def configure(self):
         if self.options.shared:
@@ -253,7 +255,8 @@ class OpenTelemetryCppConan(ConanFile):
         tc.cache_variables["WITH_JAEGER"] = self.options.get_safe("with_jaeger", False)
         tc.cache_variables["WITH_NO_GETENV"] = self.options.with_no_getenv
         tc.cache_variables["WITH_ETW"] = self.options.with_etw
-        tc.cache_variables["WITH_LOGS_PREVIEW"] = self.options.with_logs_preview
+        if Version(self.version) < "1.11.0":
+            tc.cache_variables["WITH_LOGS_PREVIEW"] = self.options.with_logs_preview
         tc.cache_variables["WITH_ASYNC_EXPORT_PREVIEW"] = self.options.with_async_export_preview
         tc.cache_variables["WITH_METRICS_EXEMPLAR_PREVIEW"] = self.options.with_metrics_exemplar_preview
         tc.cache_variables["OPENTELEMETRY_INSTALL"] = True
@@ -337,17 +340,17 @@ class OpenTelemetryCppConan(ConanFile):
                 libraries.append("opentelemetry_exporter_otlp_grpc_metrics")
                 if Version(self.version) >= "1.7.0":
                     libraries.append("opentelemetry_exporter_otlp_grpc_client")
-                if self.options.with_logs_preview:
+                if Version(self.version) >= "1.11" or self.options.with_logs_preview:
                     libraries.append("opentelemetry_exporter_otlp_grpc_log")
             if self.options.with_otlp_http:
                 libraries.append("opentelemetry_exporter_otlp_http")
                 libraries.append("opentelemetry_exporter_otlp_http_client")
                 libraries.append("opentelemetry_exporter_otlp_http_metric")
-                if self.options.with_logs_preview:
+                if Version(self.version) >= "1.11" or self.options.with_logs_preview:
                     libraries.append("opentelemetry_exporter_otlp_http_log")
         if self.options.with_prometheus:
             libraries.append("opentelemetry_exporter_prometheus")
-        if self.options.with_elasticsearch and self.options.with_logs_preview:
+        if self.options.with_elasticsearch and (Version(self.version) >= "1.11" or self.options.with_logs_preview):
             libraries.append("opentelemetry_exporter_elasticsearch_logs")
         if self.options.with_zipkin:
             libraries.append("opentelemetry_exporter_zipkin_trace")
@@ -355,7 +358,7 @@ class OpenTelemetryCppConan(ConanFile):
             libraries.append("opentelemetry_exporter_jaeger_trace")
         libraries.append("opentelemetry_metrics")
         libraries.append("opentelemetry_exporter_ostream_metrics")
-        if self.options.with_logs_preview:
+        if Version(self.version) >= "1.11" or self.options.with_logs_preview:
             libraries.extend([
                 "opentelemetry_logs",
                 "opentelemetry_exporter_ostream_logs",
@@ -386,7 +389,7 @@ class OpenTelemetryCppConan(ConanFile):
 
         self.cpp_info.components["opentelemetry_exporter_in_memory"].libs = []
 
-        if self.options.with_logs_preview:
+        if Version(self.version) >= "1.11" or self.options.with_logs_preview:
             self.cpp_info.components["opentelemetry_logs"].requires.extend([
                 "opentelemetry_resources",
                 "opentelemetry_common",
@@ -451,7 +454,7 @@ class OpenTelemetryCppConan(ConanFile):
                     "opentelemetry_exporter_otlp_grpc_client"
                 ])
 
-            if self.options.with_logs_preview:
+            if Version(self.version) >= "1.11" or  self.options.with_logs_preview:
                 self.cpp_info.components["opentelemetry_exporter_otlp_grpc_log"].requires.extend([
                     "opentelemetry_otlp_recordable",
                     "opentelemetry_exporter_otlp_grpc_client",
@@ -481,7 +484,7 @@ class OpenTelemetryCppConan(ConanFile):
                 "opentelemetry_exporter_otlp_http_client"
             ])
 
-            if self.options.with_logs_preview:
+            if Version(self.version) >= "1.11" or self.options.with_logs_preview:
                 self.cpp_info.components["opentelemetry_exporter_otlp_http_log"].requires.extend([
                     "opentelemetry_otlp_recordable",
                     "opentelemetry_exporter_otlp_http_client",

--- a/recipes/opentelemetry-cpp/all/patches/0b9371dcc5d26b2721482a7c0f89eb154dbe364f.patch
+++ b/recipes/opentelemetry-cpp/all/patches/0b9371dcc5d26b2721482a7c0f89eb154dbe364f.patch
@@ -1,0 +1,37 @@
+From 0b9371dcc5d26b2721482a7c0f89eb154dbe364f Mon Sep 17 00:00:00 2001
+From: Tom Tan <Tom.Tan@microsoft.com>
+Date: Wed, 13 Dec 2023 12:37:55 -0800
+Subject: [PATCH] [BUILD] Fix removing of NOMINMAX on Windows (#2449)
+
+---
+ CHANGELOG.md                         | 3 +++
+ api/include/opentelemetry/std/span.h | 2 +-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 6ba0da393c..e305d85948 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -15,6 +15,9 @@ Increment the:
+ 
+ ## [Unreleased]
+ 
++* [BUILD] Fix removing of NOMINMAX on Windows
++  [#2449](https://github.com/open-telemetry/opentelemetry-cpp/pull/2449)
++
+ ## [1.13.0] 2023-12-06
+ 
+ * [BUILD] Remove WITH_REMOVE_METER_PREVIEW, use WITH_ABI_VERSION_2 instead
+diff --git a/api/include/opentelemetry/std/span.h b/api/include/opentelemetry/std/span.h
+index 2a3dc12a84..1160d54fbe 100644
+--- a/api/include/opentelemetry/std/span.h
++++ b/api/include/opentelemetry/std/span.h
+@@ -60,7 +60,7 @@ OPENTELEMETRY_END_NAMESPACE
+ OPENTELEMETRY_BEGIN_NAMESPACE
+ namespace nostd
+ {
+-constexpr std::size_t dynamic_extent = (std::numeric_limits<std::size_t>::max());
++constexpr std::size_t dynamic_extent = (std::numeric_limits<std::size_t>::max)();
+ 
+ template <class ElementType, std::size_t Extent = nostd::dynamic_extent>
+ using span = std::span<ElementType, Extent>;

--- a/recipes/opentelemetry-cpp/all/patches/2475.patch
+++ b/recipes/opentelemetry-cpp/all/patches/2475.patch
@@ -1,0 +1,446 @@
+Fixes build failures after removal of NOMINMAX, see https://github.com/open-telemetry/opentelemetry-cpp/pull/2475
+
+From 78e34e7ccce323a830a2628333ac1a661e3b68cf Mon Sep 17 00:00:00 2001
+From: Mats Taraldsvik <mats.taraldsvik@gmail.com>
+Date: Wed, 3 Jan 2024 21:32:37 +0100
+Subject: [PATCH 1/3] fix std::chrono::microseconds::max
+
+---
+ docs/cpp-ostream-exporter-design.md                           | 2 +-
+ .../exporters/elasticsearch/es_log_record_exporter.h          | 4 ++--
+ .../include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h | 4 ++--
+ .../exporters/otlp/otlp_grpc_log_record_exporter.h            | 4 ++--
+ .../include/opentelemetry/exporters/otlp/otlp_http_exporter.h | 4 ++--
+ .../exporters/otlp/otlp_http_log_record_exporter.h            | 4 ++--
+ .../opentelemetry/sdk/logs/batch_log_record_processor.h       | 4 ++--
+ .../opentelemetry/sdk/logs/multi_log_record_processor.h       | 4 ++--
+ sdk/include/opentelemetry/sdk/trace/batch_span_processor.h    | 4 ++--
+ 9 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/docs/cpp-ostream-exporter-design.md b/docs/cpp-ostream-exporter-design.md
+index 7deb369ab3..50085e126e 100644
+--- a/docs/cpp-ostream-exporter-design.md
++++ b/docs/cpp-ostream-exporter-design.md
+@@ -154,7 +154,7 @@ public:
+         return sdktrace::ExportResult::kSuccess;
+     }
+ 
+-    bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept
++    bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept
+     {
+         isShutdown = true;
+         return true;
+diff --git a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+index 8579c99138..9550da6385 100644
+--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
++++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+@@ -100,14 +100,14 @@ class ElasticsearchLogRecordExporter final : public opentelemetry::sdk::logs::Lo
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Shutdown this exporter.
+    * @param timeout The maximum time to wait for the shutdown method to return
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+ private:
+   // Stores if this exporter had its Shutdown() method called
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+index 7aff1e24a5..01f77ec5c7 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+@@ -58,7 +58,7 @@ class OtlpGrpcExporter final : public opentelemetry::sdk::trace::SpanExporter
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Shut down the exporter.
+@@ -67,7 +67,7 @@ class OtlpGrpcExporter final : public opentelemetry::sdk::trace::SpanExporter
+    * @return return the status of this operation
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+ private:
+   // The configuration options associated with this exporter.
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
+index 29333703b1..8dc2aed2b4 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
+@@ -60,14 +60,14 @@ class OtlpGrpcLogRecordExporter : public opentelemetry::sdk::logs::LogRecordExpo
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Shutdown this exporter.
+    * @param timeout The maximum time to wait for the shutdown method to return.
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+ private:
+   // Configuration options for the exporter
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+index 1adbbc70b9..58eb7ab61c 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+@@ -59,7 +59,7 @@ class OPENTELEMETRY_EXPORT OtlpHttpExporter final : public opentelemetry::sdk::t
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Shut down the exporter.
+@@ -68,7 +68,7 @@ class OPENTELEMETRY_EXPORT OtlpHttpExporter final : public opentelemetry::sdk::t
+    * @return return the status of this operation
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+ private:
+   // The configuration options associated with this exporter.
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
+index 4393345dfd..b7fc0857fb 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
+@@ -58,14 +58,14 @@ class OtlpHttpLogRecordExporter final : public opentelemetry::sdk::logs::LogReco
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Shutdown this exporter.
+    * @param timeout The maximum time to wait for the shutdown method to return
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+ private:
+   // Configuration options for the exporter
+diff --git a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+index e93ebf3d6b..a19aa8736c 100644
+--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
++++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+@@ -72,7 +72,7 @@ class BatchLogRecordProcessor : public LogRecordProcessor
+    * NOTE: Timeout functionality not supported yet.
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Shuts down the processor and does any cleanup required. Completely drains the buffer/queue of
+@@ -82,7 +82,7 @@ class BatchLogRecordProcessor : public LogRecordProcessor
+    * NOTE: Timeout functionality not supported yet.
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Class destructor which invokes the Shutdown() method.
+diff --git a/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h b/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
+index 335da7f668..05f032773b 100644
+--- a/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
++++ b/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
+@@ -45,7 +45,7 @@ class MultiLogRecordProcessor : public LogRecordProcessor
+    * @return a result code indicating whether it succeeded, failed or timed out
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Shuts down the processor and does any cleanup required.
+@@ -55,7 +55,7 @@ class MultiLogRecordProcessor : public LogRecordProcessor
+    * @return true if the shutdown succeeded, false otherwise
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+ private:
+   std::vector<std::unique_ptr<LogRecordProcessor>> processors_;
+diff --git a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+index a748b06361..8edcb5937a 100644
+--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
++++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+@@ -69,7 +69,7 @@ class BatchSpanProcessor : public SpanProcessor
+    * NOTE: Timeout functionality not supported yet.
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Shuts down the processor and does any cleanup required. Completely drains the buffer/queue of
+@@ -79,7 +79,7 @@ class BatchSpanProcessor : public SpanProcessor
+    * NOTE: Timeout functionality not supported yet.
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+ 
+   /**
+    * Class destructor which invokes the Shutdown() method. The Shutdown() method is supposed to be
+
+From 4cbff84d65eabb615cab3037c2dac2401e65a8ec Mon Sep 17 00:00:00 2001
+From: Mats Taraldsvik <mats.taraldsvik@gmail.com>
+Date: Wed, 3 Jan 2024 21:32:38 +0100
+Subject: [PATCH 2/3] temp
+
+---
+ docs/cpp-ostream-exporter-design.md                           | 2 +-
+ .../exporters/elasticsearch/es_log_record_exporter.h          | 4 ++--
+ .../include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h | 4 ++--
+ .../exporters/otlp/otlp_grpc_log_record_exporter.h            | 4 ++--
+ .../include/opentelemetry/exporters/otlp/otlp_http_exporter.h | 4 ++--
+ .../exporters/otlp/otlp_http_log_record_exporter.h            | 4 ++--
+ .../opentelemetry/sdk/logs/batch_log_record_processor.h       | 4 ++--
+ .../opentelemetry/sdk/logs/multi_log_record_processor.h       | 4 ++--
+ sdk/include/opentelemetry/sdk/trace/batch_span_processor.h    | 4 ++--
+ 9 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/docs/cpp-ostream-exporter-design.md b/docs/cpp-ostream-exporter-design.md
+index 50085e126e..6da8bdd032 100644
+--- a/docs/cpp-ostream-exporter-design.md
++++ b/docs/cpp-ostream-exporter-design.md
+@@ -154,7 +154,7 @@ public:
+         return sdktrace::ExportResult::kSuccess;
+     }
+ 
+-    bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept
++    bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept
+     {
+         isShutdown = true;
+         return true;
+diff --git a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+index 9550da6385..b72ff4f917 100644
+--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
++++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+@@ -100,14 +100,14 @@ class ElasticsearchLogRecordExporter final : public opentelemetry::sdk::logs::Lo
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Shutdown this exporter.
+    * @param timeout The maximum time to wait for the shutdown method to return
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+ private:
+   // Stores if this exporter had its Shutdown() method called
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+index 01f77ec5c7..870e5a043a 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+@@ -58,7 +58,7 @@ class OtlpGrpcExporter final : public opentelemetry::sdk::trace::SpanExporter
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Shut down the exporter.
+@@ -67,7 +67,7 @@ class OtlpGrpcExporter final : public opentelemetry::sdk::trace::SpanExporter
+    * @return return the status of this operation
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+ private:
+   // The configuration options associated with this exporter.
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
+index 8dc2aed2b4..f1cd96888c 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
+@@ -60,14 +60,14 @@ class OtlpGrpcLogRecordExporter : public opentelemetry::sdk::logs::LogRecordExpo
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Shutdown this exporter.
+    * @param timeout The maximum time to wait for the shutdown method to return.
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+ private:
+   // Configuration options for the exporter
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+index 58eb7ab61c..b5faf1a9b8 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+@@ -59,7 +59,7 @@ class OPENTELEMETRY_EXPORT OtlpHttpExporter final : public opentelemetry::sdk::t
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Shut down the exporter.
+@@ -68,7 +68,7 @@ class OPENTELEMETRY_EXPORT OtlpHttpExporter final : public opentelemetry::sdk::t
+    * @return return the status of this operation
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+ private:
+   // The configuration options associated with this exporter.
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
+index b7fc0857fb..f481fdab0b 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
+@@ -58,14 +58,14 @@ class OtlpHttpLogRecordExporter final : public opentelemetry::sdk::logs::LogReco
+    * @return return true when all data are exported, and false when timeout
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Shutdown this exporter.
+    * @param timeout The maximum time to wait for the shutdown method to return
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+ private:
+   // Configuration options for the exporter
+diff --git a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+index a19aa8736c..d6a44df142 100644
+--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
++++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+@@ -72,7 +72,7 @@ class BatchLogRecordProcessor : public LogRecordProcessor
+    * NOTE: Timeout functionality not supported yet.
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Shuts down the processor and does any cleanup required. Completely drains the buffer/queue of
+@@ -82,7 +82,7 @@ class BatchLogRecordProcessor : public LogRecordProcessor
+    * NOTE: Timeout functionality not supported yet.
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Class destructor which invokes the Shutdown() method.
+diff --git a/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h b/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
+index 05f032773b..8ca5cffcca 100644
+--- a/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
++++ b/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
+@@ -45,7 +45,7 @@ class MultiLogRecordProcessor : public LogRecordProcessor
+    * @return a result code indicating whether it succeeded, failed or timed out
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Shuts down the processor and does any cleanup required.
+@@ -55,7 +55,7 @@ class MultiLogRecordProcessor : public LogRecordProcessor
+    * @return true if the shutdown succeeded, false otherwise
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+ private:
+   std::vector<std::unique_ptr<LogRecordProcessor>> processors_;
+diff --git a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+index 8edcb5937a..afbf4486b0 100644
+--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
++++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+@@ -69,7 +69,7 @@ class BatchSpanProcessor : public SpanProcessor
+    * NOTE: Timeout functionality not supported yet.
+    */
+   bool ForceFlush(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Shuts down the processor and does any cleanup required. Completely drains the buffer/queue of
+@@ -79,7 +79,7 @@ class BatchSpanProcessor : public SpanProcessor
+    * NOTE: Timeout functionality not supported yet.
+    */
+   bool Shutdown(
+-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
++      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+ 
+   /**
+    * Class destructor which invokes the Shutdown() method. The Shutdown() method is supposed to be
+
+From f02636d8d0becb4e1d8e6f5e8965ba48fd76f77f Mon Sep 17 00:00:00 2001
+From: Mats Taraldsvik <mats.taraldsvik@gmail.com>
+Date: Wed, 3 Jan 2024 21:32:38 +0100
+Subject: [PATCH 3/3] temp
+
+---
+ exporters/elasticsearch/src/es_log_record_exporter.cc | 2 +-
+ exporters/otlp/src/otlp_http_client.cc                | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/exporters/elasticsearch/src/es_log_record_exporter.cc b/exporters/elasticsearch/src/es_log_record_exporter.cc
+index c90072e4e4..e167faf3d9 100644
+--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
++++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
+@@ -430,7 +430,7 @@ bool ElasticsearchLogRecordExporter::ForceFlush(
+       std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
+   if (timeout_steady <= std::chrono::steady_clock::duration::zero())
+   {
+-    timeout_steady = std::chrono::steady_clock::duration::max();
++    timeout_steady = (std::chrono::steady_clock::duration::max)();
+   }
+ 
+   std::unique_lock<std::mutex> lk_cv(synchronization_data_->force_flush_cv_m);
+diff --git a/exporters/otlp/src/otlp_http_client.cc b/exporters/otlp/src/otlp_http_client.cc
+index 9c57a9bd83..7814199ef2 100644
+--- a/exporters/otlp/src/otlp_http_client.cc
++++ b/exporters/otlp/src/otlp_http_client.cc
+@@ -782,7 +782,7 @@ bool OtlpHttpClient::ForceFlush(std::chrono::microseconds timeout) noexcept
+       std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
+   if (timeout_steady <= std::chrono::steady_clock::duration::zero())
+   {
+-    timeout_steady = std::chrono::steady_clock::duration::max();
++    timeout_steady = (std::chrono::steady_clock::duration::max)();
+   }
+ 
+   while (timeout_steady > std::chrono::steady_clock::duration::zero())

--- a/recipes/opentelemetry-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/opentelemetry-cpp/all/test_package/CMakeLists.txt
@@ -6,4 +6,3 @@ find_package(opentelemetry-cpp REQUIRED CONFIG)
 
 add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE opentelemetry-cpp::opentelemetry-cpp)
-target_compile_features(${CMAKE_PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/opentelemetry-cpp/all/test_package/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/test_package/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
+from conan.tools.env import VirtualRunEnv
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
     def requirements(self):
@@ -14,6 +14,17 @@ class TestPackageConan(ConanFile):
 
     def layout(self):
         cmake_layout(self)
+
+    def generate(self):
+        VirtualRunEnv(self).generate(scope="build")
+        VirtualRunEnv(self).generate(scope="run")
+        tc = CMakeToolchain(self)
+        # Since opentelemetry-cpp may need a higher cppstd if built with abseil, we have ot set the CXX standard here.
+        if not self.settings.compiler.cppstd:
+            tc.variables["CMAKE_CXX_STANDARD"] = self.dependencies.build["opentelemetry-cpp"].conf_info.get("user.opentelemetry-cpp:min_cpp")
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/opentelemetry-cpp/config.yml
+++ b/recipes/opentelemetry-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.13.0":
+    folder: all
   "1.12.0":
     folder: all
   "1.9.1":


### PR DESCRIPTION
Also fix various issues in the current recipe:

* Pass the concrete STL-CPPSTD version to opentelemetry-cpp's WITH_STL. That way opentelemetry-cpp doesn't guess the version to use. Also define OPENTELEMETRY_STL_VERSION, since a mismatch of that and the used cppstd leads to a crash.
* Don't patch opentelemetry-proto's path when we can use OTELCPP_PROTO_PATH
* with_otlp_http also needs opentelemetry-proto and protobuf

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
