### PR TITLE
wyhash: add version final4

### DIFF
--- a/recipes/wyhash/all/conandata.yml
+++ b/recipes/wyhash/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "final4":
+    url: "https://github.com/wangyi-fudan/wyhash/archive/refs/tags/wyhash_final4.tar.gz"
+    sha256: "a3f2da3acf300fba43f51c8299dae71c4e0774cd6fdd96e264fad5777b12ae3a"
   "cci.20221102":
     url: "https://github.com/wangyi-fudan/wyhash/archive/ea3b25e1aef55d90f707c3a292eeb9162e2615d8.tar.gz"
     sha256: "94c6ca365a1ca39f4327c4e031690441a45a7d9feefbc14f86323d8b42c82cbe"

--- a/recipes/wyhash/config.yml
+++ b/recipes/wyhash/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "final4":
+    folder: all
   "cci.20221102":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **wyhash/final4**

wyhash is no longer under development.
final4 is the last released version.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
