### PR TITLE
Add libuv to list of supported version range libraries

### DIFF
--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -190,7 +190,7 @@ version range only when a requirement for a newer version is needed.
 * Libxml2: `[>=2.12.5 <3]`
 * Libuv: `[>=1 <2]`
 * qt5: `[~5.15]`, if your library depends on qt5, only the 5.15 minor version is allowed
-* qt6: `qt/[>=6.x <7]`, where 6.x is the lower bound of your needed qt6 version
+* qt6: `[>=6.x <7]`, where 6.x is the lower bound of your needed qt6 version
 * c-ares: `[>=1.27 <2]`
 
 > **Warning**: With Conan 1.x, [version ranges](https://docs.conan.io/1/versioning/version_ranges.html) adhere to a much more strict sematic version spec,

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -189,6 +189,9 @@ version range only when a requirement for a newer version is needed.
 * Expat: `[>=2.6.2 <3]`
 * Libxml2: `[>=2.12.5 <3]`
 * Libuv: `[>=1 <2]`
+* qt5: `[~5.15]`, if your library depends on qt5, only the 5.15 minor version is allowed
+* qt6: `qt/[>=6.x <7]`, where 6.x is the lower bound of your needed qt6 version
+* c-ares: `[>=1.27 <2]`
 
 > **Warning**: With Conan 1.x, [version ranges](https://docs.conan.io/1/versioning/version_ranges.html) adhere to a much more strict sematic version spec,
 > OpenSSL 1.1.x does not follow this so the client will not resolve to that range and will pick a 3.x version. In order to select a lower version you

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -178,7 +178,7 @@ for consumer, we do impose some limits on Conan features to provide a smoother f
 
 Version ranges are a useful Conan feature, [documentation here](https://docs.conan.io/2/tutorial/versioning/version_ranges.html).
 With the introduction of Conan 2.0, we are currently working to allow the use of version ranges and are allowing this for a handful of dependencies.
-Currently, these are (except if the recipe needs a newer lower version for specific reasons):
+Currently, these are (except if the recipe needs a newer lower/upper version bound for specific reasons):
 
 * OpenSSL: `[>=1.1 <4]` for libraries known to be compatible with OpenSSL 1.x and 3.x
 * CMake: `[>3.XX <4]`, where `3.XX` is the minimum version of CMake required by the relevant build scripts. Note that CCI recipes assume 3.15 is installed in the system, so add this
@@ -188,6 +188,7 @@ version range only when a requirement for a newer version is needed.
 * Libpng: `[>=1.6 <2]`
 * Expat: `[>=2.6.2 <3]`
 * Libxml2: `[>=2.12.5 <3]`
+* Libuv: `[>=1 <2]`
 
 > **Warning**: With Conan 1.x, [version ranges](https://docs.conan.io/1/versioning/version_ranges.html) adhere to a much more strict sematic version spec,
 > OpenSSL 1.1.x does not follow this so the client will not resolve to that range and will pick a 3.x version. In order to select a lower version you


### PR DESCRIPTION
Helpful because most libraries in CCI diverge on the required version

See https://github.com/libuv/libuv#versioning