### PR TITLE
artery-font-format: add version 1.1

### DIFF
--- a/recipes/artery-font-format/all/conandata.yml
+++ b/recipes/artery-font-format/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1":
+    url: "https://github.com/Chlumsky/artery-font-format/archive/v1.1.tar.gz"
+    sha256: "cd8eb58590d85069312b831ce5bc6eba21778ef2fa8ca8ac06e1ecf8eca53a7c"
   "1.0.1":
     url: "https://github.com/Chlumsky/artery-font-format/archive/v1.0.1.tar.gz"
     sha256: "23dc9450d2364c9f1a67fcb0ae8f2bef365fabc5a3f4af55d9a646f8fbcdc537"

--- a/recipes/artery-font-format/all/conanfile.py
+++ b/recipes/artery-font-format/all/conanfile.py
@@ -7,11 +7,11 @@ required_conan_version = ">=1.52.0"
 
 class ArteryFontFormatConan(ConanFile):
     name = "artery-font-format"
-    license = "MIT"
-    homepage = "https://github.com/Chlumsky/artery-font-format"
-    url = "https://github.com/conan-io/conan-center-index"
     description = "Artery Atlas Font format library"
-    topics = ("artery", "font", "atlas")
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Chlumsky/artery-font-format"
+    topics = ("artery", "font", "atlas", "header-only")
     package_type = "header-library"
     no_copy_source = True
 
@@ -20,10 +20,6 @@ class ArteryFontFormatConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
-    def build(self):
-        # header only: no build step
-        pass
 
     def package(self):
         copy(self, pattern="LICENSE.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
@@ -39,3 +35,7 @@ class ArteryFontFormatConan(ConanFile):
             dst=os.path.join(self.package_folder, "include"),
             src=self.source_folder,
         )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/artery-font-format/all/conanfile.py
+++ b/recipes/artery-font-format/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.tools.files import get, copy
 import os
 
@@ -13,10 +14,19 @@ class ArteryFontFormatConan(ConanFile):
     homepage = "https://github.com/Chlumsky/artery-font-format"
     topics = ("artery", "font", "atlas", "header-only")
     package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 11
 
     def package_id(self):
         self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/artery-font-format/all/test_package/CMakeLists.txt
+++ b/recipes/artery-font-format/all/test_package/CMakeLists.txt
@@ -4,5 +4,4 @@ project(test_package LANGUAGES CXX)
 find_package(artery-font-format REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} artery-font-format::artery-font-format)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+target_link_libraries(${PROJECT_NAME} PRIVATE artery-font-format::artery-font-format)

--- a/recipes/artery-font-format/all/test_package/CMakeLists.txt
+++ b/recipes/artery-font-format/all/test_package/CMakeLists.txt
@@ -5,3 +5,4 @@ find_package(artery-font-format REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE artery-font-format::artery-font-format)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/artery-font-format/all/test_package/conanfile.py
+++ b/recipes/artery-font-format/all/test_package/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"

--- a/recipes/artery-font-format/config.yml
+++ b/recipes/artery-font-format/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1":
+    folder: all
   "1.0.1":
     folder: all
   "1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **artery-font-format/1.1**

#### Motivation
There is a data structure updated in 1.1.

#### Details
https://github.com/Chlumsky/artery-font-format/compare/v1.0.1...v1.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
