### PR TITLE
fix: duckdb 0.10.1 jemalloc no longer built for non ARM Linux

### DIFF
--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -232,7 +232,8 @@ class DuckdbConan(ConanFile):
                 self.cpp_info.libs.append("visualizer_extension")
             if self.options.with_httpfs:
                 self.cpp_info.libs.append("httpfs_extension")
-            if Version(self.version) >= "0.6.0" and self.settings.os == "Linux":
+            if (Version(self.version) >= "0.6.0" and self.settings.os == "Linux" and 
+                (Version(self.version) < "0.10.1" or self.settings.arch == "x86_64")):
                 self.cpp_info.libs.append("jemalloc_extension")
             if self.options.with_json:
                 self.cpp_info.libs.append("json_extension")


### PR DESCRIPTION
Specify library name and version:  **duckdb/0.10.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The recipe did not build on ARM Linux.

Here is an analog change in the setup.py provided by duckdb:
https://github.com/duckdb/duckdb/commit/4a89d97db8a5a23a15f3025c8d2d2885337c2637

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
