### PR TITLE
readline: Disable example installation

### DIFF
--- a/recipes/readline/all/conanfile.py
+++ b/recipes/readline/all/conanfile.py
@@ -11,6 +11,7 @@ from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.53.0"
 
+
 class ReadLineConan(ConanFile):
     name = "readline"
     description = "A set of functions for use by applications that allow users to edit command lines as they are typed in"
@@ -18,6 +19,8 @@ class ReadLineConan(ConanFile):
     license = "GPL-3.0-only"
     homepage = "https://tiswww.case.edu/php/chet/readline/rltop.html"
     url = "https://github.com/conan-io/conan-center-index"
+
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -69,6 +72,9 @@ class ReadLineConan(ConanFile):
         ])
         if cross_building(self):
             tc.configure_args.append("bash_cv_wcwidth_broken=yes")
+
+        tc.configure_args.append("--disable-install-examples")
+
         tc.generate()
         deps = AutotoolsDeps(self)
         deps.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **readline/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The examples were always installed, but newer versions have a typo that made them fail.
Closes https://github.com/conan-io/conan-center-index/issues/24321

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

This is a follow-up/replacement of https://github.com/conan-io/conan-center-index/pull/24322 with express authorization from the author https://github.com/conan-io/conan-center-index/pull/24322#issuecomment-2166999621 - The changes are different so no cherry-pick/CLA signing is necessary on their part.

I would appreciate if I could get some extra insight into whether keeping the examples could be useful for someone - afaik it does not install any heads/libs, so it's purely documentation on our end, (which unless there's a good reason, keeping those is not what we've been doing with the rest of libraries!) @paigeadelethompson 

