### PR TITLE
octo-logger-cpp: add version 1.6.1

### DIFF
--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "1.6.1":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.6.1.tar.gz"
     sha256: "02c1d5303d8c129cb2527a92d49677229230a5feaec002791f96d47de3bccb5a"
-  "1.6.0":
-    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.6.0.tar.gz"
-    sha256: "c6146df88299791631ec0e7c1aacf83a1369954033b798cbe433150d78ef7da1"
   "1.5.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.5.0.tar.gz"
     sha256: "e62e4a54700f7c235111fd2b75c51d96f0b4deaf2c24ce7bc9ef1751ce31ea20"

--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.6.0.tar.gz"
+    sha256: "c6146df88299791631ec0e7c1aacf83a1369954033b798cbe433150d78ef7da1"
   "1.5.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.5.0.tar.gz"
     sha256: "e62e4a54700f7c235111fd2b75c51d96f0b4deaf2c24ce7bc9ef1751ce31ea20"

--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.1":
+    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.6.1.tar.gz"
+    sha256: "02c1d5303d8c129cb2527a92d49677229230a5feaec002791f96d47de3bccb5a"
   "1.6.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.6.0.tar.gz"
     sha256: "c6146df88299791631ec0e7c1aacf83a1369954033b798cbe433150d78ef7da1"

--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -52,9 +52,9 @@ class OctoLoggerCPPConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("fmt/10.1.1", transitive_headers=True)
+        self.requires("fmt/10.2.1", transitive_headers=True)
         if self.options.get_safe("with_aws"):
-            self.requires("nlohmann_json/3.11.2")
+            self.requires("nlohmann_json/3.11.3")
             self.requires("aws-sdk-cpp/1.9.234")
 
     def validate(self):

--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -52,7 +52,7 @@ class OctoLoggerCPPConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("fmt/10.2.1", transitive_headers=True)
+        self.requires("fmt/10.1.1", transitive_headers=True)
         if self.options.get_safe("with_aws"):
             self.requires("nlohmann_json/3.11.3")
             self.requires("aws-sdk-cpp/1.9.234")

--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -54,7 +54,7 @@ class OctoLoggerCPPConan(ConanFile):
     def requirements(self):
         self.requires("fmt/10.1.1", transitive_headers=True)
         if self.options.get_safe("with_aws"):
-            self.requires("nlohmann_json/3.11.3")
+            self.requires("nlohmann_json/3.11.2")
             self.requires("aws-sdk-cpp/1.9.234")
 
     def validate(self):

--- a/recipes/octo-logger-cpp/config.yml
+++ b/recipes/octo-logger-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.0":
+    folder: "all"
   "1.5.0":
     folder: "all"
   "1.4.0":

