### PR TITLE
avahi/0.8: Support cross-compilation

### DIFF
--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -56,7 +56,7 @@ class AvahiConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("glib/<host_version>")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -66,14 +66,17 @@ class AvahiConan(ConanFile):
         virtual_build_env.generate()
         if can_run(self):
             VirtualRunEnv(self).generate(scope="build")
+
         tc = AutotoolsToolchain(self)
         tc.configure_args.append("--enable-compat-libdns_sd")
+        tc.configure_args.append("--enable-introspection=no")
         tc.configure_args.append("--disable-gtk3")
         tc.configure_args.append("--disable-mono")
         tc.configure_args.append("--disable-monodoc")
         tc.configure_args.append("--disable-python")
         tc.configure_args.append("--disable-qt5")
         tc.configure_args.append("--with-systemdsystemunitdir=/lib/systemd/system")
+        tc.configure_args.append("--with-distro=none")
         tc.configure_args.append("ac_cv_func_strlcpy=no")
         if self.settings.os in ["Linux", "FreeBSD"]:
             tc.configure_args.append("ac_cv_func_setproctitle=no")

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -78,8 +78,7 @@ class AvahiConan(ConanFile):
         tc.configure_args.append("--with-systemdsystemunitdir=/lib/systemd/system")
         tc.configure_args.append("--with-distro=none")
         tc.configure_args.append("ac_cv_func_strlcpy=no")
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            tc.configure_args.append("ac_cv_func_setproctitle=no")
+        tc.configure_args.append("ac_cv_func_setproctitle=no")
         tc.generate()
         AutotoolsDeps(self).generate()
         PkgConfigDeps(self).generate()


### PR DESCRIPTION
To cross-compile Avahi, the `--with-distro` flag must be passed.
Disable introspection.
This must be disabled to cross-compile.
Strangely enough, it doesn't work when enabled when doing a native build.
It only seems to work when set to auto.
When gobject-introspection is updated to support Conan V2 an option could be added to control enabling or disabling introspection.