### PR TITLE
lely-core: add version 2.3.4

### DIFF
--- a/recipes/lely-core/all/conandata.yml
+++ b/recipes/lely-core/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3.4":
+    url: "https://gitlab.com/lely_industries/lely-core/-/archive/v2.3.4/lely-core-v2.3.4.tar.gz"
+    sha256: "6f31b4fd7ea6aafb1a62b9d956a12a900386564859099e97af1c6bd1d10bdaf2"
   "2.3.3":
     url: "https://gitlab.com/lely_industries/lely-core/-/archive/v2.3.3/lely-core-v2.3.3.tar.gz"
     sha256: "6d0810f9e835543f0aeb5f86dcdc7a24578041f5d0a714bf5a14db2cb24ce373"

--- a/recipes/lely-core/all/conanfile.py
+++ b/recipes/lely-core/all/conanfile.py
@@ -12,13 +12,18 @@ required_conan_version = ">=1.53.0"
 
 class LelyConan(ConanFile):
     name = "lely-core"
+    description = (
+        "The Lely core libraries are a collection of C and C++ libraries and tools, "
+        "providing high-performance I/O and sensor/actuator control for robotics and IoT applications. "
+        "The libraries are cross-platform and have few dependencies. "
+        "They can be even be used on bare-metal microcontrollers with as little as 32 kB RAM."
+    )
     license = "Apache-2.0"
-    homepage = "https://gitlab.com/lely_industries/lely-core/"
     url = "https://github.com/conan-io/conan-center-index"
-    description = "The Lely core libraries are a collection of C and C++ libraries and tools, providing high-performance I/O and sensor/actuator control for robotics and IoT applications. The libraries are cross-platform and have few dependencies. They can be even be used on bare-metal microcontrollers with as little as 32 kB RAM."
+    homepage = "https://gitlab.com/lely_industries/lely-core/"
     topics = ("canopen",)
     package_type = "library"
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],

--- a/recipes/lely-core/all/test_package/CMakeLists.txt
+++ b/recipes/lely-core/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
-project(test_package)
+project(test_package LANGUAGES CXX)
 
 find_package(lely-core REQUIRED)
 

--- a/recipes/lely-core/config.yml
+++ b/recipes/lely-core/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3.4":
+    folder: all
   "2.3.3":
     folder: all
   "2.3.2":


### PR DESCRIPTION
Specify library name and version:  **lely-core/2.3.4**

https://gitlab.com/lely_industries/lely-core/-/compare/v2.3.3...v2.3.4

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
