### PR TITLE
make minimum compiler version explicit in error message

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -193,7 +193,7 @@ class BotanConan(ConanFile):
             minimum_version = self._compilers_minimum_version.get(compiler_name, False)
             if minimum_version and Version(self.settings.compiler.version) < minimum_version:
                 raise ConanInvalidConfiguration(
-                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support (minimum {compiler_name} {minimum_version})."
                 )
             if not minimum_version:
                 self.output.warning(f"{self.name} recipe lacks information about the {compiler_name} compiler support.")


### PR DESCRIPTION
Minor addition to an error message. Was mildly frustrating being told that my compiler (gcc 11.0) didn't support C++20 and having to dig into the conanfile to work out exactly what the issue was.
