### PR TITLE
ffmpeg: Fix pkgconf workaround

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -629,7 +629,7 @@ class FFMpegConan(ConanFile):
         if ranlib:
             args.append(f"--ranlib={unix_path(self, ranlib)}")
         # for some reason pkgconf from conan can't find .pc files on Linux in the context of ffmpeg configure...
-        if self._settings_build.os != "Linux":
+        if self._settings_build.os == "Linux":
             pkg_config = self.conf.get("tools.gnu:pkg_config", default=buildenv_vars.get("PKG_CONFIG"), check_type=str)
             if pkg_config:
                 args.append(f"--pkg-config={unix_path(self, pkg_config)}")


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The `pkgconf` workaround in `ffmpeg` seems to have had it's logic flipped at some point so the code now does the opposite of the comment. It seems harmless to remove the os-specific check and doing so fixes the original issue for us. 

Alternatively we can also flip the logic back the right way around. 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
