### PR TITLE
openssh: Allow all openssl 3.1.x releases

### DIFF
--- a/recipes/openssh/all/conanfile.py
+++ b/recipes/openssh/all/conanfile.py
@@ -66,7 +66,7 @@ class PackageConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        if self.version == "9.1p1":
+        if self.version in ["9.1p1", "9.6p1"]:
             # Backport configure script fix to accept OpenSSL versions in the 3.x series
             # See https://github.com/openssh/openssh-portable/commit/2eded551ba96e66bc3afbbcc883812c2eac02bd7
             replace_in_file(self, join(self.source_folder, "configure"), "300*", "30*")

--- a/recipes/openssh/all/conanfile.py
+++ b/recipes/openssh/all/conanfile.py
@@ -52,7 +52,7 @@ class PackageConan(ConanFile):
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_libcrypto == "openssl":
-            self.requires("openssl/[>=1.1 <=3.1]")
+            self.requires("openssl/[>=1.1 <3.2]")
         elif self.options.with_libcrypto == "libressl":
             self.requires("libressl/3.9.1")
         if self.options.with_pam == "openpam":

--- a/recipes/openssh/all/conanfile.py
+++ b/recipes/openssh/all/conanfile.py
@@ -52,7 +52,10 @@ class PackageConan(ConanFile):
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_libcrypto == "openssl":
-            self.requires("openssl/[>=1.1 <4]")
+            if self.version == "9.1p1":
+              self.requires("openssl/[>=1.1 <3.2]")
+            else:
+              self.requires("openssl/[>=1.1 <4]")                
         elif self.options.with_libcrypto == "libressl":
             self.requires("libressl/3.9.1")
         if self.options.with_pam == "openpam":

--- a/recipes/openssh/all/conanfile.py
+++ b/recipes/openssh/all/conanfile.py
@@ -52,7 +52,7 @@ class PackageConan(ConanFile):
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_libcrypto == "openssl":
-            self.requires("openssl/[>=1.1 <3.2]")
+            self.requires("openssl/[>=1.1 <4]")
         elif self.options.with_libcrypto == "libressl":
             self.requires("libressl/3.9.1")
         if self.options.with_pam == "openpam":

--- a/recipes/openssh/all/conanfile.py
+++ b/recipes/openssh/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
-from conan.tools.files import copy, get, rmdir, export_conandata_patches
+from conan.tools.files import copy, get, replace_in_file, rmdir, export_conandata_patches
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
 from conan.tools.layout import basic_layout
 
@@ -52,10 +52,7 @@ class PackageConan(ConanFile):
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_libcrypto == "openssl":
-            if self.version == "9.1p1":
-              self.requires("openssl/[>=1.1 <3.2]")
-            else:
-              self.requires("openssl/[>=1.1 <4]")                
+            self.requires("openssl/[>=1.1 <4]")
         elif self.options.with_libcrypto == "libressl":
             self.requires("libressl/3.9.1")
         if self.options.with_pam == "openpam":
@@ -69,6 +66,10 @@ class PackageConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        if self.version == "9.1p1":
+            # Backport configure script fix to accept OpenSSL versions in the 3.x series
+            # See https://github.com/openssh/openssh-portable/commit/2eded551ba96e66bc3afbbcc883812c2eac02bd7
+            replace_in_file(self, join(self.source_folder, "configure"), "300*", "30*")
 
     def generate(self):
         env = VirtualBuildEnv(self)


### PR DESCRIPTION
openssh/*

Changed requirements to allow all openssl/3.1.x releases and not only 3.1.0

---
- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
