### PR TITLE
zeus_expected: add version 1.1.1

### DIFF
--- a/recipes/zeus_expected/all/conandata.yml
+++ b/recipes/zeus_expected/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.1":
+    url: "https://github.com/zeus-cpp/expected/archive/refs/tags/v1.1.1.tar.gz"
+    sha256: "47b411677ffb2fa0d43b308797542509ae2bdb101426cf0d4777e3c162b1d726"
   "1.1.0":
     url: "https://github.com/zeus-cpp/expected/archive/refs/tags/v1.1.0.tar.gz"
     sha256: "a963eba43f227498da2cbb924265344209696320c75ee63a92073936bb49f7e5"

--- a/recipes/zeus_expected/all/conanfile.py
+++ b/recipes/zeus_expected/all/conanfile.py
@@ -74,7 +74,6 @@ class ZeusExpectedConan(ConanFile):
         )
 
     def package_info(self):
-        self.cpp_info.set_property("cmake_file_name", "zeus_expected")
         self.cpp_info.set_property("cmake_target_name", "zeus::expected")
         self.cpp_info.bindirs = []
         self.cpp_info.frameworkdirs = []

--- a/recipes/zeus_expected/config.yml
+++ b/recipes/zeus_expected/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.1.1":
+    folder: all
   "1.1.0":
     folder: all


### PR DESCRIPTION
**zeus_expected/1.1.1**

The upstream has merged the patch from version 1.1.0 and released a new version.

Updated version and something cleanup.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
