### PR TITLE
hwloc: use version range for libxml2

### DIFF
--- a/recipes/hwloc/all/conanfile.py
+++ b/recipes/hwloc/all/conanfile.py
@@ -32,7 +32,7 @@ class HwlocConan(ConanFile):
 
     def requirements(self):
         if self.options.with_libxml2:
-            self.requires("libxml2/2.12.3")
+            self.requires("libxml2/[>=2.12.5 <3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **hwloc/all**

We can now use version range for libxml2, this should reduce conflicts.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
