### PR TITLE
vincentlaucsb-csv-parser: add version 2.2.3

### DIFF
--- a/recipes/vincentlaucsb-csv-parser/all/conandata.yml
+++ b/recipes/vincentlaucsb-csv-parser/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.3":
+    url: "https://github.com/vincentlaucsb/csv-parser/archive/refs/tags/2.2.3.tar.gz"
+    sha256: "e70ea75612fb45f9a9dd83145fb3fbf0b5929a32683de478ad429cdd85f10e4e"
   "2.2.2":
     url: "https://github.com/vincentlaucsb/csv-parser/archive/refs/tags/2.2.2.tar.gz"
     sha256: "8d7720021d19cf03880eb768d82d7f7e0a240b6d564bc6b495fceb4775b8f0c7"

--- a/recipes/vincentlaucsb-csv-parser/config.yml
+++ b/recipes/vincentlaucsb-csv-parser/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.3":
+    folder: all
   "2.2.2":
     folder: all
   "2.2.0":


### PR DESCRIPTION
Specify library name and version:  **vincentlaucsb-csv-parser/2.2.3**

https://github.com/vincentlaucsb/csv-parser/compare/2.2.2...2.2.3

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
