### PR TITLE
mrcal: new recipe

### DIFF
--- a/recipes/mrcal/all/conandata.yml
+++ b/recipes/mrcal/all/conandata.yml
@@ -1,0 +1,11 @@
+sources:
+  "2.4.1":
+    mrcal:
+      url: "https://github.com/dkogan/mrcal/archive/refs/tags/v2.4.1.tar.gz"
+      sha256: "74c746bf74ed61e2eb5766f403f7f35d4b5d793020dfbc185113a6e929457531"
+    libdogleg:
+      url: "https://github.com/dkogan/libdogleg/archive/refs/tags/v0.16.tar.gz"
+      sha256: "961a522b29d57dea771fbb47e648e35332072ed43fe8883a9b62b63b95f78e49"
+    mrbuild:
+      url: "https://github.com/dkogan/mrbuild/archive/refs/tags/v1.10.tar.gz"
+      sha256: "b0184246da6b5175c39cd4ca7784cab81804ec5c31dbfa81d3c9806b7177467c"

--- a/recipes/mrcal/all/conanfile.py
+++ b/recipes/mrcal/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.files import copy, get, chdir, replace_in_file
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.0"
 
 
 class MrcalConan(ConanFile):
@@ -29,17 +29,14 @@ class MrcalConan(ConanFile):
         # Disabled by default due to being GPL-licensed
         "with_libelas": False,
     }
-
-    def configure(self):
-        self.settings.rm_safe("compiler.cppstd")
-        self.settings.rm_safe("compiler.libcxx")
+    languages = ["C"]
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
         # https://github.com/dkogan/libdogleg/blob/master/dogleg.h#L8
-        self.requires("suitesparse-cholmod/5.2.1", transitive_headers=True, transitive_libs=True)
+        self.requires("suitesparse-cholmod/5.3.0", transitive_headers=True, transitive_libs=True)
         self.requires("freeimage/3.18.0")
         if self.options.with_libelas:
             self.requires("libelas/cci.20150630")

--- a/recipes/mrcal/all/conanfile.py
+++ b/recipes/mrcal/all/conanfile.py
@@ -22,6 +22,13 @@ class MrcalConan(ConanFile):
 
     package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "with_libelas": [True, False],
+    }
+    default_options = {
+        # Disabled by default due to being GPL-licensed
+        "with_libelas": False,
+    }
 
     def configure(self):
         self.settings.rm_safe("compiler.cppstd")
@@ -34,6 +41,8 @@ class MrcalConan(ConanFile):
         # https://github.com/dkogan/libdogleg/blob/master/dogleg.h#L8
         self.requires("suitesparse-cholmod/5.2.1", transitive_headers=True, transitive_libs=True)
         self.requires("freeimage/3.18.0")
+        if self.options.with_libelas:
+            self.requires("libelas/cci.20150630")
 
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"] and not is_apple_os(self):
@@ -55,8 +64,8 @@ class MrcalConan(ConanFile):
         env = VirtualRunEnv(self)
         env.generate(scope="build")
         tc = AutotoolsToolchain(self)
-        # TODO: add libelas to CCI
-        # tc.make_args.append("USE_LIBELAS=1")
+        if self.options.with_libelas:
+            tc.make_args.append("USE_LIBELAS=1")
         tc.extra_cflags.append("-Ilibdogleg")
         tc.extra_ldflags.append("-Llibdogleg")
         tc.generate()

