### PR TITLE
qarchive: use version range for qt 5.15

### DIFF
--- a/recipes/qarchive/all/conanfile.py
+++ b/recipes/qarchive/all/conanfile.py
@@ -49,7 +49,7 @@ class QarchiveConan(ConanFile):
 
     def requirements(self):
         self.requires("libarchive/3.7.4")
-        self.requires("qt/5.15.10", transitive_headers=True, transitive_libs=True)
+        self.requires("qt/[~5.15]", transitive_headers=True, transitive_libs=True)
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.17 <4]")


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
