### PR TITLE
add wgpu-native 0.19.4.1

### DIFF
--- a/recipes/wgpu_native/all/conandata.yml
+++ b/recipes/wgpu_native/all/conandata.yml
@@ -1,0 +1,48 @@
+sources:
+  "0.19.4.1":
+    binaries:
+      Linux:
+        "x86_64":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-linux-x86_64-release.zip"
+            sha256: "7d73bd7af2be60b632e5ab814996acb381d1b459975d6629f91c468049c8866a"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-linux-x86_64-debug.zip"
+            sha256: "1feb5419a84eb2a5710b5686b8f8c30c70f24cea5c39774853c2c5406a3857fd"
+        "armv8":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-linux-aarch64-release.zip"
+            sha256: "6e53aa3f0aec4b2b65cb0d7635000cf39bddd672bcb6138a593bf8cb8134f621"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-linux-aarch64-debug.zip"
+            sha256: "0b0598c2dda670c9c02379ba23d3ab36a6a4d4b113ba916419f92a7e7618ebee"
+      Windows:
+        "x86_64":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-windows-x86_64-release.zip"
+            sha256: "9e1591d60c2d2ee20d6d4a63bc01c7c5eecf7734761673160aa639e550a1ba4d"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-windows-x86_64-debug.zip"
+            sha256: "cac41053da833f7f40ba56fb58561ee66a373cb2e96f1658b243b7edfa3b8767"
+      Macos:
+        "x86_64":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-macos-x86_64-release.zip"
+            sha256: "e41a35bf4f2b1c7dd87092cfcb932b7a96118971129a6213b7be240deb07e614"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-macos-x86_64-debug.zip"
+            sha256: "e0f4628ce95f98295079fa6c35545d1c60fa6e82e9c7dcc5f07d35b5b1898346"
+        "armv8":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-macos-aarch64-release.zip"
+            sha256: "21cf8e69a4a775ea63f437f170a93e371df0f72c83119c81c25a668611c1771d"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v0.19.4.1/wgpu-macos-aarch64-debug.zip"
+            sha256: "f8f93d888f4f9d2d7252a638e9c8f432ef0125f436c4b6735ce91dcfbd64c676"
+    licenses:
+      mit:
+        url: https://raw.githubusercontent.com/gfx-rs/wgpu-native/v0.19.4.1/LICENSE.MIT
+        sha256: "C7FEA58D1CFE49634CD92E54FC10A9D871F4B275321A4CD8C09E449122CAAEB4"
+      apache:
+        url: https://raw.githubusercontent.com/gfx-rs/wgpu-native/v0.19.4.1/LICENSE.APACHE
+        sha256: "A6CBA85BC92E0CFF7A450B1D873C0EAA2E9FC96BF472DF0247A26BEC77BF3FF9"

--- a/recipes/wgpu_native/all/conanfile.py
+++ b/recipes/wgpu_native/all/conanfile.py
@@ -1,0 +1,58 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get, download
+import os
+
+
+class wgpu_nativeConanfile(ConanFile):
+    name = "wgpu_native"
+    description = "Native WebGPU implementation based on wgpu-core"
+    license = "MIT OR Apache-2.0"
+    homepage = "https://github.com/gfx-rs/wgpu-native"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("webgpu", "wgpu", "gpu", "graphics", "rendering", "3d", "2d")
+
+    settings = "os", "build_type", "arch"
+    options = {"shared": [True, False]}
+    default_options = {"shared": False}
+
+
+    def validate(self):
+        os = self.settings.os
+        if os not in ("Linux", "Windows", "Macos"):
+            raise ConanInvalidConfiguration(f"No prebuilt binaries exist for your OS ({os})")
+
+        arch = self.settings.arch
+        if arch not in ("x86_64", "armv8"):
+            raise ConanInvalidConfiguration(f"No prebuilt binaries exist for your architecture ({arch})")
+
+        if os is "Windows" and arch is not "x86_64":
+            raise ConanInvalidConfiguration(f"No prebuilt binaries exist for your architecture ({arch})")
+
+        if self.settings.build_type not in ("Debug", "Release"):
+            raise ConanInvalidConfiguration("Only Debug and Release build types are supported")
+
+    def build(self):
+        os = str(self.settings.os)
+        arch = str(self.settings.arch)
+        build_type = str(self.settings.build_type)
+        get(self, **self.conan_data["sources"][self.version]["binaries"][os][arch][build_type])
+
+        licenses = self.conan_data["sources"][self.version]["licenses"]
+        download(self, filename="LICENSE.MIT", **licenses["mit"])
+        download(self, filename="LICENSE.APACHE", **licenses["apache"])
+
+    def package(self):
+        copy(self, pattern="LICENSE.*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+
+        copy(self, pattern="*.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"), keep_path=False)
+
+        patterns = ["*.so", "*.dll", "*.dylib"] if self.options.shared else ["*.a", "*.lib"]
+        for p in patterns:
+            copy(self, pattern=p, src=self.source_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["wgpu_native"]
+
+        if self.settings.os is "Linux":
+            self.cpp_info.system_libs.extend(["m", "pthread", "dl"])

--- a/recipes/wgpu_native/all/test_package/CMakeLists.txt
+++ b/recipes/wgpu_native/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+find_package(wgpu_native REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} src/example.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE wgpu_native::wgpu_native)

