### PR TITLE
pdf-writer: use libpng version range

### DIFF
--- a/recipes/pdf-writer/all/conanfile.py
+++ b/recipes/pdf-writer/all/conanfile.py
@@ -56,7 +56,7 @@ class PDFWriterConan(ConanFile):
         if self.options.with_png:
             self.requires("libjpeg/9e")
         if self.options.with_jpeg:
-            self.requires("libpng/1.6.40")
+            self.requires("libpng/[>=1.6 <2]")
         if self.options.with_tiff:
             self.requires("libtiff/4.6.0")
 


### PR DESCRIPTION
Specify library name and version:  **pdf-writer/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
