### PR TITLE
cpuinfo/cci.20231129: fix missing "log" dependency with Android

### DIFF
--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -108,3 +108,6 @@ class CpuinfoConan(ConanFile):
             self.cpp_info.components["cpuinfo"].requires = ["clog"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["cpuinfo"].system_libs.append("pthread")
+
+        if self.settings.os == "Android":
+            self.cpp_info.components["cpuinfo"].system_libs.append("log")


### PR DESCRIPTION
Specify library name and version:  **cpuinfo/cci.20231129:**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

The cpuinfo package is failing when is built with Android because the `test_package` is not able to resolve the Android log function `__android_log_vprint`. See the log below:

```
======== Testing the package: Building ========
cpuinfo/cci.20231129 (test package): Calling build()
cpuinfo/cci.20231129 (test package): Running CMake.configure()
cpuinfo/cci.20231129 (test package): RUN: cmake -G "Ninja Multi-Config" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="E:/gitlab_ws/xrsw/0/conan-center-index/recipes/cpuinfo/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "E:/gitlab_ws/xrsw/0/conan-center-index/recipes/cpuinfo/all/test_package"
-- Using Conan toolchain: E:/gitlab_ws/xrsw/0/conan-center-index/recipes/cpuinfo/all/test_package/build/clang-14-armv8-20-debug/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- The C compiler identification is Clang 14.0.7
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: E:/.conan2/p/b/androc22e5d4e99cab/p/bin/toolchains/llvm/prebuilt/windows-x86_64/bin/clang.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'cpuinfo::cpuinfo'
-- Configuring done (2.7s)
-- Generating done (0.0s)
-- Build files have been written to: E:/gitlab_ws/xrsw/0/conan-center-index/recipes/cpuinfo/all/test_package/build/clang-14-armv8-20-debug
cpuinfo/cci.20231129 (test package): Running CMake.build()
cpuinfo/cci.20231129 (test package): RUN: cmake --build "E:\gitlab_ws\xrsw\0\conan-center-index\recipes\cpuinfo\all\test_package\build\clang-14-armv8-20-debug" --config Debug -- -j16
[1/2] Building C object CMakeFiles/test_package.dir/Debug/test_package.c.o
[2/2] Linking C executable Debug\test_package
FAILED: Debug/test_package 
C:\Windows\system32\cmd.exe /C "cd . && E:\.conan2\p\b\androc22e5d4e99cab\p\bin\toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe --target=aarch64-none-linux-android31 --sysroot=E:/.conan2/p/b/androc22e5d4e99cab/p/bin/toolchains/llvm/prebuilt/windows-x86_64/sysroot -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -fno-limit-debug-info -static-libstdc++ -Wl,--build-id=sha1 -Wl,--fatal-warnings -Wl,--no-undefined -Qunused-arguments CMakeFiles/test_package.dir/Debug/test_package.c.o -o Debug\test_package -LE:/.conan2/p/b/cpuin53df6394140e7/p/lib E:/.conan2/p/b/cpuin53df6394140e7/p/lib/libcpuinfo.a  -latomic -lm && cd ."
ld: error: undefined symbol: __android_log_vprint
ninja: build stopped: subcommand failed.
ERROR: cpuinfo/cci.20231129 (test package): Error in build() method, line 26
	cmake.build()
	ConanException: Error 1 while executing
```

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
