### PR TITLE
sdbus-cpp: security, bump expat

### DIFF
--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -76,7 +76,7 @@ class SdbusCppConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("pkgconf/2.1.0")
         if self.options.with_code_gen:
-            self.tool_requires("expat/2.6.2")
+            self.tool_requires("expat/[>=2.6.2 <3]")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -76,7 +76,7 @@ class SdbusCppConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("pkgconf/2.1.0")
         if self.options.with_code_gen:
-            self.tool_requires("expat/2.6.0")
+            self.tool_requires("expat/2.6.2")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **sdbus-cpp/all**

fix use of vulnerable version of expat, versions<2.6.2 have known vulnerabilites: https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
