### PR TITLE
libx264: Fix Android build

### DIFF
--- a/recipes/libx264/all/conandata.yml
+++ b/recipes/libx264/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20240224":
+    url: "https://code.videolan.org/videolan/x264/-/archive/7241d020118bb09cc0ad119d7bc9f630a1caad10/x264-7241d020118bb09cc0ad119d7bc9f630a1caad10.tar.bz2"
+    sha256: "ce6623b8b289765daee04a297c2fd1a293cb2565a1749c76d66c8d72c7ddc1ab"
   "cci.20220602":
     url: "https://code.videolan.org/videolan/x264/-/archive/baee400fa9ced6f5481a728138fed6e867b0ff7f/x264-baee400fa9ced6f5481a728138fed6e867b0ff7f.tar.bz2"
     sha256: "ce6623b8b289765daee04a297c2fd1a293cb2565a1749c76d66c8d72c7ddc1ab"

--- a/recipes/libx264/config.yml
+++ b/recipes/libx264/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20240224":
+    folder: all
   "cci.20220602":
     folder: all
   "20191217":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libx264/cci.20220602**

#### Motivation

The issue #23718 reported an error when trying to build for Android. Plus, libx264 is a ffmpeg dependency.

#### Details

When using Conan android-ndk, most of things are configured already, like ndk_path and sysroot, but still misses the toolchain path (folder level with bin, sysroot, lib, ...). That level is really important because libx264 will ask for `strings` and same is `llvm-strings` in Android NDK, it's the executable for strings in the NDK.

The toolchain path looks fragile, but is stable, same adopted in the recipe for Android NDK, and checked locally with Android NDK 26d.

As I needed to execute several builds using Android NDK, I posted the build logs here: https://gist.github.com/uilianries/f3ca036501f9c175312fb7c7df614db2


Related to #24566

fixes #23718

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
