### PR TITLE
modern-cpp-kafka: add version 2024.07.03

### DIFF
--- a/recipes/modern-cpp-kafka/all/conandata.yml
+++ b/recipes/modern-cpp-kafka/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2024.07.03":
+    url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2024.07.03.tar.gz"
+    sha256: "06b89b5f2757d2107761d65869b98c3ec71e3c8c7e2cb2ab49277f3272044f02"
   "2023.03.07":
     url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2023.03.07.tar.gz"
     sha256: "4685527a9768d44ed769ec6e502c3edde0b5cf4d341d8f9b476474955c61bba4"

--- a/recipes/modern-cpp-kafka/config.yml
+++ b/recipes/modern-cpp-kafka/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2024.07.03":
+    folder: all
   "2023.03.07":
     folder: all
   "2023.01.05":


### PR DESCRIPTION
### Summary
Changes to recipe:  **modern-cpp-kafka/2024.07.03**

#### Motivation
There are several bugfixes and interface changes in 2024.07.03.

#### Details
https://github.com/morganstanley/modern-cpp-kafka/compare/v2023.03.07...v2024.07.03

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
