### PR TITLE
libfdk_acc: Do not support building for Android when using NDK

### DIFF
--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -48,7 +48,7 @@ class LibFDKAACConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
-    def validate(self):
+    def validate_build(self):
         if cross_building(self) and self.settings.os == "Android":
             # https://github.com/mstorsjo/fdk-aac/issues/124#issuecomment-653473956
             # INFO: It's possible to inject a log.h to fix the error, but there is no official support.

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -6,7 +6,9 @@ from conan.tools.files import chdir, copy, get, rename, replace_in_file, rm, rmd
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, NMakeToolchain
+from conan.tools.build import cross_building
 from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.55.0"
@@ -45,6 +47,12 @@ class LibFDKAACConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+
+    def validate(self):
+        if cross_building(self) and self.settings.os == "Android":
+            # https://github.com/mstorsjo/fdk-aac/issues/124#issuecomment-653473956
+            # INFO: It's possible to inject a log.h to fix the error, but there is no official support.
+            raise ConanInvalidConfiguration(f"{self.ref} cross-building for Android is not supported. Please, try native build.")
 
     def layout(self):
         if self._use_cmake:


### PR DESCRIPTION
### Summary
Changes to recipe:  **libfdk_acc/2.0.4**

#### Motivation

The issue #20511 points an error when building `ffmpeg` for Android:

```
[ 66%] Building CXX object CMakeFiles/fdk-aac.dir/libSBRdec/src/lpp_tran.cpp.o
/Users/paulo/.conan/data/libfdk_aac/2.0.2/_/_/build/36795b10a36cc186da0ea4af22f48240bd009d62/src/libSBRdec/src/lpp_tran.cpp:122:10: fatal error: 'log/log.h' file not found
#include "log/log.h"
         ^~~~~~~~~~~
1 error generated.
```

That error comes from `fdk-aac`. It's missing a header named as `log.h`, the same error is  reported in the upstream already:

- https://github.com/mstorsjo/fdk-aac/issues/124
- https://github.com/mstorsjo/fdk-aac/issues/150
- https://github.com/mstorsjo/fdk-aac/issues/144

The author is clear about not supporting NDK here: https://github.com/mstorsjo/fdk-aac/issues/124

#### Details

It's possible to fix the build error by adding a log file, as suggested here: https://github.com/mstorsjo/fdk-aac/issues/150#issuecomment-1560944481

Does it build? Yes, I tested locally.

Does it work? No idea, plus, the author did not recommend an official way to support, so I preferred to just drop that support.

Related to the PR #24566 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
