### PR TITLE
wayland: security, bump deps

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -51,7 +51,7 @@ class WaylandConan(ConanFile):
             self.requires("libffi/3.4.4")
         if self.options.enable_dtd_validation:
             self.requires("libxml2/2.12.5")
-        self.requires("expat/2.6.2")
+        self.requires("expat/[>=2.6.2 <3]")
 
     def validate(self):
         if self.settings.os != "Linux":

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -50,15 +50,15 @@ class WaylandConan(ConanFile):
         if self.options.enable_libraries:
             self.requires("libffi/3.4.4")
         if self.options.enable_dtd_validation:
-            self.requires("libxml2/2.12.3")
-        self.requires("expat/2.6.0")
+            self.requires("libxml2/2.12.5")
+        self.requires("expat/2.6.2")
 
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration(f"{self.ref} only supports Linux")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.3.1")
+        self.tool_requires("meson/1.4.0")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.1.0")
         if not can_run(self):


### PR DESCRIPTION
Specify library name and version:  **wayland/all**

fix use of vulnerable version of expat, versions<2.6.2 have known vulnerabilites: https://github.com/conan-io/conan-center-index/issues/23277
fix use of vulnerable version of libxml, versions<2.12.5 have known vulnerabilites: https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
