### PR TITLE
add basu/0.2.1

### DIFF
--- a/recipes/basu/all/conandata.yml
+++ b/recipes/basu/all/conandata.yml
@@ -1,0 +1,11 @@
+sources:
+  "0.2.1":
+    url: "https://git.sr.ht/~emersion/basu/refs/download/v0.2.1/basu-0.2.1.tar.gz"
+    sha256: "d9b373a9fcb5d5eb5f6c1c56355f76edb7f2f52bc744570e80604e83455a19bd"
+
+patches:
+  "0.2.1":
+    - patch_file: "patches/0001-memfd-util.c-Use-F_ADD_SEALS-definition-from-missing.patch"
+      patch_description: "add missing header to support old glibc"
+      patch_type: "portability"
+      patch_source: "https://lists.sr.ht/~emersion/public-inbox/patches/49899"

--- a/recipes/basu/all/conanfile.py
+++ b/recipes/basu/all/conanfile.py
@@ -1,0 +1,97 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+
+class BasuConan(ConanFile):
+    name = "basu"
+    description = "The sd-bus library, extracted from systemd"
+    license = "LGPL-2.1-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://git.sr.ht/~emersion/basu"
+    topics = ("dbus", "sd-bus", "systemd")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_libcap": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_libcap": True,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os != "Linux":
+            del self.options.with_libcap
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.get_safe("with_libcap"):
+            self.requires("libcap/2.69")
+
+    def validate(self):
+        if self.settings.os not in ["Linux", "FreeBSD"]:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} does not support {self.settings.os}")
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.3.2")
+        self.tool_requires("gperf/3.1")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.1.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        feature = lambda option: "enabled" if option else "disabled"
+
+        tc = MesonToolchain(self)
+        tc.project_options["auto_features"] = "disabled"
+        tc.project_options["libcap"] = feature(self.options.get_safe("with_libcap"))
+        tc.generate()
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "LICENSE.LGPL2.1", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["basu"]
+        self.cpp_info.set_property("pkg_config_name", "basu")
+        self.cpp_info.system_libs.extend(["m", "pthread", "rt"])

--- a/recipes/basu/all/patches/0001-memfd-util.c-Use-F_ADD_SEALS-definition-from-missing.patch
+++ b/recipes/basu/all/patches/0001-memfd-util.c-Use-F_ADD_SEALS-definition-from-missing.patch
@@ -1,0 +1,34 @@
+From 8e4960e8b9d11d9be96e83b02bd3b08178ddce1b Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Wed, 28 Feb 2024 20:42:19 +0300
+Subject: [PATCH basu] memfd-util.c: Use F_ADD_SEALS definition from missing.h
+
+uClibc and glibc (until version 2.27, 2018) implementations don't
+support F_ADD_SEALS and other F_SEAL_xxx flags.
+'missing.h' was removed from 'memfd-util.c' in 37dbb2fcb ("Remove
+useless includes").
+
+Upstream: https://lists.sr.ht/~emersion/public-inbox/patches/49899
+
+Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+---
+ src/basic/memfd-util.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/basic/memfd-util.c b/src/basic/memfd-util.c
+index 89893ba..7e535c6 100644
+--- a/src/basic/memfd-util.c
++++ b/src/basic/memfd-util.c
+@@ -7,6 +7,7 @@
+ 
+ #include "alloc-util.h"
+ #include "memfd-util.h"
++#include "missing.h"
+ 
+ int memfd_set_sealed(int fd) {
+ #if defined(__FreeBSD__) && __FreeBSD__ < 13
+
+base-commit: 684a41d68cfbb05e38aacb60a8548e21ddfbecdb
+-- 
+2.44.0
+

--- a/recipes/basu/all/test_package/conanfile.py
+++ b/recipes/basu/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.3.2")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/2.1.0")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/basu/all/test_package/meson.build
+++ b/recipes/basu/all/test_package/meson.build
@@ -1,0 +1,5 @@
+project('test_package', 'c')
+package_dep = dependency('basu')
+executable('test_package',
+            sources : ['test_package.c'],
+            dependencies : [package_dep])

--- a/recipes/basu/all/test_package/test_package.c
+++ b/recipes/basu/all/test_package/test_package.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <basu/sd-bus.h>
+
+int main(void) {
+    char *id = NULL;
+    int ret = 0;
+
+    puts("decode object path");
+    ret = sd_bus_path_decode("/foo/bar", "/foo", &id);
+    free(id);
+    if (ret > 0) {
+        puts("ok");
+        return EXIT_SUCCESS;
+    }
+    puts("failed");
+    return EXIT_FAILURE;
+}

--- a/recipes/basu/config.yml
+++ b/recipes/basu/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.2.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **basu/0.2.1**

basu is the sd-bus library, extracted from systemd.

Some projects rely on the sd-bus library for DBus support. However not all systems have systemd or elogind installed. This library provides just sd-bus (and the busctl utility).


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
