### PR TITLE
[libgpg-error] Fix crosscompile errors

### DIFF
--- a/recipes/libgpg-error/all/conanfile.py
+++ b/recipes/libgpg-error/all/conanfile.py
@@ -57,10 +57,6 @@ class GPGErrorConan(ConanFile):
         ])
         if self.options.get_safe("fPIC", True):
             tc.configure_args.append("--with-pic")
-        host = None
-        if self.settings.os == "Linux" and self.settings.arch == "x86":
-            host = "i686-linux-gnu"
-        tc.update_configure_args({"--host": host})
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Specify library name and version:  **libgpg-error/1.47**

This was causing the crosscompile to fail in most cases. 
The condition is no longer needed because it should work in most cases if the compiler executable is correctly specified in the Conan profile.

Closes https://github.com/conan-io/conan-center-index/issues/22784
