### PR TITLE
glaze: add version 2.6.1

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.1":
+    url: "https://github.com/stephenberry/glaze/archive/v2.6.1.tar.gz"
+    sha256: "c8b1d981329f279b85f6ee732e2c3cc9d0d2e014ef3d79cb72bf67dc9f2357d4"
   "2.6.0":
     url: "https://github.com/stephenberry/glaze/archive/v2.6.0.tar.gz"
     sha256: "cdc2b7ada3b10abae8f8ed2700cc76574e73f0c78c4b0b83ad8a35eb5fb1a4cb"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.1":
+    folder: all
   "2.6.0":
     folder: all
   "2.5.5":


### PR DESCRIPTION
Specify library name and version:  **glaze/2.6.1**

https://github.com/stephenberry/glaze/compare/v2.6.0...v2.6.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
