### PR TITLE
etl: add version 20.38.15

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.38.15":
+    url: "https://github.com/ETLCPP/etl/archive/20.38.15.tar.gz"
+    sha256: "c4f3108b35eb669ce4a6a217264ca133fe52cc8b5bce026a474ec81c0a2c4026"
   "20.38.14":
     url: "https://github.com/ETLCPP/etl/archive/20.38.14.tar.gz"
     sha256: "d286191f0617e1c6c85e1ecb2175e84035918a7bf67d0bb347a8cb6fca3b2db4"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.38.15":
+    folder: all
   "20.38.14":
     folder: all
   "20.38.13":


### PR DESCRIPTION
Specify library name and version:  **etl/20.38.15**

https://github.com/ETLCPP/etl/compare/20.38.14...20.38.15

Small updates for compilation errors.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
