### PR TITLE
poco: add transitive_headers on zlib dependency

### DIFF
--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -149,7 +149,7 @@ class PocoConan(ConanFile):
             self.requires("pcre/8.45")
         else:
             self.requires("pcre2/10.42")
-        self.requires("zlib/[>=1.2.11 <2]")
+        self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True)
         if self.options.enable_xml:
             self.requires("expat/2.5.0", transitive_headers=True)
         if self.options.enable_data_sqlite:


### PR DESCRIPTION
Specify library name and version:  **poco/all**

Add the transitive_headers=True trait on the expat dependency to reflect that poco headers transitively include expat headers

Specifically the zlib.h header is exposed in [DeflatingStream.h](https://github.com/pocoproject/poco/blob/devel/Foundation/include/Poco/DeflatingStream.h) and [InflatingStream.h](https://github.com/pocoproject/poco/blob/devel/Foundation/include/Poco/InflatingStream.h)

Fixes #22806


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
