### PR TITLE
tree-sitter: add version 0.22.1

### DIFF
--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.22.1":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.22.1.tar.gz"
+    sha256: "b21065e78da33e529893c954e712ad15d9ad44a594b74567321d4a3a007d6090"
   "0.21.0":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.21.0.tar.gz"
     sha256: "6bb60e5b63c1dc18aba57a9e7b3ea775b4f9ceec44cc35dac4634d26db4eb69c"

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.22.1":
+    folder: all
   "0.21.0":
     folder: all
   "0.20.8":


### PR DESCRIPTION
Specify library name and version:  **tree-sitter/0.22.1**

https://github.com/tree-sitter/tree-sitter/compare/v0.21.0...v0.22.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
