### PR TITLE
[minicoro] Add new package: minicoro/0.1.3

### DIFF
--- a/recipes/minicoro/all/conandata.yml
+++ b/recipes/minicoro/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.3":
+    url: "https://github.com/edubart/minicoro/archive/refs/tags/v0.1.3.tar.gz"
+    sha256: "4f9d4c3b5f6473f8141ee45e9947a6e7e7ee6665b4d9a8c373c0602495c5f6c9"

--- a/recipes/minicoro/all/conanfile.py
+++ b/recipes/minicoro/all/conanfile.py
@@ -1,0 +1,39 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=1.52.0"
+
+
+class PackageConan(ConanFile):
+    name = "minicoro"
+    description = "Single header stackful cross-platform coroutine library in pure C"
+    license = ("Unlicense", "MIT-0")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/edubart/minicoro"
+    topics = ("lua", "coroutine", "fibers", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.h", self.source_folder, os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/minicoro/all/test_package/CMakeLists.txt
+++ b/recipes/minicoro/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(minicoro REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE minicoro::minicoro)

--- a/recipes/minicoro/all/test_package/conanfile.py
+++ b/recipes/minicoro/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/minicoro/all/test_package/test_package.c
+++ b/recipes/minicoro/all/test_package/test_package.c
@@ -1,0 +1,22 @@
+#define MINICORO_IMPL
+#include "minicoro.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+void coro_entry(mco_coro* co) {
+    printf("coroutine 1\n");
+    mco_yield(co);
+    printf("coroutine 2\n");
+}
+
+int main(void) {
+    mco_desc desc = mco_desc_init(coro_entry, 0);
+    desc.user_data = NULL;
+    mco_coro* co;
+    mco_create(&co, &desc);
+    mco_destroy(co);
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/minicoro/config.yml
+++ b/recipes/minicoro/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.3":
+    folder: all


### PR DESCRIPTION
I was checking BehaviorTree.CPP project, if could use third party libraries vendorized in the project as external dependencies.

The https://github.com/edubart/minicoro is listed there, and occurred me that small coroutine header-only project is not available in Conan Center yet.

It actually can use a back-end like ucontext or Windows fibers, via compiler definitions, but it's something that the customer should know about actually. 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
