### PR TITLE
rocksdb/6.29.5: add patch to ignore thirdparty.inc

### DIFF
--- a/recipes/rocksdb/all/conandata.yml
+++ b/recipes/rocksdb/all/conandata.yml
@@ -17,6 +17,9 @@ patches:
       patch_description: "Fix build with gcc 13 by including cstdint"
       patch_type: "portability"
       patch_source: "https://github.com/facebook/rocksdb/pull/11118"
+    - patch_file: "patches/6.29.5-0002-exclude-thirdparty.patch"
+      patch_description: "Do not include thirdparty.inc"
+      patch_type: "portability"
   "6.27.3":
     - patch_file: "patches/6.27.3-0001-add-include-cstdint-for-gcc-13.patch"
       patch_description: "Fix build with gcc 13 by including cstdint"

--- a/recipes/rocksdb/all/patches/6.29.5-0002-exclude-thirdparty.patch
+++ b/recipes/rocksdb/all/patches/6.29.5-0002-exclude-thirdparty.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec59d4491..35577c998 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -101 +100,0 @@ if(MSVC)
+-  option(WITH_GFLAGS "build with GFlags" OFF)
+@@ -103,2 +102,2 @@ if(MSVC)
+-  include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty.inc)
+-else()
++endif()
++
+@@ -117 +116 @@ else()
+-  if(MINGW)
++  if(MINGW OR MSVC)
+@@ -183 +181,0 @@ else()
+-endif()


### PR DESCRIPTION
**rocksdb/6.29.5**

RocksDB has [special instructions](https://github.com/facebook/rocksdb/blob/v6.29.5/CMakeLists.txt#L11) for compiling on Windows that asks builders to edit the special file [`thirdparty.inc`](https://github.com/facebook/rocksdb/blob/v6.29.5/thirdparty.inc) to set variables pointing to all of the optional dependencies they want to enable. The main `CMakeLists.txt` follows the best practice of calling `find_package()` and linking to imported targets, but only for non-MSVC generators.

Thus, the latest RocksDB recipe in Conan Center builds with MSVC, but does not correctly link to any optional dependencies that are enabled. `thirdparty.inc` is included with nonsense paths and the build fails when it cannot find third-party headers.

The old RocksDB recipe in Conan Center used a CMake subproject model. It had its own [`CMakeLists.txt`](https://github.com/conan-io/conan-center-index/blob/1a1b7fc7959cdf8fc97cce745fe844e31194db29/recipes/rocksdb/all/CMakeLists.txt) that first called `conan_basic_setup()` before calling `add_subdirectory()` for the project. I don't know how, but it worked.

This patch removes the branch on MSVC that includes `thirdparty.inc` instead of calling `find_package()`, but only for version 6.29.5 (the one I need for now).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
