### PR TITLE
Remove binutils unused ``conf_info`` entries

### DIFF
--- a/recipes/binutils/all/conanfile.py
+++ b/recipes/binutils/all/conanfile.py
@@ -199,8 +199,6 @@ class BinutilsConan(ConanFile):
         # v2 exports
         self.buildenv_info.append_path("PATH", bindir)
         self.buildenv_info.append_path("PATH", absolute_target_bindir)
-        self.conf_info.define("user.binutils:gnu_triplet", self.options.target_triplet)
-        self.conf_info.define("user.binutils:prefix", self.options.prefix)
 
         # Add recipe path to enable running the self test in the test package.
         # Don't use this property in production code. It's unsupported.

--- a/recipes/lcms/all/profile_msvc
+++ b/recipes/lcms/all/profile_msvc
@@ -1,0 +1,9 @@
+[settings]
+arch=arm64ec
+build_type=Debug
+compiler=msvc
+compiler.cppstd=20
+compiler.runtime=dynamic
+compiler.runtime_type=Debug
+compiler.version=193
+os=Windows

--- a/recipes/lcms/all/profile_msvc
+++ b/recipes/lcms/all/profile_msvc
@@ -1,9 +1,0 @@
-[settings]
-arch=arm64ec
-build_type=Debug
-compiler=msvc
-compiler.cppstd=20
-compiler.runtime=dynamic
-compiler.runtime_type=Debug
-compiler.version=193
-os=Windows


### PR DESCRIPTION
Specify library name and version:  **binutils**

The binutils recipe had 2 ``conf_info`` entries that are "options", not basic Python types, and this is broken, it crashes for example when using ``--format=json``. Furthermore, those are not used at all in all ConanCenter, so their existence seems not necessary. The values of those options can be read by consumers via ``self.dependencies["dep"].options``.

Close https://github.com/conan-io/conan/issues/16018

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
