### PR TITLE
coin-buildtools: new recipe

### DIFF
--- a/recipes/coin-buildtools/all/conandata.yml
+++ b/recipes/coin-buildtools/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "0.8.11":
+    url: "https://github.com/coin-or-tools/BuildTools/archive/refs/tags/releases/0.8.11.tar.gz"
+    sha256: "ec4cec2455537b4911b1ce223f1f946f5afa2ea6264fc96ae4da6bea63af34dc"
+patches:
+  "0.8.11":
+    - patch_file: "patches/0.8.11-m4-tweaks.patch"
+      patch_type: "portability"
+      patch_description: "Fixes to Autotools M4 scripts for compatibility with Conan"
+      patch_source: "https://github.com/microsoft/vcpkg/pull/29398"

--- a/recipes/coin-buildtools/all/conandata.yml
+++ b/recipes/coin-buildtools/all/conandata.yml
@@ -1,7 +1,11 @@
 sources:
   "0.8.11":
-    url: "https://github.com/coin-or-tools/BuildTools/archive/refs/tags/releases/0.8.11.tar.gz"
-    sha256: "ec4cec2455537b4911b1ce223f1f946f5afa2ea6264fc96ae4da6bea63af34dc"
+    source:
+      url: "https://github.com/coin-or-tools/BuildTools/archive/refs/tags/releases/0.8.11.tar.gz"
+      sha256: "ec4cec2455537b4911b1ce223f1f946f5afa2ea6264fc96ae4da6bea63af34dc"
+    license:
+      url: "https://raw.githubusercontent.com/coin-or-tools/BuildTools/20208f47f7bbc0056a92adefdfd43fded969f674/LICENSE"
+      sha256: "fe33d31053be0fbea60137ee7234291049d68c72f4f6880d13c03243c684e0a6"
 patches:
   "0.8.11":
     - patch_file: "patches/0.8.11-m4-tweaks.patch"

--- a/recipes/coin-buildtools/all/conandata.yml
+++ b/recipes/coin-buildtools/all/conandata.yml
@@ -8,6 +8,10 @@ sources:
       sha256: "fe33d31053be0fbea60137ee7234291049d68c72f4f6880d13c03243c684e0a6"
 patches:
   "0.8.11":
+    - patch_file: "patches/0.8.11-fix-clang-misclassified-as-cl.patch"
+      patch_type: "portability"
+      patch_description: "Fixes Clang being incorrectly identified as cl"
+      patch_source: "https://github.com/coin-or-tools/BuildTools/pull/153"
     - patch_file: "patches/0.8.11-m4-tweaks.patch"
       patch_type: "portability"
       patch_description: "Fixes to Autotools M4 scripts for compatibility with Conan"

--- a/recipes/coin-buildtools/all/conanfile.py
+++ b/recipes/coin-buildtools/all/conanfile.py
@@ -30,7 +30,7 @@ class CoinBuildtoolsConan(ConanFile):
 
     def requirements(self):
         # https://github.com/coin-or-tools/BuildTools/blob/20208f47f7bbc0056a92adefdfd43fded969f674/install_autotools.sh#L9-L12
-        self.requires("autoconf/2.71", run=True)
+        self.requires("autoconf/2.72", run=True)
         self.requires("autoconf-archive/2023.02.20", run=True)
         self.requires("automake/1.16.5", run=True)
         self.requires("libtool/2.4.7", run=True)

