### PR TITLE
opencv 4.x: re-enable quirc by default

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -203,7 +203,7 @@ class OpenCVConan(ConanFile):
         "with_msmf": True,
         "with_msmf_dxva": True,
         # objdetect module options
-        "with_quirc": False,
+        "with_quirc": True,
         # videoio module options
         "with_ffmpeg": True,
         "with_v4l": False,
@@ -350,9 +350,6 @@ class OpenCVConan(ConanFile):
             # in a big dependency graph
             if not self._has_with_wayland_option:
                 self.options.with_gtk = True
-
-        if Version(self.version) >= "4.9":
-            self.options.with_quirc = True
 
     @property
     def _opencv_modules(self):
@@ -1241,10 +1238,6 @@ class OpenCVConan(ConanFile):
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "ANDROID OR NOT UNIX", "FALSE")
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "elseif(EMSCRIPTEN)", "elseif(QNXNTO)\nelseif(EMSCRIPTEN)")
 
-        if self.options.with_quirc:
-            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "add_subdirectory(3rdparty/quirc)", "# add_subdirectory(3rdparty/quirc)")
-
-
         ## Fix link to several dependencies
         replace_in_file(self, os.path.join(self.source_folder, "modules", "imgcodecs", "CMakeLists.txt"), "JASPER_", "Jasper_")
         replace_in_file(self, os.path.join(self.source_folder, "modules", "imgcodecs", "CMakeLists.txt"), "${GDAL_LIBRARY}", "GDAL::GDAL")
@@ -1422,7 +1415,9 @@ class OpenCVConan(ConanFile):
         tc.variables["WITH_PLAIDML"] = False
         tc.variables["WITH_PVAPI"] = False
         tc.variables["WITH_QT"] = self.options.get_safe("with_qt", False)
-        tc.variables["WITH_QUIRC"] = self.options.get_safe("with_quirc", False)
+        # Do not enable WITH_QUIRC, otherwise it vendors quirc! Instead we manually inject HAVE_QUIRC
+        # when with_quirc=True, and rely on find-quirc.patch in order to link external quirc to objdetect module.
+        tc.variables["WITH_QUIRC"] = False
         tc.variables["WITH_V4L"] = self.options.get_safe("with_v4l", False)
         tc.variables["WITH_VA"] = False
         tc.variables["WITH_VA_INTEL"] = False

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -1238,6 +1238,10 @@ class OpenCVConan(ConanFile):
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "ANDROID OR NOT UNIX", "FALSE")
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "elseif(EMSCRIPTEN)", "elseif(QNXNTO)\nelseif(EMSCRIPTEN)")
 
+        ## Upstream CMakeLists vendors quirc in CMakeLists of 3rdparty/quirc.
+        ## Instead we rely on find-quirc.patch in order to link external quirc.
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "add_subdirectory(3rdparty/quirc)", "")
+
         ## Fix link to several dependencies
         replace_in_file(self, os.path.join(self.source_folder, "modules", "imgcodecs", "CMakeLists.txt"), "JASPER_", "Jasper_")
         replace_in_file(self, os.path.join(self.source_folder, "modules", "imgcodecs", "CMakeLists.txt"), "${GDAL_LIBRARY}", "GDAL::GDAL")
@@ -1415,9 +1419,7 @@ class OpenCVConan(ConanFile):
         tc.variables["WITH_PLAIDML"] = False
         tc.variables["WITH_PVAPI"] = False
         tc.variables["WITH_QT"] = self.options.get_safe("with_qt", False)
-        # Do not enable WITH_QUIRC, otherwise it vendors quirc! Instead we manually inject HAVE_QUIRC
-        # when with_quirc=True, and rely on find-quirc.patch in order to link external quirc to objdetect module.
-        tc.variables["WITH_QUIRC"] = False
+        tc.variables["WITH_QUIRC"] = self.options.get_safe("with_quirc", False)
         tc.variables["WITH_V4L"] = self.options.get_safe("with_v4l", False)
         tc.variables["WITH_VA"] = False
         tc.variables["WITH_VA_INTEL"] = False
@@ -1487,8 +1489,6 @@ class OpenCVConan(ConanFile):
         if self.options.get_safe("with_protobuf"):
             tc.variables["PROTOBUF_UPDATE_FILES"] = True
         tc.variables["WITH_ADE"] = self.options.gapi
-        if self.options.objdetect:
-            tc.variables["HAVE_QUIRC"] = self.options.with_quirc  # force usage of quirc requirement
 
         # Extra modules
         if any([self.options.get_safe(module) for module in OPENCV_EXTRA_MODULES_OPTIONS]) or self.options.with_cuda:


### PR DESCRIPTION
Revert default value of `with_quirc` option.
It has been changed by https://github.com/conan-io/conan-center-index/pull/22136, specifically by these commits: https://github.com/conan-io/conan-center-index/pull/22136/commits/a9001e4c48de8ad7ad69619e54355b06e36d7f1f & https://github.com/conan-io/conan-center-index/pull/22136/commits/b3c5e4e70bff83d0753da656e529a513e65ab92a, but I don't see any reason for these modifications.

See also https://github.com/conan-io/conan-center-index/pull/22136#discussion_r1537354793 & https://github.com/conan-io/conan-center-index/pull/22136#discussion_r1537362051

/cc @RubenRBS 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
