### PR TITLE
CPython: Use shared by default

### DIFF
--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -44,7 +44,7 @@ class CPythonConan(ConanFile):
         "env_vars": [True, False],  # set environment variables
     }
     default_options = {
-        "shared": False,
+        "shared": True,
         "fPIC": True,
         "optimizations": False,
         "lto": False,


### PR DESCRIPTION
Specify library name and version:  **cpython/all**

(See https://github.com/python/cpython/issues/110234 for more context, I will summarize below)

CPython static builds (especially in newer versions) are only supported on a best-effort basis. Shared builds are the best supported and recommended way to use it. Notably on Windows, the static build has been broken since 3.10, and extension modules only work in shared mode, so when using CPython as a requirement, it is almost always mandatory that it be built in shared mode (on Windows at least).

Given all of this, I think it makes sense to make shared the default on Windows at least certainly, on other platforms this is less important, but still useful as it is the recommended way.

This will also fix/avoid issues like [this one](https://github.com/conan-io/conan-center-index/issues/9333) which arise from static being the default. I've also seen a few other PRs pop up (now that this recipe is usable) which set shared to true, so that provides some more evidence, plus some places to clean up just a little.