### PR TITLE
base64: add OpenMP support

### DIFF
--- a/recipes/base64/all/conanfile.py
+++ b/recipes/base64/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.scm import Version
 
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class Base64Conan(ConanFile):
@@ -60,6 +60,7 @@ class Base64Conan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     @property
     def _use_cmake(self):
@@ -82,7 +83,6 @@ class Base64Conan(ConanFile):
             deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         if self._use_cmake:
             cmake = CMake(self)
             cmake.configure()

--- a/recipes/base64/all/conanfile.py
+++ b/recipes/base64/all/conanfile.py
@@ -29,7 +29,7 @@ class Base64Conan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_openmp": False,
+        "with_openmp": True,
     }
 
     def export_sources(self):

--- a/recipes/base64/all/test_package/CMakeLists.txt
+++ b/recipes/base64/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(base64 REQUIRED CONFIG)

--- a/recipes/base64/all/test_package/conanfile.py
+++ b/recipes/base64/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **base64/***

#### Motivation
Adds `with_openmp` option that defaults to `False`.

#### Details
OpenMP is now available for all compilers and without the need to export the necessary compiler and linker flags in `package_info()` now that #22353 has been merged.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
