### PR TITLE
fast_float: add version 6.1.1

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.1.1":
+    url: "https://github.com/fastfloat/fast_float/archive/v6.1.1.tar.gz"
+    sha256: "10159a4a58ba95fe9389c3c97fe7de9a543622aa0dcc12dd9356d755e9a94cb4"
   "6.1.0":
     url: "https://github.com/fastfloat/fast_float/archive/v6.1.0.tar.gz"
     sha256: "5a629e1f18f037ad0016c41ead630ea471cccbcdf60239ed3466c491d8e7c908"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.1.1":
+    folder: all
   "6.1.0":
     folder: all
   "6.0.0":


### PR DESCRIPTION
Specify library name and version:  **fast_float/6.1.1**

https://github.com/fastfloat/fast_float/compare/v6.1.0...v6.1.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
