### PR TITLE
libunwind: Bump xz_utils to avoid a dependency conflict in cpython

### DIFF
--- a/recipes/libunwind/all/conanfile.py
+++ b/recipes/libunwind/all/conanfile.py
@@ -53,7 +53,7 @@ class LiunwindConan(ConanFile):
 
     def requirements(self):
         if self.options.minidebuginfo:
-            self.requires("xz_utils/5.4.5")
+            self.requires("xz_utils/5.6.1")
         if self.options.zlibdebuginfo:
             self.requires("zlib/[>=1.2.11 <2]")
 


### PR DESCRIPTION
Fixes a conflicting dependency in #20528.