### PR TITLE
[google-cloud-cpp] skip testing with `os=macOS`, `shared=True` on conan v1

### DIFF
--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -9,6 +9,9 @@ from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
+# This PR tests whether google-cloud-cpp builds at HEAD. This test is motivated
+# by the build failures in #22993, an attempted upgrade of google-cloud-cpp.
+
 # Load the generated component dependency information.
 #
 # `google-cloud-cpp` has well over 200 components. Conan cannot use the CMake
@@ -24,7 +27,6 @@ import components_2_15_1
 import components_2_19_0
 
 required_conan_version = ">=1.56.0"
-
 
 class GoogleCloudCppConan(ConanFile):
     name = "google-cloud-cpp"

--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -9,9 +9,6 @@ from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
-# This PR tests whether google-cloud-cpp builds at HEAD. This test is motivated
-# by the build failures in #22993, an attempted upgrade of google-cloud-cpp.
-
 # Load the generated component dependency information.
 #
 # `google-cloud-cpp` has well over 200 components. Conan cannot use the CMake

--- a/recipes/google-cloud-cpp/2.x/extract_dependencies.py
+++ b/recipes/google-cloud-cpp/2.x/extract_dependencies.py
@@ -114,7 +114,7 @@ _DEFAULT_EXPERIMENTAL_COMPONENTS = {
     "pubsublite",
 }
 
-# `google-cloud-cpp` managems these dependencies using CMake code.
+# `google-cloud-cpp` manages these dependencies using CMake code.
 _HARD_CODED_DEPENDENCIES = {
     "api_annotations_protos": ["api_http_protos"],
     "api_auth_protos": ["api_annotations_protos"],

--- a/recipes/google-cloud-cpp/2.x/test_v1_package/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/test_v1_package/conanfile.py
@@ -1,20 +1,33 @@
 import os
 
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 from conan.tools.build import can_run
 
+
+# Due to SIP limitations on newer macOS, `DYLD_LIBRARY_PATH`, which is set by
+# `tools.run_environment`, will not be propagated properly, see
+# https://stackoverflow.com/questions/35568122/why-isnt-dyld-library-path-being-propagated-here
+# and https://github.com/conan-io/conan/issues/10668
+def macos_shared(cf: ConanFile):
+    return (tools.cross_building(cf) or cf.settings.os == "Macos") and cf.options["google-cloud-cpp"].shared
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
+        if macos_shared(self):
+            self.output.warning("Skipping build of test_v1_package due to limitation propagating "
+                                "runtime environment when invoking protoc and grpc_cpp_plugin. "
+                                "For a working example, please see the newer Conan 2.0 compatible "
+                                "test package.")
+            return
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not can_run(self):
+        if not can_run(self) or macos_shared(self):
             return
         for test in ["bigtable", "pubsub", "spanner", "speech", "storage"]:
             cmd = os.path.join("bin", test)


### PR DESCRIPTION
Following the lead of `grpc`, skip testing with `os=macOS`, `shared=True` on conan v1.

---

In #22993 we attempted to upgrade `google-cloud-cpp` to `2.22.0`.

We see failures[^1] to build on `os=macOS` with `shared=True` for older versions of the library. This makes us suspect that the recipe will not build at HEAD.

This PR tests the recipe at HEAD by adding a no-op comment. If the builds fail, I will use this PR to address the build failures. We failed to reproduce this on our local machines, hence the PR.

[^1]: The failures have to do with not finding `libprotoc` while running the grpc protoc plugin: `dyld[48161]: Library not loaded: @rpath/libprotoc.32.dylib`
