### PR TITLE
openvdb: Downgrade imath dependency to 3.1.9 to avoid conflitcs

### DIFF
--- a/recipes/openvdb/all/conanfile.py
+++ b/recipes/openvdb/all/conanfile.py
@@ -133,7 +133,7 @@ class OpenVDBConan(ConanFile):
         self.requires("boost/1.84.0", transitive_headers=True)
         self.requires("onetbb/2021.10.0", transitive_headers=True, transitive_libs=True)
         if self.options.use_imath_half:
-            self.requires("imath/3.1.10", transitive_headers=True, transitive_libs=True)
+            self.requires("imath/3.1.9", transitive_headers=True, transitive_libs=True)
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_blosc:


### PR DESCRIPTION
Specify library name and version:  **openvdb/1.0**

Pushes back a patch version to get in line with the rest of the imath requirements for now - evetually we'll bump them at once :)