### PR TITLE
iguana: add version 1.0.4

### DIFF
--- a/recipes/iguana/all/conandata.yml
+++ b/recipes/iguana/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.4":
+    url: "https://github.com/qicosmos/iguana/archive/refs/tags/1.0.4.tar.gz"
+    sha256: "b584cd26e65902a14a3a349ebc480beb7b4502fd5a5ffa3cb7c6102d857958b1"
   "1.0.3":
     url: "https://github.com/qicosmos/iguana/archive/refs/tags/v1.0.3.tar.gz"
     sha256: "7dcb21a36bd64a63a9ea857f3563ac61e965c49ec60ad7b99a2bfb9192f3e4c3"

--- a/recipes/iguana/config.yml
+++ b/recipes/iguana/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.4":
+    folder: all
   "1.0.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **iguana/1.0.4**

https://github.com/qicosmos/iguana/compare/v1.0.3...1.0.4

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
