### PR TITLE
Add option to opencascade to apply patch for C2-continuous Coons patches

### DIFF
--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -102,7 +102,7 @@ class OpenCascadeConan(ConanFile):
         self.requires("tcl/8.6.10")
         if self._link_tk:
             self.requires("tk/8.6.10")
-        self.requires("freetype/2.13.0")
+        self.requires("freetype/2.13.2")
         if self._link_opengl:
             self.requires("opengl/system")
         if self._is_linux:

--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.build import check_min_cppstd, valid_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import (
     apply_conandata_patches, collect_libs, copy, export_conandata_patches, get,
-    load, rename, replace_in_file, rmdir, save
+    load, patch, rename, replace_in_file, rmdir, save
 )
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
@@ -39,6 +39,7 @@ class OpenCascadeConan(ConanFile):
         "with_tbb": [True, False],
         "with_opengl": [True, False],
         "extended_debug_messages": [True, False],
+        "patch_GeomFill_CoonsC2Style": [True, False],
     }
     default_options = {
         "shared": False,
@@ -52,6 +53,7 @@ class OpenCascadeConan(ConanFile):
         "with_tbb": False,
         "with_opengl": True,
         "extended_debug_messages": False,
+        "patch_GeomFill_CoonsC2Style": False,
     }
 
     short_paths = True
@@ -80,6 +82,8 @@ class OpenCascadeConan(ConanFile):
 
     def export_sources(self):
         export_conandata_patches(self)
