### PR TITLE
jasper: add version 4.2.0, update dependencies

### DIFF
--- a/recipes/jasper/all/conandata.yml
+++ b/recipes/jasper/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.2.0":
+    url: "https://github.com/jasper-software/jasper/releases/download/version-4.2.0/jasper-4.2.0.tar.gz"
+    sha256: "69f0b08a0cc281a06eaf7feed510736854bbff9af89ab1d01b77382ad57ec957"
   "4.1.2":
     url: "https://github.com/jasper-software/jasper/releases/download/version-4.1.2/jasper-4.1.2.tar.gz"
     sha256: "22392e439b87c79aaf8689ec79a286a7147e811c4bee34edf3d0b239798d672b"
@@ -18,6 +21,10 @@ sources:
     url: "https://github.com/jasper-software/jasper/releases/download/version-2.0.33/jasper-2.0.33.tar.gz"
     sha256: "28d28290cc2eaf70c8756d391ed8bcc8ab809a895b9a67ea6e89da23a611801a"
 patches:
+  "4.2.0":
+    - patch_file: "patches/4.2.0-0003-deterministic-libname.patch"
+      patch_description: "No generator dependent libname"
+      patch_type: "conan"
   "4.1.2":
     - patch_file: "patches/4.1.1-0001-skip-rpath.patch"
       patch_description: "Do not enforce rpath configuration"

--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -12,11 +12,11 @@ required_conan_version = ">=1.53.0"
 
 class JasperConan(ConanFile):
     name = "jasper"
-    license = "JasPer-2.0"
-    homepage = "https://jasper-software.github.io/jasper"
-    url = "https://github.com/conan-io/conan-center-index"
-    topics = ("toolkit", "coding", "jpeg", "images")
     description = "JasPer Image Processing/Coding Tool Kit"
+    license = "JasPer-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://jasper-software.github.io/jasper"
+    topics = ("toolkit", "coding", "jpeg", "images")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -50,9 +50,9 @@ class JasperConan(ConanFile):
         if self.options.with_libjpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_libjpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/3.0.0")
+            self.requires("libjpeg-turbo/3.0.2")
         elif self.options.with_libjpeg == "mozjpeg":
-            self.requires("mozjpeg/4.1.1")
+            self.requires("mozjpeg/4.1.5")
 
     def build_requirements(self):
         if Version(self.version) >= "4.1.1":
@@ -77,11 +77,11 @@ class JasperConan(ConanFile):
         if Version(self.version) >= "3.0.0":
             tc.variables["JAS_ENABLE_LIBHEIF"] = False
         tc.variables["JAS_ENABLE_OPENGL"] = False
-
         if cross_building(self):
             tc.cache_variables["JAS_CROSSCOMPILING"] = True
             tc.cache_variables["JAS_STDC_VERSION"] = "199901L"
-
+        if Version(self.version) >= "4.2.0":
+            tc.variables["JAS_PACKAGING"] = True
         tc.generate()
 
         cmakedeps = CMakeDeps(self)

--- a/recipes/jasper/all/patches/4.2.0-0003-deterministic-libname.patch
+++ b/recipes/jasper/all/patches/4.2.0-0003-deterministic-libname.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c6925e4..8392edf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -274,7 +274,7 @@ message("JAS_MULTICONFIGURATION_GENERATOR ${JAS_MULTICONFIGURATION_GENERATOR}")
+ # If a multiconfiguration generator is used, ensure that various output
+ # files are not placed in subdirectories (such as Debug and Release)
+ # as this will cause the CTest test suite to fail.
+-if(JAS_MULTICONFIGURATION_GENERATOR)
++if(0)
+ 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY .)
+ 	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY .)
+ 	set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY .)

--- a/recipes/jasper/config.yml
+++ b/recipes/jasper/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.2.0":
+    folder: all
   "4.1.2":
     folder: all
   "4.1.1":


### PR DESCRIPTION
Specify library name and version:  **jasper/***

https://github.com/jasper-software/jasper/releases/tag/version-4.2.0

- add version 4.2.0
- since 4.2.0, jasper has provided "JAS_PACKAGING" cmake option to control rpath configuration
- update dependencies

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
