### PR TITLE
openfx: use version range for expat

### DIFF
--- a/recipes/openfx/all/conanfile.py
+++ b/recipes/openfx/all/conanfile.py
@@ -50,7 +50,7 @@ class openfx(ConanFile):
 
     def requirements(self):
         self.requires("opengl/system")
-        self.requires("expat/2.5.0")
+        self.requires("expat/[>=2.6.2 <3]")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Specify library name and version:  **openfx/all**

xpat<2.6.2 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
