### PR TITLE
ffmpeg: add mediacodec support

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -74,6 +74,8 @@ class FFMpegConan(ConanFile):
         "with_libsvtav1": [True, False],
         "with_libaom": [True, False],
         "with_libdav1d": [True, False],
+        "with_jni": [True, False],
+        "with_mediacodec": [True, False],
         "disable_everything": [True, False],
         "disable_all_encoders": [True, False],
         "disable_encoders": [None, "ANY"],
@@ -154,6 +156,8 @@ class FFMpegConan(ConanFile):
         "with_libsvtav1": True,
         "with_libaom": True,
         "with_libdav1d": True,
+        "with_jni": True,
+        "with_mediacodec": True,
         "disable_everything": False,
         "disable_all_encoders": False,
         "disable_encoders": None,
@@ -227,6 +231,7 @@ class FFMpegConan(ConanFile):
             "with_libsvtav1": ["avcodec"],
             "with_libaom": ["avcodec"],
             "with_libdav1d": ["avcodec"],
+            "with_mediacodec": ["with_jni"],
         }
 
     @property
@@ -262,6 +267,9 @@ class FFMpegConan(ConanFile):
             del self.options.with_videotoolbox
         if not is_apple_os(self):
             del self.options.with_avfoundation
+        if not self.settings.os == "Android":
+            del self.options.with_jni
+            del self.options.with_mediacodec
         if not self._version_supports_vulkan:
             self.options.rm_safe("with_vulkan")
         if not self._version_supports_libsvtav1:
@@ -509,6 +517,8 @@ class FFMpegConan(ConanFile):
             opt_enable_disable("audiotoolbox", self.options.get_safe("with_audiotoolbox")),
             opt_enable_disable("videotoolbox", self.options.get_safe("with_videotoolbox")),
             opt_enable_disable("securetransport", self.options.with_ssl == "securetransport"),
+            opt_enable_disable("jni", self.options.get_safe("with_jni")),
+            opt_enable_disable("mediacodec", self.options.get_safe("with_mediacodec")),
             "--disable-cuda",  # FIXME: CUDA support
             "--disable-cuvid",  # FIXME: CUVID support
             # Licenses


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/***

This PR exposes the `--enable-jni` and `--enable-mediacodec` config options in the FFmpeg recipe. This allows FFmpeg to perform encoding and decoding via MediaCodec on Android platforms.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
