### PR TITLE
botan: add version 3.4.0

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -32,6 +32,9 @@ sources:
   "3.3.0":
     url: "https://github.com/randombit/botan/archive/3.3.0.tar.gz"
     sha256: "57fefda7b9ab6f8409329620cdaf26d2d7e962b6a10eb321d331e9ecb796f804"
+  "3.4.0":
+    url: "https://github.com/randombit/botan/archive/3.4.0.tar.gz"
+    sha256: "6ef2a16a0527b1cfc9648a644877f7b95c4d07e8ef237273b030c623418c5e5b"
 patches:
   "2.18.2":
     - patch_file: "patches/fix-amalgamation-build.patch"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -21,3 +21,5 @@ versions:
     folder: all
   "3.3.0":
     folder: all
+  "3.4.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **botan/3.4.0**

This adds support for X448/Ed448. Otherwise, it is mostly a patch release without a lot of new functionality.

Details: https://github.com/randombit/botan/blob/master/news.rst

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
