### PR TITLE
butteraugli: use libpng version range

### DIFF
--- a/recipes/butteraugli/all/conanfile.py
+++ b/recipes/butteraugli/all/conanfile.py
@@ -45,7 +45,7 @@ class ButteraugliConan(ConanFile):
 
     def requirements(self):
         if self.options.tool:
-            self.requires("libpng/1.6.39")
+            self.requires("libpng/[>=1.6 <2]")
             self.requires("libjpeg/9e")
 
     def validate(self):


### PR DESCRIPTION
Specify library name and version:  **butteraugli/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
