### PR TITLE
expat: add 2.6.2 and remove several old versions

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -14,9 +14,6 @@ sources:
   "2.4.8":
     sha256: "f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25"
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_8/expat-2.4.8.tar.xz"
-  "2.4.1":
-    sha256: "a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b"
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.gz"
   "2.3.0":
     sha256: "89df123c62f2c2e2b235692d9fe76def6a9ab03dbe95835345bf412726eb1987"
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_3_0/expat-2.3.0.tar.gz"

--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.6.1":
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_6_1/expat-2.6.1.tar.xz"
-    sha256: "0c00d2760ad12efef6e26efc8b363c8eb28eb8c8de719e46d5bb67b40ba904a3"
+  "2.6.2":
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_6_2/expat-2.6.2.tar.xz"
+    sha256: "ee14b4c5d8908b1bec37ad937607eab183d4d9806a08adee472c3c3121d27364"
   "2.6.0":
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_6_0/expat-2.6.0.tar.xz"
     sha256: "cb5f5a8ea211e1cabd59be0a933a52e3c02cc326e86a4d387d8d218e7ee47a3e"
@@ -14,24 +14,6 @@ sources:
   "2.4.8":
     sha256: "f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25"
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_8/expat-2.4.8.tar.xz"
-  "2.4.7":
-    sha256: "9875621085300591f1e64c18fd3da3a0eeca4a74f884b9abac2758ad1bd07a7d"
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_7/expat-2.4.7.tar.xz"
-  "2.4.6":
-    sha256: "de55794b7a9bc214852fdc075beaaecd854efe1361597e6268ee87946951289b"
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_6/expat-2.4.6.tar.xz"
-  "2.4.5":
-    sha256: "f2af8fc7cdc63a87920da38cd6d12cb113c3c3a3f437495b1b6541e0cff32579"
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_5/expat-2.4.5.tar.xz"
-  "2.4.4":
-    sha256: "b5d25d6e373351c2ed19b562b4732d01d2589ac8c8e9e7962d8df1207cc311b8"
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_4/expat-2.4.4.tar.xz"
-  "2.4.3":
-    sha256: "b1f9f1b1a5ebb0acaa88c9ff79bfa4e145823b78aa5185e5c5d85f060824778a"
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_3/expat-2.4.3.tar.xz"
-  "2.4.2":
-    sha256: "a2fb692e8e610406168296f25ba500ae8ce22cb4c8947a8689894d744b6deb02"
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_2/expat-2.4.2.tar.gz"
   "2.4.1":
     sha256: "a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b"
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.gz"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -9,8 +9,6 @@ versions:
     folder: all
   "2.4.8":
     folder: all
-  "2.4.1":
-    folder: all
   "2.3.0":
     folder: all
   "2.2.10":

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.6.1":
+  "2.6.2":
     folder: all
   "2.6.0":
     folder: all
@@ -8,18 +8,6 @@ versions:
   "2.4.9":
     folder: all
   "2.4.8":
-    folder: all
-  "2.4.7":
-    folder: all
-  "2.4.6":
-    folder: all
-  "2.4.5":
-    folder: all
-  "2.4.4":
-    folder: all
-  "2.4.3":
-    folder: all
-  "2.4.2":
     folder: all
   "2.4.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **expat/2.6.2**

2.6.2 contains fix for CVE-2024-28757
https://github.com/libexpat/libexpat/blob/R_2_6_2/expat/Changes

I've also decided to remove older "patch" versions that aren't currently used by any recipes in CCI's master.
Through simple text search I've found only 2.4.1, 2.4.8, 2.5.0 and 2.6.0.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
