### PR TITLE
assimp: add v5.4.1

### DIFF
--- a/recipes/assimp/5.x/conandata.yml
+++ b/recipes/assimp/5.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.4.0":
+    url: "https://github.com/assimp/assimp/archive/refs/tags/v5.4.0.tar.gz"
+    sha256: "a90f77b0269addb2f381b00c09ad47710f2aab6b1d904f5e9a29953c30104d3f"
   "5.3.1":
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.3.1.tar.gz"
     sha256: "a07666be71afe1ad4bc008c2336b7c688aca391271188eb9108d0c6db1be53f1"

--- a/recipes/assimp/5.x/conandata.yml
+++ b/recipes/assimp/5.x/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "5.4.0":
-    url: "https://github.com/assimp/assimp/archive/refs/tags/v5.4.0.tar.gz"
-    sha256: "a90f77b0269addb2f381b00c09ad47710f2aab6b1d904f5e9a29953c30104d3f"
+  "5.4.1":
+    url: "https://github.com/assimp/assimp/archive/refs/tags/v5.4.1.tar.gz"
+    sha256: "a1bf71c4eb851ca336bba301730cd072b366403e98e3739d6a024f6313b8f954"
   "5.3.1":
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.3.1.tar.gz"
     sha256: "a07666be71afe1ad4bc008c2336b7c688aca391271188eb9108d0c6db1be53f1"

--- a/recipes/assimp/5.x/conandata.yml
+++ b/recipes/assimp/5.x/conandata.yml
@@ -8,14 +8,9 @@ sources:
   "5.2.5":
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.2.5.tar.gz"
     sha256: "b5219e63ae31d895d60d98001ee5bb809fb2c7b2de1e7f78ceeb600063641e1a"
-  "5.2.2":
-    url: "https://github.com/assimp/assimp/archive/refs/tags/v5.2.2.tar.gz"
-    sha256: "ad76c5d86c380af65a9d9f64e8fc57af692ffd80a90f613dfc6bd945d0b80bb4"
   "5.1.6":
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.1.6.tar.gz"
     sha256: "52ad3a3776ce320c8add531dbcb2d3b93f2e1f10fcff5ac30178b09ba934d084"
 patches:
-  "5.2.2":
-    - patch_file: "patches/0005-fix-unzip.patch"
   "5.1.6":
     - patch_file: "patches/0005-fix-unzip.patch"

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -318,8 +318,6 @@ class AssimpConan(ConanFile):
         ]:
             save(self, os.path.join(self.source_folder, "contrib", contrib_header),
                  f"#include <{include}>\n")
-        if Version(self.version) >= "5.4.0":
-            rmdir(self, self.source_path.joinpath("contrib", "utf8cpp"))
 
         # minizip is provided via conan_deps.cmake, no need to use pkgconfig
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -318,6 +318,8 @@ class AssimpConan(ConanFile):
         ]:
             save(self, os.path.join(self.source_folder, "contrib", contrib_header),
                  f"#include <{include}>\n")
+        if Version(self.version) >= "5.4.0":
+            rmdir(self, self.source_path.joinpath("contrib", "utf8cpp"))
 
         # minizip is provided via conan_deps.cmake, no need to use pkgconfig
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -270,20 +270,18 @@ class AssimpConan(ConanFile):
         apply_conandata_patches(self)
 
         # Don't force several compiler and linker flags