--- a/recipes/mrcal/all/conanfile.py
+++ b/recipes/mrcal/all/conanfile.py
@@ -1,0 +1,95 @@
+import os
+import shutil
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import copy, get, chdir, replace_in_file
+from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.54.0"
+
+
+class MrcalConan(ConanFile):
+    name = "mrcal"
+    description = "mrcal is a generic toolkit built to solve the calibration and SFM-like problems we encounter at NASA/JPL"
+    license = "Apache-2.0 AND LGPL-3.0-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://mrcal.secretsauce.net/"
+    topics = ("camera-calibration", "computer-vision")
+
+    package_type = "shared-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        # https://github.com/dkogan/libdogleg/blob/master/dogleg.h#L8
+        self.requires("suitesparse-cholmod/5.2.1", transitive_headers=True, transitive_libs=True)
+        self.requires("freeimage/3.18.0")
+
+    def validate(self):
+        if self.settings.os not in ["Linux", "FreeBSD"] and not is_apple_os(self):
+            raise ConanInvalidConfiguration("Unsupported OS")
+
+    def build_requirements(self):
+        self.tool_requires("re2c/3.1")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version]["mrcal"], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version]["libdogleg"], destination="libdogleg", strip_root=True)
+        get(self, **self.conan_data["sources"][self.version]["mrbuild"], destination="mrbuild", strip_root=True)
+        copy(self, "*", "mrbuild", os.path.join("libdogleg", "mrbuild"))
+
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+        # CHOLMOD .so file is not found without the VirtualRunEnv for some reason
+        env = VirtualRunEnv(self)
+        env.generate(scope="build")
+        tc = AutotoolsToolchain(self)
+        # TODO: add libelas to CCI
+        # tc.make_args.append("USE_LIBELAS=1")
+        tc.extra_cflags.append("-Ilibdogleg")
+        tc.extra_ldflags.append("-Llibdogleg")
+        tc.generate()
+        tc = AutotoolsDeps(self)
+        tc.generate()
+
+    @property
+    def _libdogleg_version(self):
+        url = self.conan_data["sources"][self.version]["libdogleg"]["url"]
+        return url.split("/v")[-1].replace(".tar.gz", "")
+
+    def build(self):
+        with chdir(self, os.path.join(self.source_folder, "libdogleg")):
+            replace_in_file(self, "Makefile", "$(VERSION_FROM_PROJECT)", self._libdogleg_version)
+            autotools = Autotools(self)
+            autotools.make()
+        with chdir(self, self.source_folder):
+            replace_in_file(self, "Makefile", "all: ", "all: libmrcal.$(SO) libmrcal.$(SO).${ABI_VERSION} #")
+            autotools = Autotools(self)
+            autotools.make()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        shutil.copy(os.path.join(self.source_folder, "libdogleg", "LICENSE"), os.path.join(self.package_folder, "licenses", "LICENSE.libdogleg"))
+        copy(self, "*.h", os.path.join(self.source_folder, "libdogleg"), os.path.join(self.package_folder, "include"))
+        for header in ["basic-geometry.h", "mrcal-image.h", "mrcal-internal.h", "mrcal-types.h", "mrcal.h", "poseutils.h", "stereo.h", "triangulation.h"]:
+            copy(self, header, self.source_folder, os.path.join(self.package_folder, "include", "mrcal"))
+        so_pattern = "*.dylib" if is_apple_os(self) else "*.so*"
+        copy(self, so_pattern, os.path.join(self.source_folder, "libdogleg"), os.path.join(self.package_folder, "lib"))
+        copy(self, so_pattern, self.source_folder, os.path.join(self.package_folder, "lib"), excludes="libdogleg/*")
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.libs = ["mrcal", "dogleg"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")

--- a/recipes/mrcal/all/test_package/CMakeLists.txt
+++ b/recipes/mrcal/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(mrcal REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE mrcal::mrcal)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/mrcal/all/test_package/conanfile.py
+++ b/recipes/mrcal/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/mrcal/all/test_package/conanfile.py
+++ b/recipes/mrcal/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/mrcal/all/test_package/test_package.c
+++ b/recipes/mrcal/all/test_package/test_package.c
@@ -1,0 +1,5 @@
+#include <mrcal/mrcal.h>
+
+int main() {
+    mrcal_lensmodel_type_from_name("LENSMODEL_SPLINED_STEREOGRAPHIC_2");
+}

--- a/recipes/mrcal/config.yml
+++ b/recipes/mrcal/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.4.1":
+    folder: all


### PR DESCRIPTION
Adds mrcal: https://github.com/dkogan/mrcal

mrcal is a generic toolkit built to solve the calibration and SFM-like problems we encounter at NASA/JPL.

[![Packaging status](https://repology.org/badge/tiny-repos/mrcal.svg)](https://repology.org/project/mrcal/versions)

Also bundles `libdogleg`, which is a closely-related dependency of the project which does not look like a good candidate for a separate package: https://github.com/dkogan/libdogleg

Requires:
- #23553