### PR TITLE
glaze: add version 2.8.0, remove older versions

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
+  "2.8.0":
+    url: "https://github.com/stephenberry/glaze/archive/v2.8.0.tar.gz"
+    sha256: "dc84691f2f8afde28a1abe58c69ef82f546a3955ef5aa028c34af51e53f710a9"
+  # keep 2.8.0 for breaking change: write error handling
   "2.7.0":
     url: "https://github.com/stephenberry/glaze/archive/v2.7.0.tar.gz"
     sha256: "8e3ee2ba725137cd4f61bc9ceb74e2225dc22b970da1c5a43d2a6833115adbfc"
@@ -22,27 +26,6 @@ sources:
   "2.6.2":
     url: "https://github.com/stephenberry/glaze/archive/v2.6.2.tar.gz"
     sha256: "8498de2b5e80b4eeab07108ea8ed460d4bbfef56f533ff08ca9e119501185dc4"
-  "2.6.1":
-    url: "https://github.com/stephenberry/glaze/archive/v2.6.1.tar.gz"
-    sha256: "c8b1d981329f279b85f6ee732e2c3cc9d0d2e014ef3d79cb72bf67dc9f2357d4"
-  "2.6.0":
-    url: "https://github.com/stephenberry/glaze/archive/v2.6.0.tar.gz"
-    sha256: "cdc2b7ada3b10abae8f8ed2700cc76574e73f0c78c4b0b83ad8a35eb5fb1a4cb"
-  "2.5.5":
-    url: "https://github.com/stephenberry/glaze/archive/v2.5.5.tar.gz"
-    sha256: "a7ce5c976afde4d2c09077d954b720a3af2adf0cb6742bb88605008b6887b971"
-  "2.4.0":
-    url: "https://github.com/stephenberry/glaze/archive/v2.4.0.tar.gz"
-    sha256: "be8cfb94c0b4b13c0a1fc846e2c112614d2dda02a49977fcdeea544876b3625b"
-  "2.3.2":
-    url: "https://github.com/stephenberry/glaze/archive/v2.3.2.tar.gz"
-    sha256: "360c1eab71afb69d59cc0f0e180d6b214653950340ac267a464a18c81dac585a"
-  "2.2.1":
-    url: "https://github.com/stephenberry/glaze/archive/v2.2.1.tar.gz"
-    sha256: "ef0eb30a038c623ca100696e773ba1c9888719ed02c46e9fabf6238ee07026bb"
-  "2.1.9":
-    url: "https://github.com/stephenberry/glaze/archive/v2.1.9.tar.gz"
-    sha256: "678126f068e3c21c2b3d2e1ae914c72296b68610a004cf542ea050946ab06416"
   # Keep 2.1.6 for now as 2.1.7 had some breaking changes
   "2.1.6":
     url: "https://github.com/stephenberry/glaze/archive/v2.1.6.tar.gz"

--- a/recipes/glaze/all/conanfile.py
+++ b/recipes/glaze/all/conanfile.py
@@ -29,8 +29,7 @@ class GlazeConan(ConanFile):
             "Visual Studio": "17",
             "msvc": "193",
             "gcc": "11" if Version(self.version) < "2.6.3" else "12",
-            # glaze >= 2.1.6 uses std::bit_cast which is supported by clang >= 14
-            "clang": "12" if Version(self.version) < "2.1.6" else "14",
+            "clang": "14",
             "apple-clang": "13.1",
         }
 
@@ -41,8 +40,8 @@ class GlazeConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        if Version(self.version) >= "2.1.4" and \
-            self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "11.3":
+        # remove this block when all versions of under 2.6.3 will be removed.
+        if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "11.3":
             raise ConanInvalidConfiguration(
                 f"{self.ref} doesn't support 11.0<=gcc<11.3 due to gcc bug. Please use gcc>=11.3 and set compiler.version.(ex. compiler.version=11.3)",
             )

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8.0":
+    folder: all
   "2.7.0":
     folder: all
   "2.6.9":
@@ -12,20 +14,6 @@ versions:
   "2.6.3":
     folder: all
   "2.6.2":
-    folder: all
-  "2.6.1":
-    folder: all
-  "2.6.0":
-    folder: all
-  "2.5.5":
-    folder: all
-  "2.4.0":
-    folder: all
-  "2.3.2":
-    folder: all
-  "2.2.1":
-    folder: all
-  "2.1.9":
     folder: all
   "2.1.6":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **glaze/***

https://github.com/stephenberry/glaze/compare/v2.7.0...v2.8.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
