### PR TITLE
c4core: add version 0.2.1, remove natvis file

### DIFF
--- a/recipes/c4core/all/conandata.yml
+++ b/recipes/c4core/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.1":
+    url: "https://github.com/biojppm/c4core/releases/download/v0.2.1/c4core-0.2.1-src.tgz"
+    sha256: "6447896444c59002af58c8543d0bc64184b9a5c5992c8fc09d6d71935d039f89"
   "0.2.0":
     url: "https://github.com/biojppm/c4core/releases/download/v0.2.0/c4core-0.2.0-src.tgz"
     sha256: "7843e6fb41c200fff69fc71105dbbf56bb410bdbab6b330e02cbe18430fe23bd"
@@ -15,6 +18,10 @@ sources:
     url: "https://github.com/biojppm/c4core/releases/download/v0.1.8/c4core-0.1.8-src.tgz"
     sha256: "95c0663192c6bff7a098b50afcb05d22a34dd0fd8e6be2e1b61edad2b9675fde"
 patches:
+  "0.2.1":
+    - patch_file: "patches/0.2.0-0001-make-fast_float-external.patch"
+      patch_description: "use cci's fast_float recipe"
+      patch_type: "conan"
   "0.2.0":
     - patch_file: "patches/0.2.0-0001-make-fast_float-external.patch"
       patch_description: "use cci's fast_float recipe"

--- a/recipes/c4core/all/conanfile.py
+++ b/recipes/c4core/all/conanfile.py
@@ -82,7 +82,7 @@ class C4CoreConan(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
-        rm(self, "*.natvis", os.path.join(self.package_folder, "include"))
+        rm(self, "*.natvis", os.path.join(self.package_folder, "include"), recursive=True)
 
     def package_info(self):
         self.cpp_info.libs = ["c4core"]

--- a/recipes/c4core/config.yml
+++ b/recipes/c4core/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.1":
+    folder: all
   "0.2.0":
     folder: all
   "0.1.11":


### PR DESCRIPTION
### Summary
Changes to recipe:  **c4core/***

#### Motivation

1. there are several changes in 0.2.1.
2. removing natvis file in include/c4.
   (ex. .conan2/p/b/c4cor1f07fd1a5ad74/p/include/c4/c4core.natvis)

#### Details

https://github.com/biojppm/c4core/compare/v0.2.0...v0.2.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
