### PR TITLE
[config] Re-order Mac M1 configuration

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -81,19 +81,6 @@ configurations:
               compiler.libcxx: ["libstdc++11"]
               compiler.version: ["11"]
               build_type: ["Release"]
-  - id: macos-clang
-    hrname: "macOS, Clang"
-    build_profile:
-      os: "Macos"
-      arch: "armv8"
-    content:
-      - os: [ "Macos" ]
-        arch: [ "x86_64" ]
-        compiler:
-          - "apple-clang":
-              compiler.version: [ "13" ]
-              compiler.libcxx: [ "libc++" ]
-              build_type: [ "Release"]
   - id: macos-m1-clang
     hrname: "macOS M1, Clang"
     build_profile:
@@ -105,6 +92,19 @@ configurations:
         compiler:
           - "apple-clang":
               compiler.version: ["13" ]
+              compiler.libcxx: [ "libc++" ]
+              build_type: [ "Release"]
+  - id: macos-clang
+    hrname: "macOS, Clang"
+    build_profile:
+      os: "Macos"
+      arch: "armv8"
+    content:
+      - os: [ "Macos" ]
+        arch: [ "x86_64" ]
+        compiler:
+          - "apple-clang":
+              compiler.version: [ "13" ]
               compiler.libcxx: [ "libc++" ]
               build_type: [ "Release"]
   - id: windows-msvc


### PR DESCRIPTION
This change puts Mac M1 to be listed first when building packages in ConanCenterIndexCI. It does not guarantee the result as builds are execute in parallel, so a test package could ask for package that's not available yet.

Besides this change, Conan team will check for internal options/fix in C3I Jenkins code.

Related to #23558


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
