### PR TITLE
Add LibRaw 0.22.0-Devel202403 development snapshot with a ton of newl…

### DIFF
--- a/recipes/libraw/all/conandata.yml
+++ b/recipes/libraw/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.22.0-devel202403":
+    url: "https://github.com/irieger/LibRaw/archive/0.22.0-Devel202403.tar.gz"
+    sha256: "c22c38b4a6b27e2ba08f0bf11c55974bcde9810cf332006d5c3744210ebb9135"
   "0.21.2":
     url: "https://github.com/LibRaw/LibRaw/archive/0.21.2.tar.gz"
     sha256: "7ac056e0d9e814d808f6973a950bbf45e71b53283eed07a7ea87117a6c0ced96"

--- a/recipes/libraw/config.yml
+++ b/recipes/libraw/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.22.0-devel202403":
+    folder: all
   "0.21.2":
     folder: all
   "0.21.1":


### PR DESCRIPTION
Specify library name and version:  **libraw/0.22.0-devel202403**

Add LibRaw 0.22.0-Devel202403 development snapshot with a ton of newly supported image file formats. As there is only irregular releases every ~18 Months for LibRaw, development snapshot versions are offered to allow early access to features. As LibRaw is a library to read raw photo image formats and there is often new cameras introduced with slight changes in the image format, regular updates are helpful.

Is it viable to introduce this to cci? Already added it to my local artifactory so not too urgent for me but I'd assume this can also be helpful for other users.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
