### PR TITLE
libfreenect2: Use libglvnd on FreeBSD and Linux and libva

### DIFF
--- a/recipes/libfreenect2/all/conandata.yml
+++ b/recipes/libfreenect2/all/conandata.yml
@@ -4,5 +4,5 @@ sources:
     sha256: "c09e52c97b0e90335f4762ed5363293ad0fc1ea0064e578b879e7d15cc3559df"
 patches:
   "0.2.1":
-    - patch_file: "patches/0.2.1-fix-cmake.patch"
-    - patch_file: "patches/0.2.1-generate-resources.patch"
+    - patch_file: "patches/0.2.1-0001-Fix-CMake.patch"
+    - patch_file: "patches/0.2.1-0002-Generate-resources.patch"

--- a/recipes/libfreenect2/all/patches/0.2.1-0001-Fix-CMake.patch
+++ b/recipes/libfreenect2/all/patches/0.2.1-0001-Fix-CMake.patch
@@ -1,6 +1,17 @@
+From ad00c6cbacfb9ac0a186c11615a3f3be58536e76 Mon Sep 17 00:00:00 2001
+From: Jordan Williams <jordan@jwillikers.com>
+Date: Wed, 10 Apr 2024 07:41:17 -0500
+Subject: [PATCH 1/2] Fix CMake
+
+---
+ CMakeLists.txt | 29 +++++++++++++----------------
+ 1 file changed, 13 insertions(+), 16 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d8ef047..0e6f5ec 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -157,7 +157,7 @@
+@@ -157,7 +157,7 @@ SET(SOURCES
  )
  
  SET(LIBRARIES
@@ -9,7 +20,16 @@
    ${LIBFREENECT2_THREADING_LIBRARIES}
  )
  
-@@ -276,8 +272,8 @@
+@@ -209,7 +209,7 @@ IF(ENABLE_VAAPI)
+       src/vaapi_rgb_packet_processor.cpp
+     )
+     LIST(APPEND LIBRARIES
+-      ${VAAPI_LIBRARIES}
++      ${VAAPI_LINK_LIBRARIES}
+       ${JPEG_LIBRARY}
+     )
+   ENDIF()
+@@ -276,8 +276,8 @@ IF(ENABLE_OPENGL)
  
      LIST(APPEND LIBFREENECT2_DLLS ${GLFW3_DLL})
      LIST(APPEND LIBRARIES
@@ -20,7 +40,7 @@
      )
      LIST(APPEND SOURCES
        src/flextGL.cpp
-@@ -297,10 +293,10 @@
+@@ -297,10 +297,10 @@ ENDIF(ENABLE_OPENGL)
  
  SET(HAVE_OpenCL disabled)
  IF(ENABLE_OPENCL)
@@ -33,7 +53,7 @@
      SET(LIBFREENECT2_WITH_OPENCL_SUPPORT 1)
      SET(HAVE_OpenCL yes)
  
-@@ -312,7 +308,7 @@
+@@ -312,7 +312,7 @@ IF(ENABLE_OPENCL)
          MESSAGE(WARNING "Your libOpenCL.so is incompatible with CL/cl.h. Install ocl-icd-opencl-dev to update libOpenCL.so?")
        ENDIF()
      ENDIF()
@@ -42,7 +62,7 @@
  
      LIST(APPEND SOURCES
        src/opencl_depth_packet_processor.cpp
-@@ -320,7 +316,7 @@
+@@ -320,7 +320,7 @@ IF(ENABLE_OPENCL)
      )
  
      LIST(APPEND LIBRARIES
@@ -51,7 +71,7 @@
      )
  
      LIST(APPEND RESOURCES
-@@ -334,12 +330,11 @@
+@@ -334,12 +334,11 @@ IF(ENABLE_OPENCL)
      IF(UNIX AND NOT APPLE)
        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
      ENDIF()
@@ -65,7 +85,7 @@
    SET(HAVE_CUDA no)
    IF(CUDA_FOUND AND MSVC14 AND CUDA_VERSION VERSION_LESS 8.0)
      SET(HAVE_CUDA "no (VS2015 not supported)")
-@@ -347,12 +342,15 @@
+@@ -347,12 +346,15 @@ IF(ENABLE_CUDA)
      SET(LIBFREENECT2_WITH_CUDA_SUPPORT 1)
      SET(HAVE_CUDA yes)
  
@@ -82,7 +102,7 @@
        "${NVCUDASAMPLES8_0_ROOT}/common/inc"
      )
      SET(CUDA_FLAGS -use_fast_math)
-@@ -403,11 +401,6 @@
+@@ -403,11 +405,6 @@ ENDIF()
  # Both command line -DCMAKE_INSTALL_RPATH=... and CMake GUI settings are accepted.
  #
  # Anyway if wrong versions of libusb is used, errors will be reported explicitly.
@@ -94,3 +114,6 @@
  IF(DEFINED CMAKE_INSTALL_RPATH)
    MESSAGE(STATUS "RPATH set to ${CMAKE_INSTALL_RPATH}")
  ENDIF()
+-- 
+2.44.0
+

--- a/recipes/libfreenect2/all/patches/0.2.1-0002-Generate-resources.patch
+++ b/recipes/libfreenect2/all/patches/0.2.1-0002-Generate-resources.patch
@@ -1,6 +1,11 @@
-This patch avoids compiling 'generate_resources_tool' to generate C sources of binary resources
-and instead uses CMake functionality to generate the files. This patch is necessary to enable
-cross-compiling without setting up host compiling environment. @sh0
+From dfebe6e53ac1609fc927d2b49ecd3f6574a278e5 Mon Sep 17 00:00:00 2001
+From: Jordan Williams <jordan@jwillikers.com>
+Date: Wed, 10 Apr 2024 07:41:33 -0500
+Subject: [PATCH 2/2] Generate resources
+
+---
+ cmake_modules/GenerateResources.cmake | 27 ++++++++++++++++++---------
+ 1 file changed, 18 insertions(+), 9 deletions(-)
 
 diff --git a/cmake_modules/GenerateResources.cmake b/cmake_modules/GenerateResources.cmake
 index 8616e38..6deea9a 100644
@@ -39,3 +44,6 @@ index 8616e38..6deea9a 100644
  )
  
  ENDFUNCTION(GENERATE_RESOURCES)
+-- 
+2.44.0
+


### PR DESCRIPTION
The `libglvnd` package provides the necessary `opengl/system` dependency. The `libglvnd` package is a proper, non-system Conan package. Likewise, use the `libva` Conan package instead of the `vaapi/system` package.