### PR TITLE
openblas: cross-compilation support

### DIFF
--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -141,6 +141,11 @@ class OpenblasConan(ConanFile):
                 raise ConanInvalidConfiguration(f'"{self.name}/*:build_relapack=True" option is only supported for GCC and Clang')
 
     def validate_build(self):
+        if Version(self.version) < "0.3.22" and cross_building(self, skip_x64_x86=True):
+            # OpenBLAS CMake builds did not support some of the cross-compilation targets in 0.3.20/21 and earlier.
+            # This was fixed in https://github.com/OpenMathLib/OpenBLAS/pull/3714 and https://github.com/OpenMathLib/OpenBLAS/pull/3958
+            raise ConanInvalidConfiguration(f"Cross-building is not supported for {self.name}/0.3.21 and earlier.")
+
         # If we're cross-compiling, and the user didn't provide the target, and
         # we couldn't infer the target from settings.arch, fail
         if cross_building(self, skip_x64_x86=True) and not self.options.target:

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -11,6 +11,53 @@ import textwrap
 
 required_conan_version = ">=1.53.0"
 
+# Maps Conan's settings.arch to the corresponding OpenBLAS TARGET:
+conan_arch_to_openblas_target = {
+    "x86": "SANDYBRIDGE",  # Sandy bridge was discontinued in September of 2013,
+    "x86_64": "SANDYBRIDGE",  # supporting older CPUs is a performance trade-off
+    "ppc32be": None,  # TODO: OpenBLAS has POWER4, POWER5, POWER6, POWER7,
+    "ppc32": None,  #         POWER8, POWER9, POWER10, PPCG4, PPC970, PPC970MP,
+    "ppc64le": None,  #       PPC440, PPC440FP2, CELL
+    "ppc64": None,
+    "armv4": None,  # Not supported by OpenBLAS
+    "armv4i": None,  # Not supported by OpenBLAS
+    "armv5el": "ARMV5",
+    "armv5hf": "ARMV5",
+    "armv6": "ARMV6",
+    "armv7": "ARMV7",
+    "armv7hf": "ARMV7",
+    "armv7s": "ARMV7",
+    "armv7k": "ARMV7",
+    "armv8": "ARMV8",
+    "armv8_32": "ARMV7",  # No 32-bit ARMv8 TARGET in OpenBLAS
+    "armv8.3": "ARMV8",
+    "arm64ec": "ARMV8",
+    "sparc": None,  # TODO: OpenBLAS has SPARC, SPARCV7
+    "sparcv9": None,
+    "mips": None,  # TODO: OpenBLAS has P5600, MIPS1004K and MIPS24K
+    "mips64": "MIPS64_GENERIC",
+    "avr": None,  # Not supported by OpenBLAS
+    "s390": None,  # Not supported by OpenBLAS
+    "s390x": None,  # Not supported by OpenBLAS
+    "asm.js": "GENERIC",  # TODO: ?
+    "wasm": "GENERIC",  # TODO: ?
+    "sh4le": None,  # Not supported by OpenBLAS
+    "e2k-v2": "E2K",
+    "e2k-v3": "E2K",
+    "e2k-v4": "E2K",
+    "e2k-v5": "E2K",
+    "e2k-v6": "E2K",
+    "e2k-v7": "E2K",
+    "riscv64": "RISCV64_GENERIC",
+    "riscv32": None,  # Not supported by OpenBLAS
+    "xtensalx6": None,  # Not supported by OpenBLAS
+    "xtensalx106": None,  # Not supported by OpenBLAS
+    "xtensalx7": None,  # Not supported by OpenBLAS
+}
+
+# Taken from OpenBLAS TargetList.txt
+available_openblas_targets = ["P2", "KATMAI", "COPPERMINE", "NORTHWOOD", "PRESCOTT", "BANIAS", "YONAH", "CORE2", "PENRYN", "DUNNINGTON", "NEHALEM", "SANDYBRIDGE", "HASWELL", "SKYLAKEX", "ATOM", "COOPERLAKE", "SAPPHIRERAPIDS", "ATHLON", "OPTERON", "OPTERON_SSE3", "BARCELONA", "SHANGHAI", "ISTANBUL", "BOBCAT", "BULLDOZER", "PILEDRIVER", "STEAMROLLER", "EXCAVATOR", "ZEN", "SSE_GENERIC", "VIAC3", "NANO", "POWER4", "POWER5", "POWER6", "POWER7", "POWER8", "POWER9", "POWER10", "PPCG4", "PPC970", "PPC970MP", "PPC440", "PPC440FP2", "CELL", "P5600", "MIPS1004K", "MIPS24K", "MIPS64_GENERIC", "SICORTEX", "LOONGSON3A", "LOONGSON3B", "I6400", "P6600", "I6500", "ITANIUM2", "SPARC", "SPARCV7", "CORTEXA15", "CORTEXA9", "ARMV7", "ARMV6", "ARMV5", "ARMV8", "CORTEXA53", "CORTEXA57", "CORTEXA72", "CORTEXA73", "CORTEXA76", "CORTEXA510", "CORTEXA710", "CORTEXX1", "CORTEXX2", "NEOVERSEN1", "NEOVERSEV1", "NEOVERSEN2", "CORTEXA55", "EMAG8180", "FALKOR", "THUNDERX", "THUNDERX2T99", "TSV110", "THUNDERX3T110", "VORTEX", "A64FX", "ARMV8SVE", "FT2000", "ZARCH_GENERIC", "Z13", "Z14", "RISCV64_GENERIC", "RISCV64_ZVL128B", "C910V", "x280", "RISCV64_ZVL256B", "LOONGSONGENERIC", "LOONGSON3R5", "LOONGSON2K1000", "E2K", "EV4", "EV5", "EV6", "CSKY", "CK860FV"]
+
 
 class OpenblasConan(ConanFile):
     name = "openblas"
