### PR TITLE
md4c: expose md2html option

### DIFF
--- a/recipes/md4c/all/conanfile.py
+++ b/recipes/md4c/all/conanfile.py
@@ -20,11 +20,13 @@ class Md4cConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "md2html": [True, False],
         "encoding": ["utf-8", "utf-16", "ascii"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "md2html": True,
         "encoding": "utf-8",
     }
 
@@ -53,6 +55,7 @@ class Md4cConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["BUILD_MD2HTML_EXECUTABLE"] = self.options.md2html
         if self.options.encoding == "utf-8":
             tc.preprocessor_definitions["MD4C_USE_UTF8"] = "1"
         elif self.options.encoding == "utf-16":


### PR DESCRIPTION
Specify library name and version:  **md4c/0.5.2**

Allow disabling building the md2html executable, resulting in simply the library(ies) being built.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
