### PR TITLE
mongo-c-driver: add version 1.27.3

### DIFF
--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.27.3":
+    url: "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.27.3.tar.gz"
+    sha256: "2593048270f8426c3dc60f0a3c22c3da92ae00a3ef284da7e662a1348ca1685c"
   "1.27.2":
     url: "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.27.2.tar.gz"
     sha256: "a53010803e2df097a2ea756be6ece34c8f52cda2c18e6ea21115097b75f5d4bf"

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.27.3":
+    folder: all
   "1.27.2":
     folder: all
   "1.27.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mongo-c-driver/1.27.3**

#### Motivation
There are several internal improvements in 1.27.3.

#### Details
https://github.com/mongodb/mongo-c-driver/compare/1.27.2...1.27.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
