### PR TITLE
unity: add version 2.6.0

### DIFF
--- a/recipes/unity/all/conandata.yml
+++ b/recipes/unity/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.0":
+    url: "https://github.com/ThrowTheSwitch/Unity/archive/refs/tags/v2.6.0.tar.gz"
+    sha256: "aa4c9fb1ae5fc5242f914c65f3557e817e40cb37f04a31e5ff76d1ab89dbf674"
   "2.5.2":
     url: "https://github.com/ThrowTheSwitch/Unity/archive/refs/tags/v2.5.2.tar.gz"
     sha256: "3786de6c8f389be3894feae4f7d8680a02e70ed4dbcce36109c8f8646da2671a"

--- a/recipes/unity/config.yml
+++ b/recipes/unity/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.6.0":
+    folder: all
   "2.5.2":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **unity/2.6.0**

https://github.com/ThrowTheSwitch/Unity/compare/v2.5.2...v2.6.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
