### PR TITLE
exiv2: use expat version range

### DIFF
--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -76,7 +76,7 @@ class Exiv2Conan(ConanFile):
             self.requires("libpng/[>=1.6 <2]")
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_xmp == "bundled":
-            self.requires("expat/2.5.0")
+            self.requires("expat/[>=2.6.2 <3]")
         if self.options.with_curl:
             self.requires("libcurl/[>=7.78.0 <9]")
         if self.options.get_safe("with_brotli"):


### PR DESCRIPTION
Specify library name and version:  **exiv2/all**

expat<2.6.2 has known security issues. We can now use version range: c.f. #23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
