### PR TITLE
paho-mqtt-cpp: add version 1.4.0

### DIFF
--- a/recipes/paho-mqtt-cpp/all/conandata.yml
+++ b/recipes/paho-mqtt-cpp/all/conandata.yml
@@ -1,11 +1,18 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/eclipse/paho.mqtt.cpp/archive/v1.4.0.tar.gz"
+    sha256: "758c504b585402fbeb47822e52897239bbd53b4236ac3908cc040e09d2a8d8e1"
   "1.3.2":
-    sha256: c271d521287f417102b447b3d1e8d17be0e0f6a3b0b653334ebcd2ccd20d1e46
-    url: https://github.com/eclipse/paho.mqtt.cpp/archive/v1.3.2.tar.gz
+    url: "https://github.com/eclipse/paho.mqtt.cpp/archive/v1.3.2.tar.gz"
+    sha256: "c271d521287f417102b447b3d1e8d17be0e0f6a3b0b653334ebcd2ccd20d1e46"
   "1.2.0":
-    sha256: 435e97e4d5b1da13daa26cadd3e83fe9d154930abaa78b8ff1b8c854b5345d8b
-    url: https://github.com/eclipse/paho.mqtt.cpp/archive/v1.2.0.tar.gz
+    url: "https://github.com/eclipse/paho.mqtt.cpp/archive/v1.2.0.tar.gz"
+    sha256: "435e97e4d5b1da13daa26cadd3e83fe9d154930abaa78b8ff1b8c854b5345d8b"
 patches:
+  "1.4.0":
+    - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
+      patch_description: "CMake: Honor fPIC option"
+      patch_type: "conan"
   "1.3.2":
     - patch_file: "patches/1.3.2-0001-fix-cmake.patch"
       patch_description: "CMake: Honor fPIC option and properly link paho-mqtt-c to object target"

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -72,8 +72,9 @@ class PahoMqttCppConan(ConanFile):
         tc.variables["PAHO_WITH_SSL"] = self.dependencies["paho-mqtt-c"].options.ssl
         tc.generate()
         deps = CMakeDeps(self)
-        deps.set_property("paho-mqtt-c", "cmake_file_name", "PahoMqttC")
-        deps.set_property("paho-mqtt-c", "cmake_target_name", "PahoMqttC::PahoMqttC")
+        if Version(self.version) < "1.4.0":
+            deps.set_property("paho-mqtt-c", "cmake_file_name", "PahoMqttC")
+            deps.set_property("paho-mqtt-c", "cmake_target_name", "PahoMqttC::PahoMqttC")
         deps.generate()
 
     def build(self):

--- a/recipes/paho-mqtt-cpp/all/patches/1.4.0-0001-fix-cmake.patch
+++ b/recipes/paho-mqtt-cpp/all/patches/1.4.0-0001-fix-cmake.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1155844..ace2e61 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -107,7 +107,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ 
+ # Generate position-independent code (-fPIC on UNIX)
+-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
++# set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+ # --- System Details ---
+ 
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c8b213d..2898972 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -68,6 +68,7 @@ if(PAHO_BUILD_SHARED)
+     set_target_properties(paho-mqttpp3 PROPERTIES
+         VERSION ${PROJECT_VERSION}
+         SOVERSION ${PROJECT_VERSION_MAJOR}
++		POSITION_INDEPENDENT_CODE ON
+     )
+ endif()
+ 

--- a/recipes/paho-mqtt-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/paho-mqtt-cpp/all/test_package/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(PahoMqttCpp REQUIRED CONFIG)
 

--- a/recipes/paho-mqtt-cpp/config.yml
+++ b/recipes/paho-mqtt-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.0":
+    folder: "all"
   "1.3.2":
     folder: "all"
   "1.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **paho-mqtt-cpp/1.4.0**

#### Motivation
The link definition to paho-mqtt-c has been changed since 1.4.0.

#### Details
https://github.com/eclipse/paho.mqtt.cpp/compare/v1.3.2...v1.4.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
