### PR TITLE
Bumped fmt to latest version avoiding conflicts

### DIFF
--- a/recipes/mp-units/0.8.0/conanfile.py
+++ b/recipes/mp-units/0.8.0/conanfile.py
@@ -59,7 +59,7 @@ class MPUnitsConan(ConanFile):
     def requirements(self):
         self.requires("gsl-lite/0.40.0")
         if self._use_libfmt:
-            self.requires("fmt/10.1.0")
+            self.requires("fmt/10.2.1")
         if self._use_range_v3:
             self.requires("range-v3/0.12.0")
 

--- a/recipes/mp-units/2.0.0/conanfile.py
+++ b/recipes/mp-units/2.0.0/conanfile.py
@@ -55,7 +55,7 @@ class MPUnitsConan(ConanFile):
     def requirements(self):
         self.requires("gsl-lite/0.40.0")
         if self._use_libfmt:
-            self.requires("fmt/10.1.0")
+            self.requires("fmt/10.2.1")
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):


### PR DESCRIPTION
Specify library name and version:  **mp-units/all**

Fix version conflict in fmt library
Closes #24247 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
