### PR TITLE
[cairo] Bump depencencies

### DIFF
--- a/recipes/cairo/config.yml
+++ b/recipes/cairo/config.yml
@@ -7,7 +7,5 @@ versions:
     folder: meson
   "1.17.4":
     folder: meson
-  "1.17.2":
-    folder: all
   "1.16.0":
     folder: all

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -88,7 +88,7 @@ class CairoConan(ConanFile):
     def requirements(self):
         self.requires("pixman/0.42.2")
         if self.options.with_zlib and self.options.with_png:
-            self.requires("expat/2.5.0")
+            self.requires("expat/2.6.0")
         if self.options.with_lzo:
             self.requires("lzo/2.10")
         if self.options.with_zlib:
@@ -98,7 +98,7 @@ class CairoConan(ConanFile):
         if self.options.with_fontconfig:
             self.requires("fontconfig/2.14.2", transitive_headers=True, transitive_libs=True)
         if self.options.with_png:
-            self.requires("libpng/1.6.40")
+            self.requires("libpng/1.6.42")
         if self.options.with_glib:
             self.requires("glib/2.78.1")
         if self.settings.os in ["Linux", "FreeBSD"]:


### PR DESCRIPTION
Trying to build cairo result in the following error:

```
ERROR: Version conflict: freetype/2.13.0->libpng/1.6.42, cairo/1.16.0@cci_testing/testing->libpng/1.6.40.
```

I fixed `libpng` to 1.6.40 and add:

```
ERROR: Version conflict: Conflict between expat/2.6.0 and expat/2.5.0 in the graph.
Conflict originates from fontconfig/2.14.2
```

Fixing also expat to 2.6.0 made possible to run `conan create ...`



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
