### PR TITLE
Add community alert for mocknetworkaccessmanager and qtawesome

### DIFF
--- a/.github/workflows/alert-community.yml
+++ b/.github/workflows/alert-community.yml
@@ -318,6 +318,11 @@ jobs:
 
       - uses: ./.github/actions/alert-community
         with:
+          files: "recipes/mocknetworkaccessmanager/*/*"
+          reviewers: "@MartinDelille"
+
+      - uses: ./.github/actions/alert-community
+        with:
           files: "recipes/ms-gsl/*/*"
           reviewers: "@jwillikers"
 
@@ -375,6 +380,11 @@ jobs:
         with:
           files: "recipes/psimd/*/*"
           reviewers: "@Hopobcn"
+
+      - uses: ./.github/actions/alert-community
+        with:
+          files: "recipes/qtawesome/*/*"
+          reviewers: "@MartinDelille"
 
       - uses: ./.github/actions/alert-community
         with:


### PR DESCRIPTION
Add community alert for mocknetworkaccessmanager and qtawesome
<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