--- a/recipes/coin-buildtools/all/conanfile.py
+++ b/recipes/coin-buildtools/all/conanfile.py
@@ -1,0 +1,71 @@
+import os
+
+from conan import ConanFile
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, mkdir
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import unix_path
+
+required_conan_version = ">=1.52.0"
+
+
+class CoinBuildtoolsConan(ConanFile):
+    name = "coin-buildtools"
+    description = "Macros and patches for GNU autotools for COIN-OR projects."
+    topics = ("coin", "autotools")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/coin-or-tools/BuildTools"
+    license = "EPL-2.0"
+
+    package_type = "application"
+    settings = "os", "arch", "build_type", "compiler"
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def requirements(self):
+        # https://github.com/coin-or-tools/BuildTools/blob/20208f47f7bbc0056a92adefdfd43fded969f674/install_autotools.sh#L9-L12
+        self.requires("autoconf/2.71", run=True)
+        self.requires("autoconf-archive/2023.02.20", run=True)
+        self.requires("automake/1.16.5", run=True)
+        self.requires("libtool/2.4.7", run=True)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        apply_conandata_patches(self)
+
+    @staticmethod
+    def _chmod_plus_x(name):
+        if os.name == "posix":
+            os.chmod(name, os.stat(name).st_mode | 0o111)
+
+    def package(self):
+        resdir = os.path.join(self.package_folder, "res")
+        copy(self, "*", self.source_folder, resdir)
+        if self.version.startswith("cci."):
+            mkdir(self, os.path.join(self.package_folder, "licenses"))
+            rename(self, os.path.join(resdir, "LICENSE"),
+                   os.path.join(self.package_folder, "licenses", "LICENSE"))
+        copy(self, "*.m4", self.source_folder, os.path.join(self.package_folder, "bin"))
+        rename(self, os.path.join(resdir, "run_autotools"),
+               os.path.join(self.package_folder, "bin", "run_autotools"))
+        self._chmod_plus_x(os.path.join(self.package_folder, "bin", "run_autotools"))
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = ["res"]
+
+        aclocal_dir = unix_path(self, os.path.join(self.package_folder, "res"))
+        self.buildenv_info.append_path("ACLOCAL_PATH", aclocal_dir)
+
+        # TODO: Legacy, to be removed on Conan 2.0
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+        self.env_info.ACLOCAL_PATH.append(aclocal_dir)

--- a/recipes/coin-buildtools/all/conanfile.py
+++ b/recipes/coin-buildtools/all/conanfile.py
@@ -1,11 +1,11 @@
 import os
 
 from conan import ConanFile
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, mkdir, download
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, download
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import unix_path
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.0"
 
 
 class CoinBuildtoolsConan(ConanFile):
@@ -38,8 +38,6 @@ class CoinBuildtoolsConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version]["source"], strip_root=True)
         download(self, **self.conan_data["sources"][self.version]["license"], filename="LICENSE")
-
-    def build(self):
         apply_conandata_patches(self)
 
     @staticmethod
@@ -63,7 +61,3 @@ class CoinBuildtoolsConan(ConanFile):
 
         aclocal_dir = unix_path(self, os.path.join(self.package_folder, "res"))
         self.buildenv_info.append_path("ACLOCAL_PATH", aclocal_dir)
-
-        # TODO: Legacy, to be removed on Conan 2.0
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
-        self.env_info.ACLOCAL_PATH.append(aclocal_dir)

--- a/recipes/coin-buildtools/all/conanfile.py
+++ b/recipes/coin-buildtools/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
 from conan import ConanFile
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, mkdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, mkdir, download
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import unix_path
 
@@ -36,7 +36,8 @@ class CoinBuildtoolsConan(ConanFile):
         self.requires("libtool/2.4.7", run=True)
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version]["source"], strip_root=True)
+        download(self, **self.conan_data["sources"][self.version]["license"], filename="LICENSE")
 
     def build(self):
         apply_conandata_patches(self)
@@ -47,12 +48,9 @@ class CoinBuildtoolsConan(ConanFile):
             os.chmod(name, os.stat(name).st_mode | 0o111)
 
     def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         resdir = os.path.join(self.package_folder, "res")
         copy(self, "*", self.source_folder, resdir)
-        if self.version.startswith("cci."):
-            mkdir(self, os.path.join(self.package_folder, "licenses"))
-            rename(self, os.path.join(resdir, "LICENSE"),
-                   os.path.join(self.package_folder, "licenses", "LICENSE"))
         copy(self, "*.m4", self.source_folder, os.path.join(self.package_folder, "bin"))
         rename(self, os.path.join(resdir, "run_autotools"),
                os.path.join(self.package_folder, "bin", "run_autotools"))

