### PR TITLE
suitesparse-amd: new recipe

### DIFF
--- a/recipes/suitesparse-amd/all/conandata.yml
+++ b/recipes/suitesparse-amd/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.3.2":
+    url: "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.7.0.tar.gz"
+    sha256: "529b067f5d80981f45ddf6766627b8fc5af619822f068f342aab776e683df4f3"

--- a/recipes/suitesparse-amd/all/conanfile.py
+++ b/recipes/suitesparse-amd/all/conanfile.py
@@ -1,0 +1,94 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import get, rm, rmdir, copy
+
+required_conan_version = ">=1.53.0"
+
+
+class SuiteSparseAmdConan(ConanFile):
+    name = "suitesparse-amd"
+    description = "AMD: Routines for permuting sparse matrices prior to factorization in SuiteSparse"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://people.engr.tamu.edu/davis/suitesparse.html"
+    topics = ("mathematics", "sparse-matrix", "linear-algebra", "matrix-permutation")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # OpenBLAS and OpenMP are provided via suitesparse-config
+        self.requires("suitesparse-config/7.7.0", transitive_headers=True, transitive_libs=True)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.22 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        venv = VirtualBuildEnv(self)
+        venv.generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.variables["BUILD_STATIC_LIBS"] = not self.options.shared
+        tc.variables["SUITESPARSE_USE_OPENMP"] = True
+        tc.variables["SUITESPARSE_USE_CUDA"] = False
+        tc.variables["SUITESPARSE_DEMOS"] = False
+        tc.variables["SUITESPARSE_USE_FORTRAN"] = False  # Fortran sources are translated to C instead
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, "AMD"))
+        cmake.build()
+
+    def package(self):
+        copy(self, "License.txt", os.path.join(self.source_folder, "AMD", "Doc"), os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "AMD")
+        self.cpp_info.set_property("cmake_target_name", "SuiteSparse::AMD")
+        if not self.options.shared:
+            self.cpp_info.set_property("cmake_target_aliases", ["SuiteSparse::AMD_static"])
+        self.cpp_info.set_property("pkg_config_name", "AMD")
+
+        self.cpp_info.libs = ["amd"]
+        self.cpp_info.includedirs.append(os.path.join("include", "suitesparse"))
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")

--- a/recipes/suitesparse-amd/all/test_package/CMakeLists.txt
+++ b/recipes/suitesparse-amd/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(AMD REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE SuiteSparse::AMD)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)

