### PR TITLE
libassert: Remove cpp_info.names/.filenames from libassert's conanfile

### DIFF
--- a/recipes/libassert/v1/conanfile.py
+++ b/recipes/libassert/v1/conanfile.py
@@ -140,3 +140,9 @@ class LibassertConan(ConanFile):
                 self.cpp_info.system_libs.append("dl")
             if self.settings.os == "Windows":
                 self.cpp_info.system_libs.append("dbghelp")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "assert"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "assert"
+        self.cpp_info.names["cmake_find_package"] = "assert"
+        self.cpp_info.names["cmake_find_package_multi"] = "assert"

--- a/recipes/libassert/v1/conanfile.py
+++ b/recipes/libassert/v1/conanfile.py
@@ -131,6 +131,12 @@ class LibassertConan(ConanFile):
         # appending this one but not removing the default to not break consumers
         self.cpp_info.includedirs.append(os.path.join("include", "assert"))
         
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "assert"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "assert"
+        self.cpp_info.names["cmake_find_package"] = "assert"
+        self.cpp_info.names["cmake_find_package_multi"] = "assert"
+
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
 
@@ -140,9 +146,3 @@ class LibassertConan(ConanFile):
                 self.cpp_info.system_libs.append("dl")
             if self.settings.os == "Windows":
                 self.cpp_info.system_libs.append("dbghelp")
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "assert"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "assert"
-        self.cpp_info.names["cmake_find_package"] = "assert"
-        self.cpp_info.names["cmake_find_package_multi"] = "assert"

--- a/recipes/libassert/v1/conanfile.py
+++ b/recipes/libassert/v1/conanfile.py
@@ -130,12 +130,6 @@ class LibassertConan(ConanFile):
         # the first version of this library used assert/assert as include folder
         # appending this one but not removing the default to not break consumers
         self.cpp_info.includedirs.append(os.path.join("include", "assert"))
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "assert"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "assert"
-        self.cpp_info.names["cmake_find_package"] = "assert"
-        self.cpp_info.names["cmake_find_package_multi"] = "assert"
         
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/libassert/v1/conanfile.py
+++ b/recipes/libassert/v1/conanfile.py
@@ -130,7 +130,7 @@ class LibassertConan(ConanFile):
         # the first version of this library used assert/assert as include folder
         # appending this one but not removing the default to not break consumers
         self.cpp_info.includedirs.append(os.path.join("include", "assert"))
-        
+
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "assert"
         self.cpp_info.filenames["cmake_find_package_multi"] = "assert"

--- a/recipes/libassert/v2/conanfile.py
+++ b/recipes/libassert/v2/conanfile.py
@@ -123,12 +123,6 @@ class LibassertConan(ConanFile):
         # appending this one but not removing the default to not break consumers
         self.cpp_info.includedirs.append(os.path.join("include", "libassert"))
 
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "libassert"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "libassert"
-        self.cpp_info.names["cmake_find_package"] = "libassert"
-        self.cpp_info.names["cmake_find_package_multi"] = "libassert"
-
         self.cpp_info.components["assert"].names["cmake_find_package"] = "assert"
         self.cpp_info.components["assert"].names["cmake_find_package_multi"] = "assert"
         self.cpp_info.components["assert"].requires = ["cpptrace::cpptrace"]


### PR DESCRIPTION
Specify library name and version:  **libassert/all**

I'm the author. This PR aims to remove warnings about deprecated Conan 1.X  to close https://github.com/jeremy-rifkin/libassert/issues/91. Paired with https://github.com/conan-io/conan-center-index/pull/23821.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
