### PR TITLE
[c-blosc2] Revert checksum

### DIFF
--- a/recipes/c-blosc2/all/conandata.yml
+++ b/recipes/c-blosc2/all/conandata.yml
@@ -1,25 +1,25 @@
 sources:
   "2.13.1":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.13.1.tar.gz"
-    sha256: "8e71ed3ca2eb4dad13adc34b2e88fb2687b63b8d9cc904aaf60510d75c44ff47"
+    sha256: "6e7f5940269acd54d8dfe87c2102a442ad0407b1a62266a6f916134bae234399"
   "2.13.0":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.13.0.tar.gz"
-    sha256: "931ab054e83ebc98786f2e014156c6b5168af27e52d37d63523fa1a87c080f44"
+    sha256: "d886798ff0a63948a4076f2ed60f0dc18be3aa1299ac1aff2cf705419cbe1bea"
   "2.12.0":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.12.0.tar.gz"
-    sha256: "51685bab203685100d03ece2e724a3ea035174fd6108e3c45a55a1a60e0ec350"
+    sha256: "b8fa07ab0627c19fb652e08a5ada197eb0939b75e97e2fb76bbee145eaedc6e9"
   "2.11.3":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.11.3.tar.gz"
-    sha256: "89e5e1019853e0fbb5ebb97828abb141cae8dba0d7bf5d29364d07d227f864f0"
+    sha256: "7273ec3ab42adc247425ab34b0601db86a6e2a6aa1a97a11e29df02e078f5037"
   "2.10.5":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.10.5.tar.gz"
-    sha256: "3540ac942d845beedb432cf4f65c2c30c3818e211e094f1320563f9aa2bc7b3b"
+    sha256: "a88f94bf839c1371aab8207a6a43698ceb92c72f65d0d7fe5b6e59f24c138b4d"
   "2.8.0":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.8.0.tar.gz"
-    sha256: "97327e493908911ee06dd5144afa8818de255127305e63ef39368d8d8ae2cb06"
+    sha256: "be608cdf68deb02e0d3ee62e183942a0fe5d5d3185375b9b6566e2ae35a9bdbd"
   "2.6.1":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.6.1.tar.gz"
-    sha256: "4a91b229cfa5beb89ab9edb75f7a45e501ac6bb19a9b73a26f06e9b2a1f42875"
+    sha256: "514a793368093893c1a7cae030f7e31faca7f86465ae69dd576f256d8bf28c08"
 patches:
   "2.13.1":
     - patch_file: "patches/2.11.1-0001-fix-cmake.patch"

--- a/recipes/c-blosc2/all/conanfile.py
+++ b/recipes/c-blosc2/all/conanfile.py
@@ -18,7 +18,7 @@ class CBlosc2Conan(ConanFile):
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Blosc/c-blosc2"
-    topics = ("c-blosc", "blosc", "compression")
+    topics = ("c-blosc", "blosc", "compression", "cache", "store")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {


### PR DESCRIPTION
Partially revert of https://github.com/conan-io/conan-center-index/pull/22674

The author warned about reverting back the project name, which affects the package checksum too: https://github.com/Blosc/c-blosc2/issues/583#issuecomment-1931905036

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
