### PR TITLE
glaze: add version 2.5.5

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.5":
+    url: "https://github.com/stephenberry/glaze/archive/v2.5.5.tar.gz"
+    sha256: "a7ce5c976afde4d2c09077d954b720a3af2adf0cb6742bb88605008b6887b971"
   "2.5.4":
     url: "https://github.com/stephenberry/glaze/archive/v2.5.4.tar.gz"
     sha256: "0c10cfdbd92068c0cc1e99210a3eaa29bce9339261aaced60cb7e85398603346"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.5":
+    folder: all
   "2.5.4":
     folder: all
   "2.5.3":


### PR DESCRIPTION
Specify library name and version:  **glaze/2.5.5**

https://github.com/stephenberry/glaze/compare/v2.5.4...v2.5.5

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
