### PR TITLE
[wildcards] Add new package: wilcards 1.4.0

### DIFF
--- a/recipes/wildcards/all/conandata.yml
+++ b/recipes/wildcards/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.4.0":
+    url: "https://github.com/zemasoft/wildcards/archive/refs/tags/v1.4.0.tar.gz"
+    sha256: "da8846215df2c1493e9796392d9e17ca2da8cfeae0f718fe1d6e0544cbcfaa0f"

--- a/recipes/wildcards/all/conanfile.py
+++ b/recipes/wildcards/all/conanfile.py
@@ -1,0 +1,52 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+import os
+
+
+required_conan_version = ">=1.52.0"
+
+
+class PackageConan(ConanFile):
+    name = "wildcards"
+    description = "A simple C++ header-only template library implementing matching using wildcards"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/zemasoft/wildcards"
+    topics = ("template", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["WILDCARDS_BUILD_TESTS"] = False
+        tc.variables["WILDCARDS_BUILD_EXAMPLES"] = False
+        tc.generate()
+
+    def build(self):
+        # INFO: Wildcards uses CMake to generate wildcards.hpp
+        cmake = CMake(self)
+        cmake.configure()
+
+    def package(self):
+        copy(self, "LICENSE_1_0.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/wildcards/all/test_package/CMakeLists.txt
+++ b/recipes/wildcards/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(wildcards REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE wildcards::wildcards)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/wildcards/all/test_package/conanfile.py
+++ b/recipes/wildcards/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/wildcards/all/test_package/test_package.cpp
+++ b/recipes/wildcards/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <cstdlib>
+
+#include "wildcards.hpp"
+
+
+int main(void) {
+    wildcards::match("Hello, World!", "H*World?");
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/wildcards/config.yml
+++ b/recipes/wildcards/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.4.0":
+    folder: all


### PR DESCRIPTION
Very similar context described on #23197. BehaviorTree.CPP uses wildcards as well.

The project generates the header with the version, based on CMake config file, so we need to run cmake configure at least. Another option would be using rename + replace_in_file, but is too much I guess.

https://github.com/zemasoft/wildcards


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
