### PR TITLE
Bump minizip to 1.3.1

### DIFF
--- a/recipes/minizip/all/conandata.yml
+++ b/recipes/minizip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.1":
+    url: "https://zlib.net/fossils/zlib-1.3.1.tar.gz"
+    sha256: "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
   "1.2.13":
     url: "https://zlib.net/fossils/zlib-1.2.13.tar.gz"
     sha256: "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
@@ -9,6 +12,8 @@ sources:
     url: "https://zlib.net/fossils/zlib-1.2.11.tar.gz"
     sha256: "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 patches:
+  "1.3.1":
+    - patch_file: "patches/minizip.patch"
   "1.2.13":
     - patch_file: "patches/minizip.patch"
   "1.2.12":

--- a/recipes/minizip/config.yml
+++ b/recipes/minizip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.1":
+    folder: all
   "1.2.13":
     folder: all
   "1.2.12":


### PR DESCRIPTION
Specify library name and version:  **minizip/1.3.1**

Minizip 1.3.1 can be created as Zlib as released a 1.3.1 version (with vulnerabilities fix in Minizip)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
