### PR TITLE
[dbus] Do not customize system bus listens

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -113,7 +113,6 @@ class DbusConan(ConanFile):
         tc.project_options["asserts"] = not is_apple_os(self)
         tc.project_options["checks"] = False
         tc.project_options["datadir"] = os.path.join("res", "share")
-        tc.project_options["localstatedir"] = os.path.join("res", "var")
         tc.project_options["sysconfdir"] = os.path.join("res", "etc")
         tc.project_options["doxygen_docs"] = "disabled"
         tc.project_options["ducktype_docs"] = "disabled"

--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -27,7 +27,7 @@ class DbusConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "dbus_user": ["ANY"],
+        "dbus_user": [None, "ANY"],
         "message_bus": [True, False],
         "system_socket": [None, "ANY"],
         "system_pid_file": [None, "ANY"],


### PR DESCRIPTION
### Summary

Changes to recipe:  **dbus/1.15.8**

#### Motivation

The `localstatedir` affects the system_bus_socket configuration, which is hardcoded in provided binaries. The usual case is consuming from system.

#### Details

When building DBUS, it shows:

```
Program tools/check-runstatedir.sh found: YES (/home/conan/.conan2/p/b/dbus5310cead1ccb5/b/src/tools/check-runstatedir.sh)
../src/meson.build:934: WARNING: 
NOTE: system bus listens on /res/var/run/dbus/system_bus_socket
| This build of dbus will not interoperate with the well-known
| system bus socket, /var/run/dbus/system_bus_socket.
```

The recommended folder is `/var`, not the package folder. The Prefix points to `/`, which results in `/res`.

Still, people can customize Toolchain directly via configuration: https://github.com/conan-io/conan-center-index/issues/5782#issuecomment-2161050812

/cc @garethsb 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
