### PR TITLE
libxml2: add 2.12.5 and 2.11.7

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.12.5":
+    url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.5.tar.xz"
+    sha256: "a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21"
   "2.12.4":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.4.tar.xz"
     sha256: "497360e423cf0bd99eacdb7c6215dea92e6d6e89ee940393c2bae0e77cb9b7d0"
@@ -11,6 +14,9 @@ sources:
   "2.12.1":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.1.tar.xz"
     sha256: "8982b9ccdf7f456e30d8f7012d50858c6623e495333b6191def455c7e95427eb"
+  "2.11.7":
+    url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.7.tar.xz"
+    sha256: "fb27720e25eaf457f94fd3d7189bcf2626c6dccf4201553bc8874d50e3560162"
   "2.11.6":
     url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.6.tar.xz"
     sha256: "c90eee7506764abbe07bb616b82da452529609815aefef423d66ef080eb0c300"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.12.5":
+    folder: all
   "2.12.4":
     folder: all
   "2.12.3":
@@ -6,6 +8,8 @@ versions:
   "2.12.2":
     folder: all
   "2.12.1":
+    folder: all
+  "2.11.7":
     folder: all
   "2.11.6":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libxml2/2.12.5**

New versions contain fix for CVE-2024-25062

https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.7
https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.5

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
