### PR TITLE
cuda-api-wrappers: Added versions  0.6.9 and 0.7.0-b3

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,10 +1,16 @@
 sources:
+  "0.7.0-b3":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.0-b3.tar.gz"
+    sha256: "44ecf67df59908bda2c24fdffe49e918a3cdf49f103dc52c2707c6d5a6607195"
   "0.7.0-b2":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.0-b2.tar.gz"
     sha256: "9439cb2250dd3045a05d43c4ca66b5d49535eeba123b05a2e49169354fdb3123"
   "0.7-b1":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/0.7b1.tar.gz"
     sha256: "1ed5912d8f602ccd176865b824de17f462cb57142eb2a685d7cc034831e54a71"
+  "0.6.9":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.9.tar.gz"
+    sha256: "f6f8ae1016e3236b8065a432e67462a5d77d1448be08c5df73ab951a53a832c5"
   "0.6.8":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.8.tar.gz"
     sha256: "a0d1b062dbe41c99d06df4ae7885a053c2ae3815d6fe12df0458bc5277d08ed7"

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,7 +1,11 @@
 versions:
+  "0.7.0-b3":
+    folder: all
   "0.7.0-b2":
     folder: all
   "0.7-b1":
+    folder: all
+  "0.6.9":
     folder: all
   "0.6.8":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **cuda-api-wrappers/0.6.9**

New version of the library is out; plus a new beta of an upcoming major version, that's based on the new version being released now. No new dependencies.


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6). *<- I've only added two version entries*
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated. *<- I'm not exactly sure what I'm supposed to try.*
