### PR TITLE
libnghttp2: add version 1.61.0

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.61.0":
+    url: "https://github.com/nghttp2/nghttp2/releases/download/v1.61.0/nghttp2-1.61.0.tar.bz2"
+    sha256: "4e8cf7ec32d4c5a430966242d72035d255cd9470a8766d61eed7a0190dd544fd"
   "1.60.0":
     url: "https://github.com/nghttp2/nghttp2/archive/v1.60.0.tar.gz"
     sha256: "3cc9403c64e0a133868f62132ff0884cd5dc567eee5bd7b2d03ac81293695d6b"

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.61.0":
+    folder: all
   "1.60.0":
     folder: all
   "1.59.0":


### PR DESCRIPTION
Specify library name and version:  **libnghttp2/1.61.0**

https://github.com/nghttp2/nghttp2/compare/v1.60.0...v1.61.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
