### PR TITLE
dacap-clip: add version 1.8

### DIFF
--- a/recipes/dacap-clip/all/conandata.yml
+++ b/recipes/dacap-clip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8":
+    url: "https://github.com/dacap/clip/archive/refs/tags/v1.8.tar.gz"
+    sha256: "a54d243451fb483590ffd9239a3c55f8d8e672d44df63dc2b81da01a229074bc"
   "1.7":
     url: "https://github.com/dacap/clip/archive/refs/tags/v1.7.tar.gz"
     sha256: "f494d306f3425e984368cbd94ffb213e0a3b3d44c3ab169e5134788d3342535c"

--- a/recipes/dacap-clip/all/conanfile.py
+++ b/recipes/dacap-clip/all/conanfile.py
@@ -54,7 +54,7 @@ class DacapClipConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_png", False):
-            self.requires("libpng/1.6.43")
+            self.requires("libpng/[>=1.6 <2]")
         if self.settings.os == "Linux":
             self.requires("xorg/system")
 

--- a/recipes/dacap-clip/all/conanfile.py
+++ b/recipes/dacap-clip/all/conanfile.py
@@ -7,6 +7,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc
 from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -23,11 +24,13 @@ class DacapClipConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_png": [True, False],
+        "with_image": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_png": True,
+        "with_image": True,
     }
 
     @property
@@ -37,19 +40,21 @@ class DacapClipConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self.settings.os not in ["Linux", "FreeBSD"]:
+            del self.options.with_png
+        if Version(self.version) < "1.8":
+            del self.options.with_image
 
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        if self.settings.os not in ["Linux", "FreeBSD"]:
-            del self.options.with_png
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.get_safe("with_png", False):
-            self.requires("libpng/1.6.37")
+            self.requires("libpng/1.6.43")
         if self.settings.os == "Linux":
             self.requires("xorg/system")
 
@@ -67,6 +72,7 @@ class DacapClipConan(ConanFile):
         toolchain.variables["CLIP_EXAMPLES"] = False
         toolchain.variables["CLIP_TESTS"] = False
         toolchain.variables["CLIP_X11_WITH_PNG"] = self.options.get_safe("with_png", False)
+        toolchain.variables["CLIP_ENABLE_IMAGE"] = self.options.get_safe("with_image", False)
         if is_msvc(self):
             toolchain.cache_variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = bool(self.options.shared)
         toolchain.generate()
@@ -93,6 +99,8 @@ class DacapClipConan(ConanFile):
 
         if self.options.get_safe("with_png", False):
             self.cpp_info.requires.append("libpng::libpng")
+        if self.options.get_safe("with_image", False):
+            self.cpp_info.defines.append("CLIP_ENABLE_IMAGE=1")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.requires.append("xorg::xcb")
@@ -108,6 +116,6 @@ class DacapClipConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "clip")
         self.cpp_info.set_property("cmake_target_name", "clip::clip")
 
-        # TODO: Remove on Conan 2.0
+    # TODO: Remove on Conan 2.0
         self.cpp_info.names["cmake_find_package"] = "clip"
         self.cpp_info.names["cmake_find_package_multi"] = "clip"

--- a/recipes/dacap-clip/config.yml
+++ b/recipes/dacap-clip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8":
+    folder: "all"
   "1.7":
     folder: "all"
   "1.6":


### PR DESCRIPTION
Specify library name and version:  **dacap-clip/***

- add version 1.8
- dacap-clip/1.8 introduces CLIP_ENABLE_IMAGE option
- update libpng

https://github.com/dacap/clip/compare/v1.7...v1.8


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
