### PR TITLE
expat: add version 2.6.1

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.1":
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_6_1/expat-2.6.1.tar.xz"
+    sha256: "0c00d2760ad12efef6e26efc8b363c8eb28eb8c8de719e46d5bb67b40ba904a3"
   "2.6.0":
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_6_0/expat-2.6.0.tar.xz"
     sha256: "cb5f5a8ea211e1cabd59be0a933a52e3c02cc326e86a4d387d8d218e7ee47a3e"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.1":
+    folder: all
   "2.6.0":
     folder: all
   "2.5.0":


### PR DESCRIPTION
Specify library name and version:  **expat/2.6.1**

https://github.com/libexpat/libexpat/compare/R_2_6_0...R_2_6_1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
