### PR TITLE
c4core: fix url for version 0.2.0

### DIFF
--- a/recipes/c4core/all/conandata.yml
+++ b/recipes/c4core/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "0.2.0":
-    url: "https://github.com/biojppm/c4core/releases/download/v0.1.11/c4core-0.1.11-src.tgz"
-    sha256: "67f4443f3742424f42453594e26e656f616dddfcf225a1d810e00473a741408c"
+    url: "https://github.com/biojppm/c4core/releases/download/v0.2.0/c4core-0.2.0-src.tgz"
+    sha256: "7843e6fb41c200fff69fc71105dbbf56bb410bdbab6b330e02cbe18430fe23bd"
   "0.1.11":
     url: "https://github.com/biojppm/c4core/releases/download/v0.1.11/c4core-0.1.11-src.tgz"
     sha256: "67f4443f3742424f42453594e26e656f616dddfcf225a1d810e00473a741408c"
@@ -16,7 +16,7 @@ sources:
     sha256: "95c0663192c6bff7a098b50afcb05d22a34dd0fd8e6be2e1b61edad2b9675fde"
 patches:
   "0.2.0":
-    - patch_file: "patches/0.1.11-0001-make-fast_float-external.patch"
+    - patch_file: "patches/0.2.0-0001-make-fast_float-external.patch"
       patch_description: "use cci's fast_float recipe"
       patch_type: "conan"
   "0.1.11":

--- a/recipes/c4core/all/patches/0.2.0-0001-make-fast_float-external.patch
+++ b/recipes/c4core/all/patches/0.2.0-0001-make-fast_float-external.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f1d62be..cda061c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -76,7 +76,7 @@ set(C4CORE_SRC_FILES
+ if(C4CORE_WITH_FASTFLOAT)
+     list(APPEND C4CORE_SRC_FILES
+         c4/ext/fast_float.hpp
+-        c4/ext/fast_float_all.h
++#        c4/ext/fast_float_all.h
+         )
+ endif()
+ set(C4CORE_AMALGAMATED ${C4CORE_SRC_DIR}/../src_singleheader/c4/c4core_all.hpp)
+@@ -95,7 +95,10 @@ c4_add_library(c4core
+     SOURCE_ROOT ${C4CORE_SRC_DIR}
+     SOURCES ${C4CORE_SRC_FILES}
+ )
+-if(NOT C4CORE_WITH_FASTFLOAT)
++if(C4CORE_WITH_FASTFLOAT)
++    find_package(FastFloat REQUIRED CONFIG)
++    target_link_libraries(c4core PUBLIC "FastFloat::fast_float")
++else()
+     target_compile_definitions(c4core PUBLIC -DC4CORE_NO_FAST_FLOAT)
+ endif()
+ if(C4CORE_NO_DEBUG_BREAK)
+diff --git a/src/c4/ext/fast_float.hpp b/src/c4/ext/fast_float.hpp
+index 77fac4f..db14534 100644
+--- a/src/c4/ext/fast_float.hpp
++++ b/src/c4/ext/fast_float.hpp
+@@ -18,7 +18,7 @@
+ #   pragma GCC diagnostic ignored "-Wold-style-cast"
+ #endif
+ 
+-#include "c4/ext/fast_float_all.h"
++#include "fast_float/fast_float.h"
+ 
+ #ifdef _MSC_VER
+ #   pragma warning(pop)


### PR DESCRIPTION
Specify library name and version:  **c4core/0.2.0**

I'm very sorry for my mistake.
The url of c4core/0.2.0 is wrong.
This PR will fix it.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
