### PR TITLE
[libpq] Avoid pthread_exit as exit code

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -167,9 +167,10 @@ class LibpqConan(ConanFile):
         # When linking to static openssl, it comes with static pthread library too, failing with:
         # libpq.so.5.15: U pthread_exit@GLIBC_2.2.5: libpq must not be calling any function which invokes exit
         # https://www.postgresql.org/message-id/20210703001639.GB2374652%40rfd.leadboat.com
-        replace_in_file(self, os.path.join(self.source_folder, "src", "interfaces", "libpq", "Makefile"),
-            "-v __cxa_atexit",
-            "-v __cxa_atexit -e pthread_exit")
+        if Version(self.version) >= "15":
+            replace_in_file(self, os.path.join(self.source_folder, "src", "interfaces", "libpq", "Makefile"),
+                "-v __cxa_atexit",
+                "-v __cxa_atexit -e pthread_exit")
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -164,6 +164,12 @@ class LibpqConan(ConanFile):
                 replace_in_file(self, os.path.join(self.source_folder, "src", "interfaces", "libpq", "Makefile"),
                 "ifeq ($(enable_thread_safety), yes)\nOBJS += pthread-win32.o\nendif",
                 "")
+        # When linking to static openssl, it comes with static pthread library too, failing with:
+        # libpq.so.5.15: U pthread_exit@GLIBC_2.2.5: libpq must not be calling any function which invokes exit
+        # https://www.postgresql.org/message-id/20210703001639.GB2374652%40rfd.leadboat.com
+        replace_in_file(self, os.path.join(self.source_folder, "src", "interfaces", "libpq", "Makefile"),
+            "-v __cxa_atexit",
+            "-v __cxa_atexit -e pthread_exit")
 
     def build(self):
         apply_conandata_patches(self)


### PR DESCRIPTION
Specify library name and version:  **libpq/15.4**

When building libpq as static library and openssl is static library too, it passes pthread as transitive dependency, resulting in the error reported by the issue #24208. The reason is because libpq does not allow calling `exit()` neither `abort()`, so they use a `nm` + `grep exit` with few exceptions.

https://github.com/postgres/postgres/blob/master/src/interfaces/libpq/Makefile#L118

I found few threads about adding some exception, like:

- https://www.postgresql.org/message-id/18424-bc056c6239e511fd@postgresql.org
- https://www.postgresql.org/message-id/3128896.1624742969@sss.pgh.pa.us

This PR skips excludes `pthread_exit` from the Makefile, so we can build libpq with openssl.

Out of curiosity, I found more package managers using openssl linked by default to libpq.

fixes #24208

/cc @mzbro

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
