### PR TITLE
[cgal] add cgal/5.6.1

### DIFF
--- a/recipes/cgal/all/conandata.yml
+++ b/recipes/cgal/all/conandata.yml
@@ -17,6 +17,9 @@ sources:
   "5.6":
     sha256: dcab9b08a50a06a7cc2cc69a8a12200f8d8f391b9b8013ae476965c10b45161f
     url: https://github.com/CGAL/cgal/releases/download/v5.6/CGAL-5.6.tar.xz
+  "5.6.1":
+    sha256: cdb15e7ee31e0663589d3107a79988a37b7b1719df3d24f2058545d1bcdd5837
+    url: https://github.com/CGAL/cgal/releases/download/v5.6.1/CGAL-5.6.1.tar.xz
 patches:
   "5.3.2":
     - patch_file: "patches/0001-fix-for-conan.patch"

--- a/recipes/cgal/all/conanfile.py
+++ b/recipes/cgal/all/conanfile.py
@@ -93,7 +93,7 @@ class CgalConan(ConanFile):
     def _create_cmake_module_variables(self, module_file):
         '''
         CGAL requires C++14, and specific compilers flags to enable the possibility to set FPU rounding modes.
-        This CMake module, from the upsream CGAL pull-request https://github.com/CGAL/cgal/pull/7512, takes
+        This CMake module, from the upstream CGAL pull-request https://github.com/CGAL/cgal/pull/7512, takes
         care of all the known compilers CGAL has ever supported.
         '''
         content = textwrap.dedent('''\

--- a/recipes/cgal/config.yml
+++ b/recipes/cgal/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "5.6":
     folder: all
+  "5.6.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cgal/5.6.1**

New upstream version (bug-fix): CGAL 5.6.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
