### PR TITLE
rapidcsv: add version 8.83

### DIFF
--- a/recipes/rapidcsv/all/conandata.yml
+++ b/recipes/rapidcsv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.83":
+    url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.83.tar.gz"
+    sha256: "9342eeb0ce37e30b778c4c030129d03e99f44a66d4710ac19627187bee774097"
   "8.82":
     url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.82.tar.gz"
     sha256: "4f1f57ca9db0f5447416acbef4e059cbd7cb03f6eb39fec1301732bbedaac927"

--- a/recipes/rapidcsv/config.yml
+++ b/recipes/rapidcsv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.83":
+    folder: "all"
   "8.82":
     folder: "all"
   "8.80":


### PR DESCRIPTION
### Summary
Changes to recipe:  **rapidcsv/8.83**

#### Motivation
8.83 is the bugfix release.

#### Details
https://github.com/d99kris/rapidcsv/compare/v8.82...v8.83

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
