### PR TITLE
zziplib: add version 0.13.74

### DIFF
--- a/recipes/zziplib/all/conandata.yml
+++ b/recipes/zziplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.13.74":
+    url: "https://github.com/gdraheim/zziplib/archive/v0.13.74.tar.gz"
+    sha256: "319093aa98d39453f3ea2486a86d8a2fab2d5632f6633a2665318723a908eecf"
   "0.13.72":
     url: "https://github.com/gdraheim/zziplib/archive/v0.13.72.tar.gz"
     sha256: "93ef44bf1f1ea24fc66080426a469df82fa631d13ca3b2e4abaeab89538518dc"

--- a/recipes/zziplib/config.yml
+++ b/recipes/zziplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.13.74":
+    folder: all
   "0.13.72":
     folder: all
   "0.13.71":


### PR DESCRIPTION
Specify library name and version:  **zziplib/0.13.74**

0.13.74 is the first release in three years.

https://github.com/gdraheim/zziplib/compare/v0.13.72...v0.13.74

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
