### PR TITLE
Add xml-security-c++ 2.0.4

### DIFF
--- a/recipes/xml-security-c/all/conandata.yml
+++ b/recipes/xml-security-c/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "2.0.4":
+    url: "https://github.com/apache/santuario-cpp/archive/refs/tags/2.0.4.zip"
+    sha256: "621582489cecf4d96c92cd5483f48a5e1ae9da2dbd92829c3d63e754d777d410"
+patches:
+  "2.0.4":
+    - patch_file: "patches/001-cmake-support.patch"
+      patch_description: "adds cmake based build system"
+      patch_type: "conan"
+      patch_source: "https://github.com/sivachandran/santuario-cpp/tree/cmake/2.0.4-1"

--- a/recipes/xml-security-c/all/conanfile.py
+++ b/recipes/xml-security-c/all/conanfile.py
@@ -1,0 +1,107 @@
+from conan import ConanFile, conan_version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, collect_libs
+from conan.tools.scm import Version
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+class PackageConan(ConanFile):
+    name = "xml-security-c"
+    description = (
+        "C++ library is an implementation of the XML Digital Signature and Encryption specifications"
+    )
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://santuario.apache.org/cindex.html"
+    topics = ("santuario", "xml", "dsig", "enc", "digital-signature", "encryption", "verification")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_xalan": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_xalan": False,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("xerces-c/3.2.5")
+        self.requires("openssl/3.2.1")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if self.options.with_xalan:
+            tc.variables["WITH_XALAN"] = "YES"
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        for license_file in ("LICENSE.txt", "NOTICE.txt"):
+            copy(self, license_file, src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))        
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+        if self.settings.os == "Windows":
+            rmdir(self, os.path.join(self.package_folder, "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = collect_libs(self)
+
+        # if package has an official FindPACKAGE.cmake listed in https://cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules
+        # examples: bzip2, freetype, gdal, icu, libcurl, libjpeg, libpng, libtiff, openssl, sqlite3, zlib...
+        # if package provides a CMake config file (package-config.cmake or packageConfig.cmake, with package::package target, usually installed in <prefix>/lib/cmake/<package>/)
+        self.cpp_info.set_property("cmake_file_name", "XmlSecurityC")
+        self.cpp_info.set_property("cmake_target_name", "XmlSecurityC::XmlSecurityC")
+        # if package provides a pkgconfig file (package.pc, usually installed in <prefix>/lib/pkgconfig/)
+        self.cpp_info.set_property("pkg_config_name", "xml-security-c.pc")
+
+        # If they are needed on Linux, m, pthread and dl are usually needed on FreeBSD too
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
+        elif self.settings.os == "Macos":
+            self.cpp_info.frameworks = ["CoreFoundation", "CoreServices"]
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        if Version(conan_version).major < 2:
+            self.cpp_info.names["cmake_find_package"] = "XmlSecurityC"
+            self.cpp_info.names["cmake_find_package_multi"] = "XmlSecurity-C"

--- a/recipes/xml-security-c/all/patches/001-cmake-support.patch
+++ b/recipes/xml-security-c/all/patches/001-cmake-support.patch
@@ -1,0 +1,900 @@
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 00000000..378eac25
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1 @@
++build
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 00000000..d626746a
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,671 @@
++cmake_minimum_required(VERSION 3.12...3.27)
++
++# Xerces-C++ require C++17
++set(CMAKE_CXX_STANDARD 17)
++
++project(
++  xml-security-c
++  VERSION 2.0.4
++  DESCRIPTION "Apache XML security C++ library"
++  LANGUAGES CXX)
++
++option(USE_XALAN "Enable Xalan integration" OFF)
++
++find_package(XercesC REQUIRED)
++
++if(USE_XALAN)
++  find_package(XalanC REQUIRED)
++  set(XSEC_HAVE_XALAN TRUE)
++endif()
++
++find_package(OpenSSL REQUIRED)
++set(XSEC_HAVE_OPENSSL TRUE)
++
++#
++# The following are sample programs.  They are NOT installed
++#
++
++add_custom_target(samples)
++
++# HMAC sign
++
++set(xsec_simpleHMAC_SOURCES
++    xsec/samples/simpleHMAC.cpp
++    xsec/samples/IOStreamOutputter.cpp
++    xsec/samples/IOStreamOutputter.hpp)
++add_executable(simpleHMAC EXCLUDE_FROM_ALL ${xsec_simpleHMAC_SOURCES})
++target_include_directories(simpleHMAC PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(simpleHMAC xml-security-c)
++add_dependencies(samples simpleHMAC)
++
++# HMAC validate
++
++set(xsec_simpleValidate_SOURCES
++    xsec/samples/simpleValidate.cpp
++    xsec/samples/IOStreamOutputter.cpp
++    xsec/samples/IOStreamOutputter.hpp)
++add_executable(simpleValidate EXCLUDE_FROM_ALL ${xsec_simpleValidate_SOURCES})
++target_include_directories(simpleValidate PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(simpleValidate xml-security-c)
++add_dependencies(samples simpleValidate)
++
++# Encrypt
++
++set(xsec_simpleEncrypt_SOURCES
++    xsec/samples/simpleEncrypt.cpp
++    xsec/samples/IOStreamOutputter.cpp
++    xsec/samples/IOStreamOutputter.hpp)
++add_executable(simpleEncrypt EXCLUDE_FROM_ALL ${xsec_simpleEncrypt_SOURCES})
++target_include_directories(simpleEncrypt PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(simpleEncrypt xml-security-c)
++add_dependencies(samples simpleEncrypt)
++
++# Decrypt
++
++set(xsec_simpleDecrypt_SOURCES
++    xsec/samples/simpleDecrypt.cpp
++    xsec/samples/IOStreamOutputter.cpp
++    xsec/samples/IOStreamOutputter.hpp)
++add_executable(simpleDecrypt EXCLUDE_FROM_ALL ${xsec_simpleDecrypt_SOURCES})
++target_include_directories(simpleDecrypt PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(simpleDecrypt xml-security-c)
++add_dependencies(samples simpleDecrypt)
++
++#
++# Finally we compile the tools that can be used to manipulate
++# XML Security inputs and outputs
++#
++
++add_custom_target(tools)
++set(TOOLS_DEFINITIONS "-DXSEC_BUILDING_TOOLS")
++
++if (NOT WIN32)
++  set(TOOLS_DEFINITIONS "${TOOLS_DEFINITIONS} -DHAVE_STRCASECMP -DHAVE_UNISTD_H")
++endif()
++
++# xtest
++
++set(xsec_xtest_SOURCES
++    xsec/tools/xtest/xtest.cpp)
++add_executable(xtest EXCLUDE_FROM_ALL ${xsec_xtest_SOURCES})
++target_compile_definitions(xtest PUBLIC ${TOOLS_DEFINITIONS})
++target_include_directories(xtest PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(xtest xml-security-c)
++add_dependencies(tools xtest)
++
++# c14n
++set(xsec_c14n_SOURCES
++   xsec/tools/c14n/c14n.cpp)
++add_executable(c14n EXCLUDE_FROM_ALL ${xsec_c14n_SOURCES})
++target_compile_definitions(c14n PUBLIC ${TOOLS_DEFINITIONS})
++target_include_directories(c14n PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(c14n xml-security-c)
++add_dependencies(tools c14n)
++
++# checksig
++set(xsec_checksig_SOURCES
++    xsec/tools/checksig/checksig.cpp
++    xsec/tools/checksig/AnonymousResolver.hpp
++    xsec/tools/checksig/AnonymousResolver.cpp
++    xsec/tools/checksig/InteropResolver.hpp
++    xsec/tools/checksig/InteropResolver.cpp)
++add_executable(checksig EXCLUDE_FROM_ALL ${xsec_checksig_SOURCES})
++target_compile_definitions(checksig PUBLIC ${TOOLS_DEFINITIONS})
++target_include_directories(checksig PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(checksig xml-security-c)
++add_dependencies(tools checksig)
++
++# templatesign
++set(xsec_templatesign_SOURCES
++    xsec/tools/templatesign/templatesign.cpp)
++add_executable(templatesign EXCLUDE_FROM_ALL ${xsec_templatesign_SOURCES})
++target_compile_definitions(templatesign PUBLIC ${TOOLS_DEFINITIONS})
++target_include_directories(templatesign PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(templatesign xml-security-c)
++add_dependencies(tools templatesign)
++
++# txfmout
++set(xsec_txfmout_SOURCES
++    xsec/tools/txfmout/txfmout.cpp)
++add_executable(txfmout EXCLUDE_FROM_ALL ${xsec_txfmout_SOURCES})
++target_compile_definitions(txfmout PUBLIC ${TOOLS_DEFINITIONS})
++target_include_directories(txfmout PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(txfmout xml-security-c)
++add_dependencies(tools txfmout)
++
++# siginf
++set(xsec_siginf_SOURCES
++    xsec/tools/siginf/siginf.cpp)
++add_executable(siginf EXCLUDE_FROM_ALL ${xsec_siginf_SOURCES})
++target_compile_definitions(siginf PUBLIC ${TOOLS_DEFINITIONS})
++target_include_directories(siginf PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(siginf xml-security-c)
++add_dependencies(tools siginf)
++
++# cipher
++set(xsec_cipher_SOURCES
++    xsec/tools/cipher/cipher.cpp
++    xsec/tools/cipher/XencInteropResolver.hpp
++    xsec/tools/cipher/XencInteropResolver.cpp)
++add_executable(cipher EXCLUDE_FROM_ALL ${xsec_cipher_SOURCES})
++target_compile_definitions(cipher PUBLIC ${TOOLS_DEFINITIONS})
++target_include_directories(cipher PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++target_link_libraries(cipher xml-security-c)
++add_dependencies(tools cipher)
++
++# xklient
++# set(xsec_xklient_SOURCES
++#     xsec/tools/xklient/xklient.cpp
++#     enc/OpenSSL/OpenSSLSupport.hpp)
++# add_executable(xklient EXCLUDE_FROM_ALL ${xsec_xklient_SOURCES})
++# target_compile_definitions(xklient PUBLIC -DXSEC_BUILDING_TOOLS)
++# target_link_libraries(xklient OpenSSL::Crypto)
++# add_dependencies(tools xklient)
++
++set(canoninclude_HEADERS
++    xsec/canon/XSECXMLNSStack.hpp
++    xsec/canon/XSECCanon.hpp
++    xsec/canon/XSECC14n20010315.hpp)
++
++set(encinclude_HEADERS
++    xsec/enc/XSECCryptoKeyHMAC.hpp
++    xsec/enc/XSECCryptoX509.hpp
++    xsec/enc/XSECCryptoKeyDSA.hpp
++    xsec/enc/XSECCryptoKeyEC.hpp
++    xsec/enc/XSECKeyInfoResolver.hpp
++    xsec/enc/XSECCryptoHash.hpp
++    xsec/enc/XSECCryptoBase64.hpp
++    xsec/enc/XSECCryptoSymmetricKey.hpp
++    xsec/enc/XSECCryptoKey.hpp
++    xsec/enc/XSECCryptoProvider.hpp
++    xsec/enc/XSECKeyInfoResolverDefault.hpp
++    xsec/enc/XSECCryptoKeyRSA.hpp
++    xsec/enc/XSECCryptoException.hpp
++    xsec/enc/XSECCryptoUtils.hpp)
++
++set(xscryptinclude_HEADERS
++    xsec/enc/XSCrypt/XSCryptCryptoBase64.hpp)
++
++set(opensslinclude_HEADERS
++    xsec/enc/OpenSSL/OpenSSLCryptoBase64.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoSymmetricKey.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoProvider.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoKeyRSA.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoX509.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoHashHMAC.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoKeyDSA.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoKeyEC.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoKeyHMAC.hpp
++    xsec/enc/OpenSSL/OpenSSLCryptoHash.hpp
++    xsec/enc/OpenSSL/OpenSSLSupport.hpp)
++
++set(nssinclude_HEADERS
++    xsec/enc/NSS/NSSCryptoX509.hpp
++    xsec/enc/NSS/NSSCryptoHashHMAC.hpp
++    xsec/enc/NSS/NSSCryptoKeyDSA.hpp
++    xsec/enc/NSS/NSSCryptoKeyHMAC.hpp
++    xsec/enc/NSS/NSSCryptoHash.hpp
++    xsec/enc/NSS/NSSCryptoSymmetricKey.hpp
++    xsec/enc/NSS/NSSCryptoProvider.hpp
++    xsec/enc/NSS/NSSCryptoKeyRSA.hpp)
++
++set(dsiginclude_HEADERS
++    xsec/dsig/DSIGKeyInfoSPKIData.hpp
++    xsec/dsig/DSIGXPathHere.hpp
++    xsec/dsig/DSIGAlgorithmHandlerDefault.hpp
++    xsec/dsig/DSIGXPathFilterExpr.hpp
++    xsec/dsig/DSIGKeyInfoX509.hpp
++    xsec/dsig/DSIGKeyInfoList.hpp
++    xsec/dsig/DSIGKeyInfoValue.hpp
++    xsec/dsig/DSIGKeyInfoDEREncoded.hpp
++    xsec/dsig/DSIGTransformC14n.hpp
++    xsec/dsig/DSIGTransformXSL.hpp
++    xsec/dsig/DSIGKeyInfo.hpp
++    xsec/dsig/DSIGKeyInfoPGPData.hpp
++    xsec/dsig/DSIGKeyInfoExt.hpp
++    xsec/dsig/DSIGObject.hpp
++    xsec/dsig/DSIGTransformList.hpp
++    xsec/dsig/DSIGTransform.hpp
++    xsec/dsig/DSIGTransformBase64.hpp
++    xsec/dsig/DSIGTransformXPath.hpp
++    xsec/dsig/DSIGKeyInfoMgmtData.hpp
++    xsec/dsig/DSIGSignedInfo.hpp
++    xsec/dsig/DSIGTransformXPathFilter.hpp
++    xsec/dsig/DSIGReferenceList.hpp
++    xsec/dsig/DSIGReference.hpp
++    xsec/dsig/DSIGSignature.hpp
++    xsec/dsig/DSIGKeyInfoName.hpp
++    xsec/dsig/DSIGTransformEnvelope.hpp
++    xsec/dsig/DSIGConstants.hpp)
++
++set(frameworkinclude_HEADERS
++    xsec/framework/XSECAlgorithmHandler.hpp
++    xsec/framework/XSECURIResolver.hpp
++    xsec/framework/XSECDefs.hpp
++    xsec/framework/XSECEnv.hpp
++    xsec/framework/XSECException.hpp
++    xsec/framework/XSECError.hpp
++    xsec/framework/XSECProvider.hpp
++    xsec/framework/XSECURIResolverXerces.hpp
++    xsec/framework/XSECAlgorithmMapper.hpp
++    xsec/framework/XSECW32Config.hpp
++    xsec/framework/XSECVersion.hpp)
++
++set(transformersinclude_HEADERS
++    xsec/transformers/TXFMXPathFilter.hpp
++    xsec/transformers/TXFMHash.hpp
++    xsec/transformers/TXFMParser.hpp
++    xsec/transformers/TXFMOutputFile.hpp
++    xsec/transformers/TXFMURL.hpp
++    xsec/transformers/TXFMBase.hpp
++    xsec/transformers/TXFMChar.hpp
++    xsec/transformers/TXFMCipher.hpp
++    xsec/transformers/TXFMEnvelope.hpp
++    xsec/transformers/TXFMChain.hpp
++    xsec/transformers/TXFMDocObject.hpp
++    xsec/transformers/TXFMConcatChains.hpp
++    xsec/transformers/TXFMSB.hpp
++    xsec/transformers/TXFMC14n.hpp
++    xsec/transformers/TXFMXSL.hpp
++    xsec/transformers/TXFMXPath.hpp
++    xsec/transformers/TXFMBase64.hpp)
++
++set(utilsinclude_HEADERS
++    xsec/utils/XSECSafeBuffer.hpp
++    xsec/utils/XSECSOAPRequestor.hpp
++    xsec/utils/XSECTXFMInputSource.hpp
++    xsec/utils/XSECNameSpaceExpander.hpp
++    xsec/utils/XSECSOAPRequestorSimple.hpp
++    xsec/utils/XSECXPathNodeList.hpp
++    xsec/utils/XSECSafeBufferFormatter.hpp
++    xsec/utils/XSECBinTXFMInputStream.hpp
++    xsec/utils/XSECPlatformUtils.hpp)
++
++set(xencinclude_HEADERS
++    xsec/xenc/XENCEncryptionMethod.hpp
++    xsec/xenc/XENCEncryptedType.hpp
++    xsec/xenc/XENCCipherData.hpp
++    xsec/xenc/XENCEncryptedKey.hpp
++    xsec/xenc/XENCCipherValue.hpp
++    xsec/xenc/XENCEncryptedData.hpp
++    xsec/xenc/XENCCipherReference.hpp
++    xsec/xenc/XENCCipher.hpp)
++
++set(xkmsinclude_HEADERS
++    xsec/xkms/XKMSNotBoundAuthentication.hpp
++    xsec/xkms/XKMSValidateResult.hpp
++    xsec/xkms/XKMSValidityInterval.hpp
++    xsec/xkms/XKMSStatusRequest.hpp
++    xsec/xkms/XKMSRegisterRequest.hpp
++    xsec/xkms/XKMSPendingRequest.hpp
++    xsec/xkms/XKMSCompoundRequest.hpp
++    xsec/xkms/XKMSUseKeyWith.hpp
++    xsec/xkms/XKMSValidateRequest.hpp
++    xsec/xkms/XKMSUnverifiedKeyBinding.hpp
++    xsec/xkms/XKMSLocateResult.hpp
++    xsec/xkms/XKMSRespondWith.hpp
++    xsec/xkms/XKMSQueryKeyBinding.hpp
++    xsec/xkms/XKMSPrototypeKeyBinding.hpp
++    xsec/xkms/XKMSKeyBindingAbstractType.hpp
++    xsec/xkms/XKMSMessageAbstractType.hpp
++    xsec/xkms/XKMSMessageFactory.hpp
++    xsec/xkms/XKMSConstants.hpp
++    xsec/xkms/XKMSRequestAbstractType.hpp
++    xsec/xkms/XKMSResult.hpp
++    xsec/xkms/XKMSAuthentication.hpp
++    xsec/xkms/XKMSLocateRequest.hpp
++    xsec/xkms/XKMSResultType.hpp
++    xsec/xkms/XKMSStatusResult.hpp
++    xsec/xkms/XKMSKeyBinding.hpp
++    xsec/xkms/XKMSCompoundResult.hpp
++    xsec/xkms/XKMSRegisterResult.hpp
++    xsec/xkms/XKMSResponseMechanism.hpp
++    xsec/xkms/XKMSStatus.hpp
++    xsec/xkms/XKMSRevokeRequest.hpp
++    xsec/xkms/XKMSRevokeResult.hpp
++    xsec/xkms/XKMSRecoverKeyBinding.hpp
++    xsec/xkms/XKMSRevokeKeyBinding.hpp
++    xsec/xkms/XKMSRSAKeyPair.hpp
++    xsec/xkms/XKMSRecoverResult.hpp
++    xsec/xkms/XKMSReissueResult.hpp
++    xsec/xkms/XKMSRecoverRequest.hpp
++    xsec/xkms/XKMSReissueRequest.hpp
++    xsec/xkms/XKMSReissueKeyBinding.hpp)
++
++set(include_HEADERS
++    ${xkmsinclude_HEADERS}
++    ${xencinclude_HEADERS}
++    ${utilsinclude_HEADERS}
++    ${transformersinclude_HEADERS}
++    ${frameworkinclude_HEADERS}
++    ${dsiginclude_HEADERS}
++    ${nssinclude_HEADERS}
++    ${opensslinclude_HEADERS}
++    ${xscryptinclude_HEADERS}
++    ${encinclude_HEADERS}
++    ${canoninclude_HEADERS}
++    ${XENCAlgorithmHandlerDefault}
++    ${XSECAlgorithmSupport})
++
++# canon
++
++set(canon_SOURCES
++    xsec/canon/XSECC14n20010315.cpp
++    xsec/canon/XSECXMLNSStack.cpp
++    xsec/canon/XSECCanon.cpp)
++
++# Signature
++
++set(dsig_SOURCES
++    xsec/dsig/DSIGKeyInfoPGPData.cpp
++    xsec/dsig/DSIGReferenceList.cpp
++    xsec/dsig/DSIGKeyInfoValue.cpp
++    xsec/dsig/DSIGKeyInfoDEREncoded.cpp
++    xsec/dsig/DSIGXPathHere.cpp
++    xsec/dsig/DSIGAlgorithmHandlerDefault.cpp
++    xsec/dsig/DSIGXPathFilterExpr.cpp
++    xsec/dsig/DSIGKeyInfoMgmtData.cpp
++    xsec/dsig/DSIGTransformXPathFilter.cpp
++    xsec/dsig/DSIGSignedInfo.cpp
++    xsec/dsig/DSIGKeyInfoList.cpp
++    xsec/dsig/DSIGConstants.cpp
++    xsec/dsig/DSIGSignature.cpp
++    xsec/dsig/DSIGTransformXSL.cpp
++    xsec/dsig/DSIGObject.cpp
++    xsec/dsig/DSIGTransformXPath.cpp
++    xsec/dsig/DSIGTransformEnvelope.cpp
++    xsec/dsig/DSIGKeyInfoName.cpp
++    xsec/dsig/DSIGTransformBase64.cpp
++    xsec/dsig/DSIGReference.cpp
++    xsec/dsig/DSIGKeyInfoSPKIData.cpp
++    xsec/dsig/DSIGTransformList.cpp
++    xsec/dsig/DSIGKeyInfoX509.cpp
++    xsec/dsig/DSIGKeyInfoExt.cpp
++    xsec/dsig/DSIGTransform.cpp
++    xsec/dsig/DSIGTransformC14n.cpp)
++
++# Main Crypto interface routines
++
++set(enc_SOURCES
++   xsec/enc/XSECCryptoX509.cpp
++   xsec/enc/XSECKeyInfoResolverDefault.cpp
++   xsec/enc/XSECCryptoUtils.cpp
++   xsec/enc/XSECCryptoBase64.cpp
++   xsec/enc/XSCrypt/XSCryptCryptoBase64.cpp
++   xsec/enc/XSECCryptoException.cpp)
++
++# Framework files
++
++set(framework_SOURCES
++    xsec/framework/XSECError.cpp
++    xsec/framework/XSECAlgorithmMapper.cpp
++    xsec/framework/XSECEnv.cpp
++    xsec/framework/XSECProvider.cpp
++    xsec/framework/XSECException.cpp
++    xsec/framework/XSECURIResolverXerces.cpp)
++
++set(txfm_SOURCES
++    xsec/transformers/TXFMBase.cpp
++    xsec/transformers/TXFMChain.cpp
++    xsec/transformers/TXFMCipher.cpp
++    xsec/transformers/TXFMParser.cpp
++    xsec/transformers/TXFMSB.cpp
++    xsec/transformers/TXFMEnvelope.cpp
++    xsec/transformers/TXFMBase64.cpp
++    xsec/transformers/TXFMXPathFilter.cpp
++    xsec/transformers/TXFMHash.cpp
++    xsec/transformers/TXFMC14n.cpp
++    xsec/transformers/TXFMURL.cpp
++    xsec/transformers/TXFMOutputFile.cpp
++    xsec/transformers/TXFMXPath.cpp
++    xsec/transformers/TXFMXSL.cpp
++    xsec/transformers/TXFMDocObject.cpp
++    xsec/transformers/TXFMConcatChains.cpp
++    xsec/transformers/TXFMChar.cpp)
++
++# Utility files.  Note we don't worry about checking if the UNIX stuff is
++# necessary - we just assume that we are running on a *NIX system because
++# compiling under make.  Cygwin compiles use the UNIX utilities, not windows
++
++set(utils_SOURCES
++    xsec/utils/XSECAlgorithmSupport.hpp
++    xsec/utils/XSECAlgorithmSupport.cpp
++    xsec/utils/XSECAutoPtr.hpp
++    xsec/utils/XSECBinTXFMInputStream.cpp
++    xsec/utils/XSECXPathNodeList.cpp
++    xsec/utils/XSECSafeBuffer.cpp
++    xsec/utils/XSECTXFMInputSource.cpp
++    xsec/utils/XSECDOMUtils.hpp
++    xsec/utils/XSECDOMUtils.cpp
++    xsec/utils/XSECSafeBufferFormatter.cpp
++    xsec/utils/XSECNameSpaceExpander.cpp
++    xsec/utils/XSECPlatformUtils.cpp
++    xsec/utils/XSECSOAPRequestorSimple.cpp)
++
++if (WIN32)
++  list(APPEND utils_SOURCES xsec/utils/winutils/XSECSOAPRequestorSimpleWin32.cpp)
++else()
++  list(APPEND utils_SOURCES xsec/utils/unixutils/XSECSOAPRequestorSimpleUnix.cpp)
++endif()
++
++# XML Encryption
++
++set(xenc_SOURCES
++    xsec/xenc/impl/XENCCipherReferenceImpl.cpp
++    xsec/xenc/impl/XENCEncryptionMethodImpl.cpp
++    xsec/xenc/impl/XENCEncryptedKeyImpl.hpp
++    xsec/xenc/impl/XENCCipherValueImpl.cpp
++    xsec/xenc/impl/XENCCipherImpl.hpp
++    xsec/xenc/impl/XENCAlgorithmHandlerDefault.hpp
++    xsec/xenc/impl/XENCCipherDataImpl.hpp
++    xsec/xenc/impl/XENCEncryptionMethodImpl.hpp
++    xsec/xenc/impl/XENCAlgorithmHandlerDefault.cpp
++    xsec/xenc/impl/XENCEncryptedDataImpl.cpp
++    xsec/xenc/impl/XENCEncryptedTypeImpl.hpp
++    xsec/xenc/impl/XENCCipherDataImpl.cpp
++    xsec/xenc/impl/XENCEncryptedDataImpl.hpp
++    xsec/xenc/impl/XENCCipherValueImpl.hpp
++    xsec/xenc/impl/XENCEncryptedTypeImpl.cpp
++    xsec/xenc/impl/XENCCipherImpl.cpp
++    xsec/xenc/impl/XENCEncryptedKeyImpl.cpp
++    xsec/xenc/impl/XENCCipherReferenceImpl.hpp)
++
++# XML Key Management
++set(xkms_SOURCES
++    xsec/xkms/XKMSConstants.cpp
++    xsec/xkms/impl/XKMSCompoundRequestImpl.cpp
++    xsec/xkms/impl/XKMSRevokeKeyBindingImpl.hpp
++    xsec/xkms/impl/XKMSRecoverRequestImpl.cpp
++    xsec/xkms/impl/XKMSRegisterResultImpl.cpp
++    xsec/xkms/impl/XKMSRecoverResultImpl.cpp
++    xsec/xkms/impl/XKMSValidateResultImpl.hpp
++    xsec/xkms/impl/XKMSRevokeResultImpl.hpp
++    xsec/xkms/impl/XKMSCompoundResultImpl.cpp
++    xsec/xkms/impl/XKMSRevokeKeyBindingImpl.cpp
++    xsec/xkms/impl/XKMSCompoundResultImpl.hpp
++    xsec/xkms/impl/XKMSUnverifiedKeyBindingImpl.hpp
++    xsec/xkms/impl/XKMSKeyBindingAbstractTypeImpl.cpp
++    xsec/xkms/impl/XKMSQueryKeyBindingImpl.hpp
++    xsec/xkms/impl/XKMSPrototypeKeyBindingImpl.cpp
++    xsec/xkms/impl/XKMSValidateResultImpl.cpp
++    xsec/xkms/impl/XKMSRSAKeyPairImpl.hpp
++    xsec/xkms/impl/XKMSAuthenticationImpl.cpp
++    xsec/xkms/impl/XKMSNotBoundAuthenticationImpl.hpp
++    xsec/xkms/impl/XKMSCompoundRequestImpl.hpp
++    xsec/xkms/impl/XKMSPendingRequestImpl.hpp
++    xsec/xkms/impl/XKMSStatusResultImpl.cpp
++    xsec/xkms/impl/XKMSStatusImpl.hpp
++    xsec/xkms/impl/XKMSRegisterRequestImpl.hpp
++    xsec/xkms/impl/XKMSReissueRequestImpl.cpp
++    xsec/xkms/impl/XKMSKeyBindingImpl.cpp
++    xsec/xkms/impl/XKMSUseKeyWithImpl.hpp
++    xsec/xkms/impl/XKMSRequestAbstractTypeImpl.cpp
++    xsec/xkms/impl/XKMSRespondWithImpl.cpp
++    xsec/xkms/impl/XKMSResponseMechanismImpl.hpp
++    xsec/xkms/impl/XKMSResultImpl.hpp
++    xsec/xkms/impl/XKMSReissueResultImpl.cpp
++    xsec/xkms/impl/XKMSAuthenticationImpl.hpp
++    xsec/xkms/impl/XKMSMessageAbstractTypeImpl.cpp
++    xsec/xkms/impl/XKMSRevokeResultImpl.cpp
++    xsec/xkms/impl/XKMSStatusResultImpl.hpp
++    xsec/xkms/impl/XKMSReissueKeyBindingImpl.hpp
++    xsec/xkms/impl/XKMSRespondWithImpl.hpp
++    xsec/xkms/impl/XKMSRevokeRequestImpl.cpp
++    xsec/xkms/impl/XKMSPendingRequestImpl.cpp
++    xsec/xkms/impl/XKMSRecoverResultImpl.hpp
++    xsec/xkms/impl/XKMSValidateRequestImpl.cpp
++    xsec/xkms/impl/XKMSStatusRequestImpl.hpp
++    xsec/xkms/impl/XKMSRecoverRequestImpl.hpp
++    xsec/xkms/impl/XKMSRecoverKeyBindingImpl.cpp
++    xsec/xkms/impl/XKMSRSAKeyPairImpl.cpp
++    xsec/xkms/impl/XKMSMessageAbstractTypeImpl.hpp
++    xsec/xkms/impl/XKMSUnverifiedKeyBindingImpl.cpp
++    xsec/xkms/impl/XKMSValidityIntervalImpl.hpp
++    xsec/xkms/impl/XKMSLocateResultImpl.hpp
++    xsec/xkms/impl/XKMSLocateRequestImpl.cpp
++    xsec/xkms/impl/XKMSResultTypeImpl.cpp
++    xsec/xkms/impl/XKMSRecoverKeyBindingImpl.hpp
++    xsec/xkms/impl/XKMSResultImpl.cpp
++    xsec/xkms/impl/XKMSValidityIntervalImpl.cpp
++    xsec/xkms/impl/XKMSRegisterRequestImpl.cpp
++    xsec/xkms/impl/XKMSReissueResultImpl.hpp
++    xsec/xkms/impl/XKMSStatusImpl.cpp
++    xsec/xkms/impl/XKMSReissueRequestImpl.hpp
++    xsec/xkms/impl/XKMSStatusRequestImpl.cpp
++    xsec/xkms/impl/XKMSReissueKeyBindingImpl.cpp
++    xsec/xkms/impl/XKMSKeyBindingImpl.hpp
++    xsec/xkms/impl/XKMSValidateRequestImpl.hpp
++    xsec/xkms/impl/XKMSKeyBindingAbstractTypeImpl.hpp
++    xsec/xkms/impl/XKMSResultTypeImpl.hpp
++    xsec/xkms/impl/XKMSMessageFactoryImpl.cpp
++    xsec/xkms/impl/XKMSRevokeRequestImpl.hpp
++    xsec/xkms/impl/XKMSResponseMechanismImpl.cpp
++    xsec/xkms/impl/XKMSNotBoundAuthentication.cpp
++    xsec/xkms/impl/XKMSLocateRequestImpl.hpp
++    xsec/xkms/impl/XKMSLocateResultImpl.cpp
++    xsec/xkms/impl/XKMSRequestAbstractTypeImpl.hpp
++    xsec/xkms/impl/XKMSQueryKeyBindingImpl.cpp
++    xsec/xkms/impl/XKMSUseKeyWithImpl.cpp
++    xsec/xkms/impl/XKMSMessageFactoryImpl.hpp
++    xsec/xkms/impl/XKMSPrototypeKeyBindingImpl.hpp
++    xsec/xkms/impl/XKMSRegisterResultImpl.hpp)
++
++# Conditional crypto routines
++
++set(openssl_SOURCES
++    xsec/enc/OpenSSL/OpenSSLCryptoHashHMAC.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoKeyRSA.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoHash.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoProvider.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoX509.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoBase64.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoKeyDSA.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoKeyEC.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoSymmetricKey.cpp
++    xsec/enc/OpenSSL/OpenSSLCryptoKeyHMAC.cpp
++    xsec/enc/OpenSSL/OpenSSLSupport.cpp)
++
++set(nss_SOURCES
++    xsec/enc/NSS/NSSCryptoX509.cpp
++    xsec/enc/NSS/NSSCryptoHashHMAC.cpp
++    xsec/enc/NSS/NSSCryptoHash.cpp
++    xsec/enc/NSS/NSSCryptoKeyDSA.cpp
++    xsec/enc/NSS/NSSCryptoProvider.cpp
++    xsec/enc/NSS/NSSCryptoSymmetricKey.cpp
++    xsec/enc/NSS/NSSCryptoKeyRSA.cpp
++    xsec/enc/NSS/NSSCryptoKeyHMAC.cpp)
++
++set(SOURCES
++    ${canon_SOURCES}
++    ${dsig_SOURCES}
++    ${enc_SOURCES}
++    ${framework_SOURCES}
++    ${txfm_SOURCES}
++    ${utils_SOURCES}
++    ${xenc_SOURCES}
++    ${xkms_SOURCES}
++    ${openssl_SOURCES})
++
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/xsec/framework/XSECConfig.hpp.in
++               ${CMAKE_CURRENT_BINARY_DIR}/xsec/framework/XSECConfig.hpp)
++
++add_library(xml-security-c ${SOURCES})
++
++target_include_directories(
++  xml-security-c
++  PUBLIC $<INSTALL_INTERFACE:include>
++         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++  PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
++
++target_link_libraries(xml-security-c PUBLIC XercesC::XercesC OpenSSL::Crypto)
++
++if(USE_XALAN)
++  target_link_libraries(xml-security-c PUBLIC XalanC::XalanC)
++endif()
++
++set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "d")
++
++if(WIN32)
++  set(xmlsecurityc_config_dir "cmake")
++else()
++  set(xmlsecurityc_config_dir "${CMAKE_INSTALL_LIBDIR}/cmake/XmlSecurityC")
++endif()
++
++include(GNUInstallDirs)
++
++install(
++  TARGETS xml-security-c
++  EXPORT XmlSecurityCConfigInternal
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT "runtime"
++  INCLUDES
++  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++install(
++  EXPORT XmlSecurityCConfigInternal
++  DESTINATION "${xmlsecurityc_config_dir}"
++  NAMESPACE "xmlsecurityc_"
++  COMPONENT "development")
++
++include(CMakePackageConfigHelpers)
++
++configure_package_config_file(
++  "${CMAKE_CURRENT_SOURCE_DIR}/XmlSecurityCConfig.cmake.in"
++  "${CMAKE_CURRENT_BINARY_DIR}/XmlSecurityCConfig.cmake"
++  INSTALL_DESTINATION "${xmlsecurityc_config_dir}")
++write_basic_package_version_file(
++  ${CMAKE_CURRENT_BINARY_DIR}/XmlSecurityCConfigVersion.cmake
++  VERSION "${PROJECT_VERSION}"
++  COMPATIBILITY SameMajorVersion)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/XmlSecurityCConfig.cmake
++              ${CMAKE_CURRENT_BINARY_DIR}/XmlSecurityCConfigVersion.cmake
++        DESTINATION "${xmlsecurityc_config_dir}")
++
++foreach(hdr IN LISTS include_HEADERS)
++  get_filename_component(hdrdir ${hdr} DIRECTORY)
++  install(
++    FILES "${hdr}"
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${hdrdir}"
++    COMPONENT "development")
++endforeach()
++
++# Install configure data file xsec/framework/XSECConfig.hpp
++install(
++  FILES "${CMAKE_CURRENT_BINARY_DIR}/xsec/framework/XSECConfig.hpp"
++  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/xsec/framework"
++  COMPONENT "development")
++
++# Generate pkg-config file
++set(pkgconfig-dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig" CACHE STRING "pkg-config installation directory (default ${CMAKE_INSTALL_LIBDIR}/pkgconfig)")
++set(PKGCONFIGDIR "${pkgconfig-dir}")
++
++set(prefix "${CMAKE_INSTALL_PREFIX}")
++set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
++set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
++set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/xml-security-c.pc.in
++               ${CMAKE_CURRENT_BINARY_DIR}/xml-security-c.pc)
++install(
++  FILES ${CMAKE_CURRENT_BINARY_DIR}/xml-security-c.pc
++  DESTINATION "${PKGCONFIGDIR}"
++  COMPONENT "development")
+diff --git a/Dockerfile b/Dockerfile
+new file mode 100644
+index 00000000..2893b07d
+--- /dev/null
++++ b/Dockerfile
+@@ -0,0 +1,9 @@
++# Dockerfile for libxml-security-c build environment
++FROM ubuntu:22.04
++
++RUN apt -y update && \
++    apt -y install build-essential
++
++RUN apt -y install cmake
++RUN apt -y install libxerces-c-dev libxalan-c-dev
++RUN apt -y install libssl-dev
+diff --git a/README.md b/README.md
+new file mode 100644
+index 00000000..5936c2cd
+--- /dev/null
++++ b/README.md
+@@ -0,0 +1,51 @@
++# Xml-Security-C++ with CMake support
++
++This is a forked repository of santuario-cpp/xml-security-c++ with CMake build system support.
++The original source is under `trunk` branch. The CMake build system inspired from Xerces-C++.
++
++## Build
++
++**Initialize cmake build**
++```bash
++$ cmake -S . -B build
++```
++
++**Initialize cmake build for Debug build**
++```bash
++$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
++```
++
++**Initialize cmake build for shared library**
++```bash
++$ cmake -S . -B build -DBUILD_SHARED_LIBS=ON
++```
++
++**Build the library**
++```bash
++$ cmake --build build
++```
++
++**Build the library with Xalan**
++```bash
++$ cmake -S . -B build -DUSE_XALAN=ON
++$ cmake --build build
++```
++
++**Build the samples**
++```bash
++$ cmake --build build --target samples
++```
++
++**Build the tools**
++```bash
++$ cmake --build build --target tools
++```
++
++**Install the library files(headers, .a/.so, cmake configs)**
++```bash
++$ cmake --install build
++```
++
++## What is not ported?
++- Experimental crypto libraries support, NSS and WinCAPI
++- XKMS support
+diff --git a/XmlSecurityCConfig.cmake.in b/XmlSecurityCConfig.cmake.in
+new file mode 100644
+index 00000000..3f5f944a
+--- /dev/null
++++ b/XmlSecurityCConfig.cmake.in
+@@ -0,0 +1,14 @@
++@PACKAGE_INIT@
++
++include(${CMAKE_CURRENT_LIST_DIR}/XmlSecurityCConfigInternal.cmake)
++
++find_package(OpenSSL REQUIRED)
++find_package(XercesC REQUIRED)
++
++add_library(XmlSecurityC::XmlSecurityC INTERFACE IMPORTED)
++set_target_properties(XmlSecurityC::XmlSecurityC PROPERTIES INTERFACE_LINK_LIBRARIES xmlsecurityc_xml-security-c)
++
++# For compatibility with FindXmlSecurityC.
++set(XmlSecurityC_VERSION "@xml-security-c_VERSION@")
++get_target_property(XmlSecurityC_INCLUDE_DIRS xmlsecurityc_xml-security-c INTERFACE_INCLUDE_DIRECTORIES)
++set(XmlSecurityC_LIBRARIES XmlSecurityC::XmlSecurityC)
+diff --git a/xml-security-c.pc.in b/xml-security-c.pc.in
+index c7249b06..721ca5bc 100644
+--- a/xml-security-c.pc.in
++++ b/xml-security-c.pc.in
+@@ -3,11 +3,9 @@ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@
+ 
+-Name: @PACKAGE_NAME@
++Name: Xml-Security-C++
+ Description: Apache XML security C++ library
+ Version: @VERSION@
+ Libs: -L${libdir} -lxml-security-c
+ Libs.private: @xalan_LIBS@ @PTHREAD_LIBS@
+ Cflags: -I${includedir} @xalan_CXXFLAGS@ @PTHREAD_CFLAGS@
+-Requires: @AX_PACKAGE_REQUIRES@
+-Requires.private: @AX_PACKAGE_REQUIRES_PRIVATE@
+diff --git a/xsec/framework/XSECConfig.hpp.in b/xsec/framework/XSECConfig.hpp.in
+index ea209b18..e24da964 100644
+--- a/xsec/framework/XSECConfig.hpp.in
++++ b/xsec/framework/XSECConfig.hpp.in
+@@ -1,42 +1,45 @@
+ /* xsec/framework/XSECConfig.hpp.in.  Generated from configure.ac by autoheader.  */
+ 
+ /* Define if NSS is in use. */
+-#undef XSEC_HAVE_NSS
++#cmakedefine XSEC_HAVE_NSS
+ 
+ /* Define if OpenSSL is in use. */
+-#undef XSEC_HAVE_OPENSSL
++#cmakedefine XSEC_HAVE_OPENSSL
+ 
+ /* Define to 1 if getcwd(NULL, 0) works. */
+-#undef XSEC_HAVE_GETCWD_DYN
++#cmakedefine XSEC_HAVE_GETCWD_DYN
+ 
+ /* Define to 1 if Xalan is available. */
+-#undef XSEC_HAVE_XALAN
+-
+-/* Define to 1 if OpenSSL has EVP_CIPHER_CTX_set_padding. */
+-#undef XSEC_OPENSSL_CANSET_PADDING
+-
+-/* Define to 1 if OpenSSL uses const input buffers. */
+-#undef XSEC_OPENSSL_CONST_BUFFERS
+-
+-/* Define to 1 if OpenSSL X509 API has const input buffer. */
+-#undef XSEC_OPENSSL_D2IX509_CONST_BUFFER
+-
+-/* Define to 1 if OpenSSL has full AES support. */
+-#undef XSEC_OPENSSL_HAVE_AES
+-
+-/* Define to 1 if OpenSSL has GCM support. */
+-#undef XSEC_OPENSSL_HAVE_GCM
+-
+-/* Define to 1 if OpenSSL has CRYPTO_cleanup_all_ex_data. */
+-#undef XSEC_OPENSSL_HAVE_CRYPTO_CLEANUP_ALL_EX_DATA
+-
+-/* Define to 1 if OpenSSL has EC support. */
+-#undef XSEC_OPENSSL_HAVE_EC
+-
+-/* Define to 1 if OpenSSL has SHA2 support. */
+-#undef XSEC_OPENSSL_HAVE_SHA2
++#cmakedefine XSEC_HAVE_XALAN
++
++/*
++ * Some settings for OpenSSL if we have it
++ *
++ */
++
++#if defined (XSEC_HAVE_OPENSSL)
++
++#	include <openssl/opensslv.h>
++#	if (OPENSSL_VERSION_NUMBER >= 0x00907000)
++#		define XSEC_OPENSSL_CONST_BUFFERS
++#		define XSEC_OPENSSL_HAVE_AES
++#       define XSEC_OPENSSL_HAVE_EC
++#		define XSEC_OPENSSL_CANSET_PADDING
++#		define XSEC_OPENSSL_HAVE_CRYPTO_CLEANUP_ALL_EX_DATA
++#	endif
++#	if (OPENSSL_VERSION_NUMBER >= 0x00908000)
++#		define XSEC_OPENSSL_D2IX509_CONST_BUFFER
++#       define XSEC_OPENSSL_HAVE_SHA2
++#       define XSEC_OPENSSL_HAVE_MGF1
++#       define XSEC_OPENSSL_HAVE_EVP_PKEY_ID
++#	endif
++#	if (OPENSSL_VERSION_NUMBER >= 0x10001000)
++#		define XSEC_OPENSSL_HAVE_GCM
++#	endif
++
++#endif
+ 
+ /* Define to 1 if XKMS support is included. */
+-#undef XSEC_XKMS_ENABLED
++#cmakedefine XSEC_XKMS_ENABLED
+ 
+ #include <xsec/framework/XSECVersion.hpp>
+diff --git a/xsec/framework/XSECDefs.hpp b/xsec/framework/XSECDefs.hpp
+index bfa0d69c..ff77f3a2 100644
+--- a/xsec/framework/XSECDefs.hpp
++++ b/xsec/framework/XSECDefs.hpp
+@@ -48,8 +48,8 @@
+ #	endif
+ #	define WIN32_LEAN_AND_MEAN
+ #	include <windows.h>
+-#elif defined(XSEC_BUILDING_LIBRARY) || defined(XSEC_BUILDING_TOOLS)
+-#   include "config.h"
++// #elif defined(XSEC_BUILDING_LIBRARY) || defined(XSEC_BUILDING_TOOLS)
++// #   include "config.h"
+ #else
+ #	include <xsec/framework/XSECConfig.hpp>
+ #endif
+diff --git a/xsec/framework/XSECW32Config.hpp b/xsec/framework/XSECW32Config.hpp
+index 1f4e1675..e1071077 100644
+--- a/xsec/framework/XSECW32Config.hpp
++++ b/xsec/framework/XSECW32Config.hpp
+@@ -49,7 +49,7 @@
+  * interested in assisting with maintenance and support of that code.
+  */
+ 
+-// #define XSEC_HAVE_OPENSSL 1
++#define XSEC_HAVE_OPENSSL 1
+ // #define XSEC_HAVE_WINCAPI 1
+ // #define XSEC_HAVE_NSS 1
+ 

--- a/recipes/xml-security-c/all/test_package/CMakeLists.txt
+++ b/recipes/xml-security-c/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(XercesC REQUIRED CONFIG)
+find_package(XmlSecurityC REQUIRED CONFIG)
+find_package(OpenSSL REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE XercesC::XercesC XmlSecurityC::XmlSecurityC OpenSSL::Crypto)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/xml-security-c/all/test_package/conanfile.py
+++ b/recipes/xml-security-c/all/test_package/conanfile.py
@@ -1,0 +1,28 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires("xerces-c/3.2.5")
+        self.requires("openssl/3.2.1")
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/xml-security-c/all/test_package/test_package.cpp
+++ b/recipes/xml-security-c/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <xercesc/util/PlatformUtils.hpp>
+#include <xsec/utils/XSECPlatformUtils.hpp>
+
+int main() {
+    xercesc::XMLPlatformUtils::Initialize();
+    XSECPlatformUtils::Initialise();
+    XSECPlatformUtils::Terminate();
+    xercesc::XMLPlatformUtils::Terminate();
+    return 0;
+}

--- a/recipes/xml-security-c/config.yml
+++ b/recipes/xml-security-c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **xml-security-c/2.0.4**

To build on Windows, the autotools based build system is ported to cmake. Experimental features like NSS as Crypto Provider and XKMS subsystem are built.

I'm not the author.

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
