### PR TITLE
xmlsec: add version 1.3.4

### DIFF
--- a/recipes/xmlsec/all/conandata.yml
+++ b/recipes/xmlsec/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.4":
+    url: "https://github.com/lsh123/xmlsec/releases/download/1.3.4/xmlsec1-1.3.4.tar.gz"
+    sha256: "45ad9078d41ae76844ad2f8651600ffeec0fdd128ead988a8d69e907c57aee75"
   "1.3.3":
     url: "https://github.com/lsh123/xmlsec/releases/download/1.3.3/xmlsec1-1.3.3.tar.gz"
     sha256: "ab5b9a9ffd6960f46f7466d9d91f174ec37e8c31989237ba6b9eacdd816464f2"

--- a/recipes/xmlsec/config.yml
+++ b/recipes/xmlsec/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.4":
+    folder: all
   "1.3.3":
     folder: all
   "1.3.2":


### PR DESCRIPTION
Specify library name and version:  **xmlsec/1.3.4**

https://github.com/lsh123/xmlsec/compare/xmlsec_1_3_3...1.3.4

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
