### PR TITLE
sdbus-cpp/1.4.0: Bump version and dependencies

### DIFF
--- a/recipes/sdbus-cpp/all/conandata.yml
+++ b/recipes/sdbus-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v1.4.0.tar.gz"
+    sha256: "ca7405c7f0f9ae3023dcfa37bc68974c4b8a1c9ea2909b970e0aedc3e8657ee6"
   "1.3.0":
     url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v1.3.0.tar.gz"
     sha256: "d44f59abdd64d8f1ca3af7db58bc6518cb081fc9ff16285c3d75a68f5c073d10"

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -56,7 +56,7 @@ class SdbusCppConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("libsystemd/253.10")
+        self.requires("libsystemd/255.2")
 
     def validate(self):
         if self.info.settings.os != "Linux":
@@ -74,9 +74,9 @@ class SdbusCppConan(ConanFile):
                     self.name, self._minimum_cpp_standard, self.info.settings.compiler, self.info.settings.compiler.version))
 
     def build_requirements(self):
-        self.tool_requires("pkgconf/2.0.3")
+        self.tool_requires("pkgconf/2.1.0")
         if self.options.with_code_gen:
-            self.tool_requires("expat/2.5.0")
+            self.tool_requires("expat/2.6.0")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
@@ -15,7 +15,7 @@ class SdbusCppTestConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.tool_requires("pkgconf/2.0.3")
+        self.tool_requires("pkgconf/2.1.0")
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/sdbus-cpp/all/test_v1_pkgconf/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_v1_pkgconf/conanfile.py
@@ -11,7 +11,7 @@ class SdbusCppTestConan(ConanFile):
     generators = ("cmake", "pkg_config")
 
     def build_requirements(self):
-        self.tool_requires("pkgconf/2.0.3")
+        self.tool_requires("pkgconf/2.1.0")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/sdbus-cpp/config.yml
+++ b/recipes/sdbus-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.0":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.0":


### PR DESCRIPTION
Specify library name and version:  **sdbus-cpp/1.4.0**

Bump dependencies:
 * libsystemd
 * pkgconf
 * expat

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
