### PR TITLE
[bitserializer] Add new version 0.70

### DIFF
--- a/recipes/bitserializer/all/conandata.yml
+++ b/recipes/bitserializer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.70":
+    url: "https://github.com/PavelKisliak/BitSerializer/archive/v0.70.tar.gz"
+    sha256: "094b12c729b35bf2cede8b55e8193db7793482646f0307c17bcc736de6cce7c9"
   "0.65":
     url: "https://github.com/PavelKisliak/BitSerializer/archive/v0.65.tar.gz"
     sha256: "b4d90f13dd424faebe3ee57ee0cb86ff304e893990afd259c6a29d1f8533b2ef"

--- a/recipes/bitserializer/all/test_package/CMakeLists.txt
+++ b/recipes/bitserializer/all/test_package/CMakeLists.txt
@@ -17,6 +17,9 @@ endif()
 if(WITH_CSV)
     list(APPEND BITSERIALIZER_COMPONENTS csv-archive)
 endif()
+if(WITH_MSGPACK)
+    list(APPEND BITSERIALIZER_COMPONENTS msgpack-archive)
+endif()
 
 find_package(bitserializer CONFIG REQUIRED
     COMPONENTS ${BITSERIALIZER_COMPONENTS}
@@ -31,6 +34,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     $<$<BOOL:${WITH_PUGIXML}>:BitSerializer::pugixml-archive>
     $<$<BOOL:${WITH_RAPIDYAML}>:BitSerializer::rapidyaml-archive>
     $<$<BOOL:${WITH_CSV}>:BitSerializer::csv-archive>
+    $<$<BOOL:${WITH_MSGPACK}>:BitSerializer::msgpack-archive>
 )
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     $<$<BOOL:${WITH_CPPRESTSDK}>:"WITH_CPPRESTSDK">
@@ -38,4 +42,5 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
     $<$<BOOL:${WITH_PUGIXML}>:"WITH_PUGIXML">
     $<$<BOOL:${WITH_RAPIDYAML}>:"WITH_RAPIDYAML">
     $<$<BOOL:${WITH_CSV}>:"WITH_CSV">
+    $<$<BOOL:${WITH_MSGPACK}>:"WITH_MSGPACK">
 )

--- a/recipes/bitserializer/all/test_package/conanfile.py
+++ b/recipes/bitserializer/all/test_package/conanfile.py
@@ -23,6 +23,7 @@ class TestPackageConan(ConanFile):
         tc.variables["WITH_PUGIXML"] = bitserializerOptions.with_pugixml
         tc.variables["WITH_RAPIDYAML"] = bitserializerOptions.get_safe("with_rapidyaml", False)
         tc.variables["WITH_CSV"] = bitserializerOptions.get_safe("with_csv", False)
+        tc.variables["WITH_MSGPACK"] = bitserializerOptions.get_safe("with_msgpack", False)
         tc.generate()
 
     def build(self):

--- a/recipes/bitserializer/all/test_v1_package/conanfile.py
+++ b/recipes/bitserializer/all/test_v1_package/conanfile.py
@@ -20,6 +20,7 @@ class TestPackageConan(ConanFile):
         cmake.definitions["WITH_PUGIXML"] = self.options["bitserializer"].with_pugixml
         cmake.definitions["WITH_RAPIDYAML"] = self._bitserializer_option("with_rapidyaml", False)
         cmake.definitions["WITH_CSV"] = self._bitserializer_option("with_csv", False)
+        cmake.definitions["WITH_MSGPACK"] = self._bitserializer_option("with_msgpack", False)
         cmake.configure()
         cmake.build()
 

--- a/recipes/bitserializer/config.yml
+++ b/recipes/bitserializer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.70":
+    folder: "all"
   "0.65":
     folder: "all"
   "0.50":


### PR DESCRIPTION
Specify library name and version:  **bitserializer/0.70**

I'd like to add a new version of BitSerializer 0.70 to Conan ([Release notes](https://github.com/PavelKisliak/BitSerializer/releases/tag/v0.70)). I am author of library.

---

- [√] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [√] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [√] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
