### PR TITLE
readosm: use version range for expat

### DIFF
--- a/recipes/readosm/all/conanfile.py
+++ b/recipes/readosm/all/conanfile.py
@@ -54,7 +54,7 @@ class ReadosmConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("expat/2.5.0")
+        self.requires("expat/[>=2.6.2 <3]")
         self.requires("zlib/[>=1.2.11 <2]")
 
     def build_requirements(self):


### PR DESCRIPTION
Specify library name and version:  **readosm/all**

expat<2.6.2 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
