### PR TITLE
[docs] Changelog March 13th, 2024

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 13-Mar-2024 - 11:08 CET
+
+- [feature]: Build with both */*:shared=True/False option when package type is declared as ``shared-library``.
+- [fix]: Fix ValidateInfra python version check to be aligned with the latest Jenkins version.
+
 ### 07-February-2024 - 15:43 CET
 
 - [feature] Add waiting list for new collaborators that are not found in access request issue.


### PR DESCRIPTION
The PR #20335 has been affected by a missing configuration in C3I Jenkins, not only a missing package in Conan Center. This new release fixes the case: When a package has `shared-library` as package type, the Conan 2.x build will generate both `*/*:shared=True` and `*/*:shared=False`

The second fix is an internal change to accommodate internal scripts with new Jenkins versions. It should not affect ConanCenterIndex directly, only tooling. 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
