### PR TITLE
cista: add version 0.15

### DIFF
--- a/recipes/cista/all/conandata.yml
+++ b/recipes/cista/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "0.15":
+    - url: "https://github.com/felixguendling/cista/releases/download/v0.15/cista.h"
+      sha256: "45685fde5c5ef576ad821c4db7f01e375eb2668aa6dafd6b9627fe58ce0641eb"
+    - url: "https://raw.githubusercontent.com/felixguendling/cista/v0.15/LICENSE"
+      sha256: "fcd47e35fd6dc22feec454c5c1e572ccb7587dedd91d824528ebbb00a7f37c56"
   "0.14":
     - url: "https://github.com/felixguendling/cista/releases/download/v0.14/cista.h"
       sha256: "078933804966439ae105a6a748aa027a2f197351d735712b1efca0453340562d"

--- a/recipes/cista/config.yml
+++ b/recipes/cista/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.15":
+    folder: all
   "0.14":
     folder: all
   "0.11":


### PR DESCRIPTION
Specify library name and version:  **cista/0.15**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
