### PR TITLE
dfp: Add version 1.0.3

### DIFF
--- a/recipes/dfp/all/conandata.yml
+++ b/recipes/dfp/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.0.2":
     url: "https://github.com/epam/DFP/releases/download/1.0.2-cxx/native-sources.tar.gz"
     sha256: "f62acab311086c1207f7d58185232c7e86e11ed606596d9afcff49703c196058"
+  "1.0.3":
+    url: "https://github.com/epam/DFP/releases/download/1.0.3/native-sources.zip"
+    sha256: "c211a47aae17a9f736ad0741dece39e0b9a0f0cebfbd364c9397a22ef5750a82"

--- a/recipes/dfp/config.yml
+++ b/recipes/dfp/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.0.2":
     folder: all
+  "1.0.3":
+    folder: all


### PR DESCRIPTION
**dfp/1.0.3**

I'm the dfp library maintainer.
The new function to the library is added, so all supported platforms must be updated.

---

- [*] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [*] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [*] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
