### PR TITLE
uwebsockets: add version 20.64.0

### DIFF
--- a/recipes/uwebsockets/all/conandata.yml
+++ b/recipes/uwebsockets/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.64.0":
+    url: "https://github.com/uNetworking/uWebSockets/archive/v20.64.0.tar.gz"
+    sha256: "bb81fa773dcbd6bc738904ad496554fd131a33269570e0e86fa09213d82ba9ef"
   "20.63.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v20.63.0.tar.gz"
     sha256: "3bcb3fab4242d312e227b05f34e21d8468960e5eea59e12799aa21a94f1b2b1f"

--- a/recipes/uwebsockets/config.yml
+++ b/recipes/uwebsockets/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.64.0":
+    folder: all
   "20.63.0":
     folder: all
   "20.62.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **uwebsockets/20.64.0**

#### Motivation
There are a (significant) performance improvement in 20.64.0.

#### Details
https://github.com/uNetworking/uWebSockets/compare/v20.63.0...v20.64.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
