### PR TITLE
cpr: lower minimum GCC version requirement

### DIFF
--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -44,7 +44,7 @@ class CprConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "17": {
-                "gcc": "9",
+                "gcc": "7",
                 "clang": "7",
                 "apple-clang": "10",
                 "Visual Studio": "15",


### PR DESCRIPTION
Specify library name and version:  **cpr/1.10.5**

Fixes Issue #23699

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