--- a/recipes/coin-buildtools/all/patches/0.8.11-fix-clang-misclassified-as-cl.patch
+++ b/recipes/coin-buildtools/all/patches/0.8.11-fix-clang-misclassified-as-cl.patch
@@ -1,0 +1,148 @@
+diff --git a/coin.m4 b/coin.m4
+index 1dc7d8f..77a7781 100644
+--- a/coin.m4
++++ b/coin.m4
+@@ -337,7 +337,7 @@ AM_CONDITIONAL(COIN_CXX_IS_CL, [test $coin_cxx_is_cl = true])
+ 
+ # Autoconf incorrectly concludes that cl recognises -g. It doesn't.
+ case "$CXX" in
+-  clang* ) ;;
++  clang* | */clang* ) ;;
+   cl* | */cl* | CL* | */CL* )
+     if test "$ac_cv_prog_cxx_g" = yes ; then
+       ac_cv_prog_cxx_g=no
+@@ -386,7 +386,7 @@ if test x"$CXXFLAGS" = x; then
+     case $build in
+       *-cygwin* | *-mingw*)
+         case "$CXX" in
+-          clang* ) ;;
++          clang* | */clang* ) ;;
+           cl* | */cl* | CL* | */CL*)
+             # The MT and MTd options are mutually exclusive
+             if test "$coin_disable_shared" = yes || test "$enable_shared" = yes ; then
+@@ -527,7 +527,7 @@ fi
+ 
+ # correct the LD variable in a build with MS or Intel-windows compiler
+ case "$CXX" in
+-  clang* ) ;;
++  clang* | */clang* ) ;;
+   cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+     LD=link
+     ;;
+@@ -571,7 +571,7 @@ if test -z "$CXXLIBS"; then
+     case $build in
+      *-mingw32 | *-cygwin* )
+       case "$CXX" in
+-      clang* ) ;;
++      clang* | */clang* ) ;;
+       cl* | */cl* | CL* | */CL*)
+         CXXLIBS=nothing;;
+       esac;;
+@@ -673,7 +673,7 @@ AC_LANG_PUSH(C)
+ # compiler, if the C++ is set, but the C compiler isn't (only for CXX=cl)
+ if test x"$CXX" != x; then
+   case "$CXX" in
+-    clang* ) ;;
++    clang* | */clang* ) ;;
+     cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+       if test x"$CC" = x; then
+         CC="$CXX"
+@@ -728,7 +728,7 @@ if test -z "$CC" ; then
+ fi
+ # Autoconf incorrectly concludes that cl recognises -g. It doesn't.
+ case "$CC" in
+-  clang* ) ;;
++  clang* | */clang* ) ;;
+   cl* | */cl* | CL* | */CL* )
+     if test "$ac_cv_prog_cc_g" = yes ; then
+       ac_cv_prog_cc_g=no
+@@ -745,7 +745,7 @@ CFLAGS="$save_cflags"
+ # add automake conditional so we can recognize cl compiler in makefile
+ coin_cc_is_cl=false
+ case "$CC" in
+-  clang* ) ;;
++  clang* | */clang* ) ;;
+   cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+     coin_cc_is_cl=true
+     ;;
+@@ -782,7 +782,7 @@ if test x"$CFLAGS" = x; then
+     case $build in
+       *-cygwin* | *-mingw*)
+         case "$CC" in
+-          clang* ) ;;
++          clang* | */clang* ) ;;
+           cl* | */cl* | CL* | */CL*)
+             if test "$coin_disable_shared" = yes || test "$enable_shared" = yes ; then
+               coin_opt_cflags='-MD -O2'
+@@ -915,7 +915,7 @@ fi
+ 
+ # Correct the LD variable if we are using the MS or Intel-windows compiler
+ case "$CC" in
+-  clang* ) ;;
++  clang* | */clang* ) ;;
+   cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+     LD=link
+     ;;
+@@ -1530,7 +1530,7 @@ else
+       coin_disable_shared=yes
+       if test x"$enable_shared" = xyes; then
+         case "$CC" in
+-          clang* )
++          clang* | */clang* )
+             AC_MSG_WARN([Building of DLLs not supported in this configuration.])
+             ;;
+           cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+@@ -1661,7 +1661,7 @@ if test "$dependency_linking" = auto; then
+     case $build in
+       *-cygwin* | *-mingw*)
+         case "$CC" in
+-          clang* )
++          clang* | */clang* )
+             dependency_linking=yes
+             ;;
+           cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+@@ -1720,7 +1720,7 @@ AC_SUBST(LT_LDFLAGS)
+ 
+ AC_DEFUN([AC_COIN_PATCH_LIBTOOL_CYGWIN],
+ [ case "$CXX" in
+-    clang* )
++    clang* | */clang* )
+       # we assume that libtool patches for CLANG are the same as for GNU compiler - correct???
+       AC_MSG_NOTICE(Applying patches to libtool for CLANG compiler)
+       sed -e 's|fix_srcfile_path=\"`cygpath -w \"\$srcfile\"`\"|fix_srcfile_path=\"\\\`'"$CYGPATH_W"' \\\"\\$srcfile\\\"\\\`\"|' \
+@@ -1953,7 +1953,7 @@ AC_BEFORE([AC_COIN_ENABLE_MSVC], [$0])
+ AC_MSG_CHECKING([which command should be used to link input files])
+ coin_link_input_cmd="$LN_S"
+ case "$CC" in
+-  clang* ) ;;
++  clang* | */clang* ) ;;
+   cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+     coin_link_input_cmd=cp ;;
+ esac
+@@ -1979,7 +1979,7 @@ if test x$coin_skip_ac_output != xyes; then
+   # library extension
+   AC_SUBST(LIBEXT)
+   case "$CC" in
+-    clang* )
++    clang* | */clang* )
+          LIBEXT=a ;;
+     cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+          LIBEXT=lib ;;
+@@ -2632,7 +2632,7 @@ if test $coin_vpath_config = yes; then
+     lnkcmd=cp
+   fi
+   case "$CC" in
+-    clang* ) ;;
++    clang* | */clang* ) ;;
+     cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+       lnkcmd=cp ;;
+   esac
+@@ -3965,7 +3965,7 @@ else
+       
+     *-cygwin* | *-mingw*)
+       case "$CC" in
+-        clang* ) ;;
++        clang* | */clang* ) ;;
+         cl* | */cl* | CL* | */CL* | icl* | */icl* | ICL* | */ICL*)
+           coin_save_LIBS="$LIBS"
+           LIBS="mkl_intel_c.lib mkl_sequential.lib mkl_core.lib $LIBS"

