### PR TITLE
(#24504) Remove duplicate 'boost::boost' requirement from 'libarrow' …

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -600,8 +600,6 @@ class ArrowConan(ConanFile):
             self.cpp_info.components["libarrow"].requires.append("zlib::zlib")
         if self.options.with_zstd:
             self.cpp_info.components["libarrow"].requires.append("zstd::zstd")
-        if self.options.with_boost:
-            self.cpp_info.components["libarrow"].requires.append("boost::boost")
         if self.options.with_grpc:
             self.cpp_info.components["libarrow"].requires.append("grpc::grpc")
         if self.options.with_flight_rpc:


### PR DESCRIPTION
…component


### Summary
There's a duplicate `boost::boost` requirement for the `libarrow` component due to the duplicate `with_boost` branches. This causes the `BazelDeps` generator to place two `boost` entries in the generated Bazel files, causing Bazel to error out during its build.

#### Motivation
Fixes #24504

#### Details
Removed the second `self.options.with_boost` branch in `package_info()` since the first `with_boost` branch already adds the `boost::boost` requirement.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
