### PR TITLE
aws-crt-cpp: add version 0.24.1

### DIFF
--- a/recipes/aws-crt-cpp/all/conandata.yml
+++ b/recipes/aws-crt-cpp/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "0.24.1":
     url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.24.1.tar.gz"
     sha256: "c627fbc76fc31332801e29872203a11ce0234b7c17e75811277aa913f1550d6f"
-  "0.18.8":
-    url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.18.8.tar.gz"
-    sha256: "70ea622cf8c1a7028b24078e909ee5898990444436584178f58d61b50b5b197d"
   "0.17.23":
     url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.17.23.tar.gz"
     sha256: "28061c3efa493519cfae46e4ea96389f03a81eeec7613d7da861dd8c5f4f6598"
@@ -22,10 +19,6 @@ patches:
     - patch_file: "patches/0.24.1-disable-sanitizers.patch"
       patch_description: "disable sanitizers"
       patch_type: "conan"
-  "0.18.8":
-    - patch_file: "patches/0.17.23-fix-cast-error.patch"
-      patch_description: "fix const cast error"
-      patch_type: "portability"
   "0.17.23":
     - patch_file: "patches/0.17.23-fix-cast-error.patch"
       patch_description: "fix const cast error"

--- a/recipes/aws-crt-cpp/all/conandata.yml
+++ b/recipes/aws-crt-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.24.1":
+    url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.24.1.tar.gz"
+    sha256: "c627fbc76fc31332801e29872203a11ce0234b7c17e75811277aa913f1550d6f"
   "0.18.8":
     url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.18.8.tar.gz"
     sha256: "70ea622cf8c1a7028b24078e909ee5898990444436584178f58d61b50b5b197d"
@@ -12,6 +15,13 @@ sources:
     url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.14.3.tar.gz"
     sha256: "3ea16c43e691bab0c373ba1ad072f6535390c516ebda658dfaf4d074d920e0fb"
 patches:
+  "0.24.1":
+    - patch_file: "patches/0.24.1-fix-cast-error.patch"
+      patch_description: "fix const cast error"
+      patch_type: "portability"
+    - patch_file: "patches/0.24.1-disable-sanitizers.patch"
+      patch_description: "disable sanitizers"
+      patch_type: "conan"
   "0.18.8":
     - patch_file: "patches/0.17.23-fix-cast-error.patch"
       patch_description: "fix const cast error"

--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -70,6 +70,7 @@ class AwsCrtCpp(ConanFile):
             self.requires("aws-c-io/0.13.35", transitive_headers=True)
             self.requires("aws-c-mqtt/0.9.10", transitive_headers=True)
             self.requires("aws-c-s3/0.3.24")
