### PR TITLE
Qt5: fix crash at launch on Android < 23

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -117,6 +117,11 @@ patches:
       "patch_file": "patches/5.15.12-fix-macos-cpp-lib-memory-resource.patch"
       "patch_source": "https://codereview.qt-project.org/c/qt/qtbase/+/482392"
       "patch_type": "portability"
+    - "base_path": "qt5/qtbase"
+      "patch_description": "Fix crash at launch on Android < 23"
+      "patch_file": "patches/5.15.13-android-21-22.diff"
+      "patch_source": "https://bugreports.qt.io/browse/QTBUG-120627?focusedId=789243&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-789243"
+      "patch_type": "portability"
   "5.15.12":
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/aa2a39dea5.diff"

--- a/recipes/qt/5.x.x/patches/5.15.13-android-21-22.diff
+++ b/recipes/qt/5.x.x/patches/5.15.13-android-21-22.diff
@@ -1,0 +1,82 @@
+diff --git a/src/android/jar/src/org/qtproject/qt5/android/ExtractStyle.java b/src/android/jar/src/org/qtproject/qt5/android/ExtractStyle.java
+index 9dba7f2..85a7027 100644
+--- a/src/android/jar/src/org/qtproject/qt5/android/ExtractStyle.java
++++ b/src/android/jar/src/org/qtproject/qt5/android/ExtractStyle.java
+@@ -88,6 +88,7 @@ import java.io.FileOutputStream;
+ import java.io.IOException;
+ import java.io.OutputStreamWriter;
+ import java.lang.reflect.Field;
++import java.lang.reflect.Method;
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.HashMap;
+@@ -903,11 +904,28 @@ public class ExtractStyle {
+         }
+         return json;
+     }
++    
++    private ContextThemeWrapper getContextThemeWrapper()
++    {
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
++            return new ContextThemeWrapper(m_context, m_theme);
++
++        int themeResId = 0;
++        try {
++            Class<?> clazz = ContextThemeWrapper.class;
++            Method method = clazz.getMethod("getThemeResId");
++            method.setAccessible(true);
++            themeResId = (Integer)method.invoke(m_context);
++        } catch (Exception e) {
++            Log.e(QtNative.QtTAG, "Failed to get theme resource ID", e);
++        }
++        return new ContextThemeWrapper(m_context, themeResId);
++    }
+ 
+     private TypedArray obtainStyledAttributes(int styleName, int[] attributes)
+     {
+         TypedValue typedValue = new TypedValue();
+-        Context ctx = new ContextThemeWrapper(m_context, m_theme);
++        Context ctx = getContextThemeWrapper();
+         ctx.getTheme().resolveAttribute(styleName, typedValue, true);
+         return ctx.obtainStyledAttributes(typedValue.data, attributes);
+     }
+@@ -926,7 +944,7 @@ public class ExtractStyle {
+     public void extractViewInformation(int styleName, JSONObject json, String qtClassName, AttributeSet attributeSet) {
+         try {
+             TypedValue typedValue = new TypedValue();
+-            Context ctx = new ContextThemeWrapper(m_context, m_theme);
++            Context ctx = getContextThemeWrapper();
+             ctx.getTheme().resolveAttribute(styleName, typedValue, true);
+ 
+             int[] attributes = new int[]{
+@@ -1120,7 +1138,7 @@ public class ExtractStyle {
+ 
+         try {
+             TypedValue typedValue = new TypedValue();
+-            Context ctx = new ContextThemeWrapper(m_context, m_theme);
++            Context ctx = getContextThemeWrapper();
+             ctx.getTheme().resolveAttribute(styleName, typedValue, true);
+ 
+             // Get textAppearance values
+@@ -1391,7 +1409,7 @@ public class ExtractStyle {
+         JSONObject json = extractTextAppearanceInformation(styleName, qtClass);
+ 
+         TypedValue typedValue = new TypedValue();
+-        Context ctx = new ContextThemeWrapper(m_context, m_theme);
++        Context ctx = getContextThemeWrapper();
+         ctx.getTheme().resolveAttribute(styleName, typedValue, true);
+         final int[] attributes = new int[]{android.R.attr.button};
+         TypedArray array = ctx.obtainStyledAttributes(typedValue.data, attributes);
+diff --git a/src/android/jar/src/org/qtproject/qt5/android/QtLayout.java b/src/android/jar/src/org/qtproject/qt5/android/QtLayout.java
+index e59ac39..bac333c 100644
+--- a/src/android/jar/src/org/qtproject/qt5/android/QtLayout.java
++++ b/src/android/jar/src/org/qtproject/qt5/android/QtLayout.java
+@@ -106,8 +106,6 @@ public class QtLayout extends ViewGroup
+        final WindowManager windowManager = activity.getWindowManager();
+        Display display;
+
+-       final WindowInsets rootInsets = getRootWindowInsets();
+-
+        int maxWidth = 0;
+        int maxHeight = 0;
+


### PR DESCRIPTION
Specify library name and version:  **Qt/5.15.13**

Support of Android 21 & 22 is broken in Qt 5.15.13, this patch fixes it.

https://bugreports.qt.io/browse/QTBUG-120627

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
