### PR TITLE
cimg: add version 3.3.5, remove 2.8.3, bump deps

### DIFF
--- a/recipes/cimg/all/conandata.yml
+++ b/recipes/cimg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.3.5":
+    url: "https://cimg.eu/files/CImg_3.3.5.zip"
+    sha256: "c7268c270e3b93730a3eaf5738250a1b1efb0866bd57409786d750f7f4be7705"
   "3.3.2":
     url: "https://cimg.eu/files/CImg_3.3.2.zip"
     sha256: "d49ecd63b46f53ddcee5c7695ddb0fe8b07e033bb81b5ed075cfe352462c5f73"
@@ -14,6 +17,3 @@ sources:
   "2.9.9":
     url: "https://cimg.eu/files/CImg_2.9.9.zip"
     sha256: "c94412f26800ea318fa79410c58da1cf3df71771d07e515c39b16ee743f68e92"
-  "2.8.3":
-    url: "https://cimg.eu/files/CImg_2.8.3.zip"
-    sha256: "8d92e4cc271568c5aeca6e6b1f28f620fcf161ef99ce9d070ed1905d92caec4c"

--- a/recipes/cimg/all/conanfile.py
+++ b/recipes/cimg/all/conanfile.py
@@ -68,7 +68,7 @@ class CImgConan(ConanFile):
         if self.options.enable_jpeg:
             self.requires("libjpeg/9e")
         if self.options.enable_openexr:
-            self.requires("openexr/3.2.1")
+            self.requires("openexr/3.2.3")
         if self.options.enable_png:
             self.requires("libpng/[>=1.6 <2]")
         if self.options.enable_tiff:
@@ -79,7 +79,7 @@ class CImgConan(ConanFile):
             else:
                 self.requires("ffmpeg/5.1")
         if self.options.enable_opencv:
-            self.requires("opencv/4.5.5")
+            self.requires("opencv/4.9.0")
         if self.options.enable_magick:
             self.requires("imagemagick/7.0.11-14")
 

--- a/recipes/cimg/config.yml
+++ b/recipes/cimg/config.yml
@@ -9,5 +9,3 @@ versions:
     folder: all
   "2.9.9":
     folder: all
-  "2.8.3":
-    folder: all


### PR DESCRIPTION
Specify library name and version:  **cimg/all**

add version 3.3.5
remove 2.8.3 (unused in cci)
bump deps, notably openexr, c.f. https://github.com/conan-io/conan-center-index/issues/23277

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
