### PR TITLE
dbus: don't propagate X11 libs, drop `with_glib`, update license info

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -110,10 +110,10 @@ class DbusConan(ConanFile):
         tc.project_options["selinux"] = "enabled" if self.options.get_safe("with_selinux", False) else "disabled"
         tc.project_options["systemd"] = "enabled" if self.options.get_safe("with_systemd", False) else "disabled"
         if self.options.get_safe("with_systemd", False):
-            tc.project_options["systemd_system_unitdir"] = os.path.join(self.package_folder, "lib", "systemd", "system")
-            tc.project_options["systemd_user_unitdir"] = os.path.join(self.package_folder, "lib", "systemd", "user")
+            tc.project_options["systemd_system_unitdir"] = "/res/lib/systemd/system"
+            tc.project_options["systemd_user_unitdir"] = "/res/usr/lib/systemd/system"
         if is_apple_os(self):
-            tc.project_options["launchd_agent_dir"] = os.path.join(self.package_folder, "res", "LaunchAgents")
+            tc.project_options["launchd_agent_dir"] = "/res/LaunchAgents"
         tc.project_options["x11_autolaunch"] = "enabled" if self.options.get_safe("with_x11", False) else "disabled"
         tc.project_options["xml_docs"] = "disabled"
         tc.generate()
@@ -145,7 +145,6 @@ class DbusConan(ConanFile):
 
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
-        rmdir(self, os.path.join(self.package_folder, "lib", "systemd"))
         fix_apple_shared_install_name(self)
         if self.settings.os == "Windows" and not self.options.shared:
             rename(self, os.path.join(self.package_folder, "lib", "libdbus-1.a"), os.path.join(self.package_folder, "lib", "dbus-1.lib"))

--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -113,7 +113,7 @@ class DbusConan(ConanFile):
             tc.project_options["systemd_system_unitdir"] = "/res/lib/systemd/system"
             tc.project_options["systemd_user_unitdir"] = "/res/usr/lib/systemd/system"
         if is_apple_os(self):
-            tc.project_options["launchd_agent_dir"] = "/res/LaunchAgents"
+            tc.project_options["launchd_agent_dir"] = os.path.join(self.package_folder, "res", "LaunchAgents")
         tc.project_options["x11_autolaunch"] = "enabled" if self.options.get_safe("with_x11", False) else "disabled"
         tc.project_options["xml_docs"] = "disabled"
         tc.generate()

--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -75,7 +75,10 @@ class DbusConan(ConanFile):
         if self.options.get_safe("with_selinux"):
             self.requires("libselinux/3.5")
         if self.options.get_safe("with_x11"):
-            self.requires("xorg/system")
+            # X11 is only linked into an executable and should not be propagated as a library dependency.
+            # It should still be provided in a VirtualRunEnv context, though,
+            # but Conan as of v2.2 does not yet provide a fine-grained enough control over this.
+            self.requires("xorg/system", visible=False)
 
     def validate(self):
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < 7:
@@ -194,8 +197,6 @@ class DbusConan(ConanFile):
             self.cpp_info.requires.append("libsystemd::libsystemd")
         if self.options.get_safe("with_selinux"):
             self.cpp_info.requires.append("libselinux::selinux")
-        if self.options.get_safe("with_x11"):
-            self.cpp_info.requires.append("xorg::x11")
 
         # TODO: to remove in conan v2 once cmake_find_package_* & pkg_config generators removed
         self.cpp_info.filenames["cmake_find_package"] = "DBus1"

--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -15,7 +15,8 @@ required_conan_version = ">=1.53.0"
 
 class DbusConan(ConanFile):
     name = "dbus"
-    license = ("AFL-2.1", "GPL-2.0-or-later")
+    # license is AFL-2.1 OR GPL-2.0-or-later with several other compatible licenses for smaller sections of code
+    license = "(AFL-2.1 OR GPL-2.0-or-later) AND DocumentRef-COPYING"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.freedesktop.org/wiki/Software/dbus"
     description = "D-Bus is a simple system for interprocess communication and coordination."
@@ -129,7 +130,8 @@ class DbusConan(ConanFile):
         meson.build()
 
     def package(self):
-        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*", os.path.join(self.source_folder, "LICENSES"), os.path.join(self.package_folder, "licenses"))
         meson = Meson(self)
         meson.install()
 


### PR DESCRIPTION
I dropped (deprecated) the `with_glib` option altogether since it's only used within tests and nowhere else. I guess this might have been intended to enable [`dbus-glib`](https://gitlab.freedesktop.org/dbus/dbus-glib), which has been deprecated and moved to a separate repo a long while ago.

Set the X11 dependency to `visible=False`. As noted by the recipe comment, this is not ideal but it's the best that is currently possible with the tools provided by Conan. 

I also made the licensing details a bit more accurate, since the mix of licenses covering the project is actually quite complex:
https://gitlab.freedesktop.org/dbus/dbus/-/blob/master/COPYING
https://gitlab.freedesktop.org/dbus/dbus/-/tree/master/LICENSES

Also bumped `libselinux` to avoid a conflict with `libsystemd` and removed `with_selinux` option on non-Linux OS-s.

- Fixes #22133
- Resolves #22134