### PR TITLE
asio-grpc: add version 3.4.1

### DIFF
--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.0.0":
-    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.0.0.tar.gz"
-    sha256: "299b937cba0b515e7505840ffb891ce8745879365cd918635401f19bf4886591"
+  "3.1.0":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.1.0.tar.gz"
+    sha256: "b5d9440dad653dcb9e5ac82cb9c4f6d01a33bc30bba996d9647f38258cbe75ee"
   "2.9.2":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v2.9.2.tar.gz"
     sha256: "a025587278b3332f4c5dd0464b3d5313fbecb89fc58a6ec1d611f693d6b51ef2"

--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.2.0":
-    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.2.0.tar.gz"
-    sha256: "f281e84202cf75aae055d67c4200b794f240cd7bd9ff8ecc3f9670a8912edf4f"
+  "3.4.1":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.4.1.tar.gz"
+    sha256: "3ca10e22ac628e1983ba87eff4e913e751dd66294a5ea76ca94a60ac014171f9"
   "2.9.2":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v2.9.2.tar.gz"
     sha256: "a025587278b3332f4c5dd0464b3d5313fbecb89fc58a6ec1d611f693d6b51ef2"

--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.0":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.0.0.tar.gz"
+    sha256: "299b937cba0b515e7505840ffb891ce8745879365cd918635401f19bf4886591"
   "2.9.2":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v2.9.2.tar.gz"
     sha256: "a025587278b3332f4c5dd0464b3d5313fbecb89fc58a6ec1d611f693d6b51ef2"

--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.1.0":
-    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.1.0.tar.gz"
-    sha256: "b5d9440dad653dcb9e5ac82cb9c4f6d01a33bc30bba996d9647f38258cbe75ee"
+  "3.2.0":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.2.0.tar.gz"
+    sha256: "f281e84202cf75aae055d67c4200b794f240cd7bd9ff8ecc3f9670a8912edf4f"
   "2.9.2":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v2.9.2.tar.gz"
     sha256: "a025587278b3332f4c5dd0464b3d5313fbecb89fc58a6ec1d611f693d6b51ef2"

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -56,12 +56,12 @@ class AsioGrpcConan(ConanFile):
 
     def requirements(self):
         use_latest = Version(self.version) > "2.8"
-        self.requires("grpc/1.54.3", transitive_headers=True, transitive_libs=True)
+        self.requires("grpc/1.67.1", transitive_headers=True, transitive_libs=True)
         if (self.options.get_safe("local_allocator") == "boost_container" and Version(self.version) < "3.0.0") or self.options.backend == "boost":
             version = "1.86.0" if use_latest else "1.83.0"
             self.requires(f"boost/{version}", transitive_headers=True)
         if self.options.backend == "asio":
-            version = "1.31.0" if use_latest else "1.29.0"
+            version = "1.32.0" if use_latest else "1.29.0"
             self.requires(f"asio/{version}", transitive_headers=True)
         if self.options.backend == "unifex":
             self.requires("libunifex/0.4.0", transitive_headers=True, transitive_libs=True)

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -55,11 +55,14 @@ class AsioGrpcConan(ConanFile):
             self.options.local_allocator = "boost_container" if prefer_boost_container else "memory_resource"
 
     def requirements(self):
+        use_latest = Version(self.version) > "2.8"
         self.requires("grpc/1.54.3", transitive_headers=True, transitive_libs=True)
         if (self.options.get_safe("local_allocator") == "boost_container" and Version(self.version) < "3.0.0") or self.options.backend == "boost":
-            self.requires("boost/1.85.0", transitive_headers=True)
+            version = "1.85.0" if use_latest else "1.83.0"
+            self.requires(f"boost/{version}", transitive_headers=True)
         if self.options.backend == "asio":
-            self.requires("asio/1.30.2", transitive_headers=True)
+            version = "1.30.2" if use_latest else "1.29.0"
+            self.requires(f"asio/{version}", transitive_headers=True)
         if self.options.backend == "unifex":
             self.requires("libunifex/0.4.0", transitive_headers=True, transitive_libs=True)
 

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -57,9 +57,9 @@ class AsioGrpcConan(ConanFile):
     def requirements(self):
         self.requires("grpc/1.54.3", transitive_headers=True, transitive_libs=True)
         if (self.options.get_safe("local_allocator") == "boost_container" and Version(self.version) < "3.0.0") or self.options.backend == "boost":
-            self.requires("boost/1.83.0", transitive_headers=True)
+            self.requires("boost/1.85.0", transitive_headers=True)
         if self.options.backend == "asio":
