### PR TITLE
raylib: Add some useful headers to res folder

### DIFF
--- a/recipes/raylib/all/conanfile.py
+++ b/recipes/raylib/all/conanfile.py
@@ -91,6 +91,13 @@ class RaylibConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
+        res_include_folder = os.path.join(self.package_folder, "res", "include")
+        copy(self, pattern="rcamera.h", src=os.path.join(self.source_folder, "src"), dst=res_include_folder, keep_path=False)
+        copy(self, pattern="rgestures.h", src=os.path.join(self.source_folder, "src"), dst=res_include_folder, keep_path=False)
+        copy(self, pattern="rlgl.h", src=os.path.join(self.source_folder, "src"), dst=res_include_folder, keep_path=False)
+        copy(self, pattern="raymath.h", src=os.path.join(self.source_folder, "src"), dst=res_include_folder, keep_path=False)
+        copy(self, pattern="raudio.h", src=os.path.join(self.source_folder, "src"), dst=res_include_folder, keep_path=False)
+
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),

--- a/recipes/raylib/all/conanfile.py
+++ b/recipes/raylib/all/conanfile.py
@@ -135,7 +135,11 @@ class RaylibConan(ConanFile):
             self.cpp_info.system_libs.append("winmm")
 
         # Some useful files are not packaged by default
-        self.cpp_info.resdirs = ["res/include"]
+        res_includes = os.path.join(self.package_folder, "res", "include")
+        self.cpp_info.resdirs = [res_includes]
+
+        if self.conf.get("user.raylib:include_res", default=False, check_type=bool):
+            self.cpp_info.includedirs.append(res_includes)
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]

--- a/recipes/raylib/all/conanfile.py
+++ b/recipes/raylib/all/conanfile.py
@@ -134,6 +134,9 @@ class RaylibConan(ConanFile):
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs.append("winmm")
 
+        # Some useful files are not packaged by default
+        self.cpp_info.resdirs = ["res/include"]
+
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]


### PR DESCRIPTION
### Summary
Changes to recipe:  **raylib/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
As explained in https://github.com/conan-io/conan-center-index/issues/24368, the library does not package some useful files that users might want to use as part of their build. This is similar to the imgui situation, so the solution is also similar: Add those files to the res folder, where users can then copy them from

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
The linked issue and subsequent upstream issue have all the relevant info

As a draft until I get a chance to update the hook that will fail

cc @Ezbob 