### PR TITLE
up-cpp: new recipe

### DIFF
--- a/recipes/up-cpp/all/conandata.yml
+++ b/recipes/up-cpp/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  # Newer versions at the top
+  "0.1.2-dev":
+    url: "https://github.com/eclipse-uprotocol/up-cpp/archive/refs/tags/v0.1.2-dev.tar.gz"
+    sha256: "1c1006256d0e5fd385732767e0e3b0b4867342e29e4c74e11a0d8a9a763c1288"
+proto:
+  "0.1.2-dev":
+    ssh: "git@github.com:eclipse-uprotocol/up-core-api.git"
+    https: "https://github.com/eclipse-uprotocol/up-core-api.git"
+    tag: "uprotocol-core-api-1.5.7"

--- a/recipes/up-cpp/all/conanfile.py
+++ b/recipes/up-cpp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.build import check_min_cppstd
+from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, collect_libs
@@ -89,6 +89,10 @@ class UpCppConan(ConanFile):
             )
         if is_msvc(self) and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
+        self.output.info(f"self.settings.compiler: {self.settings.compiler}")
+        self.output.info(f"stdcpp_library(self): {stdcpp_library(self)}")
+        if self.settings.compiler == "clang" and stdcpp_library(self) == "c++":
+            raise ConanInvalidConfiguration(f"{self.ref} Experiencing some interference between math.h and the protobuf generated udiscovery.pb.h when compiling with libc++ for some reason.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/up-cpp/all/conanfile.py
+++ b/recipes/up-cpp/all/conanfile.py
@@ -87,8 +87,8 @@ class UpCppConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
-        if is_msvc(self) and self.options.shared:
-            raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
+        if is_msvc(self):
+            raise ConanInvalidConfiguration(f"{self.ref} need to have paths in CMake files updated to handle both \ and /.")
         self.output.info(f"self.settings.compiler: {self.settings.compiler}")
         self.output.info(f"stdcpp_library(self): {stdcpp_library(self)}")
         if self.settings.compiler == "clang" and stdcpp_library(self) == "c++":

--- a/recipes/up-cpp/all/conanfile.py
+++ b/recipes/up-cpp/all/conanfile.py
@@ -127,7 +127,7 @@ class UpCppConan(ConanFile):
         apply_conandata_patches(self)
 
     def build(self):
-        self._patch_sources()  # It can be apply_conandata_patches(self) only in case no more patches are needed
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -137,7 +137,6 @@ class UpCppConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
 
-        # some files extensions and folders are not allowed. Please, read the FAQs to get informed.
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "share"))
@@ -147,12 +146,6 @@ class UpCppConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["up-cpp"]
-
-        # If they are needed on Linux, m, pthread and dl are usually needed on FreeBSD too
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("m")
-            self.cpp_info.system_libs.append("pthread")
-            self.cpp_info.system_libs.append("dl")
 
         self.cpp_info.set_property("cmake_file_name", "up-cpp")
         self.cpp_info.set_property("cmake_target_name", "up-cpp::up-cpp")

--- a/recipes/up-cpp/all/conanfile.py
+++ b/recipes/up-cpp/all/conanfile.py
@@ -70,6 +70,9 @@ class UpCppConan(ConanFile):
         self.folders.build = os.path.join("build", str(self.settings.build_type))
         self.folders.install = "install"
 
+    def build_requirements(self):
+        self.build_requires("cmake/[>=3.18.0]")
+
     def requirements(self):
         self.requires("protobuf/3.21.12")
         self.requires("spdlog/1.13.0")

--- a/recipes/up-cpp/all/conanfile.py
+++ b/recipes/up-cpp/all/conanfile.py
@@ -88,11 +88,14 @@ class UpCppConan(ConanFile):
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
         if is_msvc(self):
-            raise ConanInvalidConfiguration(f"{self.ref} need to have paths in CMake files updated to handle both \ and /.")
-        self.output.info(f"self.settings.compiler: {self.settings.compiler}")
-        self.output.info(f"stdcpp_library(self): {stdcpp_library(self)}")
+            raise ConanInvalidConfiguration(
+                f"{self.ref} need to have paths in CMake files updated to handle both \ and /."
+            )
         if self.settings.compiler == "clang" and stdcpp_library(self) == "c++":
-            raise ConanInvalidConfiguration(f"{self.ref} Experiencing some interference between math.h and the protobuf generated udiscovery.pb.h when compiling with libc++ for some reason.")
+            raise ConanInvalidConfiguration(
+                f"{self.ref} Experiencing some interference between math.h and the protobuf generated udiscovery.pb.h"
+                  "when compiling with libc++ for some reason."
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/up-cpp/all/conanfile.py
+++ b/recipes/up-cpp/all/conanfile.py
@@ -66,7 +66,7 @@ class UpCppConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder="src")
         self.folders.build = os.path.join("build", str(self.settings.build_type))
         self.folders.install = "install"
 

