### PR TITLE
Set min_cppstd to 11 for redis-plus-plus

### DIFF
--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -33,7 +33,7 @@ class RedisPlusPlusConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return "11" if Version(self.version) < "1.3.0" else "17"
+        return "11"
 
     @property
     def _compilers_minimum_version(self):


### PR DESCRIPTION
Fixes #22739

Specify library name and version:  **redis-plus-plus/1.3.12**

Currently the recipe is setting the min_stdcpp to 17 for 1.3.x versions.

The project [README](https://github.com/sewenew/redis-plus-plus/blob/master/README.md#installation) says:

    However, it can also be built with the -std=c++11 or -std=c++14 standard, and in that case, we have our own simple
    implementation of std::string_view and std::optional. In order to explicitly specify c++ standard, you can use the
    following cmake flag: -DREDIS_PLUS_PLUS_CXX_STANDARD=11.

It looks like 17 is the default but they support C++11 and above.
---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
