### PR TITLE
gettext: fix msvc debug builds

### DIFF
--- a/recipes/gettext/all/conanfile.py
+++ b/recipes/gettext/all/conanfile.py
@@ -91,6 +91,13 @@ class GetTextConan(ConanFile):
                 'ac_cv_func_memset=yes'
             ])
 
+            # Skip checking for the 'n' printf format directly
+            # in msvc, as it is known to not be available due to security concerns.
+            # Skipping it avoids a GUI prompt during ./configure for a debug build
+            # See https://github.com/conan-io/conan-center-index/issues/23698]
+            if self.settings.build_type == "Debug":
+                tc.configure_args.extend(['gl_cv_func_printf_directive_n=no'])
+
             # The flag above `--with-libiconv-prefix` fails to correctly detect libiconv on windows+msvc
             # so it needs an extra nudge. We could use `AutotoolsDeps` but it's currently affected by the
             # following outstanding issue: https://github.com/conan-io/conan/issues/12784


### PR DESCRIPTION
gettext: skip check during the configure phase during a Debug build with msvc, as it displays a GUI prompt during an assert failure that halts the build

Rationale: The `n` printf format directive is disabled by default in msvc due to security concerns, https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170 - so this check can be skipped altogether if it is known to be a compile-time constant (it's always "no", so we can hardcode it as such).

Close https://github.com/conan-io/conan-center-index/issues/23789
Tested locally with msvc193, `-s build_type=Debug`.
