### PR TITLE
msys2: conditionally prepend pkg_config_path

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -156,8 +156,9 @@ class MSYS2Conan(ConanFile):
             os.utime(tmp_name, None)
 
         # Prepend the PKG_CONFIG_PATH environment variable with an eventual PKG_CONFIG_PATH environment variable
+        # Note: this is no longer needed when we exclusively support Conan 2 integrations
         replace_in_file(self, os.path.join(self._msys_dir, "etc", "profile"),
-                              'PKG_CONFIG_PATH="', 'PKG_CONFIG_PATH="$PKG_CONFIG_PATH:')
+                              'PKG_CONFIG_PATH="', 'PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}')
 
     def package(self):
         excludes = None


### PR DESCRIPTION
### Summary
Changes to recipe:  **msys2/all**

#### Motivation
Windows users building ffmpeg are reporting issues with the `PKG_CONFIG_PATH` variable due to a spurious `::` empty path that may interfere with pkgconf.exe or msys2 path conversions. See: 
https://github.com/conan-io/conan-center-index/issues/23309

Based on user troubleshooting, the problem goes away if there's no empty entry in the path list.

#### Details
Use shell parameter expansion such that, if `PKG_CONFIG_PATH` already has a value, we append to it - otherwise, do noting. This avoids an empty `:` when `PKG_CONFIG_PATH` is unset.
see
https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
