### PR TITLE
Set CMP0142 policy in package templates

### DIFF
--- a/docs/package_templates/autotools_package/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/autotools_package/all/test_package/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
+
+if(POLICY CMP0142)
+  cmake_policy(SET CMP0142 NEW)
+endif()
+
 project(test_package LANGUAGES C) # if the project is pure C
 # project(test_package LANGUAGES CXX) # if the project uses c++
 

--- a/docs/package_templates/cmake_package/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/cmake_package/all/test_package/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 
+if(POLICY CMP0142)
+  cmake_policy(SET CMP0142 NEW)
+endif()
+
 project(test_package LANGUAGES C) # if the project is pure C
 # project(test_package LANGUAGES CXX) # if the project uses c++
 

--- a/docs/package_templates/header_only/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/header_only/all/test_package/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
+
+if(POLICY CMP0142)
+  cmake_policy(SET CMP0142 NEW)
+endif()
+
 project(test_package LANGUAGES C) # if the project is pure C
 # project(test_package LANGUAGES CXX) # if the project uses c++
 

--- a/docs/package_templates/msbuild_package/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/msbuild_package/all/test_package/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 
+if(POLICY CMP0142)
+  cmake_policy(SET CMP0142 NEW)
+endif()
+
 project(test_package LANGUAGES C) # if the project is pure C
 # project(test_package LANGUAGES CXX) # if the project uses C++
 


### PR DESCRIPTION
New behavior fixes warnings for Xcode generator in case of using CMake >= 3.25 and conan 2.

Without this policy CMake passes inexisting subdirectories to linker.
"ld: warning: directory not found for option '-L/Users/user/.conan2/p/b/expatbf806472793ba/p/lib/Release'"
https://cmake.org/cmake/help/latest/policy/CMP0142.html

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
