### PR TITLE
commata: add version 1.0.0

### DIFF
--- a/recipes/commata/all/conandata.yml
+++ b/recipes/commata/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/furfurylic/commata/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "ecf0a88f6a4616d10770522b4ef4838e4100511759eb640270f6b932e4b7df69"
   "0.2.9":
     url: "https://github.com/furfurylic/commata/archive/refs/tags/v0.2.9.tar.gz"
     sha256: "24c404e90e2f01a2f9e46e55c2f8121a3f146d1f2dfb819b8d7ab5cf13bd6a9f"

--- a/recipes/commata/config.yml
+++ b/recipes/commata/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.2.9":
     folder: all
   "0.2.8":


### PR DESCRIPTION
### Summary
Changes to recipe:  **commata/1.0.0**

#### Motivation
The patche files for 0.2.9 are merged in 1.0.0.

#### Details
https://github.com/furfurylic/commata/compare/v0.2.9...v1.0.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
