### PR TITLE
sqlcipher: add version 4.5.7

### DIFF
--- a/recipes/sqlcipher/all/conandata.yml
+++ b/recipes/sqlcipher/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.5.7":
+    url: "https://github.com/sqlcipher/sqlcipher/archive/v4.5.7.zip"
+    sha256: "4f7e00e4b485d162d638094daba354d04aabb0ca68b72cc1826f082b40c9fd7d"
   "4.5.6":
     url: "https://github.com/sqlcipher/sqlcipher/archive/v4.5.6.zip"
     sha256: "5d269166c33c39c4dc6fc14be4ac8cd78b022f8bd59b0775becf0c896331a539"
@@ -21,6 +24,10 @@ sources:
     url: "https://github.com/sqlcipher/sqlcipher/archive/v4.3.0.zip"
     sha256: "41e1408465488e9c478ca5b7c5f8410405a10caa73b82db60ac115a76c563c05"
 patches:
+  "4.5.7":
+    - patch_file: patches/Makefile.in-v4.5.7.patch
+    - patch_file: patches/Makefile.msc-v4.5.7.patch
+    - patch_file: patches/fix_configure-v4.5.7.patch
   "4.5.6":
     - patch_file: patches/Makefile.in-v4.5.6.patch
     - patch_file: patches/Makefile.msc-v4.5.6.patch

--- a/recipes/sqlcipher/all/patches/Makefile.in-v4.5.7.patch
+++ b/recipes/sqlcipher/all/patches/Makefile.in-v4.5.7.patch
@@ -1,0 +1,43 @@
+diff --git a/Makefile.in b/Makefile.in
+index ce2617c..77242fc 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -677,8 +677,7 @@ SQLITE3_SHELL_TARGET   = $(SQLITE3_SHELL_TARGET_@HAVE_WASI_SDK@)
+ # This is the default Makefile target.  The objects listed here
+ # are what get build when you type just "make" with no arguments.
+ #
+-all:	sqlite3.h libsqlcipher.la $(SQLITE3_SHELL_TARGET) \
+-  $(HAVE_TCL:1=libtclsqlite3.la)
++all:	sqlite3.h libsqlcipher.la
+ 
+ Makefile: $(TOP)/Makefile.in
+ 	./config.status
+@@ -1367,7 +1366,7 @@ fulltestonly:	$(TESTPROGS) fuzztest
+ # Fuzz testing
+ #
+ # WARNING: When the "fuzztest" target is run by the testrunner.tcl script,
+-# it does not actually run this code. Instead, it schedules equivalent 
++# it does not actually run this code. Instead, it schedules equivalent
+ # commands. Therefore, if this target is updated, then code in
+ # testrunner_data.tcl (search for "trd_fuzztest_data") must also be updated.
+ #
+@@ -1579,9 +1578,8 @@ lib_install:	libsqlcipher.la
+ 	$(INSTALL) -d $(DESTDIR)$(libdir)
+ 	$(LTINSTALL) libsqlcipher.la $(DESTDIR)$(libdir)
+ 
+-install:	sqlcipher$(TEXE) lib_install sqlite3.h sqlcipher.pc ${HAVE_TCL:1=tcl_install}
++install:	lib_install sqlite3.h sqlcipher.pc
+ 	$(INSTALL) -d $(DESTDIR)$(bindir)
+-	$(LTINSTALL) sqlcipher$(TEXE) $(DESTDIR)$(bindir)
+ 	$(INSTALL) -d $(DESTDIR)$(includedir)
+ 	$(INSTALL) -m 0644 sqlite3.h $(DESTDIR)$(includedir)
+ 	$(INSTALL) -m 0644 $(TOP)/src/sqlite3ext.h $(DESTDIR)$(includedir)
+@@ -1596,7 +1594,7 @@ tcl_install:	lib_install libtclsqlite3.la pkgIndex.tcl
+ 	rm -f $(DESTDIR)$(TCLLIBDIR)/libtclsqlite3.la $(DESTDIR)$(TCLLIBDIR)/libtclsqlite3.a
+ 	$(INSTALL) -m 0644 pkgIndex.tcl $(DESTDIR)$(TCLLIBDIR)
+ 
+-clean:	
++clean:
+ 	rm -f *.lo *.la *.o sqlcipher$(TEXE) libsqlcipher.la
+ 	rm -f sqlite3.h opcodes.*
+ 	rm -rf .libs .deps

