### PR TITLE
log4cxx: use version range for qt5

### DIFF
--- a/recipes/log4cxx/all/conanfile.py
+++ b/recipes/log4cxx/all/conanfile.py
@@ -104,7 +104,7 @@ class Log4cxxConan(ConanFile):
         if self.options.get_safe("with_fmt_layout"):
             self.requires("fmt/10.2.1")
         if self.options.get_safe("with_qt"):
-            self.requires("qt/5.15.12")
+            self.requires("qt/[~5.15]")
 
     def validate(self):
         if Version(self.version) < "1.0.0" or self.options.get_safe("with_multiprocess_rolling_file_appender"):


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
