### PR TITLE
libbsd: Fix check if getentropy needs building

### DIFF
--- a/recipes/libbsd/all/conandata.yml
+++ b/recipes/libbsd/all/conandata.yml
@@ -8,3 +8,7 @@ patches:
       patch_description: "Enables building on MacOS"
       patch_type: "portability"
       patch_source: "https://github.com/NixOS/nixpkgs/blob/1016bfcff1df163aff75d908df1e00f897a29b9b/pkgs/development/libraries/libbsd/darwin.patch"
+    - patch_file: "patches/0002-fix-getentropy-conditional.patch"
+      patch_description: "Fix check if getentropy needs building"
+      patch_type: "backport"
+      patch_source: "https://gitlab.freedesktop.org/libbsd/libbsd/-/commit/5cfa39e5cde6b64ccf3d1335cee4d4744d4ce242.patch"

--- a/recipes/libbsd/all/patches/0002-fix-getentropy-conditional.patch
+++ b/recipes/libbsd/all/patches/0002-fix-getentropy-conditional.patch
@@ -1,0 +1,31 @@
+From 5cfa39e5cde6b64ccf3d1335cee4d4744d4ce242 Mon Sep 17 00:00:00 2001
+From: Guillem Jover <guillem@hadrons.org>
+Date: Wed, 23 Nov 2022 23:42:49 +0100
+Subject: [PATCH] =?UTF-8?q?build:=20Use=20=C2=AByes=C2=BB=20instead=20of?=
+ =?UTF-8?q?=20=C2=ABtrue=C2=BB=20for=20AC=5FCHECK=5FFUNCS=20cache=20value?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This autoconf macro sets the ac_cv_func_ cached variable to «yes» not
+«true» so we were checking for an impossible condition.
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 17d113c..842f5d6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -173,7 +173,7 @@ AC_CHECK_FUNCS([clearenv dirfd fopencookie __fpurge \
+                 getauxval getentropy getexecname getline \
+                 pstat_getproc sysconf \
+ 		strlcpy strlcat strnstr strmode fpurge])
+-AM_CONDITIONAL([HAVE_GETENTROPY], [test "x$ac_cv_func_getentropy" = "xtrue"])
++AM_CONDITIONAL([HAVE_GETENTROPY], [test "x$ac_cv_func_getentropy" = "xyes"])
+ 
+ AC_CONFIG_FILES([
+ 	Makefile
+-- 
+GitLab
+


### PR DESCRIPTION
Specify library name and version:  **libbsd/0.10.0**

This patch fixes the check to avoid building `getentropy.c` in case the system libc already provides that symbol.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
