### PR TITLE
rapidfuzz: add version 3.0.4

### DIFF
--- a/recipes/rapidfuzz/all/conandata.yml
+++ b/recipes/rapidfuzz/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.4":
+    url: "https://github.com/rapidfuzz/rapidfuzz-cpp/archive/refs/tags/v3.0.4.tar.gz"
+    sha256: "18d1c41575ceddd6308587da8befc98c85d3b5bc2179d418daffed6d46b8cb0a"
   "3.0.2":
     url: "https://github.com/rapidfuzz/rapidfuzz-cpp/archive/refs/tags/v3.0.2.tar.gz"
     sha256: "4fddce5c0368e78bd604c6b820e6be248d669754715e39b4a8a281bda4c06de1"

--- a/recipes/rapidfuzz/config.yml
+++ b/recipes/rapidfuzz/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.4":
+    folder: "all"
   "3.0.2":
     folder: "all"
   "3.0.0":


### PR DESCRIPTION
Specify library name and version:  **rapidfuzz/3.0.4**

https://github.com/rapidfuzz/rapidfuzz-cpp/compare/v3.0.2...v3.0.4

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
