### PR TITLE
cwalk: add version 1.2.8

### DIFF
--- a/recipes/cwalk/all/conandata.yml
+++ b/recipes/cwalk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.8":
+    url: "https://github.com/likle/cwalk/archive/v1.2.8.tar.gz"
+    sha256: "48b99bd46f0b9ce027ca882b003e44a5db0369dec6fd9898fd5420aa282d780f"
   "1.2.7":
     url: "https://github.com/likle/cwalk/archive/v1.2.7.tar.gz"
     sha256: "ae424ec30830c970412e34d9092eaa6131d91af289cdad0ad66a7b1c58e768e7"
@@ -18,15 +21,31 @@ sources:
     url: "https://github.com/likle/cwalk/archive/v1.0.0.zip"
     sha256: "9ff6d85f88e7fe4877698afb40745d301491c1d3fca96f08d1622f5fe3494182"
 patches:
+  "1.2.8":
+    - patch_file: "patches/0001-fix-cmake-1.2.8.patch"
+      patch_description: "disable warnings"
+      patch_type: "conan"
   "1.2.7":
     - patch_file: "patches/0001-fix-cmake-1.2.5.patch"
+      patch_description: "disable warnings"
+      patch_type: "conan"
   "1.2.6":
     - patch_file: "patches/0001-fix-cmake-1.2.5.patch"
+      patch_description: "disable warnings"
+      patch_type: "conan"
   "1.2.5":
     - patch_file: "patches/0001-fix-cmake-1.2.5.patch"
+      patch_description: "disable warnings"
+      patch_type: "conan"
   "1.2.2":
     - patch_file: "patches/0001-fix-cmake-1.2.2.patch"
+      patch_description: "add installer, disable test"
+      patch_type: "conan"
   "1.1.0":
     - patch_file: "patches/0001-fix-cmake-1.1.0.patch"
+      patch_description: "add installer, disable test"
+      patch_type: "conan"
   "1.0.0":
     - patch_file: "patches/0001-fix-cmake-1.0.0.patch"
+      patch_description: "add installer, disable test"
+      patch_type: "conan"

--- a/recipes/cwalk/all/conanfile.py
+++ b/recipes/cwalk/all/conanfile.py
@@ -13,13 +13,12 @@ class CwalkConan(ConanFile):
     description = "Path library for C/C++. Cross-Platform for Windows, " \
                   "MacOS and Linux. Supports UNIX and Windows path styles " \
                   "on those platforms."
-    url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://likle.github.io/cwalk/"
     topics = ("cross-platform", "windows", "macos", "osx", "linux",
               "path-manipulation", "path", "directory", "file", "file-system",
               "unc", "path-parsing", "file-path")
-
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -65,6 +64,7 @@ class CwalkConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self._create_cmake_module_alias_targets(
@@ -93,6 +93,8 @@ class CwalkConan(ConanFile):
         self.cpp_info.libs = ["cwalk"]
         if self.options.shared and Version(self.version) >= "1.2.5":
             self.cpp_info.defines.append("CWK_SHARED")
+        if Version(self.version) >= "1.2.8":
+            self.cpp_info.set_property("pkg_config_name", "cwalk")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "Cwalk"

--- a/recipes/cwalk/all/patches/0001-fix-cmake-1.2.8.patch
+++ b/recipes/cwalk/all/patches/0001-fix-cmake-1.2.8.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ed38852..9d4ec62 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,7 +41,7 @@ endif()
+ add_library(cwalk
+   "${INCLUDE_DIRECTORY}/cwalk.h"
+   "${SOURCE_DIRECTORY}/cwalk.c")
+-enable_warnings(cwalk)
++# enable_warnings(cwalk)
+ target_include_directories(cwalk PUBLIC
+   $<BUILD_INTERFACE:${INCLUDE_DIRECTORY}>
+   $<INSTALL_INTERFACE:include>

--- a/recipes/cwalk/config.yml
+++ b/recipes/cwalk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.8":
+    folder: all
   "1.2.7":
     folder: all
   "1.2.6":


### PR DESCRIPTION
Specify library name and version:  **cwalk/***

- add version 1.2.8
- add patch_type, patch_description
- since 1.2.8, cwalk install a pkgconf file. (which should be removed in cci)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
