### PR TITLE
libpcap: add explicit dpdk option

### DIFF
--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -30,12 +30,14 @@ class LibPcapConan(ConanFile):
         "fPIC": [True, False],
         "enable_libusb": [True, False],
         "with_snf": [True, False],
+        "with_dpdk": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_libusb": False,
         "with_snf": False,
+        "with_dpdk": False,
     }
 
     # TODO: Add dbus-glib when available
@@ -118,7 +120,11 @@ class LibPcapConan(ConanFile):
                 "--disable-rdma",
                 f"--with-snf={yes_no(self.options.get_safe('with_snf'))}",
             ])
-            
+
+            if self.options.with_dpdk:
+                tc.configure_args.append("--with-dpdk")
+            else:
+                tc.configure_args.append("--without-dpdk")
             if cross_building(self):
                 target_os = "linux" if self.settings.os == "Linux" else "null"
                 tc.configure_args.append(f"--with-pcap={target_os}")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpcap**

#### Motivation
libpcap has [compilation errors when compiling with dpdk](https://github.com/the-tcpdump-group/libpcap/issues/1159) lib higher then v21.11-rc1. So explicitly setting this flag will allow you to control this.

#### Details
I ran into such a problem on a machine where dpdk was installed, although I did not need the compatibility of these libraries. It was possible to solve the problem by isolating the environments, but still.

To reproduce the problem, you must first install dpdk, then try to install libpcap.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
