### PR TITLE
bump boost dependency

### DIFF
--- a/recipes/cubicinterpolation/all/conanfile.py
+++ b/recipes/cubicinterpolation/all/conanfile.py
@@ -42,8 +42,7 @@ class CubicInterpolationConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # TODO: update boost dependency as soon as we deprecate conan1.x (see discussion in #11207)
-        self.requires("boost/1.83.0")
+        self.requires("boost/1.85.0")
         self.requires("eigen/3.4.0")
 
     @property


### PR DESCRIPTION
Specify library name and version:  **cubicinterpolation/0.1.5**

Bump boost dependency

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
