### PR TITLE
gfortran: revive and redesign deprecated recipe

### DIFF
--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -1,7 +1,11 @@
 sources:
   "13.2.0":
-    url:
-      - "https://mirrors.dotsrc.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
-      - "https://ftpmirror.gnu.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
-      - "https://gcc.gnu.org/ftp/gcc/releases/gcc-13.2.0/gcc-13.2.0.tar.xz"
-    sha256: "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da"
+    sources:
+      url:
+        - "https://mirrors.dotsrc.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
+        - "https://ftpmirror.gnu.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
+        - "https://gcc.gnu.org/ftp/gcc/releases/gcc-13.2.0/gcc-13.2.0.tar.xz"
+      sha256: "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da"
+    homebrew-patches:
+      url: "https://raw.githubusercontent.com/Homebrew/formula-patches/3c5cbc8e9cf444a1967786af48e430588e1eb481/gcc/gcc-13.2.0.diff"
+      sha256: "2df7ef067871a30b2531a2013b3db661ec9e61037341977bfc451e30bf2c1035"

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -1,14 +1,7 @@
 sources:
-  "10.2":
-    "Windows":
-      "x86_64":
-        url: "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z"
-        sha256: "5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44"
-    "Linux":
-      "x86_64":
-        url: "https://gfortran.meteodat.ch/download/x86_64/releases/gcc-10.2.0.tar.xz"
-        sha256: "5cfaf152db442bb967963ca62d4590980cb2664c5902c1a9578fc8a9c6efe40f"
-    "Macos":
-      "x86_64":
-        url: "https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz"
-        sha256: "2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666"
+  "13.2.0":
+    url:
+      - "https://mirrors.dotsrc.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
+      - "https://ftpmirror.gnu.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
+      - "https://gcc.gnu.org/ftp/gcc/releases/gcc-13.2.0/gcc-13.2.0.tar.xz"
+    sha256: "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da"

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -89,6 +89,7 @@ class GFortranConan(ConanFile):
         tc.configure_args.append("--disable-nls")
         tc.configure_args.append("--disable-multilib")
         tc.configure_args.append("--disable-bootstrap")
+        tc.configure_args.append("--disable-fixincludes")
         tc.configure_args.append(f"--with-zlib={self.dependencies['zlib'].package_folder}")
         tc.configure_args.append(f"--with-isl={self.dependencies['isl'].package_folder}")
         tc.configure_args.append(f"--with-gmp={self.dependencies['gmp'].package_folder}")

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -129,15 +129,16 @@ class GFortranConan(ConanFile):
     @property
     def _gfortran_full_executable(self):
         # e.g. x86_64-pc-linux-gnu
-        triplet = os.listdir(os.path.join(self.package_folder, "libexec", "gcc"))[0]
+        triplet = os.listdir(os.path.join(self.package_folder, "lib", "gcc"))[0]
         return f"{triplet}-gfortran-{self.version}"
 
     def package(self):
         copy(self, "COPYING*", self.source_folder, os.path.join(self.package_folder, "licenses"), keep_path=False)
         autotools = Autotools(self)
         autotools.install(target="install-strip")
-        rmdir(self, os.path.join(self.package_folder, "share"))
         rm(self, "*.la", self.package_folder, recursive=True)
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "libexec"))
 
         # Export shared libraries only
         # libssp_nonshared does not appear to be a critical component.

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -140,10 +140,9 @@ class GFortranConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "libexec"))
 
-        # Export shared libraries only
-        # libssp_nonshared does not appear to be a critical component.
-        # https://github.com/intc/libssp-nonshared/blob/master/README
-        rm(self, "libssp_nonshared.a", os.path.join(self.package_folder, "lib"))
+        # Don't export static libraries.
+        # This removes only libssp_nonshared.a as of v13.2.
+        rm(self, "*.a", os.path.join(self.package_folder, "lib"))
 
         # Drop ar, nm, ranlib, cpp, etc. to not clash with the existing C/C++ toolchain
         for f in self.package_path.joinpath("bin").iterdir():

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -138,10 +138,9 @@ class GFortranConan(ConanFile):
         autotools.install(target="install-strip")
         rm(self, "*.la", self.package_folder, recursive=True)
         rmdir(self, os.path.join(self.package_folder, "share"))
