### PR TITLE
glaze: add version 2.6.7, remove older versions

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.7":
+    url: "https://github.com/stephenberry/glaze/archive/v2.6.7.tar.gz"
+    sha256: "edd328b4c1a2e775cf9dbaccb57e2e6cf42b09d91b8a004c90f14439b86f417d"
   "2.6.6":
     url: "https://github.com/stephenberry/glaze/archive/v2.6.6.tar.gz"
     sha256: "c8a6b20401eb88419621c8ed25cd69bfee72e27982c1bdc3cec376922c08c2dd"
@@ -24,24 +27,12 @@ sources:
   "2.5.5":
     url: "https://github.com/stephenberry/glaze/archive/v2.5.5.tar.gz"
     sha256: "a7ce5c976afde4d2c09077d954b720a3af2adf0cb6742bb88605008b6887b971"
-  "2.5.4":
-    url: "https://github.com/stephenberry/glaze/archive/v2.5.4.tar.gz"
-    sha256: "0c10cfdbd92068c0cc1e99210a3eaa29bce9339261aaced60cb7e85398603346"
-  "2.5.3":
-    url: "https://github.com/stephenberry/glaze/archive/v2.5.3.tar.gz"
-    sha256: "f4c5eb83c80f1caa0feaa831715e9982203908ea140242cb061aead161e2b09b"
   "2.4.0":
     url: "https://github.com/stephenberry/glaze/archive/v2.4.0.tar.gz"
     sha256: "be8cfb94c0b4b13c0a1fc846e2c112614d2dda02a49977fcdeea544876b3625b"
   "2.3.2":
     url: "https://github.com/stephenberry/glaze/archive/v2.3.2.tar.gz"
     sha256: "360c1eab71afb69d59cc0f0e180d6b214653950340ac267a464a18c81dac585a"
-  "2.3.1":
-    url: "https://github.com/stephenberry/glaze/archive/v2.3.1.tar.gz"
-    sha256: "941bf3f8cea5b6a024895d37dceaaaa82071a9178af63e9935a1d9fd80caa451"
-  "2.3.0":
-    url: "https://github.com/stephenberry/glaze/archive/v2.3.0.tar.gz"
-    sha256: "9963761337941f4709458155a045ce4ab5dc5edf5e60dca8cc290200fce8330e"
   "2.2.1":
     url: "https://github.com/stephenberry/glaze/archive/v2.2.1.tar.gz"
     sha256: "ef0eb30a038c623ca100696e773ba1c9888719ed02c46e9fabf6238ee07026bb"
@@ -52,6 +43,3 @@ sources:
   "2.1.6":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.6.tar.gz"
     sha256: "5ae31b1a48a5b54b84e115a12195341bfbe39f03f92bb3bcad074f984380f72d"
-  "2.0.9":
-    url: "https://github.com/stephenberry/glaze/archive/v2.0.9.tar.gz"
-    sha256: "c1ffede3db5c74d2c46a3abe576985dc729c95df1b48ab575079427b55488bbd"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.7":
+    folder: all
   "2.6.6":
     folder: all
   "2.6.5":
@@ -15,23 +17,13 @@ versions:
     folder: all
   "2.5.5":
     folder: all
-  "2.5.4":
-    folder: all
-  "2.5.3":
-    folder: all
   "2.4.0":
     folder: all
   "2.3.2":
-    folder: all
-  "2.3.1":
-    folder: all
-  "2.3.0":
     folder: all
   "2.2.1":
     folder: all
   "2.1.9":
     folder: all
   "2.1.6":
-    folder: all
-  "2.0.9":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **glaze/***

https://github.com/stephenberry/glaze/compare/v2.6.6...v2.6.7

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
