### PR TITLE
Updated cuda-api-wrappers with versions 0.6.8 and 0.7.0-b2

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -8,15 +8,6 @@ sources:
   "0.6.8":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.8.tar.gz"
     sha256: "a0d1b062dbe41c99d06df4ae7885a053c2ae3815d6fe12df0458bc5277d08ed7"
-  "0.6.7":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.7.tar.gz"
-    sha256: "e00f0ac492fde5c39211c69d3c8ae8c694d74cb6603924be91609eb9f7c4c722"
-  "0.6.6":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.6.tar.gz"
-    sha256: "271e7393725bc42feaf1d58418ea6292fdfbe5814070c590ffaabdacc3c73e8f"
-  "0.6.4":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.4.tar.gz"
-    sha256: "7ef7de5ae82b42d67bae346e49863ee610f387cccb65c2cb8edc46ff8f3b3342"
   "0.6.3":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.3.tar.gz"
     sha256: "45d896136dbb4df6c75c36071899b9fe47df9a03629c95208c2d5bda979d109e"

--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,7 +1,22 @@
 sources:
+  "0.7.0-b2":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.0-b2.tar.gz"
+    sha256: "9439cb2250dd3045a05d43c4ca66b5d49535eeba123b05a2e49169354fdb3123"
   "0.7-b1":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/0.7b1.tar.gz"
     sha256: "1ed5912d8f602ccd176865b824de17f462cb57142eb2a685d7cc034831e54a71"
+  "0.6.8":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.8.tar.gz"
+    sha256: "a0d1b062dbe41c99d06df4ae7885a053c2ae3815d6fe12df0458bc5277d08ed7"
+  "0.6.7":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.7.tar.gz"
+    sha256: "e00f0ac492fde5c39211c69d3c8ae8c694d74cb6603924be91609eb9f7c4c722"
+  "0.6.6":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.6.tar.gz"
+    sha256: "271e7393725bc42feaf1d58418ea6292fdfbe5814070c590ffaabdacc3c73e8f"
+  "0.6.4":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.4.tar.gz"
+    sha256: "7ef7de5ae82b42d67bae346e49863ee610f387cccb65c2cb8edc46ff8f3b3342"
   "0.6.3":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.3.tar.gz"
     sha256: "45d896136dbb4df6c75c36071899b9fe47df9a03629c95208c2d5bda979d109e"

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,5 +1,15 @@
 versions:
+  "0.7.0-b2":
+    folder: all
   "0.7-b1":
+    folder: all
+  "0.6.8":
+    folder: all
+  "0.6.7":
+    folder: all
+  "0.6.6":
+    folder: all
+  "0.6.4":
     folder: all
   "0.6.3":
     folder: all

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -5,11 +5,5 @@ versions:
     folder: all
   "0.6.8":
     folder: all
-  "0.6.7":
-    folder: all
-  "0.6.6":
-    folder: all
-  "0.6.4":
-    folder: all
   "0.6.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **cuda-api-wrappers/0.6.8**

Adding the latest version, plus - a few months ago, a not-really-beta of 0.7.0 was added, and could not be easily removed. Now, I've added an actual-beta of 0.7.0 for the brave souls who do want to actually try that.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
