### PR TITLE
hwloc: add v2.10.0, drop vulnerable versions (< 2.9.3)

### DIFF
--- a/recipes/hwloc/all/conandata.yml
+++ b/recipes/hwloc/all/conandata.yml
@@ -1,19 +1,7 @@
 sources:
+  "2.10.0":
+    url: "https://download.open-mpi.org/release/hwloc/v2.10/hwloc-2.10.0.tar.bz2"
+    sha256: "0305dd60c9de2fbe6519fe2a4e8fdc6d3db8de574a0ca7812b92e80c05ae1392"
   "2.9.3":
-    sha256: "5985db3a30bbe51234c2cd26ebe4ae9b4c3352ab788b1a464c40c0483bf4de59"
-    url: https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.3.tar.gz
-  "2.9.2":
-    sha256: "ffb554d5735e0e0a19d1fd4b2b86e771d3b58b2d97f257eedacae67ade5054b3"
-    url: https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.2.tar.gz
-  "2.9.1":
-    sha256: "a440e2299f7451dc10a57ddbfa3f116c2a6c4be1bb97c663edd3b9c7b3b3b4cf"
-    url: https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.1.tar.gz
-  "2.9.0":
-    sha256: "9d7d3450e0a5fea4cb80ca07dc8db939abb7ab62e2a7bb27f9376447658738ec"
-    url: https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.0.tar.gz
-  "2.8.0":
-    sha256: "20b2bd4df436827d8e50f7afeafb6f967259f2fb374ce7330244f8d0ed2dde6f"
-    url: https://download.open-mpi.org/release/hwloc/v2.8/hwloc-2.8.0.tar.gz
-  "2.7.2":
-    sha256: "407d2712b1c9026787461ddb62044fa9b5c6007755ca37652b360d837a75344f"
-    url: https://download.open-mpi.org/release/hwloc/v2.7/hwloc-2.7.2.tar.gz
+    url: "https://download.open-mpi.org/release/hwloc/v2.9/hwloc-2.9.3.tar.bz2"
+    sha256: "5c4062ce556f6d3451fc177ffb8673a2120f81df6835dea6a21a90fbdfff0dec"

--- a/recipes/hwloc/all/conanfile.py
+++ b/recipes/hwloc/all/conanfile.py
@@ -32,7 +32,7 @@ class HwlocConan(ConanFile):
 
     def requirements(self):
         if self.options.with_libxml2:
-            self.requires("libxml2/2.12.5")
+            self.requires("libxml2/2.12.3")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/hwloc/all/conanfile.py
+++ b/recipes/hwloc/all/conanfile.py
@@ -32,7 +32,7 @@ class HwlocConan(ConanFile):
 
     def requirements(self):
         if self.options.with_libxml2:
-            self.requires("libxml2/2.12.3")
+            self.requires("libxml2/2.12.5")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/hwloc/config.yml
+++ b/recipes/hwloc/config.yml
@@ -1,13 +1,5 @@
 versions:
+  "2.10.0":
+    folder: all
   "2.9.3":
-    folder: all
-  "2.9.2":
-    folder: all
-  "2.9.1":
-    folder: all
-  "2.9.0":
-    folder: all
-  "2.8.0":
-    folder: all
-  "2.7.2":
     folder: all


### PR DESCRIPTION
Based on https://repology.org/project/hwloc/information