### PR TITLE
Add recent versions of SQLite3 Multiple Ciphers

### DIFF
--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,4 +1,16 @@
 sources:
+  "1.8.4":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.4.tar.gz"
+    sha256: "453e1938a02c91796a013169d56f746f153d7c7a77b59894bf8462b341a343ca"
+  "1.8.3":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.3.tar.gz"
+    sha256: "1a9c26082068ee36c33b0a4e061d013db345ad170bab0ab00c8dda2c7c96561a"
+  "1.8.2":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.2.tar.gz"
+    sha256: "c349f45505641a3ee3e5faa4498a18317b65697e9a3cbfbe41a6612e44389c55"
+  "1.8.1":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.1.tar.gz"
+    sha256: "44215d5812ec2cfa1a842d9aae2908be0b14dce4231bc3243394b24b3affb78a"
   "1.8.0":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.0.tar.gz"
     sha256: "13D9B939BEF7C7371D58A3874F83B18CF330EB2171205B3680ACDDB2215BE0E5"

--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -2,15 +2,15 @@ sources:
   "1.8.4":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.4.tar.gz"
     sha256: "453e1938a02c91796a013169d56f746f153d7c7a77b59894bf8462b341a343ca"
-#  "1.8.3":
-#    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.3.tar.gz"
-#    sha256: "1a9c26082068ee36c33b0a4e061d013db345ad170bab0ab00c8dda2c7c96561a"
-#  "1.8.2":
-#    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.2.tar.gz"
-#    sha256: "c349f45505641a3ee3e5faa4498a18317b65697e9a3cbfbe41a6612e44389c55"
-#  "1.8.1":
-#    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.1.tar.gz"
-#    sha256: "44215d5812ec2cfa1a842d9aae2908be0b14dce4231bc3243394b24b3affb78a"
+  #  "1.8.3":
+  #    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.3.tar.gz"
+  #    sha256: "1a9c26082068ee36c33b0a4e061d013db345ad170bab0ab00c8dda2c7c96561a"
+  #  "1.8.2":
+  #    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.2.tar.gz"
+  #    sha256: "c349f45505641a3ee3e5faa4498a18317b65697e9a3cbfbe41a6612e44389c55"
+  #  "1.8.1":
+  #    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.1.tar.gz"
+  #    sha256: "44215d5812ec2cfa1a842d9aae2908be0b14dce4231bc3243394b24b3affb78a"
   "1.8.0":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.0.tar.gz"
     sha256: "13D9B939BEF7C7371D58A3874F83B18CF330EB2171205B3680ACDDB2215BE0E5"

--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -2,15 +2,6 @@ sources:
   "1.8.4":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.4.tar.gz"
     sha256: "453e1938a02c91796a013169d56f746f153d7c7a77b59894bf8462b341a343ca"
-  #  "1.8.3":
-  #    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.3.tar.gz"
-  #    sha256: "1a9c26082068ee36c33b0a4e061d013db345ad170bab0ab00c8dda2c7c96561a"
-  #  "1.8.2":
-  #    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.2.tar.gz"
-  #    sha256: "c349f45505641a3ee3e5faa4498a18317b65697e9a3cbfbe41a6612e44389c55"
-  #  "1.8.1":
-  #    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.1.tar.gz"
-  #    sha256: "44215d5812ec2cfa1a842d9aae2908be0b14dce4231bc3243394b24b3affb78a"
   "1.8.0":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.0.tar.gz"
     sha256: "13D9B939BEF7C7371D58A3874F83B18CF330EB2171205B3680ACDDB2215BE0E5"

--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -2,15 +2,15 @@ sources:
   "1.8.4":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.4.tar.gz"
     sha256: "453e1938a02c91796a013169d56f746f153d7c7a77b59894bf8462b341a343ca"
