### PR TITLE
[openldap] Enable Macos build

### DIFF
--- a/recipes/openldap/all/conanfile.py
+++ b/recipes/openldap/all/conanfile.py
@@ -51,9 +51,6 @@ class OpenldapConan(ConanFile):
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
             raise ConanInvalidConfiguration(f"{self.name} is only supported on Unix platforms")
-        if is_apple_os(self) and cross_building(self):
-            # Produces linkage errors: Undefined symbols for architecture x86_64: "_lutil_memcmp", referenced from: ...
-            raise ConanInvalidConfiguration(f"{self.ref} recipe does not support cross-building on macOS. Contributions are welcome!")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -79,6 +76,8 @@ class OpenldapConan(ConanFile):
             # When cross-building, yielding_select should be explicit:
             # https://git.openldap.org/openldap/openldap/-/blob/OPENLDAP_REL_ENG_2_5/configure.ac#L1636
             tc.configure_args.append("--with-yielding_select=yes")
+            # Workaround: https://bugs.openldap.org/show_bug.cgi?id=9228
+            tc.configure_args.append("ac_cv_func_memcmp_working=yes")
         if is_apple_os(self):
             # macOS Ventura does not have soelim, but mandoc_soelim
             tc.make_args.append("SOELIM=soelim" if shutil.which("soelim") else "SOELIM=mandoc_soelim")

--- a/recipes/openldap/all/conanfile.py
+++ b/recipes/openldap/all/conanfile.py
@@ -53,7 +53,7 @@ class OpenldapConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.name} is only supported on Unix platforms")
         if is_apple_os(self) and cross_building(self):
             # Produces linkage errors: Undefined symbols for architecture x86_64: "_lutil_memcmp", referenced from: ...
-            raise ConanInvalidConfiguration(f"{self.ref} recipe does not support cross-building static libraries on macOS. Contributions are welcome!")
+            raise ConanInvalidConfiguration(f"{self.ref} recipe does not support cross-building on macOS. Contributions are welcome!")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -80,6 +80,7 @@ class OpenldapConan(ConanFile):
             # https://git.openldap.org/openldap/openldap/-/blob/OPENLDAP_REL_ENG_2_5/configure.ac#L1636
             tc.configure_args.append("--with-yielding_select=yes")
         if is_apple_os(self):
+            # macOS Ventura does not have soelim, but mandoc_soelim
             tc.make_args.append("SOELIM=soelim" if shutil.which("soelim") else "SOELIM=mandoc_soelim")
         tc.generate()
         tc = AutotoolsDeps(self)

--- a/recipes/openldap/all/conanfile.py
+++ b/recipes/openldap/all/conanfile.py
@@ -67,7 +67,8 @@ class OpenldapConan(ConanFile):
             return "yes" if v else "no"
 
         tc = AutotoolsToolchain(self)
-        tc.make_args = self._soelim()
+        if is_apple_os(self):
+            tc.make_args.append("SOELIM=soelim" if shutil.which("soelim") else "SOELIM=mandoc_soelim")
         tc.configure_args += [
             "--with-cyrus_sasl={}".format(yes_no(self.options.with_cyrus_sasl)),
             "--without-fetch",

--- a/recipes/openldap/all/conanfile.py
+++ b/recipes/openldap/all/conanfile.py
@@ -67,8 +67,6 @@ class OpenldapConan(ConanFile):
             return "yes" if v else "no"
 
         tc = AutotoolsToolchain(self)
-        if is_apple_os(self):
-            tc.make_args.append("SOELIM=soelim" if shutil.which("soelim") else "SOELIM=mandoc_soelim")
         tc.configure_args += [
             "--with-cyrus_sasl={}".format(yes_no(self.options.with_cyrus_sasl)),
             "--without-fetch",
@@ -81,6 +79,8 @@ class OpenldapConan(ConanFile):
             # When cross-building, yielding_select should be explicit:
             # https://git.openldap.org/openldap/openldap/-/blob/OPENLDAP_REL_ENG_2_5/configure.ac#L1636
             tc.configure_args.append("--with-yielding_select=yes")
+        if is_apple_os(self):
+            tc.make_args.append("SOELIM=soelim" if shutil.which("soelim") else "SOELIM=mandoc_soelim")
         tc.generate()
         tc = AutotoolsDeps(self)
         tc.generate()
@@ -88,12 +88,6 @@ class OpenldapConan(ConanFile):
     def _patch_sources(self):
         replace_in_file(self, os.path.join(self.source_folder, "configure"),
                         "WITH_SYSTEMD=no\nsystemdsystemunitdir=", "WITH_SYSTEMD=no")
-
-    def _soelim(self):
-        # INFO: macOS Ventura does not have soelim, but mandoc_soelim
-        if is_apple_os(self):
-            return ["SOELIM=soelim"] if shutil.which("soelim") else ["SOELIM=mandoc_soelim"]
-        return []
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
Specify library name and version:  **openldap/2.6.7**

The OpenLDAP can be built in Mac, the Brew has a formula for it: https://formulae.brew.sh/formula/openldap

Some extra references:

- http://pig.made-it.com/ldap-mac.html
- https://www.openldap.org/software/release/install.html

Closes: #16555
Fix: Added workaround to cross-build in Linux and macOS (https://bugs.openldap.org/show_bug.cgi?id=9228)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
