### PR TITLE
Qt5 various fixes

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -29,8 +29,6 @@ patches:
       "patch_file": "patches/fix-macdeployqt.diff"
     - "base_path": "qt5/qtwebengine/src/3rdparty"
       "patch_file": "patches/0001-Find-fontconfig-using-pkg-config.patch"
-    - "base_path": "qt5/qtwebengine/src/3rdparty"
-      "patch_file": "patches/Fix-errors-and-warnings-for-perfetto.patch"
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/android-openssl.diff"
     - "base_path": "qt5/qtwebengine"

--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -29,6 +29,8 @@ patches:
       "patch_file": "patches/fix-macdeployqt.diff"
     - "base_path": "qt5/qtwebengine/src/3rdparty"
       "patch_file": "patches/0001-Find-fontconfig-using-pkg-config.patch"
+    - "base_path": "qt5/qtwebengine/src/3rdparty"
+      "patch_file": "patches/Fix-errors-and-warnings-for-perfetto.patch"
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/android-openssl.diff"
     - "base_path": "qt5/qtwebengine"

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1014,9 +1014,6 @@ Prefix = ..""")
             if self.options.gui:
                 _create_private_module("Quick", ["CorePrivate", "GuiPrivate", "QmlPrivate", "Quick"])
 
-            if self.options.gui:
-                _create_private_module("Quick", ["CorePrivate", "GuiPrivate", "QmlPrivate", "Quick"])
-
         if self.options.qtscxml:
             _create_private_module("Scxml", ["Scxml", "Qml"])
 

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -56,7 +56,7 @@ class QtConan(ConanFile):
         "with_libjpeg": ["libjpeg", "libjpeg-turbo", False],
         "with_libpng": [True, False],
         "with_sqlite3": [True, False],
-        "with_mysql": [True, False],
+        "with_mysql": ["mysql", "mariadb", False],
         "with_pq": [True, False],
         "with_odbc": [True, False],
         "with_libalsa": [True, False],
@@ -100,7 +100,7 @@ class QtConan(ConanFile):
         "with_libjpeg": "libjpeg",
         "with_libpng": True,
         "with_sqlite3": True,
-        "with_mysql": True,
+        "with_mysql": "mysql",
         "with_pq": True,
         "with_odbc": True,
         "with_libalsa": False,
@@ -191,7 +191,6 @@ class QtConan(ConanFile):
         if self.settings.compiler in ["gcc", "clang"] and Version(self.settings.compiler.version) < "5.3":
             del self.options.with_mysql
         if self.settings.os == "Windows":
-            self.options.with_mysql = False
             self.options.opengl = "dynamic"
             del self.options.with_gssapi
         if self.settings.os != "Linux":
@@ -422,8 +421,10 @@ class QtConan(ConanFile):
             self.requires("libpng/[>=1.6 <2]")
         if self.options.with_sqlite3 and not self.options.multiconfiguration:
             self.requires("sqlite3/[>=3.45.0 <4]")
-        if self.options.get_safe("with_mysql", False):
+        if self.options.get_safe("with_mysql", False) == "mysql":
             self.requires("libmysqlclient/8.1.0")
+        if self.options.get_safe("with_mysql", False) == "mariadb":
+            self.requires("mariadb-connector-c/3.3.3")
         if self.options.with_pq:
             self.requires("libpq/15.4")
         if self.options.with_odbc:
@@ -760,6 +761,7 @@ class QtConan(ConanFile):
                   ("libjpeg-turbo", "LIBJPEG"),
                   ("libpng", "LIBPNG"),
                   ("sqlite3", "SQLITE"),
+                  ("mariadb-connector-c", "MYSQL"),
                   ("libmysqlclient", "MYSQL"),
                   ("libpq", "PSQL"),
                   ("odbc", "ODBC"),
@@ -787,6 +789,8 @@ class QtConan(ConanFile):
 
         if "libmysqlclient" in [d.ref.name for d in self.dependencies.direct_host.values()]:
             args.append("-mysql_config \"%s\"" % os.path.join(self.dependencies["libmysqlclient"].package_folder, "bin", "mysql_config"))
+        if "mariadb-connector-c" in [d.ref.name for d in self.dependencies.direct_host.values()]:
+            args.append("-mysql_config \"%s\"" % os.path.join(self.dependencies["mariadb-connector-c"].package_folder, "bin", "mysql_config"))
         if "libpq" in [d.ref.name for d in self.dependencies.direct_host.values()]:
             args.append("-psql_config \"%s\"" % os.path.join(self.dependencies["libpq"].package_folder, "bin", "pg_config"))
         if self.settings.os == "Macos":
@@ -1257,8 +1261,10 @@ Prefix = ..""")
             _create_plugin("QSQLiteDriverPlugin", "qsqlite", "sqldrivers", ["sqlite3::sqlite3"])
         if self.options.with_pq:
             _create_plugin("QPSQLDriverPlugin", "qsqlpsql", "sqldrivers", ["libpq::libpq"])
-        if self.options.get_safe("with_mysql", False):
+        if self.options.get_safe("with_mysql", False) == "mysql":
             _create_plugin("QMySQLDriverPlugin", "qsqlmysql", "sqldrivers", ["libmysqlclient::libmysqlclient"])
+        if self.options.get_safe("with_mysql", False) == "mariadb":
+            _create_plugin("QMySQLDriverPlugin", "qsqlmysql", "sqldrivers", ["mariadb-connector-c::mariadb-connector-c"])
         if self.options.with_odbc:
             if self.settings.os != "Windows":
                 _create_plugin("QODBCDriverPlugin", "qsqlodbc", "sqldrivers", ["odbc::odbc"])

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1010,6 +1010,12 @@ Prefix = ..""")
             if self.options.gui:
                 _create_private_module("Quick", ["CorePrivate", "GuiPrivate", "QmlPrivate", "Quick"])
 
+            if self.options.gui:
+                _create_private_module("Quick", ["CorePrivate", "GuiPrivate", "QmlPrivate", "Quick"])
+
+        if self.options.qtscxml:
+            _create_private_module("Scxml", ["Scxml", "Qml"])
+
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Qt5")
         self.cpp_info.set_property("pkg_config_name", "qt5")
@@ -1370,6 +1376,7 @@ Prefix = ..""")
 
         if self.options.qtscxml:
             _create_module("Scxml", ["Qml"])
+            _add_build_module("qtScxml", self._cmake_qt5_private_file("Scxml"))
 
         if self.options.qtpurchasing:
             _create_module("Purchasing")

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1106,6 +1106,9 @@ Prefix = ..""")
         ]
         self.cpp_info.components["qtCore"].set_property("pkg_config_custom_content", "\n".join(pkg_config_vars))
 
+        if self.settings.build_type != "Debug":
+            self.cpp_info.components['qtCore'].defines.append('QT_NO_DEBUG')
+
         if self.settings.os == "Windows":
             module = "WinMain"
             componentname = f"qt{module}"


### PR DESCRIPTION
Specify library name and version:  **qt/5.15**

* ~Added a patch for QTBUG-117073 : QtWebEngine build error for msvc 2022~ Done in https://github.com/conan-io/conan-center-index/pull/24826 and part of the last 5.15.16
* Defined QT_NO_DEBUG for non Debug build
* ~Added missing private modules for Quick~ (done in https://github.com/conan-io/conan-center-index/pull/19082)  and Scxml
* Add support to use mariadb-connector-c  as sql backend instead of libmysqlclient

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
