### PR TITLE
[boost] Add -fcoroutines for GCC10 only

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1395,7 +1395,7 @@ class BoostConan(ConanFile):
             cxx_flags.append(f"-DBOOST_STACKTRACE_ADDR2LINE_LOCATION={self.options.addr2line_location}")
 
         if not self.options.get_safe('without_cobalt', True) and \
-            (self.settings.compiler == "gcc" or Version(self.settings.compiler.version) == "10"):
+            (self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "10"):
             cxx_flags.append("-fcoroutines")
 
         cxx_flags = f'cxxflags="{" ".join(cxx_flags)}"'
@@ -2038,7 +2038,7 @@ class BoostConan(ConanFile):
                     self.cpp_info.components["headers"].defines.extend(["BOOST_AC_DISABLE_THREADS", "BOOST_SP_DISABLE_THREADS"])
 
             if not self.options.get_safe('without_cobalt', True) and \
-                (self.settings.compiler == "gcc" or Version(self.settings.compiler.version) == "10"):
+                (self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "10"):
                 self.cpp_info.components["cobalt"].cxxflags.append("-fcoroutines")
 
         #TODO: remove in the future, user_info deprecated in conan2, but kept for compatibility while recipe is cross-compatible.

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -804,7 +804,7 @@ class BoostConan(ConanFile):
 
     def build_requirements(self):
         if not self.options.header_only:
-            self.tool_requires("b2/4.10.1")
+            self.tool_requires("b2/[>=5.2 <6]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **boost/1.85.0**

The PR #24237 fixed a compatibility situation when using compiler that don't have C++20 fully supported with coroutines, so people can use Boost Cobalt as well.

When using GCC10, the coroutines support is available, but it requires passing `-fcoroutines`, as documented in https://gcc.gnu.org/gcc-10/changes.html. For GCC11 and later it's no longer required.

There was a mistake in the logic to add or not `-fcoroutines`, it uses `or`, but should `and`, to only be applied for GCC10.

The Clang project supports coroutines since version 14, and does not require `-fcoroutines`. 

This bug was originally reported in Discord: https://discord.com/channels/400588936151433218/764433875640123402/1249600810439147531

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
