### PR TITLE
gsoap: test only the created reference

### DIFF
--- a/recipes/gsoap/all/test_package/conanfile.py
+++ b/recipes/gsoap/all/test_package/conanfile.py
@@ -7,36 +7,28 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
 
     def requirements(self):
-        self.requires(self.tested_reference_str, run=can_run(self))
-
-    def build_requirements(self):
-        if not can_run(self):
-            self.tool_requires(self.tested_reference_str)
-
-    def generate(self):
-        VirtualRunEnv(self).generate()
-        if can_run(self):
-            VirtualRunEnv(self).generate(scope="build")
-        else:
-            VirtualBuildEnv(self).generate()
+        self.requires(self.tested_reference_str, run=True)
 
     def build(self):
+        if not can_run(self):
+            self.output.warning("Skipping build: the package was cross-built")
+            return
         calc_wsdl = os.path.join(self.source_folder, "calc.wsdl")
         self.output.info(f"Generating code from WSDL '{calc_wsdl}'")
-        self.run(f"wsdl2h -o calc.h {calc_wsdl}")
+        self.run(f"wsdl2h -o calc.h {calc_wsdl}", env="conanrun")
         if conan_version.major < "2":
             # conan v1 limitation: self.dependencies is not defined in build() method of test package
             import_dir = os.path.join(self.deps_cpp_info["gsoap"].rootpath, "bin", "import")
         else:
             import_dir = os.path.join(self.dependencies["gsoap"].package_folder, "bin", "import")
-        self.run(f"soapcpp2 -j -CL -I{import_dir} calc.h")
+        self.run(f"soapcpp2 -j -CL -I{import_dir} calc.h", env="conanrun")
 
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/gsoap/all/test_package/test_package.cpp
+++ b/recipes/gsoap/all/test_package/test_package.cpp
@@ -6,15 +6,7 @@
 int main()
 {
     calcProxy calc;
-    double sum;
-    if (calc.add(1.23, 4.56, sum) == SOAP_OK)
-    {
-        std::cout << "Sum = " << sum << std::endl;
-    }
-    else
-    {
-        std::cout << "Cannot sum" << std::endl;
-        calc.soap_stream_fault(std::cerr);
-    }
     calc.destroy(); // same as: soap_destroy(calc.soap); soap_end(calc.soap);
+    std::cout << "gSoap Test package successful\n";
+    return 0;
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  gsoap (test package only)

#### Motivation
Ensure the we test only a single package_id during `conan test`, to avoid build order issues on CI 

#### Details
When different package_id are required, CI cannot guarantee that the "other" ID will have been generated and uploaded before test time. We do lose some slice of testing here: it is no longer tested if it is cross-built - however, there is correlation: if `self.run(xxx, env="conanrun")` works, for the `self.requires(self.tested_reference_str)`, then `self.run(xxx, env="conanbuild")` should work for `self.tool_requires(self.tested_reference_str)`, assuming that the only thing we need is the `bin` directory added to the path.

Additionally: simplify the test package C++ file - linking is already tested with minimal code.


