### PR TITLE
avahi: security, bump expat

### DIFF
--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -46,7 +46,7 @@ class AvahiConan(ConanFile):
 
     def requirements(self):
         self.requires("glib/2.78.3")
-        self.requires("expat/2.6.2")
+        self.requires("expat/[>=2.6.2 <3]")
         self.requires("libdaemon/0.14")
         self.requires("dbus/1.15.8")
         self.requires("gdbm/1.23")


### PR DESCRIPTION
Specify library name and version:  **avahi/all**

fix use of vulnerable version of expat, versions<2.6.2 have known vulnerabilites: https://github.com/conan-io/conan-center-index/issues/23277

Blocked by #23512

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
