### PR TITLE
[pcl] Add realsense2 dependency to pcl

### DIFF
--- a/recipes/pcl/all/conanfile.py
+++ b/recipes/pcl/all/conanfile.py
@@ -75,6 +75,7 @@ class PclConan(ConanFile):
         "with_png": [True, False],
         "with_qhull": [True, False],
         "with_qt": [True, False],
+        "with_rssdk2": [True, False],
         "with_vtk": [True, False],
         # TODO:
         # "with_davidsdk": [True, False],
@@ -85,7 +86,6 @@ class PclConan(ConanFile):
         # "with_openni": [True, False],
         # "with_openni2": [True, False],
         # "with_rssdk": [True, False],
-        # "with_rssdk2": [True, False],
         # "with_qvtk": [True, False],
         # Precompile for a minimal set of point types only instead of all (e.g., pcl::PointXYZ instead of PCL_XYZ_POINT_TYPES)
         "precompile_only_core_point_types": [True, False],
@@ -148,6 +148,7 @@ class PclConan(ConanFile):
         "with_png": True,
         "with_qhull": True,
         "with_qt": True,
+        "with_rssdk2": True,
         "with_vtk": False,
         # Enabled to avoid excessive memory usage during compilation in CCI
         "precompile_only_core_point_types": True,
@@ -224,7 +225,7 @@ class PclConan(ConanFile):
             "qt": ["qt::qt"],
             "qvtk": [],
             "rssdk": [],
-            "rssdk2": [],
+            "rssdk2": ["librealsense::librealsense"],
             "vtk": [],
             "zlib": ["zlib::zlib"],
         }[dep]
@@ -393,6 +394,8 @@ class PclConan(ConanFile):
             self.requires("opencv/4.8.1", transitive_headers=True)
         if self._is_enabled("zlib"):
             self.requires("zlib/[>=1.2.11 <2]")
+        if self._is_enabled("rssdk2"):
+            self.requires("librealsense/2.53.1", transitive_headers=True)
         # TODO:
         # self.requires("vtk/9.x.x", transitive_headers=True)
         # self.requires("openni/x.x.x", transitive_headers=True)


### PR DESCRIPTION
Specify library name and version:  **pcl/1.13.1**

This PR adds realsense2 as dependency to pcl and sets `with_rssdk2=True` as default.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
