### PR TITLE
glaze: add version 2.1.6, 2.1.7

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -2,6 +2,7 @@ sources:
   "2.1.7":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.7.tar.gz"
     sha256: "e110bfc6494ca3a0616beaec214e61a53d4e0bd1489d8f1a45ca6f87594a3502"
+  # Keep 2.1.6 for now as 2.1.7 had some breaking changes
   "2.1.6":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.6.tar.gz"
     sha256: "5ae31b1a48a5b54b84e115a12195341bfbe39f03f92bb3bcad074f984380f72d"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.1.6":
-    url: "https://github.com/stephenberry/glaze/archive/v2.1.6.tar.gz"
-    sha256: "5ae31b1a48a5b54b84e115a12195341bfbe39f03f92bb3bcad074f984380f72d"
+  "2.1.7":
+    url: "https://github.com/stephenberry/glaze/archive/v2.1.7.tar.gz"
+    sha256: "e110bfc6494ca3a0616beaec214e61a53d4e0bd1489d8f1a45ca6f87594a3502"
   "2.1.4":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.4.tar.gz"
     sha256: "cbaba4dfbaaf342c8be8e6834cb79933b080ac89f3aa1470bc7a83197d9ebc1a"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.6":
+    url: "https://github.com/stephenberry/glaze/archive/v2.1.6.tar.gz"
+    sha256: "5ae31b1a48a5b54b84e115a12195341bfbe39f03f92bb3bcad074f984380f72d"
   "2.1.4":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.4.tar.gz"
     sha256: "cbaba4dfbaaf342c8be8e6834cb79933b080ac89f3aa1470bc7a83197d9ebc1a"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "2.1.7":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.7.tar.gz"
     sha256: "e110bfc6494ca3a0616beaec214e61a53d4e0bd1489d8f1a45ca6f87594a3502"
+  "2.1.6":
+    url: "https://github.com/stephenberry/glaze/archive/v2.1.6.tar.gz"
+    sha256: "5ae31b1a48a5b54b84e115a12195341bfbe39f03f92bb3bcad074f984380f72d"
   "2.1.4":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.4.tar.gz"
     sha256: "cbaba4dfbaaf342c8be8e6834cb79933b080ac89f3aa1470bc7a83197d9ebc1a"

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -29,7 +29,8 @@ class GlazeConan(ConanFile):
             "Visual Studio": "17",
             "msvc": "193",
             "gcc": "10",
-            "clang": "12",
+            # glaze >= 2.1.6 uses std::bit_cast which is supported by clang >= 14
+            "clang": "12" if Version(self.version) < "2.1.6" else "14",
             "apple-clang": "13.1",
         }
         if Version(self.version) >= "1.9.0":

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.6":
+    folder: all
   "2.1.4":
     folder: all
   "2.1.0":

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.1.6":
+  "2.1.7":
     folder: all
   "2.1.4":
     folder: all

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,6 +1,8 @@
 versions:
   "2.1.7":
     folder: all
+  "2.1.6":
+    folder: all
   "2.1.4":
     folder: all
   "2.1.0":


### PR DESCRIPTION
Specify library name and version:  **glaze/2.1.6,2.1.7**

glaze/2.1.7 has a breaking change, add glaze/2.1.6 for compatibility. (Thanks @pwqbot)
 
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
