### PR TITLE
gcc: don't use unmaintained binutils

### DIFF
--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -50,6 +50,9 @@ class GccConan(ConanFile):
     def validate_build(self):
         if is_msvc(self):
             raise ConanInvalidConfiguration("GCC can't be built with MSVC")
+        if self.settings.compiler.cppstd != "11":
+            # https://github.com/gcc-mirror/gcc/blob/6b5248d15c6d10325c6cbb92a0e0a9eb04e3f122/libcody/configure#L2505C11-L2505C25
+            raise ConanInvalidConfiguration("GCC needs exactly c++11")
 
     def validate(self):
         if self.settings.os == "Windows":

--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -40,7 +40,7 @@ class GccConan(ConanFile):
     def requirements(self):
         self.requires("mpc/1.2.0")
         self.requires("mpfr/4.1.0")
-        self.requires("gmp/6.2.1")
+        self.requires("gmp/6.3.0")
         self.requires("zlib/[>=1.2.13 <2]")
         self.requires("isl/0.24")
 

--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -29,6 +29,9 @@ class GccConan(ConanFile):
         if self.settings.compiler in ["clang", "apple-clang"]:
             # Can't remove this from cxxflags with autotools - so get rid of it
             del self.settings.compiler.libcxx
+            
+        # https://github.com/gcc-mirror/gcc/blob/6b5248d15c6d10325c6cbb92a0e0a9eb04e3f122/libcody/configure#L2505C11-L2505C25
+        del self.settings.compiler.cppstd
 
     def build_requirements(self):
         if self.settings.os == "Linux":
@@ -50,9 +53,6 @@ class GccConan(ConanFile):
     def validate_build(self):
         if is_msvc(self):
             raise ConanInvalidConfiguration("GCC can't be built with MSVC")
-        if self.settings.compiler.cppstd != "11":
-            # https://github.com/gcc-mirror/gcc/blob/6b5248d15c6d10325c6cbb92a0e0a9eb04e3f122/libcody/configure#L2505C11-L2505C25
-            raise ConanInvalidConfiguration("GCC needs exactly c++11")
 
     def validate(self):
         if self.settings.os == "Windows":

--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -39,7 +39,7 @@ class GccConan(ConanFile):
 
     def requirements(self):
         self.requires("mpc/1.2.0")
-        self.requires("mpfr/4.1.0")
+        self.requires("mpfr/4.2.0")
         self.requires("gmp/6.3.0")
         self.requires("zlib/[>=1.2.13 <2]")
         self.requires("isl/0.24")

--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -34,14 +34,14 @@ class GccConan(ConanFile):
         if self.settings.os == "Linux":
             # binutils recipe is broken for Macos, and Windows uses tools
             # distributed with msys/mingw
-            self.tool_requires("binutils/2.38")
+            self.tool_requires("binutils/2.42")
         self.tool_requires("flex/2.6.4")
 
     def requirements(self):
         self.requires("mpc/1.2.0")
         self.requires("mpfr/4.1.0")
         self.requires("gmp/6.2.1")
-        self.requires("zlib/1.2.13")
+        self.requires("zlib/[>=1.2.13 <2]")
         self.requires("isl/0.24")
 
     def package_id(self):

--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -42,7 +42,7 @@ class GccConan(ConanFile):
         self.requires("mpfr/4.2.0")
         self.requires("gmp/6.3.0")
         self.requires("zlib/[>=1.2.13 <2]")
-        self.requires("isl/0.24")
+        self.requires("isl/0.26")
 
     def package_id(self):
         del self.info.settings.compiler


### PR DESCRIPTION
Specify library name and version:  **gcc/***

also fix conflicts:
- `mpc/1.2.0->gmp/6.3.0, gcc/12.2.0->gmp/6.2.1.`
- `mpc/1.2.0->mpfr/4.2.0, gcc/12.2.0->mpfr/4.1.0.`

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
