### PR TITLE
nmos-cpp: component bindirs

### DIFF
--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -57,7 +57,6 @@ class NmosCppConan(ConanFile):
         self.requires("openssl/[>=1.1 <4]")
         self.requires("json-schema-validator/2.3.0")
         self.requires("nlohmann_json/3.11.3")
-        self.requires("zlib/[>=1.2.11 <2]")
         if Version(self.version) >= "cci.20240222":
             self.requires("jwt-cpp/0.7.0")
 
@@ -231,7 +230,6 @@ class NmosCppConan(ConanFile):
             libdir = os.path.join(libdir, config_install_dir)
         self.cpp_info.bindirs = [bindir]
         self.cpp_info.libdirs = [libdir]
-        self.cpp_info.requires = ["nlohmann_json::nlohmann_json", "zlib::zlib"]
 
         def _register_components():
             components_json_file = files.load(self, self._components_helper_filepath)

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -127,7 +127,7 @@ class NmosCppConan(ConanFile):
 
         target_content = files.load(self, target_file_path)
 
-        cmake_functions = re.findall(r"(?P<func>add_library|set_target_properties)[\n|\s]*\([\n|\s]*(?P<args>[^)]*)\)", target_content)
+        cmake_functions = re.findall(r"(?P<func>add_executable|add_library|set_target_properties)[\n|\s]*\([\n|\s]*(?P<args>[^)]*)\)", target_content)
         for (cmake_function_name, cmake_function_args) in cmake_functions:
             cmake_function_args = re.split(r"[\s|\n]+", cmake_function_args, maxsplit=2)
 
@@ -140,7 +140,9 @@ class NmosCppConan(ConanFile):
 
             components.setdefault(component_name, {"cmake_target": cmake_target_nonamespace})
 
-            if cmake_function_name == "add_library":
+            if cmake_function_name == "add_executable":
+                components[component_name]["exe"] = True
+            elif cmake_function_name == "add_library":
                 cmake_imported_target_type = cmake_function_args[1]
                 if cmake_imported_target_type in ["STATIC", "SHARED"]:
                     # library filenames are based on the target name by default
@@ -238,6 +240,7 @@ class NmosCppConan(ConanFile):
                 cmake_target = values["cmake_target"]
                 self.cpp_info.components[component_name].names["cmake_find_package"] = cmake_target
                 self.cpp_info.components[component_name].names["cmake_find_package_multi"] = cmake_target
+                self.cpp_info.components[component_name].bindirs = [bindir] if values.get("exe") else []
                 self.cpp_info.components[component_name].libs = values.get("libs", [])
                 self.cpp_info.components[component_name].libdirs = [libdir]
                 self.cpp_info.components[component_name].defines = values.get("defines", [])


### PR DESCRIPTION
Specify library name and version:  **nmos-cpp**

Add components for _nmos-cpp-node_ and _nmos-cpp-registry_ with `bindirs`. This fixes the bug that these executables were not available in the path on Windows when running:
```sh
conan install --tool-requires=nmos-cpp/cci.20240223
conanbuild.bat
```

Also remove direct dependency on **zlib** - I believe originally added only to ensure no version conflicts between the indirect dependencies via **boost** and **cpprestsdk** at the time CCI policy was to use specific versions and aggressively update recipes to latest dependency versions.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
