### PR TITLE
libgettext: fix configure so it doesnt block on MSVC debug builds

### DIFF
--- a/recipes/libgettext/all/conandata.yml
+++ b/recipes/libgettext/all/conandata.yml
@@ -9,6 +9,10 @@ sources:
     sha256: "66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c"
     url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
 patches:
+  "0.22":
+    - patch_file: "patches/0004-fix-msvc-configure-debug-abort-dialog.patch"
+      patch_description: "configure will block on MSVC debug builds"
+      patch_type: "portability"
   "0.21":
     - patch_file: "patches/0002-memmove-is-intrinsic-function-on-MSVC.patch"
       patch_description: "memmove is intrinsic function on MSVC"

--- a/recipes/libgettext/all/patches/0004-fix-msvc-configure-debug-abort-dialog.patch
+++ b/recipes/libgettext/all/patches/0004-fix-msvc-configure-debug-abort-dialog.patch
@@ -1,0 +1,30 @@
+During ./configure, the "intl" configure step tests this condition:
+checking whether printf supports the 'n' directive...
+
+This (correctly) fail the test on MSVC, which is fine on Release builds.
+
+However, in MSVC Debug builds, a GUI Dialog box pops up telling the user about an assert failure,
+and would the user like to Abort,Retry,Ignore.
+
+This blocks the configuration until the user manually presses a button.
+This behaviour has been confirmed on a "Proof-of-conan" build test.
+
+In gettext-runtime/intl/configure (in the tarball release),
+line 29702 has a call to _set_invalid_parameter_handler()
+This almost does the job, but not quite.
+adding the line: _CrtSetReportMode(_CRT_ASSERT, 0);
+changes the behaviour to fail without the dialog box.
+
+Adding a _CrtSetReportMode() call specifies the assert behaviour to simply crash.
+./configure will work correctly and not block.
+
+--- gettext-runtime/intl/configure	2023-06-17 19:53:51.000000000 +0800
++++ gettext-runtime/intl/configure	2024-04-29 10:52:53.723390500 +0800
+@@ -29700,6 +29700,7 @@
+   int count = -1;
+ #ifdef _MSC_VER
+   _set_invalid_parameter_handler (invalid_parameter_handler);
++  _CrtSetReportMode(_CRT_ASSERT, 0);
+ #endif
+   /* Copy the format string.  Some systems (glibc with _FORTIFY_SOURCE=2)
+      support %n in format strings in read-only memory but not in writable


### PR DESCRIPTION
During ./configure, the "intl" configure step tests this condition:
checking whether printf supports the 'n' directive...

This fails on MSVC, which is fine on Release builds.

However, in Debug builds, a GUI Dialog box pops up telling the user about an assert failure, and would the user like to Abort,Retry,Ignore.

This blocks the configuration until the user manually presses a button.

In gettext-runtime/intl/configure (in the tarball release),
line 29702 has a call to _set_invalid_parameter_handler()
This almost does the job, but not quite.
adding the line: _CrtSetReportMode(_CRT_ASSERT, 0);
changes the behaviour to fail without the dialog box.

There are other places in the tarball where _set_invalid_parameter_handler() is called, and this line could be added in all of those places to be sure, but my tests show it is enough to add it to just this one place,