--- a/recipes/up-cpp/all/conanfile.py
+++ b/recipes/up-cpp/all/conanfile.py
@@ -1,0 +1,156 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, collect_libs
+from conan.tools.microsoft import check_min_vs, is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version, Git
+import os
+
+required_conan_version = ">=1.59.0"
+
+class UpCppConan(ConanFile):
+    name = "up-cpp"
+    description = "C++ language implementation of a uProtocol language SDK"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/eclipse-uprotocol/up-cpp"
+    topics = ("uprotocol", "sdv", "middleware")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_containing_folder = "up-spec"
+    proto_containing_folder = "up-core-api"
+    # TODO: Upon release of up-spec 1.5.8, this will need to be updated to:
+    # proto_subfolder = "up-core-api"
+    proto_subfolder = "."
+    proto_folder = "uprotocol"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "build_testing": [True, False],
+        "build_unbundled": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": False,
+        "build_testing": False,
+        "build_unbundled": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    # unclear on what I should choose for msvc and Visual Studio
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "13",
+            "clang": "13",
+            "gcc": "11",
+            "msvc": "191",
+            "Visual Studio": "15",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self)
+        self.folders.build = os.path.join("build", str(self.settings.build_type))
+        self.folders.install = "install"
+
+    def requirements(self):
+        self.requires("protobuf/3.21.12")
+        self.requires("spdlog/1.13.0")
+        if self.options.build_testing:
+            self.requires("gtest/1.14.0")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+        if is_msvc(self) and self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+        # we clone protos from the appropriate repo at the appropriate tag to our local root to build
+        rmdir(self, self.proto_containing_folder)
+
+        git = Git(self)
+        git_method = os.getenv("GIT_METHOD", "https")
+        git.clone(self.conan_data["proto"][self.version][git_method], target=self.proto_containing_folder)
+        git.folder=self.proto_containing_folder
+        git.checkout(self.conan_data["proto"][self.version]["tag"])
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["PROTO_PATH"] = os.path.join(self.proto_containing_folder, os.path.join(self.proto_subfolder, self.proto_folder))
+        tc.variables["BUILD_TESTING"] = self.options.build_testing
+        tc.variables["BUILD_UNBUNDLED"] = self.options.build_unbundled
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        if is_msvc(self):
+            tc.variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate(scope="build")
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+
+    def build(self):
+        self._patch_sources()  # It can be apply_conandata_patches(self) only in case no more patches are needed
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        # some files extensions and folders are not allowed. Please, read the FAQs to get informed.
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["up-cpp"]
+
+        # If they are needed on Linux, m, pthread and dl are usually needed on FreeBSD too
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.append("dl")
+
+        self.cpp_info.set_property("cmake_file_name", "up-cpp")
+        self.cpp_info.set_property("cmake_target_name", "up-cpp::up-cpp")
+        self.cpp_info.set_property("pkg_config_name", "up-cpp")
+        self.cpp_info.libs = collect_libs(self)
+
+        self.cpp_info.set_property("cmake_target_name", "up-cpp::up-cpp")
+        self.cpp_info.requires = ["spdlog::spdlog", "protobuf::protobuf"]
+
+        self.cpp_info.names["cmake_find_package"] = "up-cpp"
+        self.cpp_info.names["cmake_find_package_multi"] = "up-cpp"

--- a/recipes/up-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/up-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package LANGUAGES CXX) # if the project uses c++
+
+find_package(up-cpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+# don't link to ${CONAN_LIBS} or CONAN_PKG::package
+target_link_libraries(${PROJECT_NAME} PRIVATE up-cpp::up-cpp)
+# In case the target project need a specific C++ standard
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/up-cpp/all/test_package/conanfile.py
+++ b/recipes/up-cpp/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires("protobuf/3.21.12")
+        self.requires("spdlog/1.13.0")
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/up-cpp/all/test_package/test_package.cpp
+++ b/recipes/up-cpp/all/test_package/test_package.cpp
@@ -1,0 +1,21 @@
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include <up-cpp/uuid/factory/Uuidv8Factory.h>
+#include <up-cpp/uuid/serializer/UuidSerializer.h>
+
+using namespace uprotocol::uuid;
+using namespace uprotocol::v1;
+
+int main(void) {
+
+    UUID uuId = Uuidv8Factory::create();
+    std::vector<uint8_t> vectUuid = UuidSerializer::serializeToBytes(uuId);
+    UUID uuIdFromByteArr = UuidSerializer::deserializeFromBytes(vectUuid);
+
+    std::string str = "0080b636-8303-8701-8ebe-7a9a9e767a9f";
+    UUID uuIdNew = UuidSerializer::deserializeFromString(str);
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/up-cpp/config.yml
+++ b/recipes/up-cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.2-dev":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **up-cpp/0.1.2-dev**

Hi there :wave: 

I contribute to the [Eclipse uProtocol](https://github.com/eclipse-uprotocol) project for developing a Software Defined Vehicle (SDV) middleware to knit together compute within the vehicle, cloud, mobile. We'd like to be able to host the `up-cpp` package on CCI since it seems like the reasonable first choice.

Forgive me as I've not contributed before I'm not entirely sure I've done everything correctly :sweat_smile: 

I left a few questions and TODOs in the conanfile.py as guidance to where I'm unsure in case the recipe is unable to build in certain spots. Will remove those once I can confirm the recipe passes as-is.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
