### PR TITLE
cmake: re-add from source builds as `cci.` versions

### DIFF
--- a/recipes/cmake/3.x.x/conandata.yml
+++ b/recipes/cmake/3.x.x/conandata.yml
@@ -1,28 +1,4 @@
 sources:
-  "3.19.8":
-    url: https://github.com/Kitware/CMake/releases/download/v3.19.8/cmake-3.19.8.tar.gz
-    sha256: 09b4fa4837aae55c75fb170f6a6e2b44818deba48335d1969deddfbb34e30369
-  "3.20.6":
-    url: https://github.com/Kitware/CMake/releases/download/v3.20.6/cmake-3.20.6.tar.gz
-    sha256: a0bd485e1a38dd13c0baec89d5f4adbf61c7fd32fddb38eabc69a75bc0b65d72
-  "3.21.7":
-    url: https://github.com/Kitware/CMake/releases/download/v3.21.7/cmake-3.21.7.tar.gz
-    sha256: 3523c4a5afc61ac3d7c92835301cdf092129c9b672a6ee17e68c92e928c1375a
-  "3.22.6":
-    url: https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6.tar.gz
-    sha256: 73933163670ea4ea95c231549007b0c7243282293506a2cf4443714826ad5ec3
-  "3.23.5":
-    url: "https://github.com/Kitware/CMake/releases/download/v3.23.5/cmake-3.23.5.tar.gz"
-    sha256: "f2944cde7a140b992ba5ccea2009a987a92413762250de22ebbace2319a0f47d"
-  "3.24.3":
-    url: "https://github.com/Kitware/CMake/releases/download/v3.24.3/cmake-3.24.3.tar.gz"
-    sha256: "b53aa10fa82bff84ccdb59065927b72d3bee49f4d86261249fc0984b3b367291"
-  "3.25.2":
-    url: "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2.tar.gz"
-    sha256: "c026f22cb931dd532f648f087d587f07a1843c6e66a3dfca4fb0ea21944ed33c"
-  "3.26.4":
-    url: "https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4.tar.gz"
-    sha256: "313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208"
   "cci.3.29.6":
     url: "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6.tar.gz"
     sha256: "1391313003b83d48e2ab115a8b525a557f78d8c1544618b48d1d90184a10f0af"

--- a/recipes/cmake/3.x.x/conandata.yml
+++ b/recipes/cmake/3.x.x/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "cci.3.29.6":
-    url: "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6.tar.gz"
-    sha256: "1391313003b83d48e2ab115a8b525a557f78d8c1544618b48d1d90184a10f0af"
+  "cci.3.26.4":
+    url: "https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4.tar.gz"
+    sha256: "313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208"

--- a/recipes/cmake/3.x.x/conandata.yml
+++ b/recipes/cmake/3.x.x/conandata.yml
@@ -23,3 +23,6 @@ sources:
   "3.26.4":
     url: "https://github.com/Kitware/CMake/releases/download/v3.26.4/cmake-3.26.4.tar.gz"
     sha256: "313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208"
+  "cci.3.29.6":
+    url: "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6.tar.gz"
+    sha256: "1391313003b83d48e2ab115a8b525a557f78d8c1544618b48d1d90184a10f0af"

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -11,7 +11,7 @@ from conan.errors import ConanInvalidConfiguration
 import os
 import json
 
-required_conan_version = ">=1.51.0"
+required_conan_version = ">=1.55.0"
 
 class CMakeConan(ConanFile):
     name = "cmake"

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -92,7 +92,7 @@ class CMakeConan(ConanFile):
             tc.generate()
             bootstrap_cmake_options = ["--"]
             bootstrap_cmake_options.append(f'-DCMAKE_CXX_STANDARD={"11" if not self.settings.compiler.cppstd else self.settings.compiler.cppstd}')
-            bootstrap_cmake_options.append('-CMake_ENABLE_DEBUGGER=FALSE')
+            # bootstrap_cmake_options.append('-CMake_ENABLE_DEBUGGER=FALSE')
             if self.settings.os == "Linux":
                 if self.options.with_openssl:
                     openssl = self.dependencies["openssl"]
@@ -106,7 +106,7 @@ class CMakeConan(ConanFile):
             tc = CMakeToolchain(self)
             # Disabling testing because CMake tests build can fail in Windows in some cases
             tc.variables["BUILD_TESTING"] = False
-            tc.variables["CMake_ENABLE_DEBUGGER"] = False
+            # tc.variables["CMake_ENABLE_DEBUGGER"] = False
             if not self.settings.compiler.cppstd:
                 tc.variables["CMAKE_CXX_STANDARD"] = 11
             tc.variables["CMAKE_BOOTSTRAP"] = False

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -92,6 +92,7 @@ class CMakeConan(ConanFile):
             tc.generate()
             bootstrap_cmake_options = ["--"]
             bootstrap_cmake_options.append(f'-DCMAKE_CXX_STANDARD={"11" if not self.settings.compiler.cppstd else self.settings.compiler.cppstd}')
+            bootstrap_cmake_options.append('-CMake_ENABLE_DEBUGGER=FALSE')
             if self.settings.os == "Linux":
                 if self.options.with_openssl:
                     openssl = self.dependencies["openssl"]
@@ -105,6 +106,7 @@ class CMakeConan(ConanFile):
             tc = CMakeToolchain(self)
             # Disabling testing because CMake tests build can fail in Windows in some cases
             tc.variables["BUILD_TESTING"] = False
+            tc.variables["CMake_ENABLE_DEBUGGER"] = False
             if not self.settings.compiler.cppstd:
                 tc.variables["CMAKE_CXX_STANDARD"] = 11
             tc.variables["CMAKE_BOOTSTRAP"] = False

--- a/recipes/cmake/3.x.x/test_package/conanfile.py
+++ b/recipes/cmake/3.x.x/test_package/conanfile.py
@@ -19,6 +19,7 @@ class TestPackageConan(ConanFile):
         self.output.info("Installed version: {}".format(output_str))
         tokens = re.split('[@#]', self.tested_reference_str)
         require_version = tokens[0].split("/", 1)[1]
+        require_version = require_version.replace("cci.", "")
         self.output.info("Expected version: {}".format(require_version))
         assert_cmake_version = "cmake version %s" % require_version
         assert(assert_cmake_version in output_str)

--- a/recipes/cmake/3.x.x/test_v1_package/conanfile.py
+++ b/recipes/cmake/3.x.x/test_v1_package/conanfile.py
@@ -18,6 +18,7 @@ class TestPackageConan(ConanFile):
         self.output.info("Installed version: {}".format(output_str))
         tokens = re.split('[@#]', self.tested_reference_str)
         require_version = tokens[0].split("/", 1)[1]
+        require_version = require_version.replace("cci.", "")
         self.output.info("Expected version: {}".format(require_version))
         assert_cmake_version = "cmake version %s" % require_version
         assert(assert_cmake_version in output_str)

--- a/recipes/cmake/config.yml
+++ b/recipes/cmake/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.3.29.6":
+    folder: "3.x.x"
   "3.29.6":
     folder: "binary"
   "3.29.5":

--- a/recipes/cmake/config.yml
+++ b/recipes/cmake/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "cci.3.29.6":
+  "cci.3.26.4":
     folder: "3.x.x"
   "3.29.6":
     folder: "binary"


### PR DESCRIPTION
I think that the decision to re-package binary downloads was a mistake to begin with. Most of the named arguments are also outdated today as they are solved by version ranges.

This PR makes the CMake recipe, that builds from source, again available from the Conan Center remote, under the `cci.` version prefix.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan


Might be of interest to @datalogics-kam (#17032)