### PR TITLE
lua: add version 5.4.7

### DIFF
--- a/recipes/lua/all/conandata.yml
+++ b/recipes/lua/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.4.7":
+    url: "https://www.lua.org/ftp/lua-5.4.7.tar.gz"
+    sha256: "9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30"
   "5.4.6":
     url: "https://www.lua.org/ftp/lua-5.4.6.tar.gz"
     sha256: "7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88"

--- a/recipes/lua/config.yml
+++ b/recipes/lua/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.4.7":
+    folder: all
   "5.4.6":
     folder: all
   "5.4.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lua/5.4.7**

#### Motivation
lua/5.4.7 is a bug-fix release.

#### Details
https://www.lua.org/work/diffs-lua-5.4.6-lua-5.4.7.html

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
