### PR TITLE
protobuf: Add v4.25.2

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.25.2":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v4.25.2.tar.gz"
+    sha256: "9420a5e4692036845bdf5c0eeea4ce5c7e4ec0364ef7b841ee7df9033e6d6a85"
   "3.21.12":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.21.12.tar.gz"
     sha256: "930c2c3b5ecc6c9c12615cf5ad93f1cd6e12d0aba862b572e076259970ac3a53"

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.25.2":
+    folder: all
   "3.21.12":
     folder: all
   "3.21.9":


### PR DESCRIPTION
Specify library name and version:  **protobuf/4.25.2**

Add support for protobuf v4.25.2.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
