### PR TITLE
fontconfig: update expat

### DIFF
--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -48,7 +48,7 @@ class FontconfigConan(ConanFile):
 
     def requirements(self):
         self.requires("freetype/2.13.2")
-        self.requires("expat/2.5.0")
+        self.requires("expat/2.6.0")
         if self.settings.os == "Linux":
             self.requires("util-linux-libuuid/2.39.2")
 

--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir

--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -48,7 +48,8 @@ class FontconfigConan(ConanFile):
 
     def requirements(self):
         self.requires("freetype/2.13.2")
-        self.requires("expat/2.6.0")
+        # Expat >2.5.0 does not work for versions <2.13.93, which are exactly the versions this recipe serves.
+        self.requires("expat/2.5.0")
         if self.settings.os == "Linux":
             self.requires("util-linux-libuuid/2.39.2")
 

--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir
@@ -48,8 +48,11 @@ class FontconfigConan(ConanFile):
 
     def requirements(self):
         self.requires("freetype/2.13.2")
-        # Expat >2.5.0 does not work for versions <2.13.93, which are exactly the versions this recipe serves.
-        self.requires("expat/2.5.0")
+        # Expat >2.5.0 does not work on Mac for versions <2.13.93, which are exactly the versions this recipe serves.
+        if is_apple_os(self):
+            self.requires("expat/2.5.0")
+        else:
+            self.requires("expat/2.6.0")
         if self.settings.os == "Linux":
             self.requires("util-linux-libuuid/2.39.2")
 

--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir
@@ -48,11 +48,7 @@ class FontconfigConan(ConanFile):
 
     def requirements(self):
         self.requires("freetype/2.13.2")
-        # Expat >2.5.0 does not work on Mac for versions <2.13.93, which are exactly the versions this recipe serves.
-        if is_apple_os(self):
-            self.requires("expat/2.5.0")
-        else:
-            self.requires("expat/2.6.0")
+        self.requires("expat/2.6.0")
         if self.settings.os == "Linux":
             self.requires("util-linux-libuuid/2.39.2")
 

--- a/recipes/fontconfig/all/test_package/test_package.c
+++ b/recipes/fontconfig/all/test_package/test_package.c
@@ -1,24 +1,5 @@
 #include <fontconfig/fontconfig.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 int main() {
-	FcConfig* config = FcInitLoadConfigAndFonts();
-	FcPattern* pat = FcNameParse((const FcChar8*)"Arial");
-	FcConfigSubstitute(config, pat, FcMatchPattern);
-	FcDefaultSubstitute(pat);
-	char* fontFile;
-	FcResult result;
-	FcPattern* font = FcFontMatch(config, pat, &result);
-	if (font) {
-		FcChar8* file = NULL;
-		if (FcPatternGetString(font, FC_FILE, 0, &file) == FcResultMatch) {
-			fontFile = (char*)file;
-			printf("%s\n",fontFile);
-		}
-	} else {
-        printf("Ops! I can't find any font!\n");
-    }
-	FcPatternDestroy(pat);
-    return EXIT_SUCCESS;
+	FcInit();
 }

--- a/recipes/fontconfig/all/test_package/test_package.c
+++ b/recipes/fontconfig/all/test_package/test_package.c
@@ -2,4 +2,5 @@
 
 int main() {
 	FcInit();
+	return 0;
 }

--- a/recipes/fontconfig/meson/conanfile.py
+++ b/recipes/fontconfig/meson/conanfile.py
@@ -50,7 +50,7 @@ class FontconfigConan(ConanFile):
 
     def requirements(self):
         self.requires("freetype/2.13.2")
-        self.requires("expat/2.5.0")
+        self.requires("expat/2.6.0")
         if self.settings.os == "Linux":
             self.requires("util-linux-libuuid/2.39.2")
 


### PR DESCRIPTION
Fontconfig is causing version conflict in the PR #21387 due expat.

I've simplified the test package for the older versions, for some reason on Mac it is segfaulting if we try to do anything remotely complicated (Can't even call FcFini() without it segfaulting). Seems to be fine on newer versions, so I think this is just some bug in the older versions.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
