### PR TITLE
tsl-robin-map: add version 1.2.2

### DIFF
--- a/recipes/tsl-robin-map/all/conandata.yml
+++ b/recipes/tsl-robin-map/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.2":
+    url: "https://github.com/Tessil/robin-map/archive/v1.2.2.tar.gz"
+    sha256: "c72767ecea2a90074c7efbe91620c8f955af666505e22782e82813c652710821"
   "1.2.1":
     url: "https://github.com/Tessil/robin-map/archive/v1.2.1.tar.gz"
     sha256: "2b54d2c1de2f73bea5c51d5dcbd64813a08caf1bfddcfdeee40ab74e9599e8e3"

--- a/recipes/tsl-robin-map/config.yml
+++ b/recipes/tsl-robin-map/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.2":
+    folder: all
   "1.2.1":
     folder: all
   "1.0.1":


### PR DESCRIPTION
Specify library name and version:  **tsl-robin-map/1.2.2**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
