### PR TITLE
mcap: add version 1.4.0

### DIFF
--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -1,37 +1,40 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.4.0.tar.gz"
+    sha256: "64ff3e51119f37ffcfaf9deecbd987a7cb4d4d9035d74a3fd3773395a470fda1"
   "1.3.0":
     url: "https://github.com/foxglove/mcap/archive/releases/cpp/v1.3.0.tar.gz"
     sha256: "41acf6e85d75556c64407f077e05492d31db1f099e07242ef04364bb2939acf1"
   "1.2.1":
     url: "https://github.com/foxglove/mcap/archive/releases/cpp/v1.2.1.tar.gz"
     sha256: "fdc0c351bbcf8883fec0047ff84fed74da88446859083beb6624a584e2cde669"
-  1.2.0:
+  "1.2.0":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.2.0/main.tar.gz"
     sha256: "11a6badecac2b10e9687e912648a6e9679ef8731e4ab9570346ae9845ae64a65"
-  1.1.0:
+  "1.1.0":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.1.0/main.tar.gz"
     sha256: "1cb2ae9f2e910eeb2e93b3ab722744d1805b9da45764e4fd88703b669413350d"
-  1.0.0:
+  "1.0.0":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v1.0.0/main.tar.gz"
     sha256: "e36169e46a67a9431f73df335f67488461817bc423f9af63ac0af7f29e0bd696"
-  0.9.0:
+  "0.9.0":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.9.0/main.tar.gz"
     sha256: "e17702fcc0259bf72eab0d84d3fa6e02c051256357ab7ba4421462f2c02b434f"
-  0.5.0:
+  "0.5.0":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.5.0/main.tar.gz"
     sha256: "408e255a6c6419b16de38a9ecbdd9729d60adc657767b2d52a234d1da1185349"
-  0.4.0:
+  "0.4.0":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.4.0/main.tar.gz"
     sha256: "c0ab99e51005fa8b74fe9ca1ed23b205cf532b8b0723eedd243f35a28d7b466b"
-  0.3.0:
+  "0.3.0":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.3.0/main.tar.gz"
     sha256: "ef29ea4c09520b8aaa2d78ce5e79cbbcd87511ed14d6abf3c4b249ae67a4153b"
-  0.1.2:
+  "0.1.2":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.2/main.tar.gz"
     sha256: "0f456d6c53730445c3dbf57afd285493cf748c66a02f77d6e48c075128fd0896"
-  0.1.1:
+  "0.1.1":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.1/main.tar.gz"
     sha256: "a9ea899315851bfacdb234b7acc917b1a9c67593f0d68e1920321a8f6fa2cfbf"
-  0.1.0:
+  "0.1.0":
     url: "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.0/main.tar.gz"
     sha256: "a936abb1493b0d189d7909a79c45bdc6703b6016801e10b5cd129ba39642d2b2"

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -1,25 +1,27 @@
 versions:
+  "1.4.0":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.1":
     folder: all
-  1.2.0:
+  "1.2.0":
     folder: all
-  1.1.0:
+  "1.1.0":
     folder: all
-  1.0.0:
+  "1.0.0":
     folder: all
-  0.9.0:
+  "0.9.0":
     folder: all
-  0.5.0:
+  "0.5.0":
     folder: all
-  0.4.0:
+  "0.4.0":
     folder: all
-  0.3.0:
+  "0.3.0":
     folder: all
-  0.1.2:
+  "0.1.2":
     folder: all
-  0.1.1:
+  "0.1.1":
     folder: all
-  0.1.0:
+  "0.1.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **mcap/1.4.0**

(Also clean up the formatting of these yaml files for consistency.)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
