### PR TITLE
daw_utf_range: add version 2.2.4

### DIFF
--- a/recipes/daw_utf_range/all/conandata.yml
+++ b/recipes/daw_utf_range/all/conandata.yml
@@ -1,10 +1,13 @@
 sources:
+  "2.2.4":
+    url: "https://github.com/beached/utf_range/archive/v2.2.4.tar.gz"
+    sha256: "e6df85d6da445c16507e738d70c6313df2a70e64b739a05d6437b06a5f83b8b1"
   "2.2.3":
     url: "https://github.com/beached/utf_range/archive/v2.2.3.tar.gz"
     sha256: "cfa36285ffbdf8d4d08fbbe95d054e67ad845c064a92419ea68a770415ad7a98"
   "2.2.2":
-    url: "https://github.com/beached/utf_range/archive/refs/tags/v2.2.2.tar.gz"
+    url: "https://github.com/beached/utf_range/archive/v2.2.2.tar.gz"
     sha256: "5380ade7c7eb5c82a748211896fc7385eaec00d3215af1374aec8f0e326f91fd"
   "2.2.0":
-    url: "https://github.com/beached/utf_range/archive/refs/tags/v2.2.0.tar.gz"
+    url: "https://github.com/beached/utf_range/archive/v2.2.0.tar.gz"
     sha256: "00f60360736062403c8a7a94dd07c750366958f20d1864578faecf2e09d84265"

--- a/recipes/daw_utf_range/all/conanfile.py
+++ b/recipes/daw_utf_range/all/conanfile.py
@@ -15,7 +15,7 @@ class DawUtfRangeConan(ConanFile):
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/beached/utf_range/"
-    topics = ("utf", "validator", "iterator")
+    topics = ("utf", "validator", "iterator", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
@@ -38,7 +38,10 @@ class DawUtfRangeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("daw_header_libraries/2.97.0")
+        if Version(self.version) >= "2.2.4":
+            self.requires("daw_header_libraries/2.101.0")
+        else:
+            self.requires("daw_header_libraries/2.97.0")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/daw_utf_range/config.yml
+++ b/recipes/daw_utf_range/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.4":
+    folder: "all"
   "2.2.3":
     folder: "all"
   "2.2.2":


### PR DESCRIPTION
Specify library name and version:  **daw_utf_range/2.2.4**

daw_utf_range/2.2.4 requires daw_header_libraries>=2.98.0 because daw_header_libraries has moved several functions to new header files.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
