### PR TITLE
gdalcpp: new recipe

### DIFF
--- a/recipes/gdalcpp/all/conandata.yml
+++ b/recipes/gdalcpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.3.0":
+    url: "https://github.com/joto/gdalcpp/archive/7e23085e7da80c8805fff54cc18e2705ac332074.zip"
+    sha256: "2240bbd376d91a3ea00fdef8261a1fb46f090798734422fbba0e716ea672031e"

--- a/recipes/gdalcpp/all/conanfile.py
+++ b/recipes/gdalcpp/all/conanfile.py
@@ -14,8 +14,8 @@ class GdalcppConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/joto/gdalcpp"
     topics = ("gdal", "osgeo", "geospatial", "raster", "vector", "gis", "header-only")
-    package_type = "header-library"
 
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 

--- a/recipes/gdalcpp/all/conanfile.py
+++ b/recipes/gdalcpp/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.0"
 
 class GdalcppConan(ConanFile):
     name = "gdalcpp"
@@ -23,14 +23,13 @@ class GdalcppConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("gdal/3.8.3")
+        self.requires("gdal/3.10.0")
 
     def package_id(self):
         self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, 11)
+        check_min_cppstd(self, 11)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/gdalcpp/all/conanfile.py
+++ b/recipes/gdalcpp/all/conanfile.py
@@ -1,0 +1,45 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
+
+class GdalcppConan(ConanFile):
+    name = "gdalcpp"
+    description = "C++11 wrapper classes for GDAL/OGR"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/joto/gdalcpp"
+    topics = ("gdal", "osgeo", "geospatial", "raster", "vector", "gis", "header-only")
+    package_type = "header-library"
+
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("gdal/3.8.3")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+
+    def package(self):
+        copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "gdalcpp.hpp", self.source_folder, os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/gdalcpp/all/test_package/CMakeLists.txt
+++ b/recipes/gdalcpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(gdalcpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE gdalcpp::gdalcpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/gdalcpp/all/test_package/conanfile.py
+++ b/recipes/gdalcpp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gdalcpp/all/test_package/conanfile.py
+++ b/recipes/gdalcpp/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/gdalcpp/all/test_package/test_package.cpp
+++ b/recipes/gdalcpp/all/test_package/test_package.cpp
@@ -1,0 +1,5 @@
+#include <gdalcpp.hpp>
+
+int main() {
+    gdalcpp::SRS wgs84{4326};
+}

--- a/recipes/gdalcpp/config.yml
+++ b/recipes/gdalcpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.3.0":
+    folder: all


### PR DESCRIPTION
Adds gdalcpp: https://github.com/joto/gdalcpp

C++11 wrapper classes for GDAL/OGR

[![Packaging status](https://repology.org/badge/tiny-repos/gdalcpp.svg)](https://repology.org/project/gdalcpp/versions)

Adding it to unvendor the vendored header in
- #23720
