### PR TITLE
libliftoff: add version 0.5.0, fix homepage url

### DIFF
--- a/recipes/libliftoff/all/conandata.yml
+++ b/recipes/libliftoff/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.5.0":
+    url: "https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/v0.5.0/libliftoff-v0.5.0.tar.bz2"
+    sha256: "2ed21be3c563b129bd8f188195a23256017e15908c195f3edcd3697584caf1c8"
   "0.4.1":
     url: "https://gitlab.freedesktop.org/emersion/libliftoff/-/archive/v0.4.1/libliftoff-v0.4.1.tar.bz2"
     sha256: "2ec4a6b467dda20476acb4d6bd864538ccdaa946e8666f96efa98156bf25cfb5"

--- a/recipes/libliftoff/all/conanfile.py
+++ b/recipes/libliftoff/all/conanfile.py
@@ -16,7 +16,7 @@ class LibliftoffConan(ConanFile):
     description = "Lightweight KMS plane library."
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/project/package"
+    homepage = "https://gitlab.freedesktop.org/emersion/libliftoff"
     topics = ("drm", "KMS", "plane")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"

--- a/recipes/libliftoff/config.yml
+++ b/recipes/libliftoff/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.5.0":
+    folder: all
   "0.4.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libliftoff/***

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
