### PR TITLE
Qt6 check if we are on C3I CI

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -235,11 +235,10 @@ class QtConan(ConanFile):
                 setattr(self.options, module, False)
 
     def validate(self):
-        if os.getenv('NOT_ON_C3I', '0') == '0':
+        if os.getenv('CONAN_CENTER_BUILD_SERVICE') is not None:
             if self.info.settings.compiler == "gcc" and Version(self.info.settings.compiler.version) >= "11" or \
                 self.info.settings.compiler == "clang" and Version(self.info.settings.compiler.version) >= "12":
-                raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed\n"\
-                                                "If your distro is modern enough (xcb >= 1.12), set environment variable NOT_ON_C3I=1")
+                raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed")
 
         # C++ minimum standard required
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Specify library name and version:  **qt/6.x**


Check if global environment variable `CONAN_CENTER_BUILD_SERVICE` is defined. This negates the need for consumers to have to define `NOT_ON_C3I`. 
