### PR TITLE
libcurl: bump libcurl to c-ares/1.28.1

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -188,7 +188,7 @@ class LibcurlConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.with_c_ares:
-            self.requires("c-ares/1.27.0")
+            self.requires("c-ares/[>=1.27.0]")
         if self.options.get_safe("with_libpsl"):
             self.requires("libpsl/0.21.1")
 

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -188,7 +188,7 @@ class LibcurlConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.with_c_ares:
-            self.requires("c-ares/[>=1.28.1]")
+            self.requires("c-ares/1.28.1")
         if self.options.get_safe("with_libpsl"):
             self.requires("libpsl/0.21.1")
 

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -188,7 +188,7 @@ class LibcurlConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.with_c_ares:
-            self.requires("c-ares/[>=1.27.0]")
+            self.requires("c-ares/[>=1.28.1]")
         if self.options.get_safe("with_libpsl"):
             self.requires("libpsl/0.21.1")
 


### PR DESCRIPTION
Specify library name and version:  **libcurl/***

Bump to c-ares/1.28.1.

Fixes the following bugs with c-ares 1.27, as I'm sure @jcar87 will appreciate...  Compiles for us on MacOS (ARM, x86_64), Linux (ARM, PowerPC, x86_64, S/390), Windows 11 (x86_64)

```
1.28 release notes..
* CMake: don't overwrite global required libraries/definitions/includes which could cause build errors for projects chain * building c-ares. [Issue #729](https://github.com/c-ares/c-ares/issues/729)
* On some platforms, netinet6/in6.h is not included by netinet/in.h and needs to be included separately. [PR #728](https://github.com/c-ares/c-ares/pull/728)
* Fix a potential memory leak in ares_init(). [Issue #724](https://github.com/c-ares/c-ares/issues/724)
* Some platforms don't have the isascii() function. Implement as a macro. [PR #721](https://github.com/c-ares/c-ares/pull/721)
* CMake: Fix Chain building if CMAKE runtime paths not set
* NDots configuration should allow a value of zero. [PR #735](https://github.com/c-ares/c-ares/pull/735)
```

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
