### PR TITLE
libkml: use version range for expat, limit cpp standard to c++14

### DIFF
--- a/recipes/libkml/all/conanfile.py
+++ b/recipes/libkml/all/conanfile.py
@@ -52,6 +52,8 @@ class LibkmlConan(ConanFile):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration(f"{self.ref} shared with Visual Studio and MT runtime is not supported")
         if conan_version.major >= 2:
+            # FIXME: linter complains, but function is there
+            # https://docs.conan.io/2.0/reference/tools/build.html?highlight=check_min_cppstd#conan-tools-build-check-max-cppstd
             import sys
             check_max_cppstd = getattr(sys.modules['conan.tools.build'], 'check_max_cppstd')
             # INFO: error: no template named 'unary_function' in namespace 'std'. Removed in C++17.

--- a/recipes/libkml/all/conanfile.py
+++ b/recipes/libkml/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
@@ -43,7 +43,7 @@ class LibkmlConan(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.81.0", transitive_headers=True)
-        self.requires("expat/2.5.0")
+        self.requires("expat/[>=2.6.2 <3]")
         self.requires("minizip/1.2.13")
         self.requires("uriparser/0.9.7")
         self.requires("zlib/[>=1.2.11 <2]")
@@ -51,6 +51,11 @@ class LibkmlConan(ConanFile):
     def validate(self):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration(f"{self.ref} shared with Visual Studio and MT runtime is not supported")
+        if conan_version.major >= 2:
+            import sys
+            check_max_cppstd = getattr(sys.modules['conan.tools.build'], 'check_max_cppstd')
+            # INFO: error: no template named 'unary_function' in namespace 'std'. Removed in C++17.
+            check_max_cppstd(self, 14)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **libkml/all**

expat<2.6.2 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

fix validation when using cpp standard > 14

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
