### PR TITLE
iconfontcppheaders: bump version to cci.20240128

### DIFF
--- a/recipes/iconfontcppheaders/all/conandata.yml
+++ b/recipes/iconfontcppheaders/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20240128":
+    sha256: de946a4471dca969426b2e7863d79136a91f2e4e4cc7a766df31bbb8412571f9
+    url: https://github.com/juliettef/IconFontCppHeaders/archive/8886c5657bac22b8fee34354871e3ade2a596433/main.zip
   "cci.20231102":
     sha256: 7618e844dcbfea2404c209e8b52158a37c2368a79cc77e94087375a8186442c4
     url: https://github.com/juliettef/IconFontCppHeaders/archive/41b304750e83c0a89375cc1834f65c1204308b4a/main.zip

--- a/recipes/iconfontcppheaders/config.yml
+++ b/recipes/iconfontcppheaders/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20240128":
+    folder: all
   "cci.20231102":
     folder: all
   "cci.20231026":


### PR DESCRIPTION
IconFontCppHeaders cci.20240128

Bump package to includes latest font updates.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Hooks not activated since not supported on conan 2.x.