### PR TITLE
dtl: add new version 1.21, remove cci version

### DIFF
--- a/recipes/dtl/all/conandata.yml
+++ b/recipes/dtl/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
+  "1.21":
+    url: "https://github.com/cubicdaiya/dtl/archive/v1.21.tar.gz"
+    sha256: "90ed2dbf4e6d687737fe25f118bbcb6aed778cecc3f2115d191a032bf8643dbd"
   "1.20":
     url: "https://github.com/cubicdaiya/dtl/archive/v1.20.tar.gz"
     sha256: "579f81bca88f4b9760a59d99c5a95bd8dd5dc2f20f33f1f9b5f64cb08979f54d"
   "1.19":
     url: "https://github.com/cubicdaiya/dtl/archive/v1.19.tar.gz"
     sha256: "f47b99dd11e5d771ad32a8dc960db4ab2fbe349fb0346fa0795f53c846a99c5d"
-  "cci.20210404":
-    url: "https://github.com/cubicdaiya/dtl/archive/0551c22f5ee3d30dbc4b0700bde5acdb6f1a9348.tar.gz"
-    sha256: "59c2e770454c935200179aa4457f72741aec2319072862950b2490d0758d4e43"

--- a/recipes/dtl/all/conanfile.py
+++ b/recipes/dtl/all/conanfile.py
@@ -3,6 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.files import copy, get, replace_in_file
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.52.0"
 
@@ -27,8 +28,9 @@ class DtlConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        # See https://github.com/cubicdaiya/dtl/pull/18
-        replace_in_file(self, os.path.join(self.source_folder, "dtl", "Diff.hpp"), "void enableTrivial () const {", "void enableTrivial () {")
+        if Version(self.version) < "1.21":
+            # See https://github.com/cubicdaiya/dtl/pull/18
+            replace_in_file(self, os.path.join(self.source_folder, "dtl", "Diff.hpp"), "void enableTrivial () const {", "void enableTrivial () {")
 
     def package(self):
         copy(self, "COPYING",

--- a/recipes/dtl/config.yml
+++ b/recipes/dtl/config.yml
@@ -1,7 +1,7 @@
 versions:
+  "1.21":
+    folder: "all"
   "1.20":
     folder: "all"
   "1.19":
-    folder: "all"
-  "cci.20210404":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **dtl/1.21**

#### Motivation
There are several improvements in 1.21.

#### Details
https://github.com/cubicdaiya/dtl/compare/v1.20...v1.21

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
