### PR TITLE
gperf/all: Fix build on FreeBSD

### DIFF
--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -39,6 +39,10 @@ class GperfConan(ConanFile):
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
 
+        # gperf makefile relies on GNU Make behaviour
+        if self._settings_build.os == "FreeBSD":
+            self.tool_requires("make/4.4.1")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
             destination=self.source_folder, strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **gperf/3.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The original error on FreeBSD 14.0 was:
```console
  gperf/3.1: RUN: make -j1
    cd lib; make all
    cc -m64 -O3 -DNDEBUG -I. -c ./getopt.c
    cc -m64 -O3 -DNDEBUG -I. -c ./getopt1.c
    c++ -stdlib=libc++ -std=gnu++17 -m64 -O3 -DNDEBUG -I. -c ./getline.cc
    c++ -stdlib=libc++ -std=gnu++17 -m64 -O3 -DNDEBUG -I. -c ./hash.cc
    rm -f libgp.a
    ar rc libgp.a getopt.o getopt1.o getline.o hash.o
    ranlib libgp.a
    cd src; make all
    cd: src: No such file or directory
  *** [all] Error code 2
```
The error occurs here:
```make
all : force
	cd lib; $(MAKE) all
	cd src; $(MAKE) all
	cd tests; $(MAKE) all
	cd doc; $(MAKE) all
```
in the following directory
```console
$ ls -1ap
./
../
aclocal.m4
AUTHORS
build-aux/
ChangeLog
config.log
config.status
configure
configure.ac
COPYING
doc/
INSTALL
lib/
Makefile
Makefile.devel
Makefile.in
Makefile.vms
NEWS
README
README.vms
README.windows
src/
tests/
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
