### PR TITLE
stb: add new version cci.20240531, remove old versions

### DIFF
--- a/recipes/stb/all/conandata.yml
+++ b/recipes/stb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20240531":
+    url: "https://github.com/nothings/stb/archive/013ac3beddff3dbffafd5177e7972067cd2b5083.zip"
+    sha256: "b7f476902bbef1b30f8ecc2d9d95c459c32302c8b559d09b589b5955463b7af8"
   "cci.20240213":
     url: "https://github.com/nothings/stb/archive/ae721c50eaf761660b4f90cc590453cdb0c2acd0.zip"
     sha256: "5d075769721e676746d0c25b698a0f00741f68252f9ab4b7ee245c513aeec3de"

--- a/recipes/stb/all/conandata.yml
+++ b/recipes/stb/all/conandata.yml
@@ -11,12 +11,3 @@ sources:
   "cci.20220909":
     url: "https://github.com/nothings/stb/archive/8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55.zip"
     sha256: "93a16ee3e866e719feec459f6f132cce932c5ec751eb38e3ec1975f911353d2e"
-  "cci.20210910":
-    url: "https://github.com/nothings/stb/archive/af1a5bc352164740c1cc1354942b1c6b72eacb8a.zip"
-    sha256: "e3d0edbecd356506d3d69b87419de2f9d180a98099134c6343177885f6c2cbef"
-  "cci.20210713":
-    url: "https://github.com/nothings/stb/archive/3a1174060a7dd4eb652d4e6854bc4cd98c159200.zip"
-    sha256: "9313f6871195b97771ce7da1feae0b3d92c7936456f13099edb54a78096ca93c"
-  "cci.20200203":
-    url: "https://github.com/nothings/stb/archive/0224a44a10564a214595797b4c88323f79a5f934.zip"
-    sha256: "5dd9cf8a9a8c0f253fad3e9904923b2dfc740eddbc86415c3f76152bd534f23a"

--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -10,10 +10,10 @@ required_conan_version = ">=1.50.0"
 class StbConan(ConanFile):
     name = "stb"
     description = "single-file public domain libraries for C/C++"
-    topics = ("stb", "single-file")
+    license = ("Unlicense", "MIT")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/nothings/stb"
-    license = ("Unlicense", "MIT")
+    topics = ("stb", "single-file", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
@@ -50,9 +50,6 @@ class StbConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
-    def build(self):
-        pass
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/stb/config.yml
+++ b/recipes/stb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20240531":
+    folder: all
   "cci.20240213":
     folder: all
   "cci.20230920":

--- a/recipes/stb/config.yml
+++ b/recipes/stb/config.yml
@@ -7,9 +7,3 @@ versions:
     folder: all
   "cci.20220909":
     folder: all
-  "cci.20210910":
-    folder: all
-  "cci.20210713":
-    folder: all
-  "cci.20200203":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **stb/cci.20240531**

#### Motivation
cci.20240531 has stb image resize 2.0.7.

#### Details
https://github.com/nothings/stb/blob/master/stb_image_resize2.h#L331-L334

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
