### PR TITLE
libyuv: add 1892

### DIFF
--- a/recipes/libyuv/all/conandata.yml
+++ b/recipes/libyuv/all/conandata.yml
@@ -1,6 +1,8 @@
 # Versions from LIBYUV_VERSION definition in include/libyuv/version.h
 # Pay attention to package commits incrementing this definition
 sources:
+  "1892":
+    url: "https://chromium.googlesource.com/libyuv/libyuv/+archive/4cd90347e78ff76755df2107009e900374aee9cd.tar.gz"
   "1880":
     url: "https://chromium.googlesource.com/libyuv/libyuv/+archive/fb6341d326846fbbe669ad5173e520f66b339621.tar.gz"
   "1854":
@@ -12,6 +14,10 @@ sources:
   "1768":
     url: "https://chromium.googlesource.com/libyuv/libyuv/+archive/dfaf7534e0e536f7e5ef8ddd7326797bd09b8622.tar.gz"
 patches:
+  "1892":
+    - patch_file: "patches/1892-0001-fix-cmake.patch"
+      patch_description: "Fix CMake to be more robust & predictable"
+      patch_type: "conan"
   "1880":
     - patch_file: "patches/1880-0001-fix-cmake.patch"
       patch_description: "Fix CMake to be more robust & predictable"

--- a/recipes/libyuv/all/conandata.yml
+++ b/recipes/libyuv/all/conandata.yml
@@ -18,6 +18,9 @@ patches:
     - patch_file: "patches/1892-0001-fix-cmake.patch"
       patch_description: "Fix CMake to be more robust & predictable"
       patch_type: "conan"
+    - patch_file: "patches/1892-0001-check-arm-sve.patch"
+      patch_description: "Check if -march=armv9-a+sve2 is supported"
+      patch_type: "conan"
   "1880":
     - patch_file: "patches/1880-0001-fix-cmake.patch"
       patch_description: "Fix CMake to be more robust & predictable"

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -50,9 +50,9 @@ class LibyuvConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9f")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/3.0.3")
+            self.requires("libjpeg-turbo/[~3.0.3]")
         elif self.options.with_jpeg == "mozjpeg":
-            self.requires("mozjpeg/4.1.5")
+            self.requires("mozjpeg/[~4.1.5]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version])

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file
 from conan.tools.microsoft import is_msvc
 import os
 
@@ -65,8 +65,17 @@ class LibyuvConan(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
 
-    def build(self):
+    def _patch_sources(self):
         apply_conandata_patches(self)
+        replace_in_file(
+            self,
+            os.path.join(self.source_folder, "CMakeLists.txt"),
+            "SET(CMAKE_POSITION_INDEPENDENT_CODE ON)",
+            "",
+        )
+
+    def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -51,7 +51,7 @@ class LibyuvConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9f")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/[~3.0.3]")
+            self.requires("libjpeg-turbo/[>=3.0.3 <4]")
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/[~4.1.5]")
 

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -53,7 +53,7 @@ class LibyuvConan(ConanFile):
         elif self.options.with_jpeg == "libjpeg-turbo":
             self.requires("libjpeg-turbo/[>=3.0.3 <4]")
         elif self.options.with_jpeg == "mozjpeg":
-            self.requires("mozjpeg/[~4.1.5]")
+            self.requires("mozjpeg/4.1.5")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version])

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -49,7 +49,7 @@ class LibyuvConan(ConanFile):
 
     def requirements(self):
         if self.options.with_jpeg == "libjpeg":
-            self.requires("libjpeg/9f")
+            self.requires("libjpeg/9e")
         elif self.options.with_jpeg == "libjpeg-turbo":
             self.requires("libjpeg-turbo/[>=3.0.3 <4]")
         elif self.options.with_jpeg == "mozjpeg":

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -67,12 +68,13 @@ class LibyuvConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        replace_in_file(
-            self,
-            os.path.join(self.source_folder, "CMakeLists.txt"),
-            "SET(CMAKE_POSITION_INDEPENDENT_CODE ON)",
-            "",
-        )
+        if Version(self.version) >= "1892":
+            replace_in_file(
+                self,
+                os.path.join(self.source_folder, "CMakeLists.txt"),
+                "SET(CMAKE_POSITION_INDEPENDENT_CODE ON)",
+                "",
+            )
 
     def build(self):
         self._patch_sources()

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -68,7 +68,7 @@ class LibyuvConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        if Version(self.version) >= "1892":
+        if Version(self.version) >= "1892" and not self.options.get_safe("fPIC"):
             replace_in_file(
                 self,
                 os.path.join(self.source_folder, "CMakeLists.txt"),

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -48,11 +48,11 @@ class LibyuvConan(ConanFile):
 
     def requirements(self):
         if self.options.with_jpeg == "libjpeg":
-            self.requires("libjpeg/9e")
+            self.requires("libjpeg/9f")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/3.0.1")
+            self.requires("libjpeg-turbo/3.0.3")
         elif self.options.with_jpeg == "mozjpeg":
-            self.requires("mozjpeg/4.1.3")
+            self.requires("mozjpeg/4.1.5")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version])

