### PR TITLE
glaze: add version 2.6.4

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.4":
+    url: "https://github.com/stephenberry/glaze/archive/v2.6.4.tar.gz"
+    sha256: "79aff3370c6fe79be8e1774c4fab3e450a10444b91c2aa15aeebf5f54efedc5d"
   "2.6.3":
     url: "https://github.com/stephenberry/glaze/archive/v2.6.3.tar.gz"
     sha256: "5a2fd2a1ed18a184d7f86f5f8cd1350b12b8f2389466a436dfc198e3e6912c70"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.4":
+    folder: all
   "2.6.3":
     folder: all
   "2.6.2":


### PR DESCRIPTION
Specify library name and version:  **glaze/2.6.4**

https://github.com/stephenberry/glaze/compare/v2.6.3...v2.6.4

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
