### PR TITLE
pybind11_json: relax version requirements

### DIFF
--- a/recipes/pybind11_json/all/conanfile.py
+++ b/recipes/pybind11_json/all/conanfile.py
@@ -23,8 +23,8 @@ class Pybind11JsonConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("nlohmann_json/3.11.2")
-        self.requires("pybind11/2.10.4")
+        self.requires("nlohmann_json/[>=3.9 <4]")
+        self.requires("pybind11/[>=2.6 <3]")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Specify library name and version:  **pybind11_json/all**

The pybind11_json recipe has outdated and overly strict requirements. This relaxes them. I have also lowered the minimum version required to that set by the original author before Conan 2 migration, since there were no code changes to require them.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
