### PR TITLE
libgettext: fix debug build on Windows

### DIFF
--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -124,6 +124,15 @@ class GetTextConan(ConanFile):
             if (str(self.settings.compiler) == "Visual Studio" and Version(self.settings.compiler.version) >= "12") or \
                (str(self.settings.compiler) == "msvc" and Version(self.settings.compiler.version) >= "180"):
                 tc.extra_cflags += ["-FS"]
+
+            if self.settings.build_type == "Debug":
+                # Skip checking for the 'n' printf format directly
+                # in msvc, as it is known to not be available due to security concerns.
+                # Skipping it avoids a GUI prompt during ./configure for a debug build
+                # See https://github.com/conan-io/conan-center-index/issues/23698
+                tc.configure_args.extend([
+                    'gl_cv_func_printf_directive_n=no'
+                ])
         tc.make_args += ["-C", "intl"]
         env = tc.environment()
         if is_msvc(self) or self._is_clang_cl:
@@ -189,6 +198,7 @@ class GetTextConan(ConanFile):
         autotools = Autotools(self)
         autotools.configure("gettext-runtime")
         autotools.make()
+        self.run("exit 1")
 
     def package(self):
         dest_lib_dir = os.path.join(self.package_folder, "lib")

--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -198,7 +198,6 @@ class GetTextConan(ConanFile):
         autotools = Autotools(self)
         autotools.configure("gettext-runtime")
         autotools.make()
-        self.run("exit 1")
 
     def package(self):
         dest_lib_dir = os.path.join(self.package_folder, "lib")


### PR DESCRIPTION
libgettext: skip check during the configure phase during a Debug build with msvc, as it displays a GUI prompt during an assert failure that halts the build

Rationale: The `n` printf format directive is disabled by default in msvc due to security concerns, https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170 - so this check can be skipped altogether if it is known to be a compile-time constant (it's always "no", so we can hardcode it as such).

Close https://github.com/conan-io/conan-center-index/issues/23698
Close https://github.com/conan-io/conan-center-index/pull/23805 

Tested locally with msvc193, `-s build_type=Debug`.
