### PR TITLE
[libunwind] Fix: Generate new recipe revision to upload it as the latest

### DIFF
--- a/recipes/libunwind/all/conanfile.py
+++ b/recipes/libunwind/all/conanfile.py
@@ -2,7 +2,14 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualRunEnv
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
+from conan.tools.files import (
+    apply_conandata_patches,
+    copy,
+    export_conandata_patches,
+    get,
+    rm,
+    rmdir,
+)
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
 from conan.tools.layout import basic_layout
 
@@ -10,6 +17,7 @@ import os
 import shutil
 
 required_conan_version = ">=1.53.0"
+
 
 class LiunwindConan(ConanFile):
     name = "libunwind"
@@ -59,7 +67,9 @@ class LiunwindConan(ConanFile):
 
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:
-            raise ConanInvalidConfiguration("libunwind is only supported on Linux and FreeBSD")
+            raise ConanInvalidConfiguration(
+                "libunwind is only supported on Linux and FreeBSD"
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -71,15 +81,17 @@ class LiunwindConan(ConanFile):
 
         tc = AutotoolsToolchain(self)
         yes_no = lambda v: "yes" if v else "no"
-        tc.configure_args.extend([
-            f"--enable-coredump={yes_no(self.options.coredump)}",
-            f"--enable-ptrace={yes_no(self.options.ptrace)}",
-            f"--enable-setjmp={yes_no(self.options.setjmp)}",
-            f"--enable-minidebuginfo={yes_no(self.options.minidebuginfo)}",
-            f"--enable-zlibdebuginfo={yes_no(self.options.zlibdebuginfo)}",
-            "--disable-tests",
-            "--disable-documentation",
-        ])
+        tc.configure_args.extend(
+            [
+                f"--enable-coredump={yes_no(self.options.coredump)}",
+                f"--enable-ptrace={yes_no(self.options.ptrace)}",
+                f"--enable-setjmp={yes_no(self.options.setjmp)}",
+                f"--enable-minidebuginfo={yes_no(self.options.minidebuginfo)}",
+                f"--enable-zlibdebuginfo={yes_no(self.options.zlibdebuginfo)}",
+                "--disable-tests",
+                "--disable-documentation",
+            ]
+        )
         tc.generate()
 
         tc = AutotoolsDeps(self)
@@ -92,7 +104,12 @@ class LiunwindConan(ConanFile):
         autotools.make()
 
     def package(self):
-        copy(self, pattern="COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(
+            self,
+            pattern="COPYING",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
         autotools = Autotools(self)
         autotools.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
@@ -102,8 +119,10 @@ class LiunwindConan(ConanFile):
         # As this seems to be unnecessary for the conan package.
         # rename the real file to libunwind_generic,
         lib_ext = "so" if self.options.shared else "a"
-        symlink_path = os.path.join(self.package_folder, "lib", f"libunwind-generic.{lib_ext}")
-        source_path =  os.path.realpath(symlink_path)
+        symlink_path = os.path.join(
+            self.package_folder, "lib", f"libunwind-generic.{lib_ext}"
+        )
+        source_path = os.path.realpath(symlink_path)
         rm(self, os.path.basename(symlink_path), os.path.dirname(symlink_path))
         shutil.copy(source_path, symlink_path)
 
@@ -116,18 +135,26 @@ class LiunwindConan(ConanFile):
             self.cpp_info.components["unwind"].requires.append("zlib::zlib")
         if self.settings.os == "Linux":
             self.cpp_info.components["unwind"].system_libs.append("pthread")
-        self.cpp_info.components["generic"].set_property("pkg_config_name", "libunwind-generic")
+        self.cpp_info.components["generic"].set_property(
+            "pkg_config_name", "libunwind-generic"
+        )
         self.cpp_info.components["generic"].libs = ["unwind-generic"]
         self.cpp_info.components["generic"].requires = ["unwind"]
         if self.options.ptrace:
-            self.cpp_info.components["ptrace"].set_property("pkg_config_name", "libunwind-ptrace")
+            self.cpp_info.components["ptrace"].set_property(
+                "pkg_config_name", "libunwind-ptrace"
+            )
             self.cpp_info.components["ptrace"].libs = ["unwind-ptrace"]
             self.cpp_info.components["ptrace"].requires = ["generic", "unwind"]
         if self.options.setjmp:
-            self.cpp_info.components["setjmp"].set_property("pkg_config_name", "libunwind-setjmp")
+            self.cpp_info.components["setjmp"].set_property(
+                "pkg_config_name", "libunwind-setjmp"
+            )
             self.cpp_info.components["setjmp"].libs = ["unwind-setjmp"]
             self.cpp_info.components["setjmp"].requires = ["unwind"]
         if self.options.coredump:
-            self.cpp_info.components["coredump"].set_property("pkg_config_name", "libunwind-coredump")
+            self.cpp_info.components["coredump"].set_property(
+                "pkg_config_name", "libunwind-coredump"
+            )
             self.cpp_info.components["coredump"].libs = ["unwind-coredump"]
             self.cpp_info.components["coredump"].requires = ["generic", "unwind"]


### PR DESCRIPTION
In https://github.com/conan-io/conan-center-index/pull/23312 the recipe revision was already uploaded to conan center repo at https://github.com/conan-io/conan-center-index/pull/23204, so the recipe revision was not uploaded as the latest one. This still causes some issues in dependencies that require this library regarding https://github.com/conan-io/conan-center-index/issues/23310

This PR introduces some formatting to the recipe with just the purpose of generating a new recipe revision that is uploaded as latest to solve the situation.
