### PR TITLE
cilantro: new recipe

### DIFF
--- a/recipes/cilantro/all/conan_deps.cmake
+++ b/recipes/cilantro/all/conan_deps.cmake
@@ -1,0 +1,17 @@
+# Add link_libraries() for unvendored dependencies
+
+find_package(Spectra REQUIRED CONFIG)
+find_package(Qhull REQUIRED CONFIG)
+find_package(nanoflann REQUIRED CONFIG)
+find_package(tinyply REQUIRED CONFIG)
+
+link_libraries(
+    Spectra::Spectra
+    nanoflann::nanoflann
+    tinyply::tinyply
+)
+if(TARGET Qhull::qhull_r)
+    link_libraries(Qhull::qhull_r)
+else()
+    link_libraries(Qhull::qhullstatic_r)
+endif()

--- a/recipes/cilantro/all/conan_deps.cmake
+++ b/recipes/cilantro/all/conan_deps.cmake
@@ -7,11 +7,8 @@ find_package(tinyply REQUIRED CONFIG)
 
 link_libraries(
     Spectra::Spectra
+    Qhull::qhullstatic_r
+    Qhull::qhullcpp
     nanoflann::nanoflann
     tinyply::tinyply
 )
-if(TARGET Qhull::qhull_r)
-    link_libraries(Qhull::qhull_r)
-else()
-    link_libraries(Qhull::qhullstatic_r)
-endif()

--- a/recipes/cilantro/all/conandata.yml
+++ b/recipes/cilantro/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "cci.20230816":
+    url: "https://github.com/kzampog/cilantro/archive/57ad1a397b73b6f4bbf9604fd75f8fe4363206a7.zip"
+    sha256: "6b54eefbe1121c10706d23895b9d46038c686b9888450880b78781cfc4a05b68"
+patches:
+  "cci.20230816":
+    - patch_file: "patches/0001-Fix-includes-after-unvendoring.patch"
+      patch_description: "Fix includes after unvendoring"
+      patch_type: "conan"

--- a/recipes/cilantro/all/conanfile.py
+++ b/recipes/cilantro/all/conanfile.py
@@ -5,9 +5,8 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, replace_in_file
-from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class CilantroConan(ConanFile):
@@ -38,20 +37,6 @@ class CilantroConan(ConanFile):
         "with_pangolin": False,
     }
 
