### PR TITLE
md4qt: bump version to 2.8.0

### DIFF
--- a/recipes/md4qt/all/conandata.yml
+++ b/recipes/md4qt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.8.0":
+    url: "https://github.com/igormironchik/md4qt/archive/refs/tags/2.8.0.tar.gz"
+    sha256: "82ef6acc84ea3a7891e4547f7d79af4caaef0f4d6f152bdab2a5c6ed5a48d11b"
   "2.7.4":
     url: "https://github.com/igormironchik/md4qt/archive/refs/tags/2.7.4.tar.gz"
     sha256: "adef8e96e71f13cb9f4450eee7bb02a43694682dc67519323f8e23f7bf10d0d1"

--- a/recipes/md4qt/config.yml
+++ b/recipes/md4qt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8.0":
+    folder: all
   "2.7.4":
     folder: all
   "2.7.3":


### PR DESCRIPTION
Specify library name and version:  **md4qt/2.8.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

I'm the author of this library.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
