### PR TITLE
genie: fix compiler paths

### DIFF
--- a/recipes/genie/all/conanfile.py
+++ b/recipes/genie/all/conanfile.py
@@ -57,8 +57,10 @@ class GenieConan(ConanFile):
         }[str(self.settings.os)]
 
     def _patch_compiler(self, cc, cxx):
-        replace_in_file(self, os.path.join(self.source_folder, "build", f"gmake.{self._os}", "genie.make"), "CC  = gcc", f"CC  = {cc}")
-        replace_in_file(self, os.path.join(self.source_folder, "build", f"gmake.{self._os}", "genie.make"), "CXX = g++", f"CXX = {cxx}")
+        makefile = os.path.join(self.source_folder, "build", f"gmake.{self._os}", "genie.make")
+        
+        replace_in_file(self, makefile, "CC  = gcc", f"CC = {cc}" if cc else "")
+        replace_in_file(self, makefile, "CXX = g++", f"CXX = {cxx}" if cxx else "")
 
     @property
     def _genie_config(self):
@@ -79,19 +81,7 @@ class GenieConan(ConanFile):
             self._patch_compiler("cccl", "cccl")
             self.run("make", cwd=self.source_folder)
         else:
-            cc = os.environ.get("CC")
-            cxx = os.environ.get("CXX")
-            if is_apple_os(self):
-                if not cc:
-                    cc = "clang"
-                if not cxx:
-                    cxx = "clang"
-            else:
-                if not cc:
-                    cc = "clang" if self.settings.compiler == "clang" else "gcc"
-                if not cxx:
-                    cxx = "clang++" if self.settings.compiler == "clang" else "g++"
-            self._patch_compiler(cc, cxx)
+            self._patch_compiler("", "")
 
             autotools = Autotools(self)
             autotools.make(args=[f"-C {self.source_folder}", f"OS={self._os}", f"config={self._genie_config}"])


### PR DESCRIPTION
Specify library name and version:  **genie/all**

Previously, the build system would not respect `tools.build:compiler_executables`. On my system, I don't have a "g++" command, just a handful of profiles that specifically call "g(cc/++)-\<version\>" using that.

This also simplifies a decent amount of logic.

Now it should behave similar to other make-based packages:

1. Use `tools.build:compiler_executables` if defined
2. Use CC if defined
3. Fallback to cc/cxx

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
