### PR TITLE
sqlcipher: add version 4.6.0

### DIFF
--- a/recipes/sqlcipher/all/conandata.yml
+++ b/recipes/sqlcipher/all/conandata.yml
@@ -31,6 +31,10 @@ patches:
     - patch_file: patches/Makefile.in-v4.5.7.patch
     - patch_file: patches/Makefile.msc-v4.5.7.patch
     - patch_file: patches/fix_configure-v4.5.7.patch
+  "4.5.7":
+    - patch_file: patches/Makefile.in-v4.5.7.patch
+    - patch_file: patches/Makefile.msc-v4.5.7.patch
+    - patch_file: patches/fix_configure-v4.5.7.patch
   "4.5.6":
     - patch_file: patches/Makefile.in-v4.5.6.patch
     - patch_file: patches/Makefile.msc-v4.5.6.patch

--- a/recipes/sqlcipher/all/conandata.yml
+++ b/recipes/sqlcipher/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.6.0":
+    url: "https://github.com/sqlcipher/sqlcipher/archive/v4.6.0.zip"
+    sha256: "2d41ba2bf09c74a488f546551f65f0fa8517413307a0509dd2c87d66df6bff95"
   "4.5.7":
     url: "https://github.com/sqlcipher/sqlcipher/archive/v4.5.7.zip"
     sha256: "4f7e00e4b485d162d638094daba354d04aabb0ca68b72cc1826f082b40c9fd7d"
@@ -24,7 +27,7 @@ sources:
     url: "https://github.com/sqlcipher/sqlcipher/archive/v4.3.0.zip"
     sha256: "41e1408465488e9c478ca5b7c5f8410405a10caa73b82db60ac115a76c563c05"
 patches:
-  "4.5.7":
+  "4.6.0":
     - patch_file: patches/Makefile.in-v4.5.7.patch
     - patch_file: patches/Makefile.msc-v4.5.7.patch
     - patch_file: patches/fix_configure-v4.5.7.patch

--- a/recipes/sqlcipher/config.yml
+++ b/recipes/sqlcipher/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.6.0":
+    folder: all
   "4.5.7":
     folder: all
   "4.5.6":


### PR DESCRIPTION
Specify library name and version:  **sqlcipher/4.6.0**

https://github.com/sqlcipher/sqlcipher/compare/v4.5.7...v4.6.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