-            self.requires("asio/1.29.0", transitive_headers=True)
+            self.requires("asio/1.30.2", transitive_headers=True)
         if self.options.backend == "unifex":
             self.requires("libunifex/0.4.0", transitive_headers=True, transitive_libs=True)
 

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -58,10 +58,10 @@ class AsioGrpcConan(ConanFile):
         use_latest = Version(self.version) > "2.8"
         self.requires("grpc/1.54.3", transitive_headers=True, transitive_libs=True)
         if (self.options.get_safe("local_allocator") == "boost_container" and Version(self.version) < "3.0.0") or self.options.backend == "boost":
-            version = "1.85.0" if use_latest else "1.83.0"
+            version = "1.86.0" if use_latest else "1.83.0"
             self.requires(f"boost/{version}", transitive_headers=True)
         if self.options.backend == "asio":
-            version = "1.30.2" if use_latest else "1.29.0"
+            version = "1.31.0" if use_latest else "1.29.0"
             self.requires(f"asio/{version}", transitive_headers=True)
         if self.options.backend == "unifex":
             self.requires("libunifex/0.4.0", transitive_headers=True, transitive_libs=True)

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -42,13 +42,16 @@ class AsioGrpcConan(ConanFile):
             "clang": "6",
             "apple-clang": "11",
         }
+    
+    @property
+    def _local_allocator_option(self):
+        return self.options.get_safe("local_allocator")
 
     def config_options(self):
         if Version(self.version) >= "3.0.0":
             del self.options.local_allocator
 
     def configure(self):
-        self._local_allocator_option = self.options.get_safe("local_allocator")
         if self._local_allocator_option == "auto":
             libcxx = self.settings.compiler.get_safe("libcxx")
             compiler_version = Version(self.settings.compiler.version)

--- a/recipes/asio-grpc/all/test_package/CMakeLists.txt
+++ b/recipes/asio-grpc/all/test_package/CMakeLists.txt
@@ -7,10 +7,6 @@ add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE asio-grpc::asio-grpc)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
-# See https://github.com/chriskohlhoff/asio/issues/955
-target_compile_definitions(${PROJECT_NAME}
-                           PRIVATE BOOST_ASIO_DISABLE_STD_ALIGNED_ALLOC)
-
 if(${asio-grpc_VERSION} VERSION_GREATER_EQUAL 2)
   target_compile_definitions(${PROJECT_NAME} PRIVATE ASIO_GRPC_V2)
 endif()

--- a/recipes/asio-grpc/all/test_package/test_package.cpp
+++ b/recipes/asio-grpc/all/test_package/test_package.cpp
@@ -16,21 +16,10 @@ int main() {
   boost::asio::post(grpc_context, [] {});
 
 #ifndef CROSSCOMPILING
-  std::unique_ptr<test::Test::Stub> stub;
-  grpc::ClientContext client_context;
-  std::unique_ptr<grpc::ClientAsyncResponseReader<test::TestReply>> reader;
-  test::TestRequest request;
-  test::TestReply response;
-  grpc::Status status;
-
-  boost::asio::post(grpc_context, [&]() {
-    stub = test::Test::NewStub(grpc::CreateChannel(
+  boost::asio::post(grpc_context, []() {
+    [[maybe_unused]] auto stub = test::Test::NewStub(grpc::CreateChannel(
         "localhost:50051", grpc::InsecureChannelCredentials()));
-    request.set_message("hello");
-    reader = agrpc::request(&test::Test::Stub::AsyncUnary, *stub,
-                            client_context, request, grpc_context);
-    agrpc::finish(reader, response, status,
-                  boost::asio::bind_executor(grpc_context, [](bool) {}));
+    [[maybe_unused]] test::TestRequest request;
   });
 #endif
 }

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.2.0":
+  "3.4.1":
     folder: all
   "2.9.2":
     folder: all

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.0.0":
+  "3.1.0":
     folder: all
   "2.9.2":
     folder: all

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.1.0":
+  "3.2.0":
     folder: all
   "2.9.2":
     folder: all

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.0":
+    folder: all
   "2.9.2":
     folder: all
   "2.7.0":


### PR DESCRIPTION
Specify library name and version:  **asio-grpc/3.4.1**

Asio-grpc v3.0.0 no longer uses `local_allocator_option`. It could have a new `backend_option` in https://github.com/NVIDIA/stdexec but there does not seem to be a recipe for it here in conan-center.

Contains https://github.com/conan-io/conan-center-index/pull/19070

Note, I am the author of asio-grpc.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