--- a/recipes/octo-logger-cpp/config.yml
+++ b/recipes/octo-logger-cpp/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.6.0":
+  "1.6.1":
     folder: "all"
   "1.5.0":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **octo-logger-cpp/***

https://github.com/ofiriluz/octo-logger-cpp/compare/v1.5.0...v1.6.1

<details>
<summary>
build log with `with_aws=True`
</summary>
======== Exporting recipe to the cache ========
WARN: Name containing special chars is discouraged 'octo-logger-cpp'
octo-logger-cpp/1.6.0: Exporting package recipe: /Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/conanfile.py
octo-logger-cpp/1.6.0: exports: File 'conandata.yml' found. Exporting it...
octo-logger-cpp/1.6.0: Copied 1 '.py' file: conanfile.py
octo-logger-cpp/1.6.0: Copied 1 '.yml' file: conandata.yml
octo-logger-cpp/1.6.0: Exported to cache folder: /Users/toge/.conan2/p/octo-6018dd638a395/e
octo-logger-cpp/1.6.0: Exported: octo-logger-cpp/1.6.0#ce02123000fe98a7e20bad45361286d4 (2024-03-23 15:07:25 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=apple-clang
compiler.cppstd=20
compiler.libcxx=libc++
compiler.version=15
os=Macos
[options]
*/*:with_aws=True
aws-sdk-cpp/*:logs=True

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=apple-clang
compiler.cppstd=20
compiler.libcxx=libc++
compiler.version=15
os=Macos


======== Computing dependency graph ========
Graph root
    cli
Requirements
    aws-c-auth/0.6.11#8cfb474734f7f33a1af348cb4c4ee614 - Cache
    aws-c-cal/0.5.13#b49d0e0e46d9a67f343e7d8c84fa100e - Cache
    aws-c-common/0.8.2#b8f8529d9e549fff9be397c36de6af2e - Cache
    aws-c-compression/0.2.15#8344f3873ddd82da0096ce6c2360e90a - Cache
    aws-c-event-stream/0.2.7#b47d721d67f9021cced345ab2327eab4 - Cache
    aws-c-http/0.6.13#808f973d97664731951c919a355284df - Cache
    aws-c-io/0.10.20#e198c0023d84caaa4be7c11d292d275a - Cache
    aws-c-mqtt/0.7.10#295628f02ac4718ee7ed2b27155b08e5 - Cache
    aws-c-s3/0.1.37#00f937d7d4b6c023a6ccb6338af0e033 - Cache
    aws-c-sdkutils/0.1.3#81304dc89f9ea74a3af021cedf7c4852 - Cache
    aws-checksums/0.1.13#609c98240882ae11e4e780f115f0d1c2 - Cache
    aws-crt-cpp/0.17.23#a0cd53660bda6bfe729b5e098b647961 - Cache
    aws-sdk-cpp/1.9.234#0ad8828e94ec4025c17631a41f62e629 - Cache
    fmt/10.2.1#9199a7a0611866dea5c8849a77467b25 - Cache
    libcurl/8.6.0#2f5d0b0e684214641563d25d5ff32aa1 - Cache
    nlohmann_json/3.11.3#45828be26eb619a2e04ca517bb7b828d - Cache
    octo-logger-cpp/1.6.0#ce02123000fe98a7e20bad45361286d4 - Cache
    openssl/3.2.0#30b857fa0927b5917fe3463c8c0ba38f - Cache
    zlib/1.3#06023034579559bb64357db3a53f88a4 - Cache
Build requirements
    autoconf/2.71#53be95d228b2dcb30dc199cb84262d8f - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    cmake/3.28.1#92f79424d7b65b12a84a2180866c3a78 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    meson/1.2.2#04bdfb85d665c82b08a3510aee3ffd19 - Cache
    ninja/1.11.1#77587f8c8318662ac8e5a7867eb4be21 - Cache
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
Resolved version ranges
    cmake/[>=3.16 <4]: cmake/3.28.1
    libcurl/[>=7.78.0 <9]: libcurl/8.6.0
    openssl/[>=1.1 <4]: openssl/3.2.0
    zlib/[>=1.2.11 <2]: zlib/1.3

======== Computing necessary packages ========
octo-logger-cpp/1.6.0: Checking 5 compatible configurations
octo-logger-cpp/1.6.0: Compatible configurations not found in cache, checking servers
octo-logger-cpp/1.6.0: '145431fa7b2bbffea8701ad4d72994432022d6ee': compiler.cppstd=17
octo-logger-cpp/1.6.0: '3f7de3dffba055090ce0072b23eaf194ebdfdd35': compiler.cppstd=gnu17
octo-logger-cpp/1.6.0: '53aa89e00bf3e9589a3c6eb88378a5d47f165e04': compiler.cppstd=gnu20
octo-logger-cpp/1.6.0: '5b66a17ea06b1675dd73cf3ffdafb06072b1f915': compiler.cppstd=23
octo-logger-cpp/1.6.0: '060364acaed76441ab2f822c51f197f87f5c440e': compiler.cppstd=gnu23
Requirements
    aws-c-auth/0.6.11#8cfb474734f7f33a1af348cb4c4ee614:ed14f77da2142fa3488b2a9b71085dae82f8432f#53477c844f6b5f4b544d7ba753c5cca2 - Cache
    aws-c-cal/0.5.13#b49d0e0e46d9a67f343e7d8c84fa100e:c081e31d156a7421d77e840ae1d4d4444025e82f#643c40b9b37500fa3392f2c125968ca0 - Cache
    aws-c-common/0.8.2#b8f8529d9e549fff9be397c36de6af2e:6f4139cfc7bf135c5eb5f1778e90dbdff3b88b54#2fb398c4487c89db00b178082fbc48a2 - Cache
    aws-c-compression/0.2.15#8344f3873ddd82da0096ce6c2360e90a:c081e31d156a7421d77e840ae1d4d4444025e82f#77140fb380f9ab12088751fbb6b58aeb - Cache
    aws-c-event-stream/0.2.7#b47d721d67f9021cced345ab2327eab4:38769ea24aad8f5373a6c40e216138a8783c8e9a#22fc98075c39aa5db292583c7998947e - Cache
    aws-c-http/0.6.13#808f973d97664731951c919a355284df:427864ab4c96cc850662a0746975b6d3c4d43bb0#213ff83144dc613455ac9c4e541ee845 - Cache
    aws-c-io/0.10.20#e198c0023d84caaa4be7c11d292d275a:391444a8376e79eb5adb187567515f87d14505fe#bc1e39e5fe16c3efcd5eb641f7011173 - Cache
    aws-c-mqtt/0.7.10#295628f02ac4718ee7ed2b27155b08e5:2674cd3f7cc7b772d8fdf9be3c0ae935d4345e29#7e9b8005f81d73cf0808ce2feff7343c - Cache
    aws-c-s3/0.1.37#00f937d7d4b6c023a6ccb6338af0e033:795eae79ac0f0231e23c0c3ebd1bda7872c88919#1b12c639ab38bd4acdc929b6d31ede92 - Cache
    aws-c-sdkutils/0.1.3#81304dc89f9ea74a3af021cedf7c4852:c081e31d156a7421d77e840ae1d4d4444025e82f#e2b2aaa16071664163a8a206377c7660 - Cache
    aws-checksums/0.1.13#609c98240882ae11e4e780f115f0d1c2:c081e31d156a7421d77e840ae1d4d4444025e82f#6a1aff4afa58d877ba650e7c9a16378c - Cache
    aws-crt-cpp/0.17.23#a0cd53660bda6bfe729b5e098b647961:a0a6859b500ac29e70b9aadad6db0376aaaad0a1#e88277361ec043c129638e11b7b0bea9 - Cache
    aws-sdk-cpp/1.9.234#0ad8828e94ec4025c17631a41f62e629:ac69e2dbe0855f265702582f92e2ae8ae0157f1d#fb386181dd261e48a382ac5b3b0b3269 - Cache
    fmt/10.2.1#9199a7a0611866dea5c8849a77467b25:d99555f52193cb432750957c759df6f836f471a4#192032da2d2b811b3dc9dbbc87c5011d - Cache
    libcurl/8.6.0#2f5d0b0e684214641563d25d5ff32aa1:3afaaf4b8e2b934a119aed4af8a1c282f1f24e0a#00e49265b394de21cab7c0d058324b48 - Cache
    nlohmann_json/3.11.3#45828be26eb619a2e04ca517bb7b828d:da39a3ee5e6b4b0d3255bfef95601890afd80709#552828a2560333bcbeff9d087ce0af0f - Cache
    octo-logger-cpp/1.6.0#ce02123000fe98a7e20bad45361286d4:c451318499dc086ccff3a2bf0d52cd1e7d4020ad - Build
    openssl/3.2.0#30b857fa0927b5917fe3463c8c0ba38f:39bf1cc17672c54efdbbb7c006e7caa5c8d0934c#9ff203c00f6aa21c6f53368e096faa68 - Cache
    zlib/1.3#06023034579559bb64357db3a53f88a4:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#6f6947682d94ef7b03a76164c3aa4160 - Cache
Build requirements
    cmake/3.28.1#92f79424d7b65b12a84a2180866c3a78:9e5323c65b94ae38c3c733fe12637776db0119a5#2ace414902354371affae8b3b49fd2d0 - Cache
Skipped binaries
    autoconf/2.71, automake/1.16.5, gnu-config/cci.20210814, libtool/2.4.7, m4/1.4.19, meson/1.2.2, ninja/1.11.1, pkgconf/2.1.0

======== Installing packages ========
aws-c-common/0.8.2: Already installed! (1 of 20)
cmake/3.28.1: Already installed! (2 of 20)
cmake/3.28.1: Appending PATH environment variable: /Users/toge/.conan2/p/cmake85b2f0ce1513b/p/CMake.app/Contents/bin
fmt/10.2.1: Already installed! (3 of 20)
nlohmann_json/3.11.3: Already installed! (4 of 20)
zlib/1.3: Already installed! (5 of 20)
aws-c-cal/0.5.13: Already installed! (6 of 20)
aws-c-compression/0.2.15: Already installed! (7 of 20)
aws-c-sdkutils/0.1.3: Already installed! (8 of 20)
aws-checksums/0.1.13: Already installed! (9 of 20)
openssl/3.2.0: Already installed! (10 of 20)
libcurl/8.6.0: Already installed! (11 of 20)
aws-c-io/0.10.20: Already installed! (12 of 20)
aws-c-event-stream/0.2.7: Already installed! (13 of 20)
aws-c-http/0.6.13: Already installed! (14 of 20)
aws-c-auth/0.6.11: Already installed! (15 of 20)
aws-c-mqtt/0.7.10: Already installed! (16 of 20)
aws-c-s3/0.1.37: Already installed! (17 of 20)
aws-crt-cpp/0.17.23: Already installed! (18 of 20)
aws-sdk-cpp/1.9.234: Already installed! (19 of 20)
octo-logger-cpp/1.6.0: Calling source() in /Users/toge/.conan2/p/octo-6018dd638a395/s/src

-------- Installing package octo-logger-cpp/1.6.0 (20 of 20) --------
octo-logger-cpp/1.6.0: Building from source
octo-logger-cpp/1.6.0: Package octo-logger-cpp/1.6.0:c451318499dc086ccff3a2bf0d52cd1e7d4020ad
octo-logger-cpp/1.6.0: Copying sources to build folder
octo-logger-cpp/1.6.0: Building your package in /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b
octo-logger-cpp/1.6.0: Calling generate()
octo-logger-cpp/1.6.0: Generators folder: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b/build/Release/generators
octo-logger-cpp/1.6.0: CMakeToolchain generated: conan_toolchain.cmake
octo-logger-cpp/1.6.0: CMakeToolchain generated: CMakePresets.json
octo-logger-cpp/1.6.0: CMakeToolchain generated: ../../../src/CMakeUserPresets.json
octo-logger-cpp/1.6.0: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(fmt)
    find_package(nlohmann_json)
    find_package(AWSSDK)
    target_link_libraries(... fmt::fmt nlohmann_json::nlohmann_json aws-sdk-cpp::aws-sdk-cpp)
octo-logger-cpp/1.6.0: Generating aggregated env files
octo-logger-cpp/1.6.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
octo-logger-cpp/1.6.0: Calling build()
octo-logger-cpp/1.6.0: Running CMake.configure()
octo-logger-cpp/1.6.0: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="/Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b/build/Release/generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b/src"
-- Using Conan toolchain: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- The C compiler identification is AppleClang 15.0.0.15000309
-- The CXX compiler identification is AppleClang 15.0.0.15000309
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'fmt::fmt'
-- Conan: Target declared 'nlohmann_json::nlohmann_json'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-core'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-logs'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-logs_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-monitoring'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-monitoring_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-iam'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-iam_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-cognito-identity'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-cognito-identity_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-sts'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-sts_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-sqs'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-sqs_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-s3'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-s3_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-kms'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-kms_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-polly'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-polly_alias'
-- Conan: Component target declared 'aws-sdk-cpp::plugin_scripts'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-access-management'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-access-management_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-identity-management'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-identity-management_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-queues'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-queues_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-s3-encryption'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-s3-encryption_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-text-to-speech'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-text-to-speech_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-transfer'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-transfer_alias'
-- Conan: Target declared 'aws-sdk-cpp::aws-sdk-cpp'
-- Conan: Target declared 'AWS::aws-crt-cpp'
-- Conan: Target declared 'AWS::aws-c-event-stream'
-- Conan: Target declared 'AWS::aws-c-io'
-- Conan: Target declared 'AWS::aws-c-cal'
-- Conan: Target declared 'AWS::aws-c-common'
-- Conan: Target declared 'AWS::aws-checksums'
-- Conan: Target declared 'AWS::aws-c-mqtt'
-- Conan: Target declared 'AWS::aws-c-http'
-- Conan: Target declared 'AWS::aws-c-compression'
-- Conan: Target declared 'AWS::aws-c-s3'
-- Conan: Target declared 'AWS::aws-c-auth'
-- Conan: Target declared 'AWS::aws-c-sdkutils'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/Users/toge/.conan2/p/b/opens97ab54fecb75b/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Conan: Component target declared 'CURL::libcurl'
-- Conan: Including build module from '/Users/toge/.conan2/p/b/aws-s1d21fc97b29f8/p/res/cmake/sdk_plugin_conf.cmake'
-- Building project version: 1.9.234
-- Configuring done (1.8s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b/build/Release

octo-logger-cpp/1.6.0: Running CMake.build()
octo-logger-cpp/1.6.0: RUN: cmake --build "/Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b/build/Release" -- -j8
[  7%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/manager-config.cpp.o
[ 21%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/log.cpp.o
[ 21%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/sink.cpp.o
[ 28%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/sink-config.cpp.o
[ 35%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/channel.cpp.o
[ 42%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/manager.cpp.o
[ 57%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/logger.cpp.o
[ 57%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/sink-factory.cpp.o
[ 64%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/sinks/console-sink.cpp.o
[ 71%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/sinks/file-sink.cpp.o
[ 78%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/sinks/syslog-sink.cpp.o
[ 85%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/aws/cloudwatch-sink.cpp.o
[ 92%] Building CXX object CMakeFiles/octo-logger-cpp.dir/src/aws/aws-log-system.cpp.o
[100%] Linking CXX static library libocto-logger-cpp.a
[100%] Built target octo-logger-cpp

octo-logger-cpp/1.6.0: Package 'c451318499dc086ccff3a2bf0d52cd1e7d4020ad' built
octo-logger-cpp/1.6.0: Build folder /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b/build/Release
octo-logger-cpp/1.6.0: Generating the package
octo-logger-cpp/1.6.0: Packaging in folder /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p
octo-logger-cpp/1.6.0: Calling package()
octo-logger-cpp/1.6.0: Running CMake.install()
octo-logger-cpp/1.6.0: RUN: cmake --install "/Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/b/build/Release" --prefix "/Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p"
-- Install configuration: "Release"
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/logger.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/sink-config.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/sinks
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/sinks/file-sink.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/sinks/console-sink.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/sinks/syslog-sink.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/manager-config.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/channel.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/trace-logger.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/manager.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/aws
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/aws/cloudwatch-sink.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/aws/aws-log-system.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/logger-test-definitions.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/log.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/sink.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/include/octo-logger-cpp/sink-factory.hpp
-- Installing: /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p/lib/libocto-logger-cpp.a

octo-logger-cpp/1.6.0: package(): Packaged 1 file: LICENSE
octo-logger-cpp/1.6.0: package(): Packaged 15 '.hpp' files
octo-logger-cpp/1.6.0: package(): Packaged 1 '.a' file: libocto-logger-cpp.a
octo-logger-cpp/1.6.0: Created package revision ec8bd00c79ef878f91708d81c44127f0
octo-logger-cpp/1.6.0: Package 'c451318499dc086ccff3a2bf0d52cd1e7d4020ad' created
octo-logger-cpp/1.6.0: Full package reference: octo-logger-cpp/1.6.0#ce02123000fe98a7e20bad45361286d4:c451318499dc086ccff3a2bf0d52cd1e7d4020ad#ec8bd00c79ef878f91708d81c44127f0
octo-logger-cpp/1.6.0: Package folder /Users/toge/.conan2/p/b/octo-d7c1f7a39e3bc/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.build_modules' used in: aws-c-cal/0.5.13, aws-c-auth/0.6.11, aws-c-sdkutils/0.1.3, aws-c-http/0.6.13, aws-crt-cpp/0.17.23, aws-sdk-cpp/1.9.234, aws-c-io/0.10.20, aws-c-event-stream/0.2.7, aws-c-mqtt/0.7.10, aws-c-s3/0.1.37, aws-c-common/0.8.2, openssl/3.2.0, aws-c-compression/0.2.15, aws-checksums/0.1.13
WARN: deprecated:     'env_info' used in: cmake/3.28.1, openssl/3.2.0
WARN: deprecated:     'cpp_info.names' used in: zlib/1.3, aws-sdk-cpp/1.9.234, fmt/10.2.1, openssl/3.2.0, libcurl/8.6.0
WARN: deprecated:     'cpp_info.filenames' used in: aws-sdk-cpp/1.9.234

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    octo-logger-cpp/1.6.0 (test package): /Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package/conanfile.py
Requirements
    aws-c-auth/0.6.11#8cfb474734f7f33a1af348cb4c4ee614 - Cache
    aws-c-cal/0.5.13#b49d0e0e46d9a67f343e7d8c84fa100e - Cache
    aws-c-common/0.8.2#b8f8529d9e549fff9be397c36de6af2e - Cache
    aws-c-compression/0.2.15#8344f3873ddd82da0096ce6c2360e90a - Cache
    aws-c-event-stream/0.2.7#b47d721d67f9021cced345ab2327eab4 - Cache
    aws-c-http/0.6.13#808f973d97664731951c919a355284df - Cache
    aws-c-io/0.10.20#e198c0023d84caaa4be7c11d292d275a - Cache
    aws-c-mqtt/0.7.10#295628f02ac4718ee7ed2b27155b08e5 - Cache
    aws-c-s3/0.1.37#00f937d7d4b6c023a6ccb6338af0e033 - Cache
    aws-c-sdkutils/0.1.3#81304dc89f9ea74a3af021cedf7c4852 - Cache
    aws-checksums/0.1.13#609c98240882ae11e4e780f115f0d1c2 - Cache
    aws-crt-cpp/0.17.23#a0cd53660bda6bfe729b5e098b647961 - Cache
    aws-sdk-cpp/1.9.234#0ad8828e94ec4025c17631a41f62e629 - Cache
    fmt/10.2.1#9199a7a0611866dea5c8849a77467b25 - Cache
    libcurl/8.6.0#2f5d0b0e684214641563d25d5ff32aa1 - Cache
    nlohmann_json/3.11.3#45828be26eb619a2e04ca517bb7b828d - Cache
    octo-logger-cpp/1.6.0#ce02123000fe98a7e20bad45361286d4 - Cache
    openssl/3.2.0#30b857fa0927b5917fe3463c8c0ba38f - Cache
    zlib/1.3#06023034579559bb64357db3a53f88a4 - Cache
Build requirements
    autoconf/2.71#53be95d228b2dcb30dc199cb84262d8f - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    cmake/3.28.1#92f79424d7b65b12a84a2180866c3a78 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    meson/1.2.2#04bdfb85d665c82b08a3510aee3ffd19 - Cache
    ninja/1.11.1#77587f8c8318662ac8e5a7867eb4be21 - Cache
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache

======== Computing necessary packages ========
Requirements
    aws-c-auth/0.6.11#8cfb474734f7f33a1af348cb4c4ee614:ed14f77da2142fa3488b2a9b71085dae82f8432f#53477c844f6b5f4b544d7ba753c5cca2 - Cache
    aws-c-cal/0.5.13#b49d0e0e46d9a67f343e7d8c84fa100e:c081e31d156a7421d77e840ae1d4d4444025e82f#643c40b9b37500fa3392f2c125968ca0 - Cache
    aws-c-common/0.8.2#b8f8529d9e549fff9be397c36de6af2e:6f4139cfc7bf135c5eb5f1778e90dbdff3b88b54#2fb398c4487c89db00b178082fbc48a2 - Cache
    aws-c-compression/0.2.15#8344f3873ddd82da0096ce6c2360e90a:c081e31d156a7421d77e840ae1d4d4444025e82f#77140fb380f9ab12088751fbb6b58aeb - Cache
    aws-c-event-stream/0.2.7#b47d721d67f9021cced345ab2327eab4:38769ea24aad8f5373a6c40e216138a8783c8e9a#22fc98075c39aa5db292583c7998947e - Cache
    aws-c-http/0.6.13#808f973d97664731951c919a355284df:427864ab4c96cc850662a0746975b6d3c4d43bb0#213ff83144dc613455ac9c4e541ee845 - Cache
    aws-c-io/0.10.20#e198c0023d84caaa4be7c11d292d275a:391444a8376e79eb5adb187567515f87d14505fe#bc1e39e5fe16c3efcd5eb641f7011173 - Cache
    aws-c-mqtt/0.7.10#295628f02ac4718ee7ed2b27155b08e5:2674cd3f7cc7b772d8fdf9be3c0ae935d4345e29#7e9b8005f81d73cf0808ce2feff7343c - Cache
    aws-c-s3/0.1.37#00f937d7d4b6c023a6ccb6338af0e033:795eae79ac0f0231e23c0c3ebd1bda7872c88919#1b12c639ab38bd4acdc929b6d31ede92 - Cache
    aws-c-sdkutils/0.1.3#81304dc89f9ea74a3af021cedf7c4852:c081e31d156a7421d77e840ae1d4d4444025e82f#e2b2aaa16071664163a8a206377c7660 - Cache
    aws-checksums/0.1.13#609c98240882ae11e4e780f115f0d1c2:c081e31d156a7421d77e840ae1d4d4444025e82f#6a1aff4afa58d877ba650e7c9a16378c - Cache
    aws-crt-cpp/0.17.23#a0cd53660bda6bfe729b5e098b647961:a0a6859b500ac29e70b9aadad6db0376aaaad0a1#e88277361ec043c129638e11b7b0bea9 - Cache
    aws-sdk-cpp/1.9.234#0ad8828e94ec4025c17631a41f62e629:ac69e2dbe0855f265702582f92e2ae8ae0157f1d#fb386181dd261e48a382ac5b3b0b3269 - Cache
    fmt/10.2.1#9199a7a0611866dea5c8849a77467b25:d99555f52193cb432750957c759df6f836f471a4#192032da2d2b811b3dc9dbbc87c5011d - Cache
    libcurl/8.6.0#2f5d0b0e684214641563d25d5ff32aa1:3afaaf4b8e2b934a119aed4af8a1c282f1f24e0a#00e49265b394de21cab7c0d058324b48 - Cache
    octo-logger-cpp/1.6.0#ce02123000fe98a7e20bad45361286d4:c451318499dc086ccff3a2bf0d52cd1e7d4020ad#ec8bd00c79ef878f91708d81c44127f0 - Cache
    openssl/3.2.0#30b857fa0927b5917fe3463c8c0ba38f:39bf1cc17672c54efdbbb7c006e7caa5c8d0934c#9ff203c00f6aa21c6f53368e096faa68 - Cache
    zlib/1.3#06023034579559bb64357db3a53f88a4:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#6f6947682d94ef7b03a76164c3aa4160 - Cache
Build requirements
Skipped binaries
    nlohmann_json/3.11.3, autoconf/2.71, automake/1.16.5, cmake/3.28.1, gnu-config/cci.20210814, libtool/2.4.7, m4/1.4.19, meson/1.2.2, ninja/1.11.1, pkgconf/2.1.0

======== Installing packages ========
aws-c-common/0.8.2: Already installed! (1 of 18)
fmt/10.2.1: Already installed! (2 of 18)
zlib/1.3: Already installed! (3 of 18)
aws-c-cal/0.5.13: Already installed! (4 of 18)
aws-c-compression/0.2.15: Already installed! (5 of 18)
aws-c-sdkutils/0.1.3: Already installed! (6 of 18)
aws-checksums/0.1.13: Already installed! (7 of 18)
openssl/3.2.0: Already installed! (8 of 18)
libcurl/8.6.0: Already installed! (9 of 18)
aws-c-io/0.10.20: Already installed! (10 of 18)
aws-c-event-stream/0.2.7: Already installed! (11 of 18)
aws-c-http/0.6.13: Already installed! (12 of 18)
aws-c-auth/0.6.11: Already installed! (13 of 18)
aws-c-mqtt/0.7.10: Already installed! (14 of 18)
aws-c-s3/0.1.37: Already installed! (15 of 18)
aws-crt-cpp/0.17.23: Already installed! (16 of 18)
aws-sdk-cpp/1.9.234: Already installed! (17 of 18)
octo-logger-cpp/1.6.0: Already installed! (18 of 18)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.build_modules' used in: aws-c-cal/0.5.13, aws-c-auth/0.6.11, aws-c-sdkutils/0.1.3, aws-c-http/0.6.13, aws-crt-cpp/0.17.23, aws-sdk-cpp/1.9.234, aws-c-io/0.10.20, aws-c-event-stream/0.2.7, aws-c-mqtt/0.7.10, aws-c-s3/0.1.37, aws-c-common/0.8.2, openssl/3.2.0, aws-c-compression/0.2.15, aws-checksums/0.1.13
WARN: deprecated:     'cpp_info.names' used in: zlib/1.3, aws-sdk-cpp/1.9.234, fmt/10.2.1, openssl/3.2.0, libcurl/8.6.0
WARN: deprecated:     'env_info' used in: openssl/3.2.0
WARN: deprecated:     'cpp_info.filenames' used in: aws-sdk-cpp/1.9.234

======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package/build/apple-clang-15-x86_64-20-release
octo-logger-cpp/1.6.0 (test package): Test package build: build/apple-clang-15-x86_64-20-release
octo-logger-cpp/1.6.0 (test package): Test package build folder: /Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package/build/apple-clang-15-x86_64-20-release
octo-logger-cpp/1.6.0 (test package): Writing generators to /Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package/build/apple-clang-15-x86_64-20-release/generators
octo-logger-cpp/1.6.0 (test package): Generator 'CMakeDeps' calling 'generate()'
octo-logger-cpp/1.6.0 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(octo-logger-cpp)
    target_link_libraries(... octo::octo-logger-cpp)
octo-logger-cpp/1.6.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
octo-logger-cpp/1.6.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
octo-logger-cpp/1.6.0 (test package): CMakeToolchain generated: CMakePresets.json
octo-logger-cpp/1.6.0 (test package): CMakeToolchain generated: ../../../CMakeUserPresets.json
octo-logger-cpp/1.6.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
octo-logger-cpp/1.6.0 (test package): Generating aggregated env files
octo-logger-cpp/1.6.0 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
octo-logger-cpp/1.6.0 (test package): Calling build()
octo-logger-cpp/1.6.0 (test package): Running CMake.configure()
octo-logger-cpp/1.6.0 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="/Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package/build/apple-clang-15-x86_64-20-release/generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package"
-- Using Conan toolchain: /Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package/build/apple-clang-15-x86_64-20-release/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- The CXX compiler identification is AppleClang 15.0.0.15000309
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'octo::octo-logger-cpp'
-- Conan: Component target declared 'fmt::fmt'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-core'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-logs'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-logs_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-monitoring'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-monitoring_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-iam'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-iam_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-cognito-identity'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-cognito-identity_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-sts'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-sts_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-sqs'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-sqs_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-s3'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-s3_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-kms'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-kms_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-polly'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-polly_alias'
-- Conan: Component target declared 'aws-sdk-cpp::plugin_scripts'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-access-management'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-access-management_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-identity-management'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-identity-management_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-queues'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-queues_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-s3-encryption'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-s3-encryption_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-text-to-speech'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-text-to-speech_alias'
-- Conan: Component target declared 'AWS::aws-sdk-cpp-transfer'
-- Conan: Component target declared 'aws-sdk-cpp::aws-sdk-cpp-transfer_alias'
-- Conan: Target declared 'aws-sdk-cpp::aws-sdk-cpp'
-- Conan: Target declared 'AWS::aws-crt-cpp'
-- Conan: Target declared 'AWS::aws-c-event-stream'
-- Conan: Target declared 'AWS::aws-c-io'
-- Conan: Target declared 'AWS::aws-c-cal'
-- Conan: Target declared 'AWS::aws-c-common'
-- Conan: Target declared 'AWS::aws-checksums'
-- Conan: Target declared 'AWS::aws-c-mqtt'
-- Conan: Target declared 'AWS::aws-c-http'
-- Conan: Target declared 'AWS::aws-c-compression'
-- Conan: Target declared 'AWS::aws-c-s3'
-- Conan: Target declared 'AWS::aws-c-auth'
-- Conan: Target declared 'AWS::aws-c-sdkutils'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/Users/toge/.conan2/p/b/opens97ab54fecb75b/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Conan: Component target declared 'CURL::libcurl'
-- Conan: Including build module from '/Users/toge/.conan2/p/b/aws-s1d21fc97b29f8/p/res/cmake/sdk_plugin_conf.cmake'
-- Building project version: 1.9.234
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package/build/apple-clang-15-x86_64-20-release

octo-logger-cpp/1.6.0 (test package): Running CMake.build()
octo-logger-cpp/1.6.0 (test package): RUN: cmake --build "/Users/toge/src/conan-center-index/recipes/octo-logger-cpp/all/test_package/build/apple-clang-15-x86_64-20-release" -- -j8
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
ld: warning: ignoring duplicate libraries: '-lc++'
[100%] Built target test_package


======== Testing the package: Executing test ========
octo-logger-cpp/1.6.0 (test package): Running test()
octo-logger-cpp/1.6.0 (test package): RUN: ./test_package
[24/03/2024 00:07:44.278][T][Test][PID(3034)][TID(0x200bcb240)]: A
[24/03/2024 00:07:44.278][D][Test][PID(3034)][TID(0x200bcb240)]: B
[24/03/2024 00:07:44.278][I][Test][PID(3034)][TID(0x200bcb240)]: C
[24/03/2024 00:07:44.278][N][Test][PID(3034)][TID(0x200bcb240)]: D
[24/03/2024 00:07:44.278][W][Test][PID(3034)][TID(0x200bcb240)]: E
[24/03/2024 00:07:44.278][E][Test][PID(3034)][TID(0x200bcb240)]: F
</details>

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
