### PR TITLE
xbyak: add version 7.06

### DIFF
--- a/recipes/xbyak/all/conandata.yml
+++ b/recipes/xbyak/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.06":
+    url: "https://github.com/herumi/xbyak/archive/v7.06.tar.gz"
+    sha256: "686c710a67c7fb8e99d8e326cf22aea310a29db27a9db8ba19a9fee44f8ec097"
   "7.05":
     url: "https://github.com/herumi/xbyak/archive/v7.05.tar.gz"
     sha256: "853b619a6615985dbb36e8c5528d96d83f7bba3d0728ed3b3ee8ac8f4f96d87f"

--- a/recipes/xbyak/config.yml
+++ b/recipes/xbyak/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.06":
+    folder: all
   "7.05":
     folder: all
   "7.00":


### PR DESCRIPTION
Specify library name and version:  **xbyak/7.06**

https://github.com/herumi/xbyak/compare/v7.05...v7.06

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
