### PR TITLE
opentelemetry-proto: add version 1.2.0

### DIFF
--- a/recipes/opentelemetry-proto/all/conandata.yml
+++ b/recipes/opentelemetry-proto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.0":
+    url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v1.2.0.tar.gz"
+    sha256: "516dc94685dbaa14fb792788f31d2ef2b0c3ad08dfa8a9a8164e3cf60c1ab6f7"
   "1.1.0":
     url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v1.1.0.tar.gz"
     sha256: "df491a05f3fcbf86cc5ba5c9de81f6a624d74d4773d7009d573e37d6e2b6af64"

--- a/recipes/opentelemetry-proto/config.yml
+++ b/recipes/opentelemetry-proto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.0":
+    folder: all
   "1.1.0":
     folder: all
   "1.0.0":


### PR DESCRIPTION
Specify library name and version:  **opentelemetry-proto/1.2.0**

https://github.com/open-telemetry/opentelemetry-proto/compare/v1.1.0...v1.2.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
