### PR TITLE
stale: enable cache

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: read
+      actions: write
 
 
     steps:


### PR DESCRIPTION
only 30 PRs are processed per day, so cache is needed to keep state and continue from the last PRs of the last days.

fixes error https://github.com/conan-io/conan-center-index/actions/runs/7810903828/job/21305055330#step:2:1032

```
state: persisting info about 250 issue(s)
Warning: Error delete _state: [403] Resource not accessible by integration
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/conan-center-index/conan-center-index --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key _state, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/master, Key: _state, Version: fa41d75081481069cfb6b92a5f83a94c6e06ef3ab2e6b762649ac5f86f46153f
```

cf https://github.com/actions/stale/issues/1090#issuecomment-1710940734


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
