### PR TITLE
opendis6: Deprecate in favor of libsersi

### DIFF
--- a/recipes/opendis6/all/conandata.yml
+++ b/recipes/opendis6/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.1.0":
     url: "https://github.com/crhowell3/libdis6/archive/dc1cd3bffdffcabf13b237f270d92cfebf45717c.tar.gz"
-    sha256: "3079f3bafa8f90c563ea2a0796cfff9516237a0f014d137f5bcd47c6d51136ce"
+    sha256: "ba519c5421ff63b61893c2d06b3411d0f8a8ea9a90e5a78372f5bd7ec33c7d80"

--- a/recipes/opendis6/all/conandata.yml
+++ b/recipes/opendis6/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.1.0":
-    url: "https://github.com/crhowell3/opendis6/archive/refs/tags/0.1.0.tar.gz"
-    sha256: "7acfd6ecdcea03c75f93834c4e8ad532aee03eb0fdd2736c9095e2d548214125"
+    url: "https://github.com/crhowell3/libdis6/archive/dc1cd3bffdffcabf13b237f270d92cfebf45717c.tar.gz"
+    sha256: "3079f3bafa8f90c563ea2a0796cfff9516237a0f014d137f5bcd47c6d51136ce"

--- a/recipes/opendis6/all/conanfile.py
+++ b/recipes/opendis6/all/conanfile.py
@@ -26,6 +26,8 @@ class OpenDis6Conan(ConanFile):
         "shared": False,
         "fPIC": True
     }
+    provides = "libdis6"
+    deprecated = "libdis6"
 
     @property
     def _min_cppstd(self):
@@ -63,7 +65,7 @@ class OpenDis6Conan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.22 <4]")
-    
+
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)
@@ -90,6 +92,6 @@ class OpenDis6Conan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "OpenDIS")
         self.cpp_info.set_property("cmake_target_name", "OpenDIS::OpenDIS6")
         self.cpp_info.set_property("cmake_target_aliases", ["OpenDIS::DIS6","OpenDIS6"])
-        
+
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/opendis6/all/conanfile.py
+++ b/recipes/opendis6/all/conanfile.py
@@ -26,8 +26,8 @@ class OpenDis6Conan(ConanFile):
         "shared": False,
         "fPIC": True
     }
-    provides = "libdis6"
-    deprecated = "libdis6"
+    provides = "libsersi"
+    deprecated = "libsersi"
 
     @property
     def _min_cppstd(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **opendis6/0.1.0**

#### Motivation

The author decided to rename the project to avoid name collision.

#### Details

The CI have limitations when renaming packages, so we will first mark this one as deprecated, then, open a second PR only adding a the new recipe.

/cc @crhowell3

Related to #24487

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
