### PR TITLE
[mbedtls] Add threading support as option

### DIFF
--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -143,7 +143,7 @@ class MBedTLSConan(ConanFile):
                 self.cpp_info.components[component].requires.append("zlib::zlib")
 
         if self.options.enable_threading:
-            self.cpp_info.defines.extend(["MBEDTLS_THREADING_C=1", "MBEDTLS_THREADING_PTHREAD=1"])
+            self.cpp_info.components["mbedcrypto"].defines.extend(["MBEDTLS_THREADING_C=1", "MBEDTLS_THREADING_PTHREAD=1"])
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "MbedTLS"

--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -56,8 +56,12 @@ class MBedTLSConan(ConanFile):
             self.requires("zlib/[>=1.2.11 <2]")
 
     def validate(self):
-        if self.settings.os == "Windows" and self.options.shared:
-            raise ConanInvalidConfiguration(f"{self.ref} does not support shared build on Windows")
+        if self.settings.os == "Windows":
+            if self.options.shared:
+                raise ConanInvalidConfiguration(f"{self.ref} does not support shared build on Windows")
+            if self.options.enable_threading:
+                # INFO: Planned: https://github.com/Mbed-TLS/mbedtls/issues/8455
+                raise ConanInvalidConfiguration(f"{self.ref} does not support the option enable_threading on Windows")
 
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "5":
             # The command line flags set are not supported on older versions of gcc

--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -146,8 +146,6 @@ class MBedTLSConan(ConanFile):
             for component in self.cpp_info.components:
                 self.cpp_info.components[component].requires.append("zlib::zlib")
 
-
-
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "MbedTLS"
         self.cpp_info.names["cmake_find_package_multi"] = "MbedTLS"

--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -123,6 +123,10 @@ class MBedTLSConan(ConanFile):
             self.cpp_info.components["mbedcrypto"].system_libs = ["bcrypt"]
         if Version(self.version) >= "3.6.0":
             self.cpp_info.components["mbedcrypto"].set_property("pkg_config_name", "mbedcrypto")
+        if self.options.enable_threading:
+            self.cpp_info.components["mbedcrypto"].defines.extend(["MBEDTLS_THREADING_C=1", "MBEDTLS_THREADING_PTHREAD=1"])
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.components["mbedcrypto"].system_libs.append("pthread")
 
         self.cpp_info.components["mbedx509"].set_property("cmake_target_name", "MbedTLS::mbedx509")
         self.cpp_info.components["mbedx509"].libs = ["mbedx509"]
@@ -142,8 +146,7 @@ class MBedTLSConan(ConanFile):
             for component in self.cpp_info.components:
                 self.cpp_info.components[component].requires.append("zlib::zlib")
 
-        if self.options.enable_threading:
-            self.cpp_info.components["mbedcrypto"].defines.extend(["MBEDTLS_THREADING_C=1", "MBEDTLS_THREADING_PTHREAD=1"])
+
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "MbedTLS"

--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -32,7 +32,7 @@ class MBedTLSConan(ConanFile):
         "shared": False,
         "fPIC": True,
         "with_zlib": True,
-        "enable_threading": True,
+        "enable_threading": False,
     }
 
     def config_options(self):

--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -26,11 +26,13 @@ class MBedTLSConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_zlib": [True, False],
+        "enable_threading": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_zlib": True,
+        "enable_threading": True,
     }
 
     def config_options(self):
@@ -86,6 +88,10 @@ class MBedTLSConan(ConanFile):
                 tc.preprocessor_definitions["MBEDTLS_PLATFORM_SNPRINTF_MACRO"] = "snprintf"
             else:
                 tc.preprocessor_definitions["MBEDTLS_PLATFORM_SNPRINTF_MACRO"] = "MBEDTLS_PLATFORM_STD_SNPRINTF"
+        if self.options.enable_threading:
+            tc.preprocessor_definitions["MBEDTLS_THREADING_C"] = True
+            tc.preprocessor_definitions["MBEDTLS_THREADING_PTHREAD"] = True
+
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()
@@ -131,6 +137,9 @@ class MBedTLSConan(ConanFile):
         if self.options.get_safe("with_zlib"):
             for component in self.cpp_info.components:
                 self.cpp_info.components[component].requires.append("zlib::zlib")
+
+        if self.options.enable_threading:
+            self.cpp_info.defines.extend(["MBEDTLS_THREADING_C=1", "MBEDTLS_THREADING_PTHREAD=1"])
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "MbedTLS"


