### PR TITLE
c-blosc2: add version 2.15.0

### DIFF
--- a/recipes/c-blosc2/all/conandata.yml
+++ b/recipes/c-blosc2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.15.0":
+    url: "https://github.com/Blosc/c-blosc2/archive/v2.15.0.tar.gz"
+    sha256: "1e7d9d099963ad0123ddd76b2b715b5aa1ea4b95c491d3a11508e487ebab7307"
   "2.14.4":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.14.4.tar.gz"
     sha256: "b5533c79aacc9ac152c80760ed1295a6608938780c3e1eecd7e53ea72ad986b0"
@@ -18,6 +21,10 @@ sources:
     url: "https://github.com/Blosc/c-blosc2/archive/v2.10.5.tar.gz"
     sha256: "a88f94bf839c1371aab8207a6a43698ceb92c72f65d0d7fe5b6e59f24c138b4d"
 patches:
+  "2.15.0":
+    - patch_file: "patches/2.10.5-0001-fix-cmake.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "2.14.4":
     - patch_file: "patches/2.10.5-0001-fix-cmake.patch"
       patch_description: "use cci package"

--- a/recipes/c-blosc2/config.yml
+++ b/recipes/c-blosc2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.15.0":
+    folder: all
   "2.14.4":
     folder: all
   "2.13.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **c-blosc2/2.15.0**

#### Motivation

There are API changes in 2.15.0.

#### Details

https://github.com/Blosc/c-blosc2/compare/v2.14.4...v2.15.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
