### PR TITLE
libssh2: do not rely on _WINDLL or DLL_EXPORT defines

### DIFF
--- a/recipes/libssh2/all/conandata.yml
+++ b/recipes/libssh2/all/conandata.yml
@@ -14,6 +14,20 @@ sources:
   "1.8.2":
     sha256: 088307d9f6b6c4b8c13f34602e8ff65d21c2dc4d55284dfe15d502c4ee190d67
     url: https://github.com/libssh2/libssh2/releases/download/libssh2-1.8.2/libssh2-1.8.2.tar.gz
-  "1.8.0":
-    sha256: 39f34e2f6835f4b992cafe8625073a88e5a28ba78f83e8099610a7b3af4676d4
-    url: https://github.com/libssh2/libssh2/releases/download/libssh2-1.8.0/libssh2-1.8.0.tar.gz
+patches:
+  "1.11.0":
+    - patch_file: "patches/001-1.11.0-fix-dll-defines.patch"
+      patch_description: "Do not rely on _WINDLL or DLL_EXPORT defines for DLLs"
+      patch_type: "conan"
+  "1.10.0":
+    - patch_file: "patches/001-1.8.2-fix-dll-defines.patch"
+      patch_description: "Do not rely on _WINDLL define for DLLs"
+      patch_type: "conan"
+  "1.9.0":
+    - patch_file: "patches/001-1.8.2-fix-dll-defines.patch"
+      patch_description: "Do not rely on _WINDLL define for DLLs"
+      patch_type: "conan"
+  "1.8.2":
+    - patch_file: "patches/001-1.8.2-fix-dll-defines.patch"
+      patch_description: "Do not rely on _WINDLL define for DLLs"
+      patch_type: "conan"

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -63,6 +63,10 @@ class Libssh2Conan(ConanFile):
         tc.cache_variables['BUILD_TESTING'] = not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
         tc.cache_variables["BUILD_STATIC_LIBS"] = not self.options.shared
         tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
+        # Ensure DLL symbols are exported correctly
+        tc.cache_variables["HIDE_SYMBOLS"] = True # sets -DLIBSSH2_EXPORTS
+        if Version(self.version) < "1.11" and self.options.shared:
+            tc.preprocessor_definitions["LIBSSH2_EXPORTS"] = ""
         # To install relocatable shared lib on Macos by default
         tc.variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         # Workaround until github.com/conan-io/conan/pull/12600 is merged
@@ -132,6 +136,9 @@ class Libssh2Conan(ConanFile):
             self.cpp_info.components["_libssh2"].system_libs.append("ws2_32")
         elif self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["_libssh2"].system_libs.extend(["pthread", "dl"])
+
+        if self.options.shared:
+            self.cpp_info.components["_libssh2"].defines.append("LIBSSH2_EXPORTS")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["_libssh2"].set_property("cmake_target_name", "Libssh2::libssh2")

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -130,7 +130,7 @@ class Libssh2Conan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "Libssh2")
         self.cpp_info.set_property("cmake_target_name", "Libssh2::libssh2")
         self.cpp_info.set_property("pkg_config_name", "libssh2")
-        # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
+
         self.cpp_info.components["_libssh2"].libs = collect_libs(self)
         if self.settings.os == "Windows":
             self.cpp_info.components["_libssh2"].system_libs.append("ws2_32")
@@ -140,9 +140,6 @@ class Libssh2Conan(ConanFile):
         if self.options.shared:
             self.cpp_info.components["_libssh2"].defines.append("LIBSSH2_EXPORTS")
 
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.components["_libssh2"].set_property("cmake_target_name", "Libssh2::libssh2")
-        self.cpp_info.components["_libssh2"].set_property("pkg_config_name", "libssh2")
         if self.options.with_zlib:
             self.cpp_info.components["_libssh2"].requires.append("zlib::zlib")
         if self.options.crypto_backend == "openssl":

--- a/recipes/libssh2/all/patches/001-1.11.0-fix-dll-defines.patch
+++ b/recipes/libssh2/all/patches/001-1.11.0-fix-dll-defines.patch
@@ -1,0 +1,11 @@
+--- include/libssh2.h
++++ include/libssh2.h
+@@ -105,7 +105,7 @@
+ /* Allow alternate API prefix from CFLAGS or calling app */
+ #ifndef LIBSSH2_API
+ # ifdef LIBSSH2_WIN32
+-#  if defined(LIBSSH2_EXPORTS) || defined(DLL_EXPORT) || defined(_WINDLL)
++#  if defined(LIBSSH2_EXPORTS)
+ #   ifdef LIBSSH2_LIBRARY
+ #    define LIBSSH2_API __declspec(dllexport)
+ #   else

--- a/recipes/libssh2/all/patches/001-1.8.2-fix-dll-defines.patch
+++ b/recipes/libssh2/all/patches/001-1.8.2-fix-dll-defines.patch
@@ -1,0 +1,11 @@
+--- include/libssh2.h
++++ include/libssh2.h
+@@ -100,7 +100,7 @@
+ /* Allow alternate API prefix from CFLAGS or calling app */
+ #ifndef LIBSSH2_API
+ # ifdef LIBSSH2_WIN32
+-#  ifdef _WINDLL
++#  ifdef LIBSSH2_EXPORTS
+ #   ifdef LIBSSH2_LIBRARY
+ #    define LIBSSH2_API __declspec(dllexport)
+ #   else

--- a/recipes/libssh2/all/test_package/conanfile.py
+++ b/recipes/libssh2/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/libssh2/config.yml
+++ b/recipes/libssh2/config.yml
@@ -9,5 +9,3 @@ versions:
     folder: all
   "1.8.2":
     folder: all
-  "1.8.0":
-    folder: all


### PR DESCRIPTION
Static `libssh2` Windows packages are prone to failing in consuming packages due to libssh2 relying on unnamespaced `_WINDLL` and `DLL_EXPORT` shared/static defines.

Should fix the `unresolved external symbol __imp_libssh2_init` errors in test_package for #18810.

Similar to #23680.