### PR TITLE
libvips 8.15.2: fix url of tarball

### DIFF
--- a/recipes/libvips/all/conandata.yml
+++ b/recipes/libvips/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "8.15.2":
-    url: "https://github.com/libvips/libvips/releases/download/v8.15.2a/vips-8.15.2.tar.xz"
+    url: "https://github.com/libvips/libvips/releases/download/v8.15.2/vips-8.15.2.tar.xz"
     sha256: "a2ab15946776ca7721d11cae3215f20f1f097b370ff580cd44fc0f19387aee84"
   "8.15.1":
     url: "https://github.com/libvips/libvips/releases/download/v8.15.1/vips-8.15.1.tar.xz"


### PR DESCRIPTION
This PR fixes url of 8.15.2 tarball.

Indeed, when I try to build from source, I get this error:

```
ERROR: libvips/8.15.2: Error in source() method, line 233
	get(self, **self.conan_data["sources"][self.version], strip_root=True)
	NotFoundException: Not found: https://github.com/libvips/libvips/releases/download/v8.15.2a/vips-8.15.2.tar.xz
```

Url provided by https://github.com/conan-io/conan-center-index/pull/23107 is weird. I guess it was correct when it has been submitted, but it's not anymore.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
