### PR TITLE
opendis6: Set Minimum C++ Standard to 14 for RHEL 8 Support [CRITICAL]

### DIFF
--- a/recipes/opendis6/all/conanfile.py
+++ b/recipes/opendis6/all/conanfile.py
@@ -29,7 +29,7 @@ class OpenDis6Conan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return "17"
+        return "14"
 
     @property
     def _compilers_minimum_version(self):

--- a/recipes/opendis6/all/conanfile.py
+++ b/recipes/opendis6/all/conanfile.py
@@ -36,9 +36,9 @@ class OpenDis6Conan(ConanFile):
         return {
             "Visual Studio": "15",
             "msvc": "191",
-            "gcc": "8.5",
-            "clang": "6",
-            "apple-clang": "14",
+            "gcc": "7",
+            "clang": "7",
+            "apple-clang": "10",
         }
 
     def config_options(self):

--- a/recipes/opendis6/all/test_package/CMakeLists.txt
+++ b/recipes/opendis6/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(OpenDIS CONFIG REQUIRED)
 
 add_executable(test_package_dis test_package.cpp)
 target_link_libraries(test_package_dis PRIVATE OpenDIS::OpenDIS6)
-set_target_properties(test_package_dis PROPERTIES CXX_STANDARD 17)
+set_target_properties(test_package_dis PROPERTIES CXX_STANDARD 14)


### PR DESCRIPTION
Specify library name and version:  **opendis6/0.1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The current minimum cppstd is set to 17, which excludes RHEL 8 GCC 8.x support. It is critical that opendis6 be available for RHEL 8. GCC 8.x natively uses C++14 as the default standard, so I have set the cppstd accordingly for this package.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
