### PR TITLE
libdrm: fix freebsd

### DIFF
--- a/recipes/libdrm/all/conanfile.py
+++ b/recipes/libdrm/all/conanfile.py
@@ -80,7 +80,7 @@ class LibdrmConan(ConanFile):
     def requirements(self):
         if self.options.intel:
             self.requires("libpciaccess/0.17")
-        if self.settings.os in ["Linux", "FreeBSD"]:
+        if self.settings.os == "Linux":
             self.requires("linux-headers-generic/6.5.9")
 
     def validate(self):
@@ -139,7 +139,7 @@ class LibdrmConan(ConanFile):
         self.cpp_info.components["libdrm_libdrm"].libs = ["drm"]
         self.cpp_info.components["libdrm_libdrm"].includedirs.append(os.path.join("include", "libdrm"))
         self.cpp_info.components["libdrm_libdrm"].set_property("pkg_config_name", "libdrm")
-        if self.settings.os in ["Linux", "FreeBSD"]:
+        if self.settings.os == "Linux":
             self.cpp_info.components["libdrm_libdrm"].requires = ["linux-headers-generic::linux-headers-generic"]
 
         if Version(self.version) < "2.4.111":


### PR DESCRIPTION
linux-headers-generic is linux only

Specify library name and version:  **libdrm/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
