### PR TITLE
gegles-spdlog_setup: bump 3p to `spdlog/1.14.1`

### DIFF
--- a/recipes/gegles-spdlog_setup/all/conanfile.py
+++ b/recipes/gegles-spdlog_setup/all/conanfile.py
@@ -39,7 +39,7 @@ class SpdlogSetupConan(ConanFile):
 
     def requirements(self):
         self.requires("cpptoml/0.1.1")
-        self.requires("spdlog/1.13.0")
+        self.requires("spdlog/1.14.1")
         self.requires("fmt/10.2.1")
 
     def package_id(self):


### PR DESCRIPTION
Specify library name and version:  **gegles-spdlog_setup/1.1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
