### PR TITLE
iowow: add version 1.4.18

### DIFF
--- a/recipes/iowow/all/conandata.yml
+++ b/recipes/iowow/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.18":
+    url: "https://github.com/Softmotions/iowow/archive/refs/tags/v1.4.18.tar.gz"
+    sha256: "ef4ee56dd77ce326fff25b6f41e7d78303322cca3f11cf5683ce9abfda34faf9"
   "1.4.17":
     url: "https://github.com/Softmotions/iowow/archive/refs/tags/v1.4.17.tar.gz"
     sha256: "13a851026dbc1f31583fba96986e86e94a7554f9e7d38aa12a9ea5dbebdf328b"
@@ -6,6 +9,10 @@ sources:
     url: "https://github.com/Softmotions/iowow/archive/refs/tags/v1.4.16.tar.gz"
     sha256: "6e3b92b6c342ef6ef4a2731ca2d43368749d66ca876b24b773587364cff01003"
 patches:
+  "1.4.18":
+    - patch_file: "patches/1.4.18-0002-fix-uint64_t-format.patch"
+      patch_description: "fix uint64_t printf format"
+      patch_type: "portability"
   "1.4.17":
     - patch_file: "patches/1.4.16-0002-fix-uint64_t-format.patch"
       patch_description: "fix uint64_t printf format"

--- a/recipes/iowow/all/patches/1.4.18-0002-fix-uint64_t-format.patch
+++ b/recipes/iowow/all/patches/1.4.18-0002-fix-uint64_t-format.patch
@@ -1,0 +1,13 @@
+diff --git a/src/fs/iwfsmfile.c b/src/fs/iwfsmfile.c
+index 2d1452a..121e989 100644
+--- a/src/fs/iwfsmfile.c
++++ b/src/fs/iwfsmfile.c
+@@ -1339,7 +1339,7 @@ static iwrc _fsm_read_meta_lr(struct fsm *fsm) {
+   fsm->bmlen = llv;
+   if (llv & (64 - 1)) {
+     rc = IWFS_ERROR_INVALID_FILEMETA;
+-    iwlog_ecode_error(rc, "Free-space bitmap length is not 64bit aligned: %" PRIuMAX "", fsm->bmlen);
++    iwlog_ecode_error(rc, "Free-space bitmap length is not 64bit aligned: %" PRIx64 "", fsm->bmlen);
+   }
+   rp += sizeof(llv);
+ 

--- a/recipes/iowow/config.yml
+++ b/recipes/iowow/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.18":
+    folder: all
   "1.4.17":
     folder: all
   "1.4.16":


### PR DESCRIPTION
Specify library name and version:  **iowow/1.4.18**

https://github.com/Softmotions/iowow/compare/v1.4.17...v1.4.18

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