+        # copy coons patch patch
+        copy(self, os.path.join("patches", "dlr-feature-coons_c2.patch"), self.recipe_folder, self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -188,6 +192,10 @@ class OpenCascadeConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
+
+        if self.options.patch_GeomFill_CoonsC2Style:
+            patch_file = os.path.join(self.export_sources_folder, "patches", "dlr-feature-coons_c2.patch")
+            patch(self, patch_file=patch_file)
 
         cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
         cmakelists_tools = os.path.join(self.source_folder, "tools", "CMakeLists.txt")

--- a/recipes/opencascade/all/patches/dlr-feature-coons_c2.patch
+++ b/recipes/opencascade/all/patches/dlr-feature-coons_c2.patch
@@ -1,0 +1,322 @@
+From f7278d6608f47e0bf0c91c6ea83df016889057ca Mon Sep 17 00:00:00 2001
+From: Martin Siggel <martin.siggel@dlr.de>
+Date: Tue, 25 May 2021 19:13:47 +0200
+Subject: [PATCH] Coons C2 Patch developed for DLR
+
+---
+ src/GeomFill/GeomFill_BSplineCurves.cxx | 92 ++++++++++++++++++++++---
+ src/GeomFill/GeomFill_BSplineCurves.hxx |  2 +-
+ src/GeomFill/GeomFill_Coons.cxx         | 55 ++++++++++-----
+ src/GeomFill/GeomFill_Coons.hxx         |  8 +--
+ src/GeomFill/GeomFill_FillingStyle.hxx  |  3 +-
+ 5 files changed, 129 insertions(+), 31 deletions(-)
+
+diff --git a/src/GeomFill/GeomFill_BSplineCurves.cxx b/src/GeomFill/GeomFill_BSplineCurves.cxx
+index 57c9a01f..a038e40a 100644
+--- a/src/GeomFill/GeomFill_BSplineCurves.cxx
++++ b/src/GeomFill/GeomFill_BSplineCurves.cxx
+@@ -211,7 +211,7 @@ GeomFill_BSplineCurves::GeomFill_BSplineCurves
+    const Handle(Geom_BSplineCurve)& C4, 
+    const GeomFill_FillingStyle Type      )
+ {
+-  Init( C1, C2, C3, C4, Type);
++  Init( C1, C2, C3, C4, Type, Precision::Confusion() );
+ }
+ 
+ 
+@@ -254,12 +254,13 @@ void  GeomFill_BSplineCurves::Init
+    const Handle(Geom_BSplineCurve)& C2, 
+    const Handle(Geom_BSplineCurve)& C3, 
+    const Handle(Geom_BSplineCurve)& C4, 
+-   const GeomFill_FillingStyle Type      )
++   const GeomFill_FillingStyle Type,
++   const Standard_Real Tol,
++   const Standard_Boolean SetSameDistr)
+ {
+   // On ordonne les courbes
+   Handle(Geom_BSplineCurve) CC1, CC2, CC3, CC4;
+   
+-  Standard_Real Tol = Precision::Confusion();
+ #ifndef No_Exception
+   Standard_Boolean IsOK =
+ #endif
+@@ -281,12 +282,79 @@ void  GeomFill_BSplineCurves::Init
+   if ( Deg4 < DegV) CC4->IncreaseDegree(DegV);
+ 
+   // Mise en conformite des distributions de noeuds
+-  Standard_Integer NbUPoles = SetSameDistribution(CC1,CC3);
+-  Standard_Integer NbVPoles = SetSameDistribution(CC2,CC4);
++  Standard_Integer NbUPoles, NbVPoles;
++  if(SetSameDistr)
++  {
++    NbUPoles = SetSameDistribution(CC1,CC3);
++    NbVPoles = SetSameDistribution(CC2,CC4);
++  }
++  else
++  {
++    NbUPoles = CC1->NbPoles();
++    NbVPoles = CC2->NbPoles();
++  }
+ 
+-  if(Type == GeomFill_CoonsStyle) {
+-    if(NbUPoles < 4 || NbVPoles < 4)
+-      throw Standard_ConstructionError("GeomFill_BSplineCurves: invalid filling style");
++  if(Type == GeomFill_CoonsStyle || Type == GeomFill_CoonsC2Style) {
++    //Standard_ConstructionError_Raise_if 
++    //  (NbUPoles < 4 || NbVPoles < 4, " GeomFill_BSplineCurves: invalid filling style");
++    Standard_Integer NbPolesMin = 4;
++    Standard_Integer aCont = 1;
++    if(Type == GeomFill_CoonsC2Style) {
++      NbPolesMin = 6;
++      aCont = 2;
++    }
++    while(NbUPoles < NbPolesMin)
++    {
++      if(CC1->Degree() < CC1->MaxDegree ())
++      {
++        CC1->IncreaseDegree(CC1->Degree() + 1);
++        CC3->IncreaseDegree(CC3->Degree() + 1);
++      }
++      else
++      {
++        Standard_Integer j;
++        Standard_Integer anIndx = 0;
++        Standard_Real aKnt = -RealLast();
++        for(j = CC1->FirstUKnotIndex(); j < CC1->LastUKnotIndex(); ++j)
++        {
++          Standard_Real dt = CC1->Knot(j+1) - CC1->Knot(j);
++          if(dt > aKnt)
++          {
++            aKnt = dt;
++            anIndx = j;
++          }
++        }
++        aKnt = 0.5 * (CC1->Knot(anIndx+1) + CC1->Knot(anIndx));
++        CC1->InsertKnot (aKnt, CC1->Degree() - aCont);
++        CC3->InsertKnot (aKnt, CC3->Degree() - aCont);
++      }
++    }
++    while(NbVPoles < NbPolesMin)
++    {
++      if(CC2->Degree() < CC2->MaxDegree ())
++      {
++        CC2->IncreaseDegree(CC2->Degree() + 1);
++        CC4->IncreaseDegree(CC4->Degree() + 1);
++      }
++      else
++      {
++        Standard_Integer j;
++        Standard_Integer anIndx = 0;
++        Standard_Real aKnt = -RealLast();
++        for(j = CC2->FirstUKnotIndex(); j < CC2->LastUKnotIndex(); ++j)
++        {
++          Standard_Real dt = CC2->Knot(j+1) - CC2->Knot(j);
++          if(dt > aKnt)
++          {
++            aKnt = dt;
++            anIndx = j;
++          }
++        }
++        aKnt = 0.5 * (CC2->Knot(anIndx+1) + CC2->Knot(anIndx));
++        CC2->InsertKnot (aKnt, CC2->Degree() - aCont);
++        CC4->InsertKnot (aKnt, CC4->Degree() - aCont);
++      }
++    }
+   }
+ 
+   TColgp_Array1OfPnt P1(1,NbUPoles);
+@@ -335,6 +403,9 @@ void  GeomFill_BSplineCurves::Init
+       case GeomFill_CoonsStyle   :
+ 	Caro = GeomFill_Coons  ( P1, P4, P3, P2, W1, W4, W3, W2); 
+ 	break;
++      case GeomFill_CoonsC2Style :
++	Caro = GeomFill_Coons  ( P1, P4, P3, P2, W1, W4, W3, W2, Standard_True); 
++	break;
+       case GeomFill_CurvedStyle  :
+ 	Caro = GeomFill_Curved ( P1, P2, P3, P4, W1, W2, W3, W4); 
+ 	break;
+@@ -349,6 +420,9 @@ void  GeomFill_BSplineCurves::Init
+       case GeomFill_CoonsStyle   :
+ 	Caro = GeomFill_Coons  ( P1, P4, P3, P2); 
+ 	break;
++     case GeomFill_CoonsC2Style :
++	Caro = GeomFill_Coons  ( P1, P4, P3, P2, Standard_True); 
++	break;
+       case GeomFill_CurvedStyle  :
+ 	Caro = GeomFill_Curved ( P1, P2, P3, P4); 
+ 	break;
+@@ -426,7 +500,7 @@ void  GeomFill_BSplineCurves::Init
+   Knots( 2) = C2->Knot(C2->LastUKnotIndex());
+   Mults( 1) = Mults( 2) = 2;
+   C4 = new Geom_BSplineCurve( Poles, Knots, Mults, 1);
+-  Init( C1, C2, C3, C4, Type);
++  Init( C1, C2, C3, C4, Type, Precision::Confusion() );
+ }
+ 
+ 
+diff --git a/src/GeomFill/GeomFill_BSplineCurves.hxx b/src/GeomFill/GeomFill_BSplineCurves.hxx
+index e839213e..ff7927f8 100644
+--- a/src/GeomFill/GeomFill_BSplineCurves.hxx
++++ b/src/GeomFill/GeomFill_BSplineCurves.hxx
+@@ -68,7 +68,7 @@ public:
+   Standard_EXPORT GeomFill_BSplineCurves(const Handle(Geom_BSplineCurve)& C1, const Handle(Geom_BSplineCurve)& C2, const GeomFill_FillingStyle Type);
+   
+   //! if the curves cannot be joined
+-  Standard_EXPORT void Init (const Handle(Geom_BSplineCurve)& C1, const Handle(Geom_BSplineCurve)& C2, const Handle(Geom_BSplineCurve)& C3, const Handle(Geom_BSplineCurve)& C4, const GeomFill_FillingStyle Type);
++  Standard_EXPORT void Init (const Handle(Geom_BSplineCurve)& C1, const Handle(Geom_BSplineCurve)& C2, const Handle(Geom_BSplineCurve)& C3, const Handle(Geom_BSplineCurve)& C4, const GeomFill_FillingStyle Type, const Standard_Real Tolerance,const Standard_Boolean SetSameDistr = Standard_True);
+   
+   //! if the curves cannot be joined
+   Standard_EXPORT void Init (const Handle(Geom_BSplineCurve)& C1, const Handle(Geom_BSplineCurve)& C2, const Handle(Geom_BSplineCurve)& C3, const GeomFill_FillingStyle Type);
+diff --git a/src/GeomFill/GeomFill_Coons.cxx b/src/GeomFill/GeomFill_Coons.cxx
+index 58186db1..412fe118 100644
+--- a/src/GeomFill/GeomFill_Coons.cxx
++++ b/src/GeomFill/GeomFill_Coons.cxx
+@@ -38,9 +38,10 @@ GeomFill_Coons::GeomFill_Coons()
+ GeomFill_Coons::GeomFill_Coons(const TColgp_Array1OfPnt& P1, 
+ 			 const TColgp_Array1OfPnt& P2, 
+ 			 const TColgp_Array1OfPnt& P3, 
+-			 const TColgp_Array1OfPnt& P4)
++			 const TColgp_Array1OfPnt& P4, 
++			 const Standard_Boolean isC2)
+ {
+-  Init( P1, P2, P3, P4);
++  Init( P1, P2, P3, P4, isC2);
+ }
+ 
+ 
+@@ -56,9 +57,10 @@ GeomFill_Coons::GeomFill_Coons(const TColgp_Array1OfPnt&   P1,
+ 			 const TColStd_Array1OfReal& W1, 
+ 			 const TColStd_Array1OfReal& W2, 
+ 			 const TColStd_Array1OfReal& W3, 
+-			 const TColStd_Array1OfReal& W4)
++			 const TColStd_Array1OfReal& W4, 
++			 const Standard_Boolean isC2)
+ {
+-  Init( P1, P2, P3, P4, W1, W2, W3, W4);
++  Init( P1, P2, P3, P4, W1, W2, W3, W4, isC2);
+ }
+ 
+ 
+@@ -70,7 +72,8 @@ GeomFill_Coons::GeomFill_Coons(const TColgp_Array1OfPnt&   P1,
+ void  GeomFill_Coons::Init(const TColgp_Array1OfPnt& P1, 
+ 			const TColgp_Array1OfPnt& P2, 
+ 			const TColgp_Array1OfPnt& P3, 
+-			const TColgp_Array1OfPnt& P4)
++			const TColgp_Array1OfPnt& P4, 
++			const Standard_Boolean isC2)
+ {
+   Standard_DomainError_Raise_if
+     ( P1.Length() != P3.Length() || P2.Length() != P4.Length()," ");
+@@ -94,25 +97,45 @@ void  GeomFill_Coons::Init(const TColgp_Array1OfPnt& P1,
+     myPoles->SetValue( NPolU, i, P4(i));
+   }
+ 
++  Standard_Integer aNbCoeff = 4;
++  if(isC2)
++  {
++    aNbCoeff = 6;
++  }
++
+   // Calcul des coefficients multiplicateurs
+-  TColgp_Array1OfPnt Coef ( 1, 4);
+-  TColgp_Array1OfPnt Pole ( 1, 4);
++  TColgp_Array1OfPnt Coef ( 1, aNbCoeff);
++  TColgp_Array1OfPnt Pole ( 1, aNbCoeff);
+   TColgp_Array1OfPnt CoefU( 1, NPolU);
+   TColgp_Array1OfPnt CoefV( 1, NPolV);
+-  Coef( 4) = gp_Pnt(  2., -2., 0.);
+-  Coef( 3) = gp_Pnt( -3.,  3., 0.);
+-  Coef( 2) = gp_Pnt(  0.,  0., 0.);
+-  Coef( 1) = gp_Pnt(  1.,  0., 0.);
++  if(isC2)
++  {
++    //Coefficients of Hermite polynomial of 5 degree
++    Coef( 6) = gp_Pnt(  -6.,   6., 0.);
++    Coef( 5) = gp_Pnt(  15., -15., 0.);
++    Coef( 4) = gp_Pnt( -10.,  10., 0.);
++    Coef( 3) = gp_Pnt(   0.,   0., 0.);
++    Coef( 2) = gp_Pnt(   0.,   0., 0.);
++    Coef( 1) = gp_Pnt(   1.,   0., 0.); 
++  }
++  else
++  {
++    //Coefficients of Hermite polynomial of 3 degree
++    Coef( 4) = gp_Pnt(  2., -2., 0.);
++    Coef( 3) = gp_Pnt( -3.,  3., 0.);
++    Coef( 2) = gp_Pnt(  0.,  0., 0.);
++    Coef( 1) = gp_Pnt(  1.,  0., 0.);
++  }
+   PLib::CoefficientsPoles(Coef, PLib::NoWeights(),
+ 			  Pole, PLib::NoWeights());
+-  if (NPolU > 4) {
++  if (NPolU > aNbCoeff) {
+     BSplCLib::IncreaseDegree(NPolU-1, Pole, BSplCLib::NoWeights(), 
+ 			     CoefU, BSplCLib::NoWeights());
+   }
+   else {
+      CoefU = Pole;
+   }
+-  if (NPolV > 4) {
++  if (NPolV > aNbCoeff) {
+     BSplCLib::IncreaseDegree(NPolV-1, Pole, BSplCLib::NoWeights(), 
+ 			     CoefV, BSplCLib::NoWeights());
+   }
+@@ -164,8 +187,8 @@ void  GeomFill_Coons::Init(const TColgp_Array1OfPnt&   P1,
+ 			   const TColStd_Array1OfReal& W1, 
+ 			   const TColStd_Array1OfReal& W2, 
+ 			   const TColStd_Array1OfReal& W3,
+-			   const TColStd_Array1OfReal& W4
+-                          )
++			   const TColStd_Array1OfReal& W4,
++			   const Standard_Boolean isC2)
+ {
+ 
+   Standard_DomainError_Raise_if
+@@ -175,7 +198,7 @@ void  GeomFill_Coons::Init(const TColgp_Array1OfPnt&   P1,
+       W2.Length() != P2.Length() || 
+       W3.Length() != P3.Length() || 
+       W4.Length() != P4.Length()   , " ");
+-  Init(P1,P2,P3,P4);
++  Init(P1,P2,P3,P4, isC2);
+   IsRational = Standard_True;
+ 
+   Standard_Integer NPolU = W1.Length();
+diff --git a/src/GeomFill/GeomFill_Coons.hxx b/src/GeomFill/GeomFill_Coons.hxx
+index 46d7dc2f..57286522 100644
+--- a/src/GeomFill/GeomFill_Coons.hxx
++++ b/src/GeomFill/GeomFill_Coons.hxx
+@@ -36,13 +36,13 @@ public:
+   
+   Standard_EXPORT GeomFill_Coons();
+   
+-  Standard_EXPORT GeomFill_Coons(const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4);
++  Standard_EXPORT GeomFill_Coons(const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const Standard_Boolean isC2 = Standard_False);
+   
+-  Standard_EXPORT GeomFill_Coons(const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const TColStd_Array1OfReal& W1, const TColStd_Array1OfReal& W2, const TColStd_Array1OfReal& W3, const TColStd_Array1OfReal& W4);
++  Standard_EXPORT GeomFill_Coons(const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const TColStd_Array1OfReal& W1, const TColStd_Array1OfReal& W2, const TColStd_Array1OfReal& W3, const TColStd_Array1OfReal& W4,const Standard_Boolean isC2 = Standard_False);
+   
+-  Standard_EXPORT void Init (const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4);
++  Standard_EXPORT   void Init (const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const Standard_Boolean isC2 = Standard_False);
+   
+-  Standard_EXPORT void Init (const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const TColStd_Array1OfReal& W1, const TColStd_Array1OfReal& W2, const TColStd_Array1OfReal& W3, const TColStd_Array1OfReal& W4);
++  Standard_EXPORT   void Init (const TColgp_Array1OfPnt& P1, const TColgp_Array1OfPnt& P2, const TColgp_Array1OfPnt& P3, const TColgp_Array1OfPnt& P4, const TColStd_Array1OfReal& W1, const TColStd_Array1OfReal& W2, const TColStd_Array1OfReal& W3, const TColStd_Array1OfReal& W4, const Standard_Boolean isC2 = Standard_False);
+ 
+ 
+ 
+diff --git a/src/GeomFill/GeomFill_FillingStyle.hxx b/src/GeomFill/GeomFill_FillingStyle.hxx
+index 23a7a4c9..0d947f92 100644
+--- a/src/GeomFill/GeomFill_FillingStyle.hxx
++++ b/src/GeomFill/GeomFill_FillingStyle.hxx
+@@ -26,7 +26,8 @@ enum GeomFill_FillingStyle
+ {
+ GeomFill_StretchStyle,
+ GeomFill_CoonsStyle,
+-GeomFill_CurvedStyle
++GeomFill_CurvedStyle,
++GeomFill_CoonsC2Style
+ };
+ 
+ #endif // _GeomFill_FillingStyle_HeaderFile
+-- 
+2.31.1.windows.1
+


### PR DESCRIPTION
**opencascade/7.6.2**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->
I am contributing this as developer of TiGL (https://github.com/DLR-SC/tigl). TiGL depends on a patched version of opencascade for "C2 continuous Coons-Patches" (A low-level surface modeling algorithm). We want to migrate our build system to conan so I added an option to the existing opencascade recipe to include this patch.

Note that I needed to bump the freetype version to avoid a version conflict.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
