### PR TITLE
libdis6: Add recipe based on opendis6

### DIFF
--- a/recipes/libdis6/all/conandata.yml
+++ b/recipes/libdis6/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/crhowell3/libdis6/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "3079f3bafa8f90c563ea2a0796cfff9516237a0f014d137f5bcd47c6d51136ce"

--- a/recipes/libdis6/all/conanfile.py
+++ b/recipes/libdis6/all/conanfile.py
@@ -1,0 +1,95 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.53.0"
+
+class libdis6Conan(ConanFile):
+    name = "libdis6"
+    homepage = "https://github.com/crhowell3/libdis6"
+    description = "Modern C++ implementation of IEEE 1278.1a-1998"
+    topics = ("library", "protocol", "dis")
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "BSD-2-Clause"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True
+    }
+
+    @property
+    def _min_cppstd(self):
+        return "14"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15",
+            "msvc": "191",
+            "gcc": "7",
+            "clang": "7",
+            "apple-clang": "10",
+        }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_EXAMPLES"] = False
+        tc.cache_variables["BUILD_TESTS"] = False
+        tc.generate()
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.22 <4]")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "res"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["dis6"]
+        self.cpp_info.set_property("cmake_file_name", "libdis6")
+        self.cpp_info.set_property("cmake_target_name", "libdis6::dis6")
+        self.cpp_info.set_property("cmake_target_aliases", ["libdis6::dis6","dis6"])
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")

--- a/recipes/libdis6/all/test_package/CMakeLists.txt
+++ b/recipes/libdis6/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(libdis6 CONFIG REQUIRED)
+
+add_executable(test_package_dis test_package.cpp)
+target_link_libraries(test_package_dis PRIVATE libdis6::dis6)
+set_target_properties(test_package_dis PROPERTIES CXX_STANDARD 14)

--- a/recipes/libdis6/all/test_package/conanfile.py
+++ b/recipes/libdis6/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0],
+                     "test_package_dis"), env="conanrun")

--- a/recipes/libdis6/all/test_package/test_package.cpp
+++ b/recipes/libdis6/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include "libdis6/entity_information/EntityStatePdu.h"
+
+int main() {
+  dis::EntityStatePdu pdu1, pdu2;
+
+  dis::DataStream ds(dis::kBig);
+  pdu1.Marshal(ds);
+  pdu2.Unmarshal(ds);
+
+  std::cout << "Success\n";
+  return EXIT_SUCCESS;
+}

--- a/recipes/libdis6/config.yml
+++ b/recipes/libdis6/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdis6/0.1.0**

#### Motivation

The author decided to rename the project to avoid name collision. See #24487 

#### Details

The CI have limitations when renaming packages, so we need to open this PR only adding a the new recipe name.

/cc @crhowell3

closes #24487

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
