### PR TITLE
tcl: Un-vendor sqlite, properly fix apple shared install names

### DIFF
--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -77,6 +77,7 @@ class TclConan(ConanFile):
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not is_msvc(self):
             self.win_bash = True
+            self.build_requires("autoconf/2.71")
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
 

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -55,6 +55,16 @@ class TclConan(ConanFile):
         # source folder must be a sub-directory of the build folder
         self.folders.build = "."
 
+        # In order for fix_apple_shared_install_name to work, it needs to know the package layout precisely.
+        # Unfortunately this has to be defined here, before we ever fetch the sources, so we have to do this maually.
+        extra_folders = {
+            "8.6.13": ["itcl4.2.3", "sqlite3.40.0",   "tdbc1.1.5", "tdbcpostgres1.1.5", "thread2.8.8", "tdbcmysql1.1.5", "tdbcodbc1.1.5"],
+            "8.6.11": ["itcl4.2.1", "sqlite3.34.0",   "tdbc1.1.2", "tdbcpostgres1.1.2", "thread2.8.6", "tdbcmysql1.1.2", "tdbcodbc1.1.2"],
+            "8.6.10": ["itcl4.2.0", "sqlite3.30.1.2", "tdbc1.1.1", "tdbcpostgres1.1.1", "thread2.8.5", "tdbcmysql1.1.1", "tdbcodbc1.1.1"],
+        }
+
+        self.cpp.package.libdirs.extend(os.path.join("lib", folder) for folder in extra_folders[self.version])
+
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_sqlite:

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -56,12 +56,16 @@ class TclConan(ConanFile):
         self.folders.build = "."
 
         # In order for fix_apple_shared_install_name to work, it needs to know the package layout precisely.
-        # Unfortunately this has to be defined here, before we ever fetch the sources, so we have to do this maually.
+        # Unfortunately this has to be defined here, before we ever fetch the sources, so we have to do this manually.
         extra_folders = {
-            "8.6.13": ["itcl4.2.3", "sqlite3.40.0",   "tdbc1.1.5", "tdbcpostgres1.1.5", "thread2.8.8", "tdbcmysql1.1.5", "tdbcodbc1.1.5"],
-            "8.6.11": ["itcl4.2.1", "sqlite3.34.0",   "tdbc1.1.2", "tdbcpostgres1.1.2", "thread2.8.6", "tdbcmysql1.1.2", "tdbcodbc1.1.2"],
-            "8.6.10": ["itcl4.2.0", "sqlite3.30.1.2", "tdbc1.1.1", "tdbcpostgres1.1.1", "thread2.8.5", "tdbcmysql1.1.1", "tdbcodbc1.1.1"],
+            "8.6.13": ["itcl4.2.3", "tdbc1.1.5", "tdbcpostgres1.1.5", "thread2.8.8", "tdbcmysql1.1.5", "tdbcodbc1.1.5"],
+            "8.6.11": ["itcl4.2.1", "tdbc1.1.2", "tdbcpostgres1.1.2", "thread2.8.6", "tdbcmysql1.1.2", "tdbcodbc1.1.2"],
+            "8.6.10": ["itcl4.2.0", "tdbc1.1.1", "tdbcpostgres1.1.1", "thread2.8.5", "tdbcmysql1.1.1", "tdbcodbc1.1.1"],
         }
+        if self.options.with_sqlite:
+            extra_folders["8.6.13"].append("sqlite3.40.0")
+            extra_folders["8.6.11"].append("sqlite3.34.0")
+            extra_folders["8.6.10"].append("sqlite3.30.1.2")
 
         self.cpp.package.libdirs.extend(os.path.join("lib", folder) for folder in extra_folders[self.version])
 

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -106,6 +106,8 @@ class TclConan(ConanFile):
             ])
             if self.options.with_sqlite:
                 tc.configure_args.append("--with-system-sqlite")
+            if not is_apple_os(self):
+                tc.extra_ldflags.append('-Wl,--as-needed')
             tc.generate()
 
             deps = AutotoolsDeps(self)

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -77,7 +77,6 @@ class TclConan(ConanFile):
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not is_msvc(self):
             self.win_bash = True
-            self.build_requires("autoconf/2.71")
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
 
@@ -126,9 +125,10 @@ class TclConan(ConanFile):
                     rm(self, "*.c", os.path.join(self.source_folder, "pkgs", folder, "compat"), recursive=True)
                     rm(self, "*.h", os.path.join(self.source_folder, "pkgs", folder, "compat"), recursive=True)
 
+                    # Don't override SQLITE_* variables, causes link errors
                     if Version(self.version) < "8.6.13":
-                        # Don't override SQLITE_API, causes link errors
                         replace_in_file(self, os.path.join(self.source_folder, "pkgs", folder, "Makefile.in"), "-DSQLITE_API=MODULE_SCOPE", "")
+                    replace_in_file(self, os.path.join(self.source_folder, "pkgs", folder, "Makefile.in"), "-DSQLITE_EXTERN=", "")
                     break
             else:
                 # Remove all folders referencing sqlite


### PR DESCRIPTION
Specify library name and version:  **tcl/all**

Tcl vendors sqlite3 for an extension, and it seems this had gone unnoticed until now. This also adds an option to remove sqlite entirely in case users don't want this.

Tcl has a lot of sub-directories with libraries in the package folder, and the `fix_apple_shared_install_name` tool wasn't fixing them. Adding the correct folders to `self.cpp.package.libdirs` allows it to fix everything.

Blocks https://github.com/conan-io/conan-center-index/pull/21387

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
