### PR TITLE
Fix with_xnnpack=False

### DIFF
--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -89,8 +89,7 @@ class TensorflowLiteConan(ConanFile):
             self.requires("intel-neon2sse/cci.20210225")
         if self.options.with_xnnpack:
             self.requires("xnnpack/cci.20231026")
-            # https://github.com/tensorflow/tensorflow/blob/359c3cdfc5fabac82b3c70b3b6de2b0a8c16874f/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc#L165
-            self.requires("pthreadpool/cci.20231129")
+        self.requires("pthreadpool/cci.20231129")
         if self.options.with_xnnpack or self.options.get_safe("with_nnapi", False):
             self.requires("fp16/cci.20210320")
         if self._needs_fxdiv:

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -89,7 +89,8 @@ class TensorflowLiteConan(ConanFile):
             self.requires("intel-neon2sse/cci.20210225")
         if self.options.with_xnnpack:
             self.requires("xnnpack/cci.20231026")
-        self.requires("pthreadpool/cci.20231129")
+        if Version(self.version) >= "2.12.0" or self.options.with_xnnpack:
+            self.requires("pthreadpool/cci.20231129")
         if self.options.with_xnnpack or self.options.get_safe("with_nnapi", False):
             self.requires("fp16/cci.20210320")
         if self._needs_fxdiv:

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -1,10 +1,9 @@
-import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import get, save, copy, export_conandata_patches, apply_conandata_patches, replace_in_file
+from conan.tools.files import get, save, copy, export_conandata_patches, apply_conandata_patches
 from conan.tools.scm import Version
 from os.path import join
 import textwrap

--- a/recipes/tensorflow-lite/all/patches/2.12.0-0001-remove_simple_memory_arena_debug_dump.patch
+++ b/recipes/tensorflow-lite/all/patches/2.12.0-0001-remove_simple_memory_arena_debug_dump.patch
@@ -12,10 +12,3 @@ index c71a392..7260efe 100644
  
  # This particular file is excluded because the more explicit approach to enable
  # XNNPACK delegate is preferred to the weak-symbol one.
-@@ -654,4 +657,4 @@ target_link_libraries(_pywrap_tensorflow_interpreter_wrapper
- target_compile_options(_pywrap_tensorflow_interpreter_wrapper
-   PUBLIC ${TFLITE_TARGET_PUBLIC_OPTIONS}
-   PRIVATE ${TFLITE_TARGET_PRIVATE_OPTIONS}
--)
-\ No newline at end of file
-+)

--- a/recipes/tensorflow-lite/all/patches/2.12.0-0002-disable-fetch-content.patch
+++ b/recipes/tensorflow-lite/all/patches/2.12.0-0002-disable-fetch-content.patch
@@ -1,14 +1,3 @@
-diff --git a/tensorflow/lite/CMakeLists.txt b/tensorflow/lite/CMakeLists.txt
-index 24b8265..7260efe 100644
---- a/tensorflow/lite/CMakeLists.txt
-+++ b/tensorflow/lite/CMakeLists.txt
-@@ -657,4 +657,4 @@ target_link_libraries(_pywrap_tensorflow_interpreter_wrapper
- target_compile_options(_pywrap_tensorflow_interpreter_wrapper
-   PUBLIC ${TFLITE_TARGET_PUBLIC_OPTIONS}
-   PRIVATE ${TFLITE_TARGET_PRIVATE_OPTIONS}
--)
-\ No newline at end of file
-+)
 diff --git a/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake b/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake
 index 9ed9510..4a6a45d 100644
 --- a/tensorflow/lite/tools/cmake/modules/OverridableFetchContent.cmake

--- a/recipes/tensorflow-lite/all/patches/2.12.0-0003-use-cci-dependencies.patch
+++ b/recipes/tensorflow-lite/all/patches/2.12.0-0003-use-cci-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/tensorflow/lite/CMakeLists.txt b/tensorflow/lite/CMakeLists.txt
-index 24b8265..9e0d1e0 100644
+index 24b8265..d95c0ae 100644
 --- a/tensorflow/lite/CMakeLists.txt
 +++ b/tensorflow/lite/CMakeLists.txt
