### PR TITLE
pdf-writer: add version 4.6.4

### DIFF
--- a/recipes/pdf-writer/all/conandata.yml
+++ b/recipes/pdf-writer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.6.4":
+    url: "https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.6.4.tar.gz"
+    sha256: "93b5f1dc88fd67fdebde409e927e828dfbae02efa44936e89728622411c6a047"
   "4.6.3":
     url: "https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.6.3.tar.gz"
     sha256: "3b5d9ba4b49d0380678e8172f27cdb8eda196ea448e7f1cdd79620066d082ab9"
@@ -12,6 +15,10 @@ sources:
     url: "https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.5.12.tar.gz"
     sha256: "40fcbaa66fc46fcb588ceda119ba8839ff6d2c886191ac5e68ed702475c7336e"
 patches:
+  "4.6.4":
+    - patch_file: "patches/4.6.2-0001-fix-cmake.patch"
+      patch_description: "disable cpack"
+      patch_type: "conan"
   "4.6.3":
     - patch_file: "patches/4.6.2-0001-fix-cmake.patch"
       patch_description: "disable cpack"

--- a/recipes/pdf-writer/config.yml
+++ b/recipes/pdf-writer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.6.4":
+    folder: all
   "4.6.3":
     folder: all
   "4.6.2":


### PR DESCRIPTION
Specify library name and version:  **pdf-writer/4.6.4**

https://github.com/galkahana/PDF-Writer/compare/v4.6.3...v4.6.4

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
