### PR TITLE
macdylibbundler: Add build tool for macOS

### DIFF
--- a/recipes/macdylibbundler/all/conandata.yml
+++ b/recipes/macdylibbundler/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.5":
+    url: "https://github.com/auriamg/macdylibbundler/archive/refs/tags/1.0.5.tar.gz"
+    sha256: "13384ebe7ca841ec392ac49dc5e50b1470190466623fa0e5cd30f1c634858530"

--- a/recipes/macdylibbundler/all/conanfile.py
+++ b/recipes/macdylibbundler/all/conanfile.py
@@ -1,0 +1,50 @@
+from conan import ConanFile
+from conan.tools.apple import is_apple_os
+from conan.tools.files import copy, get
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.errors import ConanInvalidConfiguration
+
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class MacDylibBundlerConan(ConanFile):
+    name = "macdylibbundler"
+    package_type = "application"
+    description = (
+        "mac dylib bundler is a tool for use when bundling mac applications"
+    )
+    topics = ("build", "dylib", "installer", "mac")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/auriamg/macdylibbundler"
+    license = "MIT"
+    settings = "os", "arch", "build_type"
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if not is_apple_os(self):
+            raise ConanInvalidConfiguration("This tool is for macOS only")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        # The CMakeLists.txt misses the install command, so for simplicity the executable is copied manually
+        copy(self, "dylibbundler", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/macdylibbundler/all/test_package/conanfile.py
+++ b/recipes/macdylibbundler/all/test_package/conanfile.py
@@ -1,0 +1,13 @@
+from conan import ConanFile
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        self.run("dylibbundler -h")

--- a/recipes/macdylibbundler/all/test_package/conanfile.py
+++ b/recipes/macdylibbundler/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
@@ -10,4 +11,5 @@ class TestPackageConan(ConanFile):
         self.tool_requires(self.tested_reference_str)
 
     def test(self):
-        self.run("dylibbundler -h")
+        if can_run(self):
+            self.run("dylibbundler -h")

--- a/recipes/macdylibbundler/config.yml
+++ b/recipes/macdylibbundler/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.5":
+    folder: all


### PR DESCRIPTION
Specify application name and version:  **macdylibbundler/1.0.5**

Helper tool for bundling macOS applications with dynamic libraries. I want to use it as a build_requirement as I before had it installed via brew but want it as a proper package now. Thought I'll share it with the community.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
