### PR TITLE
simdutf: add v4.0.9, stop building tests

### DIFF
--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.9":
+    url: "https://github.com/simdutf/simdutf/archive/v4.0.9.tar.gz"
+    sha256: "599E6558FC8D06F8346E5F210564F8B18751C93D83BCE1A40A0E6A326C57B61E"
   "4.0.5":
     url: "https://github.com/simdutf/simdutf/archive/v4.0.5.tar.gz"
     sha256: "040d80ff4321f89ea9739ccc7f468ece9c4bc2630f3d4762b6d829000d2ec625"

--- a/recipes/simdutf/all/conanfile.py
+++ b/recipes/simdutf/all/conanfile.py
@@ -62,7 +62,10 @@ class SimdutfConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["SIMDUTF_BENCHMARKS"] = False
-        tc.variables["BUILD_TESTING"] = False
+        if Version(self.version) >= "3.2.3":
+            tc.variables["SIMDUTF_TESTS"] = False
+        else:
+            tc.variables["BUILD_TESTING"] = False
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "8":
             tc.variables["CMAKE_CXX_FLAGS"] = " -mavx512f"
         tc.variables["SIMDUTF_TOOLS"] = False

--- a/recipes/simdutf/config.yml
+++ b/recipes/simdutf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.9":
+    folder: all
   "4.0.5":
     folder: all
   "4.0.4":


### PR DESCRIPTION
Specify library name and version:  **simdutf/4.0.9**

The setting for building tests changed in simdutf 3.2.3. There's a lot of tests and building them is slow. Let's spare CCI and end-users of that pain.
Also added 4.0.9

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
