### PR TITLE
dacap-clip: add version 1.9

### DIFF
--- a/recipes/dacap-clip/all/conandata.yml
+++ b/recipes/dacap-clip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9":
+    url: "https://github.com/dacap/clip/archive/refs/tags/v1.9.tar.gz"
+    sha256: "e8af414c720784a6005419afb087786c05602e998ec52b2efe9e3112b7535d30"
   "1.8":
     url: "https://github.com/dacap/clip/archive/refs/tags/v1.8.tar.gz"
     sha256: "a54d243451fb483590ffd9239a3c55f8d8e672d44df63dc2b81da01a229074bc"

--- a/recipes/dacap-clip/config.yml
+++ b/recipes/dacap-clip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9":
+    folder: "all"
   "1.8":
     folder: "all"
   "1.7":


### PR DESCRIPTION
Specify library name and version:  **dcap-clip/1.9**

https://github.com/dacap/clip/compare/v1.8...v1.9

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
