### PR TITLE
fuzztest: new recipe

### DIFF
--- a/recipes/fuzztest/all/conandata.yml
+++ b/recipes/fuzztest/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20240305":
+    url: "https://github.com/google/fuzztest/archive/e317d5277e34948ae7048cb5e48309e0288e8df3.tar.gz"
+    sha256: "cd13071a90258e9017122903ef1cd61228d8beb3b99d15bd5c60f74379d2681e"

--- a/recipes/fuzztest/all/conanfile.py
+++ b/recipes/fuzztest/all/conanfile.py
@@ -1,0 +1,152 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, load, rm, rmdir, save
+from conan.tools.scm import Version
+import os
+
+import yaml
+
+required_conan_version = ">=1.53.0"
+
+#
+# INFO: Please, remove all comments before pushing your PR!
+#
+
+class _Library:
+    name: str
+    deps: list[str]
+
+class FuzztestConan(ConanFile):
+    name = "fuzztest"
+    description = "A C++ testing framework for writing and executing fuzz tests"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/google/fuzztest"
+    topics = ("fuzzing", "testing")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    def export_sources(self):
+        copy(self, f"_package_info-{self.version}.yml",
+             os.path.join(self.recipe_folder, "package_info"),
+             os.path.join(self.export_sources_folder))
+
+    # in case the project requires C++14/17/20/... the minimum compiler version should be listed
+#    @property
+#    def _compilers_minimum_version(self):
+#        return {
+#            "apple-clang": "10",
+#            "clang": "7",
+#            "gcc": "7",
+#            "msvc": "191",
+#            "Visual Studio": "15",
+#        }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("abseil/20240116.1@local/beta", force=True) # Waiting on PR
+        self.requires("antlr4-cppruntime/4.13.1")
+        self.requires("gtest/1.14.0")
+        self.requires("re2/20240301@local/beta", force=True) # Waiting on PR, uses internal headers
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+
+        if self.settings.compiler not in ["gcc", "clang", "apple-clang"]:
+            raise ConanInvalidConfiguration(f"{self.ref} only supports GCC and (Apple) Clang")
+#        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+#        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+#            raise ConanInvalidConfiguration(
+#                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+#            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def _fetchcontent_to_findpackage(self):
+        # Replace the entirety of the FetchContent-based dependency fetching with find_packages
+        save(self, os.path.join(self.source_folder, "cmake", "BuildDependencies.cmake"), """
+find_package(re2 REQUIRED CONFIG)
+find_package(absl REQUIRED CONFIG)
+find_package(GTest REQUIRED CONFIG)
+find_package(antlr4-runtime REQUIRED CONFIG)
+""")
+
+    def build(self):
+        self._fetchcontent_to_findpackage()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        info_path = os.path.join(self.export_sources_folder, f"_package_info-{self.version}.yml")
+        info = yaml.safe_load(open(info_path, "r"))
+
+        for name, data in info.items():
+            if not data["header_only"]:
+                # Just assuming Linux/static for a minute
+                copy(self, f"*{name}*.a", os.path.join(self.build_folder, "fuzztest"), os.path.join(self.package_folder, "lib"))
+                print(name)
+            # TODO add an assertion to make sure no compiled libraries get missed
+            #print(name)
+            #print(data["header_only"])
+            #print(data["deps"])
+
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+
+    def package_info(self):
+        pass # TODO
+#        self.cpp_info.libs = ["package_lib"]
+#
+#        # if package has an official FindPACKAGE.cmake listed in https://cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules
+#        # examples: bzip2, freetype, gdal, icu, libcurl, libjpeg, libpng, libtiff, openssl, sqlite3, zlib...
+#        self.cpp_info.set_property("cmake_module_file_name", "PACKAGE")
+#        self.cpp_info.set_property("cmake_module_target_name", "PACKAGE::PACKAGE")
+#        # if package provides a CMake config file (package-config.cmake or packageConfig.cmake, with package::package target, usually installed in <prefix>/lib/cmake/<package>/)
+#        self.cpp_info.set_property("cmake_file_name", "package")
+#        self.cpp_info.set_property("cmake_target_name", "package::package")
+#        # if package provides a pkgconfig file (package.pc, usually installed in <prefix>/lib/pkgconfig/)
+#        self.cpp_info.set_property("pkg_config_name", "package")
+#
+#        # If they are needed on Linux, m, pthread and dl are usually needed on FreeBSD too
+#        if self.settings.os in ["Linux", "FreeBSD"]:
+#            self.cpp_info.system_libs.append("m")
+#            self.cpp_info.system_libs.append("pthread")
+#            self.cpp_info.system_libs.append("dl")
+#
+#        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+#        self.cpp_info.filenames["cmake_find_package"] = "PACKAGE"
+#        self.cpp_info.filenames["cmake_find_package_multi"] = "package"
+#        self.cpp_info.names["cmake_find_package"] = "PACKAGE"
+#        self.cpp_info.names["cmake_find_package_multi"] = "package"

