### PR TITLE
Remove `os.version` from package ID and also removing `no_copy_source = True` in openjdk recipe

### DIFF
--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -21,7 +21,8 @@ class OpenJDK(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
         del self.info.settings.build_type
-
+        self.info.settings.rm_safe("os.version")
+        
     def validate(self):
         if Version(self.version) < "19.0.2" and self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Unsupported Architecture.  This package currently only supports x86_64.")

--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -20,7 +20,9 @@ class OpenJDK(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
         del self.info.settings.build_type
-        self.info.settings.rm_safe("os.version")
+
+    def configure(self):
+        self.settings.rm_safe("os.version")
         
     def validate(self):
         if Version(self.version) < "19.0.2" and self.settings.arch != "x86_64":

--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -16,7 +16,6 @@ class OpenJDK(ConanFile):
     license = "GPL-2.0-only WITH Classpath-exception-2.0", "GPL-2.0-only WITH OpenJDK-assembly-exception-1.0"
     topics = ("java", "jdk", "openjdk")
     settings = "os", "arch", "compiler", "build_type"
-    no_copy_source = True
 
     def package_id(self):
         del self.info.settings.compiler
@@ -34,35 +33,35 @@ class OpenJDK(ConanFile):
         if self.settings.os in ["Macos", "Linux"]:
             key = f"{self.settings.os}_{self.settings.arch}"
         get(self, **self.conan_data["sources"][self.version][str(key)],
-                  destination=self.source_folder, strip_root=True)
+                  destination=self.build_folder, strip_root=True)
 
     def package(self):
         if self.settings.os == "Macos":
-            source_folder = os.path.join(self.source_folder, f"jdk-{self.version}.jdk", "Contents", "Home")
+            build_folder = os.path.join(self.build_folder, f"jdk-{self.version}.jdk", "Contents", "Home")
         else:
-            source_folder = self.source_folder
-        symlinks.remove_broken_symlinks(self, source_folder)
+            build_folder = self.build_folder
+        symlinks.remove_broken_symlinks(self, build_folder)
         copy(self, pattern="*",
-                src=os.path.join(source_folder, "bin"),
+                src=os.path.join(build_folder, "bin"),
                 dst=os.path.join(self.package_folder, "bin"),
                 excludes=("msvcp140.dll", "vcruntime140.dll", "vcruntime140_1.dll"))
         copy(self, pattern="*",
-                src=os.path.join(source_folder, "include"),
+                src=os.path.join(build_folder, "include"),
                 dst=os.path.join(self.package_folder, "include"))
         copy(self, pattern="*",
-                src=os.path.join(source_folder, "lib"),
+                src=os.path.join(build_folder, "lib"),
                 dst=os.path.join(self.package_folder, "lib"))
         copy(self, pattern="*",
-                src=os.path.join(source_folder, "jmods"),
+                src=os.path.join(build_folder, "jmods"),
                 dst=os.path.join(self.package_folder, "lib", "jmods"))
         copy(self, pattern="*",
-                src=os.path.join(source_folder, "legal"),
+                src=os.path.join(build_folder, "legal"),
                 dst=os.path.join(self.package_folder, "licenses"))
         # conf folder is required for security settings, to avoid
         # java.lang.SecurityException: Can't read cryptographic policy directory: unlimited
         # https://github.com/conan-io/conan-center-index/pull/4491#issuecomment-774555069
         copy(self, pattern="*",
-                src=os.path.join(source_folder, "conf"),
+                src=os.path.join(build_folder, "conf"),
                 dst=os.path.join(self.package_folder, "conf"))
 
     def package_info(self):


### PR DESCRIPTION
This PR should fix: https://github.com/conan-io/conan-center-index/issues/18564

The issue is that the zip from openjdk contains a file that is decompressed with read only values, and as we have the `no_copy_source = True` the zip is always decompressed in exactly the same location so the second time that you decompress with a subsetting that is different, for example `os.version` the decompressing fails. Removing the subsetting from the package ID and also removing `no_copy_source = True` I think should fix the issue. If you force the build it will be decompressed in a different location than the previous build and when the package ends being the same package ID than the other the older package ID will be removed leaving only one folder.