### PR TITLE
rabbitmq-c: add version 0.14.0

### DIFF
--- a/recipes/rabbitmq-c/all/conandata.yml
+++ b/recipes/rabbitmq-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.14.0":
+    url: "https://github.com/alanxz/rabbitmq-c/archive/v0.14.0.tar.gz"
+    sha256: "839b28eae20075ac58f45925fe991d16a3138cbde015db0ee11df1acb1c493df"
   "0.13.0":
     url: "https://github.com/alanxz/rabbitmq-c/archive/v0.13.0.tar.gz"
     sha256: "8b224e41bba504fc52b02f918d8df7e4bf5359d493cbbff36c06078655c676e6"

--- a/recipes/rabbitmq-c/all/conanfile.py
+++ b/recipes/rabbitmq-c/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.scm import Version
+from conan.tools.env import VirtualBuildEnv
 import os
 
 required_conan_version = ">=1.53.0"
@@ -9,10 +10,10 @@ required_conan_version = ">=1.53.0"
 
 class RabbitmqcConan(ConanFile):
     name = "rabbitmq-c"
+    description = "This is a C-language AMQP client library for use with v2.0+ of the RabbitMQ broker."
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/alanxz/rabbitmq-c"
-    description = "This is a C-language AMQP client library for use with v2.0+ of the RabbitMQ broker."
     topics = ("rabbitmq", "message queue")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
@@ -41,6 +42,10 @@ class RabbitmqcConan(ConanFile):
         if self.options.ssl:
             self.requires("openssl/[>=1.1 <4]")
 
+    def build_requirements(self):
+        if Version(self.version) >= "0.14.0":
+            self.tool_requires("cmake/[>=3.22 <4]")
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -67,6 +72,10 @@ class RabbitmqcConan(ConanFile):
         if self.options.ssl:
             deps = CMakeDeps(self)
             deps.generate()
+
+        if Version(self.version) >= "0.14.0":
+            venv = VirtualBuildEnv(self)
+            venv.generate(scope="build")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/rabbitmq-c/config.yml
+++ b/recipes/rabbitmq-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.14.0":
+    folder: all
   "0.13.0":
     folder: all
   "0.11.0":


### PR DESCRIPTION
Specify library name and version:  **rabbitmq-c/0.14.0**

https://github.com/alanxz/rabbitmq-c/compare/v0.13.0...v0.14.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
