### PR TITLE
[config] Remove Conan v2 migration check as mandatory

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -38,7 +38,6 @@ tasks:
     # * status_checks refers to notifications coming from external tools (Jenkins, CLA,...)
     check_runs:
       - name: "Lint changed files (YAML files)"
-      - name: "Lint changed conanfile.py (v2 migration)"
     status_checks:
       - name: "license/cla"
       - name: "continuous-integration/jenkins/pr-merge"


### PR DESCRIPTION
The Conan v2 migration linter was created to help us when we started to migrate +1000 recipes, and it was really useful. However, right now we have only few recipes missing to be migrated, most with an open PR.

Related to #22286


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
