### PR TITLE
bgfx: add new version and consolidated recipe

### DIFF
--- a/recipes/bgfx/config.yml
+++ b/recipes/bgfx/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.127.8771":
+    folder: consolidated
   "cci.20230216":
     folder: all

--- a/recipes/bgfx/consolidated/conandata.yml
+++ b/recipes/bgfx/consolidated/conandata.yml
@@ -1,0 +1,11 @@
+sources:
+  "1.127.8771":
+    "bgfx":
+      url: "https://github.com/bkaradzic/bgfx/archive/06d0e2af2f50fee3e8e84e0c3b407073692a678c.tar.gz"
+      sha256: "0869F9D18C63AB8D804918FEFCC53D8568626A26FCAE7273DF1A70D4C8E7AFE3"
+    "bimg":
+      url: "https://github.com/bkaradzic/bimg/archive/2afa64c14c1e3dd5d28412ee03bee0dfe7242f03.tar.gz"
+      sha256: "376E17EA4A70CEE72E6006DD942CB2F2FE3DB047F524A3F203A15A8BBA1BCD90"
+    "bx":
+      url: "https://github.com/bkaradzic/bx/archive/e64b7c097f30d33134fe8fa522b3c95fc461c3d3.tar.gz"
+      sha256: "2A6E438AC6250CD6052CBBABF2906482DFA1585E537064CB5DA47E2EC728FE92"

