### PR TITLE
Pixman: Supply cpu-features-path meson option. Required to build for Android-armv7

### DIFF
--- a/recipes/pixman/all/conanfile.py
+++ b/recipes/pixman/all/conanfile.py
@@ -62,6 +62,13 @@ class PixmanConan(ConanFile):
             "libpng": "disabled",
             "gtk": "disabled"
         })
+
+        # Android armv7 build of Pixman makes use of cpu-features functionality, provided in the NDK
+        if self.settings.os == "Android":
+            android_ndk_home = self.conf.get("tools.android:ndk_path").replace("\\", "/")
+            cpu_features_path = os.path.join(android_ndk_home, "sources", "android", "cpufeatures")
+            tc.project_options.update({'cpu-features-path' : cpu_features_path})
+
         tc.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **pixman/0.43.4**

#### Motivation
Pixman build for Android armv7 looks for the cpu-features.h header, which usually is supplied by the NDK. Without this patch Pixman does not compile for Android armv7.

#### Details
Pixman's meson build accepts option which tells it where to look for cpu-features.c and cpu-features.h . This patch does exactly just that.

I am aware of #8011 , but it is not merged, and I assume that Pixman's source code too would need to be patched to take a different library, while my suggested patch just supplies the correct meson option and Pixman just works then.

Even with this patch, older versions of pixman (0.43.0 and 0.42.2) are still build broken for Android armv7, but I am not too concerned with them, because they were buildbroken before this patch too.

Link to a CI run with proposed patch - https://github.com/ViliusSutkus89/conan-odr-index/actions/runs/9563222408
Link to a CI run without proposed patch - https://github.com/ViliusSutkus89/conan-odr-index/actions/runs/9563286270
Note how pixman/0.43.4 - android-armv7 turns green

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