--- a/recipes/fuzztest/all/package_info/_package_info-cci.20240305.yml
+++ b/recipes/fuzztest/all/package_info/_package_info-cci.20240305.yml
@@ -1,0 +1,325 @@
+# Manually derived from
+# https://github.com/google/fuzztest/blob/e317d5277e34948ae7048cb5e48309e0288e8df3/fuzztest/CMakeLists.txt
+# Any targets suffixed with "_test" were removed.
+
+fuzztest:
+  header_only: True
+  deps:
+    - fuzztest::domain
+    - fuzztest::fuzztest_macros
+
+fuzztest_core:
+  header_only: True
+  deps:
+    - fuzztest::domain_core
+    - fuzztest::fuzztest_macros
+
+fuzztest_macros:
+  header_only: True
+  deps:
+    - fuzztest::io
+    - fuzztest::registration
+    - fuzztest::registry
+
+fuzztest_gtest_main:
+  header_only: False
+  deps:
+    - absl::flags_parse
+    - absl::strings
+    - fuzztest::init_fuzztest
+    - GTest::gtest
+
+init_fuzztest:
+  header_only: False
+  deps:
+    - fuzztest::configuration
+    - fuzztest::googletest_adaptor
+    - fuzztest::io
+    - fuzztest::registry
+    - fuzztest::runtime
+    - absl::flags
+    - absl::strings
+    - absl::str_format
+    - absl::time
+    - GTest::gtest
+
+llvm_fuzzer_main:
+  header_only: False
+  deps:
+    - fuzztest::init_fuzztest
+    - absl::flags
+    - absl::flags_parse
+    - GTest::gtest
+    
+
+llvm_fuzzer_wrapper:
+  header_only: False
+  deps:
+    - fuzztest::domain_core
+    - fuzztest::fuzztest
+    - fuzztest::io
+    - fuzztest::llvm_fuzzer_main
+    - absl::flags
+    - absl::log
+    - absl::random_random
+    - absl::random_bit_gen_ref
+    - absl::strings
+    - absl::string_view
+    - re2::re2
+
+# The rest are loosely marked as "internal", though not sure which ones, as some seem useful.
+
+absl_helpers:
+  header_only: True
+  deps:
+    - fuzztest::logging
+    - absl::time
+
+any:
+  header_only: True
+  deps:
+    - fuzztest::logging
+    - fuzztest::meta
+
+compatibility_mode:
+  header_only: False
+  deps:
+    - fuzztest::domain_core
+    - fuzztest::fixture_driver
+    - fuzztest::logging
+    - fuzztest::runtime
+    - absl::random_distributions
+    - absl::strings
+    - absl::str_format
+    - absl::time
+
+configuration:
+  header_only: False
+  deps:
+    - fuzztest::io
+    - absl::strings
+    - absl::string_view
+
+coverage:
+  header_only: False
+  deps:
+    - fuzztest::logging
+    - fuzztest::table_of_recent_compares
+    - absl::core_headers
+    - absl::str_format
+    - absl::span
+
+domain:
+  header_only: False
+  deps:
+    - fuzztest::any
+    - fuzztest::domain_core
+    - fuzztest::logging
+    - fuzztest::meta
+    - fuzztest::regexp_dfa
+    - fuzztest::serialization
+    - fuzztest::status
+    - fuzztest::type_support
+    - absl::core_headers
+    - absl::flat_hash_map
+    - absl::flat_hash_set
+    - absl::random_random
+    - absl::random_bit_gen_ref
+    - absl::random_distributions
+    - absl::status
+    - absl::strings
+    - absl::synchronization
+    - absl::span
+
+domain_core:
+  header_only: False
+  deps:
+    - fuzztest::absl_helpers
+    - fuzztest::any
+    - fuzztest::coverage
+    - fuzztest::logging
+    - fuzztest::meta
+    - fuzztest::printer
+    - fuzztest::seed_seq
+    - fuzztest::serialization
+    - fuzztest::status
+    - fuzztest::table_of_recent_compares
+    - fuzztest::type_support
+    - absl::flat_hash_map
+    - absl::flat_hash_set
+    - absl::function_ref
+    - absl::bits
+    - absl::int128
+    - absl::random_random
+    - absl::random_bit_gen_ref
+    - absl::random_distributions
+    - absl::status
+    - absl::strings
+    - absl::str_format
+    - absl::time
+    - absl::span
+
+fixture_driver:
+  header_only: False
+  deps:
+    - fuzztest::any
+    - fuzztest::domain_core
+    - fuzztest::logging
+    - fuzztest::meta
+    - fuzztest::printer
+    - fuzztest::registration
+    - fuzztest::type_support
+    - absl::status
+    - absl::str_format
+    - absl::span
+
+googletest_adaptor:
+  header_only: False
+  deps:
+    - fuzztest::configuration
+    - fuzztest::io
+    - fuzztest::registry
+    - fuzztest::runtime
+    - absl::strings
+    - absl::string_view
+    - GTest::gtest
+
+googletest_fixture_adapter:
+  header_only: True
+  deps:
+    - fuzztest::fixture_driver
+    - GTest::gtest
+
+io:
+  header_only: False
+  deps:
+    - fuzztest::logging
+    - absl::hash
+    - absl::str_format
+
+logging:
+  header_only: False
+  deps:
+    - absl::strings
+
+meta:
+  header_only: True
+  deps:
+    - absl::int128
+
+printer:
+  header_only: True
+  deps:
+    - fuzztest::meta
+    - absl::str_format
+
+regexp_dfa:
+  header_only: False
+  deps:
+    - fuzztest::logging
+    - absl::flat_hash_map
+    - absl::random_bit_gen_ref
+    - absl::random_distributions
+    - re2::re2
+
+registration:
+  header_only: False
+  deps:
+    - fuzztest::domain_core
+    - fuzztest::meta
+    - fuzztest::printer
+    - fuzztest::type_support
+    - absl::any_invocable
+    - absl::status
+    - absl::str_format
+    - absl::span
+
+registry:
+  header_only: False
+  deps:
+    - fuzztest::compatibility_mode
+    - fuzztest::fixture_driver
+    - fuzztest::registration
+    - fuzztest::runtime
+    - absl::flat_hash_map
+    - absl::function_ref
+    - absl::string_view
+
+runtime:
+  header_only: False
+  deps:
+    - fuzztest::configuration
+    - fuzztest::coverage
+    - fuzztest::domain_core
+    - fuzztest::fixture_driver
+    - fuzztest::io
+    - fuzztest::logging
+    - fuzztest::meta
+    - fuzztest::printer
+    - fuzztest::registration
+    - fuzztest::seed_seq
+    - fuzztest::serialization
+    - fuzztest::type_support
+    - absl::any_invocable
+    - absl::function_ref
+    - absl::random_random
+    - absl::random_bit_gen_ref
+    - absl::random_distributions
+    - absl::status
+    - absl::strings
+    - absl::str_format
+    - absl::time
+    - absl::span
+
+seed_seq:
+  header_only: False
+  deps:
+    - fuzztest::logging
+    - absl::random_random
+    - absl::strings
+    - absl::span
+
+serialization:
+  header_only: False
+  deps:
+    - fuzztest::meta
+    - absl::int128
+    - absl::strings
+    - absl::str_format
+    - absl::span
+
+status:
+  header_only: False
+  deps:
+    - absl::status
+    - absl::strings
+    - absl::cord
+
+subprocess:
+  header_only: False
+  deps:
+    - fuzztest::logging
+    - absl::flat_hash_map
+    - absl::strings
+    - absl::time
+
+table_of_recent_compares:
+  header_only: True
+  deps:
+    - fuzztest::type_support
+    - absl::flat_hash_set
+    - absl::random_bit_gen_ref
+    - absl::random_distributions
+
+type_support:
+  header_only: False
+  deps:
+    - fuzztest::absl_helpers
+    - fuzztest::meta
+    - fuzztest::printer
+    - absl::function_ref
+    - absl::symbolize
+    - absl::int128
+    - absl::strings
+    - absl::str_format
+    - absl::time

