### PR TITLE
mongo-cxx-driver: add version 3.10.2

### DIFF
--- a/recipes/mongo-cxx-driver/all/conandata.yml
+++ b/recipes/mongo-cxx-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.10.2":
+    url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.10.2/mongo-cxx-driver-r3.10.2.tar.gz"
+    sha256: "52b99b2866019b5ea25d15c5a39e2a88c70fe1259c40f1091deff8bfae0194be"
   "3.10.1":
     url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.10.1/mongo-cxx-driver-r3.10.1.tar.gz"
     sha256: "0297d9d1a513f09438cc05254b14baa49edd1fa64a6ce5d7a80a1eb7677cf2be"
@@ -27,6 +30,13 @@ sources:
     url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.1/mongo-cxx-driver-r3.6.1.tar.gz"
     sha256: "83523e897ef18f7ce05d85d1632dd4ba486c264a1b89c09020163ab29e11eab7"
 patches:
+  "3.10.2":
+    - patch_file: "patches/3.10.2-0001-dirs.patch"
+      patch_description: "disable documentation features, fix directories"
+      patch_type: "conan"
+    - patch_file: "patches/3.10.1-0002-remove-abi-suffixes.patch"
+      patch_description: "remove abi suffixes for MSVC"
+      patch_type: "conan"
   "3.10.1":
     - patch_file: "patches/3.10.1-0001-dirs.patch"
       patch_description: "disable documentation features, fix directories"

--- a/recipes/mongo-cxx-driver/all/patches/3.10.2-0001-dirs.patch
+++ b/recipes/mongo-cxx-driver/all/patches/3.10.2-0001-dirs.patch
@@ -1,0 +1,57 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6d612a4..5b3f872 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -279,7 +279,7 @@ unset(dist_generated_depends CACHE)
+ set(BUILD_SOURCE_DIR ${CMAKE_BINARY_DIR})
+ 
+ include(MakeDistFiles)
+-
++if(FALSE)
+ add_custom_target(hugo_dir
+     COMMAND ${CMAKE_COMMAND} -E make_directory hugo
+ )
+@@ -335,7 +335,7 @@ add_custom_target(format-lint
+ add_custom_target(docs
+     DEPENDS hugo doxygen-current
+ )
+-
++endif()
+ set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
+ set(DATA_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
+ 
+@@ -348,10 +348,10 @@ endif()
+ 
+ add_subdirectory(src)
+ 
+-add_subdirectory(examples EXCLUDE_FROM_ALL)
+-
+-add_subdirectory(benchmark EXCLUDE_FROM_ALL)
++# add_subdirectory(examples EXCLUDE_FROM_ALL)
+ 
++# add_subdirectory(benchmark EXCLUDE_FROM_ALL)
++if(FALSE)
+ # Implement 'dist' target
+ #
+ # CMake does not implement anything like 'dist' from autotools.
+@@ -489,3 +489,4 @@ endif()
+ if(CMAKE_GENERATOR_TOOLSET)
+     message(STATUS "\tinstance: ${CMAKE_GENERATOR_TOOLSET}")
+ endif()
++endif()
+\ No newline at end of file
+diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
+index ce53a71..90c4fd2 100644
+--- a/src/bsoncxx/CMakeLists.txt
++++ b/src/bsoncxx/CMakeLists.txt
+@@ -93,8 +93,8 @@ if(TARGET bson_shared OR TARGET bson_static)
+     set(BSONCXX_PKG_DEP "find_dependency(bson-${LIBBSON_REQUIRED_ABI_VERSION} REQUIRED)")
+ else()
+     # Attempt to find libbson by new package name (without lib).
+-    find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} QUIET)
+-
++    find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} REQUIRED)
++    set(bson-${LIBBSON_REQUIRED_ABI_VERSION}_FOUND TRUE)
+     if(bson-${LIBBSON_REQUIRED_ABI_VERSION}_FOUND)
+         message(STATUS "found libbson version ${bson-${LIBBSON_REQUIRED_ABI_VERSION}_VERSION}")
+ 

--- a/recipes/mongo-cxx-driver/config.yml
+++ b/recipes/mongo-cxx-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.10.2":
+    folder: all
   "3.10.1":
     folder: all
   "3.8.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mongo-cxx-driver/3.10.2**

#### Motivation
Try to fix https://github.com/conan-io/conan-center-index/issues/24451.

#### Details
https://github.com/mongodb/mongo-cxx-driver/compare/r3.10.1...r3.10.2#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
