### PR TITLE
minizip-ng: add version 4.0.6

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.6":
+    url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.6.tar.gz"
+    sha256: "e96ed3866706a67dbed05bf035e26ef6b60f408e1381bf0fe9af17fe2c0abebc"
   "4.0.5":
     url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.5.tar.gz"
     sha256: "9bb636474b8a4269280d32aca7de4501f5c24cc642c9b4225b4ed7b327f4ee73"

--- a/recipes/minizip-ng/config.yml
+++ b/recipes/minizip-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.6":
+    folder: all
   "4.0.5":
     folder: all
   "4.0.4":


### PR DESCRIPTION
Specify library name and version:  **minizip-ng/4.0.6**

https://github.com/zlib-ng/minizip-ng/compare/4.0.5...4.0.6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
