### PR TITLE
boost: listen to tools.build:verbosity

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -609,6 +609,11 @@ class BoostConan(ConanFile):
         if self.options.without_fiber:
             self.options.rm_safe("numa")
 
+        # Use verbosity from [conf] if specified
+        verbosity = self.conf.get("tools.build:verbosity", default="quiet")
+        if verbosity == "verbose" and int(self.options.debug_level) < 2:
+            self.options.debug_level.value = 2
+
     def layout(self):
         basic_layout(self, src_folder="src")
 


### PR DESCRIPTION
boost/*

The conf setting tools.build:verbosity=verbose will be used to set debug_level option to 2, if it's not already set to a higher value.


---

- [x ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
