### PR TITLE
raylib: fix problems with glfw version

### DIFF
--- a/recipes/raylib/all/conanfile.py
+++ b/recipes/raylib/all/conanfile.py
@@ -49,7 +49,7 @@ class RaylibConan(ConanFile):
 
     def requirements(self):
         if self.settings.os != "Android":
-            self.requires("glfw/3.3.8")
+            self.requires("glfw/3.4")
             self.requires("opengl/system")
         if self.settings.os == "Linux":
             self.requires("xorg/system")


### PR DESCRIPTION
Specify library name and version:  **raylib/5.0**

This fixes a problem with the glfw version. Raylib needs glfw/3.4, but currently we use glfw/3.3.8.
Raylib requires version 3.4 in cmake ([raylib](https://github.com/raysan5/raylib/blob/d9c5066382615644137b4f65479c65c44820027a/cmake/GlfwImport.cmake#L3)) but it somehow still manages to compile? Raylib also uses features of 3.4, such as new mouse cursors. But when building this into a application glfw gives errors, because it does not know these new mouse cursors.
Setting the required glfw to glfw/3.4 (as this PR does) seems to fix all problems. But maybe it should be investigated, why this could build?

TLDR: raylib seems to get compiled with glfw/3.4, although glfw/3.3.8? Raylib requires 3.3.8.


---

- [ x ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ x ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
