### PR TITLE
libxml2: add new version 2.13.2

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.13.0":
-    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.0.tar.xz"
-    sha256: "d5a2f36bea96e1fb8297c6046fb02016c152d81ed58e65f3d20477de85291bc9"
+  "2.13.1":
+    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.1.tar.xz"
+    sha256: "25239263dc37f5f55a5393eff27b35f0b7d9ea4b2a7653310598ea8299e3b741"
   "2.12.7":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.tar.xz"
     sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56"

--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.13.1":
-    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.1.tar.xz"
-    sha256: "25239263dc37f5f55a5393eff27b35f0b7d9ea4b2a7653310598ea8299e3b741"
+  "2.13.2":
+    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.2.tar.xz"
+    sha256: "e7c8f5e0b5542159e0ddc409c22c9164304b581eaa9930653a76fb845b169263"
   "2.12.7":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.tar.xz"
     sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56"

--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.13.0":
+    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.0.tar.xz"
+    sha256: "d5a2f36bea96e1fb8297c6046fb02016c152d81ed58e65f3d20477de85291bc9"
   "2.12.7":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.tar.xz"
     sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56"

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -17,12 +17,12 @@ required_conan_version = ">=1.55.0"
 
 class Libxml2Conan(ConanFile):
     name = "libxml2"
-    package_type = "library"
-    url = "https://github.com/conan-io/conan-center-index"
     description = "libxml2 is a software library for parsing XML documents"
-    topics = "xml", "parser", "validation"
-    homepage = "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
     license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
+    topics = "xml", "parser", "validation"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     # from ./configure and ./win32/configure.js
     default_options = {

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.13.0":
+    folder: all
   "2.12.7":
     folder: all
   "2.12.6":

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.13.1":
+  "2.13.2":
     folder: all
   "2.12.7":
     folder: all

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.13.0":
+  "2.13.1":
     folder: all
   "2.12.7":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2/2.13.2**

#### Motivation
- 2.13.2 provides several new features
- recorder attributes in conanfile.py

#### Details
https://gitlab.gnome.org/GNOME/libxml2/-/compare/v2.12.0...v2.13.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
