### PR TITLE
norm: use version range for libxml2

### DIFF
--- a/recipes/norm/all/conanfile.py
+++ b/recipes/norm/all/conanfile.py
@@ -39,7 +39,7 @@ class NormConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libxml2/2.12.3") # dependency of protolib actually
+        self.requires("libxml2/[>=2.12.5 <3]") # dependency of protolib actually
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **norm/all**

We can now use version range for libxml2, this should reduce conflicts.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
