### PR TITLE
md4qt: bump version to 2.7.3

### DIFF
--- a/recipes/md4qt/all/conandata.yml
+++ b/recipes/md4qt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.7.3":
+    url: "https://github.com/igormironchik/md4qt/archive/refs/tags/2.7.3.tar.gz"
+    sha256: "d464cd137a69218f88af1373b198610f1db6971c7aa56c6869219ffb34e6f0dd"
   "2.7.2":
     url: "https://github.com/igormironchik/md4qt/archive/refs/tags/2.7.2.tar.gz"
     sha256: "2d6b65db799fff944f2ecb8bb411f17687e41e0d5a17a37ad1c4bd22fe997d8b"

--- a/recipes/md4qt/config.yml
+++ b/recipes/md4qt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.7.3":
+    folder: all
   "2.7.2":
     folder: all
   "2.7.1":


### PR DESCRIPTION
Specify library name and version:  **md4qt/2.7.3**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

I'm the author of this library.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
