### PR TITLE
dbus: Bump expat and glib dependencies to minimize conflicts

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -67,9 +67,9 @@ class DbusConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("expat/2.5.0")
+        self.requires("expat/2.6.0")
         if self.options.with_glib:
-            self.requires("glib/2.77.0")
+            self.requires("glib/2.78.3")
         if self.options.get_safe("with_systemd"):
             self.requires("libsystemd/253.6")
         if self.options.with_selinux:
@@ -82,9 +82,9 @@ class DbusConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} requires at least gcc 7.")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.0")
+        self.tool_requires("meson/1.3.2")
         if not self.conf.get("tools.gnu:pkg_config",check_type=str):
-            self.tool_requires("pkgconf/1.9.5")
+            self.tool_requires("pkgconf/2.1.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
The expat dependency must be bumped to not conflict with wayland. Additionally, glib/2.78.1 and glib/2.78.3 are used much more than glib/2.77.0. I went with glib/2.78.3 since it is newer and also required in the Qt packages. Bump build dependencies as well.

Blocks #22387.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
