### PR TITLE
behaviortree.cpp: add version 4.6.0

### DIFF
--- a/recipes/behaviortree.cpp/all/conandata.yml
+++ b/recipes/behaviortree.cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.6.0":
+    url: "https://github.com/BehaviorTree/BehaviorTree.CPP/archive/refs/tags/4.6.0.tar.gz"
+    sha256: "b24fed4f51212ea40bc492f7d4a310b1672bc05df6a83f2341c41ccf233307a9"
   "4.5.2":
     url: "https://github.com/BehaviorTree/BehaviorTree.CPP/archive/refs/tags/4.5.2.tar.gz"
     sha256: "1aaac034fc6a2f03d9347934e3baf3cabd5edc8bb416b9d7f5d944598019aeb9"

--- a/recipes/behaviortree.cpp/config.yml
+++ b/recipes/behaviortree.cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.6.0":
+    folder: all
   "4.5.2":
     folder: all
   "4.0.1":


### PR DESCRIPTION
Specify library name and version:  **behaviortree.cpp/4.6.0**

https://github.com/BehaviorTree/BehaviorTree.CPP/compare/4.5.2...4.6.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
