### PR TITLE
tk: Fix apple shared install name

### DIFF
--- a/recipes/tk/all/conanfile.py
+++ b/recipes/tk/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanException, ConanInvalidConfiguration
-from conan.tools.apple import is_apple_os
+from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import (
@@ -240,6 +240,8 @@ class TkConan(ConanFile):
             # This can only be modified after build since the value being replaced is a result
             # of variable substitution in tkConfig.sh.in
             replace_in_file(self, tkConfigShPath, "//", "${TK_ROOT}/")
+        
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
         tk_version = Version(self.version)


### PR DESCRIPTION
Specify library name and version:  **tk/all**

Should be self explanatory. Per documentation, this is typically needed in autotools builds.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
