### PR TITLE
xkbcommon: Disable installing bash completions

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -95,6 +95,7 @@ class XkbcommonConan(ConanFile):
             env.generate(scope="build")
 
         tc = MesonToolchain(self)
+        tc.project_options["enable-bash-completion"] = False
         tc.project_options["enable-docs"] = False
         tc.project_options["enable-wayland"] = self.options.get_safe("with_wayland", False)
         tc.project_options["enable-x11"] = self.options.with_x11

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -95,7 +95,8 @@ class XkbcommonConan(ConanFile):
             env.generate(scope="build")
 
         tc = MesonToolchain(self)
-        tc.project_options["enable-bash-completion"] = False
+        if Version(self.version) >= "1.6":
+            tc.project_options["enable-bash-completion"] = False
         tc.project_options["enable-docs"] = False
         tc.project_options["enable-wayland"] = self.options.get_safe("with_wayland", False)
         tc.project_options["enable-x11"] = self.options.with_x11


### PR DESCRIPTION
Installing attempts to install the bash completions in a system directory.

```
Installing /var/home/jordan/.conan2/p/b/xkbco18970aa15216b/b/src/tools/xkbcli-bash-completion.sh to /usr/share/bash-completion/completions
Installation failed due to insufficient permissions.
Attempt to use /usr/bin/sudo to gain elevated privileges? [y/n]
Traceback (most recent call last):
  File "/var/home/jordan/.conan2/p/mesond0eabfb2fb735/p/bin/mesonbuild/mesonmain.py", line 194, in run
    return options.run_func(options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/jordan/.conan2/p/mesond0eabfb2fb735/p/bin/mesonbuild/minstall.py", line 873, in run
    installer.do_install(datafilename)
  File "/var/home/jordan/.conan2/p/mesond0eabfb2fb735/p/bin/mesonbuild/minstall.py", line 557, in do_install
    self.install_data(d, dm, destdir, fullprefix)
  File "/var/home/jordan/.conan2/p/mesond0eabfb2fb735/p/bin/mesonbuild/minstall.py", line 631, in install_data
    if self.do_copyfile(fullfilename, outfilename, makedirs=(dm, outdir), follow_symlinks=i.follow_symlinks):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/jordan/.conan2/p/mesond0eabfb2fb735/p/bin/mesonbuild/minstall.py", line 430, in do_copyfile
    self.copy2(from_file, to_file)
  File "/var/home/jordan/.conan2/p/mesond0eabfb2fb735/p/bin/mesonbuild/minstall.py", line 327, in copy2
    shutil.copy2(*args, **kwargs)
  File "/usr/lib64/python3.12/shutil.py", line 475, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib64/python3.12/shutil.py", line 262, in copyfile
    with open(dst, 'wb') as fdst:
         ^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/usr/share/bash-completion/completions/xkbcli'
```