### PR TITLE
reproc: new recipe

### DIFF
--- a/recipes/reproc/all/conandata.yml
+++ b/recipes/reproc/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "14.2.5":
+    url: "https://github.com/DaanDeMeyer/reproc/archive/refs/tags/v14.2.5.tar.gz"
+    sha256: "69467be0cfc80734b821c54ada263c8f1439f964314063f76b7cf256c3dc7ee8"

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -1,0 +1,94 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm, rmdir
+
+required_conan_version = ">=1.53.0"
+
+
+class PackageConan(ConanFile):
+    name = "reproc"
+    description = "A cross-platform C99 process library"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/DaanDeMeyer/reproc"
+    topics = ("process-management", "process", "cross-platform")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "cxx": [True, False],
+        "multithreaded": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "cxx": True,
+        "multithreaded": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        if not self.options.cxx:
+            self.settings.rm_safe("compiler.cppstd")
+            self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.options.cxx and self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["REPROC++"] = self.options.cxx
+        tc.variables["REPROC_MULTITHREADED"] = self.options.multithreaded
+        tc.generate()
+
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        # The C++ component should have its separate reproc++-config.cmake file,
+        # but it's currently not supported by Conan
+        self.cpp_info.set_property("cmake_file_name", "reproc")
+
+        self.cpp_info.components["reproc_c"].set_property("pkg_config_name", "reproc")
+        self.cpp_info.components["reproc_c"].set_property("cmake_target_name", "reproc")
+        self.cpp_info.components["reproc_c"].libs = ["reproc"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["reproc_c"].system_libs.append("rt")
+            if self.options.multithreaded:
+                self.cpp_info.components["reproc_c"].system_libs.append("pthread")
+
+        self.cpp_info.components["reproc_cxx"].set_property("pkg_config_name", "reproc++")
+        self.cpp_info.components["reproc_cxx"].set_property("cmake_target_name", "reproc++")
+        self.cpp_info.components["reproc_cxx"].libs = ["reproc++"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["reproc_cxx"].system_libs.append("rt")
+            if self.options.multithreaded:
+                self.cpp_info.components["reproc_cxx"].system_libs.append("pthread")

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -99,4 +99,4 @@ class PackageConan(ConanFile):
             self.cpp_info.components["reproc_cxx"].set_property("pkg_config_name", "reproc++")
             self.cpp_info.components["reproc_cxx"].set_property("cmake_target_name", "reproc++")
             self.cpp_info.components["reproc_cxx"].libs = ["reproc++"]
-            self.cpp_info.components["reproc_cxx"].requires = ["reproc"]
+            self.cpp_info.components["reproc_cxx"].requires = ["reproc_c"]

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -46,7 +46,7 @@ class PackageConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.options.cxx and self.settings.compiler.cppstd:
+        if self.options.cxx:
             check_min_cppstd(self, 11)
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6":
             # drain.hpp:55:43: error: ‘stream’ is not a class, namespace, or enumeration

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -85,18 +85,18 @@ class PackageConan(ConanFile):
         cmake_config_name = "reproc++" if self.options.cxx else "reproc"
         self.cpp_info.set_property("cmake_file_name", cmake_config_name)
 
-        self.cpp_info.components["reproc"].set_property("pkg_config_name", "reproc")
-        self.cpp_info.components["reproc"].set_property("cmake_target_name", "reproc")
-        self.cpp_info.components["reproc"].libs = ["reproc"]
+        self.cpp_info.components["reproc_c"].set_property("pkg_config_name", "reproc")
+        self.cpp_info.components["reproc_c"].set_property("cmake_target_name", "reproc")
+        self.cpp_info.components["reproc_c"].libs = ["reproc"]
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["reproc"].system_libs.append("rt")
+            self.cpp_info.components["reproc_c"].system_libs.append("rt")
             if self.options.multithreaded:
-                self.cpp_info.components["reproc"].system_libs.append("pthread")
+                self.cpp_info.components["reproc_c"].system_libs.append("pthread")
         elif self.settings.os == "Windows":
-            self.cpp_info.components["reproc"].system_libs.append("Ws2_32")
+            self.cpp_info.components["reproc_c"].system_libs.append("Ws2_32")
 
         if self.options.cxx:
-            self.cpp_info.components["reprocxx"].set_property("pkg_config_name", "reproc++")
-            self.cpp_info.components["reprocxx"].set_property("cmake_target_name", "reproc++")
-            self.cpp_info.components["reprocxx"].libs = ["reproc++"]
-            self.cpp_info.components["reprocxx"].requires = ["reproc"]
+            self.cpp_info.components["reproc_cxx"].set_property("pkg_config_name", "reproc++")
+            self.cpp_info.components["reproc_cxx"].set_property("cmake_target_name", "reproc++")
+            self.cpp_info.components["reproc_cxx"].libs = ["reproc++"]
+            self.cpp_info.components["reproc_cxx"].requires = ["reproc"]

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -48,10 +48,6 @@ class PackageConan(ConanFile):
     def validate(self):
         if self.options.cxx and self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
-        if self.settings.os == "Windows" and self.options.shared:
-            # test_package fails with:
-            # unresolved external symbol "class std::chrono::duration<int,struct std::ratio<1,1000> > const reproc::infinite"
-            raise ConanInvalidConfiguration("Shared libraries are not supported on Windows")
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6":
             # drain.hpp:55:43: error: ‘stream’ is not a class, namespace, or enumeration
             raise ConanInvalidConfiguration("GCC < 6 is not supported")

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -88,7 +88,5 @@ class PackageConan(ConanFile):
         self.cpp_info.components["reproc_cxx"].set_property("pkg_config_name", "reproc++")
         self.cpp_info.components["reproc_cxx"].set_property("cmake_target_name", "reproc++")
         self.cpp_info.components["reproc_cxx"].libs = ["reproc++"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["reproc_cxx"].system_libs.append("rt")
-            if self.options.multithreaded:
-                self.cpp_info.components["reproc_cxx"].system_libs.append("pthread")
+        self.cpp_info.components["reproc_cxx"].requires = ["reproc_c"]
+

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -1,9 +1,11 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -48,6 +50,9 @@ class PackageConan(ConanFile):
     def validate(self):
         if self.options.cxx and self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
+        if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6":
+            # drain.hpp:55:43: error: ‘stream’ is not a class, namespace, or enumeration
+            raise ConanInvalidConfiguration("GCC < 6 is not supported")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -50,6 +50,10 @@ class PackageConan(ConanFile):
     def validate(self):
         if self.options.cxx and self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
+        if self.settings.os == "Windows" and self.options.shared:
+            # test_package fails with:
+            # unresolved external symbol "class std::chrono::duration<int,struct std::ratio<1,1000> > const reproc::infinite"
+            raise ConanInvalidConfiguration("Shared libraries are not supported on Windows")
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6":
             # drain.hpp:55:43: error: ‘stream’ is not a class, namespace, or enumeration
             raise ConanInvalidConfiguration("GCC < 6 is not supported")

--- a/recipes/reproc/all/conanfile.py
+++ b/recipes/reproc/all/conanfile.py
@@ -84,6 +84,8 @@ class PackageConan(ConanFile):
             self.cpp_info.components["reproc_c"].system_libs.append("rt")
             if self.options.multithreaded:
                 self.cpp_info.components["reproc_c"].system_libs.append("pthread")
+        elif self.settings.os == "Windows":
+            self.cpp_info.components["reproc_c"].system_libs.append("Ws2_32")
 
         self.cpp_info.components["reproc_cxx"].set_property("pkg_config_name", "reproc++")
         self.cpp_info.components["reproc_cxx"].set_property("cmake_target_name", "reproc++")

--- a/recipes/reproc/all/test_package/CMakeLists.txt
+++ b/recipes/reproc/all/test_package/CMakeLists.txt
@@ -1,13 +1,17 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C CXX)
 
-find_package(reproc REQUIRED CONFIG)
+if(WITH_CXX)
+    find_package(reproc++ REQUIRED CONFIG)
+else()
+    find_package(reproc REQUIRED CONFIG)
+endif()
 
 add_executable(${PROJECT_NAME}_c test_package.c)
 target_link_libraries(${PROJECT_NAME}_c PRIVATE reproc)
 target_compile_features(${PROJECT_NAME}_c PRIVATE c_std_99)
 
-if(TARGET reproc++)
+if(WITH_CXX)
     add_executable(${PROJECT_NAME}_cpp test_package.cpp)
     target_link_libraries(${PROJECT_NAME}_cpp PRIVATE reproc++)
     target_compile_features(${PROJECT_NAME}_cpp PRIVATE cxx_std_11)

--- a/recipes/reproc/all/test_package/CMakeLists.txt
+++ b/recipes/reproc/all/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C CXX)
+
+find_package(reproc REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME}_c test_package.c)
+target_link_libraries(${PROJECT_NAME}_c PRIVATE reproc)
+target_compile_features(${PROJECT_NAME}_c PRIVATE c_std_99)
+
+if(TARGET reproc++)
+    add_executable(${PROJECT_NAME}_cpp test_package.cpp)
+    target_link_libraries(${PROJECT_NAME}_cpp PRIVATE reproc++)
+    target_compile_features(${PROJECT_NAME}_cpp PRIVATE cxx_std_11)
+endif()

