### PR TITLE
liblzf: avoid WINDOWS_EXPORT_ALL_SYMBOLS

### DIFF
--- a/recipes/liblzf/all/CMakeLists.txt
+++ b/recipes/liblzf/all/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.15)
 project(liblzf LANGUAGES C)
 
 add_library(liblzf
-    src/lzf_c.c
-    src/lzf_d.c
+    lzf_c.c
+    lzf_d.c
+    liblzf.def
 )
 set_target_properties(liblzf PROPERTIES OUTPUT_NAME lzf)
 
@@ -20,14 +21,10 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(liblzf PRIVATE "-funroll-all-loops")
 endif()
 
-set_target_properties(liblzf PROPERTIES
-    WINDOWS_EXPORT_ALL_SYMBOLS ON
-    PUBLIC_HEADER src/lzf.h
-)
-
+include(GNUInstallDirs)
 install(TARGETS liblzf
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+install(FILES lzf.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/recipes/liblzf/all/conanfile.py
+++ b/recipes/liblzf/all/conanfile.py
@@ -29,7 +29,8 @@ class LiblzfConan(ConanFile):
     }
 
     def export_sources(self):
-        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+        copy(self, "CMakeLists.txt", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
+        copy(self, "liblzf.def", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
         export_conandata_patches(self)
 
     def config_options(self):
@@ -55,11 +56,11 @@ class LiblzfConan(ConanFile):
     def build(self):
         apply_conandata_patches(self)
         cmake = CMake(self)
-        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
 

--- a/recipes/liblzf/all/liblzf.def
+++ b/recipes/liblzf/all/liblzf.def
@@ -1,0 +1,3 @@
+EXPORTS
+    lzf_compress
+    lzf_decompress


### PR DESCRIPTION
Can use a `.def` file instead since the library has an extremely simple API.