### PR TITLE
[config] Fix validate infrastructure entry name

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -74,7 +74,7 @@ tasks:
   validate_infrastructure:
     macos_executors: 2
     windows_executors: 4
-    open_docs_pull-request: true
+    create_docs_pull-request: true
 
 # Profile configurations to build packages
 configurations:

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -66,7 +66,7 @@ tasks:
   validate_infrastructure:
     macos_executors: 2
     windows_executors: 4
-    open_docs_pull-request: false
+    create_docs_pull-request: false
 
 configurations:
   - id: linux-gcc


### PR DESCRIPTION
The internal CI build Validate Infrastructure is responsible for updating the document https://github.com/conan-io/conan-center-index/blob/master/docs/supported_platforms_and_configurations.md.

It reads the config yaml file to decide if it should or not open a PR to update the document. But reading the C3I code, it actually wants to read `create_docs_pull-request`, but not `open_docs_pull-request`. By default the C3I code does not open the PR, so we need to fix the entry in config anyway.


Kudos @Croydon that spotted this misconfiguration! 💚 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
