### PR TITLE
(#22661) openssl: fix handling of tc.defines in config_template

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -451,7 +451,7 @@ class OpenSSLConan(ConanFile):
         if self._perlasm_scheme:
             perlasm_scheme = 'perlasm_scheme => "%s",' % self._perlasm_scheme
 
-        defines = " ".join(defines)
+        defines = '", "'.join(defines)
         defines = 'defines => add("%s"),' % defines if defines else ""
         targets = "my %targets"
 


### PR DESCRIPTION
Specify library name and version:  **openssl/3.2.1**

Fix the handling of tc.defines into the config_template for openssl. Currently, it is generating a single string that is space-separated, but the toolchain is expecting a comma-separated list of strings.

Fixes #22661

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
