### PR TITLE
libcurl: use version range for c-ares

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -188,7 +188,7 @@ class LibcurlConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.with_c_ares:
-            self.requires("c-ares/1.27.0")
+            self.requires("c-ares/[>=1.27 <2]")
         if self.options.get_safe("with_libpsl"):
             self.requires("libpsl/0.21.1")
 


### PR DESCRIPTION
Use version range for c-ares in libcurl recipe

* c-ares is a c-library with a stable API/ABI that has been backwards compatible for years: https://abi-laboratory.pro/index.php?view=timeline&l=c-ares (note: last updated in 2020)
* curl aims to be compatible with 1.16.0 onwards, as per: https://github.com/curl/curl/blob/1ea7dce08d7dda985b0ddb153c7cf84c710a01ba/docs/INTERNALS.md?plain=1#L31
* however, here it appears the build-time checks check for API available since 1.6.0: https://github.com/curl/curl/blob/1ea7dce08d7dda985b0ddb153c7cf84c710a01ba/m4/curl-confopts.m4#L531-L547

Use a version range since c-ares is API and ABI compatible, use `1.27` as the lower bound as that is the one currently in use
