### PR TITLE
mold: remove unneeded dependency on OpenSSL

### DIFF
--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -40,7 +40,6 @@ class MoldConan(ConanFile):
 
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
-        self.requires("openssl/[>=1.1 <4]")
         self.requires("xxhash/0.8.2")
         self.requires("onetbb/2021.10.0")
         if self.options.with_mimalloc:


### PR DESCRIPTION
To my knowledge, `mold` does not depend on OpenSSL and does not need this.

Close https://github.com/conan-io/conan-center-index/issues/23574