### PR TITLE
libxml2: add latest releases libxml2/2.11.8 libxml2/2.12.7 (changes for CVE-2024-34459)

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.12.7":
+    url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.tar.xz"
+    sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56"
   "2.12.6":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.6.tar.xz"
     sha256: "889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb"
@@ -11,6 +14,9 @@ sources:
   "2.12.3":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.3.tar.xz"
     sha256: "8c8f1092340a89ff32bc44ad5c9693aff9bc8a7a3e161bb239666e5d15ac9aaa"
+  "2.11.8":
+    url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.8.tar.xz"
+    sha256: "53961af1721b72246180cd844b7ddae36ea8e1e4e27b683567990a1ee78b02c1"
   "2.11.7":
     url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.7.tar.xz"
     sha256: "fb27720e25eaf457f94fd3d7189bcf2626c6dccf4201553bc8874d50e3560162"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.12.7":
+    folder: all
   "2.12.6":
     folder: all
   "2.12.5":
@@ -6,6 +8,8 @@ versions:
   "2.12.4":
     folder: all
   "2.12.3":
+    folder: all
+  "2.11.8":
     folder: all
   "2.11.7":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libxml2/2.11.8**
Specify library name and version:  **libxml2/2.12.7**

> This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

Currently the new versions are not known at Conan and they contain security fixes too.

See also <https://gitlab.gnome.org/GNOME/libxml2/-/releases>
![image](https://github.com/conan-io/conan-center-index/assets/6735650/150dee20-2b74-41a5-bb09-173d99632a8a)



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