+            self.requires("aws-c-sdkutils/0.1.12")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir, save
 from conan.tools.build import check_min_cppstd
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
@@ -47,9 +48,14 @@ class AwsCrtCpp(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-cal/0.5.13", transitive_headers=True)
-        self.requires("aws-c-common/0.8.2", transitive_headers=True)
-        self.requires("aws-checksums/0.1.13")
+        if Version(self.version) < "0.24.1":
+            self.requires("aws-c-cal/0.5.13", transitive_headers=True)
+            self.requires("aws-c-common/0.8.2", transitive_headers=True)
+            self.requires("aws-checksums/0.1.13")
+        else:
+            self.requires("aws-c-cal/0.6.9", transitive_headers=True)
+            self.requires("aws-c-common/0.9.6", transitive_headers=True)
+            self.requires("aws-checksums/0.1.17")
         if Version(self.version) < "0.17.29":
             self.requires("aws-c-auth/0.6.11", transitive_headers=True)
             self.requires("aws-c-event-stream/0.2.7")
@@ -57,13 +63,20 @@ class AwsCrtCpp(ConanFile):
             self.requires("aws-c-io/0.10.20", transitive_headers=True)
             self.requires("aws-c-mqtt/0.7.10", transitive_headers=True)
             self.requires("aws-c-s3/0.1.37")
-        else:
+        elif Version(self.version) < "0.24.1":
             self.requires("aws-c-auth/0.6.17", transitive_headers=True)
             self.requires("aws-c-event-stream/0.2.15")
             self.requires("aws-c-http/0.6.22", transitive_headers=True)
             self.requires("aws-c-io/0.13.4", transitive_headers=True)
             self.requires("aws-c-mqtt/0.7.12", transitive_headers=True)
             self.requires("aws-c-s3/0.1.49")
+        else:
+            self.requires("aws-c-auth/0.7.8", transitive_headers=True)
+            self.requires("aws-c-event-stream/0.3.1")
+            self.requires("aws-c-http/0.7.14", transitive_headers=True)
+            self.requires("aws-c-io/0.13.35", transitive_headers=True)
+            self.requires("aws-c-mqtt/0.9.10", transitive_headers=True)
+            self.requires("aws-c-s3/0.3.24")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -74,8 +87,10 @@ class AwsCrtCpp(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        if is_msvc(self):
+            tc.variables["AWS_STATIC_MSVC_RUNTIME_LIBRARY"] = is_msvc_static_runtime(self)
         tc.variables["BUILD_TESTING"] = False
-        tc.variables["BUILD_DEPS"] = False
+        tc.cache_variables["BUILD_DEPS"] = False
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -63,13 +63,6 @@ class AwsCrtCpp(ConanFile):
             self.requires("aws-c-io/0.10.20", transitive_headers=True)
             self.requires("aws-c-mqtt/0.7.10", transitive_headers=True)
             self.requires("aws-c-s3/0.1.37")
-        elif Version(self.version) < "0.24.1":
-            self.requires("aws-c-auth/0.6.17", transitive_headers=True)
-            self.requires("aws-c-event-stream/0.2.15")
-            self.requires("aws-c-http/0.6.22", transitive_headers=True)
-            self.requires("aws-c-io/0.13.4", transitive_headers=True)
-            self.requires("aws-c-mqtt/0.7.12", transitive_headers=True)
-            self.requires("aws-c-s3/0.1.49")
         else:
             self.requires("aws-c-auth/0.7.8", transitive_headers=True)
             self.requires("aws-c-event-stream/0.3.1")

--- a/recipes/aws-crt-cpp/all/patches/0.24.1-disable-sanitizers.patch
+++ b/recipes/aws-crt-cpp/all/patches/0.24.1-disable-sanitizers.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2024-02-23 17:49:55
++++ CMakeLists.txt	2024-02-23 17:50:20
+@@ -314,7 +314,7 @@
+ aws_use_package(aws-c-event-stream)
+ aws_use_package(aws-c-s3)
+ 
+-aws_add_sanitizers(${PROJECT_NAME})
++#aws_add_sanitizers(${PROJECT_NAME})
+ 
+ target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
+ 

--- a/recipes/aws-crt-cpp/all/patches/0.24.1-fix-cast-error.patch
+++ b/recipes/aws-crt-cpp/all/patches/0.24.1-fix-cast-error.patch
@@ -1,0 +1,13 @@
+diff --git a/source/io/TlsOptions.cpp b/source/io/TlsOptions.cpp
+index 6077912..74a55c9 100644
+--- a/source/io/TlsOptions.cpp
++++ b/source/io/TlsOptions.cpp
+@@ -219,7 +219,7 @@ namespace Aws
+ 
+                 if (m_slotId)
+                 {
+-                    options.slot_id = &(*m_slotId);
++                    options.slot_id = const_cast<uint64_t*>(&(*m_slotId));
+                 }
+ 
+                 if (m_userPin)

--- a/recipes/aws-crt-cpp/config.yml
+++ b/recipes/aws-crt-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.24.1":
+    folder: all
   "0.18.8":
     folder: all
   "0.17.23":

--- a/recipes/aws-crt-cpp/config.yml
+++ b/recipes/aws-crt-cpp/config.yml
@@ -1,8 +1,6 @@
 versions:
   "0.24.1":
     folder: all
-  "0.18.8":
-    folder: all
   "0.17.23":
     folder: all
   "0.17.12":


### PR DESCRIPTION
Specify library name and version:  **aws-crt-cpp/0.24.1**

This is a required dependency to package a more recent aws-sdk-cpp (#20612)

aws-crt-cpp version 0.18.8 has a dependency conflict and is used nowhere:
```
ERROR: Version conflict: Conflict between aws-c-io/0.10.20 and aws-c-io/0.13.4 in the graph.
Conflict originates from aws-c-mqtt/0.7.12
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
