### PR TITLE
libmetalink: use version range for expat & libxml2

### DIFF
--- a/recipes/libmetalink/all/conanfile.py
+++ b/recipes/libmetalink/all/conanfile.py
@@ -53,9 +53,9 @@ class LibmetalinkConan(ConanFile):
 
     def requirements(self):
         if self.options.xml_backend == "expat":
-            self.requires("expat/2.5.0")
+            self.requires("expat/[>=2.6.2 <3]")
         elif self.options.xml_backend == "libxml2":
-            self.requires("libxml2/2.12.3")
+            self.requires("libxml2/[>=2.12.5 <3]")
 
     def validate(self):
         if is_msvc(self):


### PR DESCRIPTION
Specify library name and version:  **libmetalink/all**

expat<2.6.2 & libxml2<2.12.5 have known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
