### PR TITLE
openh264: add version 2.4.1

### DIFF
--- a/recipes/openh264/all/conandata.yml
+++ b/recipes/openh264/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.1":
+    url: "https://github.com/cisco/openh264/archive/refs/tags/v2.4.1.tar.gz"
+    sha256: "8ffbe944e74043d0d3fb53d4a2a14c94de71f58dbea6a06d0dc92369542958ea"
   "2.3.1":
     url: "https://github.com/cisco/openh264/archive/refs/tags/v2.3.1.tar.gz"
     sha256: "453afa66dacb560bc5fd0468aabee90c483741571bca820a39a1c07f0362dc32"
@@ -9,30 +12,34 @@ sources:
     url: "https://github.com/cisco/openh264/archive/v1.7.0.tar.gz"
     sha256: "9c07c38d7de00046c9c52b12c76a2af7648b70d05bd5460c8b67f6895738653f"
 patches:
+  "2.4.1":
+    - patch_file: "patches/2.4.1-0001-platform-android.mk.patch"
+      patch_description: "Android Fix"
+      patch_type: "portability"
   "2.3.1":
     - patch_file: "patches/2.3.1-0001-platform-android.mk.patch"
-      patch_type: "portability"
       patch_description: "Android Fix"
-    - patch_file: "patches/2.3.1-0002-macos-relocatable-shared.patch"
       patch_type: "portability"
+    - patch_file: "patches/2.3.1-0002-macos-relocatable-shared.patch"
       patch_description: "Macos relocatable shared fix"
+      patch_type: "portability"
   "2.1.1":
     - patch_file: "patches/2.1.1-0001-platform-android.mk.patch"
-      patch_type: "portability"
       patch_description: "Android Fix"
+      patch_type: "portability"
     - patch_file: "patches/2.1.1-0002-macos-relocatable-shared.patch"
-      patch_type: "portability"
       patch_description: "Macos relocatable shared fix"
-    - patch_file: "patches/1.7.0-0004-mingw-override-CC-CXX-AR-from-env.patch"
       patch_type: "portability"
+    - patch_file: "patches/1.7.0-0004-mingw-override-CC-CXX-AR-from-env.patch"
       patch_description: "Mingw Override CC CXX AR from env Fix"
+      patch_type: "portability"
   "1.7.0":
     - patch_file: "patches/1.7.0-0001-platform-android.mk.patch"
-      patch_type: "portability"
       patch_description: "Android Fix"
+      patch_type: "portability"
     - patch_file: "patches/1.7.0-0002-macos-relocatable-shared.patch"
-      patch_type: "portability"
       patch_description: "Macos relocatable shared fix"
-    - patch_file: "patches/1.7.0-0004-mingw-override-CC-CXX-AR-from-env.patch"
       patch_type: "portability"
+    - patch_file: "patches/1.7.0-0004-mingw-override-CC-CXX-AR-from-env.patch"
       patch_description: "Mingw Override CC CXX AR from env Fix"
+      patch_type: "portability"

--- a/recipes/openh264/all/patches/2.4.1-0001-platform-android.mk.patch
+++ b/recipes/openh264/all/patches/2.4.1-0001-platform-android.mk.patch
@@ -1,0 +1,13 @@
+diff --git a/build/platform-darwin.mk b/build/platform-darwin.mk
+index 4c7dac6..f15fdb9 100644
+--- a/build/platform-darwin.mk
++++ b/build/platform-darwin.mk
+@@ -7,7 +7,7 @@ CURRENT_VERSION := 2.4.1
+ COMPATIBILITY_VERSION := 2.4.0
+ SHLDFLAGS = -dynamiclib -twolevel_namespace -undefined dynamic_lookup \
+ 	-fno-common -headerpad_max_install_names -install_name \
+-	$(SHAREDLIB_DIR)/$(LIBPREFIX)$(PROJECT_NAME).$(SHAREDLIBSUFFIXMAJORVER)
++	@rpath/$(LIBPREFIX)$(PROJECT_NAME).$(SHAREDLIBSUFFIXMAJORVER)
+ SHARED = -dynamiclib
+ SHARED += -current_version $(CURRENT_VERSION) -compatibility_version $(COMPATIBILITY_VERSION)
+ CFLAGS += -Wall -fPIC -MMD -MP

--- a/recipes/openh264/config.yml
+++ b/recipes/openh264/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.1":
+    folder: all
   "2.3.1":
     folder: all
   "2.1.1":


### PR DESCRIPTION
Specify library name and version:  **openh264/2.4.1**

https://github.com/cisco/openh264/compare/v2.3.1...v2.4.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
