### PR TITLE
civetweb: Add option to allow to set stack size per thread.

### DIFF
--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -22,6 +22,7 @@ class CivetwebConan(ConanFile):
         "fPIC": [True, False],
         "shared": [True, False],
         "ssl_dynamic_loading": [True, False],
+        "thread_stack_size": [None, "ANY"],
         "with_caching": [True, False],
         "with_cgi": [True, False],
         "with_cxx": [True, False],
@@ -39,6 +40,7 @@ class CivetwebConan(ConanFile):
         "fPIC": True,
         "shared": False,
         "ssl_dynamic_loading": False,
+        "thread_stack_size": None,
         "with_caching": True,
         "with_cgi": True,
         "with_cxx": True,
@@ -122,6 +124,8 @@ class CivetwebConan(ConanFile):
         tc.variables["CIVETWEB_ENABLE_THIRD_PARTY_OUTPUT"] = self.options.with_third_party_output
         tc.variables["CIVETWEB_ENABLE_WEBSOCKETS"] = self.options.with_websockets
         tc.variables["CIVETWEB_SERVE_NO_FILES"] = not self.options.with_static_files
+        if self.options.thread_stack_size:
+            tc.variables["CIVETWEB_THREAD_STACK_SIZE"] = self.options.thread_stack_size
 
         if self._has_zlib_option:
             tc.variables["CIVETWEB_ENABLE_ZLIB"] = self.options.with_zlib

--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -94,6 +94,8 @@ class CivetwebConan(ConanFile):
     def validate(self):
         if self.options.get_safe("ssl_dynamic_loading") and not self.dependencies["openssl"].options.shared:
             raise ConanInvalidConfiguration("ssl_dynamic_loading requires shared openssl")
+        if self.options.thread_stack_size and not self.options.thread_stack_size.isdigit():
+            raise ConanInvalidConfiguration("-o='civetweb/*:thread_stack_size' should be a positive integer")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -94,7 +94,7 @@ class CivetwebConan(ConanFile):
     def validate(self):
         if self.options.get_safe("ssl_dynamic_loading") and not self.dependencies["openssl"].options.shared:
             raise ConanInvalidConfiguration("ssl_dynamic_loading requires shared openssl")
-        if self.options.thread_stack_size and not self.options.thread_stack_size.isdigit():
+        if self.options.thread_stack_size and not str(self.options.thread_stack_size).isdigit():
             raise ConanInvalidConfiguration("-o='civetweb/*:thread_stack_size' should be a positive integer")
 
     def source(self):


### PR DESCRIPTION
Specify library name and version:  **civetweb/1.16**

When doing memory-intensive tasks in the thread that handles http requests, then it is needed to set the stack size of the thread. Default it is set to 102400 bytes, so that is low for some situations. This PR allows to set the existing CIVETWEB_THREAD_STACK_SIZE cmake value.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
