### PR TITLE
libinterpolate: Add support for Mac

### DIFF
--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -39,8 +39,8 @@ class PackageConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.80.0", transitive_headers=True)
-        self.requires("eigen/3.3.7", transitive_headers=True)
+        self.requires("boost/1.85.0", transitive_headers=True)
+        self.requires("eigen/3.4.0", transitive_headers=True)
 
     def package_id(self):
         self.info.clear()
@@ -48,7 +48,7 @@ class PackageConan(ConanFile):
     def validate(self):
         if Version(self.version) < "2.6.4" and self.settings.os != "Linux":
             raise ConanInvalidConfiguration(f"{self.ref} is not supported by {self.settings.os}; Try the version >= 2.6.4")
-        if Version(self.version) >= "2.6.4" and self.settings.os not in ["Linux", "Windows"]:
+        if Version(self.version) >= "2.6.4" and self.settings.os not in ["Linux", "Windows", "Macos"]:
             raise ConanInvalidConfiguration(f"{self.ref} is not supported by {self.settings.os}.")
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)

--- a/recipes/libinterpolate/all/test_package/CMakeLists.txt
+++ b/recipes/libinterpolate/all/test_package/CMakeLists.txt
@@ -5,3 +5,4 @@ find_package(libInterpolate REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE libInterpolate::Interpolate)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)


### PR DESCRIPTION
### Summary
Changes to recipe:  **libinterpolate/2.6.4**

#### Motivation

The issue #24571 is about asking to add for Mac when consuming libinterpolate. The author agreed adding support for Mac: https://github.com/conan-io/conan-center-index/issues/24571#issuecomment-2223614114

/cc @thomas-harries-hasselbalch-maersk @CD3 

closes #24574
closes #24571

#### Details

The project is indeed working with Mac, we can prove it now by the CI integrated in the upstream: https://github.com/CD3/libInterpolate/actions/workflows/mac-clang.yml

I updated the dependencies versions, it should not conflict CCI, because no other package is consuming libinterpolate directly. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
