### PR TITLE
meson: add version 1.4.1

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.1":
+    url: "https://github.com/mesonbuild/meson/archive/1.4.1.tar.gz"
+    sha256: "a7efc72ecb873c5a62031ade1921a7177b67cfdcb2e9410a7ab023f9e8192f4b"
   "1.4.0":
     url: "https://github.com/mesonbuild/meson/archive/1.4.0.tar.gz"
     sha256: "61382f295378bddcd9bebb3a9a9065b1cbc671fa41b80964ab02726f9a5f3a88"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.1":
+    folder: all
   "1.4.0":
     folder: all
   "1.3.2":


### PR DESCRIPTION
Specify library name and version:  **meson/1.4.1**

https://github.com/mesonbuild/meson/compare/1.4.0...1.4.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
