### PR TITLE
[minicoro] Add include folder as namespace

### DIFF
--- a/recipes/minicoro/all/conanfile.py
+++ b/recipes/minicoro/all/conanfile.py
@@ -32,8 +32,9 @@ class PackageConan(ConanFile):
 
     def package(self):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        copy(self, "*.h", self.source_folder, os.path.join(self.package_folder, "include"))
+        copy(self, "*.h", self.source_folder, os.path.join(self.package_folder, "include", "minicoro"))
 
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.includedirs.append(os.path.join("include", "minicoro"))


### PR DESCRIPTION
Specify library name and version:  **minicoro/0.1.3**

The minicoro only exports its headers to "include" folder directly, no namespace folder included, which could result in name collision.

The BehaviorTree.CPP has a vendorized version of this library and uses a namespace folder. 

https://github.com/BehaviorTree/BehaviorTree.CPP/tree/master/3rdparty/minicoro

https://github.com/BehaviorTree/BehaviorTree.CPP/blob/55a7b70b7ab6c1f2be811009e67f6e6630839947/src/action_node.cpp#L15

The current implementation there does not work with the current package in Conan Center.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
