### PR TITLE
drogon: add version 1.9.5, update trantor

### DIFF
--- a/recipes/drogon/all/conandata.yml
+++ b/recipes/drogon/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.5":
+    url: "https://github.com/drogonframework/drogon/archive/v1.9.5.tar.gz"
+    sha256: "b23d9d01d36fb1221298fcdbedcf7fd3e1b8b8821bf6fb8ed073c8b0c290d11d"
   "1.9.4":
     url: "https://github.com/drogonframework/drogon/archive/v1.9.4.tar.gz"
     sha256: "b23d9d01d36fb1221298fcdbedcf7fd3e1b8b8821bf6fb8ed073c8b0c290d11d"
@@ -27,6 +30,13 @@ sources:
     url: "https://github.com/drogonframework/drogon/archive/v1.8.4.tar.gz"
     sha256: "6f2f59ead0f0c37b0aac4bc889cbaedf3c2540f3020e892596c72f0a4d887a18"
 patches:
+  "1.9.5":
+    - patch_file: "patches/1.8.5-0001-remove-shared-libs.patch"
+      patch_description: "remove shared libs option"
+      patch_type: "conan"
+    - patch_file: "patches/1.9.2-0002-find-cci-packages.patch"
+      patch_description: "Fix jsoncpp cmake target name"
+      patch_type: "conan"
   "1.9.4":
     - patch_file: "patches/1.8.5-0001-remove-shared-libs.patch"
       patch_description: "remove shared libs option"

--- a/recipes/drogon/all/conandata.yml
+++ b/recipes/drogon/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.9.5":
     url: "https://github.com/drogonframework/drogon/archive/v1.9.5.tar.gz"
-    sha256: "b23d9d01d36fb1221298fcdbedcf7fd3e1b8b8821bf6fb8ed073c8b0c290d11d"
+    sha256: "ec17882835abeb0672db29cb36ab0c5523f144d5d8ff177861b8f5865803eaae"
   "1.9.4":
     url: "https://github.com/drogonframework/drogon/archive/v1.9.4.tar.gz"
     sha256: "b23d9d01d36fb1221298fcdbedcf7fd3e1b8b8821bf6fb8ed073c8b0c290d11d"

--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -110,7 +110,7 @@ class DrogonConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} requires boost on C++14")
 
     def requirements(self):
-        self.requires("trantor/1.5.16", transitive_headers=True, transitive_libs=True)
+        self.requires("trantor/1.5.19", transitive_headers=True, transitive_libs=True)
         self.requires("jsoncpp/1.9.5", transitive_headers=True, transitive_libs=True)
         self.requires("openssl/[>=1.1 <4]")
         self.requires("zlib/[>=1.2.11 <2]")

--- a/recipes/drogon/config.yml
+++ b/recipes/drogon/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.5":
+    folder: "all"
   "1.9.4":
     folder: "all"
   "1.9.3":


### PR DESCRIPTION
Specify library name and version:  **drogon/1.9.5**

https://github.com/drogonframework/drogon/compare/v1.9.4...v1.9.5

trantor is reqiured by drogon only.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
