### PR TITLE
ctre: add version 3.9.0

### DIFF
--- a/recipes/ctre/all/conandata.yml
+++ b/recipes/ctre/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.9.0":
+    url: "https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.9.0.tar.gz"
+    sha256: "55778712968d4f3ad00e9d20fc4d2149d14d96b4ff3dab086613797cd2ccd2b2"
   "3.8.1":
     url: "https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.8.1.tar.gz"
     sha256: "0ce8760d43b3b97b43364cd32ee663e5c8b8b4bfd58e7890042eff6ac52db605"

--- a/recipes/ctre/config.yml
+++ b/recipes/ctre/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.9.0":
+    folder: all
   "3.8.1":
     folder: all
   "3.8":


### PR DESCRIPTION
Specify library name and version:  **ctre/3.9.0**

https://github.com/hanickadot/compile-time-regular-expressions/compare/v3.8.1...v3.9.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
