### PR TITLE
apr-util: use expat version range

### DIFF
--- a/recipes/apr-util/all/conanfile.py
+++ b/recipes/apr-util/all/conanfile.py
@@ -90,7 +90,7 @@ class AprUtilConan(ConanFile):
         if self.options.with_sqlite3:
             self.requires("sqlite3/3.45.0")
         if self.options.with_expat:
-            self.requires("expat/2.5.0")
+            self.requires("expat/[>=2.6.2 <3]")
         if self.options.with_postgresql:
             self.requires("libpq/15.4")
 


### PR DESCRIPTION
Specify library name and version:  **apr-util/all**

expat<2.6.2 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
