### PR TITLE
nng: add version 1.7.3

### DIFF
--- a/recipes/nng/all/conandata.yml
+++ b/recipes/nng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.7.3":
+    url: "https://github.com/nanomsg/nng/archive/refs/tags/v1.7.3.tar.gz"
+    sha256: "035f2c3cad4e45fc0d978c54a338c197d1937527ae6feb82180d428a96b83474"
   "1.7.2":
     url: "https://github.com/nanomsg/nng/archive/refs/tags/v1.7.2.tar.gz"
     sha256: "40e6af7bdd5d02ee98ba8fe5fd5c149ce3e5a555f202cdc837e3ead2d7cc7534"

--- a/recipes/nng/all/conanfile.py
+++ b/recipes/nng/all/conanfile.py
@@ -27,6 +27,7 @@ class NngConan(ConanFile):
         "max_expire_threads": ["ANY"],
         "max_poller_threads": ["ANY"],
         "compat": [True, False],
+        "with_ipv6": [True, False],
     }
     default_options = {
         "shared": False,
@@ -38,6 +39,7 @@ class NngConan(ConanFile):
         "max_expire_threads": "8",
         "max_poller_threads": "8",
         "compat": True,
+        "with_ipv6": True,
     }
 
     def export_sources(self):
@@ -52,6 +54,8 @@ class NngConan(ConanFile):
             del self.options.max_poller_threads
         if Version(self.version) < "1.7.2":
             del self.options.compat
+        if Version(self.version) < "1.7.3":
+            del self.options.with_ipv6
 
     def configure(self):
         if self.options.shared:
@@ -102,6 +106,8 @@ class NngConan(ConanFile):
             tc.variables["NNG_MAX_POLLER_THREADS"] = self.options.max_poller_threads
         if "compat" in self.options:
             tc.variables["NNG_ENABLE_COMPAT"] = self.options.compat
+        if "with_ipv6" in self.options:
+            tc.variables["NNG_ENABLE_IPV6"] = self.options.with_ipv6
         tc.generate()
 
     def build(self):

--- a/recipes/nng/config.yml
+++ b/recipes/nng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.7.3":
+    folder: all
   "1.7.2":
     folder: all
   "1.7.1":


### PR DESCRIPTION
Specify library name and version:  **nng/1.7.3**

- add version 1.7.3
- add `with_ipv6` option for 1.7.3 and later

https://github.com/nanomsg/nng/compare/v1.7.2...v1.7.3

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
