### PR TITLE
Add expat and libxml2 to list of allowed version ranges

### DIFF
--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -185,6 +185,7 @@ Currently, these are (except if the recipe needs a newer lower version for speci
 version range only when a requirement for a newer version is needed.
 * Libcurl: `[>=7.78 <9]`
 * Zlib: `[>=1.2.11 <2]`
+* Libpng: `[>=1.6 <2]`
 * Expat: `[>=2.6.2 <3]`
 * Libxml2: `[>=2.12.5 <3]`
 

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -178,14 +178,15 @@ for consumer, we do impose some limits on Conan features to provide a smoother f
 
 Version ranges are a useful Conan feature, [documentation here](https://docs.conan.io/2/tutorial/versioning/version_ranges.html).
 With the introduction of Conan 2.0, we are currently working to allow the use of version ranges and are allowing this for a handful of dependencies.
-Currently, these are:
+Currently, these are (expect if the recipe needs a newer lower version for specific reasons):
 
 * OpenSSL: `[>=1.1 <4]` for libraries known to be compatible with OpenSSL 1.x and 3.x
 * CMake: `[>3.XX <4]`, where `3.XX` is the minimum version of CMake required by the relevant build scripts. Note that CCI recipes assume 3.15 is installed in the system, so add this
 version range only when a requirement for a newer version is needed.
-* Libcurl: `[>=X.YY <9]`, where `X.YY` is the minimum version of Libcurl required, starting from `7.78`
-* Zlib: `[>=1.2.11 <2]` expect if the recipe needs a newer lower version for specific reasons
-* Libpng: `[>=1.6 <2]` expect if the recipe needs a newer lower version for specific reasons
+* Libcurl: `[>=7.78 <9]`
+* Zlib: `[>=1.2.11 <2]`
+* Expat: `[>=2.6.2 <3]`
+* Libxml2: `[>=2.12.5 <3]`
 
 > **Warning**: With Conan 1.x, [version ranges](https://docs.conan.io/1/versioning/version_ranges.html) adhere to a much more strict sematic version spec,
 > OpenSSL 1.1.x does not follow this so the client will not resolve to that range and will pick a 3.x version. In order to select a lower version you

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -178,7 +178,7 @@ for consumer, we do impose some limits on Conan features to provide a smoother f
 
 Version ranges are a useful Conan feature, [documentation here](https://docs.conan.io/2/tutorial/versioning/version_ranges.html).
 With the introduction of Conan 2.0, we are currently working to allow the use of version ranges and are allowing this for a handful of dependencies.
-Currently, these are (expect if the recipe needs a newer lower version for specific reasons):
+Currently, these are (except if the recipe needs a newer lower version for specific reasons):
 
 * OpenSSL: `[>=1.1 <4]` for libraries known to be compatible with OpenSSL 1.x and 3.x
 * CMake: `[>3.XX <4]`, where `3.XX` is the minimum version of CMake required by the relevant build scripts. Note that CCI recipes assume 3.15 is installed in the system, so add this


### PR DESCRIPTION
Document bounds for libxml2 and expat

/cc @mayeut who's been pushing for this lately, thanks!