### PR TITLE
openal-soft: restore dangling patch

### DIFF
--- a/recipes/openal-soft/all/conandata.yml
+++ b/recipes/openal-soft/all/conandata.yml
@@ -13,3 +13,4 @@ patches:
   "1.22.2":
     - patch_file: "patches/1.22.2-0001-fix-al-optional-in-if-compile-error.patch"
       patch_source: "https://github.com/kcat/openal-soft/commit/650a6d49e9a511d005171940761f6dd6b440ee66"
+    - patch_file: "patches/1.22.2-0002-fix-pulseaudio-find-package-vars.patch"


### PR DESCRIPTION
it got wrongly removed in a merge commit in https://github.com/conan-io/conan-center-index/pull/21221

Specify library name and version:  **openal-soft/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
