### PR TITLE
meson: add version 1.5.0, remove older versions

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.0":
+    url: "https://github.com/mesonbuild/meson/archive/1.5.0.tar.gz"
+    sha256: "781913826fb6f478eb7d77e1942ab3df39444e4c90e9a3523737e215171db469"
   "1.4.1":
     url: "https://github.com/mesonbuild/meson/archive/1.4.1.tar.gz"
     sha256: "a7efc72ecb873c5a62031ade1921a7177b67cfdcb2e9410a7ab023f9e8192f4b"
@@ -29,60 +32,23 @@ sources:
   "1.1.1":
     url: "https://github.com/mesonbuild/meson/releases/download/1.1.1/meson-1.1.1.tar.gz"
     sha256: "d04b541f97ca439fb82fab7d0d480988be4bd4e62563a5ca35fadb5400727b1c"
+  # qt requires 1.1.0
   "1.1.0":
     url: "https://github.com/mesonbuild/meson/archive/1.1.0.tar.gz"
     sha256: "f29a3e14062043d75e82d16f1e41856e6b1ed7a7c016e10c7b13afa7ee6364cc"
-  "1.0.1":
-    url: "https://github.com/mesonbuild/meson/archive/1.0.1.tar.gz"
-    sha256: "4ab3a5c0060dc22bdefb04507efc6c38acb910e91bcd467a38e1fa211e5a6cfe"
+  # wayland-protocols requires 1.0.0
   "1.0.0":
     url: "https://github.com/mesonbuild/meson/releases/download/1.0.0/meson-1.0.0.tar.gz"
     sha256: "aa50a4ba4557c25e7d48446abfde857957dcdf58385fffbe670ba0e8efacce05"
-  "0.64.1":
-    url: "https://github.com/mesonbuild/meson/archive/0.64.1.tar.gz"
-    sha256: "1d12a4bc1cf3ab18946d12cf0b6452e5254ada1ad50aacc97f87e2cccd7da315"
-  "0.64.0":
-    url: "https://github.com/mesonbuild/meson/archive/0.64.0.tar.gz"
-    sha256: "6477993d781b6efea93091616a6d6a0766c0e026076dbeb11249bf1c9b49a347"
-  "0.63.3":
-    url: "https://github.com/mesonbuild/meson/archive/0.63.3.tar.gz"
-    sha256: "7c516c2099b762203e8a0a22412aa465b7396e6f9b1ab728bad6e6db44dc2659"
-  "0.63.2":
-    url: "https://github.com/mesonbuild/meson/archive/0.63.2.tar.gz"
-    sha256: "023a3f7c74e68991154c3205a6975705861eedbf8130e013d15faa1df1af216e"
-  "0.63.1":
-    url: "https://github.com/mesonbuild/meson/archive/0.63.1.tar.gz"
-    sha256: "f355829f0e8c714423f03a06604c04c216d4cbe3586f3154cb2181076b19207a"
-  "0.63.0":
-    url: "https://github.com/mesonbuild/meson/archive/0.63.0.tar.gz"
-    sha256: "77808d47fa05875c2553d66cb6c6140c2f687b46256dc537eeb8a63889e0bea2"
+  # gtk requires 0.62.2
   "0.62.2":
     url: "https://github.com/mesonbuild/meson/archive/0.62.2.tar.gz"
     sha256: "97108f4d9bb16bc758c44749bd25ec7d42c6a762961efbed8b7589a2a3551ea6"
-  "0.62.1":
-    url: "https://github.com/mesonbuild/meson/archive/0.62.1.tar.gz"
-    sha256: "9fb52e66dbc613479a5f70e46cc2e8faf5aa65e09313f2c71fa63b8afd018107"
-  "0.62.0":
-    url: "https://github.com/mesonbuild/meson/archive/0.62.0.tar.gz"
-    sha256: "72ac3bab701dfd597604de29cc74baaa1cc0ad8ca26ae23d5288de26abfe1c80"
+  # gst-plugins-base requires 0.61.2
   "0.61.2":
     url: "https://github.com/mesonbuild/meson/archive/0.61.2.tar.gz"
     sha256: "33cd555314a94d52acfbb3f6f44d4e61c4ad0bfec7acf4301be7e40bb969b3a8"
-  "0.60.2":
-    url: "https://github.com/mesonbuild/meson/archive/0.60.2.tar.gz"
-    sha256: "fc7c2f315b5b63fee0414b0b94b5a7d0e9c71c8c9bb8487314eb5a9a33984b8d"
+  # gobject-introspection requires 0.59.3
   "0.59.3":
     url: "https://github.com/mesonbuild/meson/archive/0.59.3.tar.gz"
     sha256: "b2c5bfd5032189a66cf6a32d98ba82d94d7d314577d8efe4d9dc159c4073f282"
-  "0.58.1":
-    url: "https://github.com/mesonbuild/meson/archive/0.58.1.tar.gz"
-    sha256: "78e0f553dd3bc632d5f96ab943b1bbccb599c2c84ff27c5fb7f7fff9c8a3f6b4"
-  "0.57.2":
-    url: "https://github.com/mesonbuild/meson/archive/0.57.2.tar.gz"
-    sha256: "cd3773625253df4fd1c380faf03ffae3d02198d6301e7c8bc7bba6c66af66096"
-  "0.56.2":
-    url: "https://github.com/mesonbuild/meson/archive/0.56.2.tar.gz"
-    sha256: "aaae961c3413033789248ffe6762589e80b6cf487c334d0b808e31a32c48f35f"
-  "0.55.3":
-    url: "https://github.com/mesonbuild/meson/archive/0.55.3.tar.gz"
-    sha256: "2b276df50c5b13ccdbfb14d3333141e9e7985aca31b60400b3f3e0be2ee6897e"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.0":
+    folder: all
   "1.4.1":
     folder: all
   "1.4.0":
@@ -21,39 +23,11 @@ versions:
     folder: all
   "1.1.0":
     folder: all
-  "1.0.1":
-    folder: all
   "1.0.0":
-    folder: all
-  "0.64.1":
-    folder: all
-  "0.64.0":
-    folder: all
-  "0.63.3":
-    folder: all
-  "0.63.2":
-    folder: all
-  "0.63.1":
-    folder: all
-  "0.63.0":
     folder: all
   "0.62.2":
     folder: all
-  "0.62.1":
-    folder: all
-  "0.62.0":
-    folder: all
   "0.61.2":
     folder: all
-  "0.60.2":
-    folder: all
   "0.59.3":
-    folder: all
-  "0.58.1":
-    folder: all
-  "0.57.2":
-    folder: all
-  "0.56.2":
-    folder: all
-  "0.55.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **meson/1.5.0**

#### Motivation
There are lots of new features in 1.5.0.
https://mesonbuild.com/Release-notes-for-1-5-0.html

#### Details
https://github.com/mesonbuild/meson/compare/1.4.1...1.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
