### PR TITLE
[boost] Allow building old compilers using C++11

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -265,7 +265,7 @@ class BoostConan(ConanFile):
             return valid_min_cppstd(self, 11)
         compiler_version = self._min_compiler_version_default_cxx11
         if compiler_version:
-            return (Version(self.settings.compiler.version) >= compiler_version) and "11" in supported_cppstd(self)
+            return (Version(self.settings.compiler.version) >= compiler_version) or "11" in supported_cppstd(self)
 
     @property
     def _has_cppstd_14_supported(self):
@@ -287,7 +287,7 @@ class BoostConan(ConanFile):
     def _min_compiler_version_nowide(self):
         # Nowide needs c++11 + swappable std::fstream
         return {
-            "gcc": 5,
+            "gcc": 4.8,
             "clang": 5,
             "Visual Studio": 14,  # guess
             "msvc": 190,  # guess
@@ -435,6 +435,9 @@ class BoostConan(ConanFile):
                     self.output.warning("Assuming the compiler supports c++11 by default")
                 elif not self._has_cppstd_11_supported:
                     disable_math()
+                # Boost.Math is not built when the compiler is GCC < 5 and uses C++11
+                elif self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "5":
+                    disable_math()
 
         if Version(self.version) >= "1.79.0":
             # Starting from 1.79.0, Boost.Wave requires a c++11 capable compiler
@@ -457,6 +460,9 @@ class BoostConan(ConanFile):
                     self.output.warning("Assuming the compiler supports c++11 by default")
                 elif not self._has_cppstd_11_supported:
                     disable_wave()
+                # Boost.Wave is not built when the compiler is GCC < 5 and uses C++11
+                elif self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "5":
+                    disable_wave()
 
         if Version(self.version) >= "1.81.0":
             # Starting from 1.81.0, Boost.Locale requires a c++11 capable compiler
@@ -478,6 +484,9 @@ class BoostConan(ConanFile):
                 if min_compiler_version is None:
                     self.output.warning("Assuming the compiler supports c++11 by default")
                 elif not self._has_cppstd_11_supported:
+                    disable_locale()
+                # Boost.Locale is not built when the compiler is GCC < 5 and uses C++11
+                elif self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "5":
                     disable_locale()
 
         if Version(self.version) >= "1.84.0":

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -265,7 +265,7 @@ class BoostConan(ConanFile):
             return valid_min_cppstd(self, 11)
         compiler_version = self._min_compiler_version_default_cxx11
         if compiler_version:
-            return (Version(self.settings.compiler.version) >= compiler_version) or "11" in supported_cppstd(self)
+            return (Version(self.settings.compiler.version) >= compiler_version) and "11" in supported_cppstd(self)
 
     @property
     def _has_cppstd_14_supported(self):


### PR DESCRIPTION
Specify library name and version:  **boost/1.83.0**

Tested locally using deprecated Docker image `conanio/gcc48` and Conan 1.59.0:

```
$ conan create . 1.83.0@
Exporting package recipe
boost/1.83.0 exports: File 'conandata.yml' found. Exporting it...
boost/1.83.0 exports: Copied 1 '.yml' file: conandata.yml
boost/1.83.0: Calling export()
boost/1.83.0: Copied 1 '.yml' file: dependencies-1.83.0.yml
boost/1.83.0: Calling export_sources()
boost/1.83.0: The stored package has not changed
boost/1.83.0: Source folder is corrupted, forcing removal
boost/1.83.0: Exported revision: 8ad9800a94fb1cd8dc6ace6c815cfde3
Configuration:
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++
compiler.version=4.8
os=Linux
os_build=Linux
[options]
[build_requires]
[env]

boost/1.83.0: Forced build from source
Version ranges solved
    Version range '>=1.2.11 <2' required by 'boost/1.83.0' resolved to 'zlib/1.3.1' in local cache

boost/1.83.0 (test package): Installing package
Requirements
    boost/1.83.0 from local cache - Cache
    bzip2/1.0.8 from 'conancenter' - Cache
    libbacktrace/cci.20210118 from 'conancenter' - Cache
    zlib/1.3.1 from 'conancenter' - Cache
Packages
    boost/1.83.0:400b2cac9a3fa907dbfd380207c831419da3bbbf - Build
    bzip2/1.0.8:9060f665b3af45e4f562113d4ba55aeee0451e61 - Cache
    libbacktrace/cci.20210118:3a5f72c8cd50641b8efa6ed13e6914c6ced2747c - Cache
    zlib/1.3.1:3a5f72c8cd50641b8efa6ed13e6914c6ced2747c - Cache
Build requirements
    b2/4.10.1 from 'conancenter' - Cache
Build requirements packages
    b2/4.10.1:4db1be536558d833e52e862fd84d64d75c2b3656 - Cache

Installing (downloading, building) binaries...
b2/4.10.1: Already installed!
bzip2/1.0.8: Already installed!
libbacktrace/cci.20210118: Already installed!
zlib/1.3.1: Already installed!
boost/1.83.0: Applying build-requirement: b2/4.10.1
boost/1.83.0: WARN: Build folder is dirty, removing it: /home/conan/.conan/data/boost/1.83.0/_/_/build/400b2cac9a3fa907dbfd380207c831419da3bbbf
boost/1.83.0: Configuring sources in /home/conan/.conan/data/boost/1.83.0/_/_/source/src
Downloading boost_1_83_0.tar.bz2 completed [120012.45k]                                  boost/1.83.0: /1.83.0: 
boost/1.83.0: 
boost/1.83.0: Apply patch (conan): Optional flag to specify iconv from either libc of libiconv
boost/1.83.0: Apply patch (official): Fix compilation on windows when NOMINMAX is not defined
boost/1.83.0: Building your package in /home/conan/.conan/data/boost/1.83.0/_/_/build/400b2cac9a3fa907dbfd380207c831419da3bbbf
boost/1.83.0: Generator txt created conanbuildinfo.txt
boost/1.83.0: Calling generate()
boost/1.83.0: Aggregating env generators
boost/1.83.0: Calling build()
boost/1.83.0: WARN: replace_in_file didn't find pattern '/* thread_local */' in '/home/conan/.conan/data/boost/1.83.0/_/_/source/src/boost/stacktrace/detail/libbacktrace_impls.hpp' file.
boost/1.83.0: WARN: replace_in_file didn't find pattern '/* static __thread */' in '/home/conan/.conan/data/boost/1.83.0/_/_/source/src/boost/stacktrace/detail/libbacktrace_impls.hpp' file.
boost/1.83.0: WARN: replace_in_file didn't find pattern 'local generic-os = [ set.difference $(all-os) : aix darwin vxworks solaris osf hpux ] ;' in '/home/conan/.conan/data/boost/1.83.0/_/_/source/src/tools/build/src/tools/gcc.jam' file.
boost/1.83.0: WARN: replace_in_file didn't find pattern 'local no-threading = android beos haiku sgi darwin vxworks ;' in '/home/conan/.conan/data/boost/1.83.0/_/_/source/src/tools/build/src/tools/gcc.jam' file.
boost/1.83.0: WARN: Patching user-config.jam
boost/1.83.0: WARN: Using the new toolchains and generators without specifying a build profile (e.g: -pr:b=default) is discouraged and might cause failures and unexpected behavior
boost/1.83.0: WARN: 
using zlib : 1.3.1 : <include>"/home/conan/.conan/data/zlib/1.3.1/_/_/package/3a5f72c8cd50641b8efa6ed13e6914c6ced2747c/include" <search>"/home/conan/.conan/data/zlib/1.3.1/_/_/package/3a5f72c8cd50641b8efa6ed13e6914c6ced2747c/lib" <name>z ;
using bzip2 : 1.0.8 : <include>"/home/conan/.conan/data/bzip2/1.0.8/_/_/package/9060f665b3af45e4f562113d4ba55aeee0451e61/include" <search>"/home/conan/.conan/data/bzip2/1.0.8/_/_/package/9060f665b3af45e4f562113d4ba55aeee0451e61/lib" <name>bz2 ;
using "gcc" :  :  "/usr/bin/g++-4.8" : 
<compileflags>"-I/home/conan/.conan/data/libbacktrace/cci.20210118/_/_/package/3a5f72c8cd50641b8efa6ed13e6914c6ced2747c/include" <linkflags>"-L/home/conan/.conan/data/libbacktrace/cci.20210118/_/_/package/3a5f72c8cd50641b8efa6ed13e6914c6ced2747c/lib"  ;
boost/1.83.0: WARN: b2 -q target-os=linux architecture=x86 address-model=64 binary-format=elf abi=sysv --layout=system --user-config=/home/conan/.conan/data/boost/1.83.0/_/_/source/src/tools/build/user-config.jam -sNO_ZLIB=0 -sNO_BZIP2=0 -sNO_LZMA=1 -sNO_ZSTD=1 boost.locale.icu=off --disable-icu boost.locale.iconv=off --disable-iconv threading=multi visibility=hidden link=static variant=release --with-atomic --with-chrono --with-container --with-context --with-contract --with-coroutine --with-date_time --with-exception --with-filesystem --with-iostreams --with-log --with-program_options --with-random --with-regex --with-serialization --with-stacktrace --with-system --with-test --with-thread --with-timer --with-type_erasure toolset=gcc define=_GLIBCXX_USE_CXX11_ABI=0 pch=on -sLIBBACKTRACE_PATH=/home/conan/.conan/data/libbacktrace/cci.20210118/_/_/package/3a5f72c8cd50641b8efa6ed13e6914c6ced2747c linkflags="" cxxflags="-fPIC -DBOOST_STACKTRACE_ADDR2LINE_LOCATION=/usr/bin/addr2line" install --prefix=/home/conan/.conan/data/boost/1.83.0/_/_/package/400b2cac9a3fa907dbfd380207c831419da3bbbf -j2 --abbreviate-paths -d0 --debug-configuration --build-dir="/home/conan/.conan/data/boost/1.83.0/_/_/build/400b2cac9a3fa907dbfd380207c831419da3bbbf/build-release"
notice: found boost-build.jam at /home/conan/.conan/data/boost/1.83.0/_/_/source/src/boost-build.jam
notice: loading B2 from /home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/kernel/bootstrap.jam
notice: Searching '/etc' '/home/conan' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/kernel' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/util' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/build' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/tools' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/contrib' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/.' for site-config configuration file 'site-config.jam'.
notice: Configuration file 'site-config.jam' not found in '/etc' '/home/conan' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/kernel' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/util' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/build' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/tools' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/contrib' '/home/conan/.conan/data/b2/4.10.1/_/_/package/4db1be536558d833e52e862fd84d64d75c2b3656/bin/.b2/.'.
notice: Loading explicitly specified user configuration file:
    /home/conan/.conan/data/boost/1.83.0/_/_/source/src/tools/build/user-config.jam
notice: Searching '/home/conan/.conan/data/boost/1.83.0/_/_/source/src/tools/build' for user-config configuration file 'user-config.jam'.
notice: Loading user-config configuration file 'user-config.jam' from '/home/conan/.conan/data/boost/1.83.0/_/_/source/src/tools/build'.
notice: [zlib] Using pre-installed library
notice: [zlib] Condition
notice: [bzip2] Using pre-installed library
notice: [bzip2] Condition
notice: will use '/usr/bin/g++-4.8' for gcc, condition <toolset>gcc-4.8
notice: using gcc libraries :: <toolset>gcc-4.8 :: /usr/bin /usr/lib /usr/lib32 /usr/lib64
notice: using gcc archiver :: <toolset>gcc-4.8 :: /usr/bin/ar
warning: toolset gcc initialization: can not find tool windres
warning: initialized from /home/conan/.conan/data/boost/1.83.0/_/_/source/src/tools/build/user-config.jam:5
notice: using rc compiler :: <toolset>gcc-4.8 :: /usr/bin/as
notice: [zlib] zlib is already configured
notice: [bzip2] bzip is already configured
notice: iostreams: not using lzma compression 
notice: iostreams: not using zstd compression 
notice: [python-cfg] Configuring python...
notice: [python-cfg] Checking interpreter command "python"...
notice: [python-cfg] running command 'python -c "from sys import *; print('version=%d.%d\nplatform=%s\nprefix=%s\nexec_prefix=%s\nexecutable=%s' % (version_info[0],version_info[1],platform,prefix,exec_prefix,executable))" 2>&1'
notice: [python-cfg] ...requested configuration matched!
notice: [python-cfg] Details of this Python configuration:
notice: [python-cfg]   interpreter command: "python"
notice: [python-cfg]   include path: "/opt/pyenv/versions/3.6.15/include/python3.6m"
notice: [python-cfg]   library path: "/opt/pyenv/versions/3.6.15/lib/python3.6/config" "/opt/pyenv/versions/3.6.15/lib"
notice: [python-cfg] Checking for NumPy...
notice: [python-cfg] running command 'python -c "import sys; sys.stderr = sys.stdout; import numpy; print(numpy.get_include())"'
notice: [python-cfg] NumPy disabled. Reason:
notice: [python-cfg]   python -c "import sys; sys.stderr = sys.stdout; import numpy; print(numpy.get_include())" aborted with 
notice: [python-cfg]   Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'numpy'
Performing configuration checks

    - default address-model    : 64-bit [1]
    - default architecture     : x86 [1]
    - compiler supports SSE2   : yes [2]
    - compiler supports SSE4.1 : yes [2]
    - has std::atomic_ref      : no [2]
    - has statx                : no [2]
    - has statx syscall        : no [2]
    - has init_priority attribute : yes [2]
    - has stat::st_blksize     : yes [2]
    - has stat::st_mtim        : yes [2]
    - has stat::st_mtimensec   : no [2]
    - has stat::st_mtimespec   : no [2]
    - has stat::st_birthtim    : no [2]
    - has stat::st_birthtimensec : no [2]
    - has stat::st_birthtimespec : no [2]
    - has fdopendir(O_NOFOLLOW) : yes [2]
    - has dirent::d_type       : yes [2]
    - has POSIX *at APIs       : yes [2]
    - zlib                     : yes [3]
    - bzip2                    : yes [3]
    - native atomic int32 supported : yes [2]
    - native syslog supported  : yes [2]
    - pthread supports robust mutexes : yes [2]
    - has_icu builds           : no [2]
    - lockfree boost::atomic_flag : yes [2]
    - compiler supports SSSE3  : yes [2]
    - compiler supports AVX2   : yes [2]
    - libbacktrace builds      : yes [2]
    - addr2line builds         : yes [2]
    - WinDbg builds            : no [2]
    - WinDbg builds            : no [4]
    - WinDbgCached builds      : no [2]
    - WinDbgCached builds      : no [4]
    - BOOST_COMP_GNUC >= 4.3.0 : yes [2]

[1] gcc-4.8
[2] gcc-4.8/rls/bst.l-off/bst.l-off/lnk-sttc/pythn-3.6/thrd-mlt/vsblt-hdn
[3] lnk-sttc
[4] gcc-4.8/rls/bst.l-off/bst.l-off/bld-no/lnk-sttc/pythn-3.6/thrd-mlt/vsblt-hdn

Component configuration:

    - atomic                   : building
    - chrono                   : building
    - container                : building
    - context                  : building
    - contract                 : building
    - coroutine                : building
    - date_time                : building
    - exception                : building
    - fiber                    : not building
    - filesystem               : building
    - graph                    : not building
    - graph_parallel           : not building
    - headers                  : not building
    - iostreams                : building
    - json                     : not building
    - locale                   : not building
    - log                      : building
    - math                     : not building
    - mpi                      : not building
    - nowide                   : not building
    - program_options          : building
    - python                   : not building
    - random                   : building
    - regex                    : building
    - serialization            : building
    - stacktrace               : building
    - system                   : building
    - test                     : building
    - thread                   : building
    - timer                    : building
    - type_erasure             : building
    - url                      : not building
    - wave                     : not building

boost/1.83.0: Package '400b2cac9a3fa907dbfd380207c831419da3bbbf' built
boost/1.83.0: Build folder /home/conan/.conan/data/boost/1.83.0/_/_/build/400b2cac9a3fa907dbfd380207c831419da3bbbf/build-release
boost/1.83.0: Generated conaninfo.txt
boost/1.83.0: Generated conanbuildinfo.txt
boost/1.83.0: Generating the package
boost/1.83.0: Package folder /home/conan/.conan/data/boost/1.83.0/_/_/package/400b2cac9a3fa907dbfd380207c831419da3bbbf
boost/1.83.0: Calling package()
boost/1.83.0: Copied 1 '.txt' file: LICENSE_1_0.txt
boost/1.83.0 package(): Packaged 1 '.txt' file: LICENSE_1_0.txt
boost/1.83.0 package(): Packaged 15177 '.hpp' files
boost/1.83.0 package(): Packaged 148 '.h' files
boost/1.83.0 package(): Packaged 310 '.ipp' files
boost/1.83.0 package(): Packaged 2 '.inc' files: strict_cpp_re.inc, cpp_re.inc
boost/1.83.0 package(): Packaged 17 files
boost/1.83.0 package(): Packaged 28 '.a' files
boost/1.83.0: Package '400b2cac9a3fa907dbfd380207c831419da3bbbf' created
boost/1.83.0: Created package revision 27eae4eeff6c4a0e827774bc8959a3bf
```

fixes #23973

/cc @Rickylss


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
