### PR TITLE
jsoncons: add version 0.174.0

### DIFF
--- a/recipes/jsoncons/all/conandata.yml
+++ b/recipes/jsoncons/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.174.0":
+    url: "https://github.com/danielaparker/jsoncons/archive/refs/tags/v0.174.0.tar.gz"
+    sha256: "60507721a26c752c71fbb228568f7944ea3fd287e9b179a9128ca32d7ddbb386"
   "0.173.4":
     url: "https://github.com/danielaparker/jsoncons/archive/refs/tags/v0.173.4.tar.gz"
     sha256: "3e3525325c88b33f15af2e1f3cf7a1893a49e47aa787a2df723a098b3a4b20b1"

--- a/recipes/jsoncons/config.yml
+++ b/recipes/jsoncons/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.174.0":
+    folder: "all"
   "0.173.4":
     folder: "all"
   "0.173.3":


### PR DESCRIPTION
Specify library name and version:  **jsoncons/0.174.0**

https://github.com/danielaparker/jsoncons/compare/v0.173.4...v0.174.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
