### PR TITLE
tmx: add version 1.10.0, use version range for libxml2

### DIFF
--- a/recipes/tmx/all/conandata.yml
+++ b/recipes/tmx/all/conandata.yml
@@ -1,4 +1,13 @@
 sources:
+  "1.10.0":
+    url: "https://github.com/baylej/tmx/archive/refs/tags/tmx_1.10.0.tar.gz"
+    sha256: "8ee42d1728c567d6047a58b2624c39c8844aaf675c470f9f284c4ed17e94188f"
   "1.4.0":
     url: "https://github.com/baylej/tmx/archive/refs/tags/tmx_1.4.0.tar.gz"
     sha256: "5ab52e72976141260edd1b15ea34e1626c0f4ba9b8d2afe7f4d68b51fc9fedf7"
+patches:
+  "1.4.0":
+    - patch_file: "patches/0001-missing-stdlib-include.patch"
+      patch_description: "fix missing stdlib include"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/baylej/tmx/commit/2d20ed631618f5e9ca89d90147aab8157989f5da.patch"

--- a/recipes/tmx/all/conanfile.py
+++ b/recipes/tmx/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 import os
 import textwrap
 
-required_conan_version = ">=1.51.1"
+required_conan_version = ">=1.53.0"
 
 
 class TmxConan(ConanFile):
@@ -15,6 +15,7 @@ class TmxConan(ConanFile):
     homepage = "https://github.com/baylej/tmx"
     url = "https://github.com/conan-io/conan-center-index"
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -38,18 +39,9 @@ class TmxConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/tmx/all/conanfile.py
+++ b/recipes/tmx/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
 import os
 import textwrap
 
@@ -29,6 +29,9 @@ class TmxConan(ConanFile):
         "with_zstd": False,
     }
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -52,7 +55,7 @@ class TmxConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libxml2/2.11.6")
+        self.requires("libxml2/[>=2.12.5 <3]")
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_zstd:
@@ -75,6 +78,7 @@ class TmxConan(ConanFile):
         deps.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/tmx/all/patches/0001-missing-stdlib-include.patch
+++ b/recipes/tmx/all/patches/0001-missing-stdlib-include.patch
@@ -1,0 +1,22 @@
+From 2d20ed631618f5e9ca89d90147aab8157989f5da Mon Sep 17 00:00:00 2001
+From: Connor Rigby <connorr@hey.com>
+Date: Thu, 18 Jan 2024 18:40:53 -0700
+Subject: [PATCH] tmx_mem: add stdlib.h for free and realloc
+
+Signed-off-by: Connor Rigby <connorr@hey.com>
+---
+ src/tmx_mem.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/tmx_mem.c b/src/tmx_mem.c
+index 5ff31c9..b421af6 100644
+--- a/src/tmx_mem.c
++++ b/src/tmx_mem.c
+@@ -2,6 +2,7 @@
+ 	Node allocation
+ */
+ 
++#include <stdlib.h>
+ #include <string.h>
+ 
+ #include <libxml/xmlmemory.h>

--- a/recipes/tmx/config.yml
+++ b/recipes/tmx/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.10.0":
+    folder: all
   "1.4.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **tmx/all**

add version 1.10.0

libxml2<2.12.5 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
