### PR TITLE
glaze: add version 2.6.5

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.5":
+    url: "https://github.com/stephenberry/glaze/archive/v2.6.5.tar.gz"
+    sha256: "5d5f3b41c7803cded9602ee93c80ea38fd3521cdaad6ea1836f818046d21e504"
   "2.6.4":
     url: "https://github.com/stephenberry/glaze/archive/v2.6.4.tar.gz"
     sha256: "79aff3370c6fe79be8e1774c4fab3e450a10444b91c2aa15aeebf5f54efedc5d"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.5":
+    folder: all
   "2.6.4":
     folder: all
   "2.6.3":


### PR DESCRIPTION
Specify library name and version:  **glaze/2.6.5**

https://github.com/stephenberry/glaze/compare/v2.6.4...v2.6.5

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