### PR DESCRIPTION
Specify library name and version:  **mbedtls/3.6.0**

Related to PR https://github.com/conan-io/conan-center-index/pull/23366

The threading support could be activated via `config.py`, but it would require an extra step invoking python, only to patch that header file that will not be exported to the package folder.

As alternative, we can define it directly to the preprocessor.

About MBedTLS threading feature: https://mbed-tls.readthedocs.io/en/latest/kb/development/thread-safety-and-multi-threading
How to customize the config.h in MBedTLS: https://mbed-tls.readthedocs.io/en/latest/kb/compiling-and-building/how-do-i-configure-mbedtls

Tested the new configuration on Mac only:

```
conan create all --version=3.6.0 -o "&:enable_threading=True" -o "&:shared=True"                                                                                                                                      09:17:17

======== Exporting recipe to the cache ========
mbedtls/3.6.0: Exporting package recipe: /Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/conanfile.py
mbedtls/3.6.0: exports: File 'conandata.yml' found. Exporting it...
mbedtls/3.6.0: Copied 1 '.py' file: conanfile.py
mbedtls/3.6.0: Copied 1 '.yml' file: conandata.yml
mbedtls/3.6.0: Exported to cache folder: /Users/uilian/.conan2/p/mbedtb2e021e67040d/e
mbedtls/3.6.0: Exported: mbedtls/3.6.0#74150e45eb2c039313fcefb4d9335b0c (2024-04-05 07:17:55 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=17
compiler.libcxx=libc++
compiler.version=15
os=Macos
[options]
&:enable_threading=True
&:shared=True

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=17
compiler.libcxx=libc++
compiler.version=15
os=Macos


======== Computing dependency graph ========
Graph root
    cli
Requirements
    mbedtls/3.6.0#74150e45eb2c039313fcefb4d9335b0c - Cache

======== Computing necessary packages ========
mbedtls/3.6.0: Forced build from source
Requirements
    mbedtls/3.6.0#74150e45eb2c039313fcefb4d9335b0c:201c50b7a03393a15e34d8894d277ed514bb0edf - Build

======== Installing packages ========

-------- Installing package mbedtls/3.6.0 (1 of 1) --------
mbedtls/3.6.0: Building from source
mbedtls/3.6.0: Package mbedtls/3.6.0:201c50b7a03393a15e34d8894d277ed514bb0edf
mbedtls/3.6.0: Copying sources to build folder
mbedtls/3.6.0: Building your package in /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b
mbedtls/3.6.0: Calling generate()
mbedtls/3.6.0: Generators folder: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b/build/Release/generators
mbedtls/3.6.0: CMakeToolchain generated: conan_toolchain.cmake
mbedtls/3.6.0: CMakeToolchain generated: CMakePresets.json
mbedtls/3.6.0: CMakeToolchain generated: ../../../src/CMakeUserPresets.json
mbedtls/3.6.0: Generating aggregated env files
mbedtls/3.6.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
mbedtls/3.6.0: Calling build()
mbedtls/3.6.0: Running CMake.configure()
mbedtls/3.6.0: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="/Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b/build/Release/generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS="ON" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b/src"
-- Using Conan toolchain: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is AppleClang 15.0.0.15000309
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Python3: /opt/homebrew/Frameworks/Python.framework/Versions/3.12/bin/python3.12 (found version "3.12.2") found components: Interpreter 
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b/build/Release

mbedtls/3.6.0: Running CMake.build()
mbedtls/3.6.0: RUN: cmake --build "/Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b/build/Release" -- -j10
[  0%] Building C object 3rdparty/everest/CMakeFiles/everest.dir/library/everest.c.o
[  1%] Building C object 3rdparty/everest/CMakeFiles/everest.dir/library/x25519.c.o
[  2%] Building C object 3rdparty/everest/CMakeFiles/everest.dir/library/Hacl_Curve25519_joined.c.o
[  3%] Building C object 3rdparty/p256-m/CMakeFiles/p256m.dir/p256-m/p256-m.c.o
[  4%] Building C object 3rdparty/p256-m/CMakeFiles/p256m.dir/p256-m_driver_entrypoints.c.o
[  5%] Linking C shared library libp256m.dylib
[  6%] Linking C shared library libeverest.dylib
[  6%] Built target p256m
[  6%] Built target everest
[  7%] Building C object library/CMakeFiles/mbedcrypto.dir/aes.c.o
[  8%] Building C object library/CMakeFiles/mbedcrypto.dir/aesni.c.o
[  8%] Building C object library/CMakeFiles/mbedcrypto.dir/aesce.c.o
[  9%] Building C object library/CMakeFiles/mbedcrypto.dir/bignum.c.o
[ 10%] Building C object library/CMakeFiles/mbedcrypto.dir/bignum_core.c.o
[ 10%] Building C object library/CMakeFiles/mbedcrypto.dir/bignum_mod.c.o
[ 11%] Building C object library/CMakeFiles/mbedcrypto.dir/asn1write.c.o
[ 12%] Building C object library/CMakeFiles/mbedcrypto.dir/base64.c.o
[ 13%] Building C object library/CMakeFiles/mbedcrypto.dir/aria.c.o
[ 14%] Building C object library/CMakeFiles/mbedcrypto.dir/asn1parse.c.o
[ 15%] Building C object library/CMakeFiles/mbedcrypto.dir/bignum_mod_raw.c.o
[ 16%] Building C object library/CMakeFiles/mbedcrypto.dir/block_cipher.c.o
[ 17%] Building C object library/CMakeFiles/mbedcrypto.dir/camellia.c.o
[ 18%] Building C object library/CMakeFiles/mbedcrypto.dir/ccm.c.o
[ 18%] Building C object library/CMakeFiles/mbedcrypto.dir/chachapoly.c.o
[ 19%] Building C object library/CMakeFiles/mbedcrypto.dir/chacha20.c.o
[ 20%] Building C object library/CMakeFiles/mbedcrypto.dir/cipher.c.o
[ 21%] Building C object library/CMakeFiles/mbedcrypto.dir/cipher_wrap.c.o
[ 22%] Building C object library/CMakeFiles/mbedcrypto.dir/constant_time.c.o
[ 23%] Building C object library/CMakeFiles/mbedcrypto.dir/cmac.c.o
[ 24%] Building C object library/CMakeFiles/mbedcrypto.dir/ctr_drbg.c.o
[ 25%] Building C object library/CMakeFiles/mbedcrypto.dir/des.c.o
[ 25%] Building C object library/CMakeFiles/mbedcrypto.dir/dhm.c.o
[ 26%] Building C object library/CMakeFiles/mbedcrypto.dir/ecdh.c.o
[ 27%] Building C object library/CMakeFiles/mbedcrypto.dir/ecdsa.c.o
[ 28%] Building C object library/CMakeFiles/mbedcrypto.dir/ecjpake.c.o
[ 29%] Building C object library/CMakeFiles/mbedcrypto.dir/ecp.c.o
[ 30%] Building C object library/CMakeFiles/mbedcrypto.dir/ecp_curves.c.o
[ 30%] Building C object library/CMakeFiles/mbedcrypto.dir/ecp_curves_new.c.o
[ 31%] Building C object library/CMakeFiles/mbedcrypto.dir/entropy.c.o
[ 32%] Building C object library/CMakeFiles/mbedcrypto.dir/entropy_poll.c.o
[ 33%] Building C object library/CMakeFiles/mbedcrypto.dir/error.c.o
[ 34%] Building C object library/CMakeFiles/mbedcrypto.dir/gcm.c.o
[ 35%] Building C object library/CMakeFiles/mbedcrypto.dir/hkdf.c.o
[ 36%] Building C object library/CMakeFiles/mbedcrypto.dir/hmac_drbg.c.o
[ 36%] Building C object library/CMakeFiles/mbedcrypto.dir/lmots.c.o
[ 37%] Building C object library/CMakeFiles/mbedcrypto.dir/lms.c.o
[ 38%] Building C object library/CMakeFiles/mbedcrypto.dir/md.c.o
[ 39%] Building C object library/CMakeFiles/mbedcrypto.dir/md5.c.o
[ 40%] Building C object library/CMakeFiles/mbedcrypto.dir/memory_buffer_alloc.c.o
[ 41%] Building C object library/CMakeFiles/mbedcrypto.dir/nist_kw.c.o
[ 41%] Building C object library/CMakeFiles/mbedcrypto.dir/oid.c.o
[ 42%] Building C object library/CMakeFiles/mbedcrypto.dir/padlock.c.o
[ 43%] Building C object library/CMakeFiles/mbedcrypto.dir/pem.c.o
[ 44%] Building C object library/CMakeFiles/mbedcrypto.dir/pk.c.o
[ 45%] Building C object library/CMakeFiles/mbedcrypto.dir/pk_ecc.c.o
[ 46%] Building C object library/CMakeFiles/mbedcrypto.dir/pk_wrap.c.o
[ 47%] Building C object library/CMakeFiles/mbedcrypto.dir/pkcs12.c.o
[ 47%] Building C object library/CMakeFiles/mbedcrypto.dir/pkcs5.c.o
[ 48%] Building C object library/CMakeFiles/mbedcrypto.dir/pkparse.c.o
[ 49%] Building C object library/CMakeFiles/mbedcrypto.dir/platform.c.o
[ 50%] Building C object library/CMakeFiles/mbedcrypto.dir/pkwrite.c.o
[ 51%] Building C object library/CMakeFiles/mbedcrypto.dir/platform_util.c.o
[ 52%] Building C object library/CMakeFiles/mbedcrypto.dir/poly1305.c.o
[ 53%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto.c.o
[ 53%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_aead.c.o
[ 54%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_cipher.c.o
[ 55%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_client.c.o
[ 56%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_driver_wrappers_no_static.c.o
[ 57%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_ecp.c.o
[ 58%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_ffdh.c.o
[ 58%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_hash.c.o
[ 59%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_mac.c.o
[ 60%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_pake.c.o
[ 61%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_rsa.c.o
[ 62%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_se.c.o
[ 63%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_slot_management.c.o
[ 64%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_crypto_storage.c.o
[ 64%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_its_file.c.o
[ 65%] Building C object library/CMakeFiles/mbedcrypto.dir/psa_util.c.o
[ 66%] Building C object library/CMakeFiles/mbedcrypto.dir/ripemd160.c.o
[ 67%] Building C object library/CMakeFiles/mbedcrypto.dir/rsa.c.o
[ 68%] Building C object library/CMakeFiles/mbedcrypto.dir/rsa_alt_helpers.c.o
[ 69%] Building C object library/CMakeFiles/mbedcrypto.dir/sha1.c.o
[ 69%] Building C object library/CMakeFiles/mbedcrypto.dir/sha256.c.o
[ 70%] Building C object library/CMakeFiles/mbedcrypto.dir/sha512.c.o
[ 72%] Building C object library/CMakeFiles/mbedcrypto.dir/sha3.c.o
[ 72%] Building C object library/CMakeFiles/mbedcrypto.dir/threading.c.o
[ 73%] Building C object library/CMakeFiles/mbedcrypto.dir/timing.c.o
[ 74%] Building C object library/CMakeFiles/mbedcrypto.dir/version.c.o
[ 75%] Building C object library/CMakeFiles/mbedcrypto.dir/version_features.c.o
[ 75%] Linking C shared library libmbedcrypto.dylib
[ 75%] Built target mbedcrypto
[ 76%] Building C object library/CMakeFiles/mbedx509.dir/pkcs7.c.o
[ 77%] Building C object library/CMakeFiles/mbedx509.dir/x509.c.o
[ 78%] Building C object library/CMakeFiles/mbedx509.dir/x509write_crt.c.o
[ 78%] Building C object library/CMakeFiles/mbedx509.dir/x509write.c.o
[ 79%] Building C object library/CMakeFiles/mbedx509.dir/x509_create.c.o
[ 80%] Building C object library/CMakeFiles/mbedx509.dir/x509_csr.c.o
[ 81%] Building C object library/CMakeFiles/mbedx509.dir/x509_crt.c.o
[ 82%] Building C object library/CMakeFiles/mbedx509.dir/x509write_csr.c.o
[ 83%] Building C object library/CMakeFiles/mbedx509.dir/x509_crl.c.o
[ 84%] Linking C shared library libmbedx509.dylib
[ 84%] Built target mbedx509
[ 85%] Building C object library/CMakeFiles/mbedtls.dir/debug.c.o
[ 86%] Building C object library/CMakeFiles/mbedtls.dir/mps_reader.c.o
[ 87%] Building C object library/CMakeFiles/mbedtls.dir/mps_trace.c.o
[ 88%] Building C object library/CMakeFiles/mbedtls.dir/net_sockets.c.o
[ 89%] Building C object library/CMakeFiles/mbedtls.dir/ssl_cache.c.o
[ 90%] Building C object library/CMakeFiles/mbedtls.dir/ssl_msg.c.o
[ 91%] Building C object library/CMakeFiles/mbedtls.dir/ssl_debug_helpers_generated.c.o
[ 92%] Building C object library/CMakeFiles/mbedtls.dir/ssl_client.c.o
[ 92%] Building C object library/CMakeFiles/mbedtls.dir/ssl_ciphersuites.c.o
[ 93%] Building C object library/CMakeFiles/mbedtls.dir/ssl_cookie.c.o
[ 94%] Building C object library/CMakeFiles/mbedtls.dir/ssl_ticket.c.o
[ 95%] Building C object library/CMakeFiles/mbedtls.dir/ssl_tls.c.o
[ 95%] Building C object library/CMakeFiles/mbedtls.dir/ssl_tls12_client.c.o
[ 97%] Building C object library/CMakeFiles/mbedtls.dir/ssl_tls13_keys.c.o
[ 97%] Building C object library/CMakeFiles/mbedtls.dir/ssl_tls12_server.c.o
[ 98%] Building C object library/CMakeFiles/mbedtls.dir/ssl_tls13_server.c.o
[ 99%] Building C object library/CMakeFiles/mbedtls.dir/ssl_tls13_client.c.o
[100%] Building C object library/CMakeFiles/mbedtls.dir/ssl_tls13_generic.c.o
[100%] Linking C shared library libmbedtls.dylib
[100%] Built target mbedtls

mbedtls/3.6.0: Package '201c50b7a03393a15e34d8894d277ed514bb0edf' built
mbedtls/3.6.0: Build folder /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b/build/Release
mbedtls/3.6.0: Generating the package
mbedtls/3.6.0: Packaging in folder /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p
mbedtls/3.6.0: Calling package()
mbedtls/3.6.0: Running CMake.install()
mbedtls/3.6.0: RUN: cmake --install "/Users/uilian/.conan2/p/b/mbedt793fa98e752ed/b/build/Release" --prefix "/Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p"
-- Install configuration: "Release"
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/cmake/MbedTLS/MbedTLSConfig.cmake
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/cmake/MbedTLS/MbedTLSConfigVersion.cmake
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/cmake/MbedTLS/MbedTLSTargets.cmake
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/cmake/MbedTLS/MbedTLSTargets-release.cmake
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/aes.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/aria.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/asn1.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/asn1write.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/base64.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/bignum.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/block_cipher.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/build_info.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/camellia.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ccm.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/chacha20.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/chachapoly.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/check_config.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/cipher.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/cmac.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/compat-2.x.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/config_adjust_legacy_crypto.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/config_adjust_legacy_from_psa.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/config_adjust_psa_from_legacy.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/config_adjust_psa_superset_legacy.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/config_adjust_ssl.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/config_adjust_x509.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/config_psa.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/constant_time.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ctr_drbg.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/debug.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/des.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/dhm.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ecdh.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ecdsa.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ecjpake.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ecp.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/entropy.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/error.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/gcm.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/hkdf.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/hmac_drbg.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/lms.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/mbedtls_config.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/md.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/md5.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/memory_buffer_alloc.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/net_sockets.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/nist_kw.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/oid.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/pem.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/pk.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/pkcs12.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/pkcs5.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/pkcs7.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/platform.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/platform_time.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/platform_util.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/poly1305.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/private_access.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/psa_util.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ripemd160.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/rsa.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/sha1.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/sha256.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/sha3.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/sha512.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ssl.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ssl_cache.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ssl_ciphersuites.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ssl_cookie.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/ssl_ticket.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/threading.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/timing.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/version.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/x509.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/x509_crl.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/x509_crt.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/mbedtls/x509_csr.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/build_info.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_adjust_auto_enabled.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_adjust_config_key_pair_types.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_adjust_config_synonyms.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_builtin_composites.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_builtin_key_derivation.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_builtin_primitives.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_compat.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_config.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_driver_common.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_driver_contexts_composites.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_driver_contexts_key_derivation.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_driver_contexts_primitives.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_extra.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_legacy.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_platform.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_se_driver.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_sizes.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_struct.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_types.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/psa/crypto_values.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlib.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlib/FStar_UInt128.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlib/FStar_UInt64_FStar_UInt32_FStar_UInt16_FStar_UInt8.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/vs2013
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/vs2013/inttypes.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/vs2013/Hacl_Curve25519.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/vs2013/stdbool.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/Hacl_Curve25519.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/everest.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/x25519.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/internal
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/internal/debug.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/internal/builtin.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/internal/types.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/internal/callconv.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/internal/wasmsupport.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/internal/target.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/internal/compat.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/include/everest/kremlin/c_endianness.h
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libeverest.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libp256m.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedcrypto.3.6.0.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedcrypto.16.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedcrypto.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedx509.3.6.0.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedx509.7.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedx509.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedtls.3.6.0.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedtls.21.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedtls.dylib
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/pkgconfig/mbedcrypto.pc
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/pkgconfig/mbedtls.pc
-- Installing: /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/pkgconfig/mbedx509.pc

mbedtls/3.6.0: package(): Packaged 1 file: LICENSE
mbedtls/3.6.0: package(): Packaged 113 '.h' files
mbedtls/3.6.0: package(): Packaged 11 '.dylib' files
mbedtls/3.6.0: Created package revision 64157d55ce5d133f907cbacac078d65b
mbedtls/3.6.0: Package '201c50b7a03393a15e34d8894d277ed514bb0edf' created
mbedtls/3.6.0: Full package reference: mbedtls/3.6.0#74150e45eb2c039313fcefb4d9335b0c:201c50b7a03393a15e34d8894d277ed514bb0edf#64157d55ce5d133f907cbacac078d65b
mbedtls/3.6.0: Package folder /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: mbedtls/3.6.0

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    mbedtls/3.6.0 (test package): /Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package/conanfile.py
Requirements
    mbedtls/3.6.0#74150e45eb2c039313fcefb4d9335b0c - Cache

======== Computing necessary packages ========
Requirements
    mbedtls/3.6.0#74150e45eb2c039313fcefb4d9335b0c:201c50b7a03393a15e34d8894d277ed514bb0edf#64157d55ce5d133f907cbacac078d65b - Cache

======== Installing packages ========
mbedtls/3.6.0: Already installed! (1 of 1)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: mbedtls/3.6.0

======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package/build/apple-clang-15-armv8-17-release
mbedtls/3.6.0 (test package): Test package build: build/apple-clang-15-armv8-17-release
mbedtls/3.6.0 (test package): Test package build folder: /Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package/build/apple-clang-15-armv8-17-release
mbedtls/3.6.0 (test package): Writing generators to /Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package/build/apple-clang-15-armv8-17-release/generators
mbedtls/3.6.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
mbedtls/3.6.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
mbedtls/3.6.0 (test package): CMakeToolchain generated: CMakePresets.json
mbedtls/3.6.0 (test package): CMakeToolchain generated: ../../../CMakeUserPresets.json
mbedtls/3.6.0 (test package): Generator 'CMakeDeps' calling 'generate()'
mbedtls/3.6.0 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(MbedTLS)
    target_link_libraries(... MbedTLS::mbedtls)
mbedtls/3.6.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
mbedtls/3.6.0 (test package): Generating aggregated env files
mbedtls/3.6.0 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
mbedtls/3.6.0 (test package): Calling build()
mbedtls/3.6.0 (test package): Running CMake.configure()
mbedtls/3.6.0 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="/Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package/build/apple-clang-15-armv8-17-release/generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package"
-- Using Conan toolchain: /Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package/build/apple-clang-15-armv8-17-release/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 17 with extensions OFF
-- The C compiler identification is AppleClang 15.0.0.15000309
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'MbedTLS::mbedcrypto'
-- Conan: Component target declared 'MbedTLS::mbedx509'
-- Conan: Component target declared 'MbedTLS::mbedtls'
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package/build/apple-clang-15-armv8-17-release

mbedtls/3.6.0 (test package): Running CMake.build()
mbedtls/3.6.0 (test package): RUN: cmake --build "/Users/uilian/Development/conan/conan-center-index/recipes/mbedtls/all/test_package/build/apple-clang-15-armv8-17-release" -- -j10
[ 50%] Building C object CMakeFiles/test_package.dir/test_package.c.o
[100%] Linking C executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
mbedtls/3.6.0 (test package): Running test()
mbedtls/3.6.0 (test package): RUN: ./test_package
version: Mbed TLS 3.6.0
```

Then, checked generated symbols:

```
nm -g /Users/uilian/.conan2/p/b/mbedt793fa98e752ed/p/lib/libmbedtls.3.6.0.dylib | grep mutex                                                                                                                           09:36:12
                 U _mbedtls_mutex_free
                 U _mbedtls_mutex_init
                 U _mbedtls_mutex_lock
                 U _mbedtls_mutex_unlock
```

The regular build, without threading support, will not generate those symbols. 

/cc @obnyis

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
