### PR TITLE
dav1d: add v1.4.1, drop vulnerable versions, deprecate with_avx512

### DIFF
--- a/recipes/dav1d/all/conandata.yml
+++ b/recipes/dav1d/all/conandata.yml
@@ -1,19 +1,10 @@
 sources:
+  "1.4.1":
+    url: "http://ftp.videolan.org/pub/videolan/dav1d/1.4.1/dav1d-1.4.1.tar.xz"
+    sha256: "8d407dd5fe7986413c937b14e67f36aebd06e1fa5cfec679d10e548476f2d5f8"
   "1.3.0":
     url: "http://ftp.videolan.org/pub/videolan/dav1d/1.3.0/dav1d-1.3.0.tar.xz"
     sha256: "6d8be2741c505c47f8f1ced3c9cc427759243436553d01d1acce201f87b39e71"
   "1.2.1":
     url: "http://ftp.videolan.org/pub/videolan/dav1d/1.2.1/dav1d-1.2.1.tar.xz"
     sha256: "4e33eb61ec54c768a16da0cf8fa0928b4c4593f5f804a3c887d4a21c318340b2"
-  "1.1.0":
-    url: "http://ftp.videolan.org/pub/videolan/dav1d/1.1.0/dav1d-1.1.0.tar.xz"
-    sha256: "fb57aae7875f28c30fb3dbae4a3683d27e2f91dde09ce5c60c22cef9bc58dfd1"
-  "1.0.0":
-    url: "http://ftp.videolan.org/pub/videolan/dav1d/1.0.0/dav1d-1.0.0.tar.xz"
-    sha256: "51737db7e4897e599684f873a4725176dd3c779e639411d7c4fce134bb5ebb82"
-  "0.9.1":
-    url: "http://ftp.videolan.org/pub/videolan/dav1d/0.9.1/dav1d-0.9.1.tar.xz"
-    sha256: "a35d6468013eb14e8093ea463594f8b89aba1775a3005fc9ec6fa36b2d2c71d7"
-  "0.8.1":
-    url: "http://ftp.videolan.org/pub/videolan/dav1d/0.8.1/dav1d-0.8.1.tar.xz"
-    sha256: "a4b503063d411dd129f5eb43616675e613b36ac0aa1e449976d645c05add21ea"

--- a/recipes/dav1d/config.yml
+++ b/recipes/dav1d/config.yml
@@ -1,13 +1,7 @@
 versions:
+  "1.4.1":
+    folder: "all"
   "1.3.0":
     folder: "all"
   "1.2.1":
-    folder: "all"
-  "1.1.0":
-    folder: "all"
-  "1.0.0":
-    folder: "all"
-  "0.9.1":
-    folder: "all"
-  "0.8.1":
     folder: "all"


### PR DESCRIPTION
Based on the vulnerability info at https://repology.org/project/dav1d/information