### PR TITLE
xsimd: allow using apple-clang < 13 with cppstd 17

### DIFF
--- a/recipes/xsimd/all/conanfile.py
+++ b/recipes/xsimd/all/conanfile.py
@@ -46,7 +46,7 @@ class XsimdConan(ConanFile):
 
     def requirements(self):
         if self.options.xtl_complex:
-            self.requires("xtl/0.7.5")
+            self.requires("xtl/0.7.6")
 
     def package_id(self):
         self.info.clear()
@@ -58,7 +58,7 @@ class XsimdConan(ConanFile):
 
         # TODO: There are compilation errors on apple-clang/13.0.0 with cppstd=17
         if self.settings.compiler == "apple-clang" and \
-            Version(self.settings.compiler.version).major <= "13" and \
+            Version(self.settings.compiler.version).major == "13" and \
             self.settings.compiler.get_safe("cppstd") in ["17", "gnu17", "20", "gnu20",]:
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support apple-clang 13 with cppstd=17 or later")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **xsimd/all**
Allow using xsimd with cppstd 17 on apple-clang < 13.
Update xtl to 0.7.6.

Closes #24445

#### Motivation
xsimd 13.0.0 works perfectly fine on apple-clang 12 with cppstd 17.

#### Details
Relax apple-clang restrictions - forbid only apple-clang 13.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