--- a/recipes/wgpu_native/all/test_package/conanfile.py
+++ b/recipes/wgpu_native/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.meson import Meson
+from conan.tools.layout import basic_layout
+
+
+class wgpu_nativeTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "PkgConfigDeps", "MesonToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+    
+    def build_requirements(self):
+        self.tool_requires("meson/[>1 <2]")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def layout(self):
+        basic_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
+            self.run(cmd, env="conanrun")

--- a/recipes/wgpu_native/all/test_package/conanfile.py
+++ b/recipes/wgpu_native/all/test_package/conanfile.py
@@ -1,29 +1,25 @@
 import os
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.meson import Meson
-from conan.tools.layout import basic_layout
+from conan.tools.cmake import cmake_layout, CMake
 
 
-class wgpu_nativeTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "PkgConfigDeps", "MesonToolchain"
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-    
-    def build_requirements(self):
-        self.tool_requires("meson/[>1 <2]")
-
-    def build(self):
-        meson = Meson(self)
-        meson.configure()
-        meson.build()
 
     def layout(self):
-        basic_layout(self)
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
         if can_run(self):
-            cmd = os.path.join(self.cpp.build.bindir, "example")
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(cmd, env="conanrun")

--- a/recipes/wgpu_native/all/test_package/meson.build
+++ b/recipes/wgpu_native/all/test_package/meson.build
@@ -1,3 +1,0 @@
-project('Testwgpu-native', 'cpp')
-wgpu_native = dependency('wgpu_native', version: '>=0.19.4.1')
-executable('example', 'src/example.cpp', dependencies: wgpu_native)

--- a/recipes/wgpu_native/all/test_package/meson.build
+++ b/recipes/wgpu_native/all/test_package/meson.build
@@ -1,0 +1,3 @@
+project('Testwgpu-native', 'cpp')
+wgpu_native = dependency('wgpu_native', version: '>=0.19.4.1')
+executable('example', 'src/example.cpp', dependencies: wgpu_native)

--- a/recipes/wgpu_native/all/test_package/src/example.cpp
+++ b/recipes/wgpu_native/all/test_package/src/example.cpp
@@ -1,0 +1,9 @@
+#include "webgpu.h"
+#include "wgpu.h"
+
+#include <cstdlib>
+
+int main() {
+  uint32_t version = wgpuGetVersion();
+  return version >= 1246209 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/recipes/wgpu_native/config.yml
+++ b/recipes/wgpu_native/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.19.4.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **wgpu-native/0.19.4.1**

WebGPU, despite its name, is not only usable from web browsers. [wgpu-native](https://github.com/gfx-rs/wgpu-native) is Mozilla's native implementation in rust.
It's useful to various graphical native applications and games.

This recipe uses prebuilt binaries from the project, to avoid dependency on the rust toolchain.

I haven't tried with hooks enabled, since they don't seem to be supported by conan 2.x.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
