### PR TITLE
b2: Don't apply CXXFLAGS env var if it doesn't exist

### DIFF
--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -159,13 +159,14 @@ class B2Conan(ConanFile):
         if self.options.use_cxx_env:
             envvars = VirtualBuildEnv(self).vars()
 
-            cxx = envvars.get("CXX")
-            if cxx:
-                command += f" --cxx={cxx}"
-                self._write_project_config(cxx)
+            cxx_env = envvars.get("CXX")
+            if cxx_env:
+                command += f" --cxx={cxx_env}"
+                self._write_project_config(cxx_env)
 
             cxxflags_env = envvars.get("CXXFLAGS")
-            cxxflags = f"{cxxflags} {cxxflags_env}"
+            if cxxflags_env:
+                cxxflags = f"{cxxflags} {cxxflags_env}"
 
         if cxxflags:
             command += f' --cxxflags="{cxxflags}"'


### PR DESCRIPTION
This is a fix for a regression introduced in #21093

Without this cxxflags are set to "None" which causes a compile failure.

Specify library name and version:  **b2/5.0.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated. **[I couldn't get this working with Conan v2]**
