### PR TITLE
glaze: add version 2.1.4

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.1.3":
-    url: "https://github.com/stephenberry/glaze/archive/v2.1.3.tar.gz"
-    sha256: "10345cd0fab29a8386815fd94562f014caf90df1640e2e4409466da6a7a10ee2"
+  "2.1.4":
+    url: "https://github.com/stephenberry/glaze/archive/v2.1.4.tar.gz"
+    sha256: "cbaba4dfbaaf342c8be8e6834cb79933b080ac89f3aa1470bc7a83197d9ebc1a"
   "2.1.0":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.0.tar.gz"
     sha256: "b3bb4d886f17d266f37a6eec2c42b2e57e287918b20511297c4eb6b9960f0f8f"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "2.1.4":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.4.tar.gz"
     sha256: "cbaba4dfbaaf342c8be8e6834cb79933b080ac89f3aa1470bc7a83197d9ebc1a"
+  "2.1.3":
+    url: "https://github.com/stephenberry/glaze/archive/v2.1.3.tar.gz"
+    sha256: "10345cd0fab29a8386815fd94562f014caf90df1640e2e4409466da6a7a10ee2"
   "2.1.0":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.0.tar.gz"
     sha256: "b3bb4d886f17d266f37a6eec2c42b2e57e287918b20511297c4eb6b9960f0f8f"
@@ -14,27 +17,9 @@ sources:
   "2.0.6":
     url: "https://github.com/stephenberry/glaze/archive/v2.0.6.tar.gz"
     sha256: "aa5d4921382e9781998ebbf6d36964556daa3367a2aef5ca814122502b450abc"
-  "2.0.5":
-    url: "https://github.com/stephenberry/glaze/archive/v2.0.5.tar.gz"
-    sha256: "a826c823dd125e25ecd29881775df5db07ccacd5358a04efba2b290eb6c945eb"
-  "2.0.3":
-    url: "https://github.com/stephenberry/glaze/archive/v2.0.3.tar.gz"
-    sha256: "7e155d2970329ff4a13fe1d4c4e4b63509405a984b4f37ef9f92b8756bb3c8ce"
-  "2.0.2":
-    url: "https://github.com/stephenberry/glaze/archive/v2.0.2.tar.gz"
-    sha256: "af65752fb523c82313bfbe9c04ab47e332d881154f06c63967b973ee51e5923d"
-  "2.0.1":
-    url: "https://github.com/stephenberry/glaze/archive/v2.0.1.tar.gz"
-    sha256: "0f515588189796696a802c88b0308b5386376d202c7ff1875683f38316f09c90"
-  "2.0.0":
-    url: "https://github.com/stephenberry/glaze/archive/v2.0.0.tar.gz"
-    sha256: "8553ade81a20b1a7c8398f95490ab540f34a78f226f7fe5555dfcbbaf216e108"
   "1.9.9":
     url: "https://github.com/stephenberry/glaze/archive/v1.9.9.tar.gz"
     sha256: "7e2605046742a89ec455887a5a0d6b3188ed5c14ea309c5eb9814848c26bedca"
-  "1.9.5":
-    url: "https://github.com/stephenberry/glaze/archive/v1.9.5.tar.gz"
-    sha256: "3800fa7283a1d4e5bd2c746fe9e268d2f8af76d3a75be7318b2084f38f529c7f"
   "1.8.5":
     url: "https://github.com/stephenberry/glaze/archive/v1.8.5.tar.gz"
     sha256: "5d876eed5689f1947ea4eafd9f13a4e0b527611a6b1857c79a5d598a856287b4"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "2.1.4":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.4.tar.gz"
     sha256: "cbaba4dfbaaf342c8be8e6834cb79933b080ac89f3aa1470bc7a83197d9ebc1a"
-  "2.1.3":
-    url: "https://github.com/stephenberry/glaze/archive/v2.1.3.tar.gz"
-    sha256: "10345cd0fab29a8386815fd94562f014caf90df1640e2e4409466da6a7a10ee2"
   "2.1.0":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.0.tar.gz"
     sha256: "b3bb4d886f17d266f37a6eec2c42b2e57e287918b20511297c4eb6b9960f0f8f"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.3":
+    url: "https://github.com/stephenberry/glaze/archive/v2.1.3.tar.gz"
+    sha256: "10345cd0fab29a8386815fd94562f014caf90df1640e2e4409466da6a7a10ee2"
   "2.1.0":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.0.tar.gz"
     sha256: "b3bb4d886f17d266f37a6eec2c42b2e57e287918b20511297c4eb6b9960f0f8f"

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -25,13 +25,18 @@ class GlazeConan(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
-        return {
+        versions = {
             "Visual Studio": "17",
             "msvc": "193",
-            "gcc": "10" if Version(self.version) < "1.9.0" else "11",
+            "gcc": "10",
             "clang": "12",
             "apple-clang": "13.1",
         }
+        if Version(self.version) >= "1.9.0":
+            versions["gcc"] = "11"
+        if Version(self.version) >= "2.1.4":
+            versions["gcc"] = "12"
+        return versions
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -34,8 +34,6 @@ class GlazeConan(ConanFile):
         }
         if Version(self.version) >= "1.9.0":
             versions["gcc"] = "11"
-        if Version(self.version) >= "2.1.4":
-            versions["gcc"] = "12"
         return versions
 
     def layout(self):
@@ -45,7 +43,13 @@ class GlazeConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        if self.settings.get_safe("compiler.cppstd"):
+        if Version(self.version) >= "2.1.4" and \
+            self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "11.3":
+            raise ConanInvalidConfiguration(
+                f"{self.ref} doesn't support 11.0<=gcc<11.3 due to gcc bug. Please use gcc>=11.3 and set compiler.version.(ex. compiler.version=11.3)",
+            )
+
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.3":
+    folder: all
   "2.1.0":
     folder: all
   "2.0.9":

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,6 +1,8 @@
 versions:
   "2.1.4":
     folder: all
+  "2.1.3":
+    folder: all
   "2.1.0":
     folder: all
   "2.0.9":
@@ -9,19 +11,7 @@ versions:
     folder: all
   "2.0.6":
     folder: all
-  "2.0.5":
-    folder: all
-  "2.0.3":
-    folder: all
-  "2.0.2":
-    folder: all
-  "2.0.1":
-    folder: all
-  "2.0.0":
-    folder: all
   "1.9.9":
-    folder: all
-  "1.9.5":
     folder: all
   "1.8.5":
     folder: all

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,8 +1,6 @@
 versions:
   "2.1.4":
     folder: all
-  "2.1.3":
-    folder: all
   "2.1.0":
     folder: all
   "2.0.9":

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.1.3":
+  "2.1.4":
     folder: all
   "2.1.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **glaze/***

- glaze/2.1.4 uses `decltype(auto)` which is not supported by gcc < 11.3 due to gcc bug. [ref](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102229)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
