### PR TITLE
string-view-lite: add version 1.8.0

### DIFF
--- a/recipes/string-view-lite/all/conandata.yml
+++ b/recipes/string-view-lite/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.0":
+    url: "https://github.com/martinmoene/string-view-lite/archive/v1.8.0.tar.gz"
+    sha256: "9b38c32621eb1a81a7fa59427144309225c414a7bae522ab3a2d9ae239dd35be"
   "1.7.0":
     url: "https://github.com/martinmoene/string-view-lite/archive/v1.7.0.tar.gz"
     sha256: "265eaec08c4555259b46f5b03004dbc0f7206384edfac1cd5a837efaa642e01c"

--- a/recipes/string-view-lite/all/conanfile.py
+++ b/recipes/string-view-lite/all/conanfile.py
@@ -8,11 +8,11 @@ required_conan_version = ">=1.50.0"
 
 class StringViewLite(ConanFile):
     name = "string-view-lite"
+    description = "string-view lite - A C++17-like string_view for C++98, C++11 and later in a single-file header-only library"
+    license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/martinmoene/string-view-lite"
-    description = "string-view lite - A C++17-like string_view for C++98, C++11 and later in a single-file header-only library"
-    topics = ("cpp98", "cpp11", "cpp14", "cpp17", "string-view", "string-view-implementations")
-    license = "BSL-1.0"
+    topics = ("cpp98", "cpp11", "cpp14", "cpp17", "string-view", "string-view-implementations", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True

--- a/recipes/string-view-lite/config.yml
+++ b/recipes/string-view-lite/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.0":
+    folder: all
   "1.7.0":
     folder: all
   "1.6.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **string-view-lite/1.8.0**

#### Motivation
string-view-lite/1.8.0 has several new features.

#### Details
https://github.com/martinmoene/string-view-lite/compare/v1.7.0...v1.8.0

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
