### PR TITLE
octo-logger-cpp: update checksum for 1.12.0

### DIFF
--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.12.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.12.0.tar.gz"
-    sha256: "b4140d31910af128e1d97ae44a564bbad7f7ca889410bbc885691c5e215c0d61"
+    sha256: "77f351ae4cad973ad7836dae7498419692590f2419b5b569c1f00fc6130d8bbb"
   "1.11.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.11.0.tar.gz"
     sha256: "73c35ca2a2e0c4be2cd85c5ba1f4061bbc22637fe79570107f1123eff30936db"


### PR DESCRIPTION
### Summary
Changes to recipe:  **octo-logger-cpp/1.12.0**

#### Motivation
tar ball of 1.12.0 is updated.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
