### PR TITLE
elfutils: Bump gettext to version 0.22.5 to support GCC 14

### DIFF
--- a/recipes/elfutils/all/conanfile.py
+++ b/recipes/elfutils/all/conanfile.py
@@ -82,7 +82,7 @@ class ElfutilsConan(ConanFile):
             self.requires("libmicrohttpd/0.9.75")
 
     def build_requirements(self):
-        self.tool_requires("gettext/0.21")
+        self.tool_requires("gettext/0.22.5")
         self.tool_requires("automake/1.16.5")
         self.build_requires("m4/1.4.19")
         self.build_requires("flex/2.6.4")


### PR DESCRIPTION
See issue #24058.