### PR TITLE
iceoryx: add version 2.0.6, remove .clang-tidy

### DIFF
--- a/recipes/iceoryx/all/conandata.yml
+++ b/recipes/iceoryx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.6":
+    url: "https://github.com/eclipse-iceoryx/iceoryx/archive/v2.0.6.tar.gz"
+    sha256: "a2add8ffee0c3357ef985cc46c7de79ccb754ea2bed02c61f2ff805ab2c869f1"
   "2.0.5":
     url: "https://github.com/eclipse-iceoryx/iceoryx/archive/v2.0.5.tar.gz"
     sha256: "bf6de70e3edee71223f993a29bff5e61af95ce4871104929d8bd1729f544bafb"

--- a/recipes/iceoryx/all/conanfile.py
+++ b/recipes/iceoryx/all/conanfile.py
@@ -5,7 +5,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, mkdir, rename, replace_in_file, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, mkdir, rename, replace_in_file, rmdir, save, rm
 from conan.tools.microsoft import is_msvc, check_min_vs
 from conan.tools.scm import Version
 
@@ -146,6 +146,7 @@ class IceoryxConan(ConanFile):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, ".clang-tidy", os.path.join(self.package_folder, "include"), recursive=True)
         if self.options.toml_config:
             mkdir(self, os.path.join(self.package_folder, "res"))
             rename(self, os.path.join(self.package_folder, "etc", "roudi_config_example.toml"),

--- a/recipes/iceoryx/config.yml
+++ b/recipes/iceoryx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.6":
+    folder: all
   "2.0.5":
     folder: all
   "2.0.3":


### PR DESCRIPTION
Specify library name and version:  **iceoryx/***

https://github.com/eclipse-iceoryx/iceoryx/compare/v2.0.5...v2.0.6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
