### PR TITLE
libpng: add version 1.6.43

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.43":
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.43/libpng-1.6.43.tar.xz"
+    sha256: "6a5ca0652392a2d7c9db2ae5b40210843c0bbc081cbd410825ab00cc59f14a6c"
   "1.6.42":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.42/libpng-1.6.42.tar.xz"
     sha256: "c919dbc11f4c03b05aba3f8884d8eb7adfe3572ad228af972bb60057bdb48450"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.43":
+    folder: all
   "1.6.42":
     folder: all
   "1.6.41":


### PR DESCRIPTION
Specify library name and version:  **libpng/1.6.43**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
