### PR TITLE
vulkan-memory-allocator: Add version 3.1.0 and update vulkan-headers dependency

### DIFF
--- a/recipes/vulkan-memory-allocator/all/conandata.yml
+++ b/recipes/vulkan-memory-allocator/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "cci.20231120":
     url: "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/5e43c795daf43dd09398d8307212e85025215052.tar.gz"
     sha256: "1ee9922fb059bc3b1dc5bbf71020e7a590b6ceb27fc3025d746e15be53fe31b7"
+  "3.1.0":
+    url: "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/refs/tags/v3.1.0.tar.gz"
+    sha256: "ae134ecc37c55634f108e926f85d5d887b670360e77cd107affaf3a9539595f2"
   "3.0.1":
     url: "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/refs/tags/v3.0.1.tar.gz"
     sha256: "2a84762b2d10bf540b9dc1802a198aca8ad1f3d795a4ae144212c595696a360c"

--- a/recipes/vulkan-memory-allocator/all/conanfile.py
+++ b/recipes/vulkan-memory-allocator/all/conanfile.py
@@ -29,7 +29,7 @@ class VulkanMemoryAllocatorConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("vulkan-headers/1.3.268.0")
+        self.requires("vulkan-headers/1.3.296.0")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/vulkan-memory-allocator/all/conanfile.py
+++ b/recipes/vulkan-memory-allocator/all/conanfile.py
@@ -29,7 +29,7 @@ class VulkanMemoryAllocatorConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("vulkan-headers/1.3.243.0")
+        self.requires("vulkan-headers/1.3.268.0")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/vulkan-memory-allocator/config.yml
+++ b/recipes/vulkan-memory-allocator/config.yml
@@ -1,6 +1,8 @@
 versions:
   "cci.20231120":
     folder: all
+  "3.1.0":
+    folder: all
   "3.0.1":
     folder: all
   "3.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-memory-allocator/3.1.0**

#### Motivation
Multiple improvements compared to previous release.

#### Details
[GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@v3.0.1...v3.1.0](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/compare/v3.0.1...v3.1.0)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
