### PR TITLE
librdkafka: fix link to openssl debug for msvc

### DIFF
--- a/recipes/librdkafka/all/conanfile.py
+++ b/recipes/librdkafka/all/conanfile.py
@@ -1,8 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, replace_in_file
-from conan.tools.microsoft import is_msvc
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.gnu import PkgConfigDeps
 import os
 
@@ -110,11 +109,6 @@ class LibrdkafkaConan(ConanFile):
 
     def build(self):
         apply_conandata_patches(self)
-        # There are references to libcrypto.lib and libssl.lib in rdkafka_ssl.c for versions >= 1.8.0
-        if is_msvc(self) and self.settings.build_type == "Debug" and self.options.get_safe("ssl", False):
-            rdkafka_ssl_path = os.path.join(self.source_folder, "src", "rdkafka_ssl.c")
-            replace_in_file(self, rdkafka_ssl_path, "libcrypto.lib", "libcryptod.lib")
-            replace_in_file(self, rdkafka_ssl_path, "libssl.lib", "libssld.lib")
         cmake = CMake(self)
         cmake.configure()
         cmake.build()


### PR DESCRIPTION
Do not rename openssl libs anymore if debug in `rdkafka_ssl.c`, since openssl recipe doesn't add d postfix anymore after https://github.com/conan-io/conan-center-index/pull/20999

closes https://github.com/conan-io/conan-center-index/issues/23988

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
