### PR TITLE
[catch2] Keep recipe compatible with older Conan versions

### DIFF
--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.scm import Version
 import os
 import textwrap
 
-required_conan_version = ">=1.53.0 <2 || >=2.1.0"
+required_conan_version = ">=1.54.0"
 
 
 class Catch2Conan(ConanFile):


### PR DESCRIPTION
Specify library name and version:  **catch2/3.5.3**

Follow up to the PR https://github.com/conan-io/conan-center-index/pull/21792. The feature compatibility_cppstd is an attribute, using older Conan versions will not break, only will not have the feature available.

This keeps the behaviour of Catch2 inline with GTest which also faced a similar issue: https://github.com/conan-io/conan-center-index/pull/23909

@uilianries, @RubenRBS 
---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
