### PR TITLE
[beauty] Fix Openssl dependency management 

### DIFF
--- a/recipes/beauty/all/conandata.yml
+++ b/recipes/beauty/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.4":
+    url: "https://github.com/dfleury2/beauty/archive/refs/tags/1.0.4.tar.gz"
+    sha256: "8bfd3718470bdbed05b6b9253543d6ab9b33e21e25028e53fa513c67893a39f3"
   "1.0.3":
     url: "https://github.com/dfleury2/beauty/archive/refs/tags/1.0.3.tar.gz"
     sha256: "1707b0974537cfd8d1d2fd0b5accd5a662c0b408042aa01384cf5840ecc43594"

--- a/recipes/beauty/all/conandata.yml
+++ b/recipes/beauty/all/conandata.yml
@@ -9,6 +9,14 @@ sources:
     url: "https://github.com/dfleury2/beauty/archive/refs/tags/1.0.2.tar.gz"
     sha256: "627294d04a91c85e14d9c29475d539da5172c6d7306a48dca7c72413e47eebd6"
 patches:
+  "1.0.4":
+    - patch_file: "patches/0002-remove-openssl-target.patch"
+      patch_description: "Avoid defining openssl::openssl target when defined by Conan"
+      patch_type: "conan"
+  "1.0.3":
+    - patch_file: "patches/0002-remove-openssl-target.patch"
+      patch_description: "Avoid defining openssl::openssl target when defined by Conan"
+      patch_type: "conan"
   "1.0.2":
     - patch_file: "patches/0001-apple-compatibility.patch"
       patch_description: "Handle pthread_setname_np not being defined on macOS"

--- a/recipes/beauty/all/conandata.yml
+++ b/recipes/beauty/all/conandata.yml
@@ -22,3 +22,6 @@ patches:
       patch_description: "Handle pthread_setname_np not being defined on macOS"
       patch_type: "portability"
       patch_source: "https://github.com/dfleury2/beauty/pull/28"
+    - patch_file: "patches/0002-remove-openssl-target.patch"
+      patch_description: "Avoid defining openssl::openssl target when defined by Conan"
+      patch_type: "conan"

--- a/recipes/beauty/all/conanfile.py
+++ b/recipes/beauty/all/conanfile.py
@@ -23,23 +23,26 @@ class BeautyConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_openssl": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_openssl": True,
     }
 
     @property
     def _min_cppstd(self):
-        return "20"
+        return "17"
 
     @property
     def _compilers_minimum_version(self):
         return {
             "gcc": "8",
-            "clang": "11",
+            "clang": "7",
             "Visual Studio": "16",
             "msvc": "192",
+            "apple-clang": "10"
         }
 
     def export_sources(self):
@@ -59,9 +62,14 @@ class BeautyConan(ConanFile):
     def requirements(self):
         # beauty public headers include some boost headers.
         # For example beauty/application.hpp includes boost/asio.hpp
-        self.requires("boost/1.83.0", transitive_headers=True)
-        # dependency of asio in boost, exposed in boost/asio/ssl/detail/openssl_types.hpp
-        self.requires("openssl/[>=1.1 <4]", transitive_headers=True, transitive_libs=True)
+        if Version(self.version) >= "1.0.4":
+            # https://github.com/dfleury2/beauty/issues/30
+            self.requires("boost/1.85.0", transitive_headers=True)
+        else:
+            self.requires("boost/1.84.0", transitive_headers=True)
+        if self.options.with_openssl:
+            # dependency of asio in boost, exposed in boost/asio/ssl/detail/openssl_types.hpp
+            self.requires("openssl/[>=1.1 <4]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -74,13 +82,13 @@ class BeautyConan(ConanFile):
             )
 
         if self.settings.compiler == "clang" and self.settings.compiler.libcxx != "libc++":
-            raise ConanInvalidConfiguration("Only libc++ is supported for clang")
+            raise ConanInvalidConfiguration(f"{self.ref} clang compiler requires -s compiler.libcxx=libc++")
 
         if self.settings.compiler == "apple-clang" and self.options.shared:
-            raise ConanInvalidConfiguration("shared is not supported on apple-clang")
+            raise ConanInvalidConfiguration(f"The option {self.ref}:shared=True is not supported on Apple Clang. Use static instead.")
 
         if is_msvc(self) and self.options.shared:
-            raise ConanInvalidConfiguration("shared is not supported on Visual Studio")
+            raise ConanInvalidConfiguration(f"{self.ref} shared=True is not supported with {self.settings.compiler}")
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.21 <4]")
@@ -92,6 +100,7 @@ class BeautyConan(ConanFile):
         VirtualBuildEnv(self).generate()
         tc = CMakeToolchain(self)
         tc.variables["CONAN"] = False
+        tc.variables["BEAUTY_ENABLE_OPENSSL"] = self.options.with_openssl
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
@@ -112,6 +121,8 @@ class BeautyConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "beauty")
         self.cpp_info.set_property("cmake_target_name", "beauty::beauty")
         self.cpp_info.libs = ["beauty"]
-        self.cpp_info.requires = ["boost::headers", "openssl::openssl"]
+        self.cpp_info.requires = ["boost::headers"]
+        if self.options.with_openssl:
+            self.cpp_info.requires.append("openssl::ssl")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["m"]

--- a/recipes/beauty/all/conanfile.py
+++ b/recipes/beauty/all/conanfile.py
@@ -125,4 +125,8 @@ class BeautyConan(ConanFile):
         if self.options.with_openssl:
             self.cpp_info.requires.append("openssl::ssl")
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs = ["m"]
+            self.cpp_info.system_libs = ["m", "pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["crypt32"]
+        if self.options.with_openssl:
+            self.cpp_info.defines = ["BEAUTY_ENABLE_OPENSSL"]

--- a/recipes/beauty/all/patches/0002-remove-openssl-target.patch
+++ b/recipes/beauty/all/patches/0002-remove-openssl-target.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7cc5bda..12a5e71 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -27,7 +27,6 @@ else()
+ 
+     if (BEAUTY_ENABLE_OPENSSL)
+         find_package(OpenSSL REQUIRED)
+-        add_library(openssl::openssl ALIAS OpenSSL::SSL)
+     endif()
+ endif()
+ 

--- a/recipes/beauty/all/test_package/CMakeLists.txt
+++ b/recipes/beauty/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(beauty REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE beauty::beauty)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/beauty/config.yml
+++ b/recipes/beauty/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.4":
+    folder: all
   "1.0.3":
     folder: all
   "1.0.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **beauty/1.0.3**

#### Motivation

The current recipe uses OpenSSL, but does pass the option to activate the feature.

#### Details

- Added version 1.0.4 (Support for Boost 1.85.0): https://github.com/dfleury2/beauty/issues/30
- Downgraded required C++ version to 17: https://github.com/dfleury2/beauty/blob/master/CMakeLists.txt#L9
- Add option for OpenSSL: https://github.com/dfleury2/beauty/blob/master/CMakeLists.txt#L28

/cc @barbacar

fixes #24363

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
