### PR TITLE
grpc: set gRPC_DOWNLOAD_ARCHIVES to false

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 import yaml
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.apple import is_apple_os
 from conan.tools.build import cross_building, valid_min_cppstd, check_min_cppstd
 from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
@@ -190,6 +190,11 @@ class GrpcConan(ConanFile):
         tc.cache_variables["gRPC_BUILD_GRPC_RUBY_PLUGIN"] = self.options.ruby_plugin
         tc.cache_variables["gRPC_BUILD_GRPCPP_OTEL_PLUGIN"] = self.options.get_safe("otel_plugin", False)
 
+        # Never download unnecessary archives
+        # (supported in gRPC >= 1.62.0)
+        tc.cache_variables["gRPC_DOWNLOAD_ARCHIVES"] = False
+
+
         # Consumed targets (abseil) via interface target_compiler_feature can propagate newer standards
         if not valid_min_cppstd(self, self._cxxstd_required):
             tc.cache_variables["CMAKE_CXX_STANDARD"] = self._cxxstd_required
@@ -247,7 +252,13 @@ class GrpcConan(ConanFile):
     def build(self):
         self._patch_sources()
         cmake = CMake(self)
-        cmake.configure()
+
+        # The CMake configure step can fail spuriously, but succeed on a retry
+        try:
+            cmake.configure()
+        except ConanException:
+            cmake.configure()
+
         cmake.build()
 
     @property

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -253,7 +253,6 @@ class GrpcConan(ConanFile):
         self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
-
         cmake.build()
 
     @property

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -252,12 +252,7 @@ class GrpcConan(ConanFile):
     def build(self):
         self._patch_sources()
         cmake = CMake(self)
-
-        # The CMake configure step can fail spuriously, but succeed on a retry
-        try:
-            cmake.configure()
-        except ConanException:
-            cmake.configure()
+        cmake.configure()
 
         cmake.build()
 


### PR DESCRIPTION
The gRPC CMake configuration step can fail to due to a failure when downloading third party archives.  These failures are expected, and the user is instructed to retry.  So, if configuration fails, retry it

Also set the `gRPC_DOWNLOAD_ARCHIVES` CMake flag to `False`, to avoid downloading these unnecessary archives in the first place, in versions of gRPC that understand the flag

Specify library name and version:  **grpc/all**

This fixes https://github.com/conan-io/conan-center-index/issues/23094


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
