### PR TITLE
xz_utils: Add 5.6.0 as a new subdir

### DIFF
--- a/recipes/xz_utils/all/conandata.yml
+++ b/recipes/xz_utils/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "5.6.0":
-    url: "https://github.com/tukaani-project/xz/releases/download/v5.6.0/xz-5.6.0.tar.xz"
-    sha256: "cdafe1632f139c82937cc1ed824f7a60b7b0a0619dfbbd681dcac02b1ac28f5b"
   "5.4.5":
     url: "https://tukaani.org/xz/xz-5.4.5.tar.xz"
     sha256: "da9dec6c12cf2ecf269c31ab65b5de18e8e52b96f35d5bcd08c12b43e6878803"

--- a/recipes/xz_utils/all/conandata.yml
+++ b/recipes/xz_utils/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.6.0":
+    url: "https://github.com/tukaani-project/xz/releases/download/v5.6.0/xz-5.6.0.tar.xz"
+    sha256: "cdafe1632f139c82937cc1ed824f7a60b7b0a0619dfbbd681dcac02b1ac28f5b"
   "5.4.5":
     url: "https://tukaani.org/xz/xz-5.4.5.tar.xz"
     sha256: "da9dec6c12cf2ecf269c31ab65b5de18e8e52b96f35d5bcd08c12b43e6878803"

--- a/recipes/xz_utils/cmake/conandata.yml
+++ b/recipes/xz_utils/cmake/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "5.6.0":
+    url: "https://github.com/tukaani-project/xz/releases/download/v5.6.0/xz-5.6.0.tar.xz"
+    sha256: "cdafe1632f139c82937cc1ed824f7a60b7b0a0619dfbbd681dcac02b1ac28f5b"

--- a/recipes/xz_utils/cmake/conanfile.py
+++ b/recipes/xz_utils/cmake/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, rmdir, save
 from conan.tools.scm import Version
 import os
 import textwrap
@@ -77,6 +77,8 @@ class XZUtilsConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake", "liblzma"))
+        if self.settings.os == "Windows":
+            rename(self, os.path.join(self.package_folder, "lib", "liblzma.lib"), os.path.join(self.package_folder, "lib", "lzma.lib"))
 
     def _create_cmake_module_variables(self, module_file):
         # TODO: also add LIBLZMA_HAS_AUTO_DECODER, LIBLZMA_HAS_EASY_ENCODER & LIBLZMA_HAS_LZMA_PRESET

--- a/recipes/xz_utils/cmake/conanfile.py
+++ b/recipes/xz_utils/cmake/conanfile.py
@@ -1,0 +1,113 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, save
+from conan.tools.scm import Version
+import os
+import textwrap
+
+required_conan_version = ">=1.54.0"
+
+
+class XZUtilsConan(ConanFile):
+    name = "xz_utils"
+    description = (
+        "XZ Utils is free general-purpose data compression software with a high "
+        "compression ratio. XZ Utils were written for POSIX-like systems, but also "
+        "work on some not-so-POSIX systems. XZ Utils are the successor to LZMA Utils."
+    )
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://tukaani.org/xz"
+    topics = ("lzma", "xz", "compression")
+    license = "Unlicense", "LGPL-2.1-or-later",  "GPL-2.0-or-later", "GPL-3.0-or-later"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+    
+    def validate(self):
+        # This is only from 5.6.0 onwards, they are just in a different recipe so no need to check version.
+        if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "7":
+            raise ConanInvalidConfiguration(f"{self.ref} does not work on GCC<7 due to errors with inline assembly")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+
+        self._create_cmake_module_variables(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+        )
+        cmake = CMake(self)
+        cmake.install()
+
+    def _create_cmake_module_variables(self, module_file):
+        # TODO: also add LIBLZMA_HAS_AUTO_DECODER, LIBLZMA_HAS_EASY_ENCODER & LIBLZMA_HAS_LZMA_PRESET
+        content = textwrap.dedent(f"""\
+            set(LIBLZMA_FOUND TRUE)
+            if(DEFINED LibLZMA_INCLUDE_DIRS)
+                set(LIBLZMA_INCLUDE_DIRS ${{LibLZMA_INCLUDE_DIRS}})
+            endif()
+            if(DEFINED LibLZMA_LIBRARIES)
+                set(LIBLZMA_LIBRARIES ${{LibLZMA_LIBRARIES}})
+            endif()
+            set(LIBLZMA_VERSION_MAJOR {Version(self.version).major})
+            set(LIBLZMA_VERSION_MINOR {Version(self.version).minor})
+            set(LIBLZMA_VERSION_PATCH {Version(self.version).patch})
+            set(LIBLZMA_VERSION_STRING "{self.version}")
+        """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.set_property("cmake_file_name", "LibLZMA")
+        self.cpp_info.set_property("cmake_target_name", "LibLZMA::LibLZMA")
+        self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
+        self.cpp_info.set_property("pkg_config_name", "liblzma")
+        self.cpp_info.libs = ["lzma"]
+        if not self.options.shared:
+            self.cpp_info.defines.append("LZMA_API_STATIC")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
+
+        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
+        self.cpp_info.names["cmake_find_package"] = "LibLZMA"
+        self.cpp_info.names["cmake_find_package_multi"] = "LibLZMA"
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]

