### PR TITLE
fix gmp/6.3.0:ctest:command not found issue

### DIFF
--- a/recipes/gmp/all/test_package/conanfile.py
+++ b/recipes/gmp/all/test_package/conanfile.py
@@ -30,4 +30,5 @@ class TestPackageConan(ConanFile):
         if not can_run(self):
             return
         with chdir(self, self.folders.build_folder):
-            self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env="conanrun")
+            env = "conanrun" if self.settings.os == "Windows" else "conanbuild"
+            self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env=env)

--- a/recipes/gmp/all/test_package/conanfile.py
+++ b/recipes/gmp/all/test_package/conanfile.py
@@ -30,5 +30,5 @@ class TestPackageConan(ConanFile):
         if not can_run(self):
             return
         with chdir(self, self.folders.build_folder):
-            env = "conanrun" if self.settings.os == "Windows" else "conanbuild"
-            self.run(f"ctest --output-on-failure -C {self.settings.build_type}", env=env)
+            cmake = CMake(self)
+            cmake.ctest()


### PR DESCRIPTION
For gmp/6.3.0, it might show the below error if CMake is not present in the run environment.

```
======== Testing the package: Executing test ========
gmp/6.3.0 (test package): Running test()
gmp/6.3.0 (test package): RUN: ctest --output-on-failure -C Release
/bin/sh: line 1: ctest: command not found
```
we can bypass this by using the `conanbuild` environment on non-Windows platforms.


Specify library name and version:  **gmp/6.3.0**
- [X ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
