### PR TITLE
pulseaudio: Workaround if clang 15

### DIFF
--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -1,3 +1,5 @@
+import os
+
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
@@ -5,7 +7,6 @@ from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import copy, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
-import os
 
 required_conan_version = ">=1.53.0"
 
@@ -111,6 +112,10 @@ class PulseAudioConan(ConanFile):
             "--with-udev-rules-dir=${prefix}/bin/udev/rules.d",
             f"--with-systemduserunitdir={os.path.join(self.build_folder, 'ignore')}",
         ])
+        # Workaround for https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=268250
+        # clang-15 works, but we need to skip the gnu11 flag check
+        if self.settings.compiler == "clang" and self.settings.compiler.version == 15:
+            tc.configure_args.append("ax_cv_check_cflags__pedantic__Werror__std_gnu11=yes")
         for lib in ["alsa", "x11", "openssl", "dbus"]:
             tc.configure_args.append(f"--enable-{lib}={yes_no(getattr(self.options, f'with_{lib}'))}")
         # TODO: to remove when automatically handled by AutotoolsToolchain


### PR DESCRIPTION
### Summary
Changes to recipe:  **pulseaudio/[<=14.2]**
Closes: https://github.com/conan-io/conan-center-index/issues/24464

#### Motivation

Configure step fails with:

```shell
checking for CFLocaleCopyCurrent... no
checking for GNU gettext in libc... yes
checking whether to use NLS... yes
checking where the gettext function comes from... libc
checking host operating system... linux
checking whether C compiler accepts -std=gnu11... no
configure: error: *** Compiler does not support -std=gnu11
```
Applying this workaround:
```
....

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Debug
compiler=clang
compiler.cppstd=gnu11
compiler.libcxx=libstdc++11
compiler.version=15
os=Linux
[conf]
tools.build:compiler_executables={'c': 'clang-15', 'cpp': 'clang++-15'}

....

checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for shared library run path origin... done
checking for CFPreferencesCopyAppValue... no
checking for CFLocaleCopyCurrent... no
checking for GNU gettext in libc... yes
checking whether to use NLS... yes
checking where the gettext function comes from... libc
checking host operating system... linux
checking whether C compiler accepts -std=gnu11... (cached) yes

....

pulseaudio/14.2 (test package): Running CMake.build()
pulseaudio/14.2 (test package): RUN: cmake --build "/home/develop/conan-center-index/recipes/pulseaudio/all/test_package/build/clang-15-x86_64-gnu11-debug" -- -j2
gmake: Warning: File 'Makefile' has modification time 0.95 s in the future
gmake[1]: Warning: File 'CMakeFiles/Makefile2' has modification time 0.87 s in the future
gmake[2]: Warning: File 'CMakeFiles/test_package.dir/flags.make' has modification time 0.84 s in the future
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: Warning: File 'CMakeFiles/test_package.dir/flags.make' has modification time 0.79 s in the future
[ 50%] Building C object CMakeFiles/test_package.dir/test_package.c.o
[100%] Linking C executable test_package
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[100%] Built target test_package
gmake[1]: warning:  Clock skew detected.  Your build may be incomplete.
gmake: warning:  Clock skew detected.  Your build may be incomplete.


======== Testing the package: Executing test ========
pulseaudio/14.2 (test package): Running test()
pulseaudio/14.2 (test package): RUN: ./test_package
pulse audio verions 14.2.0
```

#### Details
Higher versions does not use Autotools and it does not fail