### PR TITLE
xkbcommon: use dependencies.build instead of deps_cpp_info

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -113,10 +113,8 @@ class XkbcommonConan(ConanFile):
             else:
                 # Manually generate pkgconfig file of wayland-protocols since
                 # PkgConfigDeps.build_context_activated can't work with legacy 1 profile
-                # We must use legacy conan v1 deps_cpp_info because self.dependencies doesn't
-                # contain build requirements when using 1 profile.
-                wp_prefix = self.deps_cpp_info["wayland-protocols"].rootpath
-                wp_version = self.deps_cpp_info["wayland-protocols"].version
+                wp_prefix = self.dependencies.build["wayland-protocols"].package_folder
+                wp_version = self.dependencies.build["wayland-protocols"].ref.version
                 wp_pkg_content = textwrap.dedent(f"""\
                     prefix={wp_prefix}
                     datarootdir=${{prefix}}/res


### PR DESCRIPTION
Prefer `dependencies.build` instead of `deps_cpp_info` for the workaround related to generation of `wayland-protocols` pkgconf file from build context in case of 1 profile (see https://github.com/conan-io/conan-center-index/pull/21242#discussion_r1499466346)

/cc @uilianries 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
