### PR TITLE
[geographiclib] Skip packaging tools when not requested

### DIFF
--- a/.c3i/authorized_users.yml
+++ b/.c3i/authorized_users.yml
@@ -1357,3 +1357,5 @@ authorized_users:
 - BLumia
 - ydcpp
 - tttapa
+- zeeshancs07
+- jll63

--- a/recipes/geographiclib/all/conanfile.py
+++ b/recipes/geographiclib/all/conanfile.py
@@ -7,6 +7,7 @@ from conan.tools.files import (
     replace_in_file, rm, rmdir
 )
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 import os
 
 required_conan_version = ">=1.53.0"
@@ -137,7 +138,9 @@ class GeographiclibConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "geographiclib")
         self.cpp_info.set_property("cmake_target_name", "GeographicLib::GeographicLib")
         self.cpp_info.set_property("pkg_config_name", "geographiclib")
-        self.cpp_info.libs = ["GeographicLib"] if Version(self.version) >= "2" else ["Geographic"]
+        suffix = "_d" if self.settings.build_type == "Debug" and is_msvc(self) else ""
+        suffix += "-i" if is_msvc(self) else ""
+        self.cpp_info.libs = [f"GeographicLib{suffix}"] if Version(self.version) >= "2" else [f"Geographic{suffix}"]
         self.cpp_info.defines.append("GEOGRAPHICLIB_SHARED_LIB={}".format("1" if self.options.shared else "0"))
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed

--- a/recipes/geographiclib/all/conanfile.py
+++ b/recipes/geographiclib/all/conanfile.py
@@ -128,15 +128,16 @@ class GeographiclibConan(ConanFile):
             rmdir(self, os.path.join(os.path.join(self.package_folder, folder)))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
         if not self.options.tools:
-            bin_files = os.listdir(os.path.join(self.package_folder, "bin"))
-            for bin_file in [it for it in bin_files if not it.endswith(".dll")]:
-                rm(self, bin_file, os.path.join(self.package_folder, "bin"))
+            rmdir(self, os.path.join(self.package_folder, "sbin"))
+            bin_files = [it for it in os.listdir(os.path.join(self.package_folder, "bin")) if not it.endswith(".dll")]
+            for it in bin_files:
+                rm(self, it, os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "geographiclib")
         self.cpp_info.set_property("cmake_target_name", "GeographicLib::GeographicLib")
         self.cpp_info.set_property("pkg_config_name", "geographiclib")
-        self.cpp_info.libs = ["GeographicLib"]
+        self.cpp_info.libs = ["GeographicLib"] if Version(self.version) >= "2" else ["Geographic"]
         self.cpp_info.defines.append("GEOGRAPHICLIB_SHARED_LIB={}".format("1" if self.options.shared else "0"))
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed

--- a/recipes/geographiclib/all/conanfile.py
+++ b/recipes/geographiclib/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import (
-    apply_conandata_patches, collect_libs, copy, export_conandata_patches, get,
+    apply_conandata_patches, copy, export_conandata_patches, get,
     replace_in_file, rm, rmdir
 )
 from conan.tools.scm import Version
@@ -105,11 +105,6 @@ class GeographiclibConan(ConanFile):
             replace_in_file(self, cmakelists, "add_subdirectory (js)", "")
         # Don't install system libs
         replace_in_file(self, cmakelists, "include (InstallRequiredSystemLibraries)", "")
-        # Don't build tools if asked
-        if not self.options.tools:
-            replace_in_file(self, cmakelists, "add_subdirectory (tools)", "")
-            replace_in_file(self, os.path.join(self.source_folder, "cmake", "CMakeLists.txt"),
-                                  "${TOOLS}", "")
         # Disable -Werror
         replace_in_file(self, cmakelists, "-Werror", "")
         replace_in_file(self, cmakelists, "/WX", "")
@@ -132,12 +127,16 @@ class GeographiclibConan(ConanFile):
         ]:
             rmdir(self, os.path.join(os.path.join(self.package_folder, folder)))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+        if not self.options.tools:
+            bin_files = os.listdir(os.path.join(self.package_folder, "bin"))
+            for bin_file in [it for it in bin_files if not it.endswith(".dll")]:
+                rm(self, bin_file, os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "geographiclib")
         self.cpp_info.set_property("cmake_target_name", "GeographicLib::GeographicLib")
         self.cpp_info.set_property("pkg_config_name", "geographiclib")
-        self.cpp_info.libs = collect_libs(self)
+        self.cpp_info.libs = ["GeographicLib"]
         self.cpp_info.defines.append("GEOGRAPHICLIB_SHARED_LIB={}".format("1" if self.options.shared else "0"))
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed

--- a/recipes/geographiclib/all/conanfile.py
+++ b/recipes/geographiclib/all/conanfile.py
@@ -142,6 +142,8 @@ class GeographiclibConan(ConanFile):
         suffix += "-i" if is_msvc(self) else ""
         self.cpp_info.libs = [f"GeographicLib{suffix}"] if Version(self.version) >= "2" else [f"Geographic{suffix}"]
         self.cpp_info.defines.append("GEOGRAPHICLIB_SHARED_LIB={}".format("1" if self.options.shared else "0"))
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m"]
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "geographiclib"


### PR DESCRIPTION
Specify library name and version:  **geographiclib/2.3**

After checking with the upstream about adding a native option to build or not tools (PR https://github.com/geographiclib/geographiclib/pull/27), it will be more comfortable only skipping the package step instead. Those generated tools require only small amount of time to be built and so far does not break in the CI.

closes #24053
closes #24092

/cc @zeeshancs07

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
