### PR TITLE
samurai: add version 0.13.0, solve version conflict

### DIFF
--- a/recipes/samurai/all/conandata.yml
+++ b/recipes/samurai/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.13.0":
+    url: "https://github.com/hpc-maths/samurai/archive/v0.13.0.tar.gz"
+    sha256: "f38e379218b1206fc5c5e157ee5e80687721a896f70b892623d9f30280529448"
   "0.9.0":
     url: "https://github.com/hpc-maths/samurai/archive/v0.9.0.tar.gz"
     sha256: "49f94a7451b1b50cab335a62e294e612fea27cbf5b131827eb69a8e228ad8010"

--- a/recipes/samurai/all/conanfile.py
+++ b/recipes/samurai/all/conanfile.py
@@ -43,8 +43,8 @@ class PackageConan(ConanFile):
         self.requires("fmt/10.1.1")
         self.requires("highfive/2.7.1")
         self.requires("pugixml/1.14")
-        self.requires("xsimd/11.1.0")
-        self.requires("xtensor/0.24.6")
+        self.requires("xsimd/12.0.0")
+        self.requires("xtensor/0.24.7")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/samurai/config.yml
+++ b/recipes/samurai/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.13.0":
+    folder: all
   "0.9.0":
     folder: all
   "0.8.0":


### PR DESCRIPTION
Specify library name and version:  **samurai/0.13.0**

https://github.com/hpc-maths/samurai/compare/v0.9.0...v0.13.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
