### PR TITLE
fixed-containers: fix cmake names, require magic_enum

### DIFF
--- a/recipes/fixed-containers/all/conanfile.py
+++ b/recipes/fixed-containers/all/conanfile.py
@@ -37,6 +37,9 @@ class FixedContainersConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
+    def requirements(self):
+       self.requires("magic_enum/0.9.3", transitive_headers=True)
+
     def package_id(self):
         self.info.clear()
 

--- a/recipes/fixed-containers/all/conanfile.py
+++ b/recipes/fixed-containers/all/conanfile.py
@@ -67,3 +67,6 @@ class FixedContainersConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+
+        self.cpp_info.set_property("cmake_file_name", "fixed_containers")
+        self.cpp_info.set_property("cmake_target_name", "fixed_containers::fixed_containers")

--- a/recipes/fixed-containers/all/conanfile.py
+++ b/recipes/fixed-containers/all/conanfile.py
@@ -38,7 +38,7 @@ class FixedContainersConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-       self.requires("magic_enum/0.9.3", transitive_headers=True)
+        self.requires("magic_enum/0.9.3", transitive_headers=True)
 
     def package_id(self):
         self.info.clear()

--- a/recipes/fixed-containers/all/test_package/CMakeLists.txt
+++ b/recipes/fixed-containers/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(fixed-containers REQUIRED CONFIG)
+find_package(fixed_containers)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE fixed-containers::fixed-containers)
+target_link_libraries(${PROJECT_NAME} PRIVATE fixed_containers::fixed_containers)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/recipes/fixed-containers/all/test_package/test_package.cpp
+++ b/recipes/fixed-containers/all/test_package/test_package.cpp
@@ -1,28 +1,6 @@
 #include "fixed_containers/fixed_vector.hpp"
 #include "fixed_containers/enum_utils.hpp"
 
-enum class ColorBackingEnum : int {
-  RED,
-  YELLOW,
-  GREEN,
-  BLUE,
-};
-
-class Color : public fixed_containers::rich_enums::SkeletalRichEnum<Color, ColorBackingEnum> {
-  friend SkeletalRichEnum::ValuesFriend;
-  using SkeletalRichEnum::SkeletalRichEnum;
-
-public:
-  inline static constexpr const std::array<Color, count()>& values() {
-    return ::fixed_containers::rich_enums::SkeletalRichEnumValues<Color>::VALUES;
-  }
-
-  FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(Color, RED);
-  FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(Color, YELLOW);
-  FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(Color, GREEN);
-  FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(Color, BLUE);
-};
-
 int main(void) {
   constexpr auto v1 = []() {
     fixed_containers::FixedVector<int, 11> v{};
@@ -36,10 +14,6 @@ int main(void) {
   static_assert(v1[2] == 2);
   static_assert(v1.size() == 3);
   static_assert(v1.capacity() == 11);
-
-  static_assert(fixed_containers::rich_enums::is_rich_enum<Color>);
-  auto constexpr const COLOR = Color::RED();
-  static_assert("RED" == COLOR.to_string());
 
   return 0;
 }

--- a/recipes/fixed-containers/all/test_package/test_package.cpp
+++ b/recipes/fixed-containers/all/test_package/test_package.cpp
@@ -1,10 +1,31 @@
 #include "fixed_containers/fixed_vector.hpp"
+#include "fixed_containers/enum_utils.hpp"
 
-using namespace fixed_containers;
+enum class ColorBackingEnum : int {
+  RED,
+  YELLOW,
+  GREEN,
+  BLUE,
+};
+
+class Color : public fixed_containers::rich_enums::SkeletalRichEnum<Color, ColorBackingEnum> {
+  friend SkeletalRichEnum::ValuesFriend;
+  using SkeletalRichEnum::SkeletalRichEnum;
+
+public:
+  inline static constexpr const std::array<Color, count()>& values() {
+    return ::fixed_containers::rich_enums::SkeletalRichEnumValues<Color>::VALUES;
+  }
+
+  FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(Color, RED);
+  FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(Color, YELLOW);
+  FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(Color, GREEN);
+  FIXED_CONTAINERS_RICH_ENUM_CONSTANT_GEN_HELPER(Color, BLUE);
+};
 
 int main(void) {
   constexpr auto v1 = []() {
-    FixedVector<int, 11> v{};
+    fixed_containers::FixedVector<int, 11> v{};
     v.push_back(0);
     v.emplace_back(1);
     v.push_back(2);
@@ -15,6 +36,10 @@ int main(void) {
   static_assert(v1[2] == 2);
   static_assert(v1.size() == 3);
   static_assert(v1.capacity() == 11);
+
+  static_assert(fixed_containers::rich_enums::is_rich_enum<Color>);
+  auto constexpr const COLOR = Color::RED();
+  static_assert("RED" == COLOR.to_string());
 
   return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **fixed-containers/***

fixed_containers requires magic_enum < 0.9.4.

https://github.com/toge/fixed-containers/blob/e78c79176b2d7c9d55aceccaa62ba8aa8ecabdf7/include/fixed_containers/enum_utils.hpp#L5

fix wrong cmake_file_name and cmake_target_name.

https://github.com/teslamotors/fixed-containers?tab=readme-ov-file#cmake

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