--- a/recipes/reproc/all/test_package/conanfile.py
+++ b/recipes/reproc/all/test_package/conanfile.py
@@ -1,0 +1,28 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package_c")
+            self.run(bin_path, env="conanrun")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package_cpp")
+            self.run(bin_path, env="conanrun")

--- a/recipes/reproc/all/test_package/conanfile.py
+++ b/recipes/reproc/all/test_package/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def layout(self):
@@ -14,6 +14,11 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["WITH_CXX"] = self.dependencies["reproc"].options.get_safe("cxx")
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)
@@ -24,5 +29,6 @@ class TestPackageConan(ConanFile):
         if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindir, "test_package_c")
             self.run(bin_path, env="conanrun")
-            bin_path = os.path.join(self.cpp.build.bindir, "test_package_cpp")
-            self.run(bin_path, env="conanrun")
+            if (self.dependencies["reproc"].options.get_safe("cxx")):
+                bin_path = os.path.join(self.cpp.build.bindir, "test_package_cpp")
+                self.run(bin_path, env="conanrun")

--- a/recipes/reproc/all/test_package/test_package.c
+++ b/recipes/reproc/all/test_package/test_package.c
@@ -1,7 +1,14 @@
-#include <reproc/run.h>
+#include <reproc/reproc.h>
+#include <stdio.h>
 
 int main()
 {
-  const char *const command[] = { "echo", "Hello, World!", NULL };
-  reproc_run(command, (reproc_options){ .deadline = 1000 });
+  reproc_t *process = reproc_new();
+  if (!process) {
+    fprintf(stderr, "Failed to create reproc process.\n");
+    return 1;
+  }
+  printf("reproc setup successful. Process object created.\n");
+  reproc_destroy(process);
+  return 0;
 }

