### PR TITLE
glm: add version 1.0.0

### DIFF
--- a/recipes/glm/all/conandata.yml
+++ b/recipes/glm/all/conandata.yml
@@ -2,24 +2,6 @@ sources:
   "1.0.0":
     url: "https://github.com/g-truc/glm/releases/download/1.0.0/glm-1.0.0-light.zip"
     sha256: "bfd27ba33926fbdb341545b79e0ebc810f7b5e5593f9b0fe450cea1462950731"
-  "cci.20230113":
-    url: "https://github.com/g-truc/glm/archive/efec5db081e3aad807d0731e172ac597f6a39447.zip"
-    sha256: "e7a1abc208278cc3f0dba59c5170d83863b3375f98136d588b8beb74825e503c"
-  "cci.20220420":
-    url: "https://github.com/g-truc/glm/archive/cc98465e3508535ba8c7f6208df934c156a018dc.zip"
-    sha256: "06d48e336857777d2d1f7da9ccd59e4b9d79720dbd70886d48837d19cda997bb"
   "0.9.9.8":
     url: "https://github.com/g-truc/glm/releases/download/0.9.9.8/glm-0.9.9.8.zip"
     sha256: "37e2a3d62ea3322e43593c34bae29f57e3e251ea89f4067506c94043769ade4c"
-  "0.9.9.7":
-    url: "https://github.com/g-truc/glm/releases/download/0.9.9.7/glm-0.9.9.7.zip"
-    sha256: "6b79c3d06d9745d1cce3f38c0c15666596f9aefff25ddb74df3af0a02f011ee1"
-  "0.9.9.6":
-    url: "https://github.com/g-truc/glm/releases/download/0.9.9.6/glm-0.9.9.6.zip"
-    sha256: "9db7339c3b8766184419cfe7942d668fecabe9013ccfec8136b39e11718817d0"
-  "0.9.9.5":
-    url: "https://github.com/g-truc/glm/releases/download/0.9.9.5/glm-0.9.9.5.zip"
-    sha256: "4fe34860ce69156f63eea6c3d84c91cadfc330353cf275ff394aef4e163cafee"
-  "0.9.5.4":
-    url: "https://github.com/g-truc/glm/releases/download/0.9.5.4/glm-0.9.5.4.zip"
-    sha256: "c25002f109104bb8eb37a7e74c745cbc0a713ec5d9a857050c7878edb5ee246c"

--- a/recipes/glm/all/conandata.yml
+++ b/recipes/glm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/g-truc/glm/releases/download/1.0.0/glm-1.0.0-light.zip"
+    sha256: "bfd27ba33926fbdb341545b79e0ebc810f7b5e5593f9b0fe450cea1462950731"
   "cci.20230113":
     url: "https://github.com/g-truc/glm/archive/efec5db081e3aad807d0731e172ac597f6a39447.zip"
     sha256: "e7a1abc208278cc3f0dba59c5170d83863b3375f98136d588b8beb74825e503c"

--- a/recipes/glm/all/conanfile.py
+++ b/recipes/glm/all/conanfile.py
@@ -25,7 +25,7 @@ class GlmConan(ConanFile):
         self.info.clear()
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=Version(self._get_semver()) < "1.0.0")
 
     def build(self):
         pass
@@ -34,14 +34,19 @@ class GlmConan(ConanFile):
         glm_version = self.version if self.version.startswith("cci") else Version(self._get_semver())
         if glm_version == "0.9.8" or (glm_version == "0.9.9" and self._get_tweak_number() < 6):
             save(self, os.path.join(self.package_folder, "licenses", "copying.txt"), self._get_license())
-        else:
+        elif glm_version < "1.0.0":
             copy(self, "copying.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        for headers in ("*.hpp", "*.inl", "*.h"):
+        else:
+            copy(self, "copying.txt", src=os.path.join(self.source_folder, "glm"), dst=os.path.join(self.package_folder, "licenses"))
+        for headers in ("*.hpp", "*.inl", "*.h", "*.cppm"):
             copy(self, headers, src=os.path.join(self.source_folder, "glm"),
                                 dst=os.path.join(self.package_folder, "include", "glm"))
 
     def _get_semver(self):
-        return self.version.rsplit(".", 1)[0]
+        if self.version >= Version("1.0.0"):
+            return self.version
+        else:
+            return self.version.rsplit(".", 1)[0]
 
     def _get_tweak_number(self):
         return int(self.version.rsplit(".", 1)[-1])

--- a/recipes/glm/all/conanfile.py
+++ b/recipes/glm/all/conanfile.py
@@ -25,37 +25,19 @@ class GlmConan(ConanFile):
         self.info.clear()
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=Version(self._get_semver()) < "1.0.0")
+        get(self, **self.conan_data["sources"][self.version], strip_root=self.version < Version("1.0.0"))
 
     def build(self):
         pass
 
     def package(self):
-        glm_version = self.version if self.version.startswith("cci") else Version(self._get_semver())
-        if glm_version == "0.9.8" or (glm_version == "0.9.9" and self._get_tweak_number() < 6):
-            save(self, os.path.join(self.package_folder, "licenses", "copying.txt"), self._get_license())
-        elif glm_version < "1.0.0":
+        if self.version < Version("1.0.0"):
             copy(self, "copying.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         else:
             copy(self, "copying.txt", src=os.path.join(self.source_folder, "glm"), dst=os.path.join(self.package_folder, "licenses"))
         for headers in ("*.hpp", "*.inl", "*.h", "*.cppm"):
             copy(self, headers, src=os.path.join(self.source_folder, "glm"),
                                 dst=os.path.join(self.package_folder, "include", "glm"))
-
-    def _get_semver(self):
-        if self.version >= Version("1.0.0"):
-            return self.version
-        else:
-            return self.version.rsplit(".", 1)[0]
-
-    def _get_tweak_number(self):
-        return int(self.version.rsplit(".", 1)[-1])
-
-    def _get_license(self):
-        manual = load(self, os.path.join(self.source_folder, "manual.md"))
-        begin = manual.find("### The Happy Bunny License (Modified MIT License)")
-        end = manual.find("\n![](./doc/manual/frontpage2.png)", begin)
-        return manual[begin:end]
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "glm")

--- a/recipes/glm/config.yml
+++ b/recipes/glm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "cci.20230113":
     folder: all
   "cci.20220420":

--- a/recipes/glm/config.yml
+++ b/recipes/glm/config.yml
@@ -1,17 +1,5 @@
 versions:
   "1.0.0":
     folder: all
-  "cci.20230113":
-    folder: all
-  "cci.20220420":
-    folder: all
   "0.9.9.8":
-    folder: all
-  "0.9.9.7":
-    folder: all
-  "0.9.9.6":
-    folder: all
-  "0.9.9.5":
-    folder: all
-  "0.9.5.4":
     folder: all


### PR DESCRIPTION
https://github.com/g-truc/glm/issues/1226

The released archive has a bit of a different structure than previous releases, so i had to add some conditionals for v1.0.0.
I'm wondering if I should also delete the cci.yyyymmdd versions and/or create a different subfolder for this release.