### PR TITLE
msdfgen: use libpng version range, bump deps

### DIFF
--- a/recipes/msdfgen/all/conanfile.py
+++ b/recipes/msdfgen/all/conanfile.py
@@ -49,11 +49,11 @@ class MsdfgenConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("freetype/2.12.1")
+        self.requires("freetype/2.13.2")
         if  Version(self.version) < "1.10":
             self.requires("lodepng/cci.20200615")
         else:
-            self.requires("libpng/1.6.39")
+            self.requires("libpng/[>=1.6 <2]")
         self.requires("tinyxml2/9.0.0")
 
     def validate(self):


### PR DESCRIPTION
Specify library name and version:  **msdfgen/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