--- a/recipes/coin-buildtools/all/patches/0.8.11-m4-tweaks.patch
+++ b/recipes/coin-buildtools/all/patches/0.8.11-m4-tweaks.patch
@@ -1,0 +1,45 @@
+Adapted from https://github.com/microsoft/vcpkg/blob/ad3bae57455a3c3ce528fcd47d8e8027d0498add/ports/coin-or-buildtools/buildtools.patch
+--- a/coin.m4
++++ b/coin.m4
+@@ -2137,14 +2137,12 @@
+   AC_COIN_CHECK_HEADER([zlib.h],[coin_has_zlib=yes])
+ 
+   if test $coin_has_zlib = yes; then
+-    AC_CHECK_LIB([z],[gzopen],[:],[coin_has_zlib=no])
++    AC_SEARCH_LIBS([gzopen],[z zlib zlibd],[],[coin_has_zlib=no])
+   fi
+ 
+   if test $coin_has_zlib = yes; then
+     coin_foreach_w([myvar], [$1], [
+-                    m4_toupper(myvar)_LIBS="-lz $m4_toupper(myvar)_LIBS"
+-                    m4_toupper(myvar)_PCLIBS="-lz $m4_toupper(myvar)_PCLIBS"
+-                    m4_toupper(myvar)_LIBS_INSTALLED="-lz $m4_toupper(myvar)_LIBS_INSTALLED"
++                    m4_toupper(myvar)_LFLAGS="$ac_cv_search_gzopen $m4_toupper(myvar)_LFLAGS"
+                    ])
+     AC_DEFINE([COIN_HAS_ZLIB],[1],[Define to 1 if zlib is available])
+   fi
+@@ -2181,14 +2179,12 @@
+   AC_COIN_CHECK_HEADER([bzlib.h],[coin_has_bzlib=yes])
+ 
+   if test $coin_has_bzlib = yes; then
+-    AC_CHECK_LIB([bz2],[BZ2_bzReadOpen],[:],[coin_has_bzlib=no])
++    AC_SEARCH_LIBS([BZ2_bzReadOpen],[bz2 bz2d],[],[coin_has_bzlib=no])
+   fi
+ 
+   if test $coin_has_bzlib = yes; then
+     coin_foreach_w([myvar], [$1], [
+-                    m4_toupper(myvar)_LIBS="-lbz2 $m4_toupper(myvar)_LIBS"
+-                    m4_toupper(myvar)_PCLIBS="-lbz2 $m4_toupper(myvar)_PCLIBS"
+-                    m4_toupper(myvar)_LIBS_INSTALLED="-lbz2 $m4_toupper(myvar)_LIBS_INSTALLED"
++                    m4_toupper(myvar)_LFLAGS="$ac_cv_search_BZ2_bzReadOpen $m4_toupper(myvar)_LFLAGS"
+                   ])
+     AC_DEFINE([COIN_HAS_BZLIB],[1],[Define to 1 if bzlib is available])
+   fi
+@@ -3069,6 +3065,7 @@
+    COIN_PKG_CONFIG_PATH="$withval/lib/pkgconfig:$withval/share/pkgconfig:${COIN_PKG_CONFIG_PATH}"
+   ],[])
+ 
++COIN_PKG_CONFIG_PATH=${PKG_CONFIG_PATH}
+ AC_SUBST(COIN_PKG_CONFIG_PATH)
+ 
+ # assemble additional pkg-config search paths for uninstalled projects