-        replace_mapping = [
-            ("-fPIC", ""),
-            ("-g ", ""),
-            ("/WX", ""),
-            ("-Werror", ""),
-            ("SET(CMAKE_POSITION_INDEPENDENT_CODE ON)", ""),
-            ('SET(CMAKE_CXX_FLAGS_DEBUG "/D_DEBUG /MDd /Ob2 /DEBUG:FULL /Zi")', ""),
-            ('SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /D_DEBUG /Zi /Od")', ""),
-            ('SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")', ""),
-            ('SET(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG:FULL /PDBALTPATH:%_PDB% /OPT:REF /OPT:ICF")', ""),
-        ]
-        for before, after in replace_mapping:
-            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), before, after, strict=False)
-            replace_in_file(self, os.path.join(self.source_folder, "code", "CMakeLists.txt"), before, after, strict=False)
+        for pattern in [
+            "-fPIC",
+            "-g ",
+            "SET(CMAKE_POSITION_INDEPENDENT_CODE ON)",
+            'SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /D_DEBUG /Zi /Od")',
+            'SET(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG:FULL /PDBALTPATH:%_PDB% /OPT:REF /OPT:ICF")',
+        ]:
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), pattern, "")
+
+        for pattern in ["-Werror", "/WX"]:
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), pattern, "")
+            replace_in_file(self, os.path.join(self.source_folder, "code", "CMakeLists.txt"), pattern, "")
 
         # Make sure vendored libs are not used by accident by removing their subdirs
         allow_vendored = ["Open3DGC"]

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.build import stdcpp_library, check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, replace_in_file, rmdir, save
-from conan.tools.microsoft import is_msvc
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
@@ -215,19 +215,30 @@ class AssimpConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["ASSIMP_HUNTER_ENABLED"] = False
-        tc.variables["ASSIMP_IGNORE_GIT_HASH"] = True
-        tc.variables["ASSIMP_RAPIDJSON_NO_MEMBER_ITERATOR"] = False
         tc.variables["ASSIMP_ANDROID_JNIIOSYSTEM"] = False
         tc.variables["ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT"] = False
         tc.variables["ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT"] = False
         tc.variables["ASSIMP_BUILD_ASSIMP_TOOLS"] = False
+        tc.variables["ASSIMP_BUILD_DOCS"] = False
+        tc.variables["ASSIMP_BUILD_DRACO"] = False
+        tc.variables["ASSIMP_BUILD_FRAMEWORK"] = False
+        tc.variables["ASSIMP_BUILD_MINIZIP"] = False
         tc.variables["ASSIMP_BUILD_SAMPLES"] = False
         tc.variables["ASSIMP_BUILD_TESTS"] = False
+        tc.variables["ASSIMP_BUILD_ZLIB"] = False
         tc.variables["ASSIMP_DOUBLE_PRECISION"] = self.options.double_precision
+        tc.variables["ASSIMP_HUNTER_ENABLED"] = False
+        tc.variables["ASSIMP_IGNORE_GIT_HASH"] = True
+        tc.variables["ASSIMP_INJECT_DEBUG_POSTFIX"] = False
+        tc.variables["ASSIMP_INSTALL"] = True
         tc.variables["ASSIMP_INSTALL_PDB"] = False
         tc.variables["ASSIMP_NO_EXPORT"] = False
-        tc.variables["ASSIMP_BUILD_MINIZIP"] = False
+        tc.variables["ASSIMP_OPT_BUILD_PACKAGES"] = False
+        tc.variables["ASSIMP_RAPIDJSON_NO_MEMBER_ITERATOR"] = False
+        tc.variables["ASSIMP_UBSAN"] = False
+        tc.variables["ASSIMP_WARNINGS_AS_ERRORS"] = False
+        tc.variables["USE_STATIC_CRT"] = is_msvc_static_runtime(self)
+
         for option, (definition, _) in self._format_option_map.items():
             value = self.options.get_safe(option)
             if value is not None:

--- a/recipes/assimp/config.yml
+++ b/recipes/assimp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.4.0":
+    folder: "5.x"
   "5.3.1":
     folder: "5.x"
   "5.2.5":

--- a/recipes/assimp/config.yml
+++ b/recipes/assimp/config.yml
@@ -5,7 +5,5 @@ versions:
     folder: "5.x"
   "5.2.5":
     folder: "5.x"
-  "5.2.2":
-    folder: "5.x"
   "5.1.6":
     folder: "5.x"

--- a/recipes/assimp/config.yml
+++ b/recipes/assimp/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "5.4.0":
+  "5.4.1":
     folder: "5.x"
   "5.3.1":
     folder: "5.x"


### PR DESCRIPTION
https://github.com/assimp/assimp/releases/tag/v5.4.0

No new formats or exporters were added in this release.