### PR TITLE
freexl: bump expat

### DIFF
--- a/recipes/freexl/all/conanfile.py
+++ b/recipes/freexl/all/conanfile.py
@@ -54,7 +54,7 @@ class FreexlConan(ConanFile):
     def requirements(self):
         self.requires("libiconv/1.17")
         if Version(self.version) >= "2.0.0":
-            self.requires("expat/2.5.0")
+            self.requires("expat/2.6.0")
             self.requires("minizip/1.2.13")
 
     def build_requirements(self):


### PR DESCRIPTION
Specify library name and version:  **freexl/all**

fix use of vulnerable version of expat, 2.6.0 is the most used version not vulnerable in CCI which should limit conflicts: https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
