### PR TITLE
sentry-breakpad: add version 0.7.0

### DIFF
--- a/recipes/sentry-breakpad/all/conandata.yml
+++ b/recipes/sentry-breakpad/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7.0":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.7.0/sentry-native.zip"
+    sha256: "4dfccc879a81771b9da1c335947ffc9e5987ca3d16b3035efa2c66a06f727543"
   "0.6.5":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.6.5/sentry-native.zip"
     sha256: "5f74a5c5c3abc6e1e7825d3306be9e3b3fd4e0f586f3cf7e86607d6f56a71995"
@@ -15,6 +18,15 @@ sources:
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.18/sentry-native.zip"
     sha256: "41fdf6499cd8576142beb03104badcc9e0b80b8ef27080ca71cd4408cc1d7ece"
 patches:
+  "0.7.0":
+    - patch_file: "patches/0.6.x-0001-remove-third-pary-lss.patch"
+      patch_description: "Remove third party lss from include"
+      patch_type: "conan"
+      patch_source: "https://github.com/getsentry/breakpad/pull/37"
+    - patch_file: "patches/0.6.x-0002-install-breakpad-header.patch"
+      patch_description: "Install breakpad header"
+      patch_type: "conan"
+      patch_source: "https://github.com/getsentry/sentry-native/pull/872"
   "0.6.5":
     - patch_file: "patches/0.6.x-0001-remove-third-pary-lss.patch"
       patch_description: "Remove third party lss from include"

--- a/recipes/sentry-breakpad/config.yml
+++ b/recipes/sentry-breakpad/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.7.0":
+    folder: all
   "0.6.5":
     folder: all
   "0.6.4":


### PR DESCRIPTION
Specify library name and version:  **sentry-breakpad/0.7.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
