### PR TITLE
docs: Changelog 2024 July 10

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ### 10-Jul-2024 - 13:22 CEST
 
 - [feature] Add support for Conan 2.5.0 in the CI
+- [fix] Invalid configuration from tool requirement in Conan 1.x
 
 ### 22-May-2024 - 12:04 CEST
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 10-Jul-2024 - 13:2 CEST
+### 10-Jul-2024 - 13:22 CEST
 
 - [feature] Add support for Conan 2.5.0 in the CI
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 10-Jul-2024 - 13:2 CEST
+
+- [feature] Add support for Conan 2.5.0 in the CI
+
 ### 22-May-2024 - 12:04 CEST
 
 - [feature] Add support for Conan 2.3.1 in the CI


### PR DESCRIPTION
### Summary

- ConanCenterIndex CI is now running Conan 2.5.0 for any Conan 2.x build.
- Fix internal code affecting the PR #24010 when generating graph info in Conan 1.x 


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
