### PR TITLE
libjpeg: don't force LTO by default for msvc

### DIFF
--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -93,19 +93,22 @@ class LibjpegConan(ConanFile):
                 # shared: "libjpeg.lib" (import), "libjpeg-9.dll" (DLL)
                 jpeg_vcxproj = os.path.join(self.source_folder, "jpeg.vcxproj")
                 target_name = "libjpeg-9" if self.options.shared else "libjpeg"
-                replace_in_file(self, jpeg_vcxproj, """<PropertyGroup Label="UserMacros" />""", 
+                replace_in_file(self, jpeg_vcxproj, """<PropertyGroup Label="UserMacros" />""",
                                 f""" <PropertyGroup Label="UserMacros" /><PropertyGroup Label="TargetName"> <TargetName>{target_name}</TargetName></PropertyGroup>
                                 """)
                 if self.options.shared:
                     replace_in_file(self, jpeg_vcxproj, "</SubSystem>",
                                     "</SubSystem><ImportLibrary>$(OutDir)libjpeg.lib</ImportLibrary>")
-                
+
                 # Support static/shared
                 if self.options.shared:
                     replace_in_file(self, jpeg_vcxproj,
                         "<ConfigurationType>StaticLibrary</ConfigurationType>",
                         "<ConfigurationType>DynamicLibrary</ConfigurationType>"
                     )
+
+                # Don't force LTO
+                replace_in_file(self, jpeg_vcxproj, "<WholeProgramOptimization>true</WholeProgramOptimization>", "")
 
                 # Inject conan-generated .props file
                 # Note: importing it right before Microsoft.Cpp.props also ensures we correctly
@@ -125,7 +128,6 @@ class LibjpegConan(ConanFile):
                     if self.settings.build_type == "Debug":
                         replacements.update({
                             "<Optimization>Full": "<Optimization>Disabled",
-                            "<WholeProgramOptimization>true": "<WholeProgramOptimization>False",
                             "NDEBUG;": "_DEBUG;",
                         })
                     for key, value in replacements.items():


### PR DESCRIPTION
fix regression introduced by https://github.com/conan-io/conan-center-index/pull/23840 (issue is quite obvious in test package with the message `libjpeg.lib(jerror.obj) : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance`: https://c3i.jfrog.io/c3i/misc/logs/pr/23840/6-windows-visual_studio/libjpeg/9f//3fb49604f9c2f729b85ba3115852006824e72cab-test.txt)

closes https://github.com/conan-io/conan-center-index/issues/24116

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
