### PR TITLE
android-ndk: add r26c

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,4 +1,17 @@
 sources:
+  "r26c":
+    "Windows":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26c-windows.zip"
+        sha256: "67d0c7e4ba853e9168584e8640a562af431dcf086c08efef3ec23ee827139303"
+    "Linux":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26c-linux.zip"
+        sha256: "6d6e659834d28bb24ba7ae66148ad05115ebbad7dabed1af9b3265674774fcf6"
+    "Macos":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r26c-darwin.zip"
+        sha256: "312756dfcbdbf389d35d651e17ca98683bd36cb83cc7bf7ad51cac5c06bd064b"
   "r26b":
     "Windows":
       "x86_64":

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "r26c":
+    folder: all
   "r26b":
     folder: all
   "r26":


### PR DESCRIPTION
Specify library name and version:  **android-ndk/r26c**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Upstream changelog: https://github.com/android/ndk/wiki/Changelog-r26#r26c

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
