### PR TITLE
rapidcsv: add version 8.82

### DIFF
--- a/recipes/rapidcsv/all/conandata.yml
+++ b/recipes/rapidcsv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.82":
+    url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.82.tar.gz"
+    sha256: "4f1f57ca9db0f5447416acbef4e059cbd7cb03f6eb39fec1301732bbedaac927"
   "8.80":
     url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.80.tar.gz"
     sha256: "4c9e01cb2554cc76acac61532ef33b59e5b1f822160d2eb7efee2c128ea7f4c5"

--- a/recipes/rapidcsv/config.yml
+++ b/recipes/rapidcsv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.82":
+    folder: "all"
   "8.80":
     folder: "all"
   "8.77":


### PR DESCRIPTION
Specify library name and version:  **rapidcsv/8.82**

https://github.com/d99kris/rapidcsv/compare/v8.80...v8.82

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
