### PR TITLE
Increase version-range of libwebsockets->openssl to include openssl 3

### DIFF
--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -249,7 +249,7 @@ class LibwebsocketsConan(ConanFile):
         if self.options.with_ssl == "openssl":
             no_zlib = self.dependencies["openssl"].options.get_safe("no_zlib")
             if not no_zlib and self.options.with_zlib != "zlib":
-                raise ConanInvalidConfiguration(f"{self.name} needs option with_zlib=zlib, as its dependency openssl links with it")
+                raise ConanInvalidConfiguration(f'{self.name} needs option "{self.name}/*:with_zlib=zlib", as its dependency openssl links with it')
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -109,7 +109,7 @@ class LibwebsocketsConan(ConanFile):
         "fPIC": True,
         "with_libuv": False,
         "with_libevent": False,
-        "with_zlib": False,
+        "with_zlib": "zlib",
         "with_ssl": "openssl",
         "with_sqlite3": False,
         "with_libmount": False,
@@ -225,7 +225,7 @@ class LibwebsocketsConan(ConanFile):
 
         if self.options.with_ssl == "openssl":
             # Cannot add the [>=1.1 <4] range, as it seems openssl3 makes it fail
-            self.requires("openssl/1.1.1w", transitive_headers=True)
+            self.requires("openssl/[>=1.1.1w <4]", transitive_headers=True)
         elif self.options.with_ssl == "mbedtls":
             self.requires("mbedtls/3.5.0")
         elif self.options.with_ssl == "wolfssl":
@@ -245,6 +245,11 @@ class LibwebsocketsConan(ConanFile):
         if self.options.with_hubbub:
             raise ConanInvalidConfiguration("Library hubbub not implemented (yet) in CCI")
             # TODO - Add hubbub package when available.
+
+        if self.options.with_ssl == "openssl":
+            no_zlib = self.dependencies["openssl"].options.get_safe("no_zlib")
+            if not no_zlib and self.options.with_zlib != "zlib":
+                raise ConanInvalidConfiguration(f"{self.name} needs option with_zlib=zlib, as its dependency openssl links with it")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **libwebsockets**

So far libwebsockets couldn't link with openssl3, so the range couldn't be defined as in other recipes.

https://github.com/warmcat/libwebsockets/issues/2894 reported the issue as a question, and it seems the problem is not defining that the library links with ``zlib`` too, which is brought as a transitive dependency of ``openssl``, but the consumer ``libwebsockets`` has its own definition of a variable when ``zlib`` is to be considered by the library.

NOTE: This changes the default ``with_zlib="zlib"`` option, and this can have other consequences.