### PR TITLE
wiringpi: add version 3.4, fix homepage url

### DIFF
--- a/recipes/wiringpi/all/CMakeLists.txt
+++ b/recipes/wiringpi/all/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.11)
-project(wiringPi C)
+project(wiringPi LANGUAGES C)
 
 file(GLOB SRC_FILES ${WIRINGPI_SRC_DIR}/wiringPi/*.c)
 

--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.4":
+    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.4.tar.gz"
+    sha256: "a81219e9ea0ce08295d2fc0457c69c4df0c6d2e846cb5817ba3247f673480d55"
   "3.2":
     url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.2.tar.gz"
     sha256: "45aeaf52d86631edb7a5c82a4f6d0050ef10c8b4de6c566cd8017fc52a17b68e"

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -12,7 +12,7 @@ class WiringpiConan(ConanFile):
     description = "GPIO Interface library for the Raspberry Pi"
     license = "LGPL-3.0"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "http://wiringpi.com"
+    homepage = "https://github.com/WiringPi/WiringPi"
     topics = ("wiringpi", "gpio", "raspberrypi")
     settings = "os", "arch", "compiler", "build_type"
     package_type = "library"

--- a/recipes/wiringpi/all/test_package/CMakeLists.txt
+++ b/recipes/wiringpi/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
 
 find_package(wiringpi REQUIRED CONFIG)
 
 add_executable(test_package test_package.c)
-target_link_libraries(test_package wiringpi::wiringpi)
+target_link_libraries(test_package PRIVATE wiringpi::wiringpi)

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4":
+    folder: "all"
   "3.2":
     folder: "all"
   "2.61-1":


### PR DESCRIPTION
Specify library name and version:  **wiringpi/3.4**

https://github.com/WiringPi/WiringPi/compare/3.2...3.4

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
