### PR TITLE
stdgpu: fix CUDA and HIP custom CMake modules

### DIFF
--- a/recipes/stdgpu/all/cmake/stdgpu-dependencies-cuda.cmake
+++ b/recipes/stdgpu/all/cmake/stdgpu-dependencies-cuda.cmake
@@ -1,6 +1,7 @@
 # Mimics the behavior of stdgpu-dependencies.cmake exported by stdgpu for the CUDA backend
 
 find_dependency(CUDAToolkit 11.0 REQUIRED)
+
 # Using ${stdgpu_LIBRARIES} to allow the target to be renamed using the "cmake_target_name" CMakeDeps property
-target_link_libraries(${stdgpu_LIBRARIES} INTERFACE CUDA::cudart)
+set_property(TARGET ${stdgpu_LIBRARIES} PROPERTY INTERFACE_LINK_LIBRARIES CUDA::cudart APPEND)
 set_property(TARGET ${stdgpu_LIBRARIES} PROPERTY INTERFACE_COMPILE_FEATURES cuda_std_17)

--- a/recipes/stdgpu/all/cmake/stdgpu-dependencies-hip.cmake
+++ b/recipes/stdgpu/all/cmake/stdgpu-dependencies-hip.cmake
@@ -1,9 +1,8 @@
 # Mimics the behavior of stdgpu-dependencies.cmake exported by stdgpu for the HIP backend
 
 find_dependency(thrust 1.9.9 REQUIRED)
-
 find_dependency(hip 5.1 REQUIRED)
 
 # Using ${stdgpu_LIBRARIES} to allow the target to be renamed using the "cmake_target_name" CMakeDeps property
-target_link_libraries(${stdgpu_LIBRARIES} INTERFACE hip::host)
+set_property(TARGET ${stdgpu_LIBRARIES} PROPERTY INTERFACE_LINK_LIBRARIES hip::host APPEND)
 set_property(TARGET ${stdgpu_LIBRARIES} PROPERTY INTERFACE_COMPILE_FEATURES hip_std_17)

--- a/recipes/stdgpu/all/conanfile.py
+++ b/recipes/stdgpu/all/conanfile.py
@@ -101,7 +101,7 @@ class StdgpuConan(ConanFile):
                                 "Using Thrust from system instead of Conan.")
         if self.options.backend == "openmp":
             if self.options.openmp == "llvm":
-                self.requires("llvm-openmp/12.0.1", transitive_headers=True, transitive_libs=True)
+                self.requires("llvm-openmp/17.0.6", transitive_headers=True, transitive_libs=True)
             else:
                 self.output.info("Using OpenMP backend with system OpenMP")
 

--- a/recipes/stdgpu/all/conanfile.py
+++ b/recipes/stdgpu/all/conanfile.py
@@ -57,7 +57,6 @@ class StdgpuConan(ConanFile):
                 "clang": "6",
                 "apple-clang": "6",
                 "msvc": "192",
-                "Visual Studio": "16",
             }
         else:
             # > 1.3.0
@@ -67,7 +66,6 @@ class StdgpuConan(ConanFile):
                 "clang": "10",
                 "apple-clang": "12",
                 "msvc": "192",
-                "Visual Studio": "16",
             }
 
     def export_sources(self):
@@ -110,8 +108,7 @@ class StdgpuConan(ConanFile):
             self.tool_requires("cmake/[>=3.18 <4]")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_min_versions.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(

--- a/recipes/stdgpu/all/test_package/conanfile.py
+++ b/recipes/stdgpu/all/test_package/conanfile.py
@@ -7,8 +7,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
`target_link_libraries()` cannot be used with imported targets in some cases.