### PR TITLE
libx265: Disable assembly when building for Android

### DIFF
--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -83,7 +83,7 @@ class Libx265Conan(ConanFile):
             # "x265::setupAssemblyPrimitives(x265::EncoderPrimitives&, int)", referenced from:
             # x265::x265_setup_primitives(x265_param*) in libx265.a[20](primitives.cpp.o)
             # ld: symbol(s) not found for architecture arm64
-            raise ConanInvalidConfiguration(f"{self.ref} does not support Mac M1.")
+            raise ConanInvalidConfiguration(f"{self.ref} fails to build for Mac M1. Contributions are welcome.")
 
     def build_requirements(self):
         if self.options.assembly:

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -78,7 +78,7 @@ class Libx265Conan(ConanFile):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration("shared not supported with static runtime")
 
-        if self.settings.compiler == "apple-clang" and "arm" in self.settings.arch:
+        if self.settings.compiler == "apple-clang" and "arm" in self.settings.arch and self.options.assembly:
             # Undefined symbols for architecture arm64:
             # "x265::setupAssemblyPrimitives(x265::EncoderPrimitives&, int)", referenced from:
             # x265::x265_setup_primitives(x265_param*) in libx265.a[20](primitives.cpp.o)

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -78,6 +78,13 @@ class Libx265Conan(ConanFile):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration("shared not supported with static runtime")
 
+        if self.settings.compiler == "apple-clang" and "arm" in self.settings.arch:
+            # Undefined symbols for architecture arm64:
+            # "x265::setupAssemblyPrimitives(x265::EncoderPrimitives&, int)", referenced from:
+            # x265::x265_setup_primitives(x265_param*) in libx265.a[20](primitives.cpp.o)
+            # ld: symbol(s) not found for architecture arm64
+            raise ConanInvalidConfiguration(f"{self.ref} does not support Mac M1.")
+
     def build_requirements(self):
         if self.options.assembly:
             if self.settings.arch in ["x86", "x86_64"]:

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -49,7 +49,8 @@ class Libx265Conan(ConanFile):
             del self.options.with_numa
         # FIXME: Disable assembly by default if host is arm and compiler apple-clang for the moment.
         # Indeed, apple-clang is not able to understand some asm instructions of libx265
-        if self.settings.compiler == "apple-clang" and "arm" in self.settings.arch:
+        # FIXME: Disable assembly by default if host is Android for the moment. It fails to build
+        if (self.settings.compiler == "apple-clang" and "arm" in self.settings.arch) or self.settings.os == "Android":
             self.options.assembly = False
 
     def configure(self):
@@ -62,6 +63,16 @@ class Libx265Conan(ConanFile):
     def requirements(self):
         if self.options.get_safe("with_numa", False):
             self.requires("libnuma/2.0.14")
+
+    def validate_build(self):
+        if cross_building(self) and self.settings.os == "Android" and self.options.assembly:
+            # FIXME: x265 uses custom command to invoke clang to compile assembly files.
+            #   clang++ -fPIC -c src/source/common/aarch64/mc-a.S -o mc-a.S.o
+            #   FAILED: mc-a.S.o libx2f309356bd8526/b/build/Release/mc-a.S.o
+            #   clang++ -fPIC -c src/source/common/aarch64/mc-a.S -o mc-a.S.o
+            #   <instantiation>:11:9: error: unknown directive
+            #           .func x265_pixel_avg_pp_4x4_neon
+            raise ConanInvalidConfiguration(f"{self.ref} fails to build with '&:assembly=True' for Android. Contributions are welcome.")
 
     def validate(self):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
@@ -154,7 +165,10 @@ class Libx265Conan(ConanFile):
             if not self.options.shared:
                 self.cpp_info.sharedlinkflags = ["-Wl,-Bsymbolic,-znoexecstack"]
         elif self.settings.os == "Android":
-            self.cpp_info.libs.extend(["dl", "m"])
-        libcxx = stdcpp_library(self)
-        if libcxx:
-            self.cpp_info.system_libs.append(libcxx)
+            self.cpp_info.system_libs.extend(["dl", "m"])
+        if not self.options.shared:
+            libcxx = stdcpp_library(self)
+            if libcxx:
+                if self.settings.os == "Android" and self.settings.compiler.libcxx == "c++_static":
+                    self.cpp_info.system_libs.append("c++abi")
+                self.cpp_info.system_libs.append(libcxx)


### PR DESCRIPTION
### Summary
Changes to recipe:  **libx265/3.4**

#### Motivation

As reported by the issue #23721 the libx265 fails to be built to Android when using the option value `assembly=True`. This is not only breaking this package, but also affecting ffmpeg directly when cross-building to Android.

It's a known issue reported in the upstream already, but no official solution so far: https://bitbucket.org/multicoreware/x265_git/issues/603/aarch64-assembly-code-failing-when-cross

#### Details

To build assembly code in x265, it's used a custom command in the project, which propagates manually which flags should be used by the compiler, resulting in failure when cross-build to Android-armv8.

Other package managers tried custom patches (including Gentoo) to solve the case, but it still fails for me locally. For instance, when passing target to build assembly code:

```
toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ -fPIC --target=aarch64-none-linux-android32  -c /home/uilian/.conan2/p/b/libx2c4053feaf82aa/b/src/source/common/aarch64/mc-a.S -o mc-a.S.o
<instantiation>:11:9: error: unknown directive
        .func x265_pixel_avg_pp_4x4_neon
        ^
<instantiation>:1:1: note: while in macro instantiation
function x265_pixel_avg_pp_4x4_neon
^
/home/uilian/.conan2/p/b/libx2c4053feaf82aa/b/src/source/common/aarch64/mc-a.S:44:1: note: while in macro instantiation
pixel_avg_pp_4xN_neon 4
^
<instantiation>:2:9: error: unknown directive
        .endfunc
        ^
```

I'll be disabling assembly for now, but keeping it open for contributions, as didn't remove the option.

Full build log for Android with this new change: https://gist.github.com/uilianries/971fc896b481170ee311ac6e9eb35152

closes #23721

Related to #24566

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
