### PR TITLE
daw_header_libraries: add version 2.106.1, remove older versions

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.106.1":
+    url: "https://github.com/beached/header_libraries/archive/v2.106.1.tar.gz"
+    sha256: "393815fbf249ca1220a216899cae3d2672ca193f9db228a0b99925a9b0f90854"
   "2.106.0":
     url: "https://github.com/beached/header_libraries/archive/v2.106.0.tar.gz"
     sha256: "7838ada09afa69e7a42d742991c4b24b32ba27681e7b4dadf7b1e45c168937b5"
@@ -14,30 +17,3 @@ sources:
   "2.96.1":
     url: "https://github.com/beached/header_libraries/archive/v2.96.1.tar.gz"
     sha256: "2a9a5c33baa9e3adc1d82fa13a56522638af13cc39372a0c1c8f5c5d984f1464"
-  "2.95.0":
-    url: "https://github.com/beached/header_libraries/archive/v2.95.0.tar.gz"
-    sha256: "8799c06f0587b202fd6049d95e70b04675acbfdbf6e86ac3bbd061cbb9d42b54"
-  "2.93.1":
-    url: "https://github.com/beached/header_libraries/archive/v2.93.1.tar.gz"
-    sha256: "200690094237e4a2c37ac81c23c8c5138ba90ccdeeb2a1dda37690a9d32301ad"
-  "2.92.0":
-    url: "https://github.com/beached/header_libraries/archive/v2.92.0.tar.gz"
-    sha256: "96835f0ff4d3082a38b4ef4c14653c88e193cd26a08cd406fdbfadcfd654d136"
-  "2.88.0":
-    url: "https://github.com/beached/header_libraries/archive/v2.88.0.tar.gz"
-    sha256: "2a634763f3d34f206f6b352ac9609a89d501059afea0ba7c857bd55adc435890"
-  "2.85.1":
-    url: "https://github.com/beached/header_libraries/archive/v2.85.1.tar.gz"
-    sha256: "fb4880e254a481e3c750261fdb75a1696afc9ef4404e095a7f3ba0683bcd9930"
-  "2.79.0":
-    url: "https://github.com/beached/header_libraries/archive/v2.79.0.tar.gz"
-    sha256: "2dfa8fc9495499379cff39ed648c6bba156a87eb177fc91a860045a410aebb99"
-  "2.76.3":
-    url: "https://github.com/beached/header_libraries/archive/v2.76.3.tar.gz"
-    sha256: "2d66f9aec38fb9a42779e0283fa2fc5842e04d34f2bf655c72a9beb4bf5cc8c8"
-  "2.76.2":
-    url: "https://github.com/beached/header_libraries/archive/v2.76.2.tar.gz"
-    sha256: "bfa2da192360a66e400d03a52f8a7bf0fccd23de1f446a812a8890b11df2c592"
-  "2.74.2":
-    url: "https://github.com/beached/header_libraries/archive/v2.74.2.tar.gz"
-    sha256: "32871df3d314cc9b4e293a9a8c79968d1c963dfd3dd60965dbf704eb18acb218"

--- a/recipes/daw_header_libraries/all/conanfile.py
+++ b/recipes/daw_header_libraries/all/conanfile.py
@@ -16,7 +16,7 @@ class DawHeaderLibrariesConan(ConanFile):
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/beached/header_libraries"
-    topics = ("algorithms", "helpers", "data-structures")
+    topics = ("algorithms", "helpers", "data-structures", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
@@ -44,7 +44,6 @@ class DawHeaderLibrariesConan(ConanFile):
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.get_safe("compiler.version")) < minimum_version:
             raise ConanInvalidConfiguration(
@@ -53,9 +52,6 @@ class DawHeaderLibrariesConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
-    def build(self):
-        pass
 
     def package(self):
         copy(self, pattern="LICENSE*", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.106.1":
+    folder: all
   "2.106.0":
     folder: all
   "2.101.0":
@@ -8,22 +10,4 @@ versions:
   "2.97.0":
     folder: all
   "2.96.1":
-    folder: all
-  "2.95.0":
-    folder: all
-  "2.93.1":
-    folder: all
-  "2.92.0":
-    folder: all
-  "2.88.0":
-    folder: all
-  "2.85.1":
-    folder: all
-  "2.79.0":
-    folder: all
-  "2.76.3":
-    folder: all
-  "2.76.2":
-    folder: all
-  "2.74.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **daw_header_libraries/2.106.1**

#### Motivation
Small bugfix release.

#### Details
https://github.com/beached/header_libraries/compare/v2.106.0...v2.106.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
