### PR TITLE
botan: add version 2.19.4

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -14,6 +14,9 @@ sources:
   "2.19.3":
     url: "https://github.com/randombit/botan/archive/2.19.3.tar.gz"
     sha256: "8f568bf74c2e476d92ac8a1cfc2ba8407ec038fe9458bd0a11e7da827a9b8199"
+  "2.19.4":
+    url: "https://github.com/randombit/botan/archive/2.19.4.tar.gz"
+    sha256: "5754a6b5ddc3c74b0cb8671531feea69d03a4f3b5bdafa5f75e4c73a1242e5b1"
   "3.0.0":
     url: "https://github.com/randombit/botan/archive/3.0.0.tar.gz"
     sha256: "8bafe2e965fa9ccf92ef5741165d735c9fbbe6376c373bbf5702495ad2dfb814"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -9,6 +9,8 @@ versions:
     folder: all
   "2.19.3":
     folder: all
+  "2.19.4":
+    folder: all
   "3.0.0":
     folder: all
   "3.1.0":


### PR DESCRIPTION
Specify library name and version:  **botan/2.19.4**

Botan 2.x is in maintenance mode. This is a patch release with a few improvements that are relevant to security.
See https://github.com/randombit/botan/blob/release-2/news.rst

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
