### PR TITLE
Draft: Opencolorio fix minizip static

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -94,7 +94,7 @@ class OpenColorIOConan(ConanFile):
 
         if Version(self.version) == "1.1.1" and self.options.shared and self.dependencies["yaml-cpp"].options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} requires static build yaml-cpp")
-        if Version(self.version) == "2.2.1" and self.options.shared and self.dependencies["minizip-ng"].options.shared:
+        if (Version(self.version) == "2.2.1" or Version(self.version) == "2.3.0") and self.options.shared and self.dependencies["minizip-ng"].options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} requires static build minizip-ng")
 
     def build_requirements(self):
@@ -187,6 +187,10 @@ class OpenColorIOConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "OpenColorIO")
 
         self.cpp_info.libs = ["OpenColorIO"]
+
+        self.cpp_info.requires.append("MINIZIP::minizip")
+        self.cpp_info.requires.append("yaml-cpp::yaml-cpp")
+        self.cpp_info.requires.append("pystring::pystring")
 
         if Version(self.version) < "2.1.0":
             if not self.options.shared:

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -188,9 +188,13 @@ class OpenColorIOConan(ConanFile):
 
         self.cpp_info.libs = ["OpenColorIO"]
 
+        self.cpp_info.requires.append("expat::expat")
         self.cpp_info.requires.append("minizip-ng::minizip")
         self.cpp_info.requires.append("yaml-cpp::yaml-cpp")
         self.cpp_info.requires.append("pystring::pystring")
+        self.cpp_info.requires.append("imath::imath")
+        self.cpp_info.requires.append("openexr::openexr")
+        self.cpp_info.requires.append("lcms::lcms")
 
         if Version(self.version) < "2.1.0":
             if not self.options.shared:

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -94,7 +94,7 @@ class OpenColorIOConan(ConanFile):
 
         if Version(self.version) == "1.1.1" and self.options.shared and self.dependencies["yaml-cpp"].options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} requires static build yaml-cpp")
-        if Version(self.version) >= "2.2.1" and self.options.shared and self.dependencies["minizip-ng"].options.shared:
+        if Version(self.version) == "2.2.1" and self.options.shared and self.dependencies["minizip-ng"].options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} requires static build minizip-ng")
 
     def build_requirements(self):

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -188,7 +188,7 @@ class OpenColorIOConan(ConanFile):
 
         self.cpp_info.libs = ["OpenColorIO"]
 
-        self.cpp_info.requires.append("MINIZIP::minizip")
+        self.cpp_info.requires.append("minizip-ng::minizip")
         self.cpp_info.requires.append("yaml-cpp::yaml-cpp")
         self.cpp_info.requires.append("pystring::pystring")
 

--- a/recipes/opencolorio/all/patches/2.3.0-0001-fix-cmake-source-dir-and-targets.patch
+++ b/recipes/opencolorio/all/patches/2.3.0-0001-fix-cmake-source-dir-and-targets.patch
@@ -62,13 +62,14 @@ diff --git a/src/OpenColorIO/CMakeLists.txt b/src/OpenColorIO/CMakeLists.txt
 index 7ff40bf..dec2bda 100755
 --- a/src/OpenColorIO/CMakeLists.txt
 +++ b/src/OpenColorIO/CMakeLists.txt
-@@ -309,8 +309,8 @@ target_link_libraries(OpenColorIO
+@@ -309,8 +309,9 @@ target_link_libraries(OpenColorIO
          "$<BUILD_INTERFACE:utils::from_chars>"
          "$<BUILD_INTERFACE:utils::strings>"
          "$<BUILD_INTERFACE:xxHash>"
 -        ${YAML_CPP_LIBRARIES}
 -        MINIZIP::minizip-ng
 +        yaml-cpp
++      PUBLIC
 +        MINIZIP::minizip
  )
  

--- a/recipes/opencolorio/all/patches/2.3.1-0001-fix-cmake-source-dir-and-targets.patch
+++ b/recipes/opencolorio/all/patches/2.3.1-0001-fix-cmake-source-dir-and-targets.patch
@@ -62,13 +62,14 @@ diff --git src/OpenColorIO/CMakeLists.txt src/OpenColorIO/CMakeLists.txt
 index 26b4bb4c..d54cff3d 100755
 --- src/OpenColorIO/CMakeLists.txt
 +++ src/OpenColorIO/CMakeLists.txt
-@@ -309,8 +309,8 @@ target_link_libraries(OpenColorIO
+@@ -309,8 +309,9 @@ target_link_libraries(OpenColorIO
          "$<BUILD_INTERFACE:utils::from_chars>"
          "$<BUILD_INTERFACE:utils::strings>"
          "$<BUILD_INTERFACE:xxHash>"
 -        ${YAML_CPP_LIBRARIES}
 -        MINIZIP::minizip-ng
 +        yaml-cpp
++      PUBLIC
 +        MINIZIP::minizip
  )
  

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -103,7 +103,7 @@ class OpenImageIOConan(ConanFile):
         if self.options.with_hdf5:
             self.requires("hdf5/1.14.3")
         if self.options.with_opencolorio:
-            self.requires("opencolorio/2.3.1")
+            self.requires("opencolorio/2.3.2")
         if self.options.with_opencv:
             self.requires("opencv/4.8.1")
         if self.options.with_tbb:

--- a/recipes/openimageio/all/patches/2.5.9.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/2.5.9.0-cmake-targets.patch
@@ -444,9 +444,11 @@ index aeb7b7f93..9a32e4cf2 100644
              ${OPENIMAGEIO_OPENEXR_TARGETS}
 -            ${OpenCV_LIBRARIES}
              ${format_plugin_libs} # Add all the target link libraries from the plugins
-             $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIO>
+-            $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIO>
++        PUBLIC    $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIO>
              $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIOHeaders>
-             $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
+-            $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
++        PRIVATE    $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
              $<TARGET_NAME_IF_EXISTS:TBB::tbb>
 -            $<TARGET_NAME_IF_EXISTS:Freetype::Freetype>
              ${BZIP2_LIBRARIES}


### PR DESCRIPTION
Specify library name and version:  **opencolorio/2.3.***

It is a bit of a problem when building a pack of shared dependencies, that OpenColorIO currently tries to enforce static linking.

**State**: This is draft/WIP. I'm currently trying to figure out and getting feedback, to get the linking right.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
