### PR TITLE
libftp: add version 0.5.1

### DIFF
--- a/recipes/libftp/all/conandata.yml
+++ b/recipes/libftp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.5.1":
+    url: "https://github.com/deniskovalchuk/libftp/archive/refs/tags/v0.5.1.tar.gz"
+    sha256: "6cc6e80b50ba425b66175d3b0d22358db4ebeb4941edc33bba47d72442de5645"
   "0.5.0":
     url: "https://github.com/deniskovalchuk/libftp/archive/refs/tags/v0.5.0.tar.gz"
     sha256: "566d4d176bf754571e01563c4c0182a9c54b90903cd958a609fa0d6bd4c2141e"

--- a/recipes/libftp/config.yml
+++ b/recipes/libftp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.5.1":
+    folder: all
   "0.5.0":
     folder: all
   "0.4.1":


### PR DESCRIPTION
Specify library name and version:  **libftp/0.5.1**

https://github.com/deniskovalchuk/libftp/compare/v0.5.0...v0.5.1

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
