### PR TITLE
opencv/3.x: use libpng version range, bump deps

### DIFF
--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -80,13 +80,13 @@ class OpenCVConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9e")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/3.0.0")
+            self.requires("libjpeg-turbo/3.0.2")
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.3")
         if self.options.with_png:
-            self.requires("libpng/1.6.40")
+            self.requires("libpng/[>=1.6 <2]")
         if self.options.with_jasper:
-            self.requires("jasper/4.0.0")
+            self.requires("jasper/4.1.1")
         if self.options.with_openexr:
             # opencv 3.x doesn't support openexr >= 3
             self.requires("openexr/2.5.7")
@@ -100,7 +100,7 @@ class OpenCVConan(ConanFile):
         if self.options.with_webp:
             self.requires("libwebp/1.3.2")
         if self.options.contrib:
-            self.requires("freetype/2.13.0")
+            self.requires("freetype/2.13.2")
             self.requires("harfbuzz/8.2.2")
             self.requires("gflags/2.2.2")
             self.requires("glog/0.6.0")


### PR DESCRIPTION
Specify library name and version:  **opencv/3.x**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
