### PR TITLE
mocknetworkaccessmanager: use version range for qt

### DIFF
--- a/recipes/mocknetworkaccessmanager/all/conanfile.py
+++ b/recipes/mocknetworkaccessmanager/all/conanfile.py
@@ -38,9 +38,9 @@ class MockNetworkAccessManagerConan(ConanFile):
 
     def requirements(self):
         if self.options.with_qt == 5:
-            self.requires("qt/5.15.12", transitive_headers=True)
+            self.requires("qt/[~5.15]", transitive_headers=True)
         else:
-            self.requires("qt/6.6.1", transitive_headers=True)
+            self.requires("qt/[>=6.6 <7]", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
