### PR TITLE
glaze: add version 2.6.2

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.2":
+    url: "https://github.com/stephenberry/glaze/archive/v2.6.2.tar.gz"
+    sha256: "8498de2b5e80b4eeab07108ea8ed460d4bbfef56f533ff08ca9e119501185dc4"
   "2.6.1":
     url: "https://github.com/stephenberry/glaze/archive/v2.6.1.tar.gz"
     sha256: "c8b1d981329f279b85f6ee732e2c3cc9d0d2e014ef3d79cb72bf67dc9f2357d4"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.2":
+    folder: all
   "2.6.1":
     folder: all
   "2.6.0":


### PR DESCRIPTION
Specify library name and version:  **glaze/2.6.2**

https://github.com/stephenberry/glaze/compare/v2.6.1...v2.6.2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
