### PR TITLE
[ixwebsocket] Bump dependencies

### DIFF
--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -58,9 +58,9 @@ class IXWebSocketConan(ConanFile):
         if self.options.get_safe("with_zlib", True):
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.tls == "openssl":
-            self.requires("openssl/1.1.1w")
+            self.requires("openssl/[>=1.1.1w <=3.2.1]")
         elif self.options.tls == "mbedtls":
-            self.requires("mbedtls/2.25.0")
+            self.requires("mbedtls/[>=2.25.0 <3]")
 
     @property
     def _can_use_openssl(self):


### PR DESCRIPTION
Specify library name and version: ixwebsocket/11.4.5

Bump ssl libraries versions to the latest supported by the ixwebsocket. The changes ware tested localy.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
