### PR TITLE
qt6 source method: Fix windows conditional

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -1,6 +1,7 @@
 import configparser
 import glob
 import os
+import platform
 import textwrap
 
 from conan import ConanFile
@@ -653,7 +654,7 @@ class QtConan(ConanFile):
 
     def source(self):
         destination = self.source_folder
-        if self.info.settings.os == "Windows":
+        if platform.system() == "Windows":
             # Don't use os.path.join, or it removes the \\?\ prefix, which enables long paths
             destination = rf"\\?\{self.source_folder}"
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
Fix conditional in source() method, which should not have conditionals on settings as per Conan docs (for [v1.x ](https://docs.conan.io/1/reference/conanfile/methods.html#source) and [2.0](https://docs.conan.io/2/reference/conanfile/methods/source.html))

Fix https://github.com/conan-io/conan-center-index/issues/24233

which affects Conan 2.4 since https://github.com/conan-io/conan/pull/16272

