### PR TITLE
msys2: avoid '/dev/shm' and '/dev/shm' read-only file system warnings

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -171,6 +171,8 @@ class MSYS2Conan(ConanFile):
                         os.unlink(fullname)
         # See https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#kb-h013-default-package-layout
         copy(self, "*", dst=os.path.join(self.package_folder, "bin", "msys64"), src=self._msys_dir, excludes=excludes)
+        # Avoid  '/dev/shm' and '/dev/shm': Read-only file system warnings creating the dev folder which is empty
+        os.mkdir(os.path.join(self.package_folder, "bin", "msys64", "dev"))
         shutil.copytree(os.path.join(self._msys_dir, "usr", "share", "licenses"),
                         os.path.join(self.package_folder, "licenses"))
 


### PR DESCRIPTION
…s creating the dev folder which is empty

Specify library name and version:  **msys2/cci.latest**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
