### PR TITLE
Openssl proper support for multiple defines

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -346,7 +346,7 @@ class OpenSSLConan(ConanFile):
         return ancestor
 
     def _get_default_openssl_dir(self):
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "Neutrino"]:
             return "/etc/ssl"
         return os.path.join(self.package_folder, "res")
 

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -452,9 +452,8 @@ class OpenSSLConan(ConanFile):
         if self._perlasm_scheme:
             perlasm_scheme = 'perlasm_scheme => "%s",' % self._perlasm_scheme
 
-        defines = " ".join(defines)
-        defines = 'defines => add("%s"),' % defines if defines else ""
-        targets = "my %targets"
+        defines = "\n".join(f"defines => add(\"{d}\")," for d in defines)
+        targets = "my %targets"        
 
         if self._asm_target:
             ancestor = '[ "%s", asm("%s") ]' % (self._ancestor_target, self._asm_target)

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -440,6 +440,7 @@ class OpenSSLConan(ConanFile):
                     cxxflags => add("{cxxflags}"),
                     {defines}
                     lflags => add("{lflags}"),
+                    {dso_scheme}
                     {shared_target}
                     {shared_cflag}
                     {shared_extension}
@@ -447,6 +448,10 @@ class OpenSSLConan(ConanFile):
                 }},
             );
         """)
+
+        dso_scheme = ""
+        if self.settings.os == "Neutrino":
+          dso_scheme = 'dso_scheme => "dlfcn",'
 
         perlasm_scheme = ""
         if self._perlasm_scheme:
@@ -481,6 +486,7 @@ class OpenSSLConan(ConanFile):
             cxxflags=" ".join(cxxflags),
             defines=defines,
             perlasm_scheme=perlasm_scheme,
+            dso_scheme=dso_scheme,
             shared_target=shared_target,
             shared_extension=shared_extension,
             shared_cflag=shared_cflag,


### PR DESCRIPTION
openssl/3.x.x

With current recipe multiple defines in AutotoolsToolchain results in this config:
```
openssl/3.0.13: my %targets = (
    "conan-Release-Linux-x86_64-gcc-11" => {
        inherit_from => [ "linux-x86_64" ],
        cflags => add("-m64 -fPIC -O3"),
        cxxflags => add("-m64 -fPIC -O3"),
        defines => add("NDEBUG MYDEF1 MYDEF2"),
        lflags => add("-m64"),
    },
);
```
Resulting in the gcc compile command `...-DNDEBUG MYDEF1 MYDEF2...` (note the missing '-D') which produces a compile error.

This PR fixes that issue producing this working config:
```
openssl/3.0.13: my %targets = (
    "conan-Release-Linux-x86_64-gcc-11" => {
        inherit_from => [ "linux-x86_64" ],
        cflags => add("-m64 -fPIC -O3"),
        cxxflags => add("-m64 -fPIC -O3"),
        defines => add("NDEBUG"),
        defines => add("MYDEF1"),
        defines => add("MYDEF2"),
        lflags => add("-m64"),
    },
);
```

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
