### PR TITLE
libstudxml: use version range for expat

### DIFF
--- a/recipes/libstudxml/1.1.x/conanfile.py
+++ b/recipes/libstudxml/1.1.x/conanfile.py
@@ -38,7 +38,7 @@ class LibStudXmlConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("expat/2.5.0", transitive_headers=True, transitive_libs=True)
+        self.requires("expat/[>=2.6.2 <3]", transitive_headers=True, transitive_libs=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **libstudxml/1.1.x**

expat<2.6.2 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