--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -68,7 +68,10 @@ class LibyuvConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        if Version(self.version) >= "1892" and not self.options.get_safe("fPIC"):
+
+        # remove default CMAKE_POSITION_INDEPENDENT_CODE if not requested
+        use_fpic = self.options.get_safe("fPIC") or self.options.get_safe("shared")
+        if Version(self.version) >= "1892" and not use_fpic:
             replace_in_file(
                 self,
                 os.path.join(self.source_folder, "CMakeLists.txt"),

--- a/recipes/libyuv/all/patches/1892-0001-check-arm-sve.patch
+++ b/recipes/libyuv/all/patches/1892-0001-check-arm-sve.patch
@@ -1,0 +1,48 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -107,25 +107,38 @@ if(NOT MSVC)
+     TARGET_COMPILE_OPTIONS(${ly_lib_name}_neon64 PRIVATE -march=armv8-a+dotprod+i8mm)
+     LIST(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_neon64>)
+ 
+-    # Enable AArch64 SVE kernels.
+-    ADD_LIBRARY(${ly_lib_name}_sve OBJECT
+-      ${ly_src_dir}/row_sve.cc)
+-    TARGET_COMPILE_OPTIONS(${ly_lib_name}_sve PRIVATE -march=armv9-a+sve2)
+-    LIST(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_sve>)
+-
+     set(OLD_CMAKE_REQURED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+     set(OLD_CMAKE_TRY_COMPILE_TARGET_TYPE ${CMAKE_TRY_COMPILE_TARGET_TYPE})
+-    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -march=armv9-a+sme")
++
++    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQURED_FLAGS} -march=armv9-a+sve2")
+     set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
++    # Check whether the compiler can compile SVE functions; this fails
++    # with Clang for macOS.
++    check_c_source_compiles("
++int main(void) { return 0; }
++    " CAN_COMPILE_SVE)
++
++    set(CMAKE_REQUIRED_FLAGS "${OLD_CMAKE_REQURED_FLAGS} -march=armv9-a+sme")
+     # Check whether the compiler can compile SME functions; this fails
+     # with Clang for Windows.
+     check_c_source_compiles("
+ __arm_locally_streaming void func(void) { }
+ int main(void) { return 0; }
+     " CAN_COMPILE_SME)
++
+     set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQURED_FLAGS})
+     set(CMAKE_TRY_COMPILE_TARGET_TYPE ${OLD_CMAKE_TRY_COMPILE_TARGET_TYPE})
+ 
++    # Enable AArch64 SVE kernels.
++    if (CAN_COMPILE_SVE)
++      ADD_LIBRARY(${ly_lib_name}_sve OBJECT
++        ${ly_src_dir}/row_sve.cc)
++      TARGET_COMPILE_OPTIONS(${ly_lib_name}_sve PRIVATE -march=armv9-a+sve2)
++      LIST(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_sve>)
++    else()
++      ADD_DEFINITIONS(-DLIBYUV_DISABLE_SVE)
++    endif()
++
+     if (CAN_COMPILE_SME)
+       # Enable AArch64 SME kernels.
+       ADD_LIBRARY(${ly_lib_name}_sme OBJECT

--- a/recipes/libyuv/all/patches/1892-0001-fix-cmake.patch
+++ b/recipes/libyuv/all/patches/1892-0001-fix-cmake.patch
@@ -1,0 +1,67 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,8 +4,8 @@
+ 
+ include(CheckCSourceCompiles)
+ 
++CMAKE_MINIMUM_REQUIRED( VERSION 3.8 )
+ PROJECT ( YUV C CXX )	# "C" is required even for C++ projects
+-CMAKE_MINIMUM_REQUIRED( VERSION 2.8.12 )
+ OPTION( UNIT_TEST "Built unit tests" OFF )
+ 
+ SET ( ly_base_dir	${PROJECT_SOURCE_DIR} )
+@@ -139,15 +139,10 @@ int main(void) { return 0; }
+ endif()
+ 
+ # this creates the static library (.a)
+-ADD_LIBRARY( ${ly_lib_static} STATIC ${ly_lib_parts})
++ADD_LIBRARY( ${ly_lib_static} ${ly_lib_parts})
++target_compile_features(${ly_lib_static} PUBLIC cxx_std_11)
+ 
+ # this creates the shared library (.so)
+-ADD_LIBRARY( ${ly_lib_shared} SHARED ${ly_lib_parts})
+-SET_TARGET_PROPERTIES( ${ly_lib_shared} PROPERTIES OUTPUT_NAME "${ly_lib_name}" )
+-SET_TARGET_PROPERTIES( ${ly_lib_shared} PROPERTIES PREFIX "lib" )
+-if(WIN32)
+-  SET_TARGET_PROPERTIES( ${ly_lib_shared} PROPERTIES IMPORT_PREFIX "lib" )
+-endif()
+ 
+ # this creates the cpuid tool
+ ADD_EXECUTABLE      ( cpuid ${ly_base_dir}/util/cpuid.c )
+@@ -160,12 +155,18 @@ TARGET_LINK_LIBRARIES	( yuvconvert ${ly_lib_static} )
+ # this creates the yuvconstants tool
+ ADD_EXECUTABLE      ( yuvconstants ${ly_base_dir}/util/yuvconstants.c )
+ TARGET_LINK_LIBRARIES  ( yuvconstants ${ly_lib_static} )
++include(CheckFunctionExists)
++check_function_exists(round HAVE_MATH_SYSTEM)
++if(NOT HAVE_MATH_SYSTEM)
++  target_link_libraries(yuvconstants m)
++endif()
+ 
+-find_package ( JPEG )
+-if (JPEG_FOUND)
+-  include_directories( ${JPEG_INCLUDE_DIR} )
+-  target_link_libraries( ${ly_lib_shared} ${JPEG_LIBRARY} )
+-  add_definitions( -DHAVE_JPEG )
++option(LIBYUV_WITH_JPEG "Build libyuv with jpeg" ON)
++if (LIBYUV_WITH_JPEG)
++  find_package(JPEG REQUIRED)
++  target_link_libraries(${ly_lib_static} JPEG::JPEG )
++  target_compile_definitions(${ly_lib_static} PRIVATE HAVE_JPEG)
++  target_compile_definitions(yuvconvert PRIVATE HAVE_JPEG)
+ endif()
+ 
+ if(UNIT_TEST)
+@@ -211,10 +212,8 @@ endif()
+ 
+ 
+ # install the conversion tool, .so, .a, and all the header files
+-INSTALL ( PROGRAMS ${CMAKE_BINARY_DIR}/yuvconvert			DESTINATION bin )
+-INSTALL ( TARGETS ${ly_lib_static}						DESTINATION lib )
+-INSTALL ( TARGETS ${ly_lib_shared} LIBRARY				DESTINATION lib RUNTIME DESTINATION bin )
++INSTALL ( TARGETS yuvconvert yuvconstants DESTINATION bin)
++INSTALL ( TARGETS ${ly_lib_static} RUNTIME DESTINATION bin ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
+ INSTALL ( DIRECTORY ${PROJECT_SOURCE_DIR}/include/		DESTINATION include )
+ 
+ # create the .deb and .rpm packages using cpack
+-INCLUDE ( CM_linux_packages.cmake )

--- a/recipes/libyuv/config.yml
+++ b/recipes/libyuv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1892":
+    folder: all
   "1880":
     folder: all
   "1854":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libyuv/1892**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Libyuv doesn't have a changelog. The main advancements are for ARM support.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
- Updates to 1892 (last commit that modified the version: https://chromium.googlesource.com/libyuv/libyuv/+/4cd90347e78ff76755df2107009e900374aee9cd)
- Updates dependencies to the latest version (only patch updates)
- For ARM, it's checked whether `-march=armv9-a+sve2` is supported by the compiler. This seems to fail on M1 macs (M4 devices should support this from what I understand - not sure why this isn't done in GN)

Full diff (from a GH mirror): https://github.com/lemenkov/libyuv/compare/fb6341d326846fbbe669ad5173e520f66b339621...4cd90347e78ff76755df2107009e900374aee9cd

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
