### PR TITLE
aws-lambda-cpp: add cmake module for packaging function

### DIFF
--- a/recipes/aws-lambda-cpp/all/conanfile.py
+++ b/recipes/aws-lambda-cpp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import get, copy, rmdir
+from conan.errors import ConanInvalidConfiguration, ConanException
+from conan.tools.files import get, copy, mkdir, rmdir, load, save, rename
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.scm import Version
@@ -72,10 +72,21 @@ class AwsLambdaRuntimeConan(ConanFile):
         cmake.configure()
         cmake.build()
 
+    def _extract_cmake_module(self):
+        cmake_module = load(self, os.path.join(self.source_folder, "cmake", "aws-lambda-runtime-config.cmake"))
+        start = "set(AWS_LAMBDA_PACKAGING_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/packager)"
+        start_index = cmake_module.find(start)
+        if start_index == -1:
+            raise ConanException("Could not extract aws_lambda_package_target from aws-lambda-runtime-config.cmake file.")
+        return cmake_module[start_index:]
+
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
+
+        save(self, os.path.join(self.package_folder, "lib", "cmake", "aws_lambda_package_target.cmake"), self._extract_cmake_module())
+        rename(self, os.path.join(self.package_folder, "lib", "aws-lambda-runtime", "cmake", "packager"), os.path.join(self.package_folder, "lib", "cmake", "packager"))
         rmdir(self, os.path.join(self.package_folder, "lib", "aws-lambda-runtime"))
 
     def package_info(self):
@@ -83,5 +94,6 @@ class AwsLambdaRuntimeConan(ConanFile):
 
         self.cpp_info.set_property("cmake_file_name", "aws-lambda-runtime")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-lambda-runtime")
+        self.cpp_info.set_property("cmake_build_modules", [os.path.join("lib", "cmake", "aws_lambda_package_target.cmake")])
 
         self.cpp_info.system_libs.append("m")

--- a/recipes/aws-lambda-cpp/all/conanfile.py
+++ b/recipes/aws-lambda-cpp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration, ConanException
-from conan.tools.files import get, copy, mkdir, rmdir, load, save, rename
+from conan.tools.files import get, copy, rmdir, load, save, rename
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.scm import Version

--- a/recipes/aws-lambda-cpp/all/conanfile.py
+++ b/recipes/aws-lambda-cpp/all/conanfile.py
@@ -91,6 +91,7 @@ class AwsLambdaRuntimeConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["aws-lambda-runtime"]
+        self.cpp_info.builddirs.append(os.path.join("lib", "cmake"))
 
         self.cpp_info.set_property("cmake_file_name", "aws-lambda-runtime")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-lambda-runtime")

--- a/recipes/aws-lambda-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/aws-lambda-cpp/all/test_package/CMakeLists.txt
@@ -6,3 +6,5 @@ find_package(aws-lambda-runtime REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-lambda-runtime)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+
+aws_lambda_package_target(${PROJECT_NAME})

--- a/recipes/aws-lambda-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/aws-lambda-cpp/all/test_package/CMakeLists.txt
@@ -7,4 +7,6 @@ add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-lambda-runtime)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 
-aws_lambda_package_target(${PROJECT_NAME})
+if(NOT COMMAND aws_lambda_package_target)
+    message(FATAL_ERROR "aws_lambda_package_target should have been defined as part of find_package(aws-lambda-runtime)")
+endif()

--- a/recipes/aws-lambda-cpp/all/test_package/conanfile.py
+++ b/recipes/aws-lambda-cpp/all/test_package/conanfile.py
@@ -19,6 +19,7 @@ class TestPackageConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
+        cmake.build(target="aws-lambda-package-test_package")
 
     def test(self):
         if can_run(self):

--- a/recipes/aws-lambda-cpp/all/test_package/conanfile.py
+++ b/recipes/aws-lambda-cpp/all/test_package/conanfile.py
@@ -19,7 +19,6 @@ class TestPackageConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
-        cmake.build(target="aws-lambda-package-test_package")
 
     def test(self):
         if can_run(self):


### PR DESCRIPTION
Specify library name and version:  **aws-lambda-cpp/***

aws-lambda-cpp provides cmake functions to package lambda runtime binary.
This PR try to provide such a function.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
