### PR TITLE
etl: add version 20.38.11

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.38.11":
+    url: "https://github.com/ETLCPP/etl/archive/20.38.11.tar.gz"
+    sha256: "c73b6b076ab59e02398a9f90a66198a9f8bf0cfa91af7be2eebefb3bb264ba83"
   "20.38.10":
     url: "https://github.com/ETLCPP/etl/archive/20.38.10.tar.gz"
     sha256: "562f9b5d9e6786350b09d87be9c5f030073e34d7bf0a975de3e91476ddd471a3"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.38.11":
+    folder: all
   "20.38.10":
     folder: all
   "20.38.7":


### PR DESCRIPTION
Specify library name and version:  **etl/20.38.11**

https://github.com/ETLCPP/etl/compare/20.38.10...20.38.11

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
