### PR TITLE
Add new lmdb version, fix 0.9.31 checksum

### DIFF
--- a/recipes/lmdb/all/conandata.yml
+++ b/recipes/lmdb/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "0.9.32":
+    url: "https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.32/openldap-LMDB_0.9.32.tar.gz"
+    sha256: "c0937223bba3c37c896809883a3c9b43049354578b239d6ed2476236a87f40c9"
   "0.9.31":
     url: "https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.31/openldap-LMDB_0.9.31.tar.gz"
-    sha256: "d35d4f6f46313d62fd342c9dcbf574432919ce5e802d2b6cbe2ebd549821e5c4"
+    sha256: "f7aecdd1bcc69fb32bb33d8544cfe50f8e9e916f366d598a268e1f43ee9c7603"
   "0.9.29":
     url: "https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz"
     sha256: "d4c668167a2d703ef91db733b4069b8b74dbc374405855be6626b45e2a7e2dd3"

--- a/recipes/lmdb/all/conandata.yml
+++ b/recipes/lmdb/all/conandata.yml
@@ -7,4 +7,4 @@ sources:
     sha256: "f7aecdd1bcc69fb32bb33d8544cfe50f8e9e916f366d598a268e1f43ee9c7603"
   "0.9.29":
     url: "https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz"
-    sha256: "d4c668167a2d703ef91db733b4069b8b74dbc374405855be6626b45e2a7e2dd3"
+    sha256: "e4d9f32dba4e15fcc66e0085a03432ff40a8065848d352ea47b1cb717e7369a4"

--- a/recipes/lmdb/config.yml
+++ b/recipes/lmdb/config.yml
@@ -1,4 +1,6 @@
 "versions":
+  "0.9.32":
+    "folder": "all"
   "0.9.31":
     "folder": "all"
   "0.9.29":


