### PR TITLE
octo-logger-cpp: fix checksum for 1.12.0

### DIFF
--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.12.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.12.0.tar.gz"
-    sha256: "bcf5fffebd478e9d1f192591dca44642f3ed3335b0d2ec4ea982ab75fbee62d7"
+    sha256: "b4140d31910af128e1d97ae44a564bbad7f7ca889410bbc885691c5e215c0d61"
   "1.11.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.11.0.tar.gz"
     sha256: "73c35ca2a2e0c4be2cd85c5ba1f4061bbc22637fe79570107f1123eff30936db"


### PR DESCRIPTION
Specify library name and version:  **octo-logger-cpp/1.12.0**

octo-logger-cpp/1.12.0 is updated.

https://github.com/ofiriluz/octo-logger-cpp/commit/d7069893b09dd4f21f0faa3ba454938a1b8d1718

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
