### PR TITLE
tcl: Don't include extensions in package info libs

### DIFF
--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -223,15 +223,9 @@ class TclConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "TCL")
 
-        libs = []
-        libdirs = []
-        for root, _, _ in os.walk(os.path.join(self.package_folder, "lib"), topdown=False):
-            newlibs = collect_libs(self, root)
-            if newlibs:
-                libs.extend(newlibs)
-                libdirs.append(root)
-        self.cpp_info.libs = libs
-        self.cpp_info.libdirs = libdirs
+        # There are other libs in subfolders, but they are only used
+        # for TCL extensions and should not be linked against.
+        self.cpp_info.libs = collect_libs(self, os.path.join(self.package_folder, "lib"))
 
         if self.settings.os == "Windows":
             self.cpp_info.system_libs.extend(["ws2_32", "netapi32", "userenv"])


### PR DESCRIPTION
Specify library name and version:  **tcl/all**

Alternative to https://github.com/conan-io/conan-center-index/pull/22711.

TCL has some extra libraries that it uses just for extensions. I believe these should not be included in the package info, as there is no point in linking against them. They also were not properly fixed by `fix_apple_shared_install_name`, which was causing issues in #21387. This PR fixes this by just removing those extra libraries from the package info altogether.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
