### PR TITLE
ada: add version 2.9.0, remove older versions

### DIFF
--- a/recipes/ada/all/conandata.yml
+++ b/recipes/ada/all/conandata.yml
@@ -1,49 +1,16 @@
 sources:
+  "2.9.0":
+    url: "https://github.com/ada-url/ada/archive/v2.9.0.tar.gz"
+    sha256: "8b992f0ce9134cb4eafb74b164d2ce2cb3af1900902162713b0e0c5ab0b6acd8"
   "2.8.0":
     url: "https://github.com/ada-url/ada/archive/v2.8.0.tar.gz"
     sha256: "83b77fb53d1a9eea22b1484472cea0215c50478c9ea2b4b44b0ba3b52e07c139"
   "2.7.8":
     url: "https://github.com/ada-url/ada/archive/v2.7.8.tar.gz"
     sha256: "8de067b7cb3da1808bf5439279aee6048d761ba246bf8a854c2af73b16b41c75"
-  "2.7.7":
-    url: "https://github.com/ada-url/ada/archive/v2.7.7.tar.gz"
-    sha256: "7116d86a80b79886efbc9d946d3919801815060ae62daf78de68c508552af554"
-  "2.7.5":
-    url: "https://github.com/ada-url/ada/archive/v2.7.5.tar.gz"
-    sha256: "25a5d62fdd4950dbef785db5725675c15f3df2cf899a4a920449fe9a05fc6d00"
-  "2.7.4":
-    url: "https://github.com/ada-url/ada/archive/v2.7.4.tar.gz"
-    sha256: "897942ba8c99153f916c25698a49604022f3e54441cfa9b76f657ad15b6ca041"
-  "2.7.3":
-    url: "https://github.com/ada-url/ada/archive/v2.7.3.tar.gz"
-    sha256: "8e222d536d237269488f7d454544eedf12847f47b3d42651e8c9963c3fb0cf5e"
-  "2.7.2":
-    url: "https://github.com/ada-url/ada/archive/v2.7.2.tar.gz"
-    sha256: "4dea9dd6a46695547da2dac3dc7254d32187cd35d3170179c0cdc0900090c025"
-  "2.7.0":
-    url: "https://github.com/ada-url/ada/archive/v2.7.0.tar.gz"
-    sha256: "08646b8a41cd6367b282aab2c87c82e5ce4876078a0cbe0799af7e51e4358591"
   "2.6.10":
     url: "https://github.com/ada-url/ada/archive/v2.6.10.tar.gz"
     sha256: "a43e1ea0bcdd7585edf538afffe1fc3303b936752e18bac545fa11729de088bc"
-  "2.6.7":
-    url: "https://github.com/ada-url/ada/archive/v2.6.7.tar.gz"
-    sha256: "882a0aa6e19174b60b2fa00ee75d35a31ecd5158fb97d0e4e719ba21bb07acb9"
-  "2.6.4":
-    url: "https://github.com/ada-url/ada/archive/v2.6.4.tar.gz"
-    sha256: "5b488e9a7a700de5d40a749c96c4339bcc9c425e5f5406a0887b13e70bd90907"
-  "2.6.2":
-    url: "https://github.com/ada-url/ada/archive/v2.6.2.tar.gz"
-    sha256: "425b8696a28a22d19ee7aa4516c26fc8ae3ab574870a9a74ef58ba8a345b822e"
-  "2.6.0":
-    url: "https://github.com/ada-url/ada/archive/v2.6.0.tar.gz"
-    sha256: "09551bfbd92853e59d731e5f44a88a690425fd2906977ad03a6a1059615a02a5"
   "2.5.1":
     url: "https://github.com/ada-url/ada/archive/v2.5.1.tar.gz"
     sha256: "a7591d771822c3f16e6665311b0c6b4de7dd7615333183f35d89c7573be7f7fa"
-  "2.5.0":
-    url: "https://github.com/ada-url/ada/archive/v2.5.0.tar.gz"
-    sha256: "bf11c9d0cc1ee9e377080bdd8a3b8a8bf736ac7acaedcae882587e21b3e5625c"
-  "2.4.2":
-    url: "https://github.com/ada-url/ada/archive/v2.4.2.tar.gz"
-    sha256: "d865ab8828c14fc1e2217ca9f5d7918d50775175b2873faf2fbda0085e0623d2"

--- a/recipes/ada/config.yml
+++ b/recipes/ada/config.yml
@@ -1,33 +1,11 @@
 versions:
+  "2.9.0":
+    folder: all
   "2.8.0":
     folder: all
   "2.7.8":
     folder: all
-  "2.7.7":
-    folder: all
-  "2.7.5":
-    folder: all
-  "2.7.4":
-    folder: all
-  "2.7.3":
-    folder: all
-  "2.7.2":
-    folder: all
-  "2.7.0":
-    folder: all
   "2.6.10":
     folder: all
-  "2.6.7":
-    folder: all
-  "2.6.4":
-    folder: all
-  "2.6.2":
-    folder: all
-  "2.6.0":
-    folder: all
   "2.5.1":
-    folder: all
-  "2.5.0":
-    folder: all
-  "2.4.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **ada/2.9.0**

#### Motivation
There are several improvements in 2.9.0.

#### Details
https://github.com/ada-url/ada/compare/v2.8.0...v2.9.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
