### PR TITLE
uwebsockets: add version 20.63.0

### DIFF
--- a/recipes/uwebsockets/all/conandata.yml
+++ b/recipes/uwebsockets/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
+  "20.63.0":
+    url: "https://github.com/uNetworking/uWebSockets/archive/v20.63.0.tar.gz"
+    sha256: "3bcb3fab4242d312e227b05f34e21d8468960e5eea59e12799aa21a94f1b2b1f"
+  # keep 20.62.0, the last version to provide C-API
   "20.62.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v20.62.0.tar.gz"
     sha256: "03dfc8037cf43856a41e64bbc7fc5a7cf5e6369c9158682753074ecbbe09eed1"

--- a/recipes/uwebsockets/config.yml
+++ b/recipes/uwebsockets/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.63.0":
+    folder: all
   "20.62.0":
     folder: all
   "20.60.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **uwebsockets/20.63.0**

#### Motivation
uwebsockets/20.63.0 removes C-API and provides several bug fixes.

#### Details
https://github.com/uNetworking/uWebSockets/compare/v20.62.0...v20.63.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
