### PR TITLE
Libgpiod update source url

### DIFF
--- a/recipes/libgpiod/all/conandata.yml
+++ b/recipes/libgpiod/all/conandata.yml
@@ -1,13 +1,13 @@
 sources:
   "2.1":
-    url: "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-2.1.tar.gz"
-    sha256: "fd6ed4b2c674fe6cc3b481880f6cde1eea79e296e95a139b85401eaaea6de3fc"
+    url: "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/libgpiod-2.1.tar.gz"
+    sha256: "1f7ddd3d8b1331da8735a88ed6ec55c82c1c469b4c38a118ddcd651db4808d98"
   "2.0.1":
-    url: "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-2.0.1.tar.gz"
-    sha256: "b6eda55356160a8e73906e3d48e959ef81296787d764975b10f257e9660668e9"
+    url: "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/libgpiod-2.0.1.tar.gz"
+    sha256: "b382c7135d53feb98b33f99fb9c24d61282bcc2658dc32f3be748d9d3dab71cd"
   "1.6.4":
-    url: "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-1.6.4.tar.gz"
-    sha256: "829d4ac268df07853609d67cfc7f476e9aa736cb2a68a630be99e8fad197be0a"
+    url: "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/libgpiod-1.6.4.tar.gz"
+    sha256: "9cc08303a24567546585bfc6cac6ad76654949f56d4024317fc10f1e9dae924c"
   "1.6.3":
-    url: "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-1.6.3.tar.gz"
-    sha256: "eb446070be1444fd7d32d32bbca53c2f3bbb0a21193db86198cf6050b7a28441"
+    url: "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/libgpiod-1.6.3.tar.gz"
+    sha256: "0e6f375e2c748d518c1c960c967cf84c154a00501850861343203a0e34d217b7"

--- a/recipes/libgpiod/all/conandata.yml
+++ b/recipes/libgpiod/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.1":
+    url: "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/libgpiod-2.1.1.tar.gz"
+    sha256: "dc03781a4571a95df29908cd0d308692f398f55dfa14c9dc9d555c664a9ee97f"
   "2.1":
     url: "https://mirrors.edge.kernel.org/pub/software/libs/libgpiod/libgpiod-2.1.tar.gz"
     sha256: "1f7ddd3d8b1331da8735a88ed6ec55c82c1c469b4c38a118ddcd651db4808d98"

--- a/recipes/libgpiod/config.yml
+++ b/recipes/libgpiod/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.1":
+    folder: all
   "2.1":
     folder: all
   "2.0.1":


### PR DESCRIPTION
Specify library name and version:  **libgpiod**

- Source URLs are broken. This PR updates URLs to point to authors recommend location 
https://github.com/brgl/libgpiod/issues/71

- Also added new version 2.1.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
