### PR TITLE
imguizmo: add cci.20231114 snapshot version

### DIFF
--- a/recipes/imguizmo/all/conandata.yml
+++ b/recipes/imguizmo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20231114":
+    url: "https://github.com/CedricGuillemet/ImGuizmo/archive/ba662b119d64f9ab700bb2cd7b2781f9044f5565.zip"
+    sha256: "5a63baebb5bce96d83e5e3d6daa4598844ba8d5d0e3cb1ee385fcc54cf996115"
   "1.83":
     url: "https://github.com/CedricGuillemet/ImGuizmo/archive/refs/tags/1.83.tar.gz"
     sha256: "e6d05c5ebde802df7f6c342a06bc675bd2aa1c754d2d96755399a182187098a8"

--- a/recipes/imguizmo/all/conanfile.py
+++ b/recipes/imguizmo/all/conanfile.py
@@ -55,7 +55,7 @@ class ImGuizmoConan(ConanFile):
         tc.generate()
 
     def build(self):
-        if Version(self.dependencies["imgui"].ref.version) >= "1.89.4":
+        if self.version == "1.83" and Version(self.dependencies["imgui"].ref.version) >= "1.89.4":
             # Related to a breaking change: https://github.com/ocornut/imgui/blob/master/docs/CHANGELOG.txt#L912
             # Redirection: ImDrawList::AddBezierCurve() -> use ImDrawList::AddBezierCubic()
             replace_in_file(self, os.path.join(self.source_folder, "GraphEditor.cpp"),

--- a/recipes/imguizmo/config.yml
+++ b/recipes/imguizmo/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20231114":
+    folder: "all"
   "1.83":
     folder: "all"


### PR DESCRIPTION
Required for the latest version of Iridescence in #23436.

It has been almost three years from the latest released version and there's no indication about when the next version might be released.