### PR TITLE
yomm2: add version 1.5.2

### DIFF
--- a/recipes/yomm2/all/conandata.yml
+++ b/recipes/yomm2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.2":
+    url: "https://github.com/jll63/yomm2/archive/refs/tags/v1.5.2.tar.gz"
+    sha256: "12f3f735b4870606199b889a242ebfed84cf0cd392b04a1c32db11291de684be"
   "1.5.1":
     url: "https://github.com/jll63/yomm2/archive/refs/tags/v1.5.1.tar.gz"
     sha256: "323abba27a356555cc3ead3e3e950746ab43f90d97ad21950f2ba3afaf565ecc"

--- a/recipes/yomm2/all/conanfile.py
+++ b/recipes/yomm2/all/conanfile.py
@@ -38,7 +38,7 @@ class yomm2Recipe(ConanFile):
         return {
             "gcc": "8",
             "clang": "5",
-            "apple-clang": "12",
+            "apple-clang": "13",
             "msvc": "192"
         }
 
@@ -53,6 +53,10 @@ class yomm2Recipe(ConanFile):
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+        if self.settings.compiler == "apple-clang" and not bool(self.options.header_only):
+            raise ConanInvalidConfiguration(
+                f"{self.ref} dynamic library builds are not supported on MacOS."
             )
 
     def build_requirements(self):
@@ -80,8 +84,9 @@ class yomm2Recipe(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
-        cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
-        replace_in_file(self, cmakelists, "add_subdirectory(docs.in)", "")
+        if Version(self.version) <= "1.5.1":
+            cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
+            replace_in_file(self, cmakelists, "add_subdirectory(docs.in)", "")
 
     def build(self):
         self._patch_sources()

--- a/recipes/yomm2/all/test_package/test_package.cpp
+++ b/recipes/yomm2/all/test_package/test_package.cpp
@@ -1,25 +1,53 @@
-// Copyright (c) 2021 Jean-Louis Leroy
+// Copyright (c) 2018-2024 Jean-Louis Leroy
 // Distributed under the Boost Software License, Version 1.0.
 // See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <sstream>
+
 #include <yorel/yomm2/keywords.hpp>
 
-#include <iostream>
-#include <memory>
-#include <string>
+class Animal {
+  public:
+    virtual ~Animal() {
+    }
+};
 
-using std::cout;
-using yorel::yomm2::virtual_;
+class Dog : public Animal {};
+class Cat : public Animal {};
 
-// register_class(classes);
+register_classes(Animal, Dog, Cat);
 
-// declare_method(return, name, (params));
+declare_method(
+    void, meet, (virtual_<Animal&>, virtual_<Animal&>, std::ostream&));
 
-// define_method(return, name, (params)) {
-// }
+define_method(void, meet, (Animal&, Animal&, std::ostream& os)) {
+    os << "ignore";
+}
+
+// Add definitions for specific pairs of animals.
+define_method(void, meet, (Dog& dog1, Dog& dog2, std::ostream& os)) {
+    os << "wag tail";
+}
+
+define_method(void, meet, (Dog& dog, Cat& cat, std::ostream& os)) {
+    os << "chase";
+}
+
+define_method(void, meet, (Cat& cat, Dog& dog, std::ostream& os)) {
+    os << "run";
+}
 
 int main() {
+    #ifndef NDEBUG
+    yorel::yomm2::default_policy::trace_enabled = true;
+    #endif
+
     yorel::yomm2::update();
-    return 0;
+    Animal&& snoopy = Dog();
+    Animal&& felix = Cat();
+    std::ostringstream os;
+    meet(snoopy, felix, os); // chase
+
+    return os.str() == "chase" ? 0 : 1;
 }

--- a/recipes/yomm2/config.yml
+++ b/recipes/yomm2/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.5.2":
+    folder: all
   "1.5.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **yomm2/1.5.2**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

Updating to the latest version of YOMM2, which I just published. Also:
* I think that the patch is not necessary anymore.
* I changed `test_package.cpp` to make it _call_ a method, not just build method tables (actually, this did nothing in the absence of any declared method).
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
