### PR TITLE
octo-logger-cpp: add version 1.11.0

### DIFF
--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.0":
+    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.11.0.tar.gz"
+    sha256: "73c35ca2a2e0c4be2cd85c5ba1f4061bbc22637fe79570107f1123eff30936db"
   "1.9.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.9.0.tar.gz"
     sha256: "95187b6e9ae5d405b53ecb12ff7cbde847a9824a340ca88922eecd712ce9a138"

--- a/recipes/octo-logger-cpp/config.yml
+++ b/recipes/octo-logger-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.11.0":
+    folder: "all"
   "1.9.0":
     folder: "all"
   "1.6.1":


### PR DESCRIPTION
Specify library name and version:  **octo-logger-cpp/1.11.0**

https://github.com/ofiriluz/octo-logger-cpp/compare/v1.9.0...v1.11.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
