### PR TITLE
[wildcards] Add include folder as namespace

### DIFF
--- a/recipes/wildcards/all/conanfile.py
+++ b/recipes/wildcards/all/conanfile.py
@@ -45,8 +45,9 @@ class PackageConan(ConanFile):
 
     def package(self):
         copy(self, "LICENSE_1_0.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        copy(self, "*.hpp", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+        copy(self, "*.hpp", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include", "wildcards"))
 
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.includedirs.append(os.path.join("include", "wildcards"))


### PR DESCRIPTION
Specify library name and version:  **wildcards/1.4.0**

Very similar to #23209

Here, BehaviorTree.cpp uses on these places:

https://github.com/BehaviorTree/BehaviorTree.CPP/blob/55a7b70b7ab6c1f2be811009e67f6e6630839947/src/bt_factory.cpp#L18

https://github.com/BehaviorTree/BehaviorTree.CPP/tree/master/3rdparty/wildcards

This PR exposes the headers files in a namespace folder too. 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
