### PR TITLE
cpr: Fix build with openssl on Windows and Android (#23251, #23327) 

### DIFF
--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -86,7 +86,8 @@ class CprConan(ConanFile):
         # FIXME: This is a very dirty hack.
         # with_ssl == _AUTO_SSL, cpr needs the openssl header to compile. But Conan recipe does not know which SSL library to use.
         # because cpr's CMakeLists.txt automatically detects SSL libraries with CPR_ENABLE_SSL == ON.
-        if (self.settings.os in ["Linux", "FreeBSD"] and self.options.with_ssl == CprConan._AUTO_SSL) or self.options.with_ssl == "openssl":
+        if ((self.settings.os in ["Linux", "FreeBSD", "Android"] and self.options.with_ssl == CprConan._AUTO_SSL) or
+            self.options.with_ssl == "openssl"):
             self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):
@@ -102,7 +103,7 @@ class CprConan(ConanFile):
             raise ConanInvalidConfiguration(f"Cannot compile {self.ref} with libstdc++ on clang < 9")
 
         ssl_library = str(self.options.with_ssl)
-        
+
         if ssl_library == "openssl" and is_apple_os(self):
             raise ConanInvalidConfiguration("OpenSSL is not supported on macOS")
         if ssl_library == "darwinssl" and not is_apple_os(self):

--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -86,7 +86,7 @@ class CprConan(ConanFile):
         # FIXME: This is a very dirty hack.
         # with_ssl == _AUTO_SSL, cpr needs the openssl header to compile. But Conan recipe does not know which SSL library to use.
         # because cpr's CMakeLists.txt automatically detects SSL libraries with CPR_ENABLE_SSL == ON.
-        if self.settings.os in ["Linux", "FreeBSD"] and self.options.with_ssl in ["openssl", CprConan._AUTO_SSL]:
+        if (self.settings.os in ["Linux", "FreeBSD"] and self.options.with_ssl == CprConan._AUTO_SSL) or self.options.with_ssl == "openssl":
             self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):

--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -12,9 +12,6 @@ required_conan_version = ">=1.53.0"
 
 
 class CprConan(ConanFile):
-    _AUTO_SSL = "auto"
-    _NO_SSL = "off"
-
     name = "cpr"
     description = "C++ Requests: Curl for People, a spiritual port of Python Requests"
     license = "MIT"
@@ -27,14 +24,14 @@ class CprConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_ssl": ["openssl", "darwinssl", "winssl", _AUTO_SSL, _NO_SSL],
+        "with_ssl": [False, "openssl", "darwinssl", "winssl"],
         "signal": [True, False],
         "verbose_logging": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_ssl": _AUTO_SSL,
+        "with_ssl": "openssl",
         "signal": True,
         "verbose_logging": False,
     }
@@ -70,6 +67,10 @@ class CprConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            self.options.with_ssl = "winssl"
+
+        if is_apple_os(self):
+            self.options.with_ssl = "darwinssl"
 
         if Version(self.version) < "1.10.0":
             del self.options.verbose_logging
@@ -83,11 +84,7 @@ class CprConan(ConanFile):
 
     def requirements(self):
         self.requires("libcurl/[>=7.78.0 <9]", transitive_headers=True, transitive_libs=True)
-        # FIXME: This is a very dirty hack.
-        # with_ssl == _AUTO_SSL, cpr needs the openssl header to compile. But Conan recipe does not know which SSL library to use.
-        # because cpr's CMakeLists.txt automatically detects SSL libraries with CPR_ENABLE_SSL == ON.
-        if ((self.settings.os in ["Linux", "FreeBSD", "Android"] and self.options.with_ssl == CprConan._AUTO_SSL) or
-            self.options.with_ssl == "openssl"):
+        if self.options.with_ssl == "openssl":
             self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):
@@ -102,24 +99,25 @@ class CprConan(ConanFile):
         if not self._uses_valid_abi_and_compiler:
             raise ConanInvalidConfiguration(f"Cannot compile {self.ref} with libstdc++ on clang < 9")
 
-        ssl_library = str(self.options.with_ssl)
+        if self.options.with_ssl:
+            ssl_library = str(self.options.with_ssl)
 
-        if ssl_library == "openssl" and is_apple_os(self):
-            raise ConanInvalidConfiguration("OpenSSL is not supported on macOS")
-        if ssl_library == "darwinssl" and not is_apple_os(self):
-            raise ConanInvalidConfiguration("DarwinSSL is only supported on macOS")
-        if ssl_library == "winssl" and self.settings.os != "Windows":
-            raise ConanInvalidConfiguration("WinSSL is only on Windows")
+            if ssl_library == "openssl" and is_apple_os(self):
+                raise ConanInvalidConfiguration("OpenSSL is not supported on macOS")
+            if ssl_library == "darwinssl" and not is_apple_os(self):
+                raise ConanInvalidConfiguration("DarwinSSL is only supported on macOS")
+            if ssl_library == "winssl" and self.settings.os != "Windows":
+                raise ConanInvalidConfiguration("WinSSL is only on Windows")
 
