### PR TITLE
glib: support python 3.12

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -27,13 +27,56 @@ sources:
     url: "https://download.gnome.org/sources/glib/2.75/glib-2.75.3.tar.xz"
     sha256: "7c517d0aff456c35a039bce8a8df7a08ce95a8285b09d1849f8865f633f7f871"
 patches:
+  "2.78.3":
+    - patch_file: "patches/remove-distutils-2.77.0.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
+  "2.78.1":
+    - patch_file: "patches/remove-distutils-2.77.0.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
+  "2.78.0":
+    - patch_file: "patches/remove-distutils-2.77.0.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
+  "2.77.3":
+    - patch_file: "patches/remove-distutils-2.77.0.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
+  "2.77.2":
+    - patch_file: "patches/remove-distutils-2.77.0.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
+  "2.77.1":
+    - patch_file: "patches/remove-distutils-2.77.0.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
+  "2.77.0":
+    - patch_file: "patches/remove-distutils-2.77.0.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.76.3":
     - patch_file: "patches/libintl-discovery.patch"
       patch_type: bugfix
       patch_description: fix libintl discovery
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3352
+    - patch_file: "patches/remove-distutils.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.75.3":
     - patch_file: "patches/libintl-discovery-2.75.3.patch"
       patch_type: bugfix
       patch_description: fix libintl discovery
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3352
+    - patch_file: "patches/remove-distutils.patch"
+      patch_type: backport
+      patch_description: remove distutils
+      patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133

--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -29,37 +29,37 @@ sources:
 patches:
   "2.78.3":
     - patch_file: "patches/remove-distutils-2.77.0.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.78.1":
     - patch_file: "patches/remove-distutils-2.77.0.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.78.0":
     - patch_file: "patches/remove-distutils-2.77.0.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.77.3":
     - patch_file: "patches/remove-distutils-2.77.0.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.77.2":
     - patch_file: "patches/remove-distutils-2.77.0.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.77.1":
     - patch_file: "patches/remove-distutils-2.77.0.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.77.0":
     - patch_file: "patches/remove-distutils-2.77.0.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.76.3":
@@ -68,7 +68,7 @@ patches:
       patch_description: fix libintl discovery
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3352
     - patch_file: "patches/remove-distutils.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133
   "2.75.3":
@@ -77,6 +77,6 @@ patches:
       patch_description: fix libintl discovery
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3352
     - patch_file: "patches/remove-distutils.patch"
-      patch_type: backport
+      patch_type: bugfix
       patch_description: remove distutils
       patch_source: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -81,7 +81,7 @@ class GLibConan(ConanFile):
             self.requires("libiconv/1.17")
 
     def build_requirements(self):
-        self.tool_requires("meson/[>=1.2.3]")
+        self.tool_requires("meson/[>=1.2.3 <2]")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/2.0.3")
 

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -81,7 +81,7 @@ class GLibConan(ConanFile):
             self.requires("libiconv/1.17")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/[>=1.2.3]")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/2.0.3")
 

--- a/recipes/glib/all/patches/remove-distutils-2.77.0.patch
+++ b/recipes/glib/all/patches/remove-distutils-2.77.0.patch
@@ -1,0 +1,51 @@
+diff --git a/gio/gdbus-2.0/codegen/utils.py b/gio/gdbus-2.0/codegen/utils.py
+index 0204610..f8d758c 100644
+--- a/gio/gdbus-2.0/codegen/utils.py
++++ b/gio/gdbus-2.0/codegen/utils.py
+@@ -19,7 +19,7 @@
+ #
+ # Author: David Zeuthen <davidz@redhat.com>
+ 
+-import distutils.version
++import re
+ import os
+ import sys
+ 
+@@ -159,11 +159,35 @@ def lookup_brief_docs(annotations):
+ def version_cmp_key(key):
+     # If the 'since' version is 'UNRELEASED', compare higher than anything else
+     # If it is empty put a 0 in its place as this will
+-    # allow LooseVersion to work and will always compare lower.
++    # allow _parse_version() to work and will always compare lower.
+     if key[0] == "UNRELEASED":
+         v = "9999"
+     elif key[0]:
+         v = str(key[0])
+     else:
+         v = "0"
+-    return (distutils.version.LooseVersion(v), key[1])
++        return (_parse_version(v), key[1])
++
++
++def _parse_version(version):
++    """
++    Parse a version string into a list of integers and strings.
++
++    This function takes a version string and breaks it down into its component parts.
++    It separates numeric and non-numeric segments, converting numeric segments to integers.
++
++    Args:
++        version (str): The version string to parse.
++
++    Returns:
++        list: A list where each element is either an integer (for numeric parts)
++              or a string (for non-numeric parts).
++
++    Example:
++        >>> parseversion("1.2.3a")
++        [1, 2, 3, 'a']
++        >>> parseversion("2.0.0-rc1")
++        [2, 0, 0, 'rc1']
++    """
++    blocks = re.findall(r"(\d+|\w+)", version)
++    return [int(b) if b.isdigit() else b for b in blocks]

--- a/recipes/glib/all/patches/remove-distutils.patch
+++ b/recipes/glib/all/patches/remove-distutils.patch
@@ -1,0 +1,51 @@
+diff --git a/gio/gdbus-2.0/codegen/utils.py b/gio/gdbus-2.0/codegen/utils.py
+index 95559d3..2b7a176 100644
+--- a/gio/gdbus-2.0/codegen/utils.py
++++ b/gio/gdbus-2.0/codegen/utils.py
+@@ -19,7 +19,7 @@
+ #
+ # Author: David Zeuthen <davidz@redhat.com>
+ 
+-import distutils.version
++import re
+ import os
+ import sys
+ 
+@@ -155,11 +155,35 @@ def lookup_brief_docs(annotations):
+ def version_cmp_key(key):
+     # If the 'since' version is 'UNRELEASED', compare higher than anything else
+     # If it is empty put a 0 in its place as this will
+-    # allow LooseVersion to work and will always compare lower.
++    # allow _parse_version() to work and will always compare lower.
+     if key[0] == "UNRELEASED":
+         v = "9999"
+     elif key[0]:
+         v = str(key[0])
+     else:
+         v = "0"
+-    return (distutils.version.LooseVersion(v), key[1])
++    return (_parse_version(v), key[1])
++
++
++def _parse_version(version):
++    """
++    Parse a version string into a list of integers and strings.
++
++    This function takes a version string and breaks it down into its component parts.
++    It separates numeric and non-numeric segments, converting numeric segments to integers.
++
++    Args:
++        version (str): The version string to parse.
++
++    Returns:
++        list: A list where each element is either an integer (for numeric parts)
++              or a string (for non-numeric parts).
++
++    Example:
++        >>> parseversion("1.2.3a")
++        [1, 2, 3, 'a']
++        >>> parseversion("2.0.0-rc1")
++        [2, 0, 0, 'rc1']
++    """
++    blocks = re.findall(r"(\d+|\w+)", version)
++    return [int(b) if b.isdigit() else b for b in blocks]


### PR DESCRIPTION

Changes in this PR:
* Backport: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4133 to support python 3.12 (which does not have distutils). Also compatible with earlier versions of python.
* Use newer version of meson (at least 1.2.3 is required to support python 3.12, otherwise it complains about missing distutils, see [here](https://mesonbuild.com/meson-python/reference/meson-compatibility.html#cmdoption-arg-1.2.3))

