### PR TITLE
libavrocpp: add version 1.11.3, compatibility conan v2

### DIFF
--- a/recipes/libavrocpp/all/conandata.yml
+++ b/recipes/libavrocpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.3":
+    url: "https://github.com/apache/avro/archive/release-1.11.3.tar.gz"
+    sha256: "da377ac1cf8b91458bf702cbcfb214eecb5c399b267f0ca9c0aade6cabaf126e"
   "1.11.1":
     url: "https://github.com/apache/avro/archive/release-1.11.1.tar.gz"
     sha256: "599f96bb405f72a35154b2477caa6254d723bb4e3f6a0e54e9ae540664321752"
@@ -12,6 +15,19 @@ sources:
     url: "https://github.com/apache/avro/archive/release-1.10.1.tar.gz"
     sha256: "8fd1f850ce37e60835e6d8335c0027a959aaa316773da8a9660f7d33a66ac142"
 patches:
+  "1.11.3":
+    - patch_file: "patches/0001-add-iterator-include-1-11-0.patch"
+      patch_description: "include iterator"
+      patch_type: "portability"
+    - patch_file: "patches/0002-disable-tests-1-11-1.patch"
+      patch_description: "disable tests"
+      patch_type: "conan"
+    - patch_file: "patches/0003-allow-static-boost-linkage-1-11-0.patch"
+      patch_description: "remove boost linkage definitions"
+      patch_type: "conan"
+    - patch_file: "patches/0004-fix-windows-shared-installation-1-11-1.patch"
+      patch_description: "fix runtime installation path"
+      patch_type: "portability"
   "1.11.1":
     - patch_file: "patches/0001-add-iterator-include-1-11-0.patch"
       patch_description: "include iterator"

--- a/recipes/libavrocpp/all/conandata.yml
+++ b/recipes/libavrocpp/all/conandata.yml
@@ -28,6 +28,9 @@ patches:
     - patch_file: "patches/0004-fix-windows-shared-installation-1-11-1.patch"
       patch_description: "fix runtime installation path"
       patch_type: "portability"
+    - patch_file: "patches/0006-disable-warn-as-error-1-11-3.patch"
+      patch_description: "disable warn as error for boost c++14 breaking change"
+      patch_type: "portability"
   "1.11.1":
     - patch_file: "patches/0001-add-iterator-include-1-11-0.patch"
       patch_description: "include iterator"

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -45,11 +45,9 @@ class LibavrocppConan(ConanFile):
         cmake_layout(self, src_folder="src")
         
     def requirements(self):
-        if valid_min_cppstd(self, 14) :
-            self.requires("boost/[>=1.82.0]", transitive_headers=True)
-        else:
-            self.requires("boost/[<1.82.0]", transitive_headers=True)
-        self.requires("snappy/[~1.1.9]")
+        # boost upper to 1.81.0 requires C++14 minimum
+        self.requires("boost/1.81.0", transitive_headers=True)
+        self.requires("snappy/1.1.9")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, replace_in_file
-from conan.tools.build import check_min_cppstd, default_cppstd
+from conan.tools.build import check_min_cppstd, valid_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
@@ -43,12 +43,12 @@ class LibavrocppConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
-
+        
     def requirements(self):
-        if default_cppstd(self) <= "11" :
-            self.requires("boost/[<=1.81.0]", transitive_headers=True)
-        else:
+        if valid_min_cppstd(self, 14) :
             self.requires("boost/[>=1.82.0]", transitive_headers=True)
+        else:
+            self.requires("boost/[<1.82.0]", transitive_headers=True)
         self.requires("snappy/[~1.1.9]")
 
     def validate(self):

--- a/recipes/libavrocpp/all/patches/0006-disable-warn-as-error-1-11-3.patch
+++ b/recipes/libavrocpp/all/patches/0006-disable-warn-as-error-1-11-3.patch
@@ -1,0 +1,13 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 52d6ac8a..26d8d146 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -59,7 +59,7 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
+ endif()
+ 
+ if (CMAKE_COMPILER_IS_GNUCXX)
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+ if (AVRO_ADD_PROTECTOR_FLAGS)
+     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
+     # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options

--- a/recipes/libavrocpp/config.yml
+++ b/recipes/libavrocpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  1.11.3:
+    folder: all
   1.11.1:
     folder: all
   1.11.0:


### PR DESCRIPTION
### Summary
Changes to recipe:  **libavrocpp/1.11.3**

#### Motivation
Add release 1.11.3, bug fix, Conan v2

#### Details
- Add release libavroccp/1.11.3
- Fix conan v2 compatibility
- Fix minimum c++14 requirement with some components of boost > 1.81.0

---
- [ x ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x ] Checked that this PR is not a duplicate: #19911 , #22320 (https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x ] Tested locally with at least one configuration using a recent version of Conan
