### PR TITLE
approvaltests.cpp: add 10.13.0

### DIFF
--- a/recipes/approvaltests.cpp/all/conandata.yml
+++ b/recipes/approvaltests.cpp/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "10.13.0":
+    - url: https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.13.0/ApprovalTests.v.10.13.0.hpp
+      sha256: c00f6390b81d9924dc646e9d32b61e1e09abda106c13704f714ac349241bb9ff
+    - url: "https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.10.13.0/LICENSE"
+      sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
   "10.12.2":
     - url: https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.12.2/ApprovalTests.v.10.12.2.hpp
       sha256: 4c43d0ea98669e3d6fbb5810cc47b19adaf88cabb1421b488aa306b08c434131

--- a/recipes/approvaltests.cpp/config.yml
+++ b/recipes/approvaltests.cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "10.13.0":
+    folder: all
   "10.12.2":
     folder: all
   "10.12.1":


### PR DESCRIPTION
Specify library name and version:  **approvaltests.cpp/10.13.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

I am the co-maintainer of ApprovalTests.cpp.

This just bumps the version to the latest release, ensuring all our releases in recent years will be available by Conan.

We regret to say that we have been unable to build this locally, and multiple pairing sessions of trying - we are hoping that the CI will confirm now whether we have the correct syntax, in which case it's a dev machine config problem...

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
