### PR TITLE
gnu-getopt: new recipe

### DIFF
--- a/recipes/gnu-getopt/all/conandata.yml
+++ b/recipes/gnu-getopt/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.40":
+    url: "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.tar.xz"
+    sha256: "d57a626081f9ead02fa44c63a6af162ec19c58f53e993f206ab7c3a6641c2cd7"

--- a/recipes/gnu-getopt/all/conanfile.py
+++ b/recipes/gnu-getopt/all/conanfile.py
@@ -1,0 +1,72 @@
+import os
+
+from conan import ConanFile
+from conan.tools.env import Environment, VirtualBuildEnv
+from conan.tools.files import copy, get
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, unix_path
+
+required_conan_version = ">=1.54.0"
+
+
+class GnuGetoptConan(ConanFile):
+    name = "gnu-getopt"
+    description = "GNU getopt(1) command-line utility"
+    license = "GPL-2.0-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://frodo.looijaard.name/project/getopt"
+    topics = ("gnu", "getopt", "utility", "command-line", "parsing")
+
+    package_type = "application"
+    settings = "os", "arch", "compiler", "build_type"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        del self.info.settings.compiler
+
+    def build_requirements(self):
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
+        if is_msvc(self):
+            self.tool_requires("automake/1.16.5")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
+        tc = AutotoolsToolchain(self)
+        tc.generate()
+
+        if is_msvc(self):
+            env = Environment()
+            automake_conf = self.dependencies.build["automake"].conf_info
+            compile_wrapper = unix_path(self, automake_conf.get("user.automake:compile-wrapper", check_type=str))
+            env.define("CC", f"{compile_wrapper} cl -nologo")
+            env.define("LD", "link -nologo")
+            env.vars(self).save_script("conanbuild_msvc")
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make(target="getopt")
+
+    def package(self):
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "getopt*", self.build_folder, os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.frameworkdirs = []

--- a/recipes/gnu-getopt/all/test_package/conanfile.py
+++ b/recipes/gnu-getopt/all/test_package/conanfile.py
@@ -1,0 +1,21 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        if can_run(self):
+            self.run("getopt co: -c test.c -o test")

--- a/recipes/gnu-getopt/config.yml
+++ b/recipes/gnu-getopt/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.40":
+    folder: all


### PR DESCRIPTION
Packages the GNU variant of the `getopt` command-line utility. Not to be confused with the `getopt` library.

Required on macOS for the shell scripts included in the f2c PR #23417.

The current version of the tool was originally hosted at http://frodo.looijaard.name/project/getopt but has now been merged into `linux-utils`. There's a slight question of whether we should simply build and package all of the utils in `linux-utils` instead. However, I don't think they are all compatible with other OS-s so it's safer to package `getopt` in isolation for now.

[![Packaging status](https://repology.org/badge/tiny-repos/getopt-standalone.svg)](https://repology.org/project/getopt-standalone/versions)
