### PR TITLE
aws-c-auth: add version 0.7.21

### DIFF
--- a/recipes/aws-c-auth/all/conandata.yml
+++ b/recipes/aws-c-auth/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7.16":
+    url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.16.tar.gz"
+    sha256: "7ee5afe05482f750dd0406b8b5b55dafb446fc21288f98c0b4118d62795003ba"
   "0.7.8":
     url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.8.tar.gz"
     sha256: "5db8ab91262b5c055e3634f2c9dc2bc1a3285c2dd5513fdcafcb3e79468dc7de"

--- a/recipes/aws-c-auth/all/conandata.yml
+++ b/recipes/aws-c-auth/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.7.16":
-    url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.16.tar.gz"
-    sha256: "7ee5afe05482f750dd0406b8b5b55dafb446fc21288f98c0b4118d62795003ba"
+  "0.7.17":
+    url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.17.tar.gz"
+    sha256: "8fe380255a71a2d5c9acd4979c135f9842135ce6385010ea562bc0b532bf5b84"
   "0.7.8":
     url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.8.tar.gz"
     sha256: "5db8ab91262b5c055e3634f2c9dc2bc1a3285c2dd5513fdcafcb3e79468dc7de"

--- a/recipes/aws-c-auth/all/conandata.yml
+++ b/recipes/aws-c-auth/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.7.17":
-    url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.17.tar.gz"
-    sha256: "8fe380255a71a2d5c9acd4979c135f9842135ce6385010ea562bc0b532bf5b84"
+  "0.7.20":
+    url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.20.tar.gz"
+    sha256: "c75a168a20985d59b62b447c77de9ca567d7e4d6adf1496fdbcab1934c7ac714"
   "0.7.8":
     url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.8.tar.gz"
     sha256: "5db8ab91262b5c055e3634f2c9dc2bc1a3285c2dd5513fdcafcb3e79468dc7de"

--- a/recipes/aws-c-auth/all/conandata.yml
+++ b/recipes/aws-c-auth/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.7.20":
-    url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.20.tar.gz"
-    sha256: "c75a168a20985d59b62b447c77de9ca567d7e4d6adf1496fdbcab1934c7ac714"
+  "0.7.21":
+    url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.21.tar.gz"
+    sha256: "802054ff0a82c9fc977671f7d2be1c55229a97d808e0d53784a749be32ceb5ec"
   "0.7.8":
     url: "https://github.com/awslabs/aws-c-auth/archive/v0.7.8.tar.gz"
     sha256: "5db8ab91262b5c055e3634f2c9dc2bc1a3285c2dd5513fdcafcb3e79468dc7de"

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -62,7 +62,7 @@ class AwsCAuth(ConanFile):
             self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
             self.requires("aws-c-cal/0.6.9")
             self.requires("aws-c-io/0.13.35", transitive_headers=True, transitive_libs=True)
-            self.requires("aws-c-http/0.7.14", transitive_headers=True)
+            self.requires("aws-c-http/0.8.1", transitive_headers=True)
             self.requires("aws-c-sdkutils/0.1.12", transitive_headers=True)
 
     def source(self):

--- a/recipes/aws-c-auth/config.yml
+++ b/recipes/aws-c-auth/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.7.16":
+  "0.7.17":
     folder: all
   "0.7.8":
     folder: all

--- a/recipes/aws-c-auth/config.yml
+++ b/recipes/aws-c-auth/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.7.16":
+    folder: all
   "0.7.8":
     folder: all
   "0.7.7":

--- a/recipes/aws-c-auth/config.yml
+++ b/recipes/aws-c-auth/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.7.17":
+  "0.7.20":
     folder: all
   "0.7.8":
     folder: all

--- a/recipes/aws-c-auth/config.yml
+++ b/recipes/aws-c-auth/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.7.20":
+  "0.7.21":
     folder: all
   "0.7.8":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-auth/***

- add version aws-c-auth/0.7.21
- update aws-c-http/0.8.1 

https://github.com/awslabs/aws-c-auth/compare/v0.7.8...v0.7.21

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
