### PR TITLE
ensmallen: add OpenMP support

### DIFF
--- a/recipes/ensmallen/all/conanfile.py
+++ b/recipes/ensmallen/all/conanfile.py
@@ -1,11 +1,12 @@
+import os
+
 from conan import ConanFile, conan_version
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.files import get, replace_in_file, rmdir, copy
 from conan.tools.scm import Version
 
-import os
+required_conan_version = ">=2.0"
 
-required_conan_version = ">=1.55.0"
 
 class ensmallenRecipe(ConanFile):
     name = "ensmallen"

--- a/recipes/ensmallen/all/conanfile.py
+++ b/recipes/ensmallen/all/conanfile.py
@@ -17,6 +17,12 @@ class ensmallenRecipe(ConanFile):
 
     package_type = "header-library"
     settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "with_openmp": [True, False],
+    }
+    default_options = {
+        "with_openmp": True,
+    }
 
     def package_id(self):
         self.info.clear()
@@ -26,6 +32,8 @@ class ensmallenRecipe(ConanFile):
 
     def requirements(self):
         self.requires("armadillo/12.6.4")
+        if self.options.with_openmp:
+            self.requires("llvm-openmp/18.1.8")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -37,7 +45,7 @@ class ensmallenRecipe(ConanFile):
         deps.set_property("armadillo", "cmake_config_version_compat", "AnyNewerVersion")
         deps.generate()
         tc = CMakeToolchain(self)
-        tc.variables["USE_OPENMP"] = False
+        tc.variables["USE_OPENMP"] = self.options.with_openmp
         tc.generate()
 
 

--- a/recipes/ensmallen/all/test_package/conanfile.py
+++ b/recipes/ensmallen/all/test_package/conanfile.py
@@ -14,7 +14,7 @@ class ensmallenTestConan(ConanFile):
         # and armadillo/*:use_hdf5=True by default.
         # See https://github.com/conan-io/conan-center-index/pull/17320 for more
         # information.
-        self.requires("hdf5/1.14.1")
+        self.requires("hdf5/1.14.5")
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **ensmallen/***

#### Motivation
Add parallelism support to the library.

#### Details
Adds OpenMP support via `llvm-openmp` for all compilers. Enabled by default, which matches the project config: https://github.com/mlpack/ensmallen/blob/ensmallen-1.16.2/CMakeLists.txt#L7

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
