### PR TITLE
crowcpp-crow: remove 1.1.1, add 1.1.0

### DIFF
--- a/recipes/crowcpp-crow/all/conandata.yml
+++ b/recipes/crowcpp-crow/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.1.1":
-    url: "https://github.com/CrowCpp/crow/archive/refs/tags/v1.1.1.tar.gz"
-    sha256: "9b545c1a18abecb381a6cb8a9bff9381884115f817e9d960cf96c22d81f01b6e"
+  "1.1.0":
+    url: "https://github.com/CrowCpp/crow/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "f4281c3f25769dbc82437dd4199a8ba07b2a6e8a2f42e36a6fd805c493aae5ca"
   "1.0+5":
     url: "https://github.com/CrowCpp/crow/archive/refs/tags/v1.0+5.tar.gz"
     sha256: "4eb1b80b97dda4a3c4f613c581c734e0221911c88ff859ed679bda3dd5d7b319"

--- a/recipes/crowcpp-crow/config.yml
+++ b/recipes/crowcpp-crow/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.1.1":
+  "1.1.0":
     folder: all
   "1.0+5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **crowcpp-crow/***

Since 1.1.1 has been deleted, I will add 1.1.0 instead.

https://github.com/conan-io/conan-center-index/pull/22537#issuecomment-1923322498

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
