### PR TITLE
libqasm: add version 0.6.6

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.6":
+    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.6.tar.gz"
+    sha256: "b3a2d1670f8865ce22bcc62c6a696ee7e0764a7b76901a4f082efa2287e0cbad"
   "0.6.5":
     url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.5.tar.gz"
     sha256: "0577622a512d1f64892949af02abe3d0b53195ad454045715a0ebf837ecde0d6"

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,4 +1,5 @@
 versions:
-  # Newer versions at the top
+  "0.6.6":
+    folder: all
   "0.6.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libqasm/0.6.6**

Add version 0.6.6.


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
