### PR TITLE
wiringpi: add version 3.6

### DIFF
--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6":
+    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.6.tar.gz"
+    sha256: "bec180a14ccd2d6b4eb5248d6553593511e7881348f56f8c98515a6d5d5444ee"
   "3.4":
     url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.4.tar.gz"
     sha256: "a81219e9ea0ce08295d2fc0457c69c4df0c6d2e846cb5817ba3247f673480d55"

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6":
+    folder: "all"
   "3.4":
     folder: "all"
   "3.2":


### PR DESCRIPTION
Specify library name and version:  **wiringpi/3.6**

https://github.com/WiringPi/WiringPi/compare/3.4...3.6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
