### PR TITLE
urdfdom_headers: new recipe

### DIFF
--- a/recipes/urdfdom_headers/all/conandata.yml
+++ b/recipes/urdfdom_headers/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1.1":
+    url: "https://github.com/ros/urdfdom_headers/archive/refs/tags/1.1.1.zip"
+    sha256: "dde77e3dd96ffa41e2ee0a20bddcd6ef05863e95ce0143ede77130d8cd46c644"

--- a/recipes/urdfdom_headers/all/conanfile.py
+++ b/recipes/urdfdom_headers/all/conanfile.py
@@ -1,0 +1,39 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.52.0"
+
+
+class PackageConan(ConanFile):
+    name = "urdfdom_headers"
+    description = "Headers for URDF parsers"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ros/urdfdom_headers"
+    topics = ("urdf", "ros", "robotics")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        # Add a project prefix to the headers to match the default APPEND_PROJECT_NAME_TO_INCLUDEDIR=ON
+        copy(self, "*.h",
+             os.path.join(self.source_folder, "include"),
+             os.path.join(self.package_folder, "include", "urdfdom"))
+
+    def package_info(self):
+        self.cpp_info.includedirs.append(os.path.join("include", "urdfdom"))
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/urdfdom_headers/all/test_package/CMakeLists.txt
+++ b/recipes/urdfdom_headers/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(urdfdom_headers REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE urdfdom_headers::urdfdom_headers)

--- a/recipes/urdfdom_headers/all/test_package/conanfile.py
+++ b/recipes/urdfdom_headers/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/urdfdom_headers/all/test_package/test_package.cpp
+++ b/recipes/urdfdom_headers/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <urdf_world/world.h>
+
+int main() {
+    urdf::World world;
+    return 0;
+}

--- a/recipes/urdfdom_headers/config.yml
+++ b/recipes/urdfdom_headers/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.1":
+    folder: all


### PR DESCRIPTION
Unbundles `urdfdom_headers` from the `urdfdom` recipe, so they can be used directly and versioned separately.