### PR TITLE
libgit2: add version 1.8.1

### DIFF
--- a/recipes/libgit2/all/conandata.yml
+++ b/recipes/libgit2/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.8.0":
-    url: "https://github.com/libgit2/libgit2/archive/v1.8.0.tar.gz"
-    sha256: "9e1d6a880d59026b675456fbb1593c724c68d73c34c0d214d6eb848e9bbd8ae4"
+  "1.8.1":
+    url: "https://github.com/libgit2/libgit2/archive/v1.8.1.tar.gz"
+    sha256: "8c1eaf0cf07cba0e9021920bfba9502140220786ed5d8a8ec6c7ad9174522f8e"
   "1.7.2":
     url: "https://github.com/libgit2/libgit2/archive/v1.7.2.tar.gz"
     sha256: "de384e29d7efc9330c6cdb126ebf88342b5025d920dcb7c645defad85195ea7f"
@@ -24,8 +24,8 @@ sources:
     url: "https://github.com/libgit2/libgit2/archive/v1.0.1.tar.gz"
     sha256: "1775427a6098f441ddbaa5bd4e9b8a043c7401e450ed761e69a415530fea81d2"
 patches:
-  "1.8.0":
-    - patch_file: "patches/1.8.0-0001-fix-cmake.patch"
+  "1.8.1":
+    - patch_file: "patches/1.8.1-0001-fix-cmake.patch"
       patch_description: "use cci's packages"
       patch_type: "conan"
   "1.7.2":

--- a/recipes/libgit2/all/conandata.yml
+++ b/recipes/libgit2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.0":
+    url: "https://github.com/libgit2/libgit2/archive/v1.8.0.tar.gz"
+    sha256: "9e1d6a880d59026b675456fbb1593c724c68d73c34c0d214d6eb848e9bbd8ae4"
   "1.7.2":
     url: "https://github.com/libgit2/libgit2/archive/v1.7.2.tar.gz"
     sha256: "de384e29d7efc9330c6cdb126ebf88342b5025d920dcb7c645defad85195ea7f"
@@ -21,6 +24,10 @@ sources:
     url: "https://github.com/libgit2/libgit2/archive/v1.0.1.tar.gz"
     sha256: "1775427a6098f441ddbaa5bd4e9b8a043c7401e450ed761e69a415530fea81d2"
 patches:
+  "1.8.0":
+    - patch_file: "patches/1.8.0-0001-fix-cmake.patch"
+      patch_description: "use cci's packages"
+      patch_type: "conan"
   "1.7.2":
     - patch_file: "patches/1.7.2-0001-fix-cmake.patch"
       patch_description: "use cci's packages"

--- a/recipes/libgit2/all/conanfile.py
+++ b/recipes/libgit2/all/conanfile.py
@@ -33,6 +33,7 @@ class LibGit2Conan(ConanFile):
         "with_sha1": ["collisiondetection", "commoncrypto", "openssl", "mbedtls", "generic", "win32"],
         "with_ntlmclient": [True, False],
         "with_regex": ["builtin", "pcre", "pcre2", "regcomp_l", "regcomp"],
+        "with_http_parser": ["http-parser", "llhttp"],
     }
     default_options = {
         "shared": False,
@@ -44,6 +45,7 @@ class LibGit2Conan(ConanFile):
         "with_sha1": "collisiondetection",
         "with_ntlmclient": True,
         "with_regex": "builtin",
+        "with_http_parser": "http-parser",
     }
 
     def export_sources(self):
@@ -62,6 +64,10 @@ class LibGit2Conan(ConanFile):
         if self.settings.os == "Macos":
             self.options.with_regex = "regcomp_l"
 
+        # < 1.8.1 requries http_parser only.
+        if Version(self.version) < "1.8.1":
+            del self.options.with_http_parser
+
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
@@ -73,7 +79,11 @@ class LibGit2Conan(ConanFile):
 
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
-        self.requires("http_parser/2.9.4")
+        if Version(self.version) < "1.8.1" or self.options.get_safe("with_http_parser") == "http-parser":
+            self.requires("http_parser/2.9.4")
+        else:
+            self.requires("llhttp/9.1.3")
+
         if self.options.with_libssh2:
             self.requires("libssh2/1.11.0")
         if self._need_openssl:
@@ -138,7 +148,10 @@ class LibGit2Conan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["THREADSAFE"] = self.options.threadsafe
-        tc.variables["USE_SSH"] = self.options.with_libssh2
+        if Version(self.version) < "1.8.1":
+            tc.variables["USE_SSH"] = self.options.with_libssh2
+        else:
+            tc.variables["USE_SSH"] = "libssh2" if self.options.with_libssh2 else False
         tc.variables["USE_ICONV"] = self.options.get_safe("with_iconv", False)
         tc.variables["USE_HTTPS"] = self._cmake_https[str(self.options.with_https)]
         tc.variables["USE_SHA1"] = self._cmake_sha1[str(self.options.with_sha1)]