--- a/recipes/bgfx/consolidated/conanfile.py
+++ b/recipes/bgfx/consolidated/conanfile.py
@@ -1,0 +1,368 @@
+from conan import ConanFile
+from conan.tools.files import copy, get, rename, replace_in_file
+from conan.tools.build import check_min_cppstd
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, check_min_vs, is_msvc_static_runtime
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
+from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import MSBuild, VCVars
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.env import VirtualBuildEnv
+from pathlib import Path
+import os
+
+required_conan_version = ">=1.50.0"
+
+class bgfxConan(ConanFile):
+    name = "bgfx"
+    license = "BSD-2-Clause"
+    homepage = "https://github.com/bkaradzic/bgfx"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Cross-platform, graphics API agnostic, \"Bring Your Own Engine/Framework\" style rendering library."
+    topics = ("rendering", "graphics", "gamedev")
+    settings = "os", "compiler", "arch", "build_type"
+    options = {"fPIC": [True, False], "shared": [True, False], "tools": [True, False], "rtti": [True, False]}
+    default_options = {"fPIC": True, "shared": False, "tools": False, "rtti": True}
+
+    @property
+    def _bx_folder(self):
+        return "bx"
+
+    @property
+    def _bimg_folder(self):
+        return "bimg"
+    
+    @property
+    def _bgfx_folder(self):
+        return "bgfx"
+
+    @property
+    def _bgfx_path(self):
+        return os.path.join(self.source_folder, self._bgfx_folder)
+
+    @property
+    def _genie_extra(self):
+        genie_extra = ""
+        if is_msvc(self) and not is_msvc_static_runtime(self):
+            genie_extra += " --with-dynamic-runtime"
+        if self.options.shared:
+            genie_extra += " --with-shared-lib"
+        # generate tools projects regardless of tools option because that also generates bimg_encode
+        genie_extra += " --with-tools"
+        return genie_extra
+
+    @property
+    def _lib_target_prefix(self):
+        if is_msvc(self):
+            return "libs\\"
+        else:
+            return ""
+
+    @property
+    def _tool_target_prefix(self):
+        if is_msvc(self):
+            return "tools\\"
+        else:
+            return ""
+        
+    @property
+    def _shaderc_target_prefix(self):
+        if is_msvc(self):
+            return "shaderc\\"
+        else:
+            return ""
+        
+    @property
+    def _tools(self):
+        return ["texturec", "texturev", "geometryc", "geometryv", "shaderc"]
+
+    @property
+    def _projs(self):
+        projs = [f"{self._lib_target_prefix}bx", f"{self._lib_target_prefix}bimg", f"{self._lib_target_prefix}bimg_decode", f"{self._lib_target_prefix}bimg_encode"]
+        if self.options.shared:
+            projs.extend([f"{self._lib_target_prefix}bgfx-shared-lib"])
+        else:
+            projs.extend([f"{self._lib_target_prefix}bgfx"])
+        if self.options.tools:
+            for tool in self._tools:
+                if "shaderc" in tool:
+                    projs.extend([f"{self._tool_target_prefix}{self._shaderc_target_prefix}{tool}"])
+                else:
+                    projs.extend([f"{self._tool_target_prefix}{tool}"])
+        return projs
+
+    @property
+    def _compiler_required(self):
+        return {
+            "gcc": "8",
+            "clang": "11",
+            "apple-clang": "12", #to keep CCI compiling on osx 11.0 or higher, for now
+        }
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("opengl/system")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 17)
+        check_min_vs(self, 192)
+        if not is_msvc(self):
+            try:
+                minimum_required_compiler_version = self._compiler_required[str(self.settings.compiler)]
+                if Version(self.settings.compiler.version) < minimum_required_compiler_version:
+                    raise ConanInvalidConfiguration("This package requires C++17 support. The current compiler does not support it.")
+            except KeyError:
+                self.output.warn("This recipe has no checking for the current compiler. Please consider adding it.")
+
+    def build_requirements(self):
+        self.tool_requires("genie/1170")
+        if not is_msvc(self) and self._settings_build.os == "Windows":
+            if self.settings.os == "Windows": # building for windows mingw
+                # self.win_bash = True
+                # if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                #     self.tool_requires("msys2/cci.latest")
+                if "MINGW" not in os.environ:
+                    self.tool_requires("mingw-builds/13.2.0")
+            else: # cross-compiling for something else, probably android; get native make
+                self.tool_requires("make/[>=4.4.1]")
+        if self.settings.os == "Android" and "ANDROID_NDK_ROOT" not in os.environ:
+            self.tool_requires("android-ndk/[>=r26d]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version]["bgfx"], strip_root=True,
+                    destination=os.path.join(self.source_folder, self._bgfx_folder))
+        # bgfx's genie project, and the projects generated by it, expect bx and bimg source to be present on the same relative root as bgfx's in order to build
+        # usins a pre-built bx and bimg instead would require significant changes to the genie project but may be worth looking into in the future, if upstream wants to go that route
+        get(self, **self.conan_data["sources"][self.version]["bx"], strip_root=True,
+                    destination=os.path.join(self.source_folder, self._bx_folder))
+        get(self, **self.conan_data["sources"][self.version]["bimg"], strip_root=True,
+                    destination=os.path.join(self.source_folder, self._bimg_folder))
+
+    def generate(self):
+        vbe = VirtualBuildEnv(self)
+        vbe.generate()
+        if is_msvc(self):
+            tc = VCVars(self)
+            tc.generate()
+        else:
+            tc = AutotoolsToolchain(self)
+            tc.generate()
+
+    def build(self):
+        # Patch rtti - cci expects most packages to be built with rtti enabled; mismatches can cause link issues
+        if self.options.rtti:
+            self.output.info("Disabling no-rtti.")
+            replace_in_file(self, os.path.join(self.source_folder, self._bx_folder, "scripts", "toolchain.lua"),
+                            "\"NoRTTI\",", "")
+        if is_msvc(self):
+            # Conan to Genie translation maps
+            vs_ver_to_genie = {"17": "2022", "16": "2019", "15": "2017",
+                                "194": "2022", "193": "2022", "192": "2019", "191": "2017"}
+
+            # Use genie directly, then msbuild on specific projects based on requirements
+            genie_VS = f"vs{vs_ver_to_genie[str(self.settings.compiler.version)]}"
+            genie_gen = f"{self._genie_extra} {genie_VS}"
+            self.run(f"genie {genie_gen}", cwd=self._bgfx_path)
+
+            msbuild = MSBuild(self)
+            # customize to Release when RelWithDebInfo
+            msbuild.build_type = "Debug" if self.settings.build_type == "Debug" else "Release"
+            # use Win32 instead of the default value when building x86
+            msbuild.platform = "Win32" if self.settings.arch == "x86" else msbuild.platform
+            msbuild.build(os.path.join(self._bgfx_path, ".build", "projects", genie_VS, "bgfx.sln"), targets=self._projs)
+        else:
+            # Not sure if XCode can be spefically handled by conan for building through, so assume everything not VS is make
+            # gcc-multilib and g++-multilib required for 32bit cross-compilation, should see if we can check and install through conan
+            
+            # Conan to Genie translation maps
+            compiler_str = str(self.settings.compiler)
+            compiler_and_os_to_genie = {"Windows": f"--gcc=mingw-{compiler_str}", "Linux": f"--gcc=linux-{compiler_str}",
+                                        "FreeBSD": "--gcc=freebsd", "Macos": "--gcc=osx",
+                                        "Android": "--gcc=android", "iOS": "--gcc=ios"}
+            gmake_os_to_proj = {"Windows": "mingw", "Linux": "linux", "FreeBSD": "freebsd", "Macos": "osx", "Android": "android", "iOS": "ios"}
+            gmake_android_arch_to_genie_suffix = {"x86": "-x86", "x86_64": "-x86_64", "armv8": "-arm64", "armv7": "-arm"}
+            gmake_arch_to_genie_suffix = {"x86": "-x86", "x86_64": "-x64", "armv8": "-arm64", "armv7": "-arm"}
+            os_to_use_arch_config_suffix = {"Windows": False, "Linux": False, "FreeBSD": False, "Macos": True, "Android": True, "iOS": True}
+
+            build_type_to_make_config = {"Debug": "config=debug", "Release": "config=release"}
+            arch_to_make_config_suffix = {"x86": "32", "x86_64": "64"}
+            os_to_use_make_config_suffix = {"Windows": True, "Linux": True, "FreeBSD": True, "Macos": False, "Android": False, "iOS": False}
+
+            # Generate projects through genie
+            genie_args = f"{self._genie_extra} {compiler_and_os_to_genie[str(self.settings.os)]}"
+            if os_to_use_arch_config_suffix[str(self.settings.os)]:
+                if (self.settings.os == "Android"):
+                    genie_args += F"{gmake_android_arch_to_genie_suffix[str(self.settings.arch)]}"
+                else:
+                    genie_args += f"{gmake_arch_to_genie_suffix[str(self.settings.arch)]}"
+            genie_args += " gmake"
+            self.run(f"genie {genie_args}", cwd=self._bgfx_path)
+
+            # Build project folder and path from given settings
+            proj_folder = f"gmake-{gmake_os_to_proj[str(self.settings.os)]}"
+            if self.settings.os == "Windows" or (compiler_str not in ["gcc", "apple-clang"] and self.settings.os != "Android"):
+                proj_folder += f"-{compiler_str}" #mingw-gcc or mingw-clang for windows; -clang for linux (where gcc on linux has no extra)
+            if os_to_use_arch_config_suffix[str(self.settings.os)]:
+                if (self.settings.os == "Android"):
+                    proj_folder += gmake_android_arch_to_genie_suffix[str(self.settings.arch)]
+                else:
+                    proj_folder += gmake_arch_to_genie_suffix[str(self.settings.arch)]
+            proj_path = os.path.sep.join([self._bgfx_path, ".build", "projects", proj_folder])
+
+            # Build make args from settings
+            conf = build_type_to_make_config[str(self.settings.build_type)]
+            if os_to_use_make_config_suffix[str(self.settings.os)]:
+                conf += arch_to_make_config_suffix[str(self.settings.arch)]
+            if self.settings.os == "Windows":
+                if "mingw-builds" in self.dependencies.build:
+                    # self.run("if [ ! -d /mingw64 ]; then mkdir /mingw64; fi")
+                    # self.run("pacman -Sy mingw-w64-x86_64-gcc --needed --noconfirm")
+                    # mingw = "MINGW=$MSYS_ROOT/mingw64"
+                    mingw = f"MINGW={self.dependencies.build['mingw-builds'].package_folder}"
+                else:
+                    mingw = "MINGW=$MINGW" # user is expected to have an env var pointing to mingw; x86_64-w64-mingw32-g++ is expected in $MINGW/bin/
+                proj_path = proj_path.replace("\\", "/") # Fix path for linux style...
+            else:
+                mingw = ""
+            autotools = Autotools(self)
+            # Build with make
+            for proj in self._projs:
+                autotools.make(target=proj, args=["-R", f"-C {proj_path}", mingw, conf])
+
+    def package(self):
+        lib_names =  ["bx", "bimg", "bgfx"]
+        # Set platform suffixes and prefixes
+        if self.settings.os == "Windows" and is_msvc(self):
+            package_lib_prefix = ""
+            lib_pat = ".lib"
+            shared_lib_pat = ".lib"
+        else:
+            package_lib_prefix = "lib"
+            lib_pat = ".a"
+            if self.options.shared:
+                if is_apple_os(self):
+                    shared_lib_pat = ".dylib"
+                else:
+                    shared_lib_pat = ".so"
+
+        # Get build bin folder
+        for out_dir in os.listdir(os.path.join(self._bgfx_path, ".build")):
+            if not out_dir=="projects":
+                build_bin = os.path.join(self._bgfx_path, ".build", out_dir, "bin")
+                break
+
+        # Copy license
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self._bgfx_path)
+        # Copy includes
+        copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self._bgfx_path, "include"))
+        copy(self, pattern="*.inl", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self._bgfx_path, "include"))
+        copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(os.path.join(self.source_folder, self._bx_folder), "include"))
+        copy(self, pattern="*.inl", dst=os.path.join(self.package_folder, "include"), src=os.path.join(os.path.join(self.source_folder, self._bx_folder), "include"))
+        copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(os.path.join(self.source_folder, self._bimg_folder), "include"))
+        copy(self, pattern="*.inl", dst=os.path.join(self.package_folder, "include"), src=os.path.join(os.path.join(self.source_folder, self._bimg_folder), "include"))
+        # Copy libs
+        for lib_name in lib_names:
+            if lib_name == "bgfx" and self.options.shared:
+                copy(self, pattern=f"*{lib_name}*shared*{shared_lib_pat}", dst=os.path.join(self.package_folder, "lib"), src=build_bin, keep_path=False)
+                copy(self, pattern=f"*{lib_name}*shared*{lib_pat}", dst=os.path.join(self.package_folder, "lib"), src=build_bin, keep_path=False)
+            else:
+                copy(self, pattern=f"*{lib_name}*{lib_pat}", dst=os.path.join(self.package_folder, "lib"), src=build_bin, keep_path=False)
+        if self.options.shared and self.settings.os == "Windows":
+            copy(self, pattern="*.dll", dst=os.path.join(self.package_folder, "bin"), src=build_bin, keep_path=False)
+
+        # Copy tools
+        if self.options.tools:
+            for tool in self._tools:
+                if is_msvc(self):
+                    # avoid copying pdb, exp and lib files for tools on windows msvc
+                    copy(self, pattern=f"{tool}*.exe", dst=os.path.join(self.package_folder, "bin"), src=build_bin, keep_path=False)
+                else:
+                    copy(self, pattern=f"{tool}*", dst=os.path.join(self.package_folder, "bin"), src=build_bin, keep_path=False)
+
+        # Rename for consistency across platforms and configs
+        for lib_name in lib_names:  
+            for out_file in Path(os.path.join(self.package_folder, "lib")).glob(f"*{lib_name}*"):
+                if out_file.suffix != "dylib": # dylibs break when renamed
+                    lib_name_extra = ""
+                    if out_file.name.find("encode") >= 0:
+                        lib_name_extra = "_encode"
+                    elif out_file.name.find("decode") >= 0:
+                        lib_name_extra = "_decode"
+                    rename(self, os.path.join(self.package_folder, "lib", out_file.name), 
+                            os.path.join(self.package_folder, "lib", f"{package_lib_prefix}{lib_name}{lib_name_extra}{out_file.suffix}"))
+        if self.options.tools:
+            for tool in self._tools:
+                for out_file in Path(os.path.join(self.package_folder, "bin")).glob(f"*{tool}*"):
+                    rename(self, os.path.join(self.package_folder, "bin", out_file.name), 
+                            os.path.join(self.package_folder, "bin", f"{tool}{out_file.suffix}"))
+        
+        # Maybe this helps
+        if is_apple_os(self):
+            fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.includedirs = ["include"]
+        # Warning: order of linked libs matters on linux
+        if self.options.shared and is_apple_os(self):
+            self.cpp_info.libs.extend([f"bgfx-shared-lib{self.settings.build_type}"])
+        else:
+            self.cpp_info.libs.extend(["bgfx"])        
+        self.cpp_info.libs.extend(["bimg_encode", "bimg_decode", "bimg", "bx"])
+
+        if self.options.shared:
+            self.cpp_info.defines.extend(["BGFX_SHARED_LIB_USE=1"])
+
+        if self.settings.build_type == "Debug":
+            self.cpp_info.defines.extend(["BX_CONFIG_DEBUG=1"])
+        else:
+            self.cpp_info.defines.extend(["BX_CONFIG_DEBUG=0"])
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["gdi32"])
+            if self.settings.arch == "x86":
+                self.cpp_info.system_libs.extend(["psapi"])
+            if is_msvc(self):
+                self.cpp_info.defines.extend(["__STDC_LIMIT_MACROS", "__STDC_FORMAT_MACROS", "__STDC_CONSTANT_MACROS"])
+                self.cpp_info.includedirs.extend(["include/compat/msvc"])
+                self.cpp_info.cxxflags.extend(["/Zc:__cplusplus", "/Zc:preprocessor"])
+            else:
+                self.cpp_info.includedirs.extend(["include/compat/mingw"])
+                self.cpp_info.system_libs.extend(["comdlg32"])
+        elif self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["dl", "pthread", "X11", "GL"])
+            if self.settings.os == "Linux":
+                self.cpp_info.includedirs.extend(["include/compat/linux"])
+            else:
+                self.cpp_info.includedirs.extend(["include/compat/freebsd"])
+        elif is_apple_os(self):
+            self.cpp_info.frameworks.extend(["CoreFoundation", "Foundation", "Cocoa", "AppKit", "IOKit", "QuartzCore", "Metal"])
+            if self.settings.os in ["Macos"]:
+                self.cpp_info.frameworks.extend(["OpenGL"])
+                self.cpp_info.includedirs.extend(["include/compat/osx"])
+            else:
+                self.cpp_info.frameworks.extend(["OpenGLES", "UIKit"])
+                self.cpp_info.includedirs.extend(["include/compat/ios"])
+        elif self.settings.os in ["Android"]:
+            self.cpp_info.system_libs.extend(["c", "dl", "m", "android", "log", "c++_shared", "EGL", "GLESv2"])
+
+        self.cpp_info.set_property("cmake_file_name", "bgfx")
+        self.cpp_info.set_property("cmake_target_name", "bgfx::bgfx")
+        self.cpp_info.set_property("pkg_config_name", "bgfx")
+
+        #  TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "bgfx"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "bgfx"
+        self.cpp_info.names["cmake_find_package"] = "bgfx"
+        self.cpp_info.names["cmake_find_package_multi"] = "bgfx"

