### PR TITLE
popl: new recipe

### DIFF
--- a/recipes/popl/all/conandata.yml
+++ b/recipes/popl/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.3.0":
+    url: "https://github.com/badaix/popl/archive/refs/tags/v1.3.0.tar.gz"
+    sha256: "7c59554371da3c6c093bd79c2f403f921c1938bd523f1a48682352e0d92883a6"

--- a/recipes/popl/all/conanfile.py
+++ b/recipes/popl/all/conanfile.py
@@ -1,0 +1,41 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
+
+
+class PoplConan(ConanFile):
+    name = "popl"
+    description = "Header-only C++ command line arguments parser that supports the same set of options as GNU's getopt."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/badaix/popl"
+    topics = ("cli", "command-line-arguments", "getopt", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "popl.hpp", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/popl/all/test_package/CMakeLists.txt
+++ b/recipes/popl/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(popl REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE popl::popl)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/popl/all/test_package/conanfile.py
+++ b/recipes/popl/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/popl/all/test_package/test_package.cpp
+++ b/recipes/popl/all/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#include <popl.hpp>
+
+#include <iostream>
+
+using namespace popl;
+
+int main(int argc, char **argv) {
+    OptionParser op("Allowed options");
+    auto help_option = op.add<Switch>("h", "help", "produce help message");
+    op.parse(argc, argv);
+    std::cout << op << "\n";
+}

--- a/recipes/popl/config.yml
+++ b/recipes/popl/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.3.0":
+    folder: all


### PR DESCRIPTION
Adds popl/1.3.0: https://github.com/badaix/popl

Header-only C++ command line arguments parser that supports the same set of options as GNU's getopt.

[![Packaging status](https://repology.org/badge/tiny-repos/popl.svg)](https://repology.org/project/popl/versions)
