### PR TITLE
trompeloeil: add version 48

### DIFF
--- a/recipes/trompeloeil/all/conandata.yml
+++ b/recipes/trompeloeil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "48":
+    url: "https://github.com/rollbear/trompeloeil/archive/v48.tar.gz"
+    sha256: "eebd18456975251ea3450b815e241cccfefba5b883e4a36bd309f9cf629bdec6"
   "47":
     url: "https://github.com/rollbear/trompeloeil/archive/v47.tar.gz"
     sha256: "4a1d79260c1e49e065efe0817c8b9646098ba27eed1802b0c3ba7d959e4e5e84"

--- a/recipes/trompeloeil/config.yml
+++ b/recipes/trompeloeil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "48":
+    folder: all
   "47":
     folder: all
   "46":


### PR DESCRIPTION
### Summary
Changes to recipe:  **trompeloeil/48**

#### Motivation
There are several improvements in 48.

#### Details
https://github.com/rollbear/trompeloeil/compare/v47...v48

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
