### PR TITLE
[config] Enable github status checks for conan v2 profiles

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -54,7 +54,7 @@ tasks:
   cci:
     conan_v2_run_export: false
     write_comments: true
-    detailed_status_checks: true
+    detailed_status_checks: false
     update_labels: true
     build_bump_deps_pr: false
     description_bump_deps_pr: ":vertical_traffic_light: Thank for your Bump dependencies PR. The build service will be triggered soon by a Conan team member."

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -46,7 +46,7 @@ tasks:
     parallel_strategy: unlimited
   cci:
     conan_v2_run_export: false
-    detailed_status_checks: false
+    detailed_status_checks: true
     write_comments: false
     update_labels: false
     build_bump_deps_pr: false
@@ -56,7 +56,7 @@ tasks:
       regression: "> **Regression**: Conan v2 builds are mandatory and they are required for the PR to be merged, because this recipe worked with Conan v2 previously."
       text_on_failure: "The v2 pipeline failed. Please, review the errors and note this is required for pull requests to be merged. In case this recipe is still not ported to Conan 2.x, please, ping `@conan-io/barbarians` on the PR and we will help you."
       collapse_on_success: false
-      collapse_on_failure: true
+      collapse_on_failure: false
   list_packages:
     update_yaml_list_path: ".c3i/conan_v2_ready_references"
     update_yaml_list_key: "required_for_references"


### PR DESCRIPTION
### Summary
This enables the status checks for conan v2 and disables the conan v1 one.

#### Motivation
As the conan v2 builds gain importance, it is better feedback to the user to show the conan v2 builds in the status checks than the ones in conan 1. As in conan 2 there are less configurations built than in conan 1, this will also help on reducing the noise in the PRs.

#### Details
See this as an example of a PR with a recipe that has just one version:
![image](https://github.com/conan-io/conan-center-index/assets/10808592/83213485-fb21-409e-a3d3-811c1d60f9d3)



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