@@ -29,6 +76,7 @@ class OpenblasConan(ConanFile):
         "use_thread": [True, False],
         "use_locking": [True, False],
         "dynamic_arch": [True, False],
+        "target": [None] + available_openblas_targets
     }
     default_options = {
         "shared": False,
@@ -38,6 +86,7 @@ class OpenblasConan(ConanFile):
         "use_thread": True,
         "use_locking": True,
         "dynamic_arch": False,
+        "target": None,
     }
     options_description = {
         "build_lapack": "Build LAPACK and LAPACKE",
@@ -45,6 +94,7 @@ class OpenblasConan(ConanFile):
         "use_thread": "Enable threads support",
         "use_locking": "Use locks even in single-threaded builds to make them callable from multiple threads",
         "dynamic_arch": "Include support for multiple CPU targets, with automatic selection at runtime (x86/x86_64, aarch64 or ppc only)",
+        "target": "OpenBLAS TARGET variable (see TargetList.txt)",
     }
     short_paths = True
 
@@ -68,6 +118,14 @@ class OpenblasConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
+        # When cross-compiling, OpenBLAS requires explicitly setting TARGET
+        if cross_building(self, skip_x64_x86=True) and not self.options.target:
+            # Try inferring the target from settings.arch
+            target = conan_arch_to_openblas_target.get(str(self.settings.arch))
+            if target:
+                self.output.warning(f'Setting OpenBLAS TARGET={target} based on settings.arch. This may result in suboptimal performance. Set the "{self.name}/*:target=XXX" option to silence this warning.')
+                self.options.target = target
+
     def validate(self):
         if Version(self.version) < "0.3.24" and self.settings.arch == "armv8":
             # OpenBLAS fails to detect the appropriate target architecture for armv8 for versions < 0.3.24, as it matches the 32 bit variant instead of 64.
@@ -75,15 +133,18 @@ class OpenblasConan(ConanFile):
             # This would be a reasonably trivial hotfix to backport.
             raise ConanInvalidConfiguration("armv8 builds are not currently supported for versions lower than 0.3.24. Contributions to support this are welcome.")
 
-        if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
-            raise ConanInvalidConfiguration("Cross-building not implemented")
-
         if self.options.build_relapack:
             if not self.options.build_lapack:
                 raise ConanInvalidConfiguration(f'"{self.name}/*:build_relapack=True" option requires "{self.name}/*:build_lapack=True"')
             if self.settings.compiler not in ["gcc", "clang"]:
                 # ld: unknown option: --allow-multiple-definition on apple-clang
                 raise ConanInvalidConfiguration(f'"{self.name}/*:build_relapack=True" option is only supported for GCC and Clang')
+
+    def validate_build(self):
+        # If we're cross-compiling, and the user didn't provide the target, and
+        # we couldn't infer the target from settings.arch, fail
+        if cross_building(self, skip_x64_x86=True) and not self.options.target:
+            raise ConanInvalidConfiguration(f'Could not determine OpenBLAS TARGET. Please set the "{self.name}/*:target=XXX" option.')
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -119,6 +180,9 @@ class OpenblasConan(ConanFile):
         # This is a workaround to add the libm dependency on linux,
         # which is required to successfully compile on older gcc versions.
         tc.variables["ANDROID"] = self.settings.os in ["Linux", "Android"]
+
+        if self.options.target:
+            tc.cache_variables["TARGET"] = self.options.target
 
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()


### PR DESCRIPTION
Specify library name and version:  **openblas/\***

This PR adds support for cross-compiling OpenBLAS. In previous versions of the recipe, cross-building was explicitly disabled.

When cross-compiling, OpenBLAS requires the `TARGET` option to be set, so this option has also been added to the Conan recipe. By default, it is set to `None` which has no effect. When cross-compiling, the default `TARGET` is determined based on `settings.arch`.

Native builds should not be affected by these changes.

---

Differences compared to other open pull requests for the OpenBLAS recipe:

- https://github.com/conan-io/conan-center-index/pull/24038:  
_Checking for cross-compilation support should be done in `validate_build()`, not `validate()`_.  
This change is included in the present PR as well, but the check is now different.

- https://github.com/conan-io/conan-center-index/pull/23207:  
Support for ARMv8 is also covered by the present PR, without the need for backporting patches.  
`#23207` uses `tc.cache_variables["TARGET"] = str(self.settings.arch).upper()`, which only works for some architectures, the dictionary in the present PR supports all common architectures, not just ARM.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
