### PR TITLE
raylib: add emscripten support

### DIFF
--- a/recipes/raylib/all/conanfile.py
+++ b/recipes/raylib/all/conanfile.py
@@ -48,7 +48,7 @@ class RaylibConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if self.settings.os != "Android":
+        if self.settings.os not in ["Android", "Emscripten"]:
             self.requires("glfw/3.4")
             self.requires("opengl/system")
         if self.settings.os == "Linux":
@@ -60,6 +60,10 @@ class RaylibConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_EXAMPLES"] = False
+        if self.settings.os == "Emscripten":
+            tc.variables["PLATFORM"] = "Web"
+            tc.variables["USE_EXTERNAL_GLFW"] = "ON"
+            tc.variables["OPENGL_VERSION"] = "ES 2.0"
         if self.settings.os == "Android":
             tc.variables["PLATFORM"] = "Android"
             tc.variables["USE_EXTERNAL_GLFW"] = "OFF"


### PR DESCRIPTION
Specify library name and version:  **raylib/5.0**

This allows the consumer to use the emsdk and raylib packages to build raylib games for the web-browser.
I have built a minimal example project [here](https://github.com/Mercotui/conan-raylib-examples)
I followed the documentation about building raylib for the web from [here](https://github.com/raysan5/raylib/wiki/Working-for-Web-(HTML5)).

I wanted to run the conan-center hook but the documentation says it's not supported on conan 2 yet.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
