### PR TITLE
nsync: add version 1.27.0

### DIFF
--- a/recipes/nsync/all/conandata.yml
+++ b/recipes/nsync/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.27.0":
+    url: "https://github.com/google/nsync/archive/1.27.0.tar.gz"
+    sha256: "e8e552a358f4a28e844207a7c5cb51767e4aeb0b29e22d23ac2a09924130f761"
   "1.26.0":
     url: "https://github.com/google/nsync/archive/1.26.0.tar.gz"
     sha256: "80fc1e605bb3cf5f272811ece39c4fb6761ffcb9b30563301845cc9ff381eb8b"
@@ -12,6 +15,8 @@ sources:
     sha256: "b7e75b17957c62bd02dd73890bde22da3a564903fcaad651b395453d41d3325b"
     url: "https://github.com/google/nsync/archive/refs/tags/1.23.0.tar.gz"
 patches:
+  "1.27.0":
+    - patch_file: "patches/0001-1.27.0-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
   "1.26.0":
     - patch_file: "patches/0001-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
   "1.25.0":

--- a/recipes/nsync/all/patches/0001-1.27.0-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch
+++ b/recipes/nsync/all/patches/0001-1.27.0-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -125,7 +125,6 @@
+ 		${NSYNC_OS_CPP_SRC}
+ 		"platform/c++11/src/nsync_semaphore_mutex.cc"
+ 		"platform/posix/src/clock_gettime.c"
+-		"platform/posix/src/nsync_semaphore_mutex.c"
+ 	)
+ elseif ("${CMAKE_SYSTEM_NAME}X" STREQUAL "LinuxX")
+ 	set (NSYNC_POSIX ON)

--- a/recipes/nsync/config.yml
+++ b/recipes/nsync/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.27.0":
+    folder: "all"
   "1.26.0":
     folder: "all"
   "1.25.0":


### PR DESCRIPTION
Specify library name and version:  **nsync/1.27.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
