### PR TITLE
commata: add version 0.2.9

### DIFF
--- a/recipes/commata/all/conandata.yml
+++ b/recipes/commata/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.9":
+    url: "https://github.com/furfurylic/commata/archive/refs/tags/v0.2.9.tar.gz"
+    sha256: "24c404e90e2f01a2f9e46e55c2f8121a3f146d1f2dfb819b8d7ab5cf13bd6a9f"
   "0.2.8":
     url: "https://github.com/furfurylic/commata/archive/refs/tags/v0.2.8.tar.gz"
     sha256: "a762ec3ef1549aa5aebef78a160a40ee16d396fd976154f1f5c160837d145c8a"

--- a/recipes/commata/config.yml
+++ b/recipes/commata/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.9":
+    folder: all
   "0.2.8":
     folder: all
   "0.2.7":


### PR DESCRIPTION
Specify library name and version:  **commata/0.2.9**

https://github.com/furfurylic/commata/compare/v0.2.8...v0.2.9

--

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
