### PR TITLE
mbedtls: add version 3.6.0

### DIFF
--- a/recipes/mbedtls/all/conandata.yml
+++ b/recipes/mbedtls/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.0":
+    url: "https://github.com/Mbed-TLS/mbedtls/releases/download/v3.6.0/mbedtls-3.6.0.tar.bz2"
+    sha256: "3ecf94fcfdaacafb757786a01b7538a61750ebd85c4b024f56ff8ba1490fcd38"
   "3.5.2":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-3.5.2.tar.gz"
     sha256: "eedecc468b3f8d052ef05a9d42bf63f04c8a1c50d1c5a94c251c681365a2c723"

--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -100,6 +100,7 @@ class MBedTLSConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "cmake"))
 
     def package_info(self):
@@ -110,16 +111,22 @@ class MBedTLSConan(ConanFile):
         self.cpp_info.components["mbedcrypto"].libs = ["mbedcrypto"]
         if self.settings.os == "Windows":
             self.cpp_info.components["mbedcrypto"].system_libs = ["bcrypt"]
+        if Version(self.version) >= "3.6.0":
+            self.cpp_info.components["mbedcrypto"].set_property("pkg_config_name", "mbedcrypto")
 
         self.cpp_info.components["mbedx509"].set_property("cmake_target_name", "MbedTLS::mbedx509")
         self.cpp_info.components["mbedx509"].libs = ["mbedx509"]
         if self.settings.os == "Windows":
             self.cpp_info.components["mbedx509"].system_libs = ["ws2_32"]
         self.cpp_info.components["mbedx509"].requires = ["mbedcrypto"]
+        if Version(self.version) >= "3.6.0":
+            self.cpp_info.components["mbedx509"].set_property("pkg_config_name", "mbedx509")
 
         self.cpp_info.components["libembedtls"].set_property("cmake_target_name", "MbedTLS::mbedtls")
         self.cpp_info.components["libembedtls"].libs = ["mbedtls"]
         self.cpp_info.components["libembedtls"].requires = ["mbedx509"]
+        if Version(self.version) >= "3.6.0":
+            self.cpp_info.components["libembedtls"].set_property("pkg_config_name", "embedtls")
 
         if self.options.get_safe("with_zlib"):
             for component in self.cpp_info.components:

--- a/recipes/mbedtls/config.yml
+++ b/recipes/mbedtls/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.0":
+    folder: all
   "3.5.2":
     folder: all
   "3.5.1":


### PR DESCRIPTION
Specify library name and version:  **mbedtls/3.6.0**

https://github.com/Mbed-TLS/mbedtls/compare/v3.5.2...v3.6.0

The source code structure has been changed since 3.6.0, and the `framework` is now referenced by submodules.
For this reason, a download tarball is now provided.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