### PR DESCRIPTION
Specify library name and version:  **lmdb/**

Closes #23888

I've been able to use the [backup source feature](https://blog.conan.io/2023/10/03/backup-sources-feature.html) that Conan Center has had active for a while to download the old release tar, and I've been able to confirm that all the files match between the old and new version, BUT that the new version for some reason has a `.gitignore` file added to it:

Old contents:
```
$ ls -a | xargs shasum -a 256
3c87f63656b6a12fda225b6f798c547fe89e3404f499e890b445761eb310fd4f  COPYRIGHT
30e5862a8cbd7a7f7ce990946460e8761351a2d68b1382a3c1091e0aa2472659  CHANGES
5545f6b049040ce58e6d1a603eaea6b7fb8ae92459f2ab8d3bcbacabcce1014d  Doxyfile
310fe25c858a9515fc8c8d7d1f24a67c9496f84a91e0a0e41ea9975b1371e569  LICENSE
60b5f574e6642602f692a95956da61c588a265ad50b8059960c230b9e6aaf4fd  Makefile
5c5ca041151b453f1661db3a8725eeae666a4c3cdfb8ee5c4fd8313ecce469f8  intro.doc
8316fc4df7f9c0a8f664c68e79900854f20726c0ee05510bd828c7818f88f9a7  lmdb.h
25d47ee49975808a4ef923ea711fe29dc958d111e6fa2462fc36ab95923336cc  mdb.c
201bc00529e9ba25e7ad5dd3d6b1b830f22ceccde9352fd2975038e5c0b5aa2d  mdb_copy.1
f9b9a23b13a6cb84c8683159a78974c53dd6faae2b2aae640847f07523929ca3  mdb_copy.c
fd95dbe39786fd20f23dcafe227b5b0e3ffdf7bf6aa8fcaf924ecd8f35cefad9  mdb_dump.1
5f5d9f1f32ad87a858fbcb7ddf8c33894c63f0864bbbbed65d8475f69c36d2e6  mdb_dump.c
716c7e3443f0edd979d4f5a58faf0c532cb679b2ede5b25e321a2db4fb23be2a  mdb_load.1
e159903563ae44618b98164535354b680b2c33a11565888b5e4837799ca10103  mdb_load.c
ed3fe4a49d4ad208ce42911abe0fcaaf51d8a7ba9d83c9da438bb7c7b0759232  mdb_stat.1
759ba8f3f06830acd9fc78292c8bc332b88c28d48eed6f3db4e111522180222b  mdb_stat.c
91110543f2e84c516188c1e3960b1f504e1c60a4766027a782349c000276ca93  midl.c
07c68cf7bb62625f6e893570ae6e2e30b1f3a2b4e9e0b0e5fe1729f8eb72bee8  midl.h
7038f23f65a2c492a2692e54a702a4dd930c98a4622efcd5081d11d2e73e7e3a  mtest.c
50b6fcdb58f9c94e84a4faaffb542aa67b93c82ae47a8b172a054d150b9ec093  mtest2.c
cf086f26f04bcb322064cf1d685c08dbf3dfc9d46238f08d9c61af22a19e683b  mtest3.c
cc93eaed350b5bf05fdb115eddfd3c5ba9120c08cf9e5ec84475ff07e68d59c8  mtest4.c
7ceab228195079f20b58d6044241270192a2f0d60725b414b40e0eaec6304e24  mtest5.c
73ad4b08c53c30e9fc2daac32811aee6fe3977bac51edc8e67b6cb7978bfbdd0  mtest6.c
8c23a9d1ef0edf23faf9955379edf8bb0d46aa8b71fc019ad47ebf8d7ecfa404  sample-bdb.txt
87aa6e1645087f774fab8518f62ad27bfac5be1675406f1c2073cf8b064f75d7  sample-mdb.txt
4734c6dc1fa7aec8c2e9646bd04bc5218ef6a03ad83a3b18de2ac4069eb94120  tooltag
```

New contents:
```
$ ls -a | xargs shasum -a 256
49e1a82819dab072b1c80d4570f817d6e2c6625d574df871f7a065ab44944727  .gitignore
3c87f63656b6a12fda225b6f798c547fe89e3404f499e890b445761eb310fd4f  COPYRIGHT
30e5862a8cbd7a7f7ce990946460e8761351a2d68b1382a3c1091e0aa2472659  CHANGES
5545f6b049040ce58e6d1a603eaea6b7fb8ae92459f2ab8d3bcbacabcce1014d  Doxyfile
310fe25c858a9515fc8c8d7d1f24a67c9496f84a91e0a0e41ea9975b1371e569  LICENSE
60b5f574e6642602f692a95956da61c588a265ad50b8059960c230b9e6aaf4fd  Makefile
5c5ca041151b453f1661db3a8725eeae666a4c3cdfb8ee5c4fd8313ecce469f8  intro.doc
8316fc4df7f9c0a8f664c68e79900854f20726c0ee05510bd828c7818f88f9a7  lmdb.h
25d47ee49975808a4ef923ea711fe29dc958d111e6fa2462fc36ab95923336cc  mdb.c
201bc00529e9ba25e7ad5dd3d6b1b830f22ceccde9352fd2975038e5c0b5aa2d  mdb_copy.1
f9b9a23b13a6cb84c8683159a78974c53dd6faae2b2aae640847f07523929ca3  mdb_copy.c
fd95dbe39786fd20f23dcafe227b5b0e3ffdf7bf6aa8fcaf924ecd8f35cefad9  mdb_dump.1
5f5d9f1f32ad87a858fbcb7ddf8c33894c63f0864bbbbed65d8475f69c36d2e6  mdb_dump.c
716c7e3443f0edd979d4f5a58faf0c532cb679b2ede5b25e321a2db4fb23be2a  mdb_load.1
e159903563ae44618b98164535354b680b2c33a11565888b5e4837799ca10103  mdb_load.c
ed3fe4a49d4ad208ce42911abe0fcaaf51d8a7ba9d83c9da438bb7c7b0759232  mdb_stat.1
759ba8f3f06830acd9fc78292c8bc332b88c28d48eed6f3db4e111522180222b  mdb_stat.c
91110543f2e84c516188c1e3960b1f504e1c60a4766027a782349c000276ca93  midl.c
07c68cf7bb62625f6e893570ae6e2e30b1f3a2b4e9e0b0e5fe1729f8eb72bee8  midl.h
7038f23f65a2c492a2692e54a702a4dd930c98a4622efcd5081d11d2e73e7e3a  mtest.c
50b6fcdb58f9c94e84a4faaffb542aa67b93c82ae47a8b172a054d150b9ec093  mtest2.c
cf086f26f04bcb322064cf1d685c08dbf3dfc9d46238f08d9c61af22a19e683b  mtest3.c
cc93eaed350b5bf05fdb115eddfd3c5ba9120c08cf9e5ec84475ff07e68d59c8  mtest4.c
7ceab228195079f20b58d6044241270192a2f0d60725b414b40e0eaec6304e24  mtest5.c
73ad4b08c53c30e9fc2daac32811aee6fe3977bac51edc8e67b6cb7978bfbdd0  mtest6.c
8c23a9d1ef0edf23faf9955379edf8bb0d46aa8b71fc019ad47ebf8d7ecfa404  sample-bdb.txt
87aa6e1645087f774fab8518f62ad27bfac5be1675406f1c2073cf8b064f75d7  sample-mdb.txt
4734c6dc1fa7aec8c2e9646bd04bc5218ef6a03ad83a3b18de2ac4069eb94120  tooltag
```

A simple `diff` check validates that they are indeed the same files