### PR TITLE
libpq: Update to latest release libpq/16.3 (PostgreSQL)

### DIFF
--- a/recipes/libpq/all/conandata.yml
+++ b/recipes/libpq/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "16.3":
+    url: "https://ftp.postgresql.org/pub/source/v16.3/postgresql-16.3.tar.bz2"
+    sha256: "331963d5d3dc4caf4216a049fa40b66d6bcb8c730615859411b9518764e60585"
   "15.5":
     url: "https://ftp.postgresql.org/pub/source/v15.5/postgresql-15.5.tar.bz2"
     sha256: "8f53aa95d78eb8e82536ea46b68187793b42bba3b4f65aa342f540b23c9b10a6"
@@ -27,6 +30,10 @@ sources:
     url: "https://ftp.postgresql.org/pub/source/v9.6.24/postgresql-9.6.24.tar.gz"
     sha256: "52947ecc119846eace5164399d173576c0d4a47ec116ae58a46a8fd0c576c7c3"
 patches:
+  "16.3":
+    - patch_file: "patches/16/001-mingw-build-static-libraries.patch"
+      patch_description: "port MinGW: Enable building static libraries in MinGW."
+      patch_type: "portability"
   "15.5":
     - patch_file: "patches/15/001-mingw-build-static-libraries.patch"
       patch_description: "port MinGW: Enable building static libraries in MinGW."

--- a/recipes/libpq/all/patches/16/001-mingw-build-static-libraries.patch
+++ b/recipes/libpq/all/patches/16/001-mingw-build-static-libraries.patch
@@ -1,0 +1,39 @@
+--- a/src/Makefile.shlib
++++ b/src/Makefile.shlib
+@@ -323,7 +323,10 @@
+ # Win32 case
+ 
+ # See notes in src/backend/parser/Makefile about the following two rules
+-$(stlib): $(shlib)
++$(stlib): $(OBJS) | $(SHLIB_PREREQS)
++	rm -f $@
++	$(LINK.static) $@ $^
++	$(RANLIB) $@
+ 	touch $@
+ 
+ # XXX A backend that loads a module linked with libgcc_s_dw2-1.dll will exit
+@@ -336,12 +339,12 @@
+ # Else we just use --export-all-symbols.
+ ifeq (,$(SHLIB_EXPORTS))
+ $(shlib): $(OBJS) | $(SHLIB_PREREQS)
+-	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--export-all-symbols -Wl,--out-implib=$(stlib)
++	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--export-all-symbols -Wl,--out-implib=lib$(NAME).dll.a
+ else
+ DLL_DEFFILE = lib$(NAME)dll.def
+ 
+ $(shlib): $(OBJS) $(DLL_DEFFILE) | $(SHLIB_PREREQS)
+-	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(DLL_DEFFILE) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--out-implib=$(stlib)
++	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(DLL_DEFFILE) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--out-implib=lib$(NAME).dll.a
+ 
+ UC_NAME = $(shell echo $(NAME) | tr 'abcdefghijklmnopqrstuvwxyz' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+ 
+@@ -418,6 +421,9 @@
+ ifneq (,$(findstring $(PORTNAME),win32 cygwin))
+ 	$(INSTALL_SHLIB) $< '$(DESTDIR)$(bindir)/$(shlib)'
+ endif
++ifneq (,$(findstring $(PORTNAME),win32))
++	$(INSTALL_SHLIB) $< '$(DESTDIR)$(libdir)/lib$(NAME).dll.a'
++endif
+ else # no soname
+ 	$(INSTALL_SHLIB) $< '$(DESTDIR)$(pkglibdir)/$(shlib)'
+ endif

--- a/recipes/libpq/config.yml
+++ b/recipes/libpq/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "16.3":
+    folder: all
   "15.5":
     folder: all
   "15.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpq** - added version 16.3

#### Motivation
Make latest major version of libpq available at Conan.

#### Details
Added the latest release download. Also noticed the mingw patch. Tried to manually apply it with `patch` and it applied the diff without problem here (patch is by Conan and not upstreamed). Didn't work at Conan somehow so exported the patch for 16.3 as own patch file again.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