-    @property
-    def _min_cppstd(self):
-        return 17
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "apple-clang": "10",
-            "clang": "6",
-            "gcc": "7",
-            "Visual Studio": "16",
-            "msvc": "192",
-        }
-
     def export_sources(self):
         export_conandata_patches(self)
         copy(self, "conan_deps.cmake", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
@@ -63,8 +48,8 @@ class CilantroConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        self.options["qhull/*"].shared = False
         self.options["qhull/*"].reentrant = True
-        # self.options["qhull/*"].cpp = True
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -74,10 +59,7 @@ class CilantroConan(ConanFile):
         self.requires("spectra/1.0.1", transitive_headers=True, transitive_libs=True)
         self.requires("nanoflann/1.5.2", transitive_headers=True, transitive_libs=True)
         self.requires("tinyply/2.3.4", transitive_headers=True, transitive_libs=True)
-        # TODO: qhullcpp component is not available on CCI
-        # https://github.com/conan-io/conan-center-index/issues/16321
-        # Using a vendored version of qhullcpp in the meantime
-        self.requires("qhull/8.0.1", transitive_headers=True, transitive_libs=True)
+        self.requires("qhull/8.1.alpha4", transitive_headers=True, transitive_libs=True)
         if self.options.with_openmp:
             # '#pragma omp' is used in public headers
             self.requires("llvm-openmp/18.1.8", transitive_headers=True, transitive_libs=True)
@@ -85,19 +67,14 @@ class CilantroConan(ConanFile):
             self.requires("pangolin/0.9.1", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
-
-        if not self.dependencies["qhull"].options.reentrant:
-            raise ConanInvalidConfiguration("-o qhull:reentrant=True is required")
+        check_min_cppstd(self, 17)
+        qhull = self.dependencies["qhull"].options
+        if qhull.shared or not qhull.reentrant:
+            raise ConanInvalidConfiguration("qhull must be built with -o qhull/*:shared=False -o qhull/*:reentrant=True")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -116,15 +93,14 @@ class CilantroConan(ConanFile):
         deps.generate()
 
     def _patch_sources(self):
-        apply_conandata_patches(self)
         # Don't embed absolute RPATHs in the shared library
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                         "set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)",
                         'set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN")')
         # Unvendor 3rd-party dependencies
-        for pkg in ["Spectra", "nanoflann", "tinyply", "libqhull_r"]:
+        for pkg in ["Spectra", "nanoflann", "tinyply", "libqhull_r", "libqhullcpp"]:
             rmdir(self, os.path.join(self.source_folder, "include", "cilantro", "3rd_party", pkg))
-        for pkg in ["tinyply", "libqhull_r"]:
+        for pkg in ["tinyply", "libqhull_r", "libqhullcpp"]:
             rmdir(self, os.path.join(self.source_folder, "src", "3rd_party", pkg))
 
     def build(self):

--- a/recipes/cilantro/all/conanfile.py
+++ b/recipes/cilantro/all/conanfile.py
@@ -1,0 +1,149 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, replace_in_file
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
+
+
+class CilantroConan(ConanFile):
+    name = "cilantro"
+    description = "A lean C++ library for working with point cloud data"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "github.com/kzampog/cilantro"
+    topics = ("point-cloud", "3d", "clustering", "registration", "segmentation", "convex-hull", "3d-reconstruction",
+              "ransac", "visualization", "iterative-closest-point", "spectral-clustering", "model-fitting")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "march_native": [True, False],
+        "non_deterministic_parallelism": [True, False],
+        "with_openmp": [True, False],
+        "with_pangolin": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "march_native": False,
+        "non_deterministic_parallelism": True,
+        "with_openmp": False,  # TODO: enabled after #22353 is merged
+        "with_pangolin": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "10",
+            "clang": "6",
+            "gcc": "7",
+            "Visual Studio": "16",
+            "msvc": "192",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+        copy(self, "conan_deps.cmake", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.options["qhull/*"].reentrant = True
+        # self.options["qhull/*"].cpp = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("eigen/3.4.0", transitive_headers=True, transitive_libs=True)
+        self.requires("spectra/1.0.1", transitive_headers=True, transitive_libs=True)
+        self.requires("nanoflann/1.5.2", transitive_headers=True, transitive_libs=True)
+        self.requires("tinyply/2.3.4", transitive_headers=True, transitive_libs=True)
+        # TODO: qhullcpp component is not available on CCI
+        # https://github.com/conan-io/conan-center-index/issues/16321
+        # Using a vendored version of qhullcpp in the meantime
+        self.requires("qhull/8.0.1", transitive_headers=True, transitive_libs=True)
+        if self.options.with_openmp:
+            # '#pragma omp' is used in public headers
+            self.requires("llvm-openmp/18.1.8", transitive_headers=True, transitive_libs=True)
+        if self.options.with_pangolin:
+            self.requires("pangolin/0.9.1", transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+        if not self.dependencies["qhull"].options.reentrant:
+            raise ConanInvalidConfiguration("-o qhull:reentrant=True is required")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_EXAMPLES"] = False
+        tc.variables["ENABLE_NATIVE_BUILD_OPTIMIZATIONS"] = self.options.march_native
+        tc.variables["ENABLE_NON_DETERMINISTIC_PARALLELISM"] = self.options.non_deterministic_parallelism
+        tc.variables["CMAKE_PROJECT_cilantro_INCLUDE"] = "conan_deps.cmake"
+        tc.variables["CMAKE_OpenMP_FIND_REQUIRED"] = self.options.with_openmp
+        tc.variables["CMAKE_DISABLE_FIND_PACKAGE_OpenMP"] = not self.options.with_openmp
+        tc.variables["CMAKE_Pangolin_FIND_REQUIRED"] = self.options.with_pangolin
+        tc.variables["CMAKE_DISABLE_FIND_PACKAGE_Pangolin"] = not self.options.with_pangolin
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+        # Don't embed absolute RPATHs in the shared library
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        "set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)",
+                        'set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN")')
+        # Unvendor 3rd-party dependencies
+        for pkg in ["Spectra", "nanoflann", "tinyply", "libqhull_r"]:
+            rmdir(self, os.path.join(self.source_folder, "include", "cilantro", "3rd_party", pkg))
+        for pkg in ["tinyply", "libqhull_r"]:
+            rmdir(self, os.path.join(self.source_folder, "src", "3rd_party", pkg))
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "cilantro")
+        self.cpp_info.set_property("cmake_target_name", "cilantro")
+        self.cpp_info.libs = ["cilantro"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m", "pthread"]

--- a/recipes/cilantro/all/patches/0001-Fix-includes-after-unvendoring.patch
+++ b/recipes/cilantro/all/patches/0001-Fix-includes-after-unvendoring.patch
@@ -1,0 +1,305 @@
+From f23fbab92f7d1551584b3960382e3e64446c013d Mon Sep 17 00:00:00 2001
+From: Martin Valgur <martin.valgur@gmail.com>
+Date: Fri, 5 Jul 2024 14:40:22 +0300
+Subject: [PATCH] Fix includes after unvendoring
+
+---
+ include/cilantro/3rd_party/libqhullcpp/Coordinates.h      | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/PointCoordinates.h | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullFacet.h       | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullHyperplane.h  | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullIterator.h    | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullLinkedList.h  | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullPoint.h       | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullPointSet.h    | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullPoints.h      | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullQh.h          | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullRidge.h       | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullSet.h         | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullStat.h        | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullUser.h        | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/QhullVertex.h      | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/RboxPoints.h       | 2 +-
+ include/cilantro/3rd_party/libqhullcpp/RoadError.h        | 2 +-
+ include/cilantro/clustering/spectral_clustering.hpp       | 4 ++--
+ include/cilantro/core/kd_tree.hpp                         | 2 +-
+ include/cilantro/utilities/multidimensional_scaling.hpp   | 2 +-
+ include/cilantro/utilities/ply_io.hpp                     | 2 +-
+ 21 files changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/include/cilantro/3rd_party/libqhullcpp/Coordinates.h b/include/cilantro/3rd_party/libqhullcpp/Coordinates.h
+index ca646f2..c33f778 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/Coordinates.h
++++ b/include/cilantro/3rd_party/libqhullcpp/Coordinates.h
+@@ -9,7 +9,7 @@
+ #ifndef QHCOORDINATES_H
+ #define QHCOORDINATES_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullError.h>
+ 
+ #include <cstddef> // ptrdiff_t, size_t
+diff --git a/include/cilantro/3rd_party/libqhullcpp/PointCoordinates.h b/include/cilantro/3rd_party/libqhullcpp/PointCoordinates.h
+index c4a851a..d14a85d 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/PointCoordinates.h
++++ b/include/cilantro/3rd_party/libqhullcpp/PointCoordinates.h
+@@ -9,7 +9,7 @@
+ #ifndef QHPOINTCOORDINATES_H
+ #define QHPOINTCOORDINATES_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullPoints.h>
+ #include <cilantro/3rd_party/libqhullcpp/Coordinates.h>
+ 
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullFacet.h b/include/cilantro/3rd_party/libqhullcpp/QhullFacet.h
+index efce927..5699341 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullFacet.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullFacet.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLFACET_H
+ #define QHULLFACET_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullHyperplane.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullPoint.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullSet.h>
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullHyperplane.h b/include/cilantro/3rd_party/libqhullcpp/QhullHyperplane.h
+index 3150b15..0ae9336 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullHyperplane.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullHyperplane.h
+@@ -9,7 +9,7 @@
+ #ifndef QHHYPERPLANE_H
+ #define QHHYPERPLANE_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullError.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullIterator.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullQh.h>
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullIterator.h b/include/cilantro/3rd_party/libqhullcpp/QhullIterator.h
+index e2ae902..07dfa03 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullIterator.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullIterator.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLITERATOR_H
+ #define QHULLITERATOR_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ 
+ #include <assert.h>
+ #include <iterator>
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullLinkedList.h b/include/cilantro/3rd_party/libqhullcpp/QhullLinkedList.h
+index b31fb04..a0e6067 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullLinkedList.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullLinkedList.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLLINKEDLIST_H
+ #define QHULLLINKEDLIST_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullError.h>
+ 
+ #include <cstddef>  // ptrdiff_t, size_t
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullPoint.h b/include/cilantro/3rd_party/libqhullcpp/QhullPoint.h
+index 51dc36c..fa73fc0 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullPoint.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullPoint.h
+@@ -9,7 +9,7 @@
+ #ifndef QHPOINT_H
+ #define QHPOINT_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullError.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullIterator.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullQh.h>
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullPointSet.h b/include/cilantro/3rd_party/libqhullcpp/QhullPointSet.h
+index ddf1c0a..db914d6 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullPointSet.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullPointSet.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLPOINTSET_H
+ #define QHULLPOINTSET_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullSet.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullPoint.h>
+ 
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullPoints.h b/include/cilantro/3rd_party/libqhullcpp/QhullPoints.h
+index 7848f05..939b08a 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullPoints.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullPoints.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLPOINTS_H
+ #define QHULLPOINTS_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullPoint.h>
+ 
+ #include <cstddef>  // ptrdiff_t, size_t
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullQh.h b/include/cilantro/3rd_party/libqhullcpp/QhullQh.h
+index d2c174f..7a505c9 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullQh.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullQh.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLQH_H
+ #define QHULLQH_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ 
+ #include <string>
+ 
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullRidge.h b/include/cilantro/3rd_party/libqhullcpp/QhullRidge.h
+index 1f10a65..66ca9d4 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullRidge.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullRidge.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLRIDGE_H
+ #define QHULLRIDGE_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullSet.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullVertex.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullVertexSet.h>
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullSet.h b/include/cilantro/3rd_party/libqhullcpp/QhullSet.h
+index e2e713e..8063712 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullSet.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullSet.h
+@@ -9,7 +9,7 @@
+ #ifndef QhullSet_H
+ #define QhullSet_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullError.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullQh.h>
+ 
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullStat.h b/include/cilantro/3rd_party/libqhullcpp/QhullStat.h
+index c0e8287..c35bedb 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullStat.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullStat.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLSTAT_H
+ #define QHULLSTAT_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ 
+ #include <string>
+ #include <vector>
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullUser.h b/include/cilantro/3rd_party/libqhullcpp/QhullUser.h
+index 4d46fb4..cc6c008 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullUser.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullUser.h
+@@ -9,7 +9,7 @@
+ #ifndef QhullUser_H
+ #define QhullUser_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullPoint.h>
+ #include <cilantro/3rd_party/libqhullcpp/PointCoordinates.h>
+ 
+diff --git a/include/cilantro/3rd_party/libqhullcpp/QhullVertex.h b/include/cilantro/3rd_party/libqhullcpp/QhullVertex.h
+index cf92110..55aeddc 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/QhullVertex.h
++++ b/include/cilantro/3rd_party/libqhullcpp/QhullVertex.h
+@@ -9,7 +9,7 @@
+ #ifndef QHULLVERTEX_H
+ #define QHULLVERTEX_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullPoint.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullLinkedList.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullSet.h>
+diff --git a/include/cilantro/3rd_party/libqhullcpp/RboxPoints.h b/include/cilantro/3rd_party/libqhullcpp/RboxPoints.h
+index 9fe4e5c..e396ff9 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/RboxPoints.h
++++ b/include/cilantro/3rd_party/libqhullcpp/RboxPoints.h
+@@ -9,7 +9,7 @@
+ #ifndef RBOXPOINTS_H
+ #define RBOXPOINTS_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/qhull_ra.h>
++#include <libqhull_r/qhull_ra.h>
+ #include <cilantro/3rd_party/libqhullcpp/QhullPoint.h>
+ #include <cilantro/3rd_party/libqhullcpp/PointCoordinates.h>
+ 
+diff --git a/include/cilantro/3rd_party/libqhullcpp/RoadError.h b/include/cilantro/3rd_party/libqhullcpp/RoadError.h
+index a73e2c3..5e283a2 100644
+--- a/include/cilantro/3rd_party/libqhullcpp/RoadError.h
++++ b/include/cilantro/3rd_party/libqhullcpp/RoadError.h
+@@ -9,7 +9,7 @@
+ #ifndef ROADERROR_H
+ #define ROADERROR_H
+ 
+-#include <cilantro/3rd_party/libqhull_r/user_r.h>  /* for QHULL_CRTDBG */
++#include <libqhull_r/user_r.h>  /* for QHULL_CRTDBG */
+ #include <cilantro/3rd_party/libqhullcpp/RoadLogEvent.h>
+ 
+ #include <iostream>
+diff --git a/include/cilantro/clustering/spectral_clustering.hpp b/include/cilantro/clustering/spectral_clustering.hpp
+index 6fd9268..4cf585c 100644
+--- a/include/cilantro/clustering/spectral_clustering.hpp
++++ b/include/cilantro/clustering/spectral_clustering.hpp
+@@ -1,8 +1,8 @@
+ #pragma once
+ 
+ #include <memory>
+-#include <cilantro/3rd_party/Spectra/SymEigsSolver.h>
+-#include <cilantro/3rd_party/Spectra/SymGEigsSolver.h>
++#include <Spectra/SymEigsSolver.h>
++#include <Spectra/SymGEigsSolver.h>
+ #include <cilantro/core/spectral_embedding_base.hpp>
+ #include <cilantro/clustering/kmeans.hpp>
+ 
+diff --git a/include/cilantro/core/kd_tree.hpp b/include/cilantro/core/kd_tree.hpp
+index b92d8db..cad0321 100644
+--- a/include/cilantro/core/kd_tree.hpp
++++ b/include/cilantro/core/kd_tree.hpp
+@@ -1,6 +1,6 @@
+ #pragma once
+ 
+-#include <cilantro/3rd_party/nanoflann/nanoflann.hpp>
++#include <nanoflann.hpp>
+ #include <cilantro/core/data_containers.hpp>
+ #include <cilantro/core/nearest_neighbors.hpp>
+ 
+diff --git a/include/cilantro/utilities/multidimensional_scaling.hpp b/include/cilantro/utilities/multidimensional_scaling.hpp
+index f81e428..6713a66 100644
+--- a/include/cilantro/utilities/multidimensional_scaling.hpp
++++ b/include/cilantro/utilities/multidimensional_scaling.hpp
+@@ -1,6 +1,6 @@
+ #pragma once
+ 
+-#include <cilantro/3rd_party/Spectra/SymEigsSolver.h>
++#include <Spectra/SymEigsSolver.h>
+ #include <cilantro/core/data_containers.hpp>
+ #include <cilantro/core/spectral_embedding_base.hpp>
+ 
+diff --git a/include/cilantro/utilities/ply_io.hpp b/include/cilantro/utilities/ply_io.hpp
+index 0ceb9f1..35610ec 100644
+--- a/include/cilantro/utilities/ply_io.hpp
++++ b/include/cilantro/utilities/ply_io.hpp
+@@ -2,7 +2,7 @@
+ 
+ #include <set>
+ #include <fstream>
+-#include <cilantro/3rd_party/tinyply/tinyply.h>
++#include <tinyply.h>
+ #include <cilantro/core/data_containers.hpp>
+ 
+ namespace cilantro {
+-- 
+2.25.1
+

--- a/recipes/cilantro/all/test_package/CMakeLists.txt
+++ b/recipes/cilantro/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(cilantro REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE cilantro)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/cilantro/all/test_package/conanfile.py
+++ b/recipes/cilantro/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cilantro/all/test_package/conanfile.py
+++ b/recipes/cilantro/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/cilantro/all/test_package/test_package.cpp
+++ b/recipes/cilantro/all/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#include <cilantro/core/kd_tree.hpp>
+#include <iostream>
+#include <vector>
+
+int main() {
+    std::vector<Eigen::Vector3f> points;
+    points.emplace_back(0, 0, 0);
+    points.emplace_back(1, 1, 1);
+    cilantro::KDTree3f<> tree(points);
+    std::cout << "KDTree size: " << tree.getPointsMatrixMap().cols() << std::endl;
+    return 0;
+}

--- a/recipes/cilantro/config.yml
+++ b/recipes/cilantro/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20230816":
+    folder: all


### PR DESCRIPTION
### Summary
Adds  **cilantro/cci.20230816**

#### Motivation
Adds cilantro: a lean C++ library for working with point cloud data.

https://github.com/kzampog/cilantro

#### Details
Requires #22353 for proper OpenMP support. Disabled OpenMP for now.
Vendors and uses the `qhullcpp` component from `qhull`, which is not available on CCI (#16321).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
