### PR TITLE
pcre2: Add support for PCRE2_LINK_SIZE

### DIFF
--- a/recipes/pcre2/all/conanfile.py
+++ b/recipes/pcre2/all/conanfile.py
@@ -29,6 +29,7 @@ class PCRE2Conan(ConanFile):
         "with_bzip2": [True, False],
         "support_jit": [True, False],
         "grep_support_callout_fork": [True, False],
+        "link_size": [2, 3, 4],
     }
     default_options = {
         "shared": False,
@@ -41,6 +42,7 @@ class PCRE2Conan(ConanFile):
         "with_bzip2": True,
         "support_jit": False,
         "grep_support_callout_fork": True,
+        "link_size": 2,
     }
 
     def export_sources(self):
@@ -96,6 +98,7 @@ class PCRE2Conan(ConanFile):
         tc.variables["PCRE2_BUILD_PCRE2_16"] = self.options.build_pcre2_16
         tc.variables["PCRE2_BUILD_PCRE2_32"] = self.options.build_pcre2_32
         tc.variables["PCRE2_SUPPORT_JIT"] = self.options.support_jit
+        tc.variables["PCRE2_LINK_SIZE"] = self.options.link_size
         tc.variables["PCRE2GREP_SUPPORT_CALLOUT_FORK"] = self.options.get_safe("grep_support_callout_fork", False)
         if Version(self.version) < "10.38":
             # relocatable shared libs on Macos


### PR DESCRIPTION
### Summary
Changes to recipe:  **pcre2/10.XX**

#### Motivation
Add support for passing a configurable PCRE2_LINK_SIZE. 

This directly translates to LINK_SIZE here https://github.com/PCRE2Project/pcre2/blob/9a51f31da1c2d45e1f31d6a0d6b2f62975fed373/src/config.h.generic#L167.

In short, the default size of 2 creates a hard limit of 65535 bytes to be used by the compiled regular expression. This creates a hard upper limit for the size of regular expressions that can be compiled. Using a link size of 4 expands this to 4GB. For most use cases, 64KB is more than enough. But in some edge cases, it's not:

https://github.com/PCRE2Project/pcre2/issues/271

https://github.com/PCRE2Project/pcre2/issues/406

This adds support for the flag in the conan package to support the users in those edge cases.

#### Details
This just adds an option (`link_size` to the package that gets passed through as `PCRE2_LINK_SIZE` to cmake which passes `LINK_SIZE` to the compiler.

I am not well versed on the CI system that conan-center-index uses to know whether I'm missing a step to add this to all of the test builds of the package, and where to add it.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
