### PR TITLE
dtl: support gcc 14

### DIFF
--- a/recipes/dtl/all/conanfile.py
+++ b/recipes/dtl/all/conanfile.py
@@ -17,6 +17,7 @@ class DtlConan(ConanFile):
 
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -26,8 +27,6 @@ class DtlConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
-    def build(self):
         # See https://github.com/cubicdaiya/dtl/pull/18
         replace_in_file(self, os.path.join(self.source_folder, "dtl", "Diff.hpp"), "void enableTrivial () const {", "void enableTrivial () {")
 

--- a/recipes/dtl/all/conanfile.py
+++ b/recipes/dtl/all/conanfile.py
@@ -1,8 +1,7 @@
 import os
 
 from conan import ConanFile
-from conan.tools.build import check_min_cppstd
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, replace_in_file
 from conan.tools.layout import basic_layout
 
 required_conan_version = ">=1.52.0"
@@ -18,7 +17,6 @@ class DtlConan(ConanFile):
 
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
-    no_copy_source = True
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -28,6 +26,10 @@ class DtlConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        # See https://github.com/cubicdaiya/dtl/pull/18
+        replace_in_file(self, os.path.join(self.source_folder, "dtl", "Diff.hpp"), "void enableTrivial () const {", "void enableTrivial () {")
 
     def package(self):
         copy(self, "COPYING",


### PR DESCRIPTION
### Summary
Changes to recipe:  **dtl/***

#### Motivation
To support gcc 14, make `enableTrivial` mutable.
https://github.com/cubicdaiya/dtl/pull/18

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
