### PR TITLE
OpenVR: move to conan2, new version 2.2.3

### DIFF
--- a/recipes/openvr/all/conandata.yml
+++ b/recipes/openvr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.3":
+    url: https://github.com/ValveSoftware/openvr/archive/v2.2.3.tar.gz
+    sha256: 4da20c2c33e7488703802eafd7f2e6c92dd0f324e887711e1e11e9b9d3dd3daa
   "1.12.5":
     url: https://github.com/ValveSoftware/openvr/archive/v1.12.5.tar.gz
     sha256: f3cdbaa946688553638e6d65978f156311c9b08825316198d925f5eade6cfeb7
@@ -11,4 +14,3 @@ sources:
 patches:
   "1.16.8":
     - patch_file: "patches/fix-includes-and-assert-1.16.8.patch"
-      base_path: "source_subfolder"

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -1,6 +1,8 @@
 import os
-from conans import ConanFile, tools, CMake
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.files import copy, get, rm, apply_conandata_patches, replace_in_file
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
 
 class OpenvrConan(ConanFile):
     name = "openvr"
@@ -21,12 +23,6 @@ class OpenvrConan(ConanFile):
     }
 
     exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake"
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -34,69 +30,59 @@ class OpenvrConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, "11")
+            self.options.rm_safe("fPIC")
 
-        if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "5":
-            raise ConanInvalidConfiguration("OpenVR can't be compiled by {0} {1}".format(self.settings.compiler,
-                                                                                         self.settings.compiler.version))
-
-    def requirements(self):
-        self.requires("jsoncpp/1.9.4")
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "{}-{}".format(self.name, self.version)
-        os.rename(extracted_dir, self._source_subfolder)
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        apply_conandata_patches(self)
+
         # Honor fPIC=False
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "-fPIC", "")
-        # Unvendor jsoncpp (we rely on our CMake wrapper for jsoncpp injection)
-        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
-                              "jsoncpp.cpp", "")
-        tools.rmdir(os.path.join(self._source_subfolder, "src", "json"))
-
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_SHARED"] = self.options.shared
-        self._cmake.definitions["BUILD_UNIVERSAL"] = False
-        self._cmake.definitions["USE_LIBCXX"] = False
-        self._cmake.configure()
-
-        return self._cmake
-
-    def build(self):
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        "-fPIC", "")
+        
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
         self._patch_sources()
-        cmake = self._configure_cmake()
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_UNIVERSAL"] = False
+
+        runtime = self.settings.get_safe("compiler.libcxx")
+        if runtime != None and runtime != "libc++":
+            tc.variables["USE_LIBCXX"] = False
+
+        if self.options.shared:
+            tc.variables["BUILD_SHARED"] = True
+        else:
+            tc.variables["BUILD_SHARED"] = False
+        tc.generate()    
+
+    def build(self):        
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", src=os.path.join(self.source_folder, self._source_subfolder), dst="licenses")
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
-        self.copy(pattern="openvr_api*.dll", dst="bin", src="bin", keep_path=False)
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        copy(self, "openvr_*.dll", src=os.path.join(self.package_folder,
+             "lib"), dst=os.path.join(self.package_folder, "bin"))
+        rm(self, "openvr_*.dll", folder=os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
-        self.cpp_info.names["pkg_config"] = "openvr"
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.set_property("pkg_config_name", "openvr")
+        if self.settings.os == "Windows":
+            self.cpp_info.libs = ["openvr_api64"]
+        else:
+            self.cpp_info.libs = ["openvr_api"]
         self.cpp_info.includedirs.append(os.path.join("include", "openvr"))
-
         if not self.options.shared:
             self.cpp_info.defines.append("OPENVR_BUILD_STATIC")
-            libcxx = tools.stdcpp_library(self)
-            if libcxx:
-                self.cpp_info.system_libs.append(libcxx)
-
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("dl")
-
-        if tools.is_apple_os(self.settings.os):
+            self.cpp_info.defines.append("OPENVR_API_NODLL")
+        if self.settings.os == "Macos":
             self.cpp_info.frameworks.append("Foundation")

--- a/recipes/openvr/all/test_package/CMakeLists.txt
+++ b/recipes/openvr/all/test_package/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(openvr REQUIRED CONFIG)
 
-add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
-target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE openvr::openvr)

--- a/recipes/openvr/all/test_package/conanfile.py
+++ b/recipes/openvr/all/test_package/conanfile.py
@@ -1,9 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
+
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -11,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/openvr/config.yml
+++ b/recipes/openvr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.3":
+    folder: "all"
   "1.12.5":
     folder: "all"
   "1.14.15":


### PR DESCRIPTION
Specify library name and version:  **openvr/2.2.3**

Ported to conan2, added new version, checked old version works too

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
