### PR TITLE
flatbuffers: add version 24.3.7

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "24.3.7":
+    url: "https://github.com/google/flatbuffers/archive/v24.3.7.tar.gz"
+    sha256: "bfff9d2150fcff88f844e8c608b02b2a0e94c92aea39b04c0624783464304784"
   "23.5.26":
     url: "https://github.com/google/flatbuffers/archive/v23.5.26.tar.gz"
     sha256: "1cce06b17cddd896b6d73cc047e36a254fb8df4d7ea18a46acf16c4c0cd3f3f3"

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "24.3.7":
+    folder: all
   "23.5.26":
     folder: all
   "23.3.3":


### PR DESCRIPTION
Specify library name and version:  **flatbuffers/24.3.7**

https://github.com/google/flatbuffers/compare/v23.5.26...v24.3.7

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