-@@ -142,31 +142,16 @@
+@@ -142,31 +142,17 @@ endmacro()
  find_package(absl REQUIRED)
  find_package(Eigen3 REQUIRED)
  find_package(farmhash REQUIRED)
@@ -32,6 +32,7 @@ index 24b8265..9e0d1e0 100644
 -  add_subdirectory(
 -    "${PTHREADPOOL_SOURCE_DIR}"
 -    "${CMAKE_BINARY_DIR}/pthreadpool")
++find_package(pthreadpool REQUIRED)
 +
 +if(TARGET flatbuffers::flatbuffers_shared)
 +  set(FLATBUFFERS_TARGET flatbuffers::flatbuffers_shared)
@@ -40,7 +41,7 @@ index 24b8265..9e0d1e0 100644
  endif()
  set(TF_TARGET_PRIVATE_OPTIONS "")
  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-@@ -180,6 +165,10 @@
+@@ -180,6 +166,10 @@ set(TFLITE_TARGET_PRIVATE_OPTIONS "")
  set(TFLITE_TARGET_PRIVATE_DEFINITIONS "")
  # Additional library dependencies based upon enabled features.
  set(TFLITE_TARGET_DEPENDENCIES "")
@@ -51,13 +52,12 @@ index 24b8265..9e0d1e0 100644
  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
    # TFLite uses deprecated methods in neon2sse which generates a huge number of
    # warnings so surpress these until they're fixed.
-@@ -429,13 +418,14 @@
+@@ -429,13 +419,13 @@ else()
  endif()
  if(TFLITE_ENABLE_XNNPACK)
    find_package(fp16_headers REQUIRED)
 -  find_package(XNNPACK REQUIRED)
 +  find_package(xnnpack REQUIRED)
-+  find_package(pthreadpool REQUIRED)
    populate_tflite_source_vars("delegates/xnnpack"
      TFLITE_DELEGATES_XNNPACK_SRCS
      FILTER ".*(_test|_tester)\\.(cc|h)"
@@ -68,7 +68,7 @@ index 24b8265..9e0d1e0 100644
    )
    list(APPEND TFLITE_TARGET_PUBLIC_OPTIONS "-DTFLITE_BUILD_WITH_XNNPACK_DELEGATE")
  endif()
-@@ -492,6 +482,7 @@
+@@ -492,6 +482,7 @@ populate_tflite_source_vars("kernels/internal/reference/sparse_ops"
    TFLITE_KERNEL_INTERNAL_REF_SPARSE_OPS_SRCS
  )
  set(TFLITE_PROFILER_SRCS
@@ -76,7 +76,7 @@ index 24b8265..9e0d1e0 100644
    ${TFLITE_SOURCE_DIR}/profiling/platform_profiler.cc
    ${TFLITE_SOURCE_DIR}/profiling/root_profiler.h
    ${TFLITE_SOURCE_DIR}/profiling/root_profiler.cc
-@@ -555,19 +546,18 @@
+@@ -555,19 +546,18 @@ target_include_directories(tensorflow-lite
  target_link_libraries(tensorflow-lite
    PUBLIC
      Eigen3::Eigen


### PR DESCRIPTION
### Summary
Changes to recipe:  **tensorflow-lite/2.12.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The patch always links with `pthreadpool`, but it was only ever `find_package`ed if running with `with_xnnpack=True`. This PR fixes the issue for 2.12.0. In 2.10.0, the pthreadpool dependency was exclusive to xnn_pack, but we didn't update properly

Closes https://github.com/conan-io/conan-center-index/issues/24359

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
The patches unvendorize the `pthreadpool` dependency and assumes it always needs to link, which AFAIK it's correct, (but would appreciate a double check of my findings!), but did not correctly call the `find_package` when necessary

