### PR TITLE
[openapi-generator] Bump openjdk to 21.0.2

### DIFF
--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -20,7 +20,7 @@ class OpenApiGeneratorConan(ConanFile):
         pass
 
     def requirements(self):
-        self.requires("openjdk/19.0.2")
+        self.requires("openjdk/21.0.2")
 
     def package_id(self):
         del self.info.settings.arch


### PR DESCRIPTION
Everything is in the title

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
