### PR TITLE
stale workflow: don't remove stale label twice

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -42,8 +42,6 @@ jobs:
 
         # Label to apply on staled PRs
         stale-pr-label: 'stale'
-        # Label to be removed when updating a PR
-        labels-to-remove-when-unstale: 'stale'
 
         # Skip issues when having stale state
         remove-issue-stale-when-updated: false


### PR DESCRIPTION
the stale label is already removed automatically by the action. `labels-to-remove-when-unstale` is used to remove additional labels.
https://github.com/actions/stale?tab=readme-ov-file#labels-to-remove-when-unstale
https://github.com/conan-io/conan-center-index/actions/runs/8044709241/job/21968729920#step:2:25205
https://github.com/conan-io/conan-center-index/actions/runs/8044709241/job/21968729920#step:2:25208

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
