### PR TITLE
OpenImageIO: Add version 2.5.13.0

### DIFF
--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "2.5.12.0":
     url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.12.0.tar.gz"
     sha256: "51ea3c309bad7381fd0d7ef793e93a72d8e0edaeff4ff329f4f21fb5de3d90bd"
+  "2.5.13.0":
+    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.13.0.tar.gz"
+    sha256: "663d712e4623e5e083b4ad5c5046c7b8ba65dc73a5380e7cfc12f9950c90d217"
 patches:
   "2.4.7.1":
     - patch_file: "patches/2.4.7.1-cmake-targets.patch"
@@ -52,3 +55,8 @@ patches:
     - patch_file: "patches/2.5.12.0-cmake-targets.patch"
       patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"
       patch_type: "conan"
+  "2.5.13.0":
+    - patch_file: "patches/2.5.12.0-cmake-targets.patch"
+      patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"
+      patch_type: "conan"
+

--- a/recipes/openimageio/config.yml
+++ b/recipes/openimageio/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "2.5.12.0":
     folder: all
+  "2.5.13.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/2.5.13.0**

#### Motivation
Adding the newest version as I use this library for reading/writing images and like to stay up to date.

#### Details
Just adding a new source & applying the patch of the previous version. The CMake files haven't been changed so the patch for finding dependencies didn't need manual adaptation.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
