### PR TITLE
libudev: Set the pkg-config version to the real version number

### DIFF
--- a/recipes/libudev/all/conanfile.py
+++ b/recipes/libudev/all/conanfile.py
@@ -48,3 +48,7 @@ class LibUDEVConan(ConanFile):
         self.cpp_info.libdirs = []
         pkg_config = PkgConfig(self, "libudev")
         pkg_config.fill_cpp_info(self.cpp_info)
+        self.cpp_info.set_property("system_package_version", str(pkg_config.version))
+
+        # todo Remove this workaround for Conan v1
+        self.cpp_info.set_property("component_version", str(pkg_config.version))


### PR DESCRIPTION
The pkg-config file contains the version of the Conan package. This is problematic because it is `system` which causes version checks for libudev to fail. This happens in Weston I'm making for instance:

```
Dependency libudev found: NO found system but need: '>= 136'
Found CMake: /usr/local/bin/cmake (3.28.20240202)
Run-time dependency libudev found: NO (tried cmake)

../src/libweston/meson.build:196:2: ERROR: Dependency lookup for libudev with method 'pkgconfig' failed: Invalid version, need 'libudev' ['>= 136'] found 'system'.
```

I've set the version in the pkg-config file to that of the version on the system. This fixes version checks in consumers using pkg-config.