### PR TITLE
emsdk: Update emsdk versions + add Node.js version option

### DIFF
--- a/recipes/emsdk/all/conandata.yml
+++ b/recipes/emsdk/all/conandata.yml
@@ -1,4 +1,19 @@
 sources:
+  "3.1.55":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.55.tar.gz"
+    sha256: "86a6af30e43d7b501772e5d2993457c924b73f1d1c0a3484a8c6c48452af549f"
+  "3.1.54":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.54.tar.gz"
+    sha256: "e19eb3cfd2f8c6c2e3404467396f07733837c1e6f66d964bd29095b083186990"
+  "3.1.53":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.53.tar.gz"
+    sha256: "1ae9753740dddd271a18bd6ce874bf0c96fa59cc64783fbf23dec263047375c0"
+  "3.1.52":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.52.tar.gz"
+    sha256: "865b26dd4c2b75657089d8c20fc7435f42117477ca3a3c183476b012fc73f2ab"
+  "3.1.51":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.51.tar.gz"
+    sha256: "6edeb200c28505db64a1a9f14373ecc3ba3151cebf3d8314895e603561bc61c2"
   "3.1.50":
     url: "https://github.com/emscripten-core/emsdk/archive/3.1.50.tar.gz"
     sha256: "7491a881eb5ee15fe81bbabcfff1fd571e45ccdb24a81890af429f9970cbd1f3"

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -19,6 +19,18 @@ class EmSDKConan(ConanFile):
     license = "MIT"
     settings = "os", "arch", "compiler", "build_type"
 
+    options = {
+        "nodejs_version": [
+            "16.3.0",
+            "16.20.2",
+            "18.15.0"
+        ]
+    }
+
+    default_options = {
+        "nodejs_version": "16.3.0"
+    }
+
     short_paths = True
 
     @property
@@ -29,7 +41,7 @@ class EmSDKConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("nodejs/16.3.0")
+        self.requires("nodejs/" + str(self.options.nodejs_version))
         # self.requires("python")  # FIXME: Not available as Conan package
         # self.requires("wasm")  # FIXME: Not available as Conan package
 

--- a/recipes/emsdk/config.yml
+++ b/recipes/emsdk/config.yml
@@ -1,4 +1,14 @@
 versions:
+  "3.1.55":
+    folder: all
+  "3.1.54":
+    folder: all
+  "3.1.53":
+    folder: all
+  "3.1.52":
+    folder: all
+  "3.1.51":
+    folder: all
   "3.1.50":
     folder: all
   "3.1.49":


### PR DESCRIPTION
Specify library name and version:  **emskd/1.3.X**

- Add versions up to 1.3.55
- Add an option to set the node.js Version used (defaulting to the previous constant 16.3.0)

There is another PR bumping emsdk to 1.3.53. I can rebase my PR if that one gets merged.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
