### PR TITLE
[changelog] Deployment March 20, 2023

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,9 +1,14 @@
 # Changelog
 
-### 13-Mar-2024 - 11:08 CET
+### 20-March-2024 - 11:13 CET
 
-- [feature]: Build with both */*:shared=True/False option when package type is declared as ``shared-library``.
-- [fix]: Fix ValidateInfra python version check to be aligned with the latest Jenkins version.
+- [fix] Changing Version Ranges in dependencies is now bump dependencies
+- [fix] Static library package type should be built with both all static and all shared dependencies
+
+### 13-March-2024 - 11:08 CET
+
+- [feature] Build with both */*:shared=True/False option when package type is declared as ``shared-library``.
+- [fix] Fix ValidateInfra python version check to be aligned with the latest Jenkins version.
 
 ### 07-February-2024 - 15:43 CET
 


### PR DESCRIPTION
A new deployment arrives with the beginning of the spring (north hemisphere).

- When opening PR related to change regular version to version range, it will be classified as bump dependencies PR too. In past the rule was the opposite and very strict because the CI bot was merging PRs automatically without reviews.

- When a recipe uses package type `static-library`, it will be built with both `*/*:shared=True/False`. This behavior will avoid missing package when using these packages as dependency.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
