### PR TITLE
imgui: add version 1.90.2, 1.90.2-docking

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.90.2":
+    url: "https://github.com/ocornut/imgui/archive/v1.90.2.tar.gz"
+    sha256: "452d1c11e5c4b4dfcca272915644a65f1c076498e8318b141ca75cd30470dd68"
+  "1.90.2-docking":
+    url: "https://github.com/ocornut/imgui/archive/v1.90.2-docking.tar.gz"
+    sha256: "69f1cd78d49ec9cc847b7082d641434ea731f0be41c6930bea08a46a0794ac17"
   "1.90.1":
     url: "https://github.com/ocornut/imgui/archive/v1.90.1.tar.gz"
     sha256: "21dcc985bb2ae8fe48047c86135dbc438d6980a8f2e08babbda5be820592f282"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.90.2":
+    folder: all
+  "1.90.2-docking":
+    folder: all
   "1.90.1":
     folder: all
   "1.90.1-docking":


### PR DESCRIPTION
Specify library name and version:  **imgui/1.90.2, 1.90.2-docking**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
