### PR TITLE
xnnpack: fix cross-compiling for Android/armv7

### DIFF
--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -64,7 +64,7 @@ class XnnpackConan(ConanFile):
 
     def validate(self):
         check_min_vs(self, 192)
-        compiler = self.info.settings.compiler
+        compiler = self.settings.compiler
         compiler_version = Version(compiler.version)
         if self.version < "cci.20230715":
             if (compiler == "gcc" and compiler_version < "6") or \
@@ -75,6 +75,10 @@ class XnnpackConan(ConanFile):
             if (compiler == "gcc" and compiler_version < "11") or \
                 (compiler == "clang" and compiler_version < "8"):
                 raise ConanInvalidConfiguration(f"{self.ref} doesn't support {compiler} {compiler.version}")
+        if self.options.assembly and compiler == "clang" and self.settings.arch == "armv6":
+            # clang assembly validator fails on XNNPACK's math.h for armv6:
+            # https://github.com/google/XNNPACK/issues/4348#issuecomment-1445437613
+            raise ConanInvalidConfiguration(f"{self.ref} assembly option is incompatible with clang+armv6")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -120,6 +124,12 @@ class XnnpackConan(ConanFile):
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                               "LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}",
                               "LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}")
+        if self.settings.compiler == "clang" and self.settings.arch == "armv7":
+            # https://github.com/google/XNNPACK/issues/4348
+            # XNNPACK targets armv6, but clang fails to compile to due to a bug in the assembler (see linked issue).
+            # The user is targetting armv7, so adjust XNNPACK's -march accordingly to avoid the bug.
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                                  "-march=armv6 -mfpu=vfp", "-march=armv7-a -mfpu=neon")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
Specify library name and version: xnnpack/*

This works around a long-standing bug of XNNPACK, which prevents building for Android with assembly=True set:

https://github.com/google/XNNPACK/issues/4348

The issue will not be fixed upstream and the maintainers comment that this is a clang bug. While correct, it would be impossible to build for Android with the NDK without a recipe-level workaround. Disabling assembly is not really an option for performance reasons. This integrates the workaround suggested in the ticket.

In essence I raise the target level from XNNPACK's default of armv6 to armv7 if the Conan user targets armv7 anyway. Should thus be free of side-effects. The previously broken armv6 build is now explicitly aborted with an invalid configuration error, and the user must turn off the "assembly" option to build for armv6.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.