### PR TITLE
opentelemetry-cpp: fix an invalid optional library, drop v1.7.0

### DIFF
--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -8,6 +8,3 @@ sources:
   "1.8.3":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.3.tar.gz"
     sha256: "b23d3c80d2e0012734ea343d2be69b2a7139ec5545453c503b13e629eb8fbe05"
-  "1.7.0":
-    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.7.0.tar.gz"
-    sha256: "2ad0911cdc94fe84a93334773bef4789a38bd1f01e39560cabd4a5c267e823c3"

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -235,14 +235,9 @@ class OpenTelemetryCppConan(ConanFile):
             replace_in_file(self, protos_cmake_path,
                             "if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto/.git)",
                             "if(1)")
-            if Version(self.version) < "1.8.3":
-                replace_in_file(self, protos_cmake_path,
-                                'set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")',
-                                f'set(PROTO_PATH "{protos_path}")')
-            else:
-                replace_in_file(self, protos_cmake_path,
-                                '"${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")',
-                                f'"{protos_path}")')
+            replace_in_file(self, protos_cmake_path,
+                            '"${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")',
+                            f'"{protos_path}")')
             if self.options.with_otlp_grpc and Version(self.version) < "1.9.1":
                 save(self, protos_cmake_path, "\ntarget_link_libraries(opentelemetry_proto PUBLIC gRPC::grpc++)", append=True)
 
@@ -385,12 +380,6 @@ class OpenTelemetryCppConan(ConanFile):
             ])
 
         if self.options.with_otlp_grpc:
-            if Version(self.version) <= "1.7.0":
-                self.cpp_info.components["opentelemetry_exporter_otlp_grpc"].requires.extend([
-                    "grpc::grpc++",
-                    "opentelemetry_otlp_recordable",
-                ])
-
             self.cpp_info.components["opentelemetry_exporter_otlp_grpc_client"].requires.extend([
                 "grpc::grpc++",
                 "opentelemetry_proto",

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -284,7 +284,6 @@ class OpenTelemetryCppConan(ConanFile):
     @property
     def _otel_libraries(self):
         libraries = [
-            self._http_client_name,
             "opentelemetry_common",
             "opentelemetry_exporter_in_memory",
             "opentelemetry_exporter_ostream_span",
@@ -292,6 +291,9 @@ class OpenTelemetryCppConan(ConanFile):
             "opentelemetry_trace",
             "opentelemetry_version",
         ]
+        if self.options.with_otlp_http or self.options.with_elasticsearch or self.options.get_safe("with_jaeger") or self.options.with_zipkin:
+            # https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.12.0/CMakeLists.txt#L452-L460
+            libraries.append(self._http_client_name)
         if self.options.with_otlp_grpc or self.options.with_otlp_http:
             libraries.extend([
                 "opentelemetry_proto",

--- a/recipes/opentelemetry-cpp/config.yml
+++ b/recipes/opentelemetry-cpp/config.yml
@@ -5,5 +5,3 @@ versions:
     folder: all
   "1.8.3":
     folder: all
-  "1.7.0":
-    folder: all


### PR DESCRIPTION
- Fixes #22985

Dropped v1.7.0 for maintainability as it handles that library differently altogether.