### PR TITLE
relax build requirements for cairo

### DIFF
--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -84,20 +84,20 @@ class CairoConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_freetype", True):
-            self.requires("freetype/2.13.0")
+            self.requires("freetype/[>=2.13.0 <2.14]")
         if self.options.get_safe("with_fontconfig", False):
-            self.requires("fontconfig/2.14.2")
+            self.requires("fontconfig/[>=2.14.2 <2.15]",)
         if self.settings.os == "Linux":
             if self.options.with_xlib or self.options.with_xlib_xrender or self.options.with_xcb:
                 self.requires("xorg/system")
         if self.options.get_safe("with_glib", True):
-            self.requires("glib/2.76.3")
+            self.requires("glib/[>=2.76.3 <2.79]")
         self.requires("zlib/1.2.13")
         self.requires("pixman/0.40.0")
-        self.requires("libpng/1.6.40")
+        self.requires("libpng/[>=1.6.40 <1.7]")
 
     def package_id(self):
-        if self.options.get_safe("with_glib") and not self.dependencies["glib"].options.shared:
+        if "glib" in self.dependencies and not self.dependencies["glib"].options.shared:
             self.info.requires["glib"].full_package_mode()
 
     def validate(self):

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -97,7 +97,7 @@ class CairoConan(ConanFile):
         self.requires("libpng/[>=1.6.40 <1.7]")
 
     def package_id(self):
-        if "glib" in self.dependencies and not self.dependencies["glib"].options.shared:
+        if self.info.options.get_safe("with_glib") and not self.dependencies["glib"].options.shared:
             self.info.requires["glib"].full_package_mode()
 
     def validate(self):

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -88,19 +88,19 @@ class CairoConan(ConanFile):
     def requirements(self):
         self.requires("pixman/0.42.2")
         if self.options.with_zlib and self.options.with_png:
-            self.requires("expat/2.5.0")
+            self.requires("expat/[>=2.5.0 <2.7.0]")
         if self.options.with_lzo:
             self.requires("lzo/2.10")
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_freetype:
-            self.requires("freetype/2.13.2", transitive_headers=True, transitive_libs=True)
+            self.requires("freetype/[>=2.13.0 <2.14]", transitive_headers=True, transitive_libs=True)
         if self.options.with_fontconfig:
-            self.requires("fontconfig/2.14.2", transitive_headers=True, transitive_libs=True)
+            self.requires("fontconfig/[>=2.14.2 <2.15]", transitive_headers=True, transitive_libs=True)
         if self.options.with_png:
-            self.requires("libpng/1.6.40")
+            self.requires("libpng/[>=1.6.40 <1.7]")
         if self.options.with_glib:
-            self.requires("glib/2.78.1")
+            self.requires("glib/[>=2.76.3 <2.79]")
         if self.settings.os in ["Linux", "FreeBSD"]:
             if self.options.with_xlib or self.options.with_xlib_xrender or self.options.with_xcb:
                 self.requires("xorg/system", transitive_headers=True, transitive_libs=True)


### PR DESCRIPTION
Specify library name and version:  **cairo/1.18.0**

Relax the build requirements for `cairo` to what is truly needed to avoid excessive conflicts


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
