### PR TITLE
mathter: add version 1.1.1

### DIFF
--- a/recipes/mathter/all/conandata.yml
+++ b/recipes/mathter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.1":
+    url: "https://github.com/petiaccja/Mathter/archive/v1.1.1.tar.gz"
+    sha256: "510e6aa198cd7b207a44d319e4471021f207cba8c4d2d7e40086f1f042fe13ab"
   "1.1.0":
     url: "https://github.com/petiaccja/Mathter/archive/v1.1.0.tar.gz"
     sha256: "a9a82126ecd80112854098a5646d38f72f0af03e9655b28ab8fa38b4c03b0870"

--- a/recipes/mathter/config.yml
+++ b/recipes/mathter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.1":
+    folder: all
   "1.1.0":
     folder: all
   "1.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mathter/1.1.1**

#### Motivation
The new version of the library contains small but important fixes.

#### Details
The new version (mathter/1.1.1) is appended to the `config.yml`, and the sources are updated.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
