### PR TITLE
zlib: Bad alternative url for zlib 1.3.1

### DIFF
--- a/recipes/zlib/all/conandata.yml
+++ b/recipes/zlib/all/conandata.yml
@@ -2,7 +2,7 @@ sources:
   "1.3.1":
     url:
       - "https://zlib.net/fossils/zlib-1.3.1.tar.gz"
-      - "https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.1.tar.gz"
+      - "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
     sha256: "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
   "1.3":
     url:


### PR DESCRIPTION
zlib 1.3.1

The alternative url for zlib 1.3.1 in conandata was bad!

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
