### PR TITLE
libvpx: small recipe fix to support MSVC 19.40 aka 194 --> vs17

### DIFF
--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -103,7 +103,7 @@ class LibVPXConan(ConanFile):
             compiler = f"vs{vc_version}"
         elif is_msvc(self):
             vc_version = str(self.settings.compiler.version)
-            vc_version = {"170": "11", "180": "12", "190": "14", "191": "15", "192": "16", "193": "17"}[vc_version]
+            vc_version = {"170": "11", "180": "12", "190": "14", "191": "15", "192": "16", "193": "17", "194": "17"}[vc_version]
             compiler = f"vs{vc_version}"
         elif self.settings.compiler in ["gcc", "clang", "apple-clang"]:
             compiler = 'gcc'


### PR DESCRIPTION
### Summary
Changes to recipe:  **libvpx/1.13.1**  and 1.14.0

#### Motivation
New MSVC 19.40 is out, aka 194, and this recipe only considered 19.3x
This adds support by mapping 194 to vs17 (vs18 hasn't been released yet)

#### Details
One line change in recipe to add 193 to the version list.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
