### PR TITLE
Include newer ixwebsocket version ixwebsocket/11.4.5

### DIFF
--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "11.4.5":
+    folder: all
   "11.4.3":
     folder: all
   "11.2.4":


### PR DESCRIPTION
version 11.4.3 has a gcc13 bug that is corrected in this update

Specify library name and version:  **ixwebsocket/11.4.5**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

version 11.4.3 has a gcc13 bug that is corrected in this update
---

- [y] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [y] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [y] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
