### PR TITLE
eudev: Bump libxslt to avoid conflicts

### DIFF
--- a/recipes/eudev/all/conanfile.py
+++ b/recipes/eudev/all/conanfile.py
@@ -56,7 +56,7 @@ class EudevConan(ConanFile):
     def requirements(self):
         self.requires("acl/2.3.1")
         self.requires("libcap/2.69")
-        self.requires("libxslt/1.1.34")
+        self.requires("libxslt/1.1.39")
         self.requires("linux-headers-generic/6.5.9")
 
         if self.options.with_kmod:
@@ -73,7 +73,7 @@ class EudevConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("gperf/3.1")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/2.2.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
Fixes conflicts with libxml2 in the graph caused by older version of libxslt.
