### PR TITLE
glib: add v2.80.0

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.80.0":
+    url: "https://download.gnome.org/sources/glib/2.80/glib-2.80.0.tar.xz"
+    sha256: "8228a92f92a412160b139ae68b6345bd28f24434a7b5af150ebe21ff587a561d"
   "2.78.3":
     url: "https://download.gnome.org/sources/glib/2.78/glib-2.78.3.tar.xz"
     sha256: "609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21"

--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,7 +1,11 @@
 sources:
   "2.80.0":
-    url: "https://download.gnome.org/sources/glib/2.80/glib-2.80.0.tar.xz"
-    sha256: "8228a92f92a412160b139ae68b6345bd28f24434a7b5af150ebe21ff587a561d"
+    source:
+      url: "https://download.gnome.org/sources/glib/2.80/glib-2.80.0.tar.xz"
+      sha256: "8228a92f92a412160b139ae68b6345bd28f24434a7b5af150ebe21ff587a561d"
+    pypa-packaging:
+      url: "https://github.com/pypa/packaging/archive/refs/tags/24.0.tar.gz"
+      sha256: "1bf35cf2c2be982f2ae6c905760ae19cb744fadbf56269f2e54f7bdcef64d291"
   "2.78.3":
     url: "https://download.gnome.org/sources/glib/2.78/glib-2.78.3.tar.xz"
     sha256: "609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21"

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
-from conan.tools.env import VirtualBuildEnv, Environment
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, load, save
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -123,6 +123,9 @@ class GLibConan(ConanFile):
             tc.project_options["xattr"] = "false"
         tc.project_options["tests"] = "false"
         tc.project_options["libelf"] = "enabled" if self.options.get_safe("with_elf") else "disabled"
+        if Version(self.version) >= "2.79.0":
+            # https://gitlab.gnome.org/GNOME/glib/-/commit/fe32c3f5c5155eab5cd4838867b0c95beefa2239
+            tc.project_options["introspection"] = "disabled"
         tc.generate()
 
     def _patch_sources(self):

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -6,6 +6,7 @@ from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 import shutil
 
@@ -81,9 +82,11 @@ class GLibConan(ConanFile):
             self.requires("libiconv/1.17")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/1.4.0")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
+        if Version(self.version) >= "2.79.0":
+            self.tool_requires("python_packaging/24.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -2,7 +2,8 @@ from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake, CMakeDeps, CMakeToolchain
 from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
-from conan.tools.gnu import PkgConfig, PkgConfigDeps
+from conan.tools.gnu import PkgConfigDeps
+import io
 import os
 
 
@@ -54,6 +55,6 @@ class TestPackageConan(ConanFile):
             self.run(bin_path, env="conanrun")
 
             if self.settings.os != "Windows":
-                pkg_config = PkgConfig(self, "gio-2.0", pkg_config_path=self.generators_folder)
-                gdbus_codegen = pkg_config.variables["gdbus_codegen"]
-                self.run(f"{gdbus_codegen} -h")
+                mybuf = io.StringIO()
+                self.run(f"PKG_CONFIG_PATH={self.generators_folder} pkgconf --variable=gdbus_codegen gio-2.0", mybuf, env="conanbuild")
+                self.run(f"{mybuf.getvalue().strip()} -h")

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -15,10 +15,11 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+        self.requires("python_packaging/24.0")
 
     def build_requirements(self):
         if self.settings.os != "Windows" and not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/2.1.0")
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -15,7 +15,6 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        self.requires("python_packaging/24.0")
 
     def build_requirements(self):
         if self.settings.os != "Windows" and not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -56,4 +56,4 @@ class TestPackageConan(ConanFile):
             if self.settings.os != "Windows":
                 pkg_config = PkgConfig(self, "gio-2.0", pkg_config_path=self.generators_folder)
                 gdbus_codegen = pkg_config.variables["gdbus_codegen"]
-                self.run(f"{gdbus_codegen} -h", env="conanrun")
+                self.run(f"{gdbus_codegen} -h")

--- a/recipes/glib/all/test_v1_package/conanfile.py
+++ b/recipes/glib/all/test_v1_package/conanfile.py
@@ -6,6 +6,9 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi", "pkg_config"
 
+    def requirements(self):
+        self.requires("python_packaging/24.0")
+
     def build_requirements(self):
         if self.settings.os != "Windows":
             self.tool_requires("pkgconf/2.0.3")

--- a/recipes/glib/all/test_v1_package/conanfile.py
+++ b/recipes/glib/all/test_v1_package/conanfile.py
@@ -6,9 +6,6 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi", "pkg_config"
 
-    def requirements(self):
-        self.requires("python_packaging/24.0")
-
     def build_requirements(self):
         if self.settings.os != "Windows":
             self.tool_requires("pkgconf/2.0.3")

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.80.0":
+    folder: all
   "2.78.3":
     folder: all
   "2.78.1":


### PR DESCRIPTION
Continues from #23193. Related to #23557 and https://github.com/conan-io/conan-docker-tools/pull/554#issuecomment-1999860485

~~Adds `self.tool_requires("cpython/3.12.2")` and installs a pinned version of `packaging` from PyPI locally into the build folder.~~

~~The published package artifacts on PyPI are immutable, so the pinned version will provide reproducible builds and is reflected in the package hash via the conanfile.py contents, if I'm not mistaken.~~

~~I think this approach is a simple and scalable way to deal with build-scope Python dependencies on CCI in general.~~

Edit: @ericLemanissier pointed out to me that the `packaging` dependency is a transitive build dep. Since we decided not to package it separately, the only option left was to vendor the two required files. Which I did.