### PR TITLE
zstd: add version 1.5.6

### DIFF
--- a/recipes/zstd/all/conandata.yml
+++ b/recipes/zstd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.6":
+    url: "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz"
+    sha256: "8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1"
   "1.5.5":
     url: "https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"
     sha256: "9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4"

--- a/recipes/zstd/config.yml
+++ b/recipes/zstd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.6":
+    folder: all
   "1.5.5":
     folder: all
   "1.5.4":


### PR DESCRIPTION
Specify library name and version:  **zstd/1.5.6**

https://github.com/facebook/zstd/compare/v1.5.5...v1.5.6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
