### PR TITLE
Add install_substitutes for zypper with "xorgproto-devel"

### DIFF
--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -36,7 +36,8 @@ class SysConfigOpenGLConan(ConanFile):
         pacman.install(["libglvnd"], update=True, check=True)
 
         zypper = package_manager.Zypper(self)
-        zypper.install(["Mesa-libGL-devel", "glproto-devel"], update=True, check=True)
+        zypper.install_substitutes(["Mesa-libGL-devel", "glproto-devel"], 
+                                   ["Mesa-libGL-devel", "xorgproto-devel"], update=True, check=True)
 
         pkg = package_manager.Pkg(self)
         pkg.install(["libglvnd"], update=True, check=True)


### PR DESCRIPTION
Using install_substitutes in zypper because in opensuse tumbleweed `glproto-devel` is not available but `xorgproto-devel` provides the same.

I think this should close: https://github.com/conan-io/conan-center-index/issues/18912
And also close: https://github.com/conan-io/conan/issues/15335