### PR TITLE
Compile as C

### DIFF
--- a/recipes/qr-code-generator/all/CMakeLists.txt
+++ b/recipes/qr-code-generator/all/CMakeLists.txt
@@ -3,7 +3,17 @@ project(QR-Code-Generator)
 
 include(src/files.cmake)
 
+IF (COMPILE_AS_C)
+    set(SRC ${CMAKE_SOURCE_DIR}/src/c/qrcodegen.c)
+    set(CMAKE_C_STANDARD 99)
+    set(LIBRARY_NAME qrcodegenc)
+    set(HEADERS ${CMAKE_SOURCE_DIR}/src/c/qrcodegen.h)
+    set(INCLUDE_DIR qrcodegenc)
+ELSE ()
+    set(INCLUDE_DIR qrcodegen)
+ENDIF ()
+
 add_library(${LIBRARY_NAME} ${SRC})
 
 set_target_properties(${LIBRARY_NAME} PROPERTIES PUBLIC_HEADER "${HEADERS}")
-install(TARGETS ${LIBRARY_NAME} RUNTIME LIBRARY ARCHIVE PUBLIC_HEADER DESTINATION include/qrcodegen)
+install(TARGETS ${LIBRARY_NAME} RUNTIME LIBRARY ARCHIVE PUBLIC_HEADER DESTINATION include/${INCLUDE_DIR})

--- a/recipes/qr-code-generator/all/CMakeLists.txt
+++ b/recipes/qr-code-generator/all/CMakeLists.txt
@@ -1,19 +1,16 @@
 ﻿cmake_minimum_required(VERSION 3.15)
 project(QR-Code-Generator)
 
+
+set(SRC_C ${CMAKE_SOURCE_DIR}/src/c/qrcodegen.c)
+set(LIBRARY_NAME_C qrcodegenc)
+set(HEADERS_C ${CMAKE_SOURCE_DIR}/src/c/qrcodegen.h)
+
+add_library(${LIBRARY_NAME_C} ${SRC_C})
+set_target_properties(${LIBRARY_NAME_C} PROPERTIES PUBLIC_HEADER "${HEADERS_C}")
+install(TARGETS ${LIBRARY_NAME_C} RUNTIME LIBRARY ARCHIVE PUBLIC_HEADER DESTINATION include/qrcodegenc)
+
 include(src/files.cmake)
-
-IF (COMPILE_AS_C)
-    set(SRC ${CMAKE_SOURCE_DIR}/src/c/qrcodegen.c)
-    set(CMAKE_C_STANDARD 99)
-    set(LIBRARY_NAME qrcodegenc)
-    set(HEADERS ${CMAKE_SOURCE_DIR}/src/c/qrcodegen.h)
-    set(INCLUDE_DIR qrcodegenc)
-ELSE ()
-    set(INCLUDE_DIR qrcodegen)
-ENDIF ()
-
 add_library(${LIBRARY_NAME} ${SRC})
-
 set_target_properties(${LIBRARY_NAME} PROPERTIES PUBLIC_HEADER "${HEADERS}")
-install(TARGETS ${LIBRARY_NAME} RUNTIME LIBRARY ARCHIVE PUBLIC_HEADER DESTINATION include/${INCLUDE_DIR})
+install(TARGETS ${LIBRARY_NAME} RUNTIME LIBRARY ARCHIVE PUBLIC_HEADER DESTINATION include/qrcodegen)

--- a/recipes/qr-code-generator/all/conanfile.py
+++ b/recipes/qr-code-generator/all/conanfile.py
@@ -102,7 +102,7 @@ class QrCodeGeneratorConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = [
-            "qrcodegen" if Version(self.version) < "1.7.0" else "qrcodegencpp"
+            "qrcodegen" if Version(self.version) < "1.7.0" else "qrcodegencpp", "qrcodegenc"
         ]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/qr-code-generator/all/conanfile.py
+++ b/recipes/qr-code-generator/all/conanfile.py
@@ -27,12 +27,10 @@ class QrCodeGeneratorConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "compile_as_c": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "compile_as_c": False,
     }
 
     @property
@@ -56,10 +54,6 @@ class QrCodeGeneratorConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
-        if not self.options.compile_as_c:
-            self.options.rm_safe("compiler.libcxx")
-            self.options.rm_safe("compiler.cppstd")
-
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -77,13 +71,10 @@ class QrCodeGeneratorConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["COMPILE_AS_C"] = self.options.compile_as_c
         if self.settings.os == "Windows" and self.options.shared:
             tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         if not valid_min_cppstd(self, self._min_cppstd):
             tc.variables["CMAKE_CXX_STANDARD"] = self._min_cppstd
-        if not valid_min_cppstd(self, self._min_cppstd):
-            tc.variables["CMAKE_C_STANDARD"] = "11"
         tc.generate()
 
     def build(self):
@@ -93,14 +84,10 @@ class QrCodeGeneratorConan(ConanFile):
         cmake.build()
 
     def _extract_license(self):
-        if self.options.compile_as_c:
-            header_name = ("qrcodegen.h")
-            header = load(self, os.path.join(self.source_folder, "c", header_name))
-        else:
-            header_name = (
-                "QrCode.hpp" if Version(self.version) < "1.7.0" else "qrcodegen.hpp"
-            )
-            header = load(self, os.path.join(self.source_folder, "cpp", header_name))
+        header_name = (
+            "QrCode.hpp" if Version(self.version) < "1.7.0" else "qrcodegen.hpp"
+        )
+        header = load(self, os.path.join(self.source_folder, "cpp", header_name))
         license_contents = header[2 : header.find("*/", 1)]
         return license_contents
 
@@ -114,12 +101,8 @@ class QrCodeGeneratorConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        if self.options.compile_as_c:
-            self.cpp_info.libs = ["qrcodegen"]
-        else:
-            self.cpp_info.libs =[
-                "qrcodegen" if Version(self.version) < "1.7.0" else "qrcodegencpp"
-                ]
-
+        self.cpp_info.libs = [
+            "qrcodegen" if Version(self.version) < "1.7.0" else "qrcodegencpp"
+        ]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/qr-code-generator/all/conanfile.py
+++ b/recipes/qr-code-generator/all/conanfile.py
@@ -101,8 +101,9 @@ class QrCodeGeneratorConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = [
-            "qrcodegen" if Version(self.version) < "1.7.0" else "qrcodegencpp", "qrcodegenc"
-        ]
+        self.cpp_info.components["qrcodegencpp"].set_property("cmake_target_name", "qr-code-generator::qrcodegencpp")
+        self.cpp_info.components["qrcodegencpp"].libs = ["qrcodegen" if Version(self.version) < "1.7.0" else "qrcodegencpp"]
+        self.cpp_info.components["qrcodegenc"].set_property("cmake_target_name", "qr-code-generator::qrcodegenc")
+        self.cpp_info.components["qrcodegenc"].libs = ["qrcodegenc"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")


### PR DESCRIPTION
Specify library name and version:  **qr-code-generator/1.8.0**

* Compile as C when the package is built with the new "compile_as_c" option.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
