### PR TITLE
outcome: add version 2.2.9

### DIFF
--- a/recipes/outcome/all/conandata.yml
+++ b/recipes/outcome/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.9":
+    url: "https://github.com/ned14/outcome/archive/v2.2.9.tar.gz"
+    sha256: "2840e403b1d7a0d3a75ecc4df574ab0674284bb21d76ac5f817695f2b56905f2"
   "2.2.8":
     url: "https://github.com/ned14/outcome/archive/v2.2.8.tar.gz"
     sha256: "6ef322867aee454792bd71b61950703dd18608670a69a1780cab81be22f78a1e"

--- a/recipes/outcome/all/conanfile.py
+++ b/recipes/outcome/all/conanfile.py
@@ -12,11 +12,11 @@ required_conan_version = ">=1.50.0"
 
 class OutcomeConan(ConanFile):
     name = "outcome"
-    homepage = "https://github.com/ned14/outcome"
     description = "Provides very lightweight outcome<T> and result<T>"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
-    topics = ("result",)
+    homepage = "https://github.com/ned14/outcome"
+    topics = ("result", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True

--- a/recipes/outcome/config.yml
+++ b/recipes/outcome/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.9":
+    folder: all
   "2.2.8":
     folder: all
   "2.2.7":


### PR DESCRIPTION
### Summary
Changes to recipe:  **output/2.2.9**

#### Motivation

- adding version 2.2.9
- reorder attributes on conanfile.py
- add "header-only" topic

#### Details

https://github.com/ned14/outcome/compare/v2.2.8...v2.2.9

Using Boost is option. 
We can use outcome without Boost.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
