### PR TITLE
dbus: security, bump expat

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -80,7 +80,7 @@ class DbusConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("expat/2.6.0")
+        self.requires("expat/2.6.2")
         if self.options.get_safe("with_systemd"):
             self.requires("libsystemd/253.6")
         if self.options.get_safe("with_selinux"):


### PR DESCRIPTION
Specify library name and version:  ** dbus/1.x.x**

expat<2.6.2 has known vulnerabilites, bump to 2.6.2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
