### PR TITLE
Update msgpack to v2

### DIFF
--- a/recipes/msgpack/all/CMakeLists.txt
+++ b/recipes/msgpack/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.0)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/msgpack/all/test_package/CMakeLists.txt
+++ b/recipes/msgpack/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+project(test_package LANGUAGES CXX)
 
 find_package(msgpack REQUIRED CONFIG)
 


### PR DESCRIPTION
Update of msgpack to conan v2.
Probably, on the road, I drop support for conan v1. 

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
