### PR TITLE
octo-logger-cpp: bumped fmt dependency

### DIFF
--- a/recipes/octo-keygen-cpp/all/conanfile.py
+++ b/recipes/octo-keygen-cpp/all/conanfile.py
@@ -40,7 +40,7 @@ class OctoKeygenCPPConan(ConanFile):
     def requirements(self):
         self.requires("octo-logger-cpp/1.1.0", transitive_headers=True)
         self.requires("octo-encryption-cpp/1.1.0", transitive_headers=True)
-        self.requires("fmt/10.1.1")
+        self.requires("fmt/10.2.1")
         self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):


### PR DESCRIPTION
Specify library name and version:  **octo-keygen-cpp**

Bumped `fmt` library from `v10.1.1` to `v10.2.1` to match `octo-logger-cpp` recent recipe update avoiding conflicts.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
