### PR TITLE
Fix protobuf compilation under MSYS2

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -97,7 +97,8 @@ class ProtobufConan(ConanFile):
             runtime = msvc_runtime_flag(self)
             if not runtime:
                 runtime = self.settings.get_safe("compiler.runtime")
-            tc.cache_variables["protobuf_MSVC_STATIC_RUNTIME"] = "MT" in runtime
+            if runtime:
+                tc.cache_variables["protobuf_MSVC_STATIC_RUNTIME"] = "MT" in runtime
         if is_apple_os(self) and self.options.shared:
             # Workaround against SIP on macOS for consumers while invoking protoc when protobuf lib is shared
             tc.variables["CMAKE_INSTALL_RPATH"] = "@loader_path/../lib"


### PR DESCRIPTION
Building protobuf on MSYS2 fails on the line 100. Apparently the conan detection of `is_msvc` and `is_clang_cl` is flawed. Work around this by guarding the statement.

Specify library name and version:  **protobuf/3.21.12**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated. --No, the hooks only work on v1.
