### PR TITLE
[gtest] Keep recipe compatible with older Conan versions

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.microsoft import is_msvc_static_runtime, msvc_runtime_flag
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0 <2 || >=2.1.0"
+required_conan_version = ">=1.54.0"
 
 
 class GTestConan(ConanFile):
@@ -39,6 +39,7 @@ class GTestConan(ConanFile):
     }
     # disallow cppstd compatibility, as it affects the ABI in this library
     # see https://github.com/conan-io/conan-center-index/issues/23854
+    # Requires Conan >=1.53.0 <2 || >=2.1.0 to work
     extension_properties = {"compatibility_cppstd": False}
 
     @property


### PR DESCRIPTION
Specify library name and version:  **gtest/1.14.0**

Follow up to the PR #23856. The feature `compatibility_cppstd` is an attribute, using older Conan versions will not break, only will not have the feature available. 

/cc @Twon @hhowe29

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
