### PR TITLE
octo-logger-cpp: add version 1.12.0, update dependencies

### DIFF
--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.12.0":
+    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.12.0.tar.gz"
+    sha256: "bcf5fffebd478e9d1f192591dca44642f3ed3335b0d2ec4ea982ab75fbee62d7"
   "1.11.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.11.0.tar.gz"
     sha256: "73c35ca2a2e0c4be2cd85c5ba1f4061bbc22637fe79570107f1123eff30936db"

--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -52,9 +52,9 @@ class OctoLoggerCPPConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("fmt/10.1.1", transitive_headers=True)
+        self.requires("fmt/10.2.1", transitive_headers=True)
         if self.options.get_safe("with_aws"):
-            self.requires("nlohmann_json/3.11.2")
+            self.requires("nlohmann_json/3.11.3")
             self.requires("aws-sdk-cpp/1.9.234")
 
     def validate(self):

--- a/recipes/octo-logger-cpp/config.yml
+++ b/recipes/octo-logger-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.12.0":
+    folder: "all"
   "1.11.0":
     folder: "all"
   "1.9.0":


### PR DESCRIPTION
Specify library name and version:  **octo-logger-cpp/***

https://github.com/ofiriluz/octo-logger-cpp/compare/v1.11.0...v1.12.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
