### PR TITLE
safe: new recipe

### DIFF
--- a/recipes/safe/all/conandata.yml
+++ b/recipes/safe/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1.1":
+    url: "https://github.com/LouisCharlesC/safe/archive/v1.1.1.tar.gz"
+    sha256: "A6E161EAFC32AA522CD2CE1A5F95A3DF963C51263053089FC8F7A9765D054F00"

--- a/recipes/safe/all/conanfile.py
+++ b/recipes/safe/all/conanfile.py
@@ -1,0 +1,48 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.build import check_min_cppstd
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.51.1"
+
+class SafeConan(ConanFile):
+    name = "safe"
+    description = "Header only read and write locks for mutexes"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/LouisCharlesC/safe"
+    topics = ("multi-threading ", "lock", "guard", "raii", "thread-safety", "mutexes", "lock-guard", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 11
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.h",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/safe/all/test_package/CMakeLists.txt
+++ b/recipes/safe/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+find_package(safe REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE safe::safe)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/safe/all/test_package/conanfile.py
+++ b/recipes/safe/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/safe/all/test_package/test_package.cpp
+++ b/recipes/safe/all/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#include "safe/safe.h"
+
+int main(void) {
+    safe::Safe<int> safeValue;
+
+    {
+        safe::WriteAccess<safe::Safe<int>> value(safeValue);
+        *value = 5;
+    }
+    
+    return 0;
+}

--- a/recipes/safe/config.yml
+++ b/recipes/safe/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **safe/1.1.1**

[Safe ](https://github.com/LouisCharlesC/safe/) is a header-only mutex wrapper.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
