### PR TITLE
mpdecimal: remove deprecated 'path' functions

### DIFF
--- a/recipes/mpdecimal/2.4.2/conanfile.py
+++ b/recipes/mpdecimal/2.4.2/conanfile.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
@@ -171,18 +172,18 @@ class MpdecimalConan(ConanFile):
 
     @property
     def _libmpdec_folder(self):
-        return self.source_path / "libmpdec"
+        return Path(self.source_folder) / "libmpdec"
 
     @property
     def _dist_folder(self):
-        vcbuild_folder = self.build_path / "vcbuild"
+        vcbuild_folder = Path(self.build_folder) / "vcbuild"
         arch_ext = "32" if self.settings.arch == "x86" else "64"
         return vcbuild_folder / f"dist{arch_ext}"
 
     def _build_msvc(self):
         libmpdec_folder = self._libmpdec_folder
-        copy(self, "Makefile.vc", libmpdec_folder, self.build_path)
-        rename(self, self.build_path / "Makefile.vc", libmpdec_folder / "Makefile")
+        copy(self, "Makefile.vc", libmpdec_folder, self.build_folder)
+        rename(self, os.path.join(self.build_folder, "Makefile.vc"), libmpdec_folder / "Makefile")
 
         ext = "dll" if self.options.shared else "lib"
         mpdec_target = f"libmpdec-{self.version}.{ext}"

--- a/recipes/mpdecimal/2.4.2/conanfile.py
+++ b/recipes/mpdecimal/2.4.2/conanfile.py
@@ -183,7 +183,7 @@ class MpdecimalConan(ConanFile):
     def _build_msvc(self):
         libmpdec_folder = self._libmpdec_folder
         copy(self, "Makefile.vc", libmpdec_folder, self.build_folder)
-        rename(self, os.path.join(self.build_folder, "Makefile.vc"), libmpdec_folder / "Makefile")
+        rename(self, Path(self.build_folder) / "Makefile.vc", libmpdec_folder / "Makefile")
 
         ext = "dll" if self.options.shared else "lib"
         mpdec_target = f"libmpdec-{self.version}.{ext}"

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from conan import ConanFile

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -120,11 +120,11 @@ class MpdecimalConan(ConanFile):
         return vcbuild_folder / f"dist{arch_ext}"
 
     def _build_msvc(self):
-        libmpdec_folder = os.path.join(self.source_folder, "libmpdec")
-        libmpdecpp_folder = os.path.join(self.source_folder, "libmpdec++")
+        libmpdec_folder = Path(self.source_folder) / "libmpdec"
+        libmpdecpp_folder = Path(self.source_folder) / "libmpdec++"
 
         copy(self, "Makefile.vc", libmpdec_folder, self.build_folder)
-        rename(self, os.path.join(self.build_folder, "Makefile.vc"), os.path.join(libmpdec_folder, "Makefile"))
+        rename(self, Path(self.build_folder) / "Makefile.vc", libmpdec_folder / "Makefile")
 
         mpdec_target = "libmpdec-{}.{}".format(self.version, "dll" if self.options.shared else "lib")
         mpdecpp_target = "libmpdec++-{}.{}".format(self.version, "dll" if self.options.shared else "lib")
@@ -183,11 +183,11 @@ class MpdecimalConan(ConanFile):
             autotools = Autotools(self)
             autotools.configure()
             libmpdec, libmpdecpp = self._target_names
-            copy(self, "*", os.path.join(self.source_folder, "libmpdec"), os.path.join(self.build_folder, "libmpdec"))
+            copy(self, "*", Path(self.source_folder) / "libmpdec", Path(self.build_folder) / "libmpdec")
             with chdir(self, "libmpdec"):
                 autotools.make(target=libmpdec)
             if self.options.cxx:
-                copy(self, "*", os.path.join(self.source_folder, "libmpdec++"), os.path.join(self.build_folder, "libmpdec++"))
+                copy(self, "*", Path(self.source_folder) / "libmpdec++", Path(self.build_folder) / "libmpdec++")
                 with chdir(self, "libmpdec++"):
                     autotools.make(target=libmpdecpp)
 
@@ -196,15 +196,15 @@ class MpdecimalConan(ConanFile):
         copy(self, "LICENSE.txt", src=self.source_folder, dst=pkg_dir / "licenses")
         if is_msvc(self):
             distfolder = self._dist_folder
-            copy(self, "vc*.h", src=os.path.join(self.source_folder, "libmpdec"), dst=pkg_dir / "include")
+            copy(self, "vc*.h", src=Path(self.source_folder) / "libmpdec", dst=pkg_dir / "include")
             copy(self, "*.h", src=distfolder, dst=pkg_dir / "include")
             if self.options.cxx:
                 copy(self, "*.hh", src=distfolder, dst=pkg_dir / "include")
             copy(self, "*.lib", src=distfolder, dst=pkg_dir / "lib")
             copy(self, "*.dll", src=distfolder, dst=pkg_dir / "bin")
         else:
-            mpdecdir = os.path.join(self.build_folder, "libmpdec")
-            mpdecppdir = os.path.join(self.build_folder, "libmpdec++")
+            mpdecdir = Path(self.build_folder) / "libmpdec"
+            mpdecppdir = Path(self.build_folder) / "libmpdec++"
             copy(self, "mpdecimal.h", src=mpdecdir, dst=pkg_dir / "include")
             if self.options.cxx:
                 copy(self, "decimal.hh", src=mpdecppdir, dst=pkg_dir / "include")


### PR DESCRIPTION
Specify library name and version:  mpdecimal

Replace deprecated `path` functions with the corresponding `folder` functions.

Follow up to: https://github.com/conan-io/conan/pull/16247

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
