### PR TITLE
hictk: add v0.0.12 and drop v0.0.11

### DIFF
--- a/recipes/hictk/all/conandata.yml
+++ b/recipes/hictk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.0.12":
+    url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v0.0.12.tar.gz"
+    sha256: "03e8f7c0076ea6209fdfee1580658e871895f6a59b895407c4a25512b9558fb7"
   "0.0.10":
     url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v0.0.10.tar.gz"
     sha256: "0b2d60af73578b292317e5ab513f24965176f9852ceda29e8d02007a434588c3"

--- a/recipes/hictk/all/conandata.yml
+++ b/recipes/hictk/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "0.0.11":
-    url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v0.0.11.tar.gz"
-    sha256: "a06b674de2301918188d1c890a95aaa4d6164377ebaa44cc07efb77fd9eb654c"
   "0.0.10":
     url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v0.0.10.tar.gz"
     sha256: "0b2d60af73578b292317e5ab513f24965176f9852ceda29e8d02007a434588c3"

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -40,7 +40,7 @@ class HictkConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("bshoshany-thread-pool/4.0.1", transitive_headers=True)
+        self.requires("bshoshany-thread-pool/4.1.0", transitive_headers=True)
         self.requires("fast_float/6.1.1", transitive_headers=True)
         if self.options.with_eigen:
             self.requires("eigen/3.4.0", transitive_headers=True)
@@ -51,7 +51,7 @@ class HictkConan(ConanFile):
         self.requires("parallel-hashmap/1.3.11", transitive_headers=True)  # Note: v1.3.11 is more recent than v1.37
         self.requires("span-lite/0.11.0", transitive_headers=True)
         self.requires("spdlog/1.13.0", transitive_headers=True)
-        self.requires("zstd/1.5.5", transitive_headers=True)
+        self.requires("zstd/1.5.6", transitive_headers=True)
 
         if Version(self.version) == "0.0.3":
             self.requires("xxhash/0.8.2", transitive_headers=True)

--- a/recipes/hictk/all/test_package/test_package.cpp
+++ b/recipes/hictk/all/test_package/test_package.cpp
@@ -1,8 +1,15 @@
 #include <fmt/format.h>
-#include "hictk/fmt.hpp"
-#include "hictk/cooler/utils.hpp"
+
+#include <stdexcept>
+
+#include "hictk/file.hpp"
 
 
 int main(int argc, char** argv) {
-  fmt::print("{}\n", hictk::cooler::utils::is_cooler(argv[0]));
+  try {
+    const hictk::File f(argv[0], 10);  // This is expected to throw
+    return 1;
+  } catch (const std::exception& e) {
+    return 0;
+  }
 }

--- a/recipes/hictk/all/test_package/test_package.cpp
+++ b/recipes/hictk/all/test_package/test_package.cpp
@@ -1,5 +1,3 @@
-#include <fmt/format.h>
-
 #include <stdexcept>
 
 #include "hictk/file.hpp"

--- a/recipes/hictk/config.yml
+++ b/recipes/hictk/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.0.11":
+  "0.0.12":
     folder: all
   "0.0.10":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **hictk/all**

hictk v0.0.11 turned out to be broken due to some targets not being installed properly.
Updating the test_package to include one of hictk's main header files highlights this issue (as in the test package no longer compiles).
I think the best way forward is to entirely drop v0.0.11. Should this not be acceptable, then I can use #ifdef guards to include the old test_package code when version == 0.0.11. 

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
