### PR TITLE
cpp-httplib: add version 0.16.0

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.16.0":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.0.tar.gz"
+    sha256: "c125022eb85eaa12235518dc4638be93b62c3216d0f87b655af7b17b71b38851"
   "0.15.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.15.3.tar.gz"
     sha256: "2121bbf38871bb2aafb5f7f2b9b94705366170909f434428352187cb0216124e"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.16.0":
+    folder: all
   "0.15.3":
     folder: all
   "0.15.2":


### PR DESCRIPTION
Specify library name and version:  **cpp-httplib/0.16.0**

https://github.com/yhirose/cpp-httplib/compare/v0.15.3...v0.16.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
