### PR TITLE
elfutils: Correctly set pkg-config names for libraries

### DIFF
--- a/recipes/elfutils/all/conanfile.py
+++ b/recipes/elfutils/all/conanfile.py
@@ -171,6 +171,7 @@ class ElfutilsConan(ConanFile):
         # library components
         self.cpp_info.components["libelf"].libs = ["elf"]
         self.cpp_info.components["libelf"].requires = ["zlib::zlib"]
+        self.cpp_info.components["libelf"].set_property("pkg_config_name", "libelf")
         if self.options.with_bzlib:
             self.cpp_info.components["libelf"].requires.append("bzip2::bzip2")
         if self.options.with_lzma:
@@ -182,6 +183,7 @@ class ElfutilsConan(ConanFile):
 
         self.cpp_info.components["libdw"].libs = ["dw"]
         self.cpp_info.components["libdw"].requires = ["libelf"]
+        self.cpp_info.components["libdw"].set_property("pkg_config_name", "libdw")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libdw"].system_libs.extend(["dl"])
 
@@ -192,6 +194,7 @@ class ElfutilsConan(ConanFile):
         if self.options.get_safe("libdebuginfod"):
             self.cpp_info.components["libdebuginfod"].libs = ["debuginfod"]
             self.cpp_info.components["libdebuginfod"].requires = ["libcurl::curl"]
+            self.cpp_info.components["libdebuginfod"].set_property("pkg_config_name", "libdebuginfod")
 
         # utilities
         bin_path = os.path.join(self.package_folder, "bin")


### PR DESCRIPTION
The pkg-config names should be set as provided by the project. See https://sourceware.org/git/?p=elfutils.git;a=tree;f=config;hb=HEAD.