### PR TITLE
aaf: use expat version range

### DIFF
--- a/recipes/aaf/all/conanfile.py
+++ b/recipes/aaf/all/conanfile.py
@@ -35,7 +35,7 @@ class AafConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("expat/2.5.0")
+        self.requires("expat/[>=2.6.2 <3]")
         self.requires("libjpeg/9e")
         if self.settings.os in ("FreeBSD", "Linux"):
             self.requires("util-linux-libuuid/2.39")


### PR DESCRIPTION
Specify library name and version:  **aaf/all**

expat<2.6.2 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
