### PR TITLE
kdbindings: add version 1.0.5

### DIFF
--- a/recipes/kdbindings/all/conandata.yml
+++ b/recipes/kdbindings/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.5":
+    url: "https://github.com/KDAB/KDBindings/archive/refs/tags/v1.0.5.tar.gz"
+    sha256: "4d001419809a719f8c966e9bc73f457180325655deca0a11c07c47ee112447a3"
   "1.0.3":
     url: "https://github.com/KDAB/KDBindings/archive/refs/tags/v1.0.3.tar.gz"
     sha256: "da8de679d12bf123df6a3c63a482a862d4122a2f3d3567c9b3b2fc2c4f574393"

--- a/recipes/kdbindings/config.yml
+++ b/recipes/kdbindings/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.5":
+    folder: all
   "1.0.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **kdbindings/1.0.5**

Adding newest version of kdbindings as it has some features we need.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
