### PR TITLE
fix template conan doesn't pass the linter

### DIFF
--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -132,7 +132,7 @@ class PackageConan(ConanFile):
         # --enable/disable-shared is automatically managed when 'shared' option is declared
         tc = AutotoolsToolchain(self)
         # autotools usually uses 'yes' and 'no' to enable/disable options
-        yes_no = lambda v: "yes" if v else "no"
+        def yes_no(v): return "yes" if v else "no"
         tc.configure_args.extend([
             f"--with-foobar={yes_no(self.options.with_foobar)}",
             "--enable-tools=no",


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

code from template doesn't pass the linter:
```
[C3001(unnecessary-lambda-assignment), OpenldapConan.generate.<lambda>] Lambda expression assigned to a variable. Define a function using the "def" keyword instead.
```

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
