### PR TITLE
libdisplay-info: add version 0.2.0

### DIFF
--- a/recipes/libdisplay-info/all/conandata.yml
+++ b/recipes/libdisplay-info/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.0":
+    url: "https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/0.2.0/libdisplay-info-0.2.0.tar.bz2"
+    sha256: "f6cf2ddbba3753ae38de5113d1fcb8fab977dfaf5fb07b38cd68d8482765e208"
   "0.1.1":
     url: "https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/0.1.1/libdisplay-info-0.1.1.tar.bz2"
     sha256: "51cdb0362882ca2af62532ab4d95e60d81e9890b339264719fd55f8e3945d695"

--- a/recipes/libdisplay-info/config.yml
+++ b/recipes/libdisplay-info/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.2.0":
+    folder: all
   "0.1.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdisplay-info/0.2.0**

#### Motivation
There are several new features on 0.2.0.

#### Details
https://gitlab.freedesktop.org/emersion/libdisplay-info/-/compare/0.1.1...0.2.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
