### PR TITLE
[nmos-cpp] Bump dependencies to match upstream

### DIFF
--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -54,8 +54,8 @@ class NmosCppConan(ConanFile):
         self.requires("cpprestsdk/2.10.18", transitive_headers=True)
         self.requires("websocketpp/0.8.2")
         self.requires("openssl/[>=1.1 <4]")
-        self.requires("json-schema-validator/2.2.0")
-        self.requires("nlohmann_json/3.11.2")
+        self.requires("json-schema-validator/2.3.0")
+        self.requires("nlohmann_json/3.11.3")
         self.requires("zlib/[>=1.2.11 <2]")
 
         if self.options.get_safe("with_dnssd") == "mdnsresponder":


### PR DESCRIPTION
Specify library name and version:  **nmos-cpp**

Bump to json-schema-validator/2.3.0 and nlohmann_json/3.11.3 to align with upstream ahead of new release.

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
