### PR TITLE
tomlplusplus: Fix exception option handling

### DIFF
--- a/recipes/tomlplusplus/all/conanfile.py
+++ b/recipes/tomlplusplus/all/conanfile.py
@@ -79,6 +79,6 @@ class TomlPlusPlusConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "tomlplusplus::tomlplusplus")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-        if self.options.exceptions.value is not None:
+        if self.options.exceptions is not None:
             define_value = "1" if self.options.exceptions is True else "0"
             self.cpp_info.defines.append(f"TOML_EXCEPTIONS={define_value}")

--- a/recipes/tomlplusplus/all/conanfile.py
+++ b/recipes/tomlplusplus/all/conanfile.py
@@ -79,6 +79,8 @@ class TomlPlusPlusConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "tomlplusplus::tomlplusplus")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-        if self.options.exceptions is not None:
+        # Casting as a String because None value would not be properly handled, this is a PackageOption, not the value itself
+        # which `is` never None
+        if str(self.options.exceptions) != "None":
             define_value = "1" if self.options.exceptions is True else "0"
             self.cpp_info.defines.append(f"TOML_EXCEPTIONS={define_value}")


### PR DESCRIPTION
### Summary
Changes to recipe:  **tomlplusplus/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
https://github.com/conan-io/conan-center-index/pull/24336 added toggling of the exception support, but it was checking the internal `.value` member of options, which is not correct

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Simply checking for the option is enough in all 3 cases


cc @xoorath 