--- a/recipes/xz_utils/cmake/conanfile.py
+++ b/recipes/xz_utils/cmake/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
 from conan.tools.scm import Version
 import os
 import textwrap
@@ -73,6 +73,10 @@ class XZUtilsConan(ConanFile):
         )
         cmake = CMake(self)
         cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake", "liblzma"))
 
     def _create_cmake_module_variables(self, module_file):
         # TODO: also add LIBLZMA_HAS_AUTO_DECODER, LIBLZMA_HAS_EASY_ENCODER & LIBLZMA_HAS_LZMA_PRESET

--- a/recipes/xz_utils/cmake/test_package/CMakeLists.txt
+++ b/recipes/xz_utils/cmake/test_package/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+find_package(LibLZMA REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE LibLZMA::LibLZMA)
+
+# Test whether variables from https://cmake.org/cmake/help/latest/module/FindLibLZMA.html
+# are properly defined in conan generators
+set(_custom_vars
+    LIBLZMA_FOUND
+    LIBLZMA_INCLUDE_DIRS
+    LIBLZMA_LIBRARIES
+    LIBLZMA_VERSION_MAJOR
+    LIBLZMA_VERSION_MINOR
+    LIBLZMA_VERSION_PATCH
+    LIBLZMA_VERSION_STRING
+)
+foreach(_custom_var ${_custom_vars})
+    if(DEFINED ${_custom_var})
+        message(STATUS "${_custom_var}: ${${_custom_var}}")
+    else()
+        message(FATAL_ERROR "${_custom_var} not defined")
+    endif()
+endforeach()

--- a/recipes/xz_utils/cmake/test_package/conanfile.py
+++ b/recipes/xz_utils/cmake/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/xz_utils/cmake/test_package/test_package.c
+++ b/recipes/xz_utils/cmake/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <lzma.h>
+
+int main() {
+    printf("LZMA version %s\n", lzma_version_string());
+    return EXIT_SUCCESS;
+}

--- a/recipes/xz_utils/cmake/test_v1_package/CMakeLists.txt
+++ b/recipes/xz_utils/cmake/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/xz_utils/cmake/test_v1_package/conanfile.py
+++ b/recipes/xz_utils/cmake/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/xz_utils/config.yml
+++ b/recipes/xz_utils/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.6.0":
+    folder: all
   "5.4.5":
     folder: all
   "5.4.4":

--- a/recipes/xz_utils/config.yml
+++ b/recipes/xz_utils/config.yml
@@ -1,6 +1,6 @@
 versions:
   "5.6.0":
-    folder: all
+    folder: cmake
   "5.4.5":
     folder: all
   "5.4.4":


### PR DESCRIPTION
Specify library name and version:  **xz_utils/5.6.0**

It seems the project has started hosting their releases on github primarily rather than their website. The old links seem to still exist for backwards compatibility, but I can't find any reference to them on the site, and doesn't exist for this new version.

5.6.0 also removed the visual studio projects, and has moved fully to CMake for Windows. CMake hasn't fully replaced Autotools for them yet, but hopefully it should be good enough for us to use.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
