### PR TITLE
daw_header_libraries: add version 2.106.0

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.106.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.106.0.tar.gz"
+    sha256: "7838ada09afa69e7a42d742991c4b24b32ba27681e7b4dadf7b1e45c168937b5"
   "2.101.0":
     url: "https://github.com/beached/header_libraries/archive/v2.101.0.tar.gz"
     sha256: "468b3a40b90295f1da8eb79ae5723909269c020e7e8bf3d93d3f4fac7c35195b"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.106.0":
+    folder: all
   "2.101.0":
     folder: all
   "2.98.5":


### PR DESCRIPTION
Specify library name and version:  **daw_header_libraries/2.106.0**

https://github.com/beached/header_libraries/compare/v2.101.0...v2.106.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
