### PR TITLE
add Qt 5.15.14

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -127,8 +127,6 @@ patches:
     - "base_path": "qt5/qtwebengine/src/3rdparty"
       "patch_file": "patches/0001-Find-fontconfig-using-pkg-config.patch"
     - "base_path": "qt5/qtbase"
-      "patch_file": "patches/android-backtrace.diff"
-    - "base_path": "qt5/qtbase"
       "patch_file": "patches/android-openssl.diff"
     - "base_path": "qt5/qtbase"
       "patch_description": "Fix qmake build with apple-clang>=15"

--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -1,4 +1,27 @@
 sources:
+  "5.15.14":
+    url:
+      - "https://download.qt.io/official_releases/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://download.qt.io/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://qt-mirror.dannhauer.de/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirror.netcologne.de/qtproject/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://ftp.fau.de/qtproject/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://ftp.nluug.nl/languages/qt/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirrors.dotsrc.org/qtproject/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirrors.20i.com/pub/qt.io/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://ftp.icm.edu.pl/packages/qt/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://ftp.acc.umu.se/mirror/qt.io/qtproject/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://www.nic.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://qt.mirror.constant.com/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirrors.sau.edu.cn/qt/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirrors.cloud.tencent.com/qt/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirror.bjtu.edu.cn/qt/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirrors.sjtug.sjtu.edu.cn/qt/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://ftp.jaist.ac.jp/pub/qtproject/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://ftp.yz.yamagata-u.ac.jp/pub/qtproject/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+      - "https://mirror.aarnet.edu.au/pub/qtproject/archive/qt/5.15/5.15.14/single/qt-everywhere-opensource-src-5.15.14.tar.xz"
+    sha256: "fdd3a4f197d2c800ee0085c721f4bef60951cbda9e9c46e525d1412f74264ed7"
   "5.15.13":
     url:
       - "https://download.qt.io/official_releases/qt/5.15/5.15.13/single/qt-everywhere-opensource-src-5.15.13.tar.xz"
@@ -94,6 +117,30 @@ sources:
       - "https://ftp.yz.yamagata-u.ac.jp/pub/qtproject/archive/qt/5.15/5.15.9/single/qt-everywhere-opensource-src-5.15.9.tar.xz"
     sha256: "26d5f36134db03abe4a6db794c7570d729c92a3fc1b0bf9b1c8f86d0573cd02f"
 patches:
+  "5.15.14":
+    - "base_path": "qt5/qtbase"
+      "patch_file": "patches/aa2a39dea5.diff"
+    - "base_path": "qt5/qtwebengine"
+      "patch_file": "patches/c72097e.diff"
+    - "base_path": "qt5/qttools"
+      "patch_file": "patches/fix-macdeployqt.diff"
+    - "base_path": "qt5/qtwebengine/src/3rdparty"
+      "patch_file": "patches/0001-Find-fontconfig-using-pkg-config.patch"
+    - "base_path": "qt5/qtbase"
+      "patch_file": "patches/android-backtrace.diff"
+    - "base_path": "qt5/qtbase"
+      "patch_file": "patches/android-openssl.diff"
+    - "base_path": "qt5/qtbase"
+      "patch_description": "Fix qmake build with apple-clang>=15"
+      "patch_file": "patches/5.15.8-fix-qmake-default-libdirs-apple-clang-15.patch"
+      "patch_source": "https://codereview.qt-project.org/c/qt/qtbase/+/503916"
+      "patch_type": "portability"
+    - "base_path": "qt5/qtbase"
+      "patch_description": "Fix usage of memory_resource with apple-clang>=15 and deployment\
+        \ target of macOS < 14"
+      "patch_file": "patches/5.15.12-fix-macos-cpp-lib-memory-resource.patch"
+      "patch_source": "https://codereview.qt-project.org/c/qt/qtbase/+/482392"
+      "patch_type": "portability"
   "5.15.13":
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/aa2a39dea5.diff"

