### PR TITLE
mongo-cxx-driver: add version 3.10.1, update mongo-c-driver

### DIFF
--- a/recipes/mongo-cxx-driver/all/conandata.yml
+++ b/recipes/mongo-cxx-driver/all/conandata.yml
@@ -31,6 +31,9 @@ patches:
     - patch_file: "patches/3.10.1-0001-dirs.patch"
       patch_description: "disable documentation features, fix directories"
       patch_type: "conan"
+    - patch_file: "patches/3.10.1-0002-remove-abi-suffixes.patch"
+      patch_description: "remove abi suffixes for MSVC"
+      patch_type: "conan"
   "3.8.1":
     - patch_file: "patches/3.8.1-0001-dirs.patch"
       patch_description: "disable documentation features, fix directories"

--- a/recipes/mongo-cxx-driver/all/conandata.yml
+++ b/recipes/mongo-cxx-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.10.1":
+    url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.10.1/mongo-cxx-driver-r3.10.1.tar.gz"
+    sha256: "0297d9d1a513f09438cc05254b14baa49edd1fa64a6ce5d7a80a1eb7677cf2be"
   "3.8.1":
     url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.8.1/mongo-cxx-driver-r3.8.1.tar.gz"
     sha256: "b12c96670e1e68bae1a6f5cb08541f3da52f5ddeb5def274d2cf5d662ef73160"
@@ -24,6 +27,10 @@ sources:
     url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.1/mongo-cxx-driver-r3.6.1.tar.gz"
     sha256: "83523e897ef18f7ce05d85d1632dd4ba486c264a1b89c09020163ab29e11eab7"
 patches:
+  "3.10.1":
+    - patch_file: "patches/3.10.1-0001-dirs.patch"
+      patch_description: "disable documentation features, fix directories"
+      patch_type: "conan"
   "3.8.1":
     - patch_file: "patches/3.8.1-0001-dirs.patch"
       patch_description: "disable documentation features, fix directories"

--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -12,10 +12,10 @@ required_conan_version = ">=1.54.0"
 
 class MongoCxxConan(ConanFile):
     name = "mongo-cxx-driver"
+    description = "C++ Driver for MongoDB"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://mongocxx.org"
-    description = "C++ Driver for MongoDB"
     topics = ("libbsoncxx", "libmongocxx", "mongo", "mongodb", "database", "db")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
@@ -47,7 +47,7 @@ class MongoCxxConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("mongo-c-driver/1.24.3")
+        self.requires("mongo-c-driver/1.27.1")
         if self.options.polyfill == "boost":
             self.requires("boost/1.82.0", transitive_headers=True)
 
@@ -182,6 +182,8 @@ class MongoCxxConan(ConanFile):
         if not self.options.shared:
             self.cpp_info.components["mongocxx"].defines.append("MONGOCXX_STATIC")
         self.cpp_info.components["mongocxx"].requires = ["mongo-c-driver::mongoc", "bsoncxx"]
+        if Version(self.version) >= "3.10.1":
+            self.cpp_info.components["mongocxx"].includedirs.append(os.path.join("include", "mongocxx", "v_noabi"))
 
         # bsoncxx
         bsoncxx_target = "bsoncxx_shared" if self.options.shared else "bsoncxx_static"
@@ -197,3 +199,5 @@ class MongoCxxConan(ConanFile):
         self.cpp_info.components["bsoncxx"].requires = ["mongo-c-driver::bson"]
         if self.options.polyfill == "boost":
             self.cpp_info.components["bsoncxx"].requires.append("boost::headers")
+        if Version(self.version) >= "3.10.1":
+            self.cpp_info.components["bsoncxx"].includedirs.append(os.path.join("include", "bsoncxx", "v_noabi"))

--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.build import check_min_cppstd, valid_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import export_conandata_patches, apply_conandata_patches, copy, get, rm, rmdir
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 import os
 import shutil
 
@@ -129,6 +130,8 @@ class MongoCxxConan(ConanFile):
         if not valid_min_cppstd(self, self._minimal_std_version):
             tc.variables["CMAKE_CXX_STANDARD"] = self._minimal_std_version
         tc.variables["ENABLE_TESTS"] = False
