### PR TITLE
Update STB to cci.20240213

### DIFF
--- a/recipes/stb/all/conandata.yml
+++ b/recipes/stb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20240213":
+    url: "https://github.com/nothings/stb/archive/ae721c50eaf761660b4f90cc590453cdb0c2acd0.zip"
+    sha256: "5d075769721e676746d0c25b698a0f00741f68252f9ab4b7ee245c513aeec3de"
   "cci.20230920":
     url: "https://github.com/nothings/stb/archive/5736b15f7ea0ffb08dd38af21067c314d6a3aae9.zip"
     sha256: "b6601f182fa4bc04dd0f135e38231e8a2c6c9e7901c66a942871f03285713b05"

--- a/recipes/stb/config.yml
+++ b/recipes/stb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20240213":
+    folder: all
   "cci.20230920":
     folder: all
   "cci.20220909":


### PR DESCRIPTION
Specify library name and version:  **STB/cci.20240213**

Simple update with latest stb commit available. The recipe version number is the date of the commit in the official repository.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
