### PR TITLE
openssl/3.2.1: Patch for MD5 cert names on Android.

### DIFF
--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -36,7 +36,7 @@ sources:
     sha256: f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61
 patches:
   3.2.1:
-    - patch_file: "patches/3.2.1-android-x509-md5-names.patch"
+    - patch_file: "patches/3.2.1-x509-md5-names.patch"
       patch_description: "Android ships MD5 hash named certificates which OpenSSL no longer supports by default."
       patch_type: portability
       patch_source: https://github.com/openssl/openssl/issues/13565

--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -35,6 +35,11 @@ sources:
       - "https://github.com/openssl/openssl/releases/download/openssl-3.0.12/openssl-3.0.12.tar.gz"
     sha256: f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61
 patches:
+  3.2.1:
+    - patch_file: "patches/3.2.1-android-x509-md5-names.patch"
+      patch_description: "Android ships MD5 hash named certificates which OpenSSL no longer supports by default."
+      patch_type: portability
+      patch_source: https://github.com/openssl/openssl/issues/13565
   3.2.0:
     - patch_file: "patches/3.2.0-fix-winsock2.patch"
       patch_description: "Only include winsock2.h for struct timeval if needed"

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -89,6 +89,7 @@ class OpenSSLConan(ConanFile):
         "no_zlib": [True, False],
         "openssldir": [None, "ANY"],
         "tls_security_level": [None, 0, 1, 2, 3, 4, 5],
+        "force_md5_x509_name_hashes": [True, False],
     }
     default_options = {key: False for key in options.keys()}
     default_options["fPIC"] = True
@@ -412,8 +413,11 @@ class OpenSSLConan(ConanFile):
                 f'--with-zlib-lib="{lib_path}"',
             ])
 
+        if self.options.force_md5_x509_name_hashes:
+            args.append("-DFORCE_MD5_X509_NAME_HASHES=1")
+
         for option_name in self.default_options.keys():
-            if self.options.get_safe(option_name, False) and option_name not in ("shared", "fPIC", "openssldir", "tls_security_level", "capieng_dialog", "enable_capieng", "zlib", "no_fips", "no_md2"):
+            if self.options.get_safe(option_name, False) and option_name not in ("shared", "fPIC", "openssldir", "tls_security_level", "capieng_dialog", "enable_capieng", "zlib", "no_fips", "no_md2", "force_md5_x509_name_hashes"):
                 self.output.info(f"Activated option: {option_name}")
                 args.append(option_name.replace("_", "-"))
         return args

--- a/recipes/openssl/3.x.x/patches/3.2.1-android-x509-md5-names.patch
+++ b/recipes/openssl/3.x.x/patches/3.2.1-android-x509-md5-names.patch
@@ -1,0 +1,18 @@
+diff --git a/crypto/x509/by_dir.c b/crypto/x509/by_dir.c
+index 1d401d0420..5788e95932 100644
+--- a/crypto/x509/by_dir.c
++++ b/crypto/x509/by_dir.c
+@@ -257,9 +257,13 @@ static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
+     }
+ 
+     ctx = (BY_DIR *)xl->method_data;
++#ifdef __ANDROID__
++    h = X509_NAME_hash_old(name);
++#else
+     h = X509_NAME_hash_ex(name, libctx, propq, &i);
+     if (i == 0)
+         goto finish;
++#endif
+     for (i = 0; i < sk_BY_DIR_ENTRY_num(ctx->dirs); i++) {
+         BY_DIR_ENTRY *ent;
+         int idx;

--- a/recipes/openssl/3.x.x/patches/3.2.1-x509-md5-names.patch
+++ b/recipes/openssl/3.x.x/patches/3.2.1-x509-md5-names.patch
@@ -1,12 +1,12 @@
 diff --git a/crypto/x509/by_dir.c b/crypto/x509/by_dir.c
-index 1d401d0420..5788e95932 100644
+index 1d401d0420..49a32d694f 100644
 --- a/crypto/x509/by_dir.c
 +++ b/crypto/x509/by_dir.c
 @@ -257,9 +257,13 @@ static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
      }
  
      ctx = (BY_DIR *)xl->method_data;
-+#ifdef __ANDROID__
++#ifdef FORCE_MD5_X509_NAME_HASHES
 +    h = X509_NAME_hash_old(name);
 +#else
      h = X509_NAME_hash_ex(name, libctx, propq, &i);


### PR DESCRIPTION
Specify library name and version:  **openssl/3.2.1**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Android ships CA Certificates with MD5 hash names which OpenSSL stopped supporting in v1.0.0 in favour of canonically encoded SHA1 names (according to https://github.com/openssl/openssl/issues/13565#issuecomment-736579342). This means that by default you can't use the certificates Android ships with OpenSSL to enable https support with libcurl etc. Instead you would have to include your own CA bundle with your app/library or do some work to copy & rehash the system certificates, neither of which are ideal.

There is a [PR open](https://github.com/openssl/openssl/pull/24002) (not mine) with OpenSSL which addresses this problem in a more generic way by allowing the library to fallback to MD5 when no file is found with SHA1, but this PR appears to be slightly contentious and it's not clear if/when this will be merged. Even if it is merged, it will not enable us to use OpenSSL easily on Android right now, with the currently released versions.

This PR provides a patch allowing the use of the older MD5 based names in favour of the SHA1 names when the `FORCE_MD5_X509_NAME_HASHES` preprocessor definition is detected. Combined with a new option in the recipe, this enables the build to be configured to work with the Android system CA certs without forcing this on anyone already building for Android and using other workarounds.

Hopefully if/when the linked PR is approved, this will no longer be needed, but until then it makes it much easier to get https working on Android with curl etc. (for anyone finding this from a search engine, you also need to point curl at the certs using something like `curl_easy_setopt(handle, CURLOPT_CAPATH, "/system/etc/security/cacerts");` )

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
