### PR TITLE
velodyne_decoder: add new recipe

### DIFF
--- a/recipes/velodyne_decoder/all/conandata.yml
+++ b/recipes/velodyne_decoder/all/conandata.yml
@@ -2,3 +2,9 @@ sources:
   "3.0.0":
     url: "https://github.com/valgur/velodyne_decoder/archive/refs/tags/v3.0.0.tar.gz"
     sha256: "bce471232205f9d559464ba8cb99bfb96a2245115e54b744115fe71cd9e42042"
+patches:
+  "3.0.0":
+    - patch_file: "patches/3.0.0-001-fix-msvc-flags.patch"
+      patch_type: "portability"
+      patch_description: "Fix /O2 conflicting with debug flags on MSVC"
+      patch_source: "https://github.com/valgur/velodyne_decoder/commit/22809df3a4d550c3746b17aaca1d6c20692730c4"

--- a/recipes/velodyne_decoder/all/conandata.yml
+++ b/recipes/velodyne_decoder/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.0.0":
+    url: "https://github.com/valgur/velodyne_decoder/archive/refs/tags/v3.0.0.tar.gz"
+    sha256: "bce471232205f9d559464ba8cb99bfb96a2245115e54b744115fe71cd9e42042"

--- a/recipes/velodyne_decoder/all/conanfile.py
+++ b/recipes/velodyne_decoder/all/conanfile.py
@@ -1,0 +1,96 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.53.0"
+
+class PackageConan(ConanFile):
+    name = "velodyne_decoder"
+    description = "A decoder library for raw Velodyne data and telemetry info"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/valgur/velodyne_decoder"
+    topics = ("velodyne", "lidar", "point-cloud")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "9",
+            "clang": "5",
+            "apple-clang": "10",
+            "Visual Studio": "15",
+            "msvc": "191",
+        }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("yaml-cpp/0.8.0")
+        self.requires("ms-gsl/4.0.0", transitive_headers=True)
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["INSTALL_THIRD_PARTY"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "velodyne_decoder")
+        self.cpp_info.set_property("cmake_target_name", "velodyne_decoder::velodyne_decoder")
+        self.cpp_info.set_property("pkg_config_name", "velodyne_decoder")
+
+        self.cpp_info.libs = ["velodyne_decoder"]
+        self.cpp_info.defines = ["_USE_MATH_DEFINES"]

--- a/recipes/velodyne_decoder/all/conanfile.py
+++ b/recipes/velodyne_decoder/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.files import copy, get, rm, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.scm import Version
 import os
 
@@ -49,6 +49,9 @@ class PackageConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -76,6 +79,7 @@ class PackageConan(ConanFile):
         deps.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/velodyne_decoder/all/patches/3.0.0-001-fix-msvc-flags.patch
+++ b/recipes/velodyne_decoder/all/patches/3.0.0-001-fix-msvc-flags.patch
@@ -1,0 +1,15 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -17,7 +17,11 @@
+ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ 
+ if(MSVC)
+-  add_compile_options(/W4 /O2)
++  add_compile_options(
++      "$<$<CONFIG:RelWithDebInfo>:/O2>"
++      "$<$<CONFIG:Release>:/O2>"
++      /W4
++  )
+ else()
+   add_compile_options(
+     "$<$<CONFIG:Debug>:-ggdb3;-Og>"

--- a/recipes/velodyne_decoder/all/test_package/CMakeLists.txt
+++ b/recipes/velodyne_decoder/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(velodyne_decoder REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE velodyne_decoder::velodyne_decoder)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/velodyne_decoder/all/test_package/conanfile.py
+++ b/recipes/velodyne_decoder/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/velodyne_decoder/all/test_package/test_package.cpp
+++ b/recipes/velodyne_decoder/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <velodyne_decoder/config.h>
+#include <velodyne_decoder/scan_decoder.h>
+#include <velodyne_decoder/stream_decoder.h>
+#include <velodyne_decoder/types.h>
+
+int main() {
+  velodyne_decoder::Config config;
+  velodyne_decoder::StreamDecoder stream_decoder(config);
+}

--- a/recipes/velodyne_decoder/config.yml
+++ b/recipes/velodyne_decoder/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.0.0":
+    folder: all


### PR DESCRIPTION
Adds `velodyne_decoder`: https://github.com/valgur/velodyne_decoder

A decoder library for raw Velodyne data and telemetry info.

I'm the author of the library as well this time.