--- a/recipes/qt/5.x.x/qtmodules5.15.14.conf
+++ b/recipes/qt/5.x.x/qtmodules5.15.14.conf
@@ -1,0 +1,326 @@
+[submodule "qtbase"]
+	path = qtbase
+	url = ../qtbase.git
+	branch = 5.15
+	status = essential
+[submodule "qtsvg"]
+	depends = qtbase
+	path = qtsvg
+	url = ../qtsvg.git
+	branch = 5.15
+	status = addon
+[submodule "qtdeclarative"]
+	depends = qtbase
+	recommends = qtsvg
+	path = qtdeclarative
+	url = ../qtdeclarative.git
+	branch = 5.15
+	status = essential
+[submodule "qtactiveqt"]
+	depends = qtbase
+	path = qtactiveqt
+	url = ../qtactiveqt.git
+	branch = 5.15
+	status = addon
+[submodule "qtscript"]
+	depends = qtbase
+	recommends = qttools
+	path = qtscript
+	url = ../qtscript.git
+	branch = 5.15
+	status = deprecated
+[submodule "qtmultimedia"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtmultimedia
+	url = ../qtmultimedia.git
+	branch = 5.15
+	status = essential
+[submodule "qttools"]
+	depends = qtbase
+	recommends = qtdeclarative qtactiveqt
+	path = qttools
+	url = ../qttools.git
+	branch = 5.15
+	status = essential
+[submodule "qtxmlpatterns"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtxmlpatterns
+	url = ../qtxmlpatterns.git
+	branch = 5.15
+	status = deprecated
+[submodule "qttranslations"]
+	depends = qttools
+	path = qttranslations
+	url = ../qttranslations.git
+	branch = 5.15
+	status = essential
+	priority = 30
+[submodule "qtdoc"]
+	depends = qtdeclarative qttools
+	recommends = qtmultimedia qtquickcontrols qtquickcontrols2
+	path = qtdoc
+	url = ../qtdoc.git
+	branch = 5.15
+	status = essential
+	priority = 40
+[submodule "qtrepotools"]
+	path = qtrepotools
+	url = ../qtrepotools.git
+	branch = master
+	status = essential
+	project = -
+[submodule "qtqa"]
+	depends = qtbase
+	path = qtqa
+	url = ../qtqa.git
+	branch = master
+	status = essential
+	priority = 50
+[submodule "qtlocation"]
+	depends = qtbase
+	recommends = qtdeclarative qtquickcontrols qtquickcontrols2 qtserialport
+	path = qtlocation
+	url = ../qtlocation.git
+	branch = 5.15
+	status = addon
+[submodule "qtsensors"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtsensors
+	url = ../qtsensors.git
+	branch = 5.15
+	status = addon
+[submodule "qtsystems"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtsystems
+	url = ../qtsystems.git
+	branch = dev
+	status = ignore
+[submodule "qtfeedback"]
+	depends = qtdeclarative
+	recommends = qtmultimedia
+	path = qtfeedback
+	url = ../qtfeedback.git
+	branch = master
+	status = ignore
+[submodule "qtdocgallery"]
+	depends = qtdeclarative
+	path = qtdocgallery
+	url = ../qtdocgallery.git
+	branch = master
+	status = ignore
+[submodule "qtpim"]
+	depends = qtdeclarative
+	path = qtpim
+	url = ../qtpim.git
+	branch = dev
+	status = ignore
+[submodule "qtconnectivity"]
+	depends = qtbase
+	recommends = qtdeclarative qtandroidextras
+	path = qtconnectivity
+	url = ../qtconnectivity.git
+	branch = 5.15
+	status = addon
+[submodule "qtwayland"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtwayland
+	url = ../qtwayland.git
+	branch = 5.15
+	status = addon
+[submodule "qt3d"]
+	depends = qtbase
+	recommends = qtdeclarative qtimageformats qtgamepad
+	path = qt3d
+	url = ../qt3d.git
+	branch = 5.15
+	status = addon
+[submodule "qtimageformats"]
+	depends = qtbase
+	path = qtimageformats
+	url = ../qtimageformats.git
+	branch = 5.15
+	status = addon
+[submodule "qtgraphicaleffects"]
+	depends = qtdeclarative
+	path = qtgraphicaleffects
+	url = ../qtgraphicaleffects.git
+	branch = 5.15
+	status = essential
+[submodule "qtquickcontrols"]
+	depends = qtdeclarative
+	recommends = qtgraphicaleffects
+	path = qtquickcontrols
+	url = ../qtquickcontrols.git
+	branch = 5.15
+	status = addon
+[submodule "qtserialbus"]
+	depends = qtbase
+	recommends = qtserialport
+	path = qtserialbus
+	url = ../qtserialbus.git
+	branch = 5.15
+	status = addon
+[submodule "qtserialport"]
+	depends = qtbase
+	path = qtserialport
+	url = ../qtserialport.git
+	branch = 5.15
+	status = addon
+[submodule "qtx11extras"]
+	depends = qtbase
+	path = qtx11extras
+	url = ../qtx11extras.git
+	branch = 5.15
+	status = addon
+[submodule "qtmacextras"]
+	depends = qtbase
+	path = qtmacextras
+	url = ../qtmacextras.git
+	branch = 5.15
+	status = addon
+[submodule "qtwinextras"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtwinextras
+	url = ../qtwinextras.git
+	branch = 5.15
+	status = addon
+[submodule "qtandroidextras"]
+	depends = qtbase
+	path = qtandroidextras
+	url = ../qtandroidextras.git
+	branch = 5.15
+	status = addon
+[submodule "qtwebsockets"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtwebsockets
+	url = ../qtwebsockets.git
+	branch = 5.15
+	status = addon
+[submodule "qtwebchannel"]
+	depends = qtbase
+	recommends = qtdeclarative qtwebsockets
+	path = qtwebchannel
+	url = ../qtwebchannel.git
+	branch = 5.15
+	status = addon
+[submodule "qtwebengine"]
+	depends = qtdeclarative
+	recommends = qtquickcontrols qtquickcontrols2 qtlocation qtwebchannel qttools
+	path = qtwebengine
+	url = ../qtwebengine.git
+	branch = 5.15
+	status = addon
+	priority = 10
+[submodule "qtcanvas3d"]
+	depends = qtdeclarative
+	path = qtcanvas3d
+	url = ../qtcanvas3d.git
+	branch = dev
+	status = ignore
+[submodule "qtwebview"]
+	depends = qtdeclarative
+	recommends = qtwebengine
+	path = qtwebview
+	url = ../qtwebview.git
+	branch = 5.15
+	status = addon
+[submodule "qtquickcontrols2"]
+	depends = qtgraphicaleffects
+	recommends = qtimageformats
+	path = qtquickcontrols2
+	url = ../qtquickcontrols2.git
+	branch = 5.15
+	status = essential
+[submodule "qtpurchasing"]
+	depends = qtbase
+	recommends = qtdeclarative qtandroidextras
+	path = qtpurchasing
+	url = ../qtpurchasing.git
+	branch = 5.15
+	status = addon
+[submodule "qtcharts"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtcharts
+	url = ../qtcharts.git
+	branch = 5.15
+	status = addon
+[submodule "qtdatavis3d"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtdatavis3d
+	url = ../qtdatavis3d.git
+	branch = 5.15
+	status = addon
+[submodule "qtvirtualkeyboard"]
+	depends = qtbase qtdeclarative qtsvg
+	recommends = qtmultimedia qtquickcontrols
+	path = qtvirtualkeyboard
+	url = ../qtvirtualkeyboard.git
+	branch = 5.15
+	status = addon
+[submodule "qtgamepad"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtgamepad
+	url = ../qtgamepad.git
+	branch = 5.15
+	status = addon
+[submodule "qtscxml"]
+	depends = qtbase qtdeclarative
+	path = qtscxml
+	url = ../qtscxml.git
+	branch = 5.15
+	status = addon
+[submodule "qtspeech"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtspeech
+	url = ../qtspeech.git
+	branch = 5.15
+	status = addon
+[submodule "qtnetworkauth"]
+	depends = qtbase
+	path = qtnetworkauth
+	url = ../qtnetworkauth.git
+	branch = 5.15
+	status = addon
+[submodule "qtremoteobjects"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtremoteobjects
+	url = ../qtremoteobjects.git
+	branch = 5.15
+	status = addon
+[submodule "qtwebglplugin"]
+	depends = qtbase qtwebsockets
+	recommends = qtdeclarative
+	path = qtwebglplugin
+	url = ../qtwebglplugin.git
+	branch = 5.15
+	status = addon
+[submodule "qtlottie"]
+	depends = qtbase qtdeclarative
+	path = qtlottie
+	url = ../qtlottie.git
+	branch = 5.15
+	status = addon
+[submodule "qtquicktimeline"]
+	depends = qtbase qtdeclarative
+	path = qtquicktimeline
+	url = ../qtquicktimeline
+	branch = 5.15
+	status = addon
+[submodule "qtquick3d"]
+	depends = qtbase qtdeclarative
+	path = qtquick3d
+	url = ../qtquick3d.git
+	branch = 5.15
+	status = addon

--- a/recipes/qt/config.yml
+++ b/recipes/qt/config.yml
@@ -15,6 +15,8 @@ versions:
     folder: 6.x.x
   "6.3.2":
     folder: 6.x.x
+  "5.15.14":
+    folder: 5.x.x
   "5.15.13":
     folder: 5.x.x
   "5.15.12":


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.14**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

- adds Qt 5.15.14
- removes Android backtrace patch as the fix was upstreamed: https://code.qt.io/cgit/qt/qtbase.git/commit/?h=5.15&id=1f154eec608db6caa027db534856f40d2c7ccf87

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
