### PR TITLE
opentdf-client: use version range for libxml2

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -8,9 +8,6 @@ sources:
   "1.5.3":
     url: "https://github.com/opentdf/client-cpp/archive/1.5.3.tar.gz"
     sha256: "43812a99b8942cd8f600f7ea284118e8af7d000705b2602991f889fe49dd3455"
-  "1.5.0":
-    url: "https://github.com/opentdf/client-cpp/archive/1.5.0.tar.gz"
-    sha256: "0d6134634c0c6fde5e8457361332242259e1ef238e5254ccbed2f94549998c48"
   "1.4.0":
     url: "https://github.com/opentdf/client-cpp/archive/1.4.0.tar.gz"
     sha256: "0ef9cdf5e49f83a8ddcde10d64cdf9108652e781396cfab000f50cc067e6f795"
@@ -18,14 +15,29 @@ sources:
     url: "https://github.com/opentdf/client-cpp/archive/1.3.10.tar.gz"
     sha256: "539bd5e64bceb86f63b3f7db75de470d5ea1d52ae6436a6a2d6789f7d0710dd4"
 patches:
-  "1.5.0":
-    - patch_file: "patches/1.3.10-0001-cmake-fixes.patch"
-      patch_description: "CMake build fixes for Conan 2.0-compatible recipe"
-      patch_type: "conan"
+  "1.5.6":
+    - patch_file: "patches/1.5.x-0001-fix-invalid-types.patch"
+      patch_description: "Fix build with libxml2 2.12+"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/opentdf/client-cpp/pull/140"
+  "1.5.4":
+    - patch_file: "patches/1.5.x-0001-fix-invalid-types.patch"
+      patch_description: "Fix build with libxml2 2.12+"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/opentdf/client-cpp/pull/140"
+  "1.5.3":
+    - patch_file: "patches/1.5.x-0001-fix-invalid-types.patch"
+      patch_description: "Fix build with libxml2 2.12+"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/opentdf/client-cpp/pull/140"
   "1.4.0":
     - patch_file: "patches/1.3.10-0001-cmake-fixes.patch"
       patch_description: "CMake build fixes for Conan 2.0-compatible recipe"
       patch_type: "conan"
+    - patch_file: "patches/1.4.0-0001-fix-invalid-types.patch"
+      patch_description: "Fix build with libxml2 2.12+"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/opentdf/client-cpp/pull/140"
   "1.3.10":
     - patch_file: "patches/1.3.10-0001-cmake-fixes.patch"
       patch_description: "CMake build fixes for Conan 2.0-compatible recipe"

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -73,7 +73,7 @@ class OpenTDFConan(ConanFile):
         self.requires("jwt-cpp/0.4.0")
         self.requires("zlib/[>=1.2.11 <2]")
         self.requires("boost/1.83.0")
-        self.requires("libxml2/2.11.6")
+        self.requires("libxml2/[>=2.12.5 <3]")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/opentdf-client/all/patches/1.4.0-0001-fix-invalid-types.patch
+++ b/recipes/opentdf-client/all/patches/1.4.0-0001-fix-invalid-types.patch
@@ -1,0 +1,29 @@
+diff --git a/src/lib/src/tdf_xml_validator.cpp b/src/lib/src/tdf_xml_validator.cpp
+index 450ecbf..02b936b 100644
+--- a/src/lib/src/tdf_xml_validator.cpp
++++ b/src/lib/src/tdf_xml_validator.cpp
+@@ -19,7 +19,7 @@ using namespace virtru;
+ // Based on https://stackoverflow.com/questions/54124989/libxml2-get-xsd-validation-errors
+ 
+ // This routine is a callback for the parser, used when there is an error validating the supplied XML against the schema
+-static void schemaParseErrorHandler(void *arg, xmlErrorPtr error)
++static void schemaParseErrorHandler(void *arg, xmlError const* error)
+ {
+     std::ostringstream errorMsg;
+ 
+@@ -115,7 +115,7 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
+ 
+                 if (moreToRead != 0) {
+                     // There was an error parsing the supplied XML
+-                    xmlErrorPtr error = xmlGetLastError();
++                    xmlError const* error = xmlGetLastError();
+                     std::ostringstream errorMsg;
+                     errorMsg << "Schema validation error " << error->file << "(" << error->line << ") " << error->int2 << " " << error->code << " " << error->message;
+                     ThrowException(errorMsg.str(), VIRTRU_TDF_FORMAT_ERROR);
+@@ -127,4 +127,4 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
+         }
+     }
+     return retval;
+-}
+\ No newline at end of file
++}

