### PR TITLE
freetype: use libpng version range

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -64,7 +64,7 @@ class FreetypeConan(ConanFile):
 
     def requirements(self):
         if self.options.with_png:
-            self.requires("libpng/1.6.42")
+            self.requires("libpng/[>=1.6 <2]")
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.10 <2]")
         if self.options.with_bzip2:


### PR DESCRIPTION
freetype: all versions

Use a version range for libpng in requirements. This avoids version conflicts when libpng is consumed transitively, since most of the repo is still in `1.6.40` rather than `1.6.42`.

It's a rather artificial conflict when it happens - `libpng` is backwards compatible at the API level, and Conan 2 defaults (the `minor` version component is encoded in the consumers) will ensure binary compatibility of produced binaries (e.g. `libpng/1.6.x` may not necessarily be binary compatible with `libpng/1.5.x`, but .patch versions of the same minor will be). `libpng` changes the library filename and soname when jumping to new minors. The default documented behaviour https://docs.conan.io/2.0/reference/conanfile/attributes.html#package-id-embed-non-embed-unknown-mode should ensure that new binary packages are generated in that case if libpng is updated.


