### PR TITLE
libnghttp2: add version 1.60.0, disable tests and examples build

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.60.0":
+    url: "https://github.com/nghttp2/nghttp2/archive/v1.60.0.tar.gz"
+    sha256: "3cc9403c64e0a133868f62132ff0884cd5dc567eee5bd7b2d03ac81293695d6b"
   "1.59.0":
     url: "https://github.com/nghttp2/nghttp2/archive/v1.59.0.tar.gz"
     sha256: "0dd5c980f1262ff5f03676fd99f46f250b66c842f7d864fa1ca9f8453e5f8868"

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -99,6 +99,9 @@ class Nghttp2Conan(ConanFile):
         tc.variables["WITH_JEMALLOC"] = self.options.get_safe("with_jemalloc", False)
         if Version(self.version) < "1.52.0":
             tc.variables["ENABLE_ASIO_LIB"] = self.options.with_asio
+        # To avoid overwriting dll import lib by static lib
+        if Version(self.version) >= "1.60.0" and self.options.shared:
+            tc.variables["STATIC_LIB_SUFFIX"] = "-static"
         if is_apple_os(self):
             # workaround for: install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
             tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
@@ -153,6 +156,7 @@ class Nghttp2Conan(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.components["nghttp2"].set_property("pkg_config_name", "libnghttp2")

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.60.0":
+    folder: all
   "1.59.0":
     folder: all
   "1.58.0":


### PR DESCRIPTION
Specify library name and version:  **libnghttp2/***

https://github.com/nghttp2/nghttp2/compare/v1.59.0...v1.60.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