--- a/recipes/opentdf-client/all/patches/1.4.0-0001-fix-invalid-types.patch
+++ b/recipes/opentdf-client/all/patches/1.4.0-0001-fix-invalid-types.patch
@@ -1,17 +1,28 @@
 diff --git a/src/lib/src/tdf_xml_validator.cpp b/src/lib/src/tdf_xml_validator.cpp
-index 450ecbf..02b936b 100644
+index 450ecbf..22392f4 100644
 --- a/src/lib/src/tdf_xml_validator.cpp
 +++ b/src/lib/src/tdf_xml_validator.cpp
-@@ -19,7 +19,7 @@ using namespace virtru;
+@@ -11,6 +11,7 @@
+ #include "tdf_xml_validator.h"
+ #include "tdf_exception.h"
+ #include "logger.h"
++#include "libxml/xmlversion.h"
+ #include <string>
+ #include <sstream>
+ 
+@@ -19,7 +20,11 @@ using namespace virtru;
  // Based on https://stackoverflow.com/questions/54124989/libxml2-get-xsd-validation-errors
  
  // This routine is a callback for the parser, used when there is an error validating the supplied XML against the schema
--static void schemaParseErrorHandler(void *arg, xmlErrorPtr error)
++#if LIBXML_VERSION >= 21200
 +static void schemaParseErrorHandler(void *arg, xmlError const* error)
++#else
+ static void schemaParseErrorHandler(void *arg, xmlErrorPtr error)
++#endif
  {
      std::ostringstream errorMsg;
  
-@@ -115,7 +115,7 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
+@@ -115,7 +120,7 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
  
                  if (moreToRead != 0) {
                      // There was an error parsing the supplied XML
@@ -20,7 +31,7 @@ index 450ecbf..02b936b 100644
                      std::ostringstream errorMsg;
                      errorMsg << "Schema validation error " << error->file << "(" << error->line << ") " << error->int2 << " " << error->code << " " << error->message;
                      ThrowException(errorMsg.str(), VIRTRU_TDF_FORMAT_ERROR);
-@@ -127,4 +127,4 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
+@@ -127,4 +132,4 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
          }
      }
      return retval;

--- a/recipes/opentdf-client/all/patches/1.5.x-0001-fix-invalid-types.patch
+++ b/recipes/opentdf-client/all/patches/1.5.x-0001-fix-invalid-types.patch
@@ -1,0 +1,39 @@
+From 20f19d19c4903a606d32e6313c7609f3436fe138 Mon Sep 17 00:00:00 2001
+From: mayeut <mayeut@users.noreply.github.com>
+Date: Sat, 20 Apr 2024 13:43:28 +0200
+Subject: [PATCH] fix: use `xmlError cont*` instead of xmlErrorPtr
+
+This fixes issues on Xcode15 (at least) when building against libxml 2.12+
+---
+ src/lib/src/tdf_xml_validator.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/lib/src/tdf_xml_validator.cpp b/src/lib/src/tdf_xml_validator.cpp
+index bbf0390..57670e0 100644
+--- a/src/lib/src/tdf_xml_validator.cpp
++++ b/src/lib/src/tdf_xml_validator.cpp
+@@ -19,7 +19,7 @@ using namespace virtru;
+ // Based on https://stackoverflow.com/questions/54124989/libxml2-get-xsd-validation-errors
+ 
+ // This routine is a callback for the parser, used when there is an error validating the supplied XML against the schema
+-static void schemaParseErrorHandler(void *arg, xmlErrorPtr error)
++static void schemaParseErrorHandler(void *arg, xmlError const* error)
+ {
+     std::ostringstream errorMsg;
+ 
+@@ -95,7 +95,7 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
+ 
+                 if (moreToRead != 0) {
+                     // There was an error parsing the supplied XML
+-                    xmlErrorPtr error = xmlGetLastError();
++                    xmlError const* error = xmlGetLastError();
+                     std::ostringstream errorMsg;
+                     errorMsg << "Schema validation error " << error->file << "(" << error->line << ") " << error->int2 << " " << error->code << " " << error->message;
+                     ThrowException(errorMsg.str(), VIRTRU_TDF_FORMAT_ERROR);
+@@ -107,4 +107,4 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
+         }
+     }
+     return retval;
+-}
+\ No newline at end of file
++}