-        rmdir(self, os.path.join(self.package_folder, "libexec"))
 
         # Don't export static libraries.
-        # This removes only libssp_nonshared.a as of v13.2.
+        # This only removes libssp_nonshared.a as of v13.2.
         rm(self, "*.a", os.path.join(self.package_folder, "lib"))
 
         # Drop ar, nm, ranlib, cpp, etc. to not clash with the existing C/C++ toolchain
@@ -171,9 +170,18 @@ class GFortranConan(ConanFile):
         # libssp.so: Stack Smashing Protector library
         self.cpp_info.components["libssp"].libs = ["ssp"]
 
+        self.cpp_info.components["executables"].bindirs = ["bin", "libexec"]
+        self.cpp_info.components["executables"].requires = [
+            "mpc::mpc",
+            "mpfr::mpfr",
+            "gmp::gmp",
+            "zlib::zlib",
+            "isl::isl",
+        ]
+
         gfortran_path = os.path.join(self.package_folder, "bin", self._gfortran_full_executable)
         self.buildenv_info.define_path("FC", gfortran_path)
 
         # TODO: Legacy, remove when Conan v1 support is dropped
-        self.env_info.PATH = os.path.join(self.package_folder, "bin")
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
         self.env_info.FC = gfortran_path

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -70,7 +70,7 @@ class GFortranConan(ConanFile):
         if self.settings.os == "Linux":
             # binutils recipe is broken for Macos, and Windows uses tools
             # distributed with msys/mingw
-            self.tool_requires("binutils/2.41")
+            self.tool_requires("binutils/2.42")
         self.tool_requires("flex/2.6.4")
 
     def source(self):

--- a/recipes/gfortran/all/test_package/CMakeLists.txt
+++ b/recipes/gfortran/all/test_package/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES Fortran)
+
+message("CMAKE_Fortran_COMPILER: ${CMAKE_Fortran_COMPILER}")
+
+add_executable(${PROJECT_NAME} test_package.f90)

--- a/recipes/gfortran/all/test_package/conanfile.py
+++ b/recipes/gfortran/all/test_package/conanfile.py
@@ -1,14 +1,44 @@
+import os
+
 from conan import ConanFile
 from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMakeToolchain, CMake
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualBuildEnv"
     test_type = "explicit"
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        buildenv = VirtualBuildEnv(self)
+        buildenv.generate()
+
+        # Hack to avoid adding tool_requires(self.tested_reference_str),
+        # which tends to fail with a missing binaries error
+        runenv = VirtualRunEnv(self)
+        runenv.generate(scope="build")
+        runenv.generate(scope="run")
+
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+
+    def build(self):
+        if can_run(self):
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
 
     def test(self):
         if can_run(self):
-            self.run("gfortran --version")
+            self.run("$FC --version", env="conanbuild")
+            self.run("$FC -dumpversion", env="conanbuild")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gfortran/all/test_package/test_package.f90
+++ b/recipes/gfortran/all/test_package/test_package.f90
@@ -1,0 +1,4 @@
+program hello
+  implicit none
+  write(*,*) 'gfortran: Hello, World!'
+end program hello

--- a/recipes/gfortran/config.yml
+++ b/recipes/gfortran/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "10.2":
+  "13.2.0":
     folder: all


### PR DESCRIPTION
This PR revives the `gfortran` recipe by adapting the GCC recipe from #21193 to focus solely on GFortran.

There is currently no usable Fortran compiler available on CCI, which is limiting for quite a few numerics libraries.

I don't think melding GFortran with the broader GCC recipe was a good idea. The additional C and C++ compilers plus the rest of the toolchain provided by the recipe are not required for Fortran compilation and they are only very likely to cause issues by accidentally overriding the C/C++ compiler. Plus, it makes for a slightly smaller package to download as well.
