### PR TITLE
boost: ignore dependency if it doesn't provide a library [v1]

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1344,6 +1344,9 @@ class BoostConan(ConanFile):
 
         def create_library_config(deps_name, name):
             aggregated_cpp_info = self.dependencies[deps_name].cpp_info.aggregated_components()
+            if len(aggregated_cpp_info.libs) == 0:
+                return ""
+
             includedir = aggregated_cpp_info.includedirs[0].replace("\\", "/")
             includedir = f"\"{includedir}\""
             libdir = aggregated_cpp_info.libdirs[0].replace("\\", "/")


### PR DESCRIPTION
Specify library name and version:  **boost/any**

For Conan v1 I use the following custom recipes that wrap system libraries on Apple platforms:
- bzip2: https://github.com/kambala-decapitator/conan-system-libs/blob/main/bzip2/conanfile.py
- zlib: https://github.com/kambala-decapitator/conan-system-libs/blob/main/zlib/conanfile.py

But when I try to build Boost against those, it fails due to attempt to access first element of an empty array. This patch prevents that.

Tested by building Boost as shared library and my project and then running my project successfully.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
