### PR TITLE
suitesparse-graphblas: new recipe

### DIFF
--- a/recipes/suitesparse-graphblas/all/conandata.yml
+++ b/recipes/suitesparse-graphblas/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "9.1.0":
+    url: "https://github.com/DrTimothyAldenDavis/GraphBLAS/archive/refs/tags/v9.1.0.tar.gz"
+    sha256: "f3e9c3abc5cc5a4d561f56c659c94f2d08058dc7ccdbe8cb92d8dc833b8ea6e0"

--- a/recipes/suitesparse-graphblas/all/conanfile.py
+++ b/recipes/suitesparse-graphblas/all/conanfile.py
@@ -1,0 +1,116 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv, Environment
+from conan.tools.files import copy, get, rm, rmdir
+
+required_conan_version = ">=1.53.0"
+
+
+class SuiteSparseGraphBlasConan(ConanFile):
+    name = "suitesparse-graphblas"
+    description = "SuiteSparse:GraphBLAS: graph algorithms in the language of linear algebra"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://people.engr.tamu.edu/davis/GraphBLAS.html"
+    topics = ("graph-algorithms", "mathematics", "sparse-matrix", "linear-algebra")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "compact": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "compact": True,
+    }
+    options_description = {
+        "compact": ("If True, disable creation of many fast FactoryKernels at compile time. "
+                    "The necessary kernels are compiled at run-time, via JIT, instead and "
+                    "performance will be the same. JIT-compiled kernels are placed in <package_folder>/share. "
+                    "Non-compact builds are significantly slower to compile and produce a larger library (both about 15x).")
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        # note: C++ is used if CUDA is enabled
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # OpenMP is not used in any public headers
+        self.requires("llvm-openmp/17.0.6")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.20 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    @property
+    def _jit_cache_dir(self):
+        return os.path.join(self.package_folder, "share")
+
+    def generate(self):
+        venv = VirtualBuildEnv(self)
+        venv.generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.variables["BUILD_STATIC_LIBS"] = not self.options.shared
+        tc.variables["GRAPHBLAS_COMPACT"] = self.options.compact
+        tc.variables["GRAPHBLAS_USE_OPENMP"] = True
+        tc.variables["GRAPHBLAS_USE_CUDA"] = False  # experimental, not ready for production as of 9.1.0
+        tc.variables["SUITESPARSE_USE_CUDA"] = False
+        tc.variables["SUITESPARSE_USE_STRICT"] = True  # require dependencies to be handled explicitly
+        tc.variables["SUITESPARSE_USE_FORTRAN"] = False  # Fortran sources are translated to C instead
+        tc.variables["SUITESPARSE_DEMOS"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        env = Environment()
+        env.define_path("GRAPHBLAS_CACHE_PATH", self._jit_cache_dir)
+        env.vars(self).save_script("graphblas_jit_cache")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.libs = ["graphblas"]
+        self.cpp_info.set_property("cmake_file_name", "GraphBLAS")
+        self.cpp_info.set_property("cmake_target_name", "SuiteSparse::GraphBLAS")
+        if not self.options.shared:
+            self.cpp_info.set_property("cmake_target_aliases", ["SuiteSparse::GraphBLAS_static"])
+        self.cpp_info.set_property("pkg_config_name", "GraphBLAS")
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["m", "pthread", "dl"])
+
+        # FIXME: The JIT cache contains both input sources as well as the compilation cache.
+        # The latter should not be located under the Conan package folder.
+        self.buildenv_info.define_path("GRAPHBLAS_CACHE_PATH", self._jit_cache_dir)
+        self.runenv_info.define_path("GRAPHBLAS_CACHE_PATH", self._jit_cache_dir)

--- a/recipes/suitesparse-graphblas/all/test_package/CMakeLists.txt
+++ b/recipes/suitesparse-graphblas/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(GraphBLAS REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE SuiteSparse::GraphBLAS)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/suitesparse-graphblas/all/test_package/conanfile.py
+++ b/recipes/suitesparse-graphblas/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/suitesparse-graphblas/all/test_package/test_package.c
+++ b/recipes/suitesparse-graphblas/all/test_package/test_package.c
@@ -1,0 +1,12 @@
+#include <GraphBLAS.h>
+
+int main() {
+  GrB_Index const NUM_NODES = 3;
+  GrB_Index const NUM_EDGES = 4;
+  GrB_Index row_indices[] = {0, 1, 1, 2};
+  GrB_Index col_indices[] = {1, 0, 2, 1};
+  bool values[] = {true, true, true, true};
+  GrB_Matrix graph;
+  GrB_Matrix_new(&graph, GrB_BOOL, NUM_NODES, NUM_NODES);
+  GrB_Matrix_build(graph, row_indices, col_indices, (bool *)values, NUM_EDGES, GrB_LOR);
+}

--- a/recipes/suitesparse-graphblas/config.yml
+++ b/recipes/suitesparse-graphblas/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "9.1.0":
+    folder: all


### PR DESCRIPTION
Adds SuiteSparse:GraphBLAS: https://github.com/DrTimothyAldenDavis/GraphBLAS

It's the reference implementation for GraphBLAS: https://graphblas.org/

Required for packaging of SuiteSparse.

Requires #22353.

`suitesparse-graphblas`:
[![Packaging status](https://repology.org/badge/tiny-repos/suitesparse-graphblas.svg)](https://repology.org/project/suitesparse-graphblas/versions)

`graphblas`:
[![Packaging status](https://repology.org/badge/tiny-repos/graphblas.svg)](https://repology.org/project/graphblas/versions)
