### PR TITLE
flatbush: add release v1.2.1

### DIFF
--- a/recipes/flatbush/all/conandata.yml
+++ b/recipes/flatbush/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.1":
+    url: "https://github.com/chusitoo/flatbush/archive/refs/tags/v1.2.1.zip"
+    sha256: "7f8226cb9a58cc75c99800a8fb213b1c2c5df81051ec559d5ff7b4ed0e8c097a"
   "1.2.0":
     url: "https://github.com/chusitoo/flatbush/archive/refs/tags/v1.2.0.zip"
     sha256: "d8d0471ad6aba1e4b1160abc38a0fe21a35e3ea1c2a9509ce9910072f7fc24bb"

--- a/recipes/flatbush/config.yml
+++ b/recipes/flatbush/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.1":
+    folder: "all"
   "1.2.0":
     folder: "all"
   "1.1.0":


### PR DESCRIPTION
Specify library name and version: flatbush/1.2.1

Fix multiple definition error when #included in more than one source file
Address several findings reported by clang-tidy and other minor fine-tunings
Ran through clang-format and include-what-you-use

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
