### PR TITLE
Update to SQLite3 Multiple Ciphers 1.8.6

### DIFF
--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.6":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.6.tar.gz"
+    sha256: "7250e3d9ca4368df00d0ebfaa744add66b458a5de318728b95369d621ebf2028"
   "1.8.4":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.4.tar.gz"
     sha256: "453e1938a02c91796a013169d56f746f153d7c7a77b59894bf8462b341a343ca"

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.6":
+    folder: all
   "1.8.4":
     folder: all
   "1.8.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3mc**

#### Motivation

While working on a Python3 wrapper several bugs/issues were detected and fixed in [_SQLite3 Multiple Ciphers 1.8.6_](https://github.com/utelle/SQLite3MultipleCiphers/releases/tag/v1.8.6). Some of the bugs can potentially cause database corruption. Therefore an update is recommended.

#### Details

Version 1.8.6 (based on _SQLite 3.46.0_) added.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
