### PR TITLE
tensorflow-lite: resolve conflicts

### DIFF
--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -83,9 +83,9 @@ class TensorflowLiteConan(ConanFile):
         if self.settings.arch in ("x86", "x86_64"):
             self.requires("intel-neon2sse/cci.20210225")
         if self.options.with_xnnpack:
-            self.requires("xnnpack/cci.20220801")
+            self.requires("xnnpack/cci.20231026")
             # https://github.com/tensorflow/tensorflow/blob/359c3cdfc5fabac82b3c70b3b6de2b0a8c16874f/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc#L165
-            self.requires("pthreadpool/cci.20210218")
+            self.requires("pthreadpool/cci.20231129")
         if self.options.with_xnnpack or self.options.get_safe("with_nnapi", False):
             self.requires("fp16/cci.20210320")
 

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -73,7 +73,7 @@ class TensorflowLiteConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("abseil/20230125.1")
+        self.requires("abseil/20230125.3")
         self.requires("eigen/3.4.0")
         self.requires("farmhash/cci.20190513")
         self.requires("fft/cci.20061228")


### PR DESCRIPTION
Work in progress pending tests.

Solve dependency conflicts caused by https://github.com/conan-io/conan-center-index/pull/21762/files.

Need to ensure all tests pass - as it's hard to reason whether tensorflow-lite is still compatible with these newer versions.

Before this PR:
* `conan graph info --requires=tensorflow-lite/2.12.0 --requires=opencv/4.5.5 --profile:host Linux-gcc11-x86_64-Release --profile:build Linux-gcc11-x86_64-Release` fails

After this PR: the command above should pass without conflicts.