### PR TITLE
xmlsec: use version range for libxml2

### DIFF
--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -60,7 +60,7 @@ class XmlSecConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libxml2/2.12.4", transitive_headers=True)
+        self.requires("libxml2/[>=2.12.5 <3]", transitive_headers=True)
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
         if self.options.with_xslt:


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

We can now use version range for libxml2, this should reduce conflicts.

**depends on #23633**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
