### PR TITLE
implot: bump imgui for consistency with other packages

### DIFF
--- a/recipes/implot/all/CMakeLists.txt
+++ b/recipes/implot/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(implot LANGUAGES CXX)
 
 file(GLOB HEADER_FILES ${IMPLOT_SRC_DIR}/*.h)
@@ -6,7 +6,6 @@ file(GLOB HEADER_FILES ${IMPLOT_SRC_DIR}/*.h)
 add_library(${PROJECT_NAME}
     ${IMPLOT_SRC_DIR}/implot.cpp
     ${IMPLOT_SRC_DIR}/implot_items.cpp
-    ${IMPLOT_SRC_DIR}/implot_demo.cpp
 )
 target_include_directories(${PROJECT_NAME} PRIVATE ${IMPLOT_SRC_DIR})
 
@@ -14,7 +13,6 @@ find_package(imgui CONFIG REQUIRED)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC imgui::imgui)
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE IMGUI_DEFINE_MATH_OPERATORS)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/recipes/implot/all/CMakeLists.txt
+++ b/recipes/implot/all/CMakeLists.txt
@@ -6,6 +6,10 @@ file(GLOB HEADER_FILES ${IMPLOT_SRC_DIR}/*.h)
 add_library(${PROJECT_NAME}
     ${IMPLOT_SRC_DIR}/implot.cpp
     ${IMPLOT_SRC_DIR}/implot_items.cpp
+    # implot_demo.cpp is included so that user can use it to display the main documentation of implot.
+    # Note that these functions are not declared by the public headers.
+    # https://github.com/conan-io/conan-center-index/pull/20374
+    ${IMPLOT_SRC_DIR}/implot_demo.cpp
 )
 target_include_directories(${PROJECT_NAME} PRIVATE ${IMPLOT_SRC_DIR})
 

--- a/recipes/implot/all/conanfile.py
+++ b/recipes/implot/all/conanfile.py
@@ -61,6 +61,9 @@ class ImplotConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["IMPLOT_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        if Version(self.version) < "0.16":
+            # Set in code since v0.16 https://github.com/epezent/implot/commit/33c5a965f55f80057f197257d1d1cdb06523e963
+            tc.preprocessor_definitions["IMGUI_DEFINE_MATH_OPERATORS"] = ""
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/implot/all/conanfile.py
+++ b/recipes/implot/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, replace_in_file
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
 import os
@@ -38,10 +38,8 @@ class ImplotConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        if Version(self.version) >= "0.15":
+        if Version(self.version) >= "0.14":
             self.requires("imgui/1.90.4", transitive_headers=True)
-        elif Version(self.version) >= "0.14":
-            self.requires("imgui/1.89.5", transitive_headers=True)
         elif Version(self.version) >= "0.13":
             # imgui 1.89 renamed ImGuiKeyModFlags_* to  ImGuiModFlags_*
             self.requires("imgui/1.88", transitive_headers=True)
@@ -68,7 +66,15 @@ class ImplotConan(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
 
+    def _patch_sources(self):
+        if Version(self.version) == "0.14" and Version(self.dependencies["imgui"].ref.version) >= "1.89.7":
+            # https://github.com/ocornut/imgui/commit/51f564eea6333bae9242f40c983a3e29d119a9c2
+            replace_in_file(self, os.path.join(self.source_folder, "implot.cpp"),
+                            "ImGuiButtonFlags_AllowItemOverlap",
+                            "ImGuiButtonFlags_AllowOverlap")
+
     def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()

--- a/recipes/implot/all/conanfile.py
+++ b/recipes/implot/all/conanfile.py
@@ -31,7 +31,7 @@ class ImplotConan(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC # rm_safe not needed
+            del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
@@ -39,9 +39,9 @@ class ImplotConan(ConanFile):
 
     def requirements(self):
         if Version(self.version) >= "0.15":
-            self.requires("imgui/1.90", transitive_headers=True)
+            self.requires("imgui/1.90.4", transitive_headers=True)
         elif Version(self.version) >= "0.14":
-            self.requires("imgui/1.89.4", transitive_headers=True)
+            self.requires("imgui/1.89.5", transitive_headers=True)
         elif Version(self.version) >= "0.13":
             # imgui 1.89 renamed ImGuiKeyModFlags_* to  ImGuiModFlags_*
             self.requires("imgui/1.88", transitive_headers=True)

--- a/recipes/implot/all/conanfile.py
+++ b/recipes/implot/all/conanfile.py
@@ -39,7 +39,7 @@ class ImplotConan(ConanFile):
 
     def requirements(self):
         if Version(self.version) >= "0.14":
-            self.requires("imgui/1.90.4", transitive_headers=True)
+            self.requires("imgui/1.90.5", transitive_headers=True)
         elif Version(self.version) >= "0.13":
             # imgui 1.89 renamed ImGuiKeyModFlags_* to  ImGuiModFlags_*
             self.requires("imgui/1.88", transitive_headers=True)


### PR DESCRIPTION
Also adds support for v1.89.7+ for v0.14 by renaming a single imgui constant in a .cpp file.

`IMGUI_DEFINE_MATH_OPERATORS` no longer needs to be set in CMake. Dropped it to get rid of a related warning.

The imgui version bump is for compatibility with `imguizmo` (#23435) and `iridescence` (#23436). There are no other packages depending on `implot`.