### PR TITLE
daw_utf_range: update daw_header_libraries/2.106.0, add with_old_header_libraries option

### DIFF
--- a/recipes/daw_utf_range/all/conanfile.py
+++ b/recipes/daw_utf_range/all/conanfile.py
@@ -19,6 +19,12 @@ class DawUtfRangeConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+    options = {
+        "with_old_header_libraries": [True, False],
+    }
+    default_options = {
+        "with_old_header_libraries": False,
+    }
 
     @property
     def _minimum_cpp_standard(self):
@@ -34,12 +40,18 @@ class DawUtfRangeConan(ConanFile):
             "apple-clang": "12",
         }
 
+    def config_options(self):
+        if self.version != "2.2.4":
+            del self.options.with_old_header_libraries
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "2.2.4":
+        if self.version == "2.2.4" and self.options.get_safe("with_old_header_libraries", False):
             self.requires("daw_header_libraries/2.101.0")
+        elif Version(self.version) >= "2.2.4":
+            self.requires("daw_header_libraries/2.106.0")
         else:
             self.requires("daw_header_libraries/2.97.0")
 


### PR DESCRIPTION
Specify library name and version:  **daw_utf_range/***

This PR is for updating daw_json_link to 3.24.0.

daw_json_link/3.24.0 requires daw_utf_range/2.2.4 and daw_header_libraries/2.106.0.
daw_json_link/3.23.2 requires daw_utf_range/2.2.4 and daw_header_libraries/2.101.0.
(daw_json_link/3.23.2 doesn't support daw_header_libraries/2.106.0.)

![image](https://github.com/conan-io/conan-center-index/assets/465629/8db30d62-5f47-4d5f-aeca-201d41bf974b)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