--- a/recipes/fuzztest/all/package_info/_package_info-cci.20240305.yml
+++ b/recipes/fuzztest/all/package_info/_package_info-cci.20240305.yml
@@ -5,66 +5,66 @@
 fuzztest:
   header_only: True
   deps:
-    - fuzztest::domain
-    - fuzztest::fuzztest_macros
+    - domain
+    - fuzztest_macros
 
 fuzztest_core:
   header_only: True
   deps:
-    - fuzztest::domain_core
-    - fuzztest::fuzztest_macros
+    - domain_core
+    - fuzztest_macros
 
 fuzztest_macros:
   header_only: True
   deps:
-    - fuzztest::io
-    - fuzztest::registration
-    - fuzztest::registry
+    - io
+    - registration
+    - registry
 
 fuzztest_gtest_main:
   header_only: False
   deps:
-    - absl::flags_parse
-    - absl::strings
-    - fuzztest::init_fuzztest
-    - GTest::gtest
+    - abseil::absl_flags_parse
+    - abseil::absl_strings
+    - init_fuzztest
+    - gtest::gtest
 
 init_fuzztest:
   header_only: False
   deps:
-    - fuzztest::configuration
-    - fuzztest::googletest_adaptor
-    - fuzztest::io
-    - fuzztest::registry
-    - fuzztest::runtime
-    - absl::flags
-    - absl::strings
-    - absl::str_format
-    - absl::time
-    - GTest::gtest
+    - configuration
+    - googletest_adaptor
+    - io
+    - registry
+    - runtime
+    - abseil::absl_flags
+    - abseil::absl_strings
+    - abseil::absl_str_format
+    - abseil::absl_time
+    - gtest::gtest
 
 llvm_fuzzer_main:
   header_only: False
   deps:
