### PR TITLE
gtest: don't link pthreads if disabled

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -158,7 +158,8 @@ class GTestConan(ConanFile):
         self.cpp_info.components["libgtest"].libs = [f"gtest{self._postfix}"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libgtest"].system_libs.append("m")
-            self.cpp_info.components["libgtest"].system_libs.append("pthread")
+            if not self.options.disable_pthreads:
+                self.cpp_info.components["libgtest"].system_libs.append("pthread")
         if self.settings.os == "Neutrino" and self.settings.os.version == "7.1":
             self.cpp_info.components["libgtest"].system_libs.append("regex")
         if self.options.shared:


### PR DESCRIPTION
**gtest/1.14.0**

This PR fixes an issue on Linux where pthreads would be linked anyway as a system library even if the option `gtest_disable_pthreads` was set to `True`. Also mentioned in #19113.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
