### PR TITLE
boost: First gcc version to support c++11 was gcc 5

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -166,7 +166,7 @@ class BoostConan(ConanFile):
         """ Minimum compiler version having c++ standard >= 11
         """
         return {
-            "gcc": 6,
+            "gcc": 5,
             "clang": 6,
             "apple-clang": 99,  # still uses C++98 by default. XCode does not reflect apple-clang
             "Visual Studio": 14,  # guess


### PR DESCRIPTION
boost

First gcc version to support c++11 was gcc 5:
https://gcc.gnu.org/projects/cxx-status.html

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
