### PR TITLE
cpr/1.10.5: Compute OpenSSL include path when not correctly configured by Conan/CMake.

### DIFF
--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -19,6 +19,9 @@ patches:
     - patch_file: "patches/008-1.10.0-remove-warning-flags.patch"
       patch_description: "disable warning flags and warning as error"
       patch_type: "portability"
+    - patch_file: "patches/009-1.10.5.missing-openssl-includes.patch"
+      patch_description: "OpenSSL include paths are not found when building with the Android NDK."
+      patch_type: "portability"
   "1.10.4":
     - patch_file: "patches/008-1.10.0-remove-warning-flags.patch"
       patch_description: "disable warning flags and warning as error"

--- a/recipes/cpr/all/patches/009-1.10.5.missing-openssl-includes.patch
+++ b/recipes/cpr/all/patches/009-1.10.5.missing-openssl-includes.patch
@@ -1,0 +1,19 @@
+diff --git a/cpr/CMakeLists.txt b/cpr/CMakeLists.txt
+index 52787f5..e663cce 100644
+--- a/cpr/CMakeLists.txt
++++ b/cpr/CMakeLists.txt
+@@ -37,6 +37,14 @@ target_link_libraries(cpr PUBLIC CURL::libcurl) # todo should be private, but fi
+ # Fix missing OpenSSL includes for Windows since in 'ssl_ctx.cpp' we include OpenSSL directly
+ if(SSL_BACKEND_USED STREQUAL "OpenSSL")
+         target_link_libraries(cpr PRIVATE OpenSSL::SSL)
++
++        if(NOT OPENSSL_INCLUDE_DIR)
++                message(STATUS "OPENSSL_INCLUDE_DIR not set, computing it from OpenSSL::SSL target link directories.")
++                get_target_property(OPENSSL_LINK_DIRS OpenSSL::SSL INTERFACE_LINK_DIRECTORIES)
++                list(GET OPENSSL_LINK_DIRS 0 OPENSSL_LINK_DIR)
++                set(OPENSSL_INCLUDE_DIR "${OPENSSL_LINK_DIR}/../include")
++        endif()
++
+         target_include_directories(cpr PRIVATE ${OPENSSL_INCLUDE_DIR})
+ endif()
+ 


### PR DESCRIPTION
Specify library name and version:  **cpr/1.10.5**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Fixes https://github.com/conan-io/conan-center-index/issues/23327. 

When building for Android with the NDK (external & tool_requires), the OpenSSL headers cannot be found:
```
src/cpr/ssl_ctx.cpp:8:10: fatal error: 'openssl/err.h' file not found
```

This is because while the OpenSSL package is found, the `OPENSSL_INCLUDE_DIR` variable is not set. The usual workaround for this seems to be setting the `OPENSSL_ROOT_DIR` variable in the environment (or by passing it directly to CMake with `-DOPENSSL_ROOT_DIR`), which is a bit impractical when the build is happening in the middle of a package dependency tree. 

An alternative solution is to instead compute the include path from the link paths, which are set correctly, when it is found to be unset. This seems to work well here and doesn't impact currently working builds, since `OPENSSL_INCLUDE_DIR` will already be set in those cases.

This is not an ideal fix, but it's the best I could come up with while avoiding hard coding paths or requiring manual intervention by passing in extra configuration etc. I'm open to better fixes if anyone has suggestions. If/when this is merged, I'll look at putting in a PR with the upstream project so that we don't have to have this patch long term.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
