### PR TITLE
glib: Bump libselinux from 3.5 to 3.6 to avoid conflicts

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -72,7 +72,7 @@ class GLibConan(ConanFile):
         if self.options.get_safe("with_mount"):
             self.requires("libmount/2.39")
         if self.options.get_safe("with_selinux"):
-            self.requires("libselinux/3.5")
+            self.requires("libselinux/3.6")
         if self.settings.os != "Linux":
             # for Linux, gettext is provided by libc
             self.requires("libgettext/0.22", transitive_headers=True, transitive_libs=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **glib/***

#### Motivation
Both libsystemd and eudev use libselinux 3.6.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