-    - fuzztest::init_fuzztest
-    - absl::flags
-    - absl::flags_parse
-    - GTest::gtest
+    - init_fuzztest
+    - abseil::absl_flags
+    - abseil::absl_flags_parse
+    - gtest::gtest
     
 
 llvm_fuzzer_wrapper:
   header_only: False
   deps:
-    - fuzztest::domain_core
-    - fuzztest::fuzztest
-    - fuzztest::io
-    - fuzztest::llvm_fuzzer_main
-    - absl::flags
-    - absl::log
-    - absl::random_random
-    - absl::random_bit_gen_ref
-    - absl::strings
-    - absl::string_view
+    - domain_core
+    - fuzztest
+    - io
+    - llvm_fuzzer_main
+    - abseil::absl_flags
+    - abseil::absl_log
+    - abseil::absl_random_random
+    - abseil::absl_random_bit_gen_ref
+    - abseil::absl_strings
+    - abseil::absl_string_view
     - re2::re2
 
 # The rest are loosely marked as "internal", though not sure which ones, as some seem useful.
@@ -72,254 +72,254 @@ llvm_fuzzer_wrapper:
 absl_helpers:
   header_only: True
   deps:
-    - fuzztest::logging
-    - absl::time
+    - logging
+    - abseil::absl_time
 
 any:
   header_only: True
   deps:
-    - fuzztest::logging
-    - fuzztest::meta
+    - logging
+    - meta
 
 compatibility_mode:
   header_only: False
   deps:
-    - fuzztest::domain_core
-    - fuzztest::fixture_driver
-    - fuzztest::logging
-    - fuzztest::runtime
-    - absl::random_distributions
-    - absl::strings
-    - absl::str_format
-    - absl::time
+    - domain_core
+    - fixture_driver
+    - logging
+    - runtime
+    - abseil::absl_random_distributions
+    - abseil::absl_strings
+    - abseil::absl_str_format
+    - abseil::absl_time
 
 configuration:
   header_only: False
   deps:
-    - fuzztest::io
-    - absl::strings
-    - absl::string_view
+    - io
+    - abseil::absl_strings
+    - abseil::absl_string_view
 
 coverage:
   header_only: False
   deps:
-    - fuzztest::logging
-    - fuzztest::table_of_recent_compares
-    - absl::core_headers
-    - absl::str_format
-    - absl::span
+    - logging
+    - table_of_recent_compares
+    - abseil::absl_core_headers
+    - abseil::absl_str_format
+    - abseil::absl_span
 
 domain:
   header_only: False
   deps:
