### PR TITLE
uriparser: add version 0.9.8

### DIFF
--- a/recipes/uriparser/all/conandata.yml
+++ b/recipes/uriparser/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.8":
+    url: "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.8/uriparser-0.9.8.tar.xz"
+    sha256: "1d71c054837ea32a31e462bce5a1af272379ecf511e33448e88100b87ff73b2e"
   "0.9.7":
     url: "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.7/uriparser-0.9.7.tar.xz"
     sha256: "1ddae35cb3cc2c36e8199829d46f1c7f8b222e74a723fdae67ec8561e1ac5a39"

--- a/recipes/uriparser/all/conanfile.py
+++ b/recipes/uriparser/all/conanfile.py
@@ -10,10 +10,10 @@ required_conan_version = ">=1.54.0"
 class UriparserConan(ConanFile):
     name = "uriparser"
     description = "Strictly RFC 3986 compliant URI parsing and handling library written in C89"
-    topics = ("uri", "parser")
+    license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://uriparser.github.io/"
-    license = "BSD-3-Clause"
+    topics = ("uri", "parser")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/uriparser/config.yml
+++ b/recipes/uriparser/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.8":
+    folder: "all"
   "0.9.7":
     folder: "all"
   "0.9.6":


### PR DESCRIPTION
Specify library name and version:  **uriparser/0.9.8**

https://github.com/uriparser/uriparser/compare/uriparser-0.9.7...uriparser-0.9.8

The new CMake option `URIPARSER_SHARED_LIBS` is added since 0.9.8.
But it's default value refers `BUILD_SHARED_LIBS` values.
So I think it is not needed to set `URIPARSER_SHARED_LIBS`.

```cmake
if(DEFINED BUILD_SHARED_LIBS)
    set(_URIPARSER_SHARED_LIBS_DEFAULT ${BUILD_SHARED_LIBS})
else()
    set(_URIPARSER_SHARED_LIBS_DEFAULT ON)
endif()
option(URIPARSER_SHARED_LIBS "Build shared libraries (rather than static ones)" ${_URIPARSER_SHARED_LIBS_DEFAULT})
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
