### PR TITLE
tinyply: do not remove fPIC option if static

### DIFF
--- a/recipes/tinyply/all/conanfile.py
+++ b/recipes/tinyply/all/conanfile.py
@@ -31,7 +31,8 @@ class TinyplyConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        self.options.rm_safe("fPIC")
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/22787

Condition based on shared option has been removed unintentionally by https://github.com/conan-io/conan-center-index/pull/15865, so it's restored in this PR.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
