### PR TITLE
[docs] Add changelog 07-February-2024

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 07-February-2024 - 15:43 CET
+
+- [feature] Add waiting list for new collaborators that are not found in access request issue.
+- [feature] Skip building bump dependencies PRs by default. It will require manual CI trigger.
+
 ### 24-January-2024 - 12:13 CET
 
 - [feature] Update Conan 1.x branch to version 1.62.0


### PR DESCRIPTION
The new version of C3I Jenkins is here:

- There are few cases when an user can change the username between asking for access in the #4 and the time when the CI bot opens the PR to update the authorized users. In case it happens, we will have a missing username, and sometimes we can't contact the outdated user name. So, this feature pushes those usernames to a second list, where we can ask again from time to time.

- The Bump dependencies PR is used to have all recipe's dependencies aligned to the latest version, or to solve conflicts with other recipes that are consuming a same package with different version. Pushing this kind of PR can result in missing binaries, as an entire dependencies graph will be update and may affect other packages. Second, bump deps usually is not something with high priority, but the current CI service does not know about, resulting in delays when needing to build other priorities, like broken recipes or releasing a very popular package. From now, any bump dependencies PR will be started manually by a Conan team member (please, only ping `@conan-io/barbarians`) to be built in the CI. 


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