-    - fuzztest::any
-    - fuzztest::domain_core
-    - fuzztest::logging
-    - fuzztest::meta
-    - fuzztest::regexp_dfa
-    - fuzztest::serialization
-    - fuzztest::status
-    - fuzztest::type_support
-    - absl::core_headers
-    - absl::flat_hash_map
-    - absl::flat_hash_set
-    - absl::random_random
-    - absl::random_bit_gen_ref
-    - absl::random_distributions
-    - absl::status
-    - absl::strings
-    - absl::synchronization
-    - absl::span
+    - any
+    - domain_core
+    - logging
+    - meta
+    - regexp_dfa
+    - serialization
+    - status
+    - type_support
+    - abseil::absl_core_headers
+    - abseil::absl_flat_hash_map
+    - abseil::absl_flat_hash_set
+    - abseil::absl_random_random
+    - abseil::absl_random_bit_gen_ref
+    - abseil::absl_random_distributions
+    - abseil::absl_status
+    - abseil::absl_strings
+    - abseil::absl_synchronization
+    - abseil::absl_span
 
 domain_core:
   header_only: False
   deps:
-    - fuzztest::absl_helpers
-    - fuzztest::any
-    - fuzztest::coverage
-    - fuzztest::logging
-    - fuzztest::meta
-    - fuzztest::printer
-    - fuzztest::seed_seq
-    - fuzztest::serialization
-    - fuzztest::status
-    - fuzztest::table_of_recent_compares
-    - fuzztest::type_support
-    - absl::flat_hash_map
-    - absl::flat_hash_set
-    - absl::function_ref
-    - absl::bits
-    - absl::int128
-    - absl::random_random
-    - absl::random_bit_gen_ref
-    - absl::random_distributions
-    - absl::status
-    - absl::strings
-    - absl::str_format
-    - absl::time
-    - absl::span
+    - absl_helpers
+    - any
+    - coverage
+    - logging
+    - meta
+    - printer
+    - seed_seq
+    - serialization
+    - status
+    - table_of_recent_compares
+    - type_support
+    - abseil::absl_flat_hash_map
+    - abseil::absl_flat_hash_set
+    - abseil::absl_function_ref
+    - abseil::absl_bits
+    - abseil::absl_int128
+    - abseil::absl_random_random
+    - abseil::absl_random_bit_gen_ref
+    - abseil::absl_random_distributions
+    - abseil::absl_status
+    - abseil::absl_strings
+    - abseil::absl_str_format
+    - abseil::absl_time
+    - abseil::absl_span
 
 fixture_driver:
   header_only: False
   deps:
-    - fuzztest::any
-    - fuzztest::domain_core
-    - fuzztest::logging
-    - fuzztest::meta
-    - fuzztest::printer
-    - fuzztest::registration
-    - fuzztest::type_support
-    - absl::status
-    - absl::str_format
-    - absl::span
+    - any
+    - domain_core
+    - logging
+    - meta
+    - printer
+    - registration
+    - type_support
+    - abseil::absl_status
+    - abseil::absl_str_format
+    - abseil::absl_span
 
 googletest_adaptor:
   header_only: False
   deps:
-    - fuzztest::configuration
-    - fuzztest::io
-    - fuzztest::registry
-    - fuzztest::runtime
-    - absl::strings
-    - absl::string_view
-    - GTest::gtest
+    - configuration
+    - io
+    - registry
+    - runtime
+    - abseil::absl_strings
+    - abseil::absl_string_view
+    - gtest::gtest
 
 googletest_fixture_adapter:
   header_only: True
   deps:
-    - fuzztest::fixture_driver
-    - GTest::gtest
+    - fixture_driver
+    - gtest::gtest
 
 io:
   header_only: False
   deps:
-    - fuzztest::logging
-    - absl::hash
-    - absl::str_format
+    - logging
+    - abseil::absl_hash
+    - abseil::absl_str_format
 
 logging:
   header_only: False
   deps:
-    - absl::strings
+    - abseil::absl_strings
 
 meta:
   header_only: True
   deps:
-    - absl::int128
+    - abseil::absl_int128
 
 printer:
   header_only: True
   deps:
