### PR TITLE
perfetto: add version 43.1

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "43.1":
+    url: "https://github.com/google/perfetto/archive/refs/tags/v43.1.tar.gz"
+    sha256: "0f23ba39520c9ec629c48dc36a3a4bb92ed9653ac6694445be22985205a3f4ce"
   "42.0":
     url: "https://github.com/google/perfetto/archive/refs/tags/v42.0.tar.gz"
     sha256: "1c474a0f16cc2f9da826fd3f9e44ffd77785c433e997cdaf0ee390ae3d64b53e"

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "43.1":
+    folder: all
   "42.0":
     folder: all
   "41.0":


### PR DESCRIPTION
Specify library name and version:  **perfetto/43.1**

```
https://android.googlesource.com/platform/external/perfetto/+/refs/tags/v43.1
https://github.com/google/perfetto/tree/v43.1

v43.1 - 2024-03-05:
  Tracing service and probes:
    * Cherry-pick of https://r.android.com/2988674, which fixes the android x86
      standalone build.

v43.0 - 2024-03-05:
  Tracing service and probes:
    * Buffers marked as `transfer_on_clone` will be flushed independently when
      cloning.
    * ftrace: added drain_buffer_percent option to read kernel ring buffer
      based on occupancy in addition to existing periodic reads. Requires Linux
      kernel v6.1+.
    * ftrace: changed default kernel per-cpu ring buffer sizes if a config
      doesn't request an explicit size via buffer_size_kb. Added
      buffer_size_lower_bound option that lets the service choose a bigger ring
      buffer size than requested.
    * "linux.process_stats" data source: added options to record: process age,
      time spent running in userspace, and time spent running in kernel mode,
      using /proc/pid/stat. See "record_process_age" and
      "record_process_runtime" options.
  Trace Processor:
    * Added `decompress_packets` mode to the traceconv tool.
    * Support memory mapped file access on Windows.
    * Deprecated `common` standard library module, it will be removed by v45.
      Some of the functionality have been migrated to other parts of standard
      library.
  UI:
    * Added a "defaultPlugins" list to allow control over which plugins are
      enabled by default.
    * Added a feature to allow enabling/disabling plugins permanently from the
      plugins page.
    * Added plugin load times to the plugin page.
    * Added scrolling to the pinned track area.
    * Added commands for expanding and closing all tracks.
    * Added {expand,collapse}GroupsByPredicate to plugin API.
    * Added SimpleSliceTrack & SimpleCounterTrack which have the same
      functionality of debug tracks but may be added on trace load from within
      plugins.
    * Added naive track crash containment, which means tracks that crash should
      not crash the entire UI.
    * Don't render "idle" kernel thread slices in thread state tracks.
    * Fixed crash when using autofill in text inputs in chrome.
    * Fixed bug where "incomplete" slices were sometimes not rendered.
    * Fixed crash when calls to CacheStorage fail via promise rejection.
    * Fixed bug causing slices to occasionally disappear in tracks v2.
    * Fixes crash in tracksV2 when visible window is negative.
    * Fix bug when toggling the sidebar without a trace loaded would either
      crash the UI or simply not work.
    * Various TabsV2 QoL improvements.
    * Various AndroidLongBatteryTracing plugin improvements.
```

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
