### PR TITLE
[boost] Add default support for from_exception in non intel platforms

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -272,7 +272,7 @@ class BoostConan(ConanFile):
         cppstd = self.settings.compiler.get_safe("cppstd")
         if cppstd:
             return valid_min_cppstd(self, 14)
-        required_compiler_version = self._min_compiler_version_default_cxx14        
+        required_compiler_version = self._min_compiler_version_default_cxx14
         if required_compiler_version:
             msvc_versions = {14: 190, 15: 191, 16: 192, 17: 193}
             compiler_version = Version(self.settings.compiler.version)
@@ -1317,7 +1317,7 @@ class BoostConan(ConanFile):
                 cxx_flags.append("-fembed-bitcode")
         if self._with_stacktrace_backtrace:
             flags.append(f"-sLIBBACKTRACE_PATH={self.dependencies['libbacktrace'].package_folder}")
-        if self._stacktrace_from_exception_available and is_apple_os(self) and str(self.settings.compiler.libcxx) == "libc++":
+        if self._stacktrace_from_exception_available and is_apple_os(self) and (str(self.settings.compiler.libcxx) == "libc++" or "x86" not in str(self.settings.arch)):
             # https://github.com/boostorg/stacktrace/blob/boost-1.85.0/src/from_exception.cpp#L29
             flags.append("define=BOOST_STACKTRACE_LIBCXX_RUNTIME_MAY_CAUSE_MEMORY_LEAK=1")
         if self._with_iconv:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1317,8 +1317,9 @@ class BoostConan(ConanFile):
                 cxx_flags.append("-fembed-bitcode")
         if self._with_stacktrace_backtrace:
             flags.append(f"-sLIBBACKTRACE_PATH={self.dependencies['libbacktrace'].package_folder}")
-        if self._stacktrace_from_exception_available and is_apple_os(self) and (str(self.settings.compiler.libcxx) == "libc++" or "x86" not in str(self.settings.arch)):
+        if self._stacktrace_from_exception_available and "x86" not in str(self.settings.arch):
             # https://github.com/boostorg/stacktrace/blob/boost-1.85.0/src/from_exception.cpp#L29
+            # This feature is guarded by BOOST_STACKTRACE_ALWAYS_STORE_IN_PADDING, but that is only enabled on x86.
             flags.append("define=BOOST_STACKTRACE_LIBCXX_RUNTIME_MAY_CAUSE_MEMORY_LEAK=1")
         if self._with_iconv:
             flags.append(f"-sICONV_PATH={self.dependencies['libiconv'].package_folder}")


### PR DESCRIPTION
Affects boost 1.85.0 only.

Please, read #23877 and https://github.com/boostorg/stacktrace/issues/163 to understand the context.

This PR does not disable the feature, but enforce the define to ignore errors.

An alternative, would be add a new option like `without_stacktrace_from_exception` and disable it when running on Mac M1/2, for instance. 

fixes #23877


/cc @randomphrase

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
