### PR TITLE
mpc: Unset LIBS before configuring

### DIFF
--- a/recipes/mpc/all/conanfile.py
+++ b/recipes/mpc/all/conanfile.py
@@ -79,6 +79,11 @@ class MpcConan(ConanFile):
         tc = AutotoolsToolchain(self)
         tc.configure_args.append(f'--with-gmp={unix_path(self, self.dependencies["gmp"].package_folder)}')
         tc.configure_args.append(f'--with-mpfr={unix_path(self, self.dependencies["mpfr"].package_folder)}')
+        # Unset LIBS which contains -lgmp, -lmpfr, etc. because mpc's configure
+        # script will incorporate it in its command-line when checking whether
+        # the compiler works and will in turn fail with:
+        #  ./conftest: error while loading shared libraries: libmpfr.so.6: cannot open shared object file: No such file or directory
+        tc.environment.unset('LIBS')
         tc.generate()
 
         tc = AutotoolsDeps(self)


### PR DESCRIPTION
mpc/1.3.1

On systems that do not have `libmpfr.so.6` installed, I fail to configure this package:
```
configure:3919: checking whether we are cross compiling
configure:3927: clang-16 -o conftest  -m64 -O3 -I/local/users/guyd/conan/.conan/data/gmp/6.3.0/_/_/package/581209b46b4309cd0f7261e5f10bfe21d5d4fc08/include -I/local/users/guyd/conan/.conan/data/mpfr/4.2.0/_/_/package/e4297c5e065990fd51a06a706f890cb821c50fae/include  -DNDEBUG -I/local/users/guyd/conan/.conan/data/mpfr/4.2.0/_/_/package/e4297c5e065990fd51a06a706f890cb821c50fae/include -I/local/users/guyd/conan/.conan/data/gmp/6.3.0/_/_/package/581209b46b4309cd0f7261e5f10bfe21d5d4fc08/include -L/local/users/guyd/conan/.conan/data/gmp/6.3.0/_/_/package/581209b46b4309cd0f7261e5f10bfe21d5d4fc08/lib -L/local/users/guyd/conan/.conan/data/mpfr/4.2.0/_/_/package/e4297c5e065990fd51a06a706f890cb821c50fae/lib  -m64 -L/local/users/guyd/conan/.conan/data/mpfr/4.2.0/_/_/package/e4297c5e065990fd51a06a706f890cb821c50fae/lib -L/local/users/guyd/conan/.conan/data/gmp/6.3.0/_/_/package/581209b46b4309cd0f7261e5f10bfe21d5d4fc08/lib conftest.c -lm -lmpfr -lgmpxx -lgmp -lm >&5
configure:3931: $? = 0
configure:3938: ./conftest
./conftest: error while loading shared libraries: libmpfr.so.6: cannot open shared object file: No such file or directory
```

My theory is that the AutoToolsToolchain populates the `LIBS` environment variable with the package's dependencies (i.e. `-lgmp, -lmpfr`), MPC then adds these to the implicit list of libraries it should link (`LIBS        libraries to pass to the linker, e.g. -l<library>`). That works fine during linking but to actually run the resulting executable, one needs to set `LD_LIBRARY_PATH` or compile with an `RPATH` which I believe is undesirable.
I think that it's not MPC at fault in this case because it manually configures the paths to its dependencies, so therefore I limited the scope of this "fix" but I'd rather someone with more experience will take a look.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
