### PR TITLE
qt: add fix for virtual can backend usage in multithreaded environment

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -139,6 +139,11 @@ patches:
       "patch_file": "patches/5.15.12-fix-macos-cpp-lib-memory-resource.patch"
       "patch_source": "https://codereview.qt-project.org/c/qt/qtbase/+/482392"
       "patch_type": "portability"
+    - "base_path": "qt5/qtserialbus"
+      "patch_description": "Fix virtual can backend usage in multithreaded environment"
+      "patch_file": "patches/virtualcanback_mutex.patch"
+      "patch_source": "https://codereview.qt-project.org/c/qt/qtserialbus/+/565329"
+      "patch_type": "backport"
   "5.15.13":
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/aa2a39dea5.diff"
@@ -162,6 +167,11 @@ patches:
       "patch_file": "patches/5.15.12-fix-macos-cpp-lib-memory-resource.patch"
       "patch_source": "https://codereview.qt-project.org/c/qt/qtbase/+/482392"
       "patch_type": "portability"
+    - "base_path": "qt5/qtserialbus"
+      "patch_description": "Fix virtual can backend usage in multithreaded environment"
+      "patch_file": "patches/virtualcanback_mutex.patch"
+      "patch_source": "https://codereview.qt-project.org/c/qt/qtserialbus/+/565329"
+      "patch_type": "backport"
   "5.15.12":
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/aa2a39dea5.diff"

--- a/recipes/qt/5.x.x/patches/virtualcanback_mutex.patch
+++ b/recipes/qt/5.x.x/patches/virtualcanback_mutex.patch
@@ -1,0 +1,32 @@
+diff --git a/src/plugins/canbus/virtualcan/virtualcanbackend.cpp b/src/plugins/canbus/virtualcan/virtualcanbackend.cpp
+index ce1ca3e9..fee09322 100644
+--- a/src/plugins/canbus/virtualcan/virtualcanbackend.cpp
++++ b/src/plugins/canbus/virtualcan/virtualcanbackend.cpp
+@@ -38,6 +38,7 @@
+ 
+ #include <QtCore/qdatetime.h>
+ #include <QtCore/qloggingcategory.h>
++#include <QtCore/qmutex.h>
+ #include <QtCore/qregularexpression.h>
+ 
+ #include <QtNetwork/qtcpserver.h>
+@@ -164,6 +165,7 @@ void VirtualCanServer::readyRead()
+ }
+ 
+ Q_GLOBAL_STATIC(VirtualCanServer, g_server)
++static QBasicMutex g_serverMutex;
+ 
+ VirtualCanBackend::VirtualCanBackend(const QString &interface, QObject *parent)
+     : QCanBusDevice(parent)
+@@ -205,8 +207,10 @@ bool VirtualCanBackend::open()
+     const QHostAddress address = host.isEmpty() ? QHostAddress::LocalHost : QHostAddress(host);
+     const quint16 port = static_cast<quint16>(m_url.port(ServerDefaultTcpPort));
+ 
+-    if (address.isLoopback())
++    if (address.isLoopback()) {
++        const QMutexLocker locker(&g_serverMutex);
+         g_server->start(port);
++    }
+ 
+     m_clientSocket = new QTcpSocket(this);
+     m_clientSocket->connectToHost(address, port, QIODevice::ReadWrite);


### PR DESCRIPTION
**qt/5.15.13 and qt/5.15.14**

This commit adds a patch for an issue in the QtSerialport virtual can backend.

The issue was identified by KDAB in one of our projects. KDAB has pushed a patch upstream, targeting Qt 6 (see https://codereview.qt-project.org/c/qt/qtserialbus/+/565329). As we are still using Qt 5, I'm providing a backported patch for Qt 5.15.13 and Qt 5.15.14 (sources are more or less unchanged, only some offset adaptions).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Also tested successfully with conan 1.64.1
