### PR TITLE
RtMidi: Replace https URLs with http ones to prevent cerificate errors

### DIFF
--- a/recipes/rtmidi/all/conandata.yml
+++ b/recipes/rtmidi/all/conandata.yml
@@ -1,12 +1,18 @@
 sources:
   "6.0.0":
-    url: "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz"
+    url:
+      - "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz"
+      - "http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz"
     sha256: "5960ccf64b42c23400720ccc880e2f205677ce9457f747ef758b598acd64db5b"
   "5.0.0":
-    url: "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
+    url:
+      - "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
+      - "http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
     sha256: "48db0ed58c8c0e207b5d7327a0210b5bcaeb50e26387935d02829239b0f3c2b9"
   "4.0.0":
-    url: "http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-4.0.0.tar.gz"
+    url:
+      - "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-4.0.0.tar.gz"
+      - "http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-4.0.0.tar.gz"
     sha256: "370cfe710f43fbeba8d2b8c8bc310f314338c519c2cf2865e2d2737b251526cd"
 patches:
   "4.0.0":


### PR DESCRIPTION
Specify library name and version:  **rtmidi/5.0**, **rtmidi/6.0**

The SSL cerificate on the server is broken - missing cerificate chain - and won't validate correctly via conan download, wget etc.
(Firefox contains the R3 Let's encrypt certificate so it validates correctly.)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
