### PR TITLE
openvino: Add threading option supporting tbb and omp

### DIFF
--- a/recipes/openvino/all/conanfile.py
+++ b/recipes/openvino/all/conanfile.py
@@ -309,10 +309,9 @@ class OpenvinoConan(ConanFile):
 
         openvino_runtime = self.cpp_info.components["Runtime"]
         openvino_runtime.set_property("cmake_target_name", "openvino::runtime")
+        openvino_runtime.requires = ["pugixml::pugixml"]
         if self.options.threading == "tbb":
-            openvino_runtime.requires = ["onetbb::libtbb", "pugixml::pugixml"]
-        else:
-            openvino_runtime.requires = ["pugixml::pugixml"]
+            openvino_runtime.append("onetbb::libtbb")
         openvino_runtime.libs = ["openvino"]
         if self._preprocessing_available:
             openvino_runtime.requires.append("ade::ade")


### PR DESCRIPTION
Specify library name and version:  **openvino/***

Adds the option to set the threading cmake option to either tbb or omp.

Currently has an issue upon cmake config with projects using this option with openvino.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
