### PR TITLE
tar: add version 1.35

### DIFF
--- a/recipes/tar/all/conandata.yml
+++ b/recipes/tar/all/conandata.yml
@@ -1,4 +1,13 @@
 sources:
+  "1.35":
+    url: "https://ftp.gnu.org/gnu/tar/tar-1.35.tar.xz"
+    sha256: "4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16"
   "1.32.90":
     url: "https://alpha.gnu.org/gnu/tar/tar-1.32.90.tar.gz"
     sha256: "641fe07b7403c8eb801e7bfb91d1b7e5800ab15df524e22e0b2e89501280b6d7"
+patches:
+  "1.35":
+    - patch_file: "patches/1.35-001-fix-iconv-link.patch"
+      patch_description: "Fix iconv link"
+      patch_type: "portability"
+      patch_source: "http://git.savannah.gnu.org/cgit/tar.git/patch/?id=8632df398b2f548465ebe68b8f494c0d6f8d913d"

--- a/recipes/tar/all/conanfile.py
+++ b/recipes/tar/all/conanfile.py
@@ -3,10 +3,11 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import apply_conandata_patches, copy, get, replace_in_file, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -26,6 +27,9 @@ class TarConan(ConanFile):
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def configure(self):
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
@@ -39,9 +43,13 @@ class TarConan(ConanFile):
     def requirements(self):
         self.requires("bzip2/1.0.8", run=True, headers=False, libs=False)
         self.requires("lzip/1.23", run=True, headers=False, libs=False)
-        self.requires("xz_utils/5.4.4", run=True, headers=False, libs=False)
+        self.requires("xz_utils/5.4.5", run=True, headers=False, libs=False)
         self.requires("zstd/1.5.5", run=True, headers=False, libs=False)
         # self.requires("lzo/2.10", run=True, headers=False, libs=False)
+
+    def build_requirements(self):
+        if Version(self.version) == "1.35":
+            self.build_requires("automake/1.16.5")
 
     def validate(self):
         if self.settings.os == "Windows":
@@ -86,6 +94,8 @@ class TarConan(ConanFile):
     def build(self):
         self._patch_sources()
         autotools = Autotools(self)
+        if Version(self.version) == "1.35":
+            autotools.autoreconf()  # autoreconf needed after patching
         autotools.configure()
         autotools.make()
 

--- a/recipes/tar/all/conanfile.py
+++ b/recipes/tar/all/conanfile.py
@@ -50,6 +50,7 @@ class TarConan(ConanFile):
     def build_requirements(self):
         if Version(self.version) == "1.35":
             self.build_requires("automake/1.16.5")
+            self.build_requires("gettext/0.22.5")
 
     def validate(self):
         if self.settings.os == "Windows":

--- a/recipes/tar/all/patches/1.35-001-fix-iconv-link.patch
+++ b/recipes/tar/all/patches/1.35-001-fix-iconv-link.patch
@@ -1,0 +1,24 @@
+From 8632df398b2f548465ebe68b8f494c0d6f8d913d Mon Sep 17 00:00:00 2001
+From: Sergey Poznyakoff <gray@gnu.org>
+Date: Tue, 18 Jul 2023 17:02:23 +0300
+Subject: Fix savannah bug #64441
+
+* src/Makefile.am (tar_LDADD): Add libiconv libraries.
+---
+ src/Makefile.am | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 36c9543..e2ec58d 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -52,4 +52,5 @@ AM_CFLAGS = $(WARN_CFLAGS) $(WERROR_CFLAGS)
+ tar_LDADD = $(LIBS) ../lib/libtar.a ../gnu/libgnu.a\
+  $(LIB_ACL) $(LIB_CLOCK_GETTIME) $(LIB_EACCESS)\
+  $(LIB_GETRANDOM) $(LIB_HARD_LOCALE) $(FILE_HAS_ACL_LIB) $(LIB_MBRTOWC)\
+- $(LIB_SELINUX) $(LIB_SETLOCALE_NULL)
++ $(LIB_SELINUX) $(LIB_SETLOCALE_NULL) \
++ $(LIBINTL) $(LIBICONV)
+-- 
+cgit v1.1
+

--- a/recipes/tar/config.yml
+++ b/recipes/tar/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.35":
+    folder: "all"
   "1.32.90":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **tar/1.35**

Add version 1.35
bump xz_utils to 5.4.5

All versions < 1.35 have known security issues: https://repology.org/project/tar/information

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