--- a/recipes/sqlcipher/all/patches/Makefile.msc-v4.5.7.patch
+++ b/recipes/sqlcipher/all/patches/Makefile.msc-v4.5.7.patch
@@ -1,0 +1,170 @@
+diff --git a/Makefile.msc b/Makefile.msc
+index eb6461c..0e8907b 100644
+--- a/Makefile.msc
++++ b/Makefile.msc
+@@ -299,9 +299,9 @@ SQLITE3H = sqlite3.h
+ #
+ !IFNDEF SQLITE3DLL
+ !IF $(FOR_WIN10)!=0
+-SQLITE3DLL = winsqlite3.dll
++SQLITE3DLL = sqlcipher.dll
+ !ELSE
+-SQLITE3DLL = sqlite3.dll
++SQLITE3DLL = sqlcipher.dll
+ !ENDIF
+ !ENDIF
+ 
+@@ -309,9 +309,9 @@ SQLITE3DLL = sqlite3.dll
+ #
+ !IFNDEF SQLITE3LIB
+ !IF $(FOR_WIN10)!=0
+-SQLITE3LIB = winsqlite3.lib
++SQLITE3LIB = sqlcipher.lib
+ !ELSE
+-SQLITE3LIB = sqlite3.lib
++SQLITE3LIB = sqlcipher.lib
+ !ENDIF
+ !ENDIF
+ 
+@@ -696,7 +696,7 @@ SHELL_CORE_SRC = $(SQLITE3C)
+ SHELL_CORE_DEP = $(SQLITE3DLL)
+ # <<mark>>
+ !ELSEIF $(USE_AMALGAMATION)==0
+-SHELL_CORE_DEP = libsqlite3.lib
++SHELL_CORE_DEP = sqlcipher.lib
+ # <</mark>>
+ !ELSE
+ SHELL_CORE_DEP =
+@@ -719,7 +719,7 @@ TESTFIXTURE_DEP = zlib $(TESTFIXTURE_DEP)
+ SHELL_CORE_LIB = $(SQLITE3LIB)
+ # <<mark>>
+ !ELSEIF $(USE_AMALGAMATION)==0
+-SHELL_CORE_LIB = libsqlite3.lib
++SHELL_CORE_LIB = sqlcipher.lib
+ # <</mark>>
+ !ELSE
+ SHELL_CORE_LIB =
+@@ -754,8 +754,9 @@ RCC = $(RCC) -DWINAPI_FAMILY=WINAPI_FAMILY_APP
+ # C compiler options for the Windows 10 platform (needs MSVC 2015).
+ #
+ !IF $(FOR_WIN10)!=0
+-TCC = $(TCC) /d2guard4 -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
+-BCC = $(BCC) /d2guard4 -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
++# /d2guard4 requires /guard:cf to be present as well, but it doesn't work with /Zi (Debug builds)
++TCC = $(TCC) -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
++BCC = $(BCC) -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
+ !ENDIF
+ 
+ # Also, we need to dynamically link to the correct MSVC runtime
+@@ -1039,8 +1040,9 @@ TLIBS =
+ # default to file, 2 to default to memory, and 3 to force temporary
+ # tables to always be in memory.
+ #
+-TCC = $(TCC) -DSQLITE_TEMP_STORE=1
+-RCC = $(RCC) -DSQLITE_TEMP_STORE=1
++# Allow overriding the value
++TCC = $(TCC) -DSQLITE_TEMP_STORE=$(SQLITE_TEMP_STORE)
++RCC = $(RCC) -DSQLITE_TEMP_STORE=$(SQLITE_TEMP_STORE)
+ 
+ # Enable/disable loadable extensions, and other optional features
+ # based on configuration. (-DSQLITE_OMIT*, -DSQLITE_ENABLE*).
+@@ -1206,14 +1208,15 @@ LTLINKOPTS = $(LTLINKOPTS) "/LIBPATH:$(WP81LIBPATH)"
+ !ENDIF
+ LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE
+ LTLINKOPTS = $(LTLINKOPTS) WindowsPhoneCore.lib RuntimeObject.lib PhoneAppModelHost.lib
+-LTLINKOPTS = $(LTLINKOPTS) /NODEFAULTLIB:kernel32.lib /NODEFAULTLIB:ole32.lib
++# Remove /NODEFAULTLIB:kernel32.lib, required by OpenSSL
+ !ENDIF
+ 
+ # When compiling for UWP or the Windows 10 platform, some extra linker
+ # options are also required.
+ #
+ !IF $(FOR_UWP)!=0 || $(FOR_WIN10)!=0
+-LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE /NODEFAULTLIB:kernel32.lib
++# Remove /NODEFAULTLIB:kernel32.lib, required by OpenSSL
++LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE
+ LTLINKOPTS = $(LTLINKOPTS) mincore.lib
+ !IFDEF PSDKLIBPATH
+ LTLINKOPTS = $(LTLINKOPTS) "/LIBPATH:$(PSDKLIBPATH)"
+@@ -1268,7 +1271,7 @@ LTLIBS = $(LTLIBS) $(LIBICU)
+ #
+ LIBOBJS0 = vdbe.lo parse.lo alter.lo analyze.lo attach.lo auth.lo \
+          backup.lo bitvec.lo btmutex.lo btree.lo build.lo \
+-         callback.lo complete.lo ctime.lo \
++         callback.lo complete.lo crypto.lo crypto_impl.lo crypto_openssl.lo ctime.lo \
+          date.lo dbpage.lo dbstat.lo delete.lo \
+          expr.lo fault.lo fkey.lo \
+          fts3.lo fts3_aux.lo fts3_expr.lo fts3_hash.lo fts3_icu.lo \
+@@ -1603,7 +1606,7 @@ TESTEXT = \
+   $(TOP)\ext\rtree\test_rtreedoc.c \
+   $(TOP)\ext\recover\sqlite3recover.c \
+   $(TOP)\ext\recover\test_recover.c \
+-  $(TOP)\ext\recover\dbdata.c 
++  $(TOP)\ext\recover\dbdata.c
+ 
+ # If use of zlib is enabled, add the "zipfile.c" source file.
+ #
+@@ -1779,7 +1782,7 @@ ALL_TCL_TARGETS =
+ # This is the default Makefile target.  The objects listed here
+ # are what get build when you type just "make" with no arguments.
+ #
+-core:	dll libsqlite3.lib shell
++core:	dll sqlcipher.lib shell
+ 
+ # Targets that require the Tcl library.
+ #
+@@ -1798,11 +1801,13 @@ dll:	$(SQLITE3DLL)
+ shell:	$(SQLITE3EXE)
+ 
+ # <<mark>>
+-libsqlite3.lib:	$(LIBOBJ)
+-	$(LTLIB) $(LTLIBOPTS) /OUT:$@ $(LIBOBJ) $(TLIBS)
++# LTLIBPATHS is required to find the openssl/libressl libs
++sqlcipher.lib:	$(LIBOBJ)
++	$(LTLIB) $(LTLIBPATHS) $(LTLIBOPTS) /OUT:$@ $(LIBOBJ) $(TLIBS)
++
++libtclsqlite3.lib:	tclsqlite.lo sqlcipher.lib
++	$(LTLIB) $(LTLIBOPTS) $(TCLLIBPATHS) $(LTLIBPATHS) /OUT:$@ tclsqlite.lo sqlcipher.lib $(LIBTCLSTUB) $(TLIBS)
+ 
+-libtclsqlite3.lib:	tclsqlite.lo libsqlite3.lib
+-	$(LTLIB) $(LTLIBOPTS) $(TCLLIBPATHS) $(LTLIBPATHS) /OUT:$@ tclsqlite.lo libsqlite3.lib $(LIBTCLSTUB) $(TLIBS)
+ 
+ tclsqlite3.def:	tclsqlite.lo
+ 	echo EXPORTS > tclsqlite3.def
+@@ -1824,9 +1829,9 @@ $(SQLITE3DLL):	$(LIBOBJ) $(LIBRESOBJS) $(CORE_LINK_DEP)
+ 	$(LD) $(LDFLAGS) $(LTLINKOPTS) $(LTLIBPATHS) /DLL $(CORE_LINK_OPTS) /OUT:$@ $(LIBOBJ) $(LIBRESOBJS) $(LTLIBS) $(TLIBS)
+ 
+ # <<block2>>
+-sqlite3.def:	libsqlite3.lib
++sqlite3.def:	sqlcipher.lib
+ 	echo EXPORTS > sqlite3.def
+-	dumpbin /all libsqlite3.lib \
++	dumpbin /all sqlcipher.lib \
+ 		| $(TCLSH_CMD) $(TOP)\tool\replace.tcl include "^\s+1 _?(sqlite3(?:session|changeset|changegroup|rebaser|rbu)?_[^@]*)(?:@\d+)?$$" \1 \
+ 		| sort >> sqlite3.def
+ # <</block2>>
+@@ -2013,6 +2018,15 @@ callback.lo:	$(TOP)\src\callback.c $(HDR)
+ complete.lo:	$(TOP)\src\complete.c $(HDR)
+ 	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\complete.c
+ 
++crypto.lo:	$(TOP)\src\crypto.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto.c
++
++crypto_impl.lo:	$(TOP)\src\crypto_impl.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto_impl.c
++
++crypto_openssl.lo:	$(TOP)\src\crypto_openssl.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto_openssl.c
++
+ ctime.lo:	$(TOP)\src\ctime.c $(HDR)
+ 	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\ctime.c
+ 
+@@ -2432,7 +2446,7 @@ sqlite3rbu.lo:	$(TOP)\ext\rbu\sqlite3rbu.c $(HDR) $(EXTHDR)
+ # Rules to build the 'testfixture' application.
+ #
+ # If using the amalgamation, use sqlite3.c directly to build the test
+-# fixture.  Otherwise link against libsqlite3.lib.  (This distinction is
++# fixture.  Otherwise link against sqlcipher.lib.  (This distinction is
+ # necessary because the test fixture requires non-API symbols which are
+ # hidden when the library is built via the amalgamation).
+ #

