### PR TITLE
vvenc: add version 0.12.0, relax c++ std version on 0.10.0 and later

### DIFF
--- a/recipes/vvenc/all/conandata.yml
+++ b/recipes/vvenc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.12.0":
+    url: "https://github.com/fraunhoferhhi/vvenc/archive/refs/tags/v1.12.0.tar.gz"
+    sha256: "e7311ffcc87d8fcc4b839807061cca1b89be017ae7c449a69436dc2dd07615c2"
   "1.11.1":
     url: "https://github.com/fraunhoferhhi/vvenc/archive/refs/tags/v1.11.1.tar.gz"
     sha256: "4f0c8ac3f03eb970bee7a0cacc57a886ac511d58f081bb08ba4bce6f547d92fa"

--- a/recipes/vvenc/all/conanfile.py
+++ b/recipes/vvenc/all/conanfile.py
@@ -8,6 +8,7 @@ from conan import ConanFile, conan_version
 from conan.tools.build import stdcpp_library, check_min_cppstd
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.files import get, copy, rmdir, rm
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.60.1"
 
@@ -22,11 +23,11 @@ class vvencRecipe(ConanFile):
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
-        "shared": [True, False], 
+        "shared": [True, False],
         "fPIC": [True, False],
     }
     default_options = {
-        "shared": False, 
+        "shared": False,
         "fPIC": True,
     }
 
@@ -59,10 +60,11 @@ class vvencRecipe(ConanFile):
         # and it cannot be built with newer C++ standard
         # because they have existing C++ features removed
         check_min_cppstd(self, 14)
-        # FIXME: linter complains, but function is there
-        # https://docs.conan.io/2.0/reference/tools/build.html?highlight=check_min_cppstd#conan-tools-build-check-max-cppstd
-        check_max_cppstd = getattr(sys.modules['conan.tools.build'], 'check_max_cppstd')
-        check_max_cppstd(self, 14)
+        if Version(self.version) < "1.10.0":
+            # FIXME: linter complains, but function is there
+            # https://docs.conan.io/2.0/reference/tools/build.html?highlight=check_min_cppstd#conan-tools-build-check-max-cppstd
+            check_max_cppstd = getattr(sys.modules['conan.tools.build'], 'check_max_cppstd')
+            check_max_cppstd(self, 14)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -80,7 +82,7 @@ class vvencRecipe(ConanFile):
         # object files created with newer binutils,
         # thus linker cannot find any valid object and therefore symbols
         # (fails to find `vvenc_get_version`, which is obviously always there)
-        # this is not exactly modeled by conan right now, 
+        # this is not exactly modeled by conan right now,
         # so "compiler" setting is closest thing to avoid an issue
         # (while technically it's not a compiler, but linker and archiver)
         # del self.info.settings.compiler

--- a/recipes/vvenc/config.yml
+++ b/recipes/vvenc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.12.0":
+    folder: "all"
   "1.11.1":
     folder: "all"
   "1.10.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **vvenc/0.12.0**

#### Motivation
`vvenc/0.12.0` is required by `libheif/1.18.0`. [ref](https://github.com/strukturag/libheif/blob/v1.18.0/CMakeLists.txt#L158)

`vvenc/[>= 0.10.0]` seems to be relaxed C++14 limitation. [ref](https://github.com/fraunhoferhhi/vvenc/pull/321) (Thanks a lot, @uilianries!)

#### Details
https://github.com/fraunhoferhhi/vvenc/compare/v1.11.1...v1.12.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