--- a/recipes/reproc/all/test_package/test_package.c
+++ b/recipes/reproc/all/test_package/test_package.c
@@ -1,0 +1,7 @@
+#include <reproc/run.h>
+
+int main()
+{
+  const char *const command[] = { "echo", "Hello, World!", NULL };
+  reproc_run(command, (reproc_options){ .deadline = 1000 });
+}

--- a/recipes/reproc/all/test_package/test_package.cpp
+++ b/recipes/reproc/all/test_package/test_package.cpp
@@ -1,13 +1,16 @@
-#include <reproc++/run.hpp>
-
-#include <array>
-#include <string>
+#include <reproc++/reproc.hpp>
+#include <iostream>
 
 int main()
 {
-  std::array<std::string, 2> command = { "echo", "Hello, World!" };
-  reproc::options options;
-  options.redirect.parent = true;
-  options.deadline = reproc::milliseconds(1000);
-  reproc::run(command, options);
+  try {
+    reproc::process process;
+    reproc::options options;
+    options.redirect.parent = true;
+    std::cout << "reproc++ setup successful. Process object created.\n";
+  } catch (const std::exception &e) {
+    std::cerr << "Error: " << e.what() << '\n';
+    return 1;
+  }
+  return 0;
 }

--- a/recipes/reproc/all/test_package/test_package.cpp
+++ b/recipes/reproc/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include <reproc++/run.hpp>
+
+#include <array>
+#include <string>
+
+int main()
+{
+  std::array<std::string, 2> command = { "echo", "Hello, World!" };
+  reproc::options options;
+  options.redirect.parent = true;
+  options.deadline = reproc::milliseconds(1000);
+  reproc::run(command, options);
+}

--- a/recipes/reproc/config.yml
+++ b/recipes/reproc/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "14.2.5":
+    folder: all


### PR DESCRIPTION
### Summary
Adds  **reproc/14.2.5**

#### Motivation
https://github.com/DaanDeMeyer/reproc

reproc (Redirected Process) is a cross-platform C/C++ library that simplifies starting, stopping and communicating with external programs. The main use case is executing command line applications directly from C or C++ code and retrieving their output.

[![Packaging status](https://repology.org/badge/tiny-repos/reproc.svg)](https://repology.org/project/reproc/versions)

#### Details
This project exports two CMake config files (`reproc` and `reproc++`) but due to a Conan limitation the recipe exports just a single `reproc` one.

- Closes: https://github.com/conan-io/conan-center-index/issues/978
- Closes: https://github.com/conan-io/conan-center-index/issues/25531

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