+        if Version(self.version) >= "3.10.1" and is_msvc(self):
+            tc.variables["ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES"] = False
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/mongo-cxx-driver/all/patches/3.10.1-0001-dirs.patch
+++ b/recipes/mongo-cxx-driver/all/patches/3.10.1-0001-dirs.patch
@@ -1,0 +1,61 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2a960f7..f809b6c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -315,7 +315,7 @@ unset(dist_generated_depends CACHE)
+ set(BUILD_SOURCE_DIR ${CMAKE_BINARY_DIR})
+ 
+ include(MakeDistFiles)
+-
++if(FALSE)
+ add_custom_target(hugo_dir
+     COMMAND ${CMAKE_COMMAND} -E make_directory hugo
+ )
+@@ -371,7 +371,7 @@ add_custom_target(format-lint
+ add_custom_target(docs
+     DEPENDS hugo doxygen-current
+ )
+-
++endif()
+ set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
+ set(DATA_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
+ 
+@@ -381,13 +381,13 @@ option(ENABLE_MACRO_GUARD_TESTS "Enable targets for macro guard compile tests."
+ if(ENABLE_TESTS)
+     enable_testing()
+ endif()
+-
++set(MONGO_CXX_PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
++set(MONGO_CXX_PROJECT_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR})
+ add_subdirectory(src)
++# add_subdirectory(examples EXCLUDE_FROM_ALL)
+ 
+-add_subdirectory(examples EXCLUDE_FROM_ALL)
+-
+-add_subdirectory(benchmark EXCLUDE_FROM_ALL)
+-
++# add_subdirectory(benchmark EXCLUDE_FROM_ALL)
++if(FALSE)
+ # Implement 'dist' target
+ #
+ # CMake does not implement anything like 'dist' from autotools.
+@@ -525,3 +525,4 @@ endif()
+ if(CMAKE_GENERATOR_TOOLSET)
+     message(STATUS "\tinstance: ${CMAKE_GENERATOR_TOOLSET}")
+ endif()
++endif()
+diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
+index ce53a71..bcd0a61 100644
+--- a/src/bsoncxx/CMakeLists.txt
++++ b/src/bsoncxx/CMakeLists.txt
+@@ -93,8 +93,8 @@ if(TARGET bson_shared OR TARGET bson_static)
+     set(BSONCXX_PKG_DEP "find_dependency(bson-${LIBBSON_REQUIRED_ABI_VERSION} REQUIRED)")
+ else()
+     # Attempt to find libbson by new package name (without lib).
+-    find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} QUIET)
+-
++    find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} REQUIRED)
++    set(bson-${LIBBSON_REQUIRED_ABI_VERSION}_FOUND TRUE)
+     if(bson-${LIBBSON_REQUIRED_ABI_VERSION}_FOUND)
+         message(STATUS "found libbson version ${bson-${LIBBSON_REQUIRED_ABI_VERSION}_VERSION}")
+ 

--- a/recipes/mongo-cxx-driver/all/patches/3.10.1-0002-remove-abi-suffixes.patch
+++ b/recipes/mongo-cxx-driver/all/patches/3.10.1-0002-remove-abi-suffixes.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/BsoncxxUtil.cmake b/cmake/BsoncxxUtil.cmake
+index c72f98e..5f977e1 100644
+--- a/cmake/BsoncxxUtil.cmake
++++ b/cmake/BsoncxxUtil.cmake
+@@ -76,7 +76,7 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
+         endif()
+ 
+         # MSVC-specific ABI tag suffixes.
+-        if(MSVC)
++        if(0)
+             set(vs_suffix "")
+ 
+             # Include the target architecture if applicable (Win32, x64, etc.).
+diff --git a/cmake/MongocxxUtil.cmake b/cmake/MongocxxUtil.cmake
+index de9210c..f9937f4 100644
+--- a/cmake/MongocxxUtil.cmake
++++ b/cmake/MongocxxUtil.cmake
+@@ -63,7 +63,7 @@ function(mongocxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
+         endif()
+ 
+         # MSVC-specific ABI tag suffixes. Inherit from bsoncxx.
+-        if(MSVC)
++        if(0)
+             get_target_property(vs_suffix ${bsoncxx_target} BSONCXX_ABI_TAG_VS_SUFFIX)
+             set_target_properties(${TARGET} PROPERTIES
+                 BSONCXX_ABI_TAG_VS_SUFFIX ${vs_suffix}

--- a/recipes/mongo-cxx-driver/config.yml
+++ b/recipes/mongo-cxx-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.10.1":
+    folder: all
   "3.8.1":
     folder: all
   "3.8.0":


### PR DESCRIPTION
Specify library name and version:  **mongo-cxx-driver/3.10.1**

https://github.com/mongodb/mongo-cxx-driver/compare/r3.8.1...r3.10.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
