### PR TITLE
c-ares: add version 1.32.0, remove older versions

### DIFF
--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.32.0":
+    url: "https://github.com/c-ares/c-ares/releases/download/v1.32.0/c-ares-1.32.0.tar.gz"
+    sha256: "5ab3fad06edb98fe8081febe1e41a027cfa3199fc525a59c851376414fe24c5b"
   "1.31.0":
     url: "https://github.com/c-ares/c-ares/releases/download/v1.31.0/c-ares-1.31.0.tar.gz"
     sha256: "0167a33dba96ca8de29f3f598b1e6cabe531799269fd63d0153aa0e6f5efeabd"
@@ -14,27 +17,11 @@ sources:
   "1.26.0":
     url: "https://github.com/c-ares/c-ares/releases/download/cares-1_26_0/c-ares-1.26.0.tar.gz"
     sha256: "bed58c4f02b009080ebda6c2467ba469722ac6aebbf4497dc44a83d8c6194e50"
+  # keep 1.25.0 for libnghttp2, trantor, libcoro
   "1.25.0":
     url: "https://github.com/c-ares/c-ares/releases/download/cares-1_25_0/c-ares-1.25.0.tar.gz"
     sha256: "71832b93a48f5ff579c505f4869120c14e57b783275367207f1a98314aa724e5"
-  "1.22.1":
-    url: "https://github.com/c-ares/c-ares/releases/download/cares-1_22_1/c-ares-1.22.1.tar.gz"
-    sha256: "f67c180deb799c670d9dda995a18ce06f6c7320b6c6363ff8fa85b77d0da9db8"
-  "1.22.0":
-    url: "https://github.com/c-ares/c-ares/releases/download/cares-1_22_0/c-ares-1.22.0.tar.gz"
-    sha256: "ad2e205088083317147c9f9eab5f24b82c3d50927c381a7c963deeb1182dbc21"
-  "1.21.0":
-    url: "https://github.com/c-ares/c-ares/releases/download/cares-1_21_0/c-ares-1.21.0.tar.gz"
-    sha256: "cd7aa3af1d3ee780d6437039a7ddb7f1ec029f9c4f7aabb0197e384eb5bc2f2d"
-  "1.20.1":
-    url: "https://github.com/c-ares/c-ares/releases/download/cares-1_20_1/c-ares-1.20.1.tar.gz"
-    sha256: "de24a314844cb157909730828560628704f4f896d167dd7da0fa2fb93ea18b10"
+  # keep 1.19.1 for grpc
   "1.19.1":
     url: "https://github.com/c-ares/c-ares/releases/download/cares-1_19_1/c-ares-1.19.1.tar.gz"
     sha256: "321700399b72ed0e037d0074c629e7741f6b2ec2dda92956abe3e9671d3e268e"
-  "1.19.0":
-    url: "https://github.com/c-ares/c-ares/releases/download/cares-1_19_0/c-ares-1.19.0.tar.gz"
-    sha256: "bfceba37e23fd531293829002cac0401ef49a6dc55923f7f92236585b7ad1dd3"
-  "1.18.1":
-    url: "https://github.com/c-ares/c-ares/releases/download/cares-1_18_1/c-ares-1.18.1.tar.gz"
-    sha256: "1a7d52a8a84a9fbffb1be9133c0f6e17217d91ea5a6fa61f6b4729cda78ebbcf"

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.32.0":
+    folder: all
   "1.31.0":
     folder: all
   "1.30.0":
@@ -11,17 +13,5 @@ versions:
     folder: all
   "1.25.0":
     folder: all
-  "1.22.1":
-    folder: all
-  "1.22.0":
-    folder: all
-  "1.21.0":
-    folder: all
-  "1.20.1":
-    folder: all
   "1.19.1":
-    folder: all
-  "1.19.0":
-    folder: all
-  "1.18.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **c-ares/1.32.0**

#### Motivation
There are several new features in 1.32.0.

#### Details
https://github.com/c-ares/c-ares/compare/v1.31.0...v1.32.0

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
