### PR TITLE
qt: fix setting cppstd

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -613,16 +613,16 @@ class QtConan(ConanFile):
         current_cpp_std = self.settings.get_safe("compiler.cppstd", default_cppstd(self))
         current_cpp_std = str(current_cpp_std).replace("gnu", "")
         cpp_std_map = {
-            11: "FEATURE_cxx11",
-            14: "FEATURE_cxx14",
-            17: "FEATURE_cxx17",
-            20: "FEATURE_cxx20"
+            "11": "FEATURE_cxx11",
+            "14": "FEATURE_cxx14",
+            "17": "FEATURE_cxx17",
+            "20": "FEATURE_cxx20"
         }
         if Version(self.version) >= "6.5.0":
-            cpp_std_map[23] = "FEATURE_cxx2b"
+            cpp_std_map["23"] = "FEATURE_cxx2b"
 
         for std, feature in cpp_std_map.items():
-            tc.variables[feature] = "ON" if int(current_cpp_std) >= std else "OFF"
+            tc.variables[feature] = "ON" if int(current_cpp_std) >= int(std) else "OFF"
 
         tc.variables["QT_USE_VCPKG"] = False
         tc.cache_variables["QT_USE_VCPKG"] = False


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.x**

#### Motivation
"current_cpp_std" is of type str, so the list elements that are indexed by it should also be of this type


---
- [ X ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ X ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ X ] Tested locally with at least one configuration using a recent version of Conan
