### PR TITLE
openssh: Added ability to control "--disable-strip" configure argument

### DIFF
--- a/recipes/openssh/all/conanfile.py
+++ b/recipes/openssh/all/conanfile.py
@@ -25,6 +25,7 @@ class PackageConan(ConanFile):
         "with_pam": [False, "openpam"],  # linux-pam and Solaris PAM are also supported
         "with_selinux": [True, False],
         "with_libedit": [True, False],
+        "with_strip": [True, False],
         "with_sandbox": [False, "auto", "capsicum", "darwin", "rlimit", "seccomp_filter", "systrace", "pledge"]
     }
     default_options = {
@@ -32,6 +33,7 @@ class PackageConan(ConanFile):
         "with_pam": False,
         "with_selinux": False,
         "with_libedit": False,
+        "with_strip": True,
         "with_sandbox": "auto"
     }
 
@@ -80,6 +82,9 @@ class PackageConan(ConanFile):
 
         tc = AutotoolsToolchain(self)
         tc.configure_args.append("--without-zlib-version-check")
+
+        if not self.options.with_strip:
+            tc.configure_args.append("--disable-strip")
 
         if self.options.with_selinux:
             tc.configure_args.append("--with-selinux")


### PR DESCRIPTION
openssh/*

openssh: Added ability to control "--disable-strip" configure argument

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
