### PR TITLE
add extra-cmake-modules 6.2.0

### DIFF
--- a/recipes/extra-cmake-modules/all/conandata.yml
+++ b/recipes/extra-cmake-modules/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.2.0":
+    url: "https://download.kde.org/stable/frameworks/6.2/extra-cmake-modules-6.2.0.tar.xz"
+    sha256: "6374bfa0dded8be265c702acd5de11eecd2851c625b93e1c87d8d0f5f1a8ebe1"
   "5.113.0":
     url: "https://download.kde.org/stable/frameworks/5.113/extra-cmake-modules-5.113.0.tar.xz"
     sha256: "265e5440eebeca07351a469e617a4bf35748927bd907b00ace9c018392bb3bc4"

--- a/recipes/extra-cmake-modules/config.yml
+++ b/recipes/extra-cmake-modules/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.2.0":
+    folder: "all"
   "5.113.0":
     folder: "all"
   "5.111.0":


### PR DESCRIPTION
Specify library name and version:  **extra-cmake-modules/6.2.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

I'm updating this because I'm interested in using it in one of my own projects (and maybe other projects as well). If everything goes well, I might also attempt to add some other libraries from KDE Framework 6 (currently interested in `karchive`, `kimageformats` and `kconfig`).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
