### PR TITLE
cpp-dump: add version 0.6.0

### DIFF
--- a/recipes/cpp-dump/all/conandata.yml
+++ b/recipes/cpp-dump/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.0":
+    url: "https://github.com/philip82148/cpp-dump/archive/refs/tags/v0.6.0.tar.gz"
+    sha256: "22bc5fafa22ac7c1e99db8824fdabec4af6baabed0c8b7cc80a0205dfb550414"
   "0.5.0":
     url: "https://github.com/philip82148/cpp-dump/archive/refs/tags/v0.5.0.tar.gz"
     sha256: "31fa8b03c9ee820525137be28f37b36e2abe7fd91df7d67681cb894db2230fe6"

--- a/recipes/cpp-dump/config.yml
+++ b/recipes/cpp-dump/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.6.0":
+    folder: all
   "0.5.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **cpp-dump/0.6.0**

https://github.com/philip82148/cpp-dump/compare/v0.5.0...v0.6.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
