### PR TITLE
nsync: add version 1.29.1

### DIFF
--- a/recipes/nsync/all/conandata.yml
+++ b/recipes/nsync/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.29.1":
+    url: "https://github.com/google/nsync/archive/1.29.1.tar.gz"
+    sha256: "3045a8922171430426b695edf794053182d245f6a382ddcc59ef4a6190848e98"
   "1.28.0":
     url: "https://github.com/google/nsync/archive/1.28.0.tar.gz"
     sha256: "1e6a7193bd85d480faaf992cef204c5cf09f9da72766c9987e25b4f88508eed1"
@@ -18,6 +21,8 @@ sources:
     sha256: "b7e75b17957c62bd02dd73890bde22da3a564903fcaad651b395453d41d3325b"
     url: "https://github.com/google/nsync/archive/refs/tags/1.23.0.tar.gz"
 patches:
+  "1.29.1":
+    - patch_file: "patches/0001-1.27.0-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
   "1.28.0":
     - patch_file: "patches/0001-1.27.0-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
   "1.27.0":

--- a/recipes/nsync/config.yml
+++ b/recipes/nsync/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.29.1":
+    folder: "all"
   "1.28.0":
     folder: "all"
   "1.27.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **nsync/1.29.1**

#### Motivation
add version 1.29.1

#### Details
https://github.com/google/nsync/compare/1.28.0...1.29.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
