### PR TITLE
imath: add v3.1.11, drop old versions

### DIFF
--- a/recipes/imath/all/conandata.yml
+++ b/recipes/imath/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.11":
+    url: "https://github.com/AcademySoftwareFoundation/Imath/archive/v3.1.11.tar.gz"
+    sha256: "9057849585e49b8b85abe7cc1e76e22963b01bfdc3b6d83eac90c499cd760063"
   "3.1.10":
     url: "https://github.com/AcademySoftwareFoundation/Imath/archive/v3.1.10.tar.gz"
     sha256: "f2943e86bfb694e216c60b9a169e5356f8a90f18fbd34d7b6e3450be14f60b10"
@@ -8,18 +11,6 @@ sources:
   "3.1.8":
     url: "https://github.com/AcademySoftwareFoundation/Imath/archive/v3.1.8.tar.gz"
     sha256: "a23a4e2160ca8ff68607a4e129e484edd1d0d13f707394d32af7aed659020803"
-  "3.1.7":
-    url: "https://github.com/AcademySoftwareFoundation/Imath/archive/v3.1.7.tar.gz"
-    sha256: "bff1fa140f4af0e7f02c6cb78d41b9a7d5508e6bcdfda3a583e35460eb6d4b47"
-  "3.1.6":
-    url: "https://github.com/AcademySoftwareFoundation/Imath/archive/v3.1.6.tar.gz"
-    sha256: "ea5592230f5ab917bea3ceab266cf38eb4aa4a523078d46eac0f5a89c52304db"
-  "3.1.5":
-    url: "https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.5.tar.gz"
-    sha256: "1e9c7c94797cf7b7e61908aed1f80a331088cc7d8873318f70376e4aed5f25fb"
-  "3.1.4":
-    url: "https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.4.tar.gz"
-    sha256: "fcca5fbb37d375a252bacd8a29935569bdc28b888f01ef1d9299ca0c9e87c17a"
 patches:
   "3.1.10":
     - patch_file: "patches/3.1.10-gcc5-backport.patch"

--- a/recipes/imath/config.yml
+++ b/recipes/imath/config.yml
@@ -1,15 +1,9 @@
 versions:
+  "3.1.11":
+    folder: all
   "3.1.10":
     folder: all
   "3.1.9":
     folder: all
   "3.1.8":
-    folder: all
-  "3.1.7":
-    folder: all
-  "3.1.6":
-    folder: all
-  "3.1.5":
-    folder: all
-  "3.1.4":
     folder: all


### PR DESCRIPTION
https://github.com/AcademySoftwareFoundation/Imath/compare/v3.1.10...v3.1.11

It's virtually identical to v3.1.10 on CCI due to the bugfix in this relase being backported here.