### PR TITLE
exiv2: use version range for libpng

### DIFF
--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -73,7 +73,7 @@ class Exiv2Conan(ConanFile):
     def requirements(self):
         self.requires("libiconv/1.17")
         if self.options.with_png:
-            self.requires("libpng/1.6.40")
+            self.requires("libpng/[>=1.6 <2]")
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_xmp == "bundled":
             self.requires("expat/2.5.0")


### PR DESCRIPTION
Specify library name and version:  **exiv2/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
