### PR TITLE
[openssl] Set tls security level to automatic for OpenSSL 3.x

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -88,13 +88,13 @@ class OpenSSLConan(ConanFile):
         "no_whirlpool": [True, False],
         "no_zlib": [True, False],
         "openssldir": [None, "ANY"],
-        "tls_security_level": [0, 1, 2, 3, 4, 5],
+        "tls_security_level": [None, 0, 1, 2, 3, 4, 5],
     }
     default_options = {key: False for key in options.keys()}
     default_options["fPIC"] = True
     default_options["no_md2"] = True
     default_options["openssldir"] = None
-    default_options["tls_security_level"] = 1
+    default_options["tls_security_level"] = None
 
     @property
     def _is_clang_cl(self):
@@ -114,8 +114,6 @@ class OpenSSLConan(ConanFile):
         return getattr(self, "settings_build", self.settings)
 
     def config_options(self):
-        self.options.tls_security_level = 1 if Version(self.version) < "3.2" else 2
-
         if self.settings.os != "Windows":
             self.options.rm_safe("capieng_dialog")
             self.options.rm_safe("enable_capieng")
@@ -386,7 +384,8 @@ class OpenSSLConan(ConanFile):
 
         args.append("no-fips" if self.options.get_safe("no_fips", True) else "enable-fips")
         args.append("no-md2" if self.options.get_safe("no_md2", True) else "enable-md2")
-        args.append("-DOPENSSL_TLS_SECURITY_LEVEL=%s" % str(self.options.tls_security_level))
+        if self.options.tls_security_level.value is not None:
+            args.append(f"-DOPENSSL_TLS_SECURITY_LEVEL={self.options.tls_security_level}")
 
         if self.options.get_safe("enable_trace"):
             args.append("enable-trace")

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -384,7 +384,7 @@ class OpenSSLConan(ConanFile):
 
         args.append("no-fips" if self.options.get_safe("no_fips", True) else "enable-fips")
         args.append("no-md2" if self.options.get_safe("no_md2", True) else "enable-md2")
-        if self.options.tls_security_level.value is not None:
+        if str(self.options.tls_security_level) != "None":
             args.append(f"-DOPENSSL_TLS_SECURITY_LEVEL={self.options.tls_security_level}")
 
         if self.options.get_safe("enable_trace"):


### PR DESCRIPTION
Specify library name and version:  **openssl/3.x**

The PR #21708 added the new option `tls_security_level` which is capable to configure a OpenSSL property. It's configured according to current versions available for 3.x, but OpenSSL moves fast it can be changed in the future, resulting in a misconfiguration in a solitary bump version PR.

Thanks to @jcar87 for pointing it, this PR keeps the current option, but instead, uses the default value from OpenSSL when not configured to an explicit value.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
