### PR TITLE
catch2: add version 3.6.0

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.0":
+    url: "https://github.com/catchorg/Catch2/archive/v3.6.0.tar.gz"
+    sha256: "485932259a75c7c6b72d4b874242c489ea5155d17efa345eb8cc72159f49f356"
   "3.5.4":
     url: "https://github.com/catchorg/Catch2/archive/v3.5.4.tar.gz"
     sha256: "b7754b711242c167d8f60b890695347f90a1ebc95949a045385114165d606dbb"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.0":
+    folder: 3.x.x
   "3.5.4":
     folder: 3.x.x
   "3.5.3":


### PR DESCRIPTION
Specify library name and version:  **catch2/3.6.0**

https://github.com/catchorg/Catch2/compare/v3.5.4...v3.6.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
