### PR TITLE
reflect-cpp: add version 0.11.1

### DIFF
--- a/recipes/reflect-cpp/all/conandata.yml
+++ b/recipes/reflect-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.1":
+    url: "https://github.com/getml/reflect-cpp/archive/v0.11.1.tar.gz"
+    sha256: "e45f112fb3f14507a4aa53b99ae2d4ab6a4e7b2d5f04dd06fec00bf7faa7bbdc"
   "0.11.0":
     url: "https://github.com/getml/reflect-cpp/archive/v0.11.0.tar.gz"
     sha256: "85f66939608acacf66dc782529af0c5a36b7d695c55b310b10c49700251b6221"

--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -61,6 +61,9 @@ class ReflectCppConan(ConanFile):
         if self.options.with_msgpack:
             self.requires("msgpack-c/6.0.0", transitive_headers=True)
 
+        if Version(self.version) >= "0.11.1":
+            self.requires("ctre/3.9.0", transitive_headers=True)
+
     def package_id(self):
         self.info.clear()
 
@@ -88,3 +91,5 @@ class ReflectCppConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        if Version(self.version) >= "0.11.1":
+            self.cpp_info.defines.append("REFLECTCPP_NO_BUNDLED_DEPENDENCIES")

--- a/recipes/reflect-cpp/config.yml
+++ b/recipes/reflect-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.1":
+    folder: all
   "0.11.0":
     folder: all
   "0.10.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **reflect/0.11.1**

#### Motivation
- add version 0.11.1
- 0.11.1 introduces `REFLECTCPP_NO_BUNDLED_DEPENDENCIES` which forces using  third-party libraries from external
- defining `REFLECTCPP_NO_BUNDLED_DEPENDENCIES` forces using external ctre library.

#### Details
https://github.com/getml/reflect-cpp/compare/v0.11.0...v0.11.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
