### PR TITLE
luau: add version 0.625

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.625":
+    url: "https://github.com/Roblox/luau/archive/0.625.tar.gz"
+    sha256: "4dd9295a67c2de6536b6e1208ea81cebfc5caefadcdacd7e09341c7a1dbbb9e2"
   "0.620":
     url: "https://github.com/Roblox/luau/archive/0.620.tar.gz"
     sha256: "a6ae1f0396334e72b1241dabb73aa123037613f3276bf2e71d0dc75568b1eb52"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.625":
+    folder: all
   "0.620":
     folder: all
   "0.615":


### PR DESCRIPTION
Specify library name and version:  **luau/0.625**

https://github.com/luau-lang/luau/compare/0.620...0.625

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