-    - fuzztest::meta
-    - absl::str_format
+    - meta
+    - abseil::absl_str_format
 
 regexp_dfa:
   header_only: False
   deps:
-    - fuzztest::logging
-    - absl::flat_hash_map
-    - absl::random_bit_gen_ref
-    - absl::random_distributions
+    - logging
+    - abseil::absl_flat_hash_map
+    - abseil::absl_random_bit_gen_ref
+    - abseil::absl_random_distributions
     - re2::re2
 
 registration:
-  header_only: False
+  header_only: True
   deps:
-    - fuzztest::domain_core
-    - fuzztest::meta
-    - fuzztest::printer
-    - fuzztest::type_support
-    - absl::any_invocable
-    - absl::status
-    - absl::str_format
-    - absl::span
+    - domain_core
+    - meta
+    - printer
+    - type_support
+    - abseil::absl_any_invocable
+    - abseil::absl_status
+    - abseil::absl_str_format
+    - abseil::absl_span
 
 registry:
   header_only: False
   deps:
-    - fuzztest::compatibility_mode
-    - fuzztest::fixture_driver
-    - fuzztest::registration
-    - fuzztest::runtime
-    - absl::flat_hash_map
-    - absl::function_ref
-    - absl::string_view
+    - compatibility_mode
+    - fixture_driver
+    - registration
+    - runtime
+    - abseil::absl_flat_hash_map
+    - abseil::absl_function_ref
+    - abseil::absl_string_view
 
 runtime:
   header_only: False
   deps:
-    - fuzztest::configuration
-    - fuzztest::coverage
-    - fuzztest::domain_core
-    - fuzztest::fixture_driver
-    - fuzztest::io
-    - fuzztest::logging
-    - fuzztest::meta
-    - fuzztest::printer
-    - fuzztest::registration
-    - fuzztest::seed_seq
-    - fuzztest::serialization
-    - fuzztest::type_support
-    - absl::any_invocable
-    - absl::function_ref
-    - absl::random_random
-    - absl::random_bit_gen_ref
-    - absl::random_distributions
-    - absl::status
-    - absl::strings
-    - absl::str_format
-    - absl::time
-    - absl::span
+    - configuration
+    - coverage
+    - domain_core
+    - fixture_driver
+    - io
+    - logging
+    - meta
+    - printer
+    - registration
+    - seed_seq
+    - serialization
+    - type_support
+    - abseil::absl_any_invocable
+    - abseil::absl_function_ref
+    - abseil::absl_random_random
+    - abseil::absl_random_bit_gen_ref
+    - abseil::absl_random_distributions
+    - abseil::absl_status
+    - abseil::absl_strings
+    - abseil::absl_str_format
+    - abseil::absl_time
+    - abseil::absl_span
 
 seed_seq:
   header_only: False
   deps:
-    - fuzztest::logging
-    - absl::random_random
-    - absl::strings
-    - absl::span
+    - logging
+    - abseil::absl_random_random
+    - abseil::absl_strings
+    - abseil::absl_span
 
 serialization:
   header_only: False
   deps:
-    - fuzztest::meta
-    - absl::int128
-    - absl::strings
-    - absl::str_format
-    - absl::span
+    - meta
+    - abseil::absl_int128
+    - abseil::absl_strings
+    - abseil::absl_str_format
+    - abseil::absl_span
 
 status:
   header_only: False
   deps:
-    - absl::status
-    - absl::strings
-    - absl::cord
+    - abseil::absl_status
+    - abseil::absl_strings
+    - abseil::absl_cord
 
 subprocess:
   header_only: False
   deps:
-    - fuzztest::logging
-    - absl::flat_hash_map
-    - absl::strings
-    - absl::time
+    - logging
+    - abseil::absl_flat_hash_map
+    - abseil::absl_strings
+    - abseil::absl_time
 
 table_of_recent_compares:
   header_only: True
   deps:
-    - fuzztest::type_support
-    - absl::flat_hash_set
-    - absl::random_bit_gen_ref
-    - absl::random_distributions
+    - type_support
+    - abseil::absl_flat_hash_set
+    - abseil::absl_random_bit_gen_ref
+    - abseil::absl_random_distributions
 
 type_support:
   header_only: False
   deps:
