### PR TITLE
openexr 2.x: avoid conflict in PkgConfigDeps

### DIFF
--- a/recipes/openexr/2.x/conanfile.py
+++ b/recipes/openexr/2.x/conanfile.py
@@ -141,6 +141,9 @@ class OpenEXRConan(ConanFile):
         #        waiting an implementation of https://github.com/conan-io/conan/issues/9000
         self.cpp_info.set_property("cmake_file_name", "OpenEXR")
 
+        # Avoid conflict in PkgConfigDeps with OpenEXR.pc file coming from openexr_ilmimf component
+        self.cpp_info.set_property("pkg_config_name", "openexr_conan_full_package")
+
         lib_suffix = ""
         if not self.options.shared or self.settings.os == "Windows":
             openexr_version = Version(self.version)


### PR DESCRIPTION
### Summary
Changes to recipe:  **openexr/2.x**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

Avoid conflict between files generated by `PkgConfigDeps` for openexr 2.x on case-insensitive file systems.

closes https://github.com/conan-io/conan-center-index/issues/24559

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

`PkgConfigDeps` generate `OpenEXR.pc` file for `openexr_ilmimf` component , while an unwanted `openexr.pc` file is generated by default for the "global" component. To avoid conflict on case-insensitive file systems like Windows, we enforce an another custom `pkg_config_name` for this global component.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