--- a/recipes/opentdf-client/all/patches/1.5.x-0001-fix-invalid-types.patch
+++ b/recipes/opentdf-client/all/patches/1.5.x-0001-fix-invalid-types.patch
@@ -1,27 +1,39 @@
-From 20f19d19c4903a606d32e6313c7609f3436fe138 Mon Sep 17 00:00:00 2001
+From b172bdd69b85cd2da068621c0795afa76c44eb0a Mon Sep 17 00:00:00 2001
 From: mayeut <mayeut@users.noreply.github.com>
 Date: Sat, 20 Apr 2024 13:43:28 +0200
-Subject: [PATCH] fix: use `xmlError cont*` instead of xmlErrorPtr
+Subject: [PATCH] fix: use `xmlError const*` instead of xmlErrorPtr for libxml
+ 2.12+
 
 This fixes issues on Xcode15 (at least) when building against libxml 2.12+
 ---
- src/lib/src/tdf_xml_validator.cpp | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ src/lib/src/tdf_xml_validator.cpp | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/src/lib/src/tdf_xml_validator.cpp b/src/lib/src/tdf_xml_validator.cpp
-index bbf0390..57670e0 100644
+index bbf0390..343ab86 100644
 --- a/src/lib/src/tdf_xml_validator.cpp
 +++ b/src/lib/src/tdf_xml_validator.cpp
-@@ -19,7 +19,7 @@ using namespace virtru;
+@@ -11,6 +11,7 @@
+ #include "tdf_xml_validator.h"
+ #include "tdf_exception.h"
+ #include "logger.h"
++#include "libxml/xmlversion.h"
+ #include <string>
+ #include <sstream>
+ 
+@@ -19,7 +20,11 @@ using namespace virtru;
  // Based on https://stackoverflow.com/questions/54124989/libxml2-get-xsd-validation-errors
  
  // This routine is a callback for the parser, used when there is an error validating the supplied XML against the schema
--static void schemaParseErrorHandler(void *arg, xmlErrorPtr error)
++#if LIBXML_VERSION >= 21200
 +static void schemaParseErrorHandler(void *arg, xmlError const* error)
++#else
+ static void schemaParseErrorHandler(void *arg, xmlErrorPtr error)
++#endif
  {
      std::ostringstream errorMsg;
  
-@@ -95,7 +95,7 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
+@@ -95,7 +100,7 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
  
                  if (moreToRead != 0) {
                      // There was an error parsing the supplied XML
@@ -30,7 +42,7 @@ index bbf0390..57670e0 100644
                      std::ostringstream errorMsg;
                      errorMsg << "Schema validation error " << error->file << "(" << error->line << ") " << error->int2 << " " << error->code << " " << error->message;
                      ThrowException(errorMsg.str(), VIRTRU_TDF_FORMAT_ERROR);
-@@ -107,4 +107,4 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
+@@ -107,4 +112,4 @@ bool TDFXMLValidator::validate(xmlTextReaderPtr reader) {
          }
      }
      return retval;

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -5,8 +5,6 @@ versions:
     folder: all
   "1.5.3":
     folder: all
-  "1.5.0":
-    folder: all
   "1.4.0":
     folder: all
   "1.3.10":


### PR DESCRIPTION
Specify library name and version:  **opentdf-client/all**

libxml2<2.12.5 has known security issues. We can now use version range: c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