@@ -147,16 +160,19 @@ class LibGit2Conan(ConanFile):
         tc.variables["BUILD_CLAR"] = False
         tc.variables["BUILD_CLI"] = False
         tc.variables["BUILD_EXAMPLES"] = False
-        tc.variables["USE_HTTP_PARSER"] = "system"
+        if Version(self.version) < "1.8.1":
+            tc.variables["USE_HTTP_PARSER"] = "system"
+        else:
+            tc.variables["USE_HTTP_PARSER"] = self.options.get_safe("with_http_parser")
         tc.variables["REGEX_BACKEND"] = self.options.with_regex
         if is_msvc(self):
             tc.variables["STATIC_CRT"] = is_msvc_static_runtime(self)
-        if Version(self.version) >= "1.8.0":
-            tc.variables["USE_SSH"] = "libssh2"
         # REGEX_BACKEND is SET(), avoid options overriding it
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
         deps = CMakeDeps(self)
+        if self.options.get_safe("with_http_parser") == "llhttp":
+            deps.set_property("llhttp", "cmake_file_name", "LLHTTP")
         deps.generate()
 
     def build(self):

--- a/recipes/libgit2/all/conanfile.py
+++ b/recipes/libgit2/all/conanfile.py
@@ -151,6 +151,8 @@ class LibGit2Conan(ConanFile):
         tc.variables["REGEX_BACKEND"] = self.options.with_regex
         if is_msvc(self):
             tc.variables["STATIC_CRT"] = is_msvc_static_runtime(self)
+        if Version(self.version) >= "1.8.0":
+            tc.variables["USE_SSH"] = "libssh2"
         # REGEX_BACKEND is SET(), avoid options overriding it
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()

--- a/recipes/libgit2/all/patches/1.8.0-0001-fix-cmake.patch
+++ b/recipes/libgit2/all/patches/1.8.0-0001-fix-cmake.patch
@@ -1,0 +1,72 @@
+diff --git a/cmake/SelectHTTPParser.cmake b/cmake/SelectHTTPParser.cmake
+index 955aea3..ff94eb8 100644
+--- a/cmake/SelectHTTPParser.cmake
++++ b/cmake/SelectHTTPParser.cmake
+@@ -1,10 +1,10 @@
+ # Optional external dependency: http-parser
+ if(USE_HTTP_PARSER STREQUAL "system")
+-	find_package(HTTPParser)
++	find_package(http_parser)
+ 
+-	if(HTTP_PARSER_FOUND AND HTTP_PARSER_VERSION_MAJOR EQUAL 2)
+-		list(APPEND LIBGIT2_SYSTEM_INCLUDES ${HTTP_PARSER_INCLUDE_DIRS})
+-		list(APPEND LIBGIT2_SYSTEM_LIBS ${HTTP_PARSER_LIBRARIES})
++	if(http_parser_FOUND)
++		list(APPEND LIBGIT2_SYSTEM_INCLUDES ${http_parser_INCLUDE_DIRS})
++		list(APPEND LIBGIT2_SYSTEM_LIBS ${http_parser_LIBRARIES})
+ 		list(APPEND LIBGIT2_PC_LIBS "-lhttp_parser")
+ 		add_feature_info(http-parser ON "http-parser support (system)")
+ 	else()
+diff --git a/cmake/SelectHTTPSBackend.cmake b/cmake/SelectHTTPSBackend.cmake
+index d293001..acffba9 100644
+--- a/cmake/SelectHTTPSBackend.cmake
++++ b/cmake/SelectHTTPSBackend.cmake
+@@ -9,6 +9,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+ endif()
+ 
+ if(USE_HTTPS)
++	if(WIN32)
++		list(APPEND LIBGIT2_SYSTEM_LIBS "secur32")
++		list(APPEND LIBGIT2_PC_LIBS "-lsecur32")
++	endif()
++
+ 	# Auto-select TLS backend
+ 	sanitizebool(USE_HTTPS)
+ 	if(USE_HTTPS STREQUAL ON)
+diff --git a/cmake/SelectSSH.cmake b/cmake/SelectSSH.cmake
+index 079857f..652b310 100644
+--- a/cmake/SelectSSH.cmake
++++ b/cmake/SelectSSH.cmake
+@@ -4,15 +4,11 @@ if(USE_SSH STREQUAL "exec")
+ 
+ 	add_feature_info(SSH ON "using OpenSSH exec support")
+ elseif(USE_SSH STREQUAL ON OR USE_SSH STREQUAL "libssh2")
+-	find_pkglibraries(LIBSSH2 libssh2)
+-
+-	if(NOT LIBSSH2_FOUND)
+-		find_package(LibSSH2)
+-		set(LIBSSH2_INCLUDE_DIRS ${LIBSSH2_INCLUDE_DIR})
+-		get_filename_component(LIBSSH2_LIBRARY_DIRS "${LIBSSH2_LIBRARY}" DIRECTORY)
+-		set(LIBSSH2_LIBRARIES ${LIBSSH2_LIBRARY})
+-		set(LIBSSH2_LDFLAGS "-lssh2")
+-	endif()
++	FIND_PACKAGE(Libssh2 REQUIRED)
++	SET(LIBSSH2_FOUND ON)
++	SET(LIBSSH2_INCLUDE_DIRS ${Libssh2_INCLUDE_DIRS})
++	SET(LIBSSH2_LIBRARIES ${Libssh2_LIBRARIES})
++	SET(LIBSSH2_LIBRARY_DIRS ${Libssh2_LIB_DIRS})
+ 
+ 	if(NOT LIBSSH2_FOUND)
+ 		message(FATAL_ERROR "LIBSSH2 not found. Set CMAKE_PREFIX_PATH if it is installed outside of the default search path.")
+@@ -22,10 +18,7 @@ elseif(USE_SSH STREQUAL ON OR USE_SSH STREQUAL "libssh2")
+ 	list(APPEND LIBGIT2_SYSTEM_LIBS ${LIBSSH2_LIBRARIES})
+ 	list(APPEND LIBGIT2_PC_LIBS ${LIBSSH2_LDFLAGS})
+ 
+-	check_library_exists("${LIBSSH2_LIBRARIES}" libssh2_userauth_publickey_frommemory "${LIBSSH2_LIBRARY_DIRS}" HAVE_LIBSSH2_MEMORY_CREDENTIALS)
+-	if(HAVE_LIBSSH2_MEMORY_CREDENTIALS)
+-		set(GIT_SSH_LIBSSH2_MEMORY_CREDENTIALS 1)
+-	endif()
++	set(GIT_SSH_MEMORY_CREDENTIALS 1)
+ 
+ 	if(WIN32 AND EMBED_SSH_PATH)
+ 		file(GLOB SSH_SRC "${EMBED_SSH_PATH}/src/*.c")