--- a/recipes/sqlcipher/all/patches/fix_configure-v4.5.7.patch
+++ b/recipes/sqlcipher/all/patches/fix_configure-v4.5.7.patch
@@ -1,0 +1,20 @@
+diff --git a/configure b/configure
+index 2ee4143..753e9b1 100755
+--- a/configure
++++ b/configure
+@@ -12732,7 +12732,6 @@ then :
+   printf %s "(cached) " >&6
+ else $as_nop
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lcrypto  $LIBS"
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -12764,7 +12763,6 @@ if test "x$ac_cv_lib_crypto_HMAC_Init_ex" = xyes
+ then :
+   printf "%s\n" "#define HAVE_LIBCRYPTO 1" >>confdefs.h
+ 
+-  LIBS="-lcrypto $LIBS"
+ 
+ else $as_nop
+   as_fn_error $? "Library crypto not found. Install openssl!\"" "$LINENO" 5

--- a/recipes/sqlcipher/config.yml
+++ b/recipes/sqlcipher/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.5.7":
+    folder: all
   "4.5.6":
     folder: all
   "4.5.1":


### PR DESCRIPTION
Specify library name and version:  **sqlcipher/4.5.7**

https://github.com/sqlcipher/sqlcipher/compare/v4.5.6...v4.5.7

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
