### PR TITLE
[boost] Fix support for intel-cc

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1601,7 +1601,7 @@ class BoostConan(ConanFile):
             return str(self.settings.compiler)
         if self.settings.compiler == "sun-cc":
             return "sunpro"
-        if self.settings.compiler == "intel":
+        if "intel" in str(self.settings.compiler):
             return {
                 "Macos": "intel-darwin",
                 "Windows": "intel-win",


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/[*]**

#### Motivation

Current Conan recipe for Boost checks for `intel` as compiler name, but in Conan 2.x it should be `intel-cc`.

fixes #22222

#### Details

In Conan 1.x, the compiler provided by Intel was identified as `intel` initially. Later, a new configuration was added with a new name:  `intel-cc`: https://docs.conan.io/1/reference/config_files/settings.yml.html#settings-yml

The same `intel-cc` compiler name is adopted in Conan 2.x and `intel` is no longer supported: 
https://docs.conan.io/2/reference/config_files/settings.html#settings-yml

I can't build using this compiler, but I checked Boost Build sources and the toolset names are still correct after all this time: https://github.com/boostorg/build/blob/4a52d8c06635435b64e31a56eaf7ca5dc912a71d/src/tools/intel.jam#L68


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
