### PR TITLE
OpenImageIO: Fix CMake patch for non-default option

### DIFF
--- a/recipes/openimageio/all/patches/2.4.17.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/2.4.17.0-cmake-targets.patch
@@ -70,7 +70,7 @@ index a4f895c07..f55da37cb 100644
 -                                  JPEG_LIBRARIES JPEG_VERSION)
 -if (NOT JPEG_FOUND) # Try to find the non-turbo version
 +if (USE_JPEGTURBO)
-+    checked_find_package (JPEGTurbo
++    checked_find_package (libjpeg-turbo REQUIRED
 +                          DEFINITIONS -DUSE_JPEG_TURBO=1
 +                          PRINT libjpeg-turbo_INCLUDES libjpeg-turbo_LIBRARIES)
 +    add_library(JPEG::JPEG ALIAS libjpeg-turbo::libjpeg-turbo)

--- a/recipes/openimageio/all/patches/2.4.7.1-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/2.4.7.1-cmake-targets.patch
@@ -60,7 +60,7 @@ index 48e871418..21f709b1d 100644
 -                                  JPEG_LIBRARIES JPEG_VERSION)
 -if (NOT JPEG_FOUND) # Try to find the non-turbo version
 +if (USE_JPEGTURBO)
-+    checked_find_package (JPEGTurbo
++    checked_find_package (libjpeg-turbo REQUIRED
 +                          DEFINITIONS -DUSE_JPEG_TURBO=1
 +                          PRINT libjpeg-turbo_INCLUDES libjpeg-turbo_LIBRARIES)
 +    add_library(JPEG::JPEG ALIAS libjpeg-turbo::libjpeg-turbo)

--- a/recipes/openimageio/all/patches/2.5.6.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/2.5.6.0-cmake-targets.patch
@@ -69,7 +69,7 @@ index 3cfaedd57..f75fee7a3 100644
 -                      DEFINITIONS -DUSE_JPEG_TURBO=1)
 -if (NOT TARGET libjpeg-turbo::jpeg) # Try to find the non-turbo version
 +if (USE_JPEGTURBO)
-+    checked_find_package (JPEGTurbo REQUIRED
++    checked_find_package (libjpeg-turbo REQUIRED
 +                          DEFINITIONS -DUSE_JPEG_TURBO=1
 +                          PRINT libjpeg-turbo_INCLUDES libjpeg-turbo_LIBRARIES)
 +    add_library(JPEG::JPEG ALIAS libjpeg-turbo::libjpeg-turbo)


### PR DESCRIPTION
Specify library name and version:  **openimageio/2.x.x.x**

While I had recently ported OpenImageIO to Conan 2, I missed that one external dependency I locally normally build with is failing with the patching required to the packages CMake files.

This fixes the build option `'openimageio/*:with_libjpeg=libjpeg-turbo'` (which for the graph also needs `'libtiff/*:jpeg=libjpeg-turbo'` to use the same jpeg library for all dependencies).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
