### PR TITLE
fmt: add version 11.0.0

### DIFF
--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "11.0.0":
+    url: "https://github.com/fmtlib/fmt/releases/download/11.0.0/fmt-11.0.0.zip"
+    sha256: "583ce480ef07fad76ef86e1e2a639fc231c3daa86c4aa6bcba524ce908f30699"
   "10.2.1":
     url: "https://github.com/fmtlib/fmt/releases/download/10.2.1/fmt-10.2.1.zip"
     sha256: "312151a2d13c8327f5c9c586ac6cf7cddc1658e8f53edae0ec56509c8fa516c9"

--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -6,17 +6,18 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.layout import basic_layout
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 
 required_conan_version = ">=1.53.0"
 
 
 class FmtConan(ConanFile):
     name = "fmt"
-    homepage = "https://github.com/fmtlib/fmt"
     description = "A safe and fast alternative to printf and IOStreams."
-    topics = ("format", "iostream", "printf")
-    url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/fmtlib/fmt"
+    topics = ("format", "iostream", "printf")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -25,6 +26,7 @@ class FmtConan(ConanFile):
         "fPIC": [True, False],
         "with_fmt_alias": [True, False],
         "with_os_api": [True, False],
+        "with_unicode": [True, False],
     }
     default_options = {
         "header_only": False,
@@ -32,11 +34,16 @@ class FmtConan(ConanFile):
         "fPIC": True,
         "with_fmt_alias": False,
         "with_os_api": True,
+        "with_unicode": True,
     }
 
     @property
     def _has_with_os_api_option(self):
         return Version(self.version) >= "7.0.0"
+
+    @property
+    def _has_with_unicode_option(self):
+        return Version(self.version) >= "11.0.0"
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -48,6 +55,8 @@ class FmtConan(ConanFile):
             del self.options.with_os_api
         elif str(self.settings.os) == "baremetal":
             self.options.with_os_api = False
+        if not self._has_with_unicode_option:
+            del self.options.with_unicode
 
     def configure(self):
         if self.options.header_only:
@@ -85,6 +94,8 @@ class FmtConan(ConanFile):
             tc.cache_variables["FMT_LIB_DIR"] = "lib"
             if self._has_with_os_api_option:
                 tc.cache_variables["FMT_OS"] = bool(self.options.with_os_api)
+            if self._has_with_unicode_option:
+                tc.cache_variables["FMT_UNICODE"] = bool(self.options.with_unicode)
             tc.generate()
 
     def build(self):
@@ -123,6 +134,8 @@ class FmtConan(ConanFile):
             self.cpp_info.components["_fmt"].defines.append("FMT_HEADER_ONLY=1")
             self.cpp_info.components["_fmt"].libdirs = []
             self.cpp_info.components["_fmt"].bindirs = []
+            if self._has_with_unicode_option and is_msvc(self):
+                self.cpp_info.components["_fmt"].cxxflags.append("/utf-8")
 
         else:
             postfix = "d" if self.settings.build_type == "Debug" else ""

--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -126,6 +126,9 @@ class FmtConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", f"fmt::{target}")
         self.cpp_info.set_property("pkg_config_name",  "fmt")
 
+        if self.options.get_safe("with_unicode") and is_msvc(self):
+            self.cpp_info.components["_fmt"].cxxflags.append("/utf-8")
+
         # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
         if self.options.with_fmt_alias:
             self.cpp_info.components["_fmt"].defines.append("FMT_STRING_ALIAS=1")
@@ -134,9 +137,6 @@ class FmtConan(ConanFile):
             self.cpp_info.components["_fmt"].defines.append("FMT_HEADER_ONLY=1")
             self.cpp_info.components["_fmt"].libdirs = []
             self.cpp_info.components["_fmt"].bindirs = []
-            if self._has_with_unicode_option and is_msvc(self):
-                self.cpp_info.components["_fmt"].cxxflags.append("/utf-8")
-
         else:
             postfix = "d" if self.settings.build_type == "Debug" else ""
             libname = "fmt" + postfix

--- a/recipes/fmt/all/test_package/test_package.cpp
+++ b/recipes/fmt/all/test_package/test_package.cpp
@@ -40,7 +40,6 @@ namespace fmt {
 int main() {
     const std::string thing("World");
     fmt::print("PRINT: Hello {}!\n", thing);
-    fmt::printf("PRINTF: Hello, %s!\n", thing);
 
     const std::string formatted = fmt::format("{0}{1}{0}", "abra", "cad");
     fmt::print("{}\n", formatted);

--- a/recipes/fmt/config.yml
+++ b/recipes/fmt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "11.0.0":
+    folder: all
   "10.2.1":
     folder: all
   "10.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fmt/11.0.0**

#### Motivation
There are lots of update since 10.2.1.

#### Details
https://github.com/fmtlib/fmt/compare/10.2.1...11.0.0

I deleted one line in test_package.cpp because it failed in gcc14 with c++20.
I already created [PR](https://github.com/fmtlib/fmt/pull/4042) about this issue. 
Since this seems to be a rare case, I decided to delete this line without waiting for the merge.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
