### PR TITLE
uwebsockets: add version 20.62.0

### DIFF
--- a/recipes/uwebsockets/all/conandata.yml
+++ b/recipes/uwebsockets/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.62.0":
+    url: "https://github.com/uNetworking/uWebSockets/archive/v20.62.0.tar.gz"
+    sha256: "03dfc8037cf43856a41e64bbc7fc5a7cf5e6369c9158682753074ecbbe09eed1"
   "20.60.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v20.60.0.tar.gz"
     sha256: "eb72223768f93d40038181653ee5b59a53736448a6ff4e8924fd56b2fcdc00db"

--- a/recipes/uwebsockets/config.yml
+++ b/recipes/uwebsockets/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.62.0":
+    folder: all
   "20.60.0":
     folder: all
   "20.58.0":


### PR DESCRIPTION
Specify library name and version:  **uwebsockets/20.62.0**

https://github.com/uNetworking/uWebSockets/compare/v20.60.0...v20.62.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
