### PR TITLE
[hiredis] Use cache variables to make work with Cmake

### DIFF
--- a/recipes/hiredis/all/conanfile.py
+++ b/recipes/hiredis/all/conanfile.py
@@ -56,9 +56,9 @@ class HiredisConan(ConanFile):
         # Since 1.2.0, BUILD_SHARED_LIBS has been defined by option()
         if Version(self.version) >= "1.2.0":
             tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
-        tc.variables["ENABLE_SSL"] = self.options.with_ssl
-        tc.variables["DISABLE_TESTS"] = True
-        tc.variables["ENABLE_EXAMPLES"] = False
+        tc.cache_variables["ENABLE_SSL"] = self.options.with_ssl
+        tc.cache_variables["DISABLE_TESTS"] = True
+        tc.cache_variables["ENABLE_EXAMPLES"] = False
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
The version 1.1.0 has a patch move `project()` in CMakeLists.txt, which works when using toolchain. However, we didn't have it to 1.2.0, than fails.

This PR uses cache variables to pass all variables via command line, skip toolchain.

fixes #22514

/cc @aligirayhanozbay-abex
/cc @bronekrab

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
