### PR TITLE
lapack: new recipe

### DIFF
--- a/recipes/lapack/all/conandata.yml
+++ b/recipes/lapack/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.12.0":
+    url: "https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.0.tar.gz"
+    sha256: "eac9570f8e0ad6f30ce4b963f4f033f0f643e7c3912fc9ee6cd99120675ad48b"

--- a/recipes/lapack/all/conanfile.py
+++ b/recipes/lapack/all/conanfile.py
@@ -1,0 +1,126 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rm, rmdir
+
+required_conan_version = ">=1.53.0"
+
+
+class LapackConan(ConanFile):
+    name = "lapack"
+    description = "LAPACK is a library of Fortran subroutines for solving the most commonly occurring problems in numerical linear algebra"
+    license = "BSD-3-Clause-Open-MPI"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Reference-LAPACK/lapack"
+    topics = ("linear-algebra", "matrix-factorization", "linear-equations", "svd", "singular-values", "eigenvectors", "eigenvalues")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "build_deprecated": [True, False],
+        "single": [True, False],
+        "double": [True, False],
+        "complex": [True, False],
+        "complex16": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "build_deprecated": False,
+        "single": True,
+        "double": True,
+        "complex": True,
+        "complex16": True,
+    }
+    options_description = {
+        "build_deprecated": "Build deprecated routines",
+        "single": "Build single precision real",
+        "double": "Build double precision real",
+        "complex": "Build single precision complex",
+        "complex16": "Build double precision complex",
+    }
+
+    def config_options(self):
+        del self.options.fPIC
+
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("openblas/0.3.26")
+        self.requires("gfortran/13.2.0")
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            # Can probably use GFortran from MinGW or MSYS2 for this.
+            # Another alternative might be to use the Intel Fortran compiler.
+            raise ConanInvalidConfiguration("No Fortran compiler currently available for Windows")
+
+    def build_requirements(self):
+        self.tool_requires("gfortran/<host_version>")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = False
+        tc.variables["BUILD_DEPRECATED"] = self.options.build_deprecated
+        tc.variables["BUILD_SINGLE"] = self.options.single
+        tc.variables["BUILD_DOUBLE"] = self.options.double
+        tc.variables["BUILD_COMPLEX"] = self.options.complex
+        tc.variables["BUILD_COMPLEX16"] = self.options.complex16
+        tc.variables["USE_OPTIMIZED_BLAS"] = True
+        tc.variables["USE_OPTIMIZED_LAPACK"] = False
+        tc.variables["CBLAS"] = False
+        tc.variables["LAPACKE"] = True
+        # VerifyFortranC module in CMake fails to build a test executable otherwise.
+        tc.variables["CMAKE_Fortran_FLAGS"] = "-fPIC"
+        tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = True
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.generate()
+
+        tc = CMakeDeps(self)
+        tc.generate()
+
+        venv = VirtualBuildEnv(self)
+        venv.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_find_mode", "module")
+        self.cpp_info.set_property("cmake_file_name", "LAPACK")
+        self.cpp_info.set_property("cmake_target_name", "LAPACK::LAPACK")
+
+        self.cpp_info.components["lapack"].libs = ["lapack"]
+        self.cpp_info.components["lapack"].set_property("cmake_target_name", "lapack")
+        self.cpp_info.components["lapack"].set_property("pkg_config_name", "lapack")
+        self.cpp_info.components["lapack"].requires = ["openblas::openblas", "gfortran::libgfortran"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["lapack"].system_libs.append("m")
+
+        self.cpp_info.components["lapacke"].libs = ["lapacke"]
+        self.cpp_info.components["lapacke"].set_property("cmake_target_name", "lapacke")
+        self.cpp_info.components["lapacke"].set_property("pkg_config_name", "lapacke")
+        self.cpp_info.components["lapacke"].requires = ["lapack"]

--- a/recipes/lapack/all/conanfile.py
+++ b/recipes/lapack/all/conanfile.py
@@ -56,7 +56,7 @@ class LapackConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("openblas/0.3.26")
+        self.requires("openblas/0.3.28")
         self.requires("gfortran/13.2.0")
 
     def validate(self):

--- a/recipes/lapack/all/test_package/CMakeLists.txt
+++ b/recipes/lapack/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(LAPACK REQUIRED MODULE)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE LAPACK::LAPACK)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/lapack/all/test_package/conanfile.py
+++ b/recipes/lapack/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/lapack/all/test_package/test_package.c
+++ b/recipes/lapack/all/test_package/test_package.c
@@ -1,0 +1,27 @@
+#include <lapacke.h>
+
+#include <stdio.h>
+
+int main() {
+    double a[4] = {3.0, 1.0, 1.0, 2.0};
+    double b[2] = {9.0, 8.0};
+    lapack_int n = 2;
+    lapack_int nrhs = 1;
+    lapack_int lda = 2;
+    lapack_int ipiv[2];
+    lapack_int ldb = 2;
+
+    lapack_int info = LAPACKE_dgesv(LAPACK_ROW_MAJOR, n, nrhs, a, lda, ipiv, b, ldb);
+
+    if(info != 0) {
+        printf("LAPACKE_dgesv failed.\n");
+        return 1;
+    }
+
+    printf("LAPACKE_dgesv() solution: \n");
+    for(int i = 0; i < n; i++) {
+        printf("%.1lf\n", b[i]);
+    }
+
+    return 0;
+}

--- a/recipes/lapack/config.yml
+++ b/recipes/lapack/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.12.0":
+    folder: all


### PR DESCRIPTION
Adds LAPACK and LAPACKE from the reference implementation at https://github.com/Reference-LAPACK/lapack/releases

LAPACK is a library of Fortran subroutines for solving the most commonly occurring problems in numerical linear algebra.

Together wih BLAS, it is required for nearly all packages dealing with linear algebra that don't use Eigen. tT's currently available as a part of the OpenBLAS package on CCI, but it is not quite sufficient in practice. CMake projects that need LAPACK usually rely on [`FindLAPACK`](https://cmake.org/cmake/help/latest/module/FindLAPACK.html) from CMake to find the package, which OpenBLAS and others cannot provide with the current CMakeDeps functionality.

The other motivation for decoupling LAPACK from OpenBLAS is that there are several alternative BLAS implementations available and LAPACK, which builds upon BLAS, can generally be handled separately and use the reference implementation.

[![Packaging status](https://repology.org/badge/tiny-repos/lapack.svg)](https://repology.org/project/lapack/versions)


- Requires #23334

- Resolves #4509