-  "1.8.3":
-    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.3.tar.gz"
-    sha256: "1a9c26082068ee36c33b0a4e061d013db345ad170bab0ab00c8dda2c7c96561a"
-  "1.8.2":
-    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.2.tar.gz"
-    sha256: "c349f45505641a3ee3e5faa4498a18317b65697e9a3cbfbe41a6612e44389c55"
-  "1.8.1":
-    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.1.tar.gz"
-    sha256: "44215d5812ec2cfa1a842d9aae2908be0b14dce4231bc3243394b24b3affb78a"
+#  "1.8.3":
+#    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.3.tar.gz"
+#    sha256: "1a9c26082068ee36c33b0a4e061d013db345ad170bab0ab00c8dda2c7c96561a"
+#  "1.8.2":
+#    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.2.tar.gz"
+#    sha256: "c349f45505641a3ee3e5faa4498a18317b65697e9a3cbfbe41a6612e44389c55"
+#  "1.8.1":
+#    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.1.tar.gz"
+#    sha256: "44215d5812ec2cfa1a842d9aae2908be0b14dce4231bc3243394b24b3affb78a"
   "1.8.0":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.0.tar.gz"
     sha256: "13D9B939BEF7C7371D58A3874F83B18CF330EB2171205B3680ACDDB2215BE0E5"

--- a/recipes/sqlite3mc/all/conanfile.py
+++ b/recipes/sqlite3mc/all/conanfile.py
@@ -84,7 +84,7 @@ class sqlite3mc(ConanFile):
         "enable_rtree": True,
         "enable_uuid": True,
         "use_uri": True,
-        "user_authentication": True,
+        "user_authentication": False,
         "enable_preupdate_hook": False,
         "enable_session": False,
         "shell_is_utf8": True,

--- a/recipes/sqlite3mc/all/conanfile.py
+++ b/recipes/sqlite3mc/all/conanfile.py
@@ -114,6 +114,9 @@ class sqlite3mc(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "1.8.4":
+            # INFO: https://github.com/utelle/SQLite3MultipleCiphers/commit/3bb033956816b3301f026abb5e83087799de5bee
+            self.options.user_authentication = True
 
     def configure(self):
         if self.options.shared:

--- a/recipes/sqlite3mc/all/conanfile.py
+++ b/recipes/sqlite3mc/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMakeDeps, CMakeToolchain, CMake
 from conan.tools.files import get, copy
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,3 +1,11 @@
 versions:
+  "1.8.4":
+    folder: all
+  "1.8.3":
+    folder: all
+  "1.8.2":
+    folder: all
+  "1.8.1":
+    folder: all
   "1.8.0":
     folder: all

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,11 +1,5 @@
 versions:
   "1.8.4":
     folder: all
-  #  "1.8.3":
-  #    folder: all
-  #  "1.8.2":
-  #    folder: all
-  #  "1.8.1":
-  #    folder: all
   "1.8.0":
     folder: all

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,11 +1,11 @@
 versions:
   "1.8.4":
     folder: all
-  "1.8.3":
-    folder: all
-  "1.8.2":
-    folder: all
-  "1.8.1":
-    folder: all
+#  "1.8.3":
+#    folder: all
+#  "1.8.2":
+#    folder: all
+#  "1.8.1":
+#    folder: all
   "1.8.0":
     folder: all

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,11 +1,11 @@
 versions:
   "1.8.4":
     folder: all
-#  "1.8.3":
-#    folder: all
-#  "1.8.2":
-#    folder: all
-#  "1.8.1":
-#    folder: all
+  #  "1.8.3":
+  #    folder: all
+  #  "1.8.2":
+  #    folder: all
+  #  "1.8.1":
+  #    folder: all
   "1.8.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **sqlite3mc/1.8.1**,   **sqlite3mc/1.8.2**, **sqlite3mc/1.8.3**,  **sqlite3mc/1.8.4**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

A Conan recipe was added for _SQLite3 Multiple Ciphers_ version **1.8.0** in November 2023, but it was approved only recently. In the meantime further versions of _SQLite3 Multiple Ciphers_ were released. This PR adds those new versions to the Conan recipe.

One compile time option was adjusted, namely `ENABLE_USER_AUTHENTICATION`. The _user authentication_ extension was deprecated by the SQLite core developer team. Therefore this option is now disabled by default. Most likely, the source code of this extension will be removed in a future version.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
