### PR TITLE
log4cxx: use version range for expat

### DIFF
--- a/recipes/log4cxx/all/conanfile.py
+++ b/recipes/log4cxx/all/conanfile.py
@@ -61,7 +61,7 @@ class Log4cxxConan(ConanFile):
     def requirements(self):
         self.requires("apr/1.7.4")
         self.requires("apr-util/1.6.1")
-        self.requires("expat/2.5.0")
+        self.requires("expat/[>=2.6.2 <3]")
         if self.settings.os != "Windows":
             self.requires("odbc/2.3.11")
 
@@ -76,7 +76,7 @@ class Log4cxxConan(ConanFile):
     def build_requirements(self):
         if self.settings.os != "Windows":
             if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-                self.tool_requires("pkgconf/2.0.3")
+                self.tool_requires("pkgconf/2.1.0")
 
     def source(self):
         # OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect:


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

expat<2.6.2 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
