### PR TITLE
add orc/2.0.0

### DIFF
--- a/recipes/orc/all/conandata.yml
+++ b/recipes/orc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.0":
+    url: "https://dlcdn.apache.org/orc/orc-2.0.0/orc-2.0.0.tar.gz"
+    sha256: "9107730919c29eb39efaff1b9e36166634d1d4d9477e5fee76bfd6a8fec317df"
   "1.9.2":
     url: "https://dlcdn.apache.org/orc/orc-1.9.2/orc-1.9.2.tar.gz"
     sha256: "7f46f2c184ecefd6791f1a53fb062286818bd8710c3f08b94dd3cac365e240ee"

--- a/recipes/orc/config.yml
+++ b/recipes/orc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.0":
+    folder: all
   "1.9.2":
     folder: all
   "1.8.6":


### PR DESCRIPTION
Specify library name and version:  **orc/2.0.0**

Apache ORC 2.0.0 is released: https://orc.apache.org/news/2024/03/08/ORC-2.0.0/

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
