### PR TITLE
libid3tag: add v0.16.3 from an official fork

### DIFF
--- a/recipes/libid3tag/config.yml
+++ b/recipes/libid3tag/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.16.3":
+    folder: tenacityteam
   "0.15.1b":
     folder: all

--- a/recipes/libid3tag/tenacityteam/conandata.yml
+++ b/recipes/libid3tag/tenacityteam/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.16.3":
+    url: "https://codeberg.org/tenacityteam/libid3tag/archive/0.16.3.tar.gz"
+    sha256: "0561009778513a95d91dac33cee8418d6622f710450a7cb56a74636d53b588cb"

--- a/recipes/libid3tag/tenacityteam/conanfile.py
+++ b/recipes/libid3tag/tenacityteam/conanfile.py
@@ -1,0 +1,71 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
+from conan.tools.files import copy, get, rmdir
+
+required_conan_version = ">=1.53.0"
+
+
+class LibId3TagConan(ConanFile):
+    name = "libid3tag"
+    description = "ID3 tag manipulation library for MP3 files"
+    license = "GPL-2.0-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://codeberg.org/tenacityteam/libid3tag"
+    topics = ("mad", "id3", "MPEG", "audio", "decoder")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("zlib/[>=1.2.11 <2]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        for license_file in ["COPYRIGHT", "COPYING", "CREDITS"]:
+            copy(self, license_file, self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "id3tag")
+        self.cpp_info.set_property("cmake_target_name", "id3tag::id3tag")
+        self.cpp_info.set_property("pkg_config_name", "id3tag")
+        self.cpp_info.libs = ["id3tag"]

--- a/recipes/libid3tag/tenacityteam/test_package/CMakeLists.txt
+++ b/recipes/libid3tag/tenacityteam/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package C)
+
+find_package(id3tag REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE id3tag::id3tag)

--- a/recipes/libid3tag/tenacityteam/test_package/conanfile.py
+++ b/recipes/libid3tag/tenacityteam/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libid3tag/tenacityteam/test_package/test_package.c
+++ b/recipes/libid3tag/tenacityteam/test_package/test_package.c
@@ -1,0 +1,16 @@
+#include <id3tag.h>
+
+#include <stdio.h>
+
+int main()
+{
+    printf("id3tag version: %s\n", id3_version);
+    printf("id3tag copyright: %s\n", id3_copyright);
+    printf("id3tag author: %s\n", id3_author);
+    printf("id3tag build: %s\n", id3_build);
+
+    struct id3_tag tag;
+    id3_tag_version(&tag);
+
+    return 0;
+}


### PR DESCRIPTION
https://codeberg.org/tenacityteam/libid3tag

Used by quite a few other package repositories already: https://repology.org/project/libid3tag/versions