### PR TITLE
libssh: fix compatibility for mbedtls and gcrypt

### DIFF
--- a/recipes/libssh/all/conandata.yml
+++ b/recipes/libssh/all/conandata.yml
@@ -10,3 +10,6 @@ patches:
     - patch_file: patches/0.10.6-0002-fix-cmake.patch
       patch_description: "cmake: fix MbedTLS and GCrypt compatibility"
       patch_type: "conan"
+    - patch_file: patches/0.10.6-0003-fix-mbedtls-private-struct.patch
+      patch_description: "Fix mbedTLS issues caused by v3 API changes"
+      patch_type: "patch_source"

--- a/recipes/libssh/all/conandata.yml
+++ b/recipes/libssh/all/conandata.yml
@@ -7,3 +7,6 @@ patches:
     - patch_file: patches/0.10.6-0001-fix-cmake.patch
       patch_description: "cmake: fix OpenSSL compatibility checks, fix ZLIB targets"
       patch_type: "conan"
+    - patch_file: patches/0.10.6-0002-fix-cmake.patch
+      patch_description: "cmake: fix MbedTLS and GCrypt compatibility"
+      patch_type: "conan"

--- a/recipes/libssh/all/conandata.yml
+++ b/recipes/libssh/all/conandata.yml
@@ -12,4 +12,5 @@ patches:
       patch_type: "conan"
     - patch_file: patches/0.10.6-0003-fix-mbedtls-private-struct.patch
       patch_description: "Fix mbedTLS issues caused by v3 API changes"
-      patch_type: "patch_source"
+      patch_type: "bugfix"
+      patch_source: "https://gitlab.com/libssh/libssh-mirror/-/merge_requests/480"

--- a/recipes/libssh/all/conanfile.py
+++ b/recipes/libssh/all/conanfile.py
@@ -21,7 +21,7 @@ class LibSSHRecipe(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_zlib": [True, False],
-        "crypto_backend": ["openssl", "gcrypt"],
+        "crypto_backend": ["openssl", "gcrypt", "mbedtls"],
         "with_symbol_versioning": [True, False],
     }
     default_options = {
@@ -56,6 +56,8 @@ class LibSSHRecipe(ConanFile):
             self.requires("openssl/[>=1.1 <4]")
         elif self.options.crypto_backend == "gcrypt":
             self.requires("libgcrypt/1.8.4")
+        elif self.options.crypto_backend == "mbedtls":
+            self.requires("mbedtls/3.6.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -67,8 +69,7 @@ class LibSSHRecipe(ConanFile):
         tc.variables["WITH_EXAMPLES"] = False
         tc.variables["WITH_GCRYPT"] = self.options.crypto_backend == "gcrypt"
         tc.variables["WITH_GSSAPI"] = False
-        # TODO: Add support for mbedtls. Package available in Conan Center already.
-        tc.variables["WITH_MBEDTLS"] = False
+        tc.variables["WITH_MBEDTLS"] = self.options.crypto_backend == "mbedtls"
         tc.variables["WITH_NACL"] = False
         tc.variables["WITH_SYMBOL_VERSIONING"] = self.options.get_safe("with_symbol_versioning", True)
         tc.variables["WITH_ZLIB"] = self.options.with_zlib

--- a/recipes/libssh/all/conanfile.py
+++ b/recipes/libssh/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc_static_runtime, is_msvc

--- a/recipes/libssh/all/conanfile.py
+++ b/recipes/libssh/all/conanfile.py
@@ -59,6 +59,10 @@ class LibSSHRecipe(ConanFile):
         elif self.options.crypto_backend == "mbedtls":
             self.requires("mbedtls/3.6.0")
 
+    def validate(self):
+        if self.options.crypto_backend == "mbedtls" and not self.dependencies["mbedtls"].options.enable_threading:
+            raise ConanInvalidConfiguration(f"{self.ref} requires '-o mbedtls/*:enable_threading=True' when using '-o libssh/*:crypto_backend=mbedtls'")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/libssh/all/patches/0.10.6-0002-fix-cmake.patch
+++ b/recipes/libssh/all/patches/0.10.6-0002-fix-cmake.patch
@@ -121,16 +121,3 @@ index 91f85094..839271ad 100644
  
  if (WITH_ZLIB)
    set(LIBSSH_PRIVATE_INCLUDE_DIRS
-diff --git a/src/libmbedcrypto.c b/src/libmbedcrypto.c
-index caa3b6e9..69910a24 100644
---- a/src/libmbedcrypto.c
-+++ b/src/libmbedcrypto.c
-@@ -119,7 +119,7 @@ int hmac_update(HMACCTX c, const void *data, size_t len)
- int hmac_final(HMACCTX c, unsigned char *hashmacbuf, size_t *len)
- {
-     int rc;
--    *len = (unsigned int)mbedtls_md_get_size(c->md_info);
-+    *len = (unsigned int)mbedtls_md_get_size(c->MBEDTLS_PRIVATE(md_info));
-     rc = !mbedtls_md_hmac_finish(c, hashmacbuf);
-     mbedtls_md_free(c);
-     SAFE_FREE(c);

--- a/recipes/libssh/all/patches/0.10.6-0002-fix-cmake.patch
+++ b/recipes/libssh/all/patches/0.10.6-0002-fix-cmake.patch
@@ -1,0 +1,136 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a64b7708..6647076b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,15 +48,15 @@ if (WITH_ZLIB)
+ endif (WITH_ZLIB)
+ 
+ if (WITH_GCRYPT)
+-  find_package(GCrypt 1.5.0 REQUIRED)
+-  if (NOT GCRYPT_FOUND)
++  find_package(libgcrypt 1.5.0 REQUIRED)
++  if (NOT libgcrypt_FOUND)
+     message(FATAL_ERROR "Could not find GCrypt")
+-  endif (NOT GCRYPT_FOUND)
++  endif (NOT libgcrypt_FOUND)
+ elseif(WITH_MBEDTLS)
+     find_package(MbedTLS REQUIRED)
+-    if (NOT MBEDTLS_FOUND)
++    if (NOT MbedTLS_FOUND)
+       message(FATAL_ERROR "Could not find mbedTLS")
+-    endif (NOT MBEDTLS_FOUND)
++    endif (NOT MbedTLS_FOUND)
+ else (WITH_GCRYPT)
+   find_package(OpenSSL 1.0.1)
+   if (OPENSSL_FOUND)
+@@ -66,13 +66,13 @@ else (WITH_GCRYPT)
+       set(OPENSSL_CRYPTO_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+     endif (NOT DEFINED OPENSSL_CRYPTO_LIBRARIES)
+   else (OPENSSL_FOUND)
+-    find_package(GCrypt)
+-    if (NOT GCRYPT_FOUND)
++    find_package(libgcrypt)
++    if (NOT libgcrypt_FOUND)
+       find_package(MbedTLS)
+-      if (NOT MBEDTLS_FOUND)
++      if (NOT MbedTLS_FOUND)
+         message(FATAL_ERROR "Could not find OpenSSL, GCrypt or mbedTLS")
+-      endif (NOT MBEDTLS_FOUND)
+-    endif (NOT GCRYPT_FOUND)
++      endif (NOT MbedTLS_FOUND)
++    endif (NOT libgcrypt_FOUND)
+   endif (OPENSSL_FOUND)
+ endif(WITH_GCRYPT)
+ 
+diff --git a/ConfigureChecks.cmake b/ConfigureChecks.cmake
+index 6f881775..12585117 100644
+--- a/ConfigureChecks.cmake
++++ b/ConfigureChecks.cmake
+@@ -267,27 +267,27 @@ if (OPENSSL_FOUND)
+   set(HAVE_LIBCRYPTO 1)
+ endif (OPENSSL_FOUND)
+ 
+-if (GCRYPT_FOUND)
++if (libgcrypt_FOUND)
+     set(HAVE_LIBGCRYPT 1)
+-    if (GCRYPT_VERSION VERSION_GREATER "1.4.6")
++    if (libgcrypt_VERSION VERSION_GREATER "1.4.6")
+         set(HAVE_GCRYPT_ECC 1)
+         set(HAVE_ECC 1)
+-    endif (GCRYPT_VERSION VERSION_GREATER "1.4.6")
+-    if (NOT GCRYPT_VERSION VERSION_LESS "1.7.0")
++    endif (libgcrypt_VERSION VERSION_GREATER "1.4.6")
++    if (NOT libgcrypt_VERSION VERSION_LESS "1.7.0")
+         set(HAVE_GCRYPT_CHACHA_POLY 1)
+-    endif (NOT GCRYPT_VERSION VERSION_LESS "1.7.0")
+-endif (GCRYPT_FOUND)
++    endif (NOT libgcrypt_VERSION VERSION_LESS "1.7.0")
++endif (libgcrypt_FOUND)
+ 
+-if (MBEDTLS_FOUND)
++if (MbedTLS_FOUND)
+     set(HAVE_LIBMBEDCRYPTO 1)
+     set(HAVE_ECC 1)
+ 
+-    set(CMAKE_REQUIRED_INCLUDES "${MBEDTLS_INCLUDE_DIR}/mbedtls")
++    set(CMAKE_REQUIRED_INCLUDES "${MbedTLS_INCLUDE_DIR}/mbedtls")
+     check_include_file(chacha20.h HAVE_MBEDTLS_CHACHA20_H)
+     check_include_file(poly1305.h HAVE_MBEDTLS_POLY1305_H)
+     unset(CMAKE_REQUIRED_INCLUDES)
+ 
+-endif (MBEDTLS_FOUND)
++endif (MbedTLS_FOUND)
+ 
+ if (CMAKE_USE_PTHREADS_INIT)
+     set(HAVE_PTHREAD 1)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 91f85094..839271ad 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -21,27 +21,13 @@ if (OPENSSL_CRYPTO_LIBRARIES)
+   )
+ endif (OPENSSL_CRYPTO_LIBRARIES)
+ 
+-if (MBEDTLS_CRYPTO_LIBRARY)
+-    set(LIBSSH_PRIVATE_INCLUDE_DIRS
+-      ${LIBSSH_PRIVATE_INCLUDE_DIRS}
+-      ${MBEDTLS_INCLUDE_DIR}
+-    )
+-  set(LIBSSH_LINK_LIBRARIES
+-    ${LIBSSH_LINK_LIBRARIES}
+-    ${MBEDTLS_CRYPTO_LIBRARY}
+-  )
+-endif (MBEDTLS_CRYPTO_LIBRARY)
+-
+-if (GCRYPT_LIBRARIES)
+-  set(LIBSSH_PRIVATE_INCLUDE_DIRS
+-    ${LIBSSH_PRIVATE_INCLUDE_DIRS}
+-    ${GCRYPT_INCLUDE_DIR}
+-  )
++if (TARGET MbedTLS::mbedcrypto)
++    list(APPEND LIBSSH_LINK_LIBRARIES MbedTLS::mbedcrypto)
++endif ()
+ 
+-  set(LIBSSH_LINK_LIBRARIES
+-    ${LIBSSH_LINK_LIBRARIES}
+-    ${GCRYPT_LIBRARIES})
+-endif()
++if (TARGET libgcrypt::libgcrypt)
++    list(APPEND LIBSSH_LINK_LIBRARIES libgcrypt::libgcrypt)
++endif ()
+ 
+ if (WITH_ZLIB)
+   set(LIBSSH_PRIVATE_INCLUDE_DIRS
+diff --git a/src/libmbedcrypto.c b/src/libmbedcrypto.c
+index caa3b6e9..69910a24 100644
+--- a/src/libmbedcrypto.c
++++ b/src/libmbedcrypto.c
+@@ -119,7 +119,7 @@ int hmac_update(HMACCTX c, const void *data, size_t len)
+ int hmac_final(HMACCTX c, unsigned char *hashmacbuf, size_t *len)
+ {
+     int rc;
+-    *len = (unsigned int)mbedtls_md_get_size(c->md_info);
++    *len = (unsigned int)mbedtls_md_get_size(c->MBEDTLS_PRIVATE(md_info));
+     rc = !mbedtls_md_hmac_finish(c, hashmacbuf);
+     mbedtls_md_free(c);
+     SAFE_FREE(c);

--- a/recipes/libssh/all/patches/0.10.6-0003-fix-mbedtls-private-struct.patch
+++ b/recipes/libssh/all/patches/0.10.6-0003-fix-mbedtls-private-struct.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libmbedcrypto.c b/src/libmbedcrypto.c
+index caa3b6e9..69910a24 100644
+--- a/src/libmbedcrypto.c
++++ b/src/libmbedcrypto.c
+@@ -119,7 +119,7 @@ int hmac_update(HMACCTX c, const void *data, size_t len)
+ int hmac_final(HMACCTX c, unsigned char *hashmacbuf, size_t *len)
+ {
+     int rc;
+-    *len = (unsigned int)mbedtls_md_get_size(c->md_info);
++    *len = (unsigned int)mbedtls_md_get_size(c->MBEDTLS_PRIVATE(md_info));
+     rc = !mbedtls_md_hmac_finish(c, hashmacbuf);
+     mbedtls_md_free(c);
+     SAFE_FREE(c);

--- a/recipes/libssh/all/test_package/test_package.c
+++ b/recipes/libssh/all/test_package/test_package.c
@@ -1,14 +1,10 @@
 #include <libssh/libssh.h>
 
 int main(int argc, char *argv[]) {
-  ssh_init();
   ssh_session session = ssh_new();
-  if (session == NULL)
+  if (session == NULL) {
     return -1;
+  }
 
-  const char* host = "localhost";
-  ssh_options_set(session, SSH_OPTIONS_HOST, host);
-  ssh_options_set(session, SSH_OPTIONS_USER, "user");
-  int rc = ssh_connect(session);
   return 0;
 }

--- a/recipes/libssh/all/test_package/test_package.c
+++ b/recipes/libssh/all/test_package/test_package.c
@@ -1,6 +1,14 @@
 #include <libssh/libssh.h>
 
 int main(int argc, char *argv[]) {
+  ssh_init();
   ssh_session session = ssh_new();
+  if (session == NULL)
+    return -1;
+
+  const char* host = "localhost";
+  ssh_options_set(session, SSH_OPTIONS_HOST, host);
+  ssh_options_set(session, SSH_OPTIONS_USER, "user");
+  int rc = ssh_connect(session);
   return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **libssh/0.10.6**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Fix build with `-o crypto_backend=gcrypt`

Add option to build with `-o crypto_backend=mbedtls`

Expand test_package so it won't silently fail

## Notes:

MbedTLS build will exit with the following error in the test_package step:

```
Error in auto_init()

ERROR: libssh/0.10.6 (test package): Error in test() method, line 26
        self.run(bin_path, env="conanrun")
        ConanException: Error -11 while executing
```

Found in the [README.mbedtls](https://git.libssh.org/projects/libssh.git/tree/README.mbedtls?h=libssh-0.10.6) that "mbedTLS has to be built with threading support enabled", but don't see an option in the mbedtls conan recipe to enable threading to test if this is the cause of the failure

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