--- a/recipes/bgfx/consolidated/test_package/CMakeLists.txt
+++ b/recipes/bgfx/consolidated/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package LANGUAGES CXX)
+
+find_package(bgfx REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+target_link_libraries(${PROJECT_NAME} bgfx::bgfx)

--- a/recipes/bgfx/consolidated/test_package/conanfile.py
+++ b/recipes/bgfx/consolidated/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/bgfx/consolidated/test_package/test_package.cpp
+++ b/recipes/bgfx/consolidated/test_package/test_package.cpp
@@ -1,0 +1,71 @@
+#include <bx/bx.h>
+#include <bx/allocator.h>
+#include <bx/platform.h>
+#include <bx/math.h>
+#include <bx/debug.h>
+#include <bx/string.h>
+#include <bimg/bimg.h>
+#include <bimg/decode.h>
+
+//Important: bgfx shared on windows only works with the C99 API, the C++ API is not exported
+#if BGFX_SHARED_LIB_USE && (BX_PLATFORM_WINDOWS || BX_PLATFORM_WINRT)
+#include <bgfx/c99/bgfx.h>
+#else
+#include <bgfx/bgfx.h>
+#endif
+
+//An embedded 2x2 PNG image in RGB8 format with a red pixel, a green pixel, a blue pixel and a white pixel
+const unsigned char img[129] ={0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 
+0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x02, 
+0x00, 0x00, 0x00, 0x02, 0x08, 0x02, 0x00, 0x00, 0x00, 0xfd, 0xd4, 0x9a, 
+0x73, 0x00, 0x00, 0x00, 0x01, 0x73, 0x52, 0x47, 0x42, 0x00, 0xae, 0xce, 
+0x1c, 0xe9, 0x00, 0x00, 0x00, 0x04, 0x67, 0x41, 0x4d, 0x41, 0x00, 0x00, 
+0xb1, 0x8f, 0x0b, 0xfc, 0x61, 0x05, 0x00, 0x00, 0x00, 0x09, 0x70, 0x48, 
+0x59, 0x73, 0x00, 0x00, 0x0e, 0xc3, 0x00, 0x00, 0x0e, 0xc3, 0x01, 0xc7, 
+0x6f, 0xa8, 0x64, 0x00, 0x00, 0x00, 0x16, 0x49, 0x44, 0x41, 0x54, 0x18, 
+0x57, 0x63, 0x78, 0x2b, 0xa3, 0xa2, 0xb4, 0xd1, 0x87, 0xc1, 0xde, 0xe3, 
+0xcc, 0xff, 0xff, 0xff, 0x01, 0x24, 0xec, 0x06, 0x9d, 0x64, 0xf4, 0x18, 
+0xdc, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82};
+
+
+int main() {
+	//test bx
+	float tLerp = bx::lerp(0.0f, 10.0f, 0.5f);
+    BX_TRACE("Lerped 0.0f to 10.0f at 0.5f, result %f", tLerp);
+    BX_ASSERT(bx::isEqual(tLerp, 5.0f, 0.1f), "isEqual failed");
+	bx::debugPrintf("Length of \"test\" is: %d", bx::strLen("test"));
+
+	//test bimg
+	bx::DefaultAllocator defAlloc;
+	bimg::ImageContainer* imageContainer = nullptr;
+	imageContainer = bimg::imageParse(&defAlloc, (const void*) img, 129 * sizeof(char));
+	BX_ASSERT(imageContainer->m_format == bimg::TextureFormat::RGB8, "Image incorrectly decoded.")
+	bimg::imageFree(imageContainer);
+
+	//test bgfx
+#if BGFX_SHARED_LIB_USE && (BX_PLATFORM_WINDOWS || BX_PLATFORM_WINRT)
+	bgfx_init_t init;
+	bgfx_init_ctor(&init);
+	init.type     = bgfx_renderer_type::BGFX_RENDERER_TYPE_NOOP;
+	init.vendorId = BGFX_PCI_ID_NONE;
+	init.platformData.nwh  = nullptr;
+	init.platformData.ndt  = nullptr;
+	init.resolution.width  = 0;
+	init.resolution.height = 0;
+	init.resolution.reset  = BGFX_RESET_NONE;
+	bgfx_init(&init);
+	bgfx_shutdown();
+    return 0;
+#else
+	bgfx::Init init;
+	init.type     = bgfx::RendererType::Noop;
+	init.vendorId = BGFX_PCI_ID_NONE;
+	init.platformData.nwh  = nullptr;
+	init.platformData.ndt  = nullptr;
+	init.resolution.width  = 0;
+	init.resolution.height = 0;
+	init.resolution.reset  = BGFX_RESET_NONE;
+	bgfx::init(init);
+    bgfx::shutdown();
+#endif
+}

--- a/recipes/bgfx/consolidated/test_v1_package/CMakeLists.txt
+++ b/recipes/bgfx/consolidated/test_v1_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/bgfx/consolidated/test_v1_package/conanfile.py
+++ b/recipes/bgfx/consolidated/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class BimgTestPackageConan(ConanFile):
+    settings   = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **bgfx**

#### Motivation
This adds a consolidated recipe for bgfx going forward. This is versioned using bgfx' versioning scheme (https://github.com/bkaradzic/bgfx/blob/93961afcfd45bdcbdb91bddfb133a621d340f136/src/bgfx.cpp#L3566), and integrates bx and bimg into this package. This was done after discussions about whether having bx and bimg separate is valuable, and how due to their interdependence and reliance on specific versions, having them separate makes updates on CCI much slower and more cumbersome.

#### Details
The recipe is still based on the previous bgfx recipe, but with quite a few changes and additions.
It adds all things required for bimg and bx to be integrated into this recipe, such as defines, libs, and their headers.
It also adds an option for rtti, due to the fact that bgfx' (and bx', and bimg's) build scripts are hardcoded to build with rtti disabled. Packages on CCI are rtti enabled by default, and mixing these can cause linker issues, especially on linux in my experience.
There is also improved support for mingw and android, changes to make other things more consistent, and so on.
The new recipe has been locally tested on windows 11 msvc194 and mingw, linux gcc, and android.

Some questions I was pondering:
Would there be value in adding an option for overriding bx' CRT detection in order for this to build with something like musl?
Would there be value in exposing options for opengl version etc. and other compile-time options that bgfx has?

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
