### PR TITLE
+ [sbepp] Added support of gcc8.1 to sbeppc

### DIFF
--- a/recipes/sbepp/all/conanfile.py
+++ b/recipes/sbepp/all/conanfile.py
@@ -37,7 +37,7 @@ class PackageConan(ConanFile):
     def _compilers_minimum_version(self):
         if self.options.with_sbeppc:
             return {
-                "gcc": "8.1",
+                "gcc": "8",
                 "clang": "9",
                 "apple-clang": "11"
             }

--- a/recipes/sbepp/all/conanfile.py
+++ b/recipes/sbepp/all/conanfile.py
@@ -37,7 +37,7 @@ class PackageConan(ConanFile):
     def _compilers_minimum_version(self):
         if self.options.with_sbeppc:
             return {
-                "gcc": "9",
+                "gcc": "8.1",
                 "clang": "9",
                 "apple-clang": "11"
             }


### PR DESCRIPTION
Specify library name and version:  **sbepp/1.2.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

This commit extends the list of supported gcc compilers up to g++ v8.1

Following is a link to the ticket:  https://github.com/conan-io/conan-center-index/issues/23205

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
