### PR TITLE
nsync: add version 1.28.0

### DIFF
--- a/recipes/nsync/all/conandata.yml
+++ b/recipes/nsync/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.28.0":
+    url: "https://github.com/google/nsync/archive/1.28.0.tar.gz"
+    sha256: "1e6a7193bd85d480faaf992cef204c5cf09f9da72766c9987e25b4f88508eed1"
   "1.27.0":
     url: "https://github.com/google/nsync/archive/1.27.0.tar.gz"
     sha256: "e8e552a358f4a28e844207a7c5cb51767e4aeb0b29e22d23ac2a09924130f761"
@@ -15,6 +18,8 @@ sources:
     sha256: "b7e75b17957c62bd02dd73890bde22da3a564903fcaad651b395453d41d3325b"
     url: "https://github.com/google/nsync/archive/refs/tags/1.23.0.tar.gz"
 patches:
+  "1.28.0":
+    - patch_file: "patches/0001-1.27.0-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
   "1.27.0":
     - patch_file: "patches/0001-1.27.0-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
   "1.26.0":

--- a/recipes/nsync/all/conanfile.py
+++ b/recipes/nsync/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file, rmdir
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
 
@@ -84,6 +84,7 @@ class NsyncConan(ConanFile):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.components["nsync_c"].libs = ["nsync"]

--- a/recipes/nsync/config.yml
+++ b/recipes/nsync/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.28.0":
+    folder: "all"
   "1.27.0":
     folder: "all"
   "1.26.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **nsync/1.28.0**

#### Motivation

#### Details
https://github.com/google/nsync/compare/1.27.0...1.28.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
