### PR TITLE
ninja: add version 1.12.1

### DIFF
--- a/recipes/ninja/all/conandata.yml
+++ b/recipes/ninja/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.12.1":
+    url: "https://github.com/ninja-build/ninja/archive/v1.12.1.tar.gz"
+    sha256: "821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a"
   "1.12.0":
     url: "https://github.com/ninja-build/ninja/archive/v1.12.0.tar.gz"
     sha256: "8b2c86cd483dc7fcb7975c5ec7329135d210099a89bc7db0590a07b0bbfe49a5"

--- a/recipes/ninja/config.yml
+++ b/recipes/ninja/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.12.1":
+    folder: all
   "1.12.0":
     folder: all
   "1.11.1":


### PR DESCRIPTION
Specify library name and version:  **ninja/1.12.1**

https://github.com/ninja-build/ninja/compare/v1.12.0...v1.12.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
