### PR TITLE
[google-cloud-cpp] fix grpc_cpp_plugin on macOS, shared

### DIFF
--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -162,7 +162,7 @@ class GoogleCloudCppConan(ConanFile):
     def build_requirements(self):
         # For the `grpc-cpp-plugin` executable, and indirectly `protoc`
         if not self._is_legacy_one_profile:
-          self.tool_requires("grpc/<host_version>")
+            self.tool_requires("grpc/<host_version>")
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -173,7 +173,7 @@ class GoogleCloudCppConan(ConanFile):
         tc.generate()
         VirtualBuildEnv(self).generate()
         if self._is_legacy_one_profile:
-          VirtualRunEnv(self).generate(scope="build")
+            VirtualRunEnv(self).generate(scope="build")
         deps = CMakeDeps(self)
         deps.generate()
 

--- a/recipes/google-cloud-cpp/2.x/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd, cross_building
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.env import VirtualRunEnv
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rmdir
 from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
@@ -71,6 +71,10 @@ class GoogleCloudCppConan(ConanFile):
     _REQUIRES_CUSTOM_DEPENDENCIES = {
         "bigquery", "bigtable", "iam", "oauth2", "pubsub", "spanner", "storage",
     }
+
+    @property
+    def _is_legacy_one_profile(self):
+        return not hasattr(self, "settings_build")
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -157,7 +161,8 @@ class GoogleCloudCppConan(ConanFile):
 
     def build_requirements(self):
         # For the `grpc-cpp-plugin` executable, and indirectly `protoc`
-        self.tool_requires("grpc/<host_version>")
+        if not self._is_legacy_one_profile:
+          self.tool_requires("grpc/<host_version>")
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -166,7 +171,9 @@ class GoogleCloudCppConan(ConanFile):
         tc.variables["GOOGLE_CLOUD_CPP_ENABLE_WERROR"] = False
         tc.variables["GOOGLE_CLOUD_CPP_ENABLE"] = ",".join(self._components())
         tc.generate()
-        VirtualRunEnv(self).generate(scope="build")
+        VirtualBuildEnv(self).generate()
+        if self._is_legacy_one_profile:
+          VirtualRunEnv(self).generate(scope="build")
         deps = CMakeDeps(self)
         deps.generate()
 

--- a/recipes/google-cloud-cpp/2.x/test_package/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/test_package/conanfile.py
@@ -14,10 +14,6 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
 
-    def build_requirements(self):
-        if not self._is_legacy_one_profile:
-            self.tool_requires("grpc/<host_version>")
-
     @property
     def _is_legacy_one_profile(self):
         return not hasattr(self, "settings_build")

--- a/recipes/google-cloud-cpp/2.x/test_package/conanfile.py
+++ b/recipes/google-cloud-cpp/2.x/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.build import can_run
-from conan.tools.env import VirtualRunEnv
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.scm import Version
 
 
@@ -13,6 +13,14 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if not self._is_legacy_one_profile:
+            self.tool_requires("grpc/<host_version>")
+
+    @property
+    def _is_legacy_one_profile(self):
+        return not hasattr(self, "settings_build")
 
     def layout(self):
         cmake_layout(self)
@@ -30,9 +38,12 @@ class TestPackageConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["WITH_COMPUTE"] = self._supports_compute()
         tc.generate()
+        if self._is_legacy_one_profile:
+            VirtualRunEnv(self).generate(scope="build")
+        else:
+            VirtualBuildEnv(self).generate()
         # Environment so that the compiled test executable can load shared libraries
-        runenv = VirtualRunEnv(self)
-        runenv.generate(scope="run")
+        VirtualRunEnv(self).generate(scope="run")
         deps = CMakeDeps(self)
         deps.generate()
 


### PR DESCRIPTION
Specify library name and version:  **google-cloud-cpp/2.x**

Fixes #23266.  I am copying (without understanding) how `grpc` uses `protobuf`. More specifically, I am copying the changes from #19972.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.