### PR TITLE
add recipe for dbus-cxx

### DIFF
--- a/recipes/dbus-cxx/2.x.x/conandata.yml
+++ b/recipes/dbus-cxx/2.x.x/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "2.5.1":
+    url: "https://github.com/dbus-cxx/dbus-cxx/archive/refs/tags/2.5.1.tar.gz"
+    sha256: "848467b14db37710ac3ad31cc6474b2d65b9b24e6cdcbb7e88c7637c0ad7b388"
+  "2.4.0":
+    url: "https://github.com/dbus-cxx/dbus-cxx/archive/refs/tags/2.4.0.tar.gz"
+    sha256: "c38456ed70023d93e6e689087e4bbe030f1650bbda9de7c035d6f4ebac788379"

--- a/recipes/dbus-cxx/2.x.x/conanfile.py
+++ b/recipes/dbus-cxx/2.x.x/conanfile.py
@@ -1,0 +1,89 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.files import get
+from conan.tools.scm import Version
+
+class DbusCXX(ConanFile):
+    name = "dbus-cxx"
+    license = "LGPL-3.0-only", "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://dbus-cxx.github.io"
+    description = "DBus-cxx provides an object-oriented interface to DBus"
+    topics = "bus", "interprocess", "message"
+    package_type = "static-library"
+    settings = "os", "compiler", "build_type", "arch"
+
+    options = {
+        "fPIC": [True, False],
+        "with_glib": [True, False],
+        "with_qt": [True, False],
+        "with_uv": [True, False],
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    # Default to a relocatable static library with only the default
+    # standalone dispatcher
+    default_options = {
+        "fPIC": True,
+        "with_glib": False,
+        "with_qt": False,
+        "with_uv": False,
+   }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+        if Version(self.version) < "2.5.0":
+            del self.options.with_uv
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def requirements(self):
+        self.requires("libsigcpp/3.0.7", transitive_headers=True)
+        self.requires("expat/[>=2.6.2 <3]")
+
+        if self.options.get_safe("with_uv"):
+            self.requires("libuv/[>=1.0 <2.0]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["ENABLE_GLIB_SUPPORT"] = self.options.with_glib
+        tc.cache_variables["ENABLE_QT_SUPPORT"] = self.options.with_qt
+        if Version(self.version) >= "2.5.0":
+            tc.cache_variables["ENABLE_UV_SUPPORT"] = self.options.with_uv
+        tc.generate()
+        deps = PkgConfigDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        if self.options.with_glib:
+            self.cpp_info.libs.append("dbus-cxx-glib")
+        if self.options.with_qt:
+            self.cpp_info.libs.append("dbus-cxx-qt")
+        if self.options.get_safe("with_uv"):
+            self.cpp_info.libs.append("dbus-cxx-uv")
+
+        self.cpp_info.libs.append("dbus-cxx")
+        self.cpp_info.includedirs = ['include/dbus-cxx-2.0']

--- a/recipes/dbus-cxx/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/dbus-cxx/2.x.x/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required (VERSION 3.15)
+project (dbus_cxx_package_test CXX)
+
+find_package (dbus-cxx REQUIRED CONFIG)
+
+add_executable (test test.cpp)
+target_link_libraries (test dbus-cxx::dbus-cxx)
+

--- a/recipes/dbus-cxx/2.x.x/test_package/conanfile.py
+++ b/recipes/dbus-cxx/2.x.x/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+class DbusCXXTest(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test")
+            self.run(cmd, env="conanrun")

--- a/recipes/dbus-cxx/2.x.x/test_package/test.cpp
+++ b/recipes/dbus-cxx/2.x.x/test_package/test.cpp
@@ -1,0 +1,7 @@
+#include <dbus-cxx.h>
+
+int main()
+{
+    auto connection = DBus::Connection::create( DBus::BusType::SESSION );
+    return 0;
+}

--- a/recipes/dbus-cxx/config.yml
+++ b/recipes/dbus-cxx/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "2.5.1":
+    folder: 2.x.x
+  "2.4.0":
+    folder: 2.x.x


### PR DESCRIPTION
**dbus-cxx/2.5.1**

At NI we are using conan as our C++ packaging tool. We dbus-cxx for native C++ bindings to DBus with a path to Windows support. 

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
