### PR TITLE
glaze: add version 2.6.3 (dropped gcc11 support)

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
+  "2.6.3":
+    url: "https://github.com/stephenberry/glaze/archive/v2.6.3.tar.gz"
+    sha256: "5a2fd2a1ed18a184d7f86f5f8cd1350b12b8f2389466a436dfc198e3e6912c70"
+  # keep 2.6.2 for gcc11
   "2.6.2":
     url: "https://github.com/stephenberry/glaze/archive/v2.6.2.tar.gz"
     sha256: "8498de2b5e80b4eeab07108ea8ed460d4bbfef56f533ff08ca9e119501185dc4"

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -28,7 +28,7 @@ class GlazeConan(ConanFile):
         return {
             "Visual Studio": "17",
             "msvc": "193",
-            "gcc": "11",
+            "gcc": "11" if Version(self.version) < "2.6.3" else "12",
             # glaze >= 2.1.6 uses std::bit_cast which is supported by clang >= 14
             "clang": "12" if Version(self.version) < "2.1.6" else "14",
             "apple-clang": "13.1",

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.3":
+    folder: all
   "2.6.2":
     folder: all
   "2.6.1":


### PR DESCRIPTION
Specify library name and version:  **glaze/2.6.3**

glaze/2.6.3 dropped gcc11 support.

https://github.com/stephenberry/glaze/compare/v2.6.2...v2.6.3

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
