### PR TITLE
libxslt: use version range for libxml2

### DIFF
--- a/recipes/libxslt/all/conanfile.py
+++ b/recipes/libxslt/all/conanfile.py
@@ -62,7 +62,7 @@ class LibxsltConan(ConanFile):
     def requirements(self):
         if Version(self.version) >= "1.1.39":
             # see https://github.com/conan-io/conan-center-index/pull/16205#discussion_r1149570846
-            self.requires("libxml2/2.12.3", transitive_headers=True, transitive_libs=True)
+            self.requires("libxml2/[>=2.12.5 <3]", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("libxml2/2.11.6", transitive_headers=True, transitive_libs=True)
 


### PR DESCRIPTION
Specify library name and version:  **libxslt/all**

We can now use version range for libxml2, this should reduce conflicts.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
