### PR TITLE
vincentlaucsb-csv-parser: add version 2.2.0

### DIFF
--- a/recipes/vincentlaucsb-csv-parser/all/conandata.yml
+++ b/recipes/vincentlaucsb-csv-parser/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.0":
+    url: "https://github.com/vincentlaucsb/csv-parser/archive/refs/tags/2.2.0.tar.gz"
+    sha256: "027fd894c5e6a59f5afcedd6cc071364611df5f35fcc6fc4a8e193712b2f1e73"
   "2.1.3":
     url: "https://github.com/vincentlaucsb/csv-parser/archive/refs/tags/2.1.3.tar.gz"
-    sha256: 3f6ce9212e66d273de12a9671dcbf7be7da0241334dc690585dd434dce5e5acf
+    sha256: "3f6ce9212e66d273de12a9671dcbf7be7da0241334dc690585dd434dce5e5acf"

--- a/recipes/vincentlaucsb-csv-parser/config.yml
+++ b/recipes/vincentlaucsb-csv-parser/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.2.0":
+    folder: all
   "2.1.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **vincentlaucsb-csv-parser/2.2.0**

https://github.com/vincentlaucsb/csv-parser/compare/2.1.1...2.2.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
