### PR TITLE
fast_double_parser: add version 0.8.0

### DIFF
--- a/recipes/fast_double_parser/all/conandata.yml
+++ b/recipes/fast_double_parser/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.0":
+    url: "https://github.com/lemire/fast_double_parser/archive/v0.8.0.tar.gz"
+    sha256: "9ad74e059cc7c3e53a3057ca97a74c88ae2a6a7d36ce470193557cbd05ee8f92"
   "0.7.0":
     url: "https://github.com/lemire/fast_double_parser/archive/v0.7.0.tar.gz"
     sha256: "eb80a1d9c406bbe8cb22fffd3c007651f716abd03225009302d8aba8e9c4df77"

--- a/recipes/fast_double_parser/all/conanfile.py
+++ b/recipes/fast_double_parser/all/conanfile.py
@@ -10,12 +10,12 @@ required_conan_version = ">=1.50.0"
 class FastDoubleParserConan(ConanFile):
     name = "fast_double_parser"
     description = "Fast function to parse strings into double (binary64) floating-point values, enforces the RFC 7159 (JSON standard) grammar: 4x faster than strtod"
-    topics = ("numerical", "header-only")
+    license = ("Apache-2.0", "BSL-1.0")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/lemire/fast_double_parser"
-    license = ("Apache-2.0", "BSL-1.0")
+    topics = ("numerical", "header-only")
     package_type = "header-library"
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     def layout(self):

--- a/recipes/fast_double_parser/all/test_package/CMakeLists.txt
+++ b/recipes/fast_double_parser/all/test_package/CMakeLists.txt
@@ -4,5 +4,5 @@ project(test_package LANGUAGES CXX)
 find_package(fast_double_parser REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} fast_double_parser::fast_double_parser)
+target_link_libraries(${PROJECT_NAME} PRIVATE fast_double_parser::fast_double_parser)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/fast_double_parser/config.yml
+++ b/recipes/fast_double_parser/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.0":
+    folder: all
   "0.7.0":
     folder: all
   "0.6.0":


### PR DESCRIPTION
Specify library name and version:  **fast_double_parser/0.8.0**

https://github.com/lemire/fast_double_parser/compare/v0.7.0...v0.8.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
