### PR TITLE
grpc: allow to disable systemd support

### DIFF
--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -12,6 +12,10 @@ sources:
     url: "https://github.com/grpc/grpc/archive/v1.48.4.tar.gz"
     sha256: "0c3faa83e39d4f1ab55fe1476362b9ac3b81632a46dce7fd4d50271bce816b53"
 patches:
+  "1.54.3":
+    - patch_file: "patches/v1.50.x/002-CMake-Add-gRPC_USE_SYSTEMD-option-34384.patch"
+      patch_type: "backport"
+      patch_source: "https://github.com/grpc/grpc/commit/5c3400e8dc08d0810e3301d7e8cd8a718c82eeed"
   "1.50.1":
     - patch_file: "patches/v1.50.x/001-disable-cppstd-override.patch"
   "1.50.0":

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -15,13 +15,13 @@ required_conan_version = ">=1.60.0 <2 || >=2.0.5"
 
 class GrpcConan(ConanFile):
     name = "grpc"
-    package_type = "library"
     description = "Google's RPC (remote procedure call) library and framework."
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/grpc/grpc"
     topics = ("rpc",)
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
 
     options = {
@@ -36,7 +36,8 @@ class GrpcConan(ConanFile):
         "php_plugin": [True, False],
         "python_plugin": [True, False],
         "ruby_plugin": [True, False],
-        "secure": [True, False]
+        "secure": [True, False],
+        "with_libsystemd": [True, False]
     }
     default_options = {
         "shared": False,
@@ -51,6 +52,7 @@ class GrpcConan(ConanFile):
         "python_plugin": True,
         "ruby_plugin": True,
         "secure": False,
+        "with_libsystemd": True
     }
 
     short_paths = True
@@ -67,6 +69,10 @@ class GrpcConan(ConanFile):
     def _is_legacy_one_profile(self):
         return not hasattr(self, "settings_build")
 
+    @property
+    def _supports_libsystemd(self):
+        return self.settings.os in ["Linux", "FreeBSD"] and Version(self.version) >= "1.52"
+
     def export_sources(self):
         copy(self, "conan_cmake_project_include.cmake", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
         copy(self, f"cmake/{self._grpc_plugin_template}", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
@@ -75,6 +81,8 @@ class GrpcConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if not self._supports_libsystemd:
+            del self.options.with_libsystemd
 
     def configure(self):
         if self.options.shared:
@@ -101,7 +109,7 @@ class GrpcConan(ConanFile):
         self.requires("protobuf/3.21.12", transitive_headers=True, transitive_libs=True)
         self.requires("re2/20230301")
         self.requires("zlib/[>=1.2.11 <2]")
-        if self.settings.os in ["Linux", "FreeBSD"] and Version(self.version) >= "1.52":
+        if self.options.get_safe("with_libsystemd"):
             self.requires("libsystemd/255")
 
     def package_id(self):
@@ -184,6 +192,9 @@ class GrpcConan(ConanFile):
 
         if is_msvc(self) and Version(self.version) >= "1.48":
             tc.cache_variables["CMAKE_SYSTEM_VERSION"] = "10.0.18362.0"
+
+        if self._supports_libsystemd:
+            tc.cache_variables["gRPC_USE_SYSTEMD"] = self.options.with_libsystemd
 
         tc.generate()
 
@@ -288,7 +299,7 @@ class GrpcConan(ConanFile):
     def _grpc_components(self):
 
         def libsystemd():
-            return ["libsystemd::libsystemd"] if self.settings.os in ["Linux", "FreeBSD"] and Version(self.version) >= "1.52" else []
+            return ["libsystemd::libsystemd"] if self._supports_libsystemd else []
 
         def libm():
             return ["m"] if self.settings.os in ["Linux", "FreeBSD"] else []

--- a/recipes/grpc/all/patches/v1.50.x/002-CMake-Add-gRPC_USE_SYSTEMD-option-34384.patch
+++ b/recipes/grpc/all/patches/v1.50.x/002-CMake-Add-gRPC_USE_SYSTEMD-option-34384.patch
@@ -1,0 +1,57 @@
+From 64d855b0ddd944369e96b24210a1ce59e704a779 Mon Sep 17 00:00:00 2001
+From: Kirill <kirill@polushin.org>
+Date: Tue, 2 Apr 2024 13:17:47 -0700
+Subject: [PATCH] [CMake] Add gRPC_USE_SYSTEMD option (#34384)
+
+Issue https://github.com/grpc/grpc/issues/34304
+
+Allows to disable systemd support,
+as well as linking with libsystemd,
+when it is not required.
+
+The option has three possible values:
+AUTO - Default, Will try to find libsystemd. If found, systemd support will be enabled.
+ON - Enable systemd support. Build will fail if libsystemd is not found.
+OFF - Disable systemd support.
+
+Closes #34384
+
+COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/34384 from kirpichik:cmake-use-systemd-option 96f5f4bd68251ca62ccc45a2d44a68a8203531ac
+PiperOrigin-RevId: 621274356
+---
+ cmake/systemd.cmake | 21 ++++++++++++++++-----
+ 1 file changed, 16 insertions(+), 5 deletions(-)
+
+diff --git a/cmake/systemd.cmake b/cmake/systemd.cmake
+index a34210177e..559c8d24b6 100644
+--- a/cmake/systemd.cmake
++++ b/cmake/systemd.cmake
+@@ -12,9 +12,20 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-find_package(systemd)
+-if(TARGET systemd)
+-  set(_gRPC_SYSTEMD_LIBRARIES systemd ${SYSTEMD_LINK_LIBRARIES})
+-  add_definitions(-DHAVE_LIBSYSTEMD)
++set(gRPC_USE_SYSTEMD "AUTO" CACHE STRING "Build with libsystemd support if available. Can be ON, OFF or AUTO")
++
++if (NOT gRPC_USE_SYSTEMD STREQUAL "OFF")
++  if (gRPC_USE_SYSTEMD STREQUAL "ON")
++    find_package(systemd REQUIRED)
++  elseif (gRPC_USE_SYSTEMD STREQUAL "AUTO")
++    find_package(systemd)
++  else()
++    message(FATAL_ERROR "Unknown value for gRPC_USE_SYSTEMD = ${gRPC_USE_SYSTEMD}")
++  endif()
++
++  if(TARGET systemd)
++    set(_gRPC_SYSTEMD_LIBRARIES systemd ${SYSTEMD_LINK_LIBRARIES})
++    add_definitions(-DHAVE_LIBSYSTEMD)
++  endif()
++  set(_gRPC_FIND_SYSTEMD "if(NOT systemd_FOUND)\n  find_package(systemd)\nendif()")
+ endif()
+-set(_gRPC_FIND_SYSTEMD "if(NOT systemd_FOUND)\n  find_package(systemd)\nendif()")
+-- 
+2.43.0
+


### PR DESCRIPTION
### Summary
Changes to the recipe:  **grpc/1.54.3**

#### Motivation
Avoid building unnecessary libsystemd and its transitive dependencies.

#### Details
This merge request backports a commit from upstream that allows disabling systemd support.

The original commit can be found at:
https://github.com/grpc/grpc/commit/5c3400e8dc08d0810e3301d7e8cd8a718c82eeed


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
