### PR TITLE
sioclient: new recipe

### DIFF
--- a/recipes/sioclient/all/conandata.yml
+++ b/recipes/sioclient/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20240405":
+    url: "https://github.com/socketio/socket.io-client-cpp/archive/c6be96b226f0fe3853beaeaa99c06834342a78db.zip"
+    sha256: "7c68117185dbc49579bba09a3e877f2a716cc331c28b3d8b6d3f867c4346b639"

--- a/recipes/sioclient/all/conanfile.py
+++ b/recipes/sioclient/all/conanfile.py
@@ -1,0 +1,113 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, replace_in_file, rm, rmdir, save
+
+required_conan_version = ">=1.53.0"
+
+
+class SioclientConan(ConanFile):
+    name = "sioclient"
+    description = "C++11 implementation of Socket.IO client"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/socketio/socket.io-client-cpp"
+    topics = ("websocket", "client")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_openssl": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_openssl": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("websocketpp/0.8.2")
+        self.requires("asio/1.30.2")
+        self.requires("rapidjson/cci.20230929")
+        if self.options.with_openssl:
+            self.requires("openssl/[>=1.1 <4]")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
+
+    def build_requirements(self):
+        # 3.28+ is not supported
+        self.tool_requires("cmake/[>=3.12 <=3.27]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["USE_SUBMODULES"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        VirtualBuildEnv(self).generate()
+
+    def _patch_sources(self):
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        "asio asio::asio", "asio::asio")
+        save(self, os.path.join(self.source_folder, "test", "CMakeLists.txt"), "")
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "sioclient")
+
+        self.cpp_info.components["sioclient_"].set_property("cmake_target_name", "sioclient::sioclient")
+        self.cpp_info.components["sioclient_"].libs = ["sioclient"]
+        self.cpp_info.components["sioclient_"].requires = [
+            "websocketpp::websocketpp",
+            "asio::asio",
+            "rapidjson::rapidjson",
+        ]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["sioclient_"].system_libs.extend(["m", "pthread"])
+
+        if self.options.with_openssl:
+            self.cpp_info.components["sioclient_tls"].set_property("cmake_target_name", "sioclient::sioclient_tls")
+            self.cpp_info.components["sioclient_tls"].libs = ["sioclient_tls"]
+            self.cpp_info.components["sioclient_tls"].requires = [
+                "websocketpp::websocketpp",
+                "asio::asio",
+                "rapidjson::rapidjson",
+                "openssl::openssl",
+            ]
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.components["sioclient_tls"].system_libs.extend(["m", "pthread"])

--- a/recipes/sioclient/all/conanfile.py
+++ b/recipes/sioclient/all/conanfile.py
@@ -55,10 +55,6 @@ class SioclientConan(ConanFile):
         if self.settings.os == "Windows":
             raise ConanInvalidConfiguration("Shared builds on Windows are not supported")
 
-    def build_requirements(self):
-        # 3.28+ is not supported
-        self.tool_requires("cmake/[>=3.15 <=3.27]")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/sioclient/all/conanfile.py
+++ b/recipes/sioclient/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
@@ -51,6 +52,8 @@ class SioclientConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("Shared builds on Windows are not supported")
 
     def build_requirements(self):
         # 3.28+ is not supported

--- a/recipes/sioclient/all/conanfile.py
+++ b/recipes/sioclient/all/conanfile.py
@@ -57,7 +57,7 @@ class SioclientConan(ConanFile):
 
     def build_requirements(self):
         # 3.28+ is not supported
-        self.tool_requires("cmake/[>=3.12 <=3.27]")
+        self.tool_requires("cmake/[>=3.15 <=3.27]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/sioclient/all/test_package/CMakeLists.txt
+++ b/recipes/sioclient/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(sioclient REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE sioclient::sioclient)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/sioclient/all/test_package/conanfile.py
+++ b/recipes/sioclient/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sioclient/all/test_package/test_package.cpp
+++ b/recipes/sioclient/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <sio_client.h>
+
+int main() {
+    sio::client h;
+    h.socket();
+}

--- a/recipes/sioclient/config.yml
+++ b/recipes/sioclient/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20240405":
+    folder: all


### PR DESCRIPTION
Adds sioclient/cci.20240405: https://github.com/socketio/socket.io-client-cpp

C++11 implementation of Socket.IO client

[![Packaging status](https://repology.org/badge/tiny-repos/socket.io-client-cpp.svg)](https://repology.org/project/socket.io-client-cpp/versions)

The last official release that was published three years ago is much less compatible with packaging without patching so I did not include it.