### PR TITLE
[config] Add waitaing list for users in authorized users

### DIFF
--- a/.c3i/authorized_users.yml
+++ b/.c3i/authorized_users.yml
@@ -1266,7 +1266,6 @@ authorized_users:
 - wu-vincent
 - Inujel
 - keszegrobert
-- Mike-Solar
 - tomasz-wezyk
 - RaguzovaTatyana
 - st9007a
@@ -1278,6 +1277,5 @@ authorized_users:
 - stefansli
 - wgtmac
 - kevinAlbs
-- retroandchill
 - adamws
 - rob-baily

--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -16,6 +16,7 @@ artifactory:
 github:
   reviewers: "reviewers.yml"
   authorized_users: "authorized_users.yml"
+  waitlist_users: "waitlist_users.yml"
 
 slack:
   credential_success_url: SLACK_SUCCESS_WEBHOOK_URL

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -23,6 +23,7 @@ artifactory:
 github:
   reviewers: "reviewers.yml"
   authorized_users: "authorized_users.yml"
+  waitlist_users: "waitlist_users.yml"
 
 # Things related to Jenkins jobs:
 tasks:

--- a/.c3i/waitlist_users.yml
+++ b/.c3i/waitlist_users.yml
@@ -1,3 +1,4 @@
 waitlist_users:
 - Mike-Solar
 - retroandchill
+- refactorTractor

--- a/.c3i/waitlist_users.yml
+++ b/.c3i/waitlist_users.yml
@@ -1,0 +1,3 @@
+waitlist_users:
+- Mike-Solar
+- retroandchill

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -41,6 +41,7 @@ This section gathers the most common questions from the community related to pac
   * [How to watch only specific recipes?](#how-to-watch-only-specific-recipes)
   * [Is it possible to disable Pylint?](#is-it-possible-to-disable-pylint)
   * [How long can I be inactive before being removed from the authorized users list?](#how-long-can-i-be-inactive-before-being-removed-from-the-authorized-users-list)
+  * [What happens in case I change my user name?](#what-happens-in-case-i-change-my-user-name)
   * [Can we add package which are parts of bigger projects like Boost?](#can-we-add-package-which-are-parts-of-bigger-projects-like-boost)
     * [Can I add my project which I will submit to Boost?](#can-i-add-my-project-which-i-will-submit-to-boost)
   * [Can I add options that do not affect `package_id` or the package contents](#can-i-add-options-that-do-not-affect-package_id-or-the-package-contents)
@@ -430,6 +431,14 @@ difficult to understand [linter errors](linters.md), please comment on your pull
 ## How long can I be inactive before being removed from the authorized users list?
 
 Please, read [Inactivity and user removal section](adding_packages/README.md#inactivity-and-user-removal).
+
+## What happens in case I change my user name?
+
+Your Github user name is used to identify you in the authorized users list. If you change your user name, you will need to communicate or, in the #4, or opening a new issue.
+Otherwise, the CI will not be able to find you and will not build your pull requests.
+In case you change you user name just after asking for authorization in #4, please, communicate the change in the same issue.
+Users are revised before being added to the authorized users list, in case the user name is not found in #4, it will be asked in the pull request `Update authorized users list`.
+If the user does not answer, the user will be moved to the `waitlist_users.yml` file, until having further communication.
 
 ## Can we add package which are parts of bigger projects like Boost?
 


### PR DESCRIPTION
- This configuration is not running yet.
- Some users change name in middle of asking for access request and when asking about the old username, there is no answer about. These outdated and not responded users will be moved to a waiting list where we can ping from to time, but will not have access to PRs until be move to authorized users list.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
