### PR TITLE
iconfontcppheaders: bump version to cci.20240620

### DIFF
--- a/recipes/iconfontcppheaders/all/conandata.yml
+++ b/recipes/iconfontcppheaders/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20240620":
+    sha256: 363613c9ea6b4d4b290527bc1fcd626b09accd985a40f14442e86d1df16ec487
+    url: https://github.com/juliettef/IconFontCppHeaders/archive/62d27fa93d8f1f881dac18f13881dd97af66fa74/main.zip
   "cci.20240128":
     sha256: de946a4471dca969426b2e7863d79136a91f2e4e4cc7a766df31bbb8412571f9
     url: https://github.com/juliettef/IconFontCppHeaders/archive/8886c5657bac22b8fee34354871e3ade2a596433/main.zip

--- a/recipes/iconfontcppheaders/all/conanfile.py
+++ b/recipes/iconfontcppheaders/all/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.52.0"
 
 class FireHppConan(ConanFile):
     name = "iconfontcppheaders"
-    description = "Headers for icon fonts Font Awesome, Fork Awesome, Google Material Design, Pictogrammers Material Design icons, Kenney game icons, Fontaudio, Codicons and Lucide."
+    description = "Headers for icon fonts Font Awesome, Fork Awesome, Google Material Design Icons, Google Material Design Symbols, Pictogrammers Material Design icons, Kenney game icons, Fontaudio, Codicons and Lucide."
     license = "Zlib"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/juliettef/IconFontCppHeaders"

--- a/recipes/iconfontcppheaders/config.yml
+++ b/recipes/iconfontcppheaders/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20240620":
+    folder: all
   "cci.20240128":
     folder: all
   "cci.20231102":


### PR DESCRIPTION
The usual updates as well as adding support for Google Material Design Symbols

### Summary
Changes to recipe:  **iconfontcppheaders/cci.20240620**

#### Motivation
Get support for the latest icon sets.

#### Details
Just a bump to the latest upstream version and an updated description.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
