### PR TITLE
pango: Add missing system lib for pango >=1.50.12 in Windows

### DIFF
--- a/recipes/pango/all/conanfile.py
+++ b/recipes/pango/all/conanfile.py
@@ -223,6 +223,8 @@ class PangoConan(ConanFile):
             self.cpp_info.components["pangowin32"].set_property("pkg_config_name", "pangowin32")
             self.cpp_info.components["pangowin32"].requires = ["pango_"]
             self.cpp_info.components["pangowin32"].system_libs.append("gdi32")
+            if Version(self.version) >= "1.50.12":
+                self.cpp_info.components["pangowin32"].system_libs.append("dwrite")
 
         if self.options.with_cairo:
             self.cpp_info.components["pangocairo"].libs = ["pangocairo-1.0"]


### PR DESCRIPTION
Specify library name and version:  **pango/[>=1.50.12]**

As reported in https://github.com/conan-io/conan-center-index/issues/23876, Pango was missing a system dependency to dwrite that has been there from version 1.50.12 onwards

Thanks @fnadeau for reporting it :) This should fix your issues - could you please provide a successful log compilation with this change? (Let me know if you need some help getting this recipe into your Conan cache!) 

Requires https://github.com/conan-io/conan-center-index/pull/23506