### PR TITLE
gettext: include stdlib.h on 0.21

### DIFF
--- a/recipes/gettext/all/conandata.yml
+++ b/recipes/gettext/all/conandata.yml
@@ -24,6 +24,9 @@ patches:
       patch_description: "apply the __atribute_noreturn__ to print_and_abort"
       patch_source: "https://github.com/coreutils/gnulib/commit/0cc39712803ade7b2d4b89c36b143dad72404063"
       patch_type: "conan"
+    - patch_file: "patches/0.21-include-stdlib_h.patch"
+      patch_description: "include stdlib.h for newer gcc"
+      patch_type: "portability"
   "0.20.1":
     - patch_file: "patches/0.20.1-0001-fix-build-errors-with-MSVC.patch"
     - patch_file: "patches/0.20.1-0003-Reported-by-Gabor-Z.-Papp-gzp-papp.hu.patch"

--- a/recipes/gettext/all/patches/0.21-include-stdlib_h.patch
+++ b/recipes/gettext/all/patches/0.21-include-stdlib_h.patch
@@ -1,0 +1,12 @@
+diff --git a/gettext-tools/src/locating-rule.c b/gettext-tools/src/locating-rule.c
+index 15faee1..66ec48a 100644
+--- a/gettext-tools/src/locating-rule.c
++++ b/gettext-tools/src/locating-rule.c
+@@ -47,6 +47,7 @@
+ #include <libxml/parser.h>
+ #include <libxml/uri.h>
+ #include "xalloc.h"
++#include <stdlib.h>
+ 
+ #define _(str) gettext (str)
+ 


### PR DESCRIPTION
Specify library name and version:  **gettext/0.21**

I met compilation error on gcc 14.1.1:
```
getted9230827dca7c/b/src/gettext-tools/src/locating-rule.c: In function ‘locating_rule_match’:
getted9230827dca7c/b/src/gettext-tools/src/locating-rule.c:150:7: error: implicit declaration of function ‘free’ [-Wimplicit-function-declaration]
  150 |       free (reduced);
      |       ^~~~
getted9230827dca7c/b/src/gettext-tools/src/locating-rule.c:50:1: note: include ‘<stdlib.h>’ or provide a declaration of ‘free’
   49 | #include "xalloc.h"
  +++ |+#include <stdlib.h>
   50 | 
getted9230827dca7
```

While gettext/0.22.5 works fine on gcc 14.1.1, gettext/0.21 is required by several important recipes (harfbuzz, pulseaudio, tre).

To minimize the impact, it would be better to create an adhoc patch  rather than upgrade gettext to 0.22.5.

Please point out if it would be better to increase the version of gettext rather than such an adhoc patch.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
