### PR TITLE
wayland: Add version 1.23.0

### DIFF
--- a/recipes/wayland/all/conandata.yml
+++ b/recipes/wayland/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.23.0":
+    url: "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.0/downloads/wayland-1.23.0.tar.xz"
+    sha256: "05b3e1574d3e67626b5974f862f36b5b427c7ceeb965cb36a4e6c2d342e45ab2"
   "1.22.0":
     url: "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.22.0/downloads/wayland-1.22.0.tar.xz"
     sha256: "1540af1ea698a471c2d8e9d288332c7e0fd360c8f1d12936ebb7e7cbc2425842"

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -60,7 +60,7 @@ class WaylandConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("meson/1.4.0")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/2.2.0")
         if not can_run(self):
             self.tool_requires(str(self.ref))
 

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -58,7 +58,7 @@ class WaylandConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} only supports Linux")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.4.0")
+        self.tool_requires("meson/[>=1.4.0 <2]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.2.0")
         if not can_run(self):

--- a/recipes/wayland/all/test_package/conanfile.py
+++ b/recipes/wayland/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout, CMakeDeps, CMakeToolchain
-from conan.tools.env import VirtualBuildEnv
+from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.gnu import PkgConfig, PkgConfigDeps
 
 
@@ -21,7 +21,7 @@ class TestPackageConan(ConanFile):
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/2.2.0")
 
     def layout(self):
         cmake_layout(self)
@@ -38,6 +38,10 @@ class TestPackageConan(ConanFile):
         pkg_config_deps.generate()
         virtual_build_env = VirtualBuildEnv(self)
         virtual_build_env.generate()
+        if self._has_build_profile:
+            env = Environment()
+            env.append_path("PKG_CONFIG_PATH", self.generators_folder)
+            env.vars(self).save_script("conanbuild_cmake")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/wayland/config.yml
+++ b/recipes/wayland/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.23.0":
+    folder: all
   "1.22.0":
     folder: all
   "1.21.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **wayland/1.23.0**

#### Motivation
The latest release of the Wayland library is now available.

#### Details
Add version 1.23.0.
Bump `pkgconf`.
Use a version range for Meson.

Fix the following error from the test package when cross-compiling the Wayland package with Conan 2.5.0.

```
Package wayland-scanner_BUILD was not found in the pkg-config search path.
Perhaps you should add the directory containing `wayland-scanner_BUILD.pc'
to the PKG_CONFIG_PATH environment variable
Package 'wayland-scanner_BUILD' not found
ERROR: wayland/1.23.0 (test package): Error in build() method, line 52
	wayland_scanner = pkg_config.variables["wayland_scanner"]
	ConanException: Error 1 while executing
```

The fix was to set the `PKG_CONFIG_PATH` environment for some reason.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
