### PR TITLE
pixman: Fix license

### DIFF
--- a/recipes/pixman/all/conanfile.py
+++ b/recipes/pixman/all/conanfile.py
@@ -20,7 +20,7 @@ class PixmanConan(ConanFile):
     topics = ("graphics", "compositing", "rasterization")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.freedesktop.org/pixman/pixman"
-    license = ("LGPL-2.1-only", "MPL-1.1")
+    license = ("MIT")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {


### PR DESCRIPTION
Pixman is licensed under the MIT license: https://gitlab.freedesktop.org/pixman/pixman/-/blob/master/COPYING?ref_type=heads