--- a/recipes/suitesparse-amd/all/test_package/conanfile.py
+++ b/recipes/suitesparse-amd/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/suitesparse-amd/all/test_package/test_package.c
+++ b/recipes/suitesparse-amd/all/test_package/test_package.c
@@ -1,0 +1,182 @@
+// https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/v7.7.0/AMD/Demo/amd_demo.c
+
+//------------------------------------------------------------------------------
+// AMD/Demo/amd_demo: demo program for AMD
+//------------------------------------------------------------------------------
+
+// AMD, Copyright (c) 1996-2022, Timothy A. Davis, Patrick R. Amestoy, and
+// Iain S. Duff.  All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+/* A simple C main program that illustrates the use of the ANSI C interface
+ * to AMD.
+ */
+
+#include <amd.h>
+
+#include <stdio.h>
+
+int main (void)
+{
+    /* The symmetric can_24 Harwell/Boeing matrix, including upper and lower
+     * triangular parts, and the diagonal entries.  Note that this matrix is
+     * 0-based, with row and column indices in the range 0 to n-1. */
+    int32_t n = 24, nz,
+    Ap [ ] = { 0, 9, 15, 21, 27, 33, 39, 48, 57, 61, 70, 76, 82, 88, 94, 100,
+	106, 110, 119, 128, 137, 143, 152, 156, 160 },
+    Ai [ ] = {
+	/* column  0: */    0, 5, 6, 12, 13, 17, 18, 19, 21,
+	/* column  1: */    1, 8, 9, 13, 14, 17,
+	/* column  2: */    2, 6, 11, 20, 21, 22,
+	/* column  3: */    3, 7, 10, 15, 18, 19,
+	/* column  4: */    4, 7, 9, 14, 15, 16,
+	/* column  5: */    0, 5, 6, 12, 13, 17,
+	/* column  6: */    0, 2, 5, 6, 11, 12, 19, 21, 23,
+	/* column  7: */    3, 4, 7, 9, 14, 15, 16, 17, 18,
+	/* column  8: */    1, 8, 9, 14,
+	/* column  9: */    1, 4, 7, 8, 9, 13, 14, 17, 18,
+	/* column 10: */    3, 10, 18, 19, 20, 21,
+	/* column 11: */    2, 6, 11, 12, 21, 23,
+	/* column 12: */    0, 5, 6, 11, 12, 23,
+	/* column 13: */    0, 1, 5, 9, 13, 17,
+	/* column 14: */    1, 4, 7, 8, 9, 14,
+	/* column 15: */    3, 4, 7, 15, 16, 18,
+	/* column 16: */    4, 7, 15, 16,
+	/* column 17: */    0, 1, 5, 7, 9, 13, 17, 18, 19,
+	/* column 18: */    0, 3, 7, 9, 10, 15, 17, 18, 19,
+	/* column 19: */    0, 3, 6, 10, 17, 18, 19, 20, 21,
+	/* column 20: */    2, 10, 19, 20, 21, 22,
+	/* column 21: */    0, 2, 6, 10, 11, 19, 20, 21, 22,
+	/* column 22: */    2, 20, 21, 22,
+	/* column 23: */    6, 11, 12, 23 } ;
+
+    int32_t P [24], Pinv [24], i, j, k, jnew, p, inew, result ;
+    double Control [AMD_CONTROL], Info [AMD_INFO] ;
+    char A [24][24] ;
+
+    printf ("AMD version %d.%d.%d, date: %s\n",
+        AMD_MAIN_VERSION, AMD_SUB_VERSION, AMD_SUBSUB_VERSION, AMD_DATE) ;
+    int version [3] ;
+    amd_version (version) ;
+    if ((version [0] != AMD_MAIN_VERSION) ||
+        (version [1] != AMD_SUB_VERSION) ||
+        (version [2] != AMD_SUBSUB_VERSION))
+    {
+        fprintf (stderr, "version in header does not match library\n") ;
+        abort ( ) ;
+    }
+
+    printf ("AMD demo, with the 24-by-24 Harwell/Boeing matrix, can_24:\n") ;
+
+    /* get the default parameters, and print them */
+    amd_defaults (Control) ;
+    amd_control  (Control) ;
+
+    /* print the input matrix */
+    nz = Ap [n] ;
+    printf ("\nInput matrix:  %d-by-%d, with %d entries.\n"
+	   "   Note that for a symmetric matrix such as this one, only the\n"
+	   "   strictly lower or upper triangular parts would need to be\n"
+	   "   passed to AMD, since AMD computes the ordering of A+A'.  The\n"
+	   "   diagonal entries are also not needed, since AMD ignores them.\n"
+	   , n, n, nz) ;
+    for (j = 0 ; j < n ; j++)
+    {
+	printf ("\nColumn: %d, number of entries: %d, with row indices in"
+		" Ai [%d ... %d]:\n    row indices:",
+		j, Ap [j+1] - Ap [j], Ap [j], Ap [j+1]-1) ;
+	for (p = Ap [j] ; p < Ap [j+1] ; p++)
+	{
+	    i = Ai [p] ;
+	    printf (" %d", i) ;
+	}
+	printf ("\n") ;
+    }
+
+    /* print a character plot of the input matrix.  This is only reasonable
+     * because the matrix is small. */
+    printf ("\nPlot of input matrix pattern:\n") ;
+    for (j = 0 ; j < n ; j++)
+    {
+	for (i = 0 ; i < n ; i++) A [i][j] = '.' ;
+	for (p = Ap [j] ; p < Ap [j+1] ; p++)
+	{
+	    i = Ai [p] ;
+	    A [i][j] = 'X' ;
+	}
+    }
+    printf ("    ") ;
+    for (j = 0 ; j < n ; j++) printf (" %1d", j % 10) ;
+    printf ("\n") ;
+    for (i = 0 ; i < n ; i++)
+    {
+	printf ("%2d: ", i) ;
+	for (j = 0 ; j < n ; j++)
+	{
+	    printf (" %c", A [i][j]) ;
+	}
+	printf ("\n") ;
+    }
+
+    /* order the matrix */
+    result = amd_order (n, Ap, Ai, P, Control, Info) ;
+    printf ("return value from amd_order: %d (should be %d)\n",
+	result, AMD_OK) ;
+
+    /* print the statistics */
+    amd_info (Info) ;
+
+    if (result != AMD_OK)
+    {
+	printf ("AMD failed\n") ;
+	exit (1) ;
+    }
+
+    /* print the permutation vector, P, and compute the inverse permutation */
+    printf ("Permutation vector:\n") ;
+    for (k = 0 ; k < n ; k++)
+    {
+	/* row/column j is the kth row/column in the permuted matrix */
+	j = P [k] ;
+	Pinv [j] = k ;
+	printf (" %2d", j) ;
+    }
+    printf ("\n\n") ;
+
+    printf ("Inverse permutation vector:\n") ;
+    for (j = 0 ; j < n ; j++)
+    {
+	k = Pinv [j] ;
+	printf (" %2d", k) ;
+    }
+    printf ("\n\n") ;
+
+    /* print a character plot of the permuted matrix. */
+    printf ("\nPlot of permuted matrix pattern:\n") ;
+    for (jnew = 0 ; jnew < n ; jnew++)
+    {
+	j = P [jnew] ;
+	for (inew = 0 ; inew < n ; inew++) A [inew][jnew] = '.' ;
+	for (p = Ap [j] ; p < Ap [j+1] ; p++)
+	{
+	    inew = Pinv [Ai [p]] ;
+	    A [inew][jnew] = 'X' ;
+	}
+    }
+    printf ("    ") ;
+    for (j = 0 ; j < n ; j++) printf (" %1d", j % 10) ;
+    printf ("\n") ;
+    for (i = 0 ; i < n ; i++)
+    {
+	printf ("%2d: ", i) ;
+	for (j = 0 ; j < n ; j++)
+	{
+	    printf (" %c", A [i][j]) ;
+	}
+	printf ("\n") ;
+    }
+
+    return (0) ;
+}

--- a/recipes/suitesparse-amd/config.yml
+++ b/recipes/suitesparse-amd/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.3.2":
+    folder: all


### PR DESCRIPTION
AMD: Routines for permuting sparse matrices prior to factorization in SuiteSparse

See https://github.com/conan-io/conan-center-index/issues/5763#issuecomment-2056267818 for context.

https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/AMD

Requires
- #22353
- #23540