### PR TITLE
libkml: fall back to C++14

### DIFF
--- a/recipes/libkml/all/conandata.yml
+++ b/recipes/libkml/all/conandata.yml
@@ -1,3 +1,5 @@
+# NOTE: if a new version >1.3.0 is added, verify if it is
+#       compatible with C++17 and above to reflect this in recipe
 sources:
   "1.3.0":
     url: "https://github.com/libkml/libkml/archive/1.3.0.zip"

--- a/recipes/libkml/all/conanfile.py
+++ b/recipes/libkml/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import valid_max_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
@@ -51,6 +52,12 @@ class LibkmlConan(ConanFile):
     def validate(self):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration(f"{self.ref} shared with Visual Studio and MT runtime is not supported")
+        
+    def package_id(self):
+        cppstd = self.info.settings.get_safe("compiler.cppstd")
+        if cppstd and cppstd not in ['98', 'gnu98', '11', 'gnu11', '14', 'gnu14']:
+            prefix = "gnu" if str(cppstd).startswith("gnu") else ""
+            self.info.settings.compiler.cppstd = f"{prefix}14"
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -58,6 +65,18 @@ class LibkmlConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+
+        # Fallback to C++14 - the implementation uses
+        # functionality that is not compliant with C++17
+        # See https://github.com/conan-io/conan/issues/16148
+        cppstd = self.settings.get_safe("compiler.cppstd")
+        if cppstd and not valid_max_cppstd(self, "14"):
+            self.output.warning(f"Recipe not compatible with C++ {cppstd}, falling back to C++14")
+            use_gnu_extensions = str(cppstd).startswith("gnu")
+            tc.blocks.remove("cppstd")
+            tc.cache_variables["CMAKE_CXX_STANDARD"] = "14"
+            tc.cache_variables["CMAKE_CXX_EXTENSIONS"] = use_gnu_extensions
+
         # To install relocatable shared libs on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.generate()


### PR DESCRIPTION

This library uses features of C++ that are removed in C++17, and is currently failing building with MSVC with C++17 or higher.

in this PR: add fallback to compile with C++14 when anything higher than 14 is requested.

the `compatibility.py` extension in Conan 2 will fallback to the binary with C++14 on the consumer side.

In addition to the configurations tested by CI, this was locally tested on Windows with msvc with C++17.