### PR TITLE
daw_utf_range: add version 2.2.5

### DIFF
--- a/recipes/daw_utf_range/all/conandata.yml
+++ b/recipes/daw_utf_range/all/conandata.yml
@@ -14,3 +14,9 @@ sources:
   "2.2.0":
     url: "https://github.com/beached/utf_range/archive/v2.2.0.tar.gz"
     sha256: "00f60360736062403c8a7a94dd07c750366958f20d1864578faecf2e09d84265"
+daw_headers_mapping:
+  "2.2.5": "2.106.0"
+  "2.2.4": "2.101.0"
+  "2.2.3": "2.97.0"
+  "2.2.2": "2.97.0"
+  "2.2.0": "2.97.0"

--- a/recipes/daw_utf_range/all/conandata.yml
+++ b/recipes/daw_utf_range/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.5":
+    url: "https://github.com/beached/utf_range/archive/v2.2.5.tar.gz"
+    sha256: "18cc142c319c817da86ed037813cd50a16ff1af8e041a22b8af11beaef30ca32"
   "2.2.4":
     url: "https://github.com/beached/utf_range/archive/v2.2.4.tar.gz"
     sha256: "e6df85d6da445c16507e738d70c6313df2a70e64b739a05d6437b06a5f83b8b1"

--- a/recipes/daw_utf_range/all/conanfile.py
+++ b/recipes/daw_utf_range/all/conanfile.py
@@ -38,7 +38,9 @@ class DawUtfRangeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "2.2.4":
+        if Version(self.version) >= "2.2.5":
+            self.requires("daw_header_libraries/2.106.0")
+        elif Version(self.version) >= "2.2.4":
             self.requires("daw_header_libraries/2.101.0")
         else:
             self.requires("daw_header_libraries/2.97.0")

--- a/recipes/daw_utf_range/all/conanfile.py
+++ b/recipes/daw_utf_range/all/conanfile.py
@@ -38,12 +38,8 @@ class DawUtfRangeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "2.2.5":
-            self.requires("daw_header_libraries/2.106.0")
-        elif Version(self.version) >= "2.2.4":
-            self.requires("daw_header_libraries/2.101.0")
-        else:
-            self.requires("daw_header_libraries/2.97.0")
+        corresponding_daw_header_version = self.conan_data["daw_headers_mapping"][self.version]
+        self.requires(f"daw_header_libraries/{corresponding_daw_header_version}")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/daw_utf_range/config.yml
+++ b/recipes/daw_utf_range/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.5":
+    folder: "all"
   "2.2.4":
     folder: "all"
   "2.2.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **daw_utf_range/2.2.5**

#### Motivation
This release solves a compilation error in gcc 14.1.

#### Details
https://github.com/beached/utf_range/compare/v2.2.4...v2.2.5

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