--- a/recipes/libgit2/all/patches/1.8.1-0001-fix-cmake.patch
+++ b/recipes/libgit2/all/patches/1.8.1-0001-fix-cmake.patch
@@ -1,10 +1,10 @@
 diff --git a/cmake/SelectHTTPParser.cmake b/cmake/SelectHTTPParser.cmake
-index 955aea3..ff94eb8 100644
+index 4fc1f69..1e8d83e 100644
 --- a/cmake/SelectHTTPParser.cmake
 +++ b/cmake/SelectHTTPParser.cmake
 @@ -1,10 +1,10 @@
  # Optional external dependency: http-parser
- if(USE_HTTP_PARSER STREQUAL "system")
+ if(USE_HTTP_PARSER STREQUAL "http-parser")
 -	find_package(HTTPParser)
 +	find_package(http_parser)
  
@@ -15,8 +15,8 @@ index 955aea3..ff94eb8 100644
 +		list(APPEND LIBGIT2_SYSTEM_INCLUDES ${http_parser_INCLUDE_DIRS})
 +		list(APPEND LIBGIT2_SYSTEM_LIBS ${http_parser_LIBRARIES})
  		list(APPEND LIBGIT2_PC_LIBS "-lhttp_parser")
- 		add_feature_info(http-parser ON "http-parser support (system)")
- 	else()
+ 		set(GIT_HTTPPARSER_HTTPPARSER 1)
+ 		add_feature_info(http-parser ON "using http-parser (system)")
 diff --git a/cmake/SelectHTTPSBackend.cmake b/cmake/SelectHTTPSBackend.cmake
 index d293001..acffba9 100644
 --- a/cmake/SelectHTTPSBackend.cmake

--- a/recipes/libgit2/config.yml
+++ b/recipes/libgit2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.0":
+    folder: "all"
   "1.7.2":
     folder: "all"
   "1.5.0":

--- a/recipes/libgit2/config.yml
+++ b/recipes/libgit2/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.8.0":
+  "1.8.1":
     folder: "all"
   "1.7.2":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **libgit2/1.8.1**

https://github.com/libgit2/libgit2/compare/v1.7.2...v1.8.1

- Since 1.8.0, libgit2 add the values of `USE_SSH` as `exec` and `libssh2`. In conan CCI, `libssh2` seems to be adequate.
- Since 1.8.1, libgit2 add `USE_HTTP_PARSER` to select http parser library. (`http-parser` and `llhttp`)


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
