### PR TITLE
ipaddress: add recipe

### DIFF
--- a/recipes/ipaddress/all/conandata.yml
+++ b/recipes/ipaddress/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.1":
+    url: "https://github.com/VladimirShaleev/ipaddress/archive/v1.0.1.tar.gz"
+    sha256: "49c16294f06fe95ffc66cae828dc08d116efb4a1ede3dddd21dcc182a2eceb03"

--- a/recipes/ipaddress/all/conanfile.py
+++ b/recipes/ipaddress/all/conanfile.py
@@ -1,0 +1,72 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
+import os
+
+
+required_conan_version = ">=1.52.0"
+
+
+class IpAddressConan(ConanFile):
+    name = "ipaddress"
+    description = "A library for working and manipulating IPv4/IPv6 addresses and networks"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/VladimirShaleev/ipaddress"
+    topics = ("ipv4", "ipv6", "ipaddress", "ip", "network", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    options = {"exceptions": [True, False], "overload_std": [True, False], "ipv6_scope": [True, False], "ipv6_scope_max_length": ["ANY"]}
+    default_options = {"exceptions": True, "overload_std": True, "ipv6_scope": True, "ipv6_scope_max_length": 16}
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        compiler = self.settings.compiler
+        compiler_version = Version(self.settings.compiler.version)
+
+        if compiler == "gcc" and compiler_version < "7.5":
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support gcc < 7.5")
+        if compiler == "clang" and compiler_version < "6.0":
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support clang < 6.0")
+        if compiler == "apple-clang" and compiler_version < "13.0":
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support Apple clang < 13.0")
+        if is_msvc(self) and compiler_version < "16":
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support MSVC < 16")
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(
+            self,
+            "*.hpp",
+            os.path.join(self.source_folder, "include"),
+            os.path.join(self.package_folder, "include")
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        if not self.options.exceptions:
+            self.cpp_info.defines.append("IPADDRESS_NO_EXCEPTIONS")
+        if not self.options.overload_std:
+            self.cpp_info.defines.append("IPADDRESS_NO_OVERLOAD_STD")
+        if not self.options.ipv6_scope:
+            self.cpp_info.defines.append("IPADDRESS_NO_IPV6_SCOPE")
+        else:
+            self.cpp_info.defines.append(f"IPADDRESS_IPV6_SCOPE_MAX_LENGTH={int(self.options.ipv6_scope_max_length)}")

--- a/recipes/ipaddress/all/test_package/CMakeLists.txt
+++ b/recipes/ipaddress/all/test_package/CMakeLists.txt
@@ -5,9 +5,4 @@ find_package(ipaddress CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ipaddress::ipaddress)
-set_target_properties(${PROJECT_NAME}
-    PROPERTIES
-        CXX_STANDARD 11
-        CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/ipaddress/all/test_package/CMakeLists.txt
+++ b/recipes/ipaddress/all/test_package/CMakeLists.txt
@@ -5,4 +5,9 @@ find_package(ipaddress CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ipaddress::ipaddress)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)

--- a/recipes/ipaddress/all/test_package/CMakeLists.txt
+++ b/recipes/ipaddress/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(ipaddress CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ipaddress::ipaddress)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/ipaddress/all/test_package/conanfile.py
+++ b/recipes/ipaddress/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/ipaddress/all/test_package/test_package.cpp
+++ b/recipes/ipaddress/all/test_package/test_package.cpp
@@ -4,7 +4,7 @@
 
 
 int main(void) {
-    constexpr auto ip = ipaddress::ipv6_address::parse("fec0::1ff:fe23:4567:890a%eth2");
+    auto ip = ipaddress::ipv6_address::parse("fec0::1ff:fe23:4567:890a%eth2");
     std::cout << "Parsing ipv6: " << ip << std::endl;
 
     return EXIT_SUCCESS;

--- a/recipes/ipaddress/all/test_package/test_package.cpp
+++ b/recipes/ipaddress/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <cstdlib>
+#include <iostream>
+#include "ipaddress/ipaddress.hpp"
+
+
+int main(void) {
+    constexpr auto ip = ipaddress::ipv6_address::parse("fec0::1ff:fe23:4567:890a%eth2");
+    std::cout << "Parsing ipv6: " << ip << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/ipaddress/config.yml
+++ b/recipes/ipaddress/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ipaddress/1.0.1**

Hi! This is a new library for working with IP addresses and networks.

It is inspired by the well-thought-out API from the Python module for working with addresses and networks. Therefore, it is familiar and understandable for use by many programmers.

This library fills gaps in the implementation of other libraries: network parsing, working with stringize **scope id**, as well as network manipulation


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
