### PR TITLE
[ICU] Fix source URL in conandata

### DIFF
--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "74.2":
-    url: "https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-src-FIXED.tgz"
+    url: "https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-src.tgz"
     sha256: "68db082212a96d6f53e35d60f47d38b962e9f9d207a74cfac78029ae8ff5e08c"
   "74.1":
     url: "https://github.com/unicode-org/icu/releases/download/release-74-1/icu4c-74_1-src.tgz"


### PR DESCRIPTION
The current URL used in CCI is no longer available, making impossible to build this package from source. Without the suffix `FIXED` we can find the source package with same checksum.

https://github.com/unicode-org/icu/releases/tag/release-74-2

fixes #22632

/cc @lukasz-matysiak

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
