### PR TITLE
ipaddress: add version 1.1.0

### DIFF
--- a/recipes/ipaddress/all/conandata.yml
+++ b/recipes/ipaddress/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/VladimirShaleev/ipaddress/archive/v1.1.0.tar.gz"
+    sha256: "e5084d83ebd712210882eb6dac14ed1b9b71584dede523b35c6181e0a06375f1"
   "1.0.1":
     url: "https://github.com/VladimirShaleev/ipaddress/archive/v1.0.1.tar.gz"
     sha256: "49c16294f06fe95ffc66cae828dc08d116efb4a1ede3dddd21dcc182a2eceb03"

--- a/recipes/ipaddress/config.yml
+++ b/recipes/ipaddress/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **ipaddress/1.1.0**

Hello again, everyone! In this PR, I’d like to update the recipe to the new version 1.1.0 of the library [Release Notes](https://github.com/VladimirShaleev/ipaddress/releases/tag/v1.1.0)

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
