### PR TITLE
dice-template-library: add version 1.5.0

### DIFF
--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.0":
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.5.0.tar.gz"
+    sha256: "5ab4155097af5674dc9b34d1643db9ea8b30f78d15c1e547c58396ea31068ffd"
   "1.3.0":
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.3.0.tar.gz"
     sha256: "2e61e95eeedf31f7041a6694c0789c5d1a5e3f9e4db87546cb83c9189808d4f5"

--- a/recipes/dice-template-library/config.yml
+++ b/recipes/dice-template-library/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.0":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.0":


### PR DESCRIPTION
Specify library name and version:  **dice-template-library/1.5.0**

https://github.com/dice-group/dice-template-library/compare/v1.3.0...v1.5.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
