### PR TITLE
Qt: default options should not be dependent on CI environment

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -122,7 +122,7 @@ class QtConan(ConanFile):
         "sysroot": None,
         "config": None,
         "multiconfiguration": False,
-        "essential_modules": True
+        "essential_modules": False
     }
     default_options.update({f"{status}_modules": False for status in _module_statuses if status != "essential"})
 

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -122,7 +122,7 @@ class QtConan(ConanFile):
         "sysroot": None,
         "config": None,
         "multiconfiguration": False,
-        "essential_modules": not os.getenv('CONAN_CENTER_BUILD_SERVICE')
+        "essential_modules": True
     }
     default_options.update({f"{status}_modules": False for status in _module_statuses if status != "essential"})
 

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -121,7 +121,7 @@ class QtConan(ConanFile):
         "sysroot": None,
         "multiconfiguration": False,
         "disabled_features": "",
-        "essential_modules": not os.getenv('CONAN_CENTER_BUILD_SERVICE')
+        "essential_modules": True
     }
     default_options.update({f"{status}_modules": False for status in _module_statuses if status != "essential"})
 

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -121,7 +121,7 @@ class QtConan(ConanFile):
         "sysroot": None,
         "multiconfiguration": False,
         "disabled_features": "",
-        "essential_modules": True
+        "essential_modules": False
     }
     default_options.update({f"{status}_modules": False for status in _module_statuses if status != "essential"})
 


### PR DESCRIPTION
Qt: fix issue where CI generates binaries that differ from user environments. The environment variable was added for a specific case where CI should not _skip_ binary generation for reasons external to the recipe itself (like CI) to raise an InvalidConfiguration (this is a stop-gap measure until we have other mechanisms to skip binary generation for specific recipes without having CI fail). In any case, the recipes in Conan Center Index must not have default values for options depend on environment variables. If CI cannot generate binaries this needs to be reflected a different way altogheter.