-        if ssl_library not in (CprConan._AUTO_SSL, CprConan._NO_SSL, "winssl") and ssl_library != self.dependencies["libcurl"].options.with_ssl:
-            raise ConanInvalidConfiguration(
-                f"{self.ref}:with_ssl={self.options.with_ssl} requires libcurl:with_ssl={self.options.with_ssl}"
-            )
+            if ssl_library != "winssl" and ssl_library != self.dependencies["libcurl"].options.with_ssl:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref}:with_ssl={self.options.with_ssl} requires libcurl:with_ssl={self.options.with_ssl}"
+                )
 
-        if ssl_library == "winssl" and self.dependencies["libcurl"].options.with_ssl != "schannel":
-            raise ConanInvalidConfiguration(
-                f"{self.ref}:with_ssl=winssl requires libcurl:with_ssl=schannel"
-            )
+            if ssl_library == "winssl" and self.dependencies["libcurl"].options.with_ssl != "schannel":
+                raise ConanInvalidConfiguration(
+                    f"{self.ref}:with_ssl=winssl requires libcurl:with_ssl=schannel"
+                )
 
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration("Visual Studio build for shared library with MT runtime is not supported")
@@ -145,7 +143,7 @@ class CprConan(ConanFile):
         tc.variables["CPR_FORCE_WINSSL_BACKEND"] = (self.options.with_ssl == "winssl")
         tc.variables["CMAKE_USE_OPENSSL"] = (self.options.with_ssl == "openssl")
         # If we are on a version where disabling SSL requires a cmake option, disable it
-        if self.options.with_ssl == CprConan._NO_SSL:
+        if not self.options.with_ssl:
             tc.variables["CPR_ENABLE_SSL"] = False
 
         if self.options.get_safe("verbose_logging", False):

--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -109,16 +109,6 @@ class CprConan(ConanFile):
             if ssl_library == "winssl" and self.settings.os != "Windows":
                 raise ConanInvalidConfiguration("WinSSL is only on Windows")
 
-            if ssl_library != "winssl" and ssl_library != self.dependencies["libcurl"].options.with_ssl:
-                raise ConanInvalidConfiguration(
-                    f"{self.ref}:with_ssl={self.options.with_ssl} requires libcurl:with_ssl={self.options.with_ssl}"
-                )
-
-            if ssl_library == "winssl" and self.dependencies["libcurl"].options.with_ssl != "schannel":
-                raise ConanInvalidConfiguration(
-                    f"{self.ref}:with_ssl=winssl requires libcurl:with_ssl=schannel"
-                )
-
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration("Visual Studio build for shared library with MT runtime is not supported")
 
@@ -142,9 +132,7 @@ class CprConan(ConanFile):
         tc.variables["CPR_FORCE_OPENSSL_BACKEND"] = (self.options.with_ssl == "openssl")
         tc.variables["CPR_FORCE_WINSSL_BACKEND"] = (self.options.with_ssl == "winssl")
         tc.variables["CMAKE_USE_OPENSSL"] = (self.options.with_ssl == "openssl")
-        # If we are on a version where disabling SSL requires a cmake option, disable it
-        if not self.options.with_ssl:
-            tc.variables["CPR_ENABLE_SSL"] = False
+        tc.variables["CPR_ENABLE_SSL"] = bool(self.options.with_ssl)
 
         if self.options.get_safe("verbose_logging", False):
             tc.variables["CURL_VERBOSE_LOGGING"] = True

--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -103,7 +103,7 @@ class CprConan(ConanFile):
             ssl_library = str(self.options.with_ssl)
 
             if ssl_library == "openssl" and is_apple_os(self):
-                raise ConanInvalidConfiguration("OpenSSL is not supported on macOS")
+                raise ConanInvalidConfiguration("OpenSSL is not supported on macOS. Use DarwinSSL instead.")
             if ssl_library == "darwinssl" and not is_apple_os(self):
                 raise ConanInvalidConfiguration("DarwinSSL is only supported on macOS")
             if ssl_library == "winssl" and self.settings.os != "Windows":


### PR DESCRIPTION
* Add self.requires("openssl...") call when using openssl on windows

Specify library name and version:  **cpr/1.10.5**

This makes it possible to build cpr on windows with openssl. See issue #23251 for more discussion.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
