### PR TITLE
[config] Add additional repo to promote conan v2 only packages

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -60,6 +60,8 @@ tasks:
   list_packages:
     update_yaml_list_path: ".c3i/conan_v2_ready_references"
     update_yaml_list_key: "required_for_references"
+  promote_packages:
+    additional_repo_target: "conan-center-v2-only"
   scheduled_export_check:
     report_issue_url: https://github.com/conan-io/conan-center-index/issues/15557
     report_issue_append: false


### PR DESCRIPTION
### Summary
PRs merged to master will tigger an additional promotion to this repo only for conan v2 packages

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