--- a/recipes/coin-buildtools/all/test_package/conanfile.py
+++ b/recipes/coin-buildtools/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout
+from conan.tools.files import copy
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+    win_bash = True
+
+    def layout(self):
+        cmake_layout(self)
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+        if self._settings_build.os == "Windows":
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
+
+    def test(self):
+        if can_run(self):
+            copy(self, "configure.ac", self.source_folder, self.build_folder)
+            self.run("autoreconf -ifv", cwd=self.build_folder)

--- a/recipes/coin-buildtools/all/test_package/conanfile.py
+++ b/recipes/coin-buildtools/all/test_package/conanfile.py
@@ -6,20 +6,14 @@ from conan.tools.files import copy
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualBuildEnv"
-    test_type = "explicit"
     win_bash = True
 
     def layout(self):
         cmake_layout(self)
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
-        if self._settings_build.os == "Windows":
+        if self.settings_build.os == "Windows":
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
 

--- a/recipes/coin-buildtools/all/test_package/configure.ac
+++ b/recipes/coin-buildtools/all/test_package/configure.ac
@@ -1,0 +1,3 @@
+AC_INIT([test_package],[0.0.1],[])
+
+AC_COIN_PROJECTDIR_INIT

--- a/recipes/coin-buildtools/config.yml
+++ b/recipes/coin-buildtools/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.8.11":
+    folder: "all"


### PR DESCRIPTION
Packages Autotools M4 files required for running `autoreconf` on the COIN-OR libraries on CCI. https://github.com/coin-or-tools/BuildTools

The COIN-OR libraries have been struggling with cross-building support on macOS and shared builds on MSVC due to the included configure scripts being generated with a fairly old Autoconf version. This will hopefully resolve these issues.

It also adds newer versions of the Autotools toolchain packages as transitive build-time requirements (but as `self.requires()` due to Conan v1 limitations) to ensure that up-to-date versions are being used.