### PR TITLE
[avahi] Bump expat and glib

### DIFF
--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -45,8 +45,8 @@ class AvahiConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.78.1")
-        self.requires("expat/2.5.0")
+        self.requires("glib/2.78.3")
+        self.requires("expat/2.6.0")
         self.requires("libdaemon/0.14")
         self.requires("dbus/1.15.8")
         self.requires("gdbm/1.23")


### PR DESCRIPTION
Specify library name and version:  **avahi/0.8**

Should fix
```
ERROR: Version conflict: Conflict between expat/2.6.0 and expat/2.5.0 in the graph.
Conflict originates from dbus/1.15.8
```
