### PR TITLE
magic_enum: add version 0.9.6

### DIFF
--- a/recipes/magic_enum/all/conandata.yml
+++ b/recipes/magic_enum/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.6":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.9.6.tar.gz"
+    sha256: "814791ff32218dc869845af7eb89f898ebbcfa18e8d81aa4d682d18961e13731"
   "0.9.5":
     url: "https://github.com/Neargye/magic_enum/archive/v0.9.5.tar.gz"
     sha256: "44ad80db5a72f5047e01d90e18315751d9ac90c0ab42cbea7a6f9ec66a4cd679"

--- a/recipes/magic_enum/config.yml
+++ b/recipes/magic_enum/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.6":
+    folder: all
   "0.9.5":
     folder: all
   "0.9.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **magic_enum/0.9.6**

#### Motivation
There are several improvements in 0.9.6.

#### Details
https://github.com/Neargye/magic_enum/releases/tag/v0.9.6
https://github.com/Neargye/magic_enum/compare/v0.9.5...v0.9.6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
