### PR TITLE
pybind11: add version 2.13.1

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -1,28 +1,31 @@
 sources:
-  "2.7.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz"
-    sha256: "616d1c42e4cf14fa27b2a4ff759d7d7b33006fdc5ad8fd603bb2c22622f27020"
-  "2.8.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.8.1.tar.gz"
-    sha256: "f1bcc07caa568eb312411dde5308b1e250bd0e1bc020fae855bf9f43209940cc"
-  "2.9.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz"
-    sha256: "c6160321dc98e6e1184cc791fbeadd2907bb4a0ce0e447f2ea4ff8ab56550913"
-  "2.9.2":
-    url: "https://github.com/pybind/pybind11/archive/v2.9.2.tar.gz"
-    sha256: "6bd528c4dbe2276635dc787b6b1f2e5316cf6b49ee3e150264e455a0d68d19c1"
-  "2.10.0":
-    url: "https://github.com/pybind/pybind11/archive/v2.10.0.tar.gz"
-    sha256: "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec"
-  "2.10.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.10.1.tar.gz"
-    sha256: "111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad"
-  "2.10.4":
-    url: "https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"
-    sha256: "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970"
-  "2.11.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.11.1.tar.gz"
-    sha256: "d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c"
+  "2.13.1":
+    url: "https://github.com/pybind/pybind11/archive/v2.13.1.tar.gz"
+    sha256: "51631e88960a8856f9c497027f55c9f2f9115cafb08c0005439838a05ba17bfc"
   "2.12.0":
     url: "https://github.com/pybind/pybind11/archive/v2.12.0.tar.gz"
     sha256: "bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7"
+  "2.11.1":
+    url: "https://github.com/pybind/pybind11/archive/v2.11.1.tar.gz"
+    sha256: "d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c"
+  "2.10.4":
+    url: "https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"
+    sha256: "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970"
+  "2.10.1":
+    url: "https://github.com/pybind/pybind11/archive/v2.10.1.tar.gz"
+    sha256: "111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad"
+  "2.10.0":
+    url: "https://github.com/pybind/pybind11/archive/v2.10.0.tar.gz"
+    sha256: "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec"
+  "2.9.2":
+    url: "https://github.com/pybind/pybind11/archive/v2.9.2.tar.gz"
+    sha256: "6bd528c4dbe2276635dc787b6b1f2e5316cf6b49ee3e150264e455a0d68d19c1"
+  "2.9.1":
+    url: "https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz"
+    sha256: "c6160321dc98e6e1184cc791fbeadd2907bb4a0ce0e447f2ea4ff8ab56550913"
+  "2.8.1":
+    url: "https://github.com/pybind/pybind11/archive/v2.8.1.tar.gz"
+    sha256: "f1bcc07caa568eb312411dde5308b1e250bd0e1bc020fae855bf9f43209940cc"
+  "2.7.1":
+    url: "https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz"
+    sha256: "616d1c42e4cf14fa27b2a4ff759d7d7b33006fdc5ad8fd603bb2c22622f27020"

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -12,18 +12,22 @@ required_conan_version = ">=1.52.0"
 class PyBind11Conan(ConanFile):
     name = "pybind11"
     description = "Seamless operability between C++11 and Python"
-    topics = "pybind11", "python", "binding"
-    homepage = "https://github.com/pybind/pybind11"
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/pybind/pybind11"
+    topics = ("pybind11", "python", "binding", "header-only")
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
+    def package_id(self):
+        self.info.clear()
+
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -53,9 +57,6 @@ class PyBind11Conan(ConanFile):
         replace_in_file(self, os.path.join(self.package_folder, "lib", "cmake", "pybind11", "pybind11Common.cmake"),
                               "add_library(",
                               "# add_library(")
-
-    def package_id(self):
-        self.info.clear()
 
     def package_info(self):
         cmake_base_path = os.path.join("lib", "cmake", "pybind11")

--- a/recipes/pybind11/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11/all/test_package/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
+
 find_package(pybind11 REQUIRED CONFIG)
+
 pybind11_add_module(test_package MODULE test_package.cpp)
 set_property(TARGET test_package PROPERTY CXX_STANDARD 11)

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -1,19 +1,21 @@
 versions:
-  "2.7.1":
+  "2.13.1":
     folder: all
-  "2.8.1":
-    folder: all
-  "2.9.1":
-    folder: all
-  "2.9.2":
-    folder: all
-  "2.10.0":
-    folder: all
-  "2.10.1":
-    folder: all
-  "2.10.4":
+  "2.12.0":
     folder: all
   "2.11.1":
     folder: all
-  "2.12.0":
+  "2.10.4":
+    folder: all
+  "2.10.1":
+    folder: all
+  "2.10.0":
+    folder: all
+  "2.9.2":
+    folder: all
+  "2.9.1":
+    folder: all
+  "2.8.1":
+    folder: all
+  "2.7.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **pybind11/2.13.1**

#### Motivation
There are several new features since 2.12.0.

#### Details
https://github.com/pybind/pybind11/compare/v2.12.0...v2.13.1

Sort versions in `config.yml` and `conandata.yml`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