-    - fuzztest::absl_helpers
-    - fuzztest::meta
-    - fuzztest::printer
-    - absl::function_ref
-    - absl::symbolize
-    - absl::int128
-    - absl::strings
-    - absl::str_format
-    - absl::time
+    - absl_helpers
+    - meta
+    - printer
+    - abseil::absl_function_ref
+    - abseil::absl_symbolize
+    - abseil::absl_int128
+    - abseil::absl_strings
+    - abseil::absl_str_format
+    - abseil::absl_time

--- a/recipes/fuzztest/all/test_package/CMakeLists.txt
+++ b/recipes/fuzztest/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package LANGUAGES C) # if the project is pure C
+# project(test_package LANGUAGES CXX) # if the project uses c++
+
+find_package(package REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+# don't link to ${CONAN_LIBS} or CONAN_PKG::package
+target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
+# In case the target project need a specific C++ standard
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/fuzztest/all/test_package/CMakeLists.txt
+++ b/recipes/fuzztest/all/test_package/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
 
-project(test_package LANGUAGES C) # if the project is pure C
-# project(test_package LANGUAGES CXX) # if the project uses c++
+find_package(fuzztest REQUIRED CONFIG)
 
-find_package(package REQUIRED CONFIG)
+include(GoogleTest) # For gtest_discover_tests, built into CMake
 
-add_executable(${PROJECT_NAME} test_package.cpp)
-# don't link to ${CONAN_LIBS} or CONAN_PKG::package
-target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
-# In case the target project need a specific C++ standard
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+add_executable(test_package test_package.cpp)
+
+link_fuzztest(test_package)
+gtest_discover_tests(test_package)

--- a/recipes/fuzztest/all/test_package/conanfile.py
+++ b/recipes/fuzztest/all/test_package/conanfile.py
@@ -3,8 +3,6 @@ from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake
 import os
 
-
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"

--- a/recipes/fuzztest/all/test_package/conanfile.py
+++ b/recipes/fuzztest/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/fuzztest/all/test_package/test_package.cpp
+++ b/recipes/fuzztest/all/test_package/test_package.cpp
@@ -1,0 +1,16 @@
+#include <cstdlib>
+#include <iostream>
+#include "package/foobar.hpp"
+
+
+int main(void) {
+    std::cout << "Create a minimal usage for the target project here." << std::endl;
+    std::cout << "Avoid big examples, bigger than 100 lines" << std::endl;
+    std::cout << "Avoid networking connections." << std::endl;
+    std::cout << "Avoid background apps or servers." << std::endl;
+    std::cout << "The propose is testing the generated artifacts only." << std::endl;
+
+    foobar.print_version();
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/fuzztest/all/test_package/test_package.cpp
+++ b/recipes/fuzztest/all/test_package/test_package.cpp
@@ -1,16 +1,14 @@
-#include <cstdlib>
-#include <iostream>
-#include "package/foobar.hpp"
+// From
+// https://github.com/google/fuzztest/blob/e317d5277e34948ae7048cb5e48309e0288e8df3/doc/quickstart-cmake.md#create-and-run-a-fuzz-test
 
+#include "fuzztest/fuzztest.h"
+#include "gtest/gtest.h"
 
-int main(void) {
-    std::cout << "Create a minimal usage for the target project here." << std::endl;
-    std::cout << "Avoid big examples, bigger than 100 lines" << std::endl;
-    std::cout << "Avoid networking connections." << std::endl;
-    std::cout << "Avoid background apps or servers." << std::endl;
-    std::cout << "The propose is testing the generated artifacts only." << std::endl;
-
-    foobar.print_version();
-
-    return EXIT_SUCCESS;
+TEST(MyTestSuite, OnePlustTwoIsTwoPlusOne) {
+    EXPECT_EQ(1 + 2, 2 + 1);
 }
+
+void IntegerAdditionCommutes(int a, int b) {
+    EXPECT_EQ(a + b, b + a);
+}
+FUZZ_TEST(MyTestSuite, IntegerAdditionCommutes);

--- a/recipes/fuzztest/config.yml
+++ b/recipes/fuzztest/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20240305":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **fuzztest/cci.20240305**

Resolves #22933 

Depends on #22982, #22983

One issue that will come up is that fuzztest uses internal re2 headers ([see here](https://github.com/google/fuzztest/issues/91)). A possible fix is to just expose these headers in re2, but I don't think there's a good solution to this aside from a proper fix from upstream.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
