### PR TITLE
libdeflate: add version 1.20

### DIFF
--- a/recipes/libdeflate/all/conandata.yml
+++ b/recipes/libdeflate/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.20":
+    url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.20.tar.gz"
+    sha256: "ed1454166ced78913ff3809870a4005b7170a6fd30767dc478a09b96847b9c2a"
   "1.19":
     url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.19.tar.gz"
     sha256: "27bf62d71cd64728ff43a9feb92f2ac2f2bf748986d856133cc1e51992428c25"

--- a/recipes/libdeflate/config.yml
+++ b/recipes/libdeflate/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.20":
+    folder: "all"
   "1.19":
     folder: "all"
   "1.18":


### PR DESCRIPTION
Specify library name and version:  **libdeflate/1.20**

https://github.com/ebiggers/libdeflate/compare/v1.19...v1.20

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
