### PR TITLE
libglvnd: Bump build requirements to support Python 3.12

### DIFF
--- a/recipes/libglvnd/all/conanfile.py
+++ b/recipes/libglvnd/all/conanfile.py
@@ -59,9 +59,9 @@ class LibGlvndConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.name} is only compatible with Linux and FreeBSD")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.3.2")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
 
     def layout(self):
         basic_layout(self, src_folder="src")


### PR DESCRIPTION
Meson needs to be a newer version to support Python 3.12.

Specify library name and version:  **libglvnd/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
