### PR TITLE
imgui: add version 1.90.6

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.90.6":
+    url: "https://github.com/ocornut/imgui/archive/v1.90.6.tar.gz"
+    sha256: "70b4b05ac0938e82b4d5b8d59480d3e2ca63ca570dfb88c55023831f387237ad"
+  "1.90.6-docking":
+    url: "https://github.com/ocornut/imgui/archive/v1.90.6-docking.tar.gz"
+    sha256: "fc7f81d009ef718917aee0ac3ea1c74c8a5cfc8016049ad153b4d91d302b8aef"
   "1.90.5":
     url: "https://github.com/ocornut/imgui/archive/v1.90.5.tar.gz"
     sha256: "e94b48dba7311c85ba8e3e6fe7c734d76a0eed21b2b42c5180fd5706d1562241"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.90.6":
+    folder: all
+  "1.90.6-docking":
+    folder: all
   "1.90.5":
     folder: all
   "1.90.5-docking":


### PR DESCRIPTION
Specify library name and version:  **imgui/1.90.6**

https://github.com/ocornut/imgui/compare/v1.90.5...v1.90.6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
