### PR TITLE
fltk: honor msvc static runtime

### DIFF
--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -4,6 +4,8 @@ from conan import ConanFile
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, rm, rmdir
+from conan.tools.microsoft import msvc_runtime_flag
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -35,6 +37,14 @@ class FltkConan(ConanFile):
         "with_gdiplus": True,
         "with_xft": False,
     }
+
+    @property
+    def _is_cl_like(self):
+        return self.settings.compiler.get_safe("runtime") is not None
+
+    @property
+    def _is_cl_like_static_runtime(self):
+        return self._is_cl_like and "MT" in msvc_runtime_flag(self)
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -96,6 +106,9 @@ class FltkConan(ConanFile):
         tc.variables["OPTION_USE_SYSTEM_LIBJPEG"] = True
         tc.variables["OPTION_USE_SYSTEM_ZLIB"] = True
         tc.variables["OPTION_USE_SYSTEM_LIBPNG"] = True
+        if Version(self.version) >= "1.3.9":
+            if self._is_cl_like:
+                tc.variables["FLTK_MSVC_RUNTIME_DLL"] = not self._is_cl_like_static_runtime
 
         tc.generate()
         tc = CMakeDeps(self)


### PR DESCRIPTION
Since 1.3.9, there is an option `FLTK_MSVC_RUNTIME_DLL` which forces `CMAKE_MSVC_RUNTIME_LIBRARY` and therefore defeats conan toolchain. Therefore this `FLTK_MSVC_RUNTIME_DLL` option must be managed by recipe itself.
See https://github.com/fltk/fltk/blob/release-1.3.9/CMake/options.cmake#L76-L83

closes https://github.com/conan-io/conan-center-index/issues/24180

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
