### PR TITLE
llvm-core: unpin cmake version

### DIFF
--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -77,7 +77,7 @@ class LLVMCoreConan(ConanFile):
     # Older cmake versions may have issues generating the graphviz output used
     # to model the components
     build_requires = [
-        'cmake/3.20.5'
+        'cmake/[>=3.20.5]'
     ]
 
     generators = 'cmake', 'cmake_find_package'

--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -77,7 +77,7 @@ class LLVMCoreConan(ConanFile):
     # Older cmake versions may have issues generating the graphviz output used
     # to model the components
     build_requires = [
-        'cmake/[>=3.20.5]'
+        'cmake/[>=3.20.5 <4]'
     ]
 
     generators = 'cmake', 'cmake_find_package'


### PR DESCRIPTION
In llvm-core, the cmake version was pinned to 3.20.5, making it impossible to build with VS 2022 on Windows since VS 2022 generators were introduced with cmake 3.21. From the original comment, it seems the intention was not to pin cmake, but rather specify a minimum version.

This change simply transforms the cmake pinning to a mere minimum requirement, making it possible to compile llvm-core with toolchains born after cmake 3.20.5.

Specify library name and version:  **llvm-core/all**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
