### PR TITLE
linter: handle test_requires

### DIFF
--- a/linter/transform_conanfile.py
+++ b/linter/transform_conanfile.py
@@ -52,6 +52,7 @@ def transform_conanfile(node):
     dynamic_fields = {
         "conan_data": str_class,
         "build_requires": build_requires_class,
+        "test_requires" : build_requires_class,
         "tool_requires": build_requires_class,
         "info_build": info_class,
         "user_info_build": [_user_info_build_transform()],


### PR DESCRIPTION
it is basically like a build_requires:
https://github.com/conan-io/conan/blob/1.63.0/conans/client/graph/graph_manager.py#L321

related to https://github.com/conan-io/conan-center-index/actions/runs/8140241751/job/22245056002?pr=22286#step:8:19


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
