### PR TITLE
tree-sitter: add version 0.22.6

### DIFF
--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.22.6":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.22.6.tar.gz"
+    sha256: "e2b687f74358ab6404730b7fb1a1ced7ddb3780202d37595ecd7b20a8f41861f"
   "0.22.5":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.22.5.tar.gz"
     sha256: "6bc22ca7e0f81d77773462d922cf40b44bfd090d92abac75cb37dbae516c2417"

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.22.6":
+    folder: all
   "0.22.5":
     folder: all
   "0.22.1":


### PR DESCRIPTION
Specify library name and version:  **tree-sitter/0.22.6**

https://github.com/tree-sitter/tree-sitter/compare/v0.22.5...v0.22.6

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
