### PR TITLE
libvips: add v8.15.2

### DIFF
--- a/recipes/libvips/all/conandata.yml
+++ b/recipes/libvips/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.15.2":
+    url: "https://github.com/libvips/libvips/releases/download/v8.15.2a/vips-8.15.2.tar.xz"
+    sha256: "a2ab15946776ca7721d11cae3215f20f1f097b370ff580cd44fc0f19387aee84"
   "8.15.1":
     url: "https://github.com/libvips/libvips/releases/download/v8.15.1/vips-8.15.1.tar.xz"
     sha256: "06811f5aed3e7bc03e63d05537ff4b501de5283108c8ee79396c60601a00830c"

--- a/recipes/libvips/config.yml
+++ b/recipes/libvips/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.15.2":
+    folder: all
   "8.15.1":
     folder: all
   "8.14.2":


### PR DESCRIPTION
Specify library name and version:  **libvips/8.15.2**

Adding libvips/8.15.2 which contains several bugfixes, including one for https://github.com/conan-io/conan/issues/15578#issuecomment-1952784238 .

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
