### PR TITLE
fast-cdr: Add version 2.2.0

### DIFF
--- a/recipes/fast-cdr/all/conandata.yml
+++ b/recipes/fast-cdr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.0":
+    url: "https://github.com/eProsima/Fast-CDR/archive/v2.2.0.tar.gz"
+    sha256: "8a75ee3aed59f495e95208050920d2c2146df92f073809505a3bd29011c21f20"
   "2.1.0":
     url: "https://github.com/eProsima/Fast-CDR/archive/v2.1.0.tar.gz"
     sha256: "7ee3b3e977381f76f8d9ab1e1df7b5202556505b104afb3f03ee79bbe6507aa0"
@@ -11,21 +14,6 @@ sources:
   "1.0.27":
     url: "https://github.com/eProsima/Fast-CDR/archive/v1.0.27.tar.gz"
     sha256: "a9bc8fd31a2c2b95e6d2fb46e6ce1ad733e86dc4442f733479e33ed9cdc54bf6"
-  "1.0.26":
-    url: "https://github.com/eProsima/Fast-CDR/archive/v1.0.26.tar.gz"
-    sha256: "812b29dd9fa8b79395dea3f4b810f9ab9e820fa4f0a666338c279b739a36595d"
-  "1.0.24":
-    url: "https://github.com/eProsima/Fast-CDR/archive/v1.0.24.tar.gz"
-    sha256: "ecd688ab89ff1c03b9031c314891ae60995e2e73d919b93569eb840d6e87dec2"
-  "1.0.23":
-    url: "https://github.com/eProsima/Fast-CDR/archive/v1.0.23.tar.gz"
-    sha256: "6f7c9c6c0c82c150b5ea2b0a58d5c9a466b87a1fcfca40d5786d99d4963a6721"
-  "1.0.22":
-    url: "https://github.com/eProsima/Fast-CDR/archive/v1.0.22.tar.gz"
-    sha256: "7ca7f09c633963622431bdb216eeb4145e378f81a2ce5113e341b9eee55e4f44"
-  "1.0.21":
-    url: "https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.21.tar.gz"
-    sha256: "C1F32BDD76910ADA00D551EB8828DE7561AD2B2846D063CB4316F9262C03C77D"
 patches:
   "2.0.0":
     - patch_file: "patches/2.0.0-0001-Fix-for-non-CWG-1270-revision-compliant-compilers-17.patch"

--- a/recipes/fast-cdr/config.yml
+++ b/recipes/fast-cdr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.0":
+    folder: all
   "2.1.0":
     folder: all
   "2.0.0":
@@ -6,14 +8,4 @@ versions:
   "1.1.0":
     folder: all
   "1.0.27":
-    folder: all
-  "1.0.26":
-    folder: all
-  "1.0.24":
-    folder: all
-  "1.0.23":
-    folder: all
-  "1.0.22":
-    folder: all
-  "1.0.21":
     folder: all


### PR DESCRIPTION
fast-cdr/2.2.0

Bump version to 2.2.0 and remove extraneous legacy versions.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
