### PR TITLE
quiche: initial commit

### DIFF
--- a/recipes/quiche/all/conandata.yml
+++ b/recipes/quiche/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "0.22.0":
+    url:
+      - "https://github.com/cloudflare/quiche/archive/refs/tags/0.22.0.zip"
+    sha256: "201b6834b65c06766f9db86edaae06297f751cd36f907c94e6c04460dc2c0aff"

--- a/recipes/quiche/all/conanfile.py
+++ b/recipes/quiche/all/conanfile.py
@@ -1,0 +1,119 @@
+from conan import ConanFile
+from conan.tools.files import files, get, copy
+from conan.tools.scm import Git
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.system.package_manager import Apt, PacMan, Brew, Zypper, Yum, Dnf, Apk, Chocolatey
+
+import os
+import subprocess
+import glob
+
+required_conan_version = ">=1.57.0"
+
+def command_exists(command, cmd="which"):
+    return subprocess.call([cmd, command]) == 0
+
+
+class QuciheConan(ConanFile):
+    name = "quiche"
+    description = "🥧 Savoury implementation of the QUIC transport protocol and HTTP/3"
+    url = "https://github.com/cloudflare/quiche"
+    version = "0.22.0"
+
+    license = "BSD-2-Clause"
+    author = "Cloudflare, Inc"
+    topics = ("cloudflare", "quiche", "rust", "quic", "http3")
+
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False], 'FFI': [True, False]}
+    default_options = {"shared": False, "fPIC": True, 'FFI': True}
+
+    package_type = "library"
+
+    def system_requirements(self):
+        Apt(self).install(["cargo"])
+        PacMan(self).install(["rust"])
+        Brew(self).install(["rustup"])
+        Zypper(self).install(["cargo"])
+        Yum(self).install(["rust-toolset"])
+        Dnf(self).install(["rust-toolset"])
+        Apk(self).install(["rust"])
+        Chocolatey(self).install(["rustup.install"])
+
+    def source(self):
+        get (self, **self.conan_data["sources"][self.version], strip_root=False)
+
+        if os.path.exists('src'):
+            files.shutil.rmtree ('src')
+
+        quichesrc = glob.glob ('quiche-*')[0]
+
+        files.rename (self, quichesrc, 'src')
+
+        boringssl = os.path.join ('src', 'quiche', 'deps', 'boringssl')
+
+        if len(os.listdir(boringssl)) == 0:
+            # boringssl not exists! Lets fix that!
+            git = Git(self)
+            git.clone ('https://github.com/google/boringssl.git', boringssl)
+
+    def generate(self):
+        cmd = "which"
+        if self.settings.os == "Windows":
+            cmd = "where"
+        
+        if not command_exists('cargo', cmd):
+            raise ConanInvalidConfiguration ("This project made on rust, so the OS must provide the 'cargo'. Can not find the 'cargo' (which cargo)")
+
+    def build(self):
+        args = ['cargo', 'build', '--manifest-path', os.path.join('src', 'Cargo.toml'), '--lib', '--release']
+
+        if self.options['FFI']:
+            args.append ('--features')
+            args.append ('ffi')
+
+        result = subprocess.call (args)
+
+        if result != 0:
+            raise ConanInvalidConfiguration ("Cargo sent an invalid code. can not compile a src")
+
+    def package_id(self):
+        self.info.clear()
+        
+    def package(self):
+        release = os.path.join ('src', 'target', 'release')
+
+        libpkg = os.path.join (self.package_folder, 'lib')
+        includepkg = os.path.join (self.package_folder, 'include')
+
+        if not os.path.exists(libpkg):
+            os.mkdir (libpkg)
+
+        if not os.path.exists(includepkg):
+            os.mkdir (includepkg)
+
+        include = os.path.join ('src', 'quiche', 'include')
+
+        # lib*
+        for item in glob.glob (os.path.join (release, 'lib*')):
+            result = files.shutil.copy (item, libpkg)
+
+            if len(item) > 3 and item[-3:] == '.so':
+                # workaround
+                os.symlink (result, os.path.join (libpkg, os.path.basename(item) + '.0'))
+
+        for item in glob.glob (os.path.join (release, '*dll')):
+            files.shutil.copy (item, libpkg)
+
+        files.shutil.copy (os.path.join(include, 'quiche.h'), includepkg)
+
+        # License
+        copy (self, 'COPYING', src=os.path.join(self.source_folder, 'src'), dst=os.path.join(self.package_folder, 'licenses', 'quiche'))
+        copy (self, 'LICENSE', src=os.path.join(self.source_folder, 'src', 'quiche', 'deps', 'boringssl'), dst=os.path.join(self.package_folder, 'licenses', 'boringssl'))
+    def package_info(self):
+        self.cpp_info.set_property ("cmake_find_mode", "both")
+        self.cpp_info.set_property ("cmake_file_name", "quiche")
+        self.cpp_info.set_property ("cmake_target_name", "quiche::quiche")
+        self.cpp_info.set_property ("pkg_config_name", "quiche")
+        self.cpp_info.libs = ["quiche"]
+

--- a/recipes/quiche/all/conanfile.py
+++ b/recipes/quiche/all/conanfile.py
@@ -39,19 +39,19 @@ class QuciheConan(ConanFile):
         apt.update()
 
         try:
-            apt.install ("rustup", check=True)
+            apt.install (["rustup"], check=True)
             return
         except:
             print ("Can not install `rustup` deb package")
         
         try:
-            apt.install ("cargo", check=True)
+            apt.install (["cargo"], check=True)
             return
         except:
             print ("Can not install `cargo` deb package")
         
         try:
-            apt.install ("rustc", check=True)
+            apt.install (["rustc"], check=True)
             return
         except:
             print ("Can not install `cargo` deb package")

--- a/recipes/quiche/all/conanfile.py
+++ b/recipes/quiche/all/conanfile.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import glob
 
-required_conan_version = ">=1.57.0"
+required_conan_version = ">=2.4.1"
 
 def command_exists(command, cmd="which"):
     return subprocess.call([cmd, command]) == 0

--- a/recipes/quiche/all/test_package/CMakeLists.txt
+++ b/recipes/quiche/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+find_package(quiche REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE quiche::quiche)

--- a/recipes/quiche/all/test_package/conanfile.py
+++ b/recipes/quiche/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/quiche/all/test_package/test_package.cpp
+++ b/recipes/quiche/all/test_package/test_package.cpp
@@ -1,0 +1,28 @@
+#include <quiche.h>
+#include <cstdio>
+
+int main (int argc, char *argv[])
+{
+    auto q_config = quiche_config_new(QUICHE_PROTOCOL_VERSION);
+    quiche_config_set_initial_max_data                      (q_config, 10000000);
+    quiche_config_set_initial_max_stream_data_bidi_local    (q_config, 1000000);
+    quiche_config_set_initial_max_stream_data_bidi_remote   (q_config, 1000000);
+    quiche_config_set_initial_max_stream_data_uni           (q_config, 1000000);
+    quiche_config_set_initial_max_streams_bidi              (q_config, 100);
+    quiche_config_set_initial_max_streams_uni               (q_config, 100);
+    quiche_config_set_disable_active_migration              (q_config, true);
+
+    auto http3_config = quiche_h3_config_new();
+
+    if (http3_config == nullptr) {
+        fprintf(stderr, "failed to create HTTP/3 config\n");
+        return 1;
+    }
+
+    quiche_h3_config_free(http3_config);
+    quiche_config_free(q_config);
+
+    printf ("WELL DONE\n");
+
+    return 0;
+}

--- a/recipes/quiche/all/test_v1_package/CMakeLists.txt
+++ b/recipes/quiche/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/quiche/all/test_v1_package/conanfile.py
+++ b/recipes/quiche/all/test_v1_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/quiche/config.yml
+++ b/recipes/quiche/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.22.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **quiche/0.22.0**

#### Motivation
quiche support via conan

#### Details
[cloudflare quiche](https://github.com/cloudflare/quiche)
quiche requires Rust (cargo)

<details>
<summary>Details</summary>
> conan create all

======== Exporting recipe to the cache ========
quiche/0.22.0: Exporting package recipe: /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/conanfile.py
quiche/0.22.0: exports: File 'conandata.yml' found. Exporting it...
quiche/0.22.0: Copied 1 '.yml' file: conandata.yml
quiche/0.22.0: Copied 1 '.py' file: conanfile.py
quiche/0.22.0: Exported to cache folder: /home/Timur/.conan2/p/quichb9418c7a88e54/e
quiche/0.22.0: Exported: quiche/0.22.0#dc4f88abcfeefb1896bf21d4a261f09c (2024-07-16 05:26:02 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    quiche/0.22.0#dc4f88abcfeefb1896bf21d4a261f09c - Cache

======== Computing necessary packages ========
quiche/0.22.0: Forced build from source
Requirements
    quiche/0.22.0#dc4f88abcfeefb1896bf21d4a261f09c:da39a3ee5e6b4b0d3255bfef95601890afd80709 - Build
Name            : rust
Version         : 1:1.79.0-1
Description     : Systems programming language focused on safety, speed and concurrency
Architecture    : x86_64
URL             : https://www.rust-lang.org/
Licenses        : Apache-2.0 OR MIT
Groups          : None
Provides        : cargo  rustfmt
Depends On      : bash  curl  gcc  gcc-libs  glibc  libssh2  llvm-libs  openssl  zlib
Optional Deps   : gdb: rust-gdb script [installed]
                  lldb: rust-lldb script
Required By     : None
Optional For    : None
Conflicts With  : cargo  rust-docs<1:1.56.1-3  rustfmt
Replaces        : cargo  cargo-tree  rust-docs<1:1.56.1-3  rustfmt
Installed Size  : 256.65 MiB
Packager        : Jan Alexander Steffens (heftig) <heftig@archlinux.org>
Build Date      : Fri 14 Jun 2024 07:26:50 AM +05
Install Date    : Thu 27 Jun 2024 08:01:42 PM +05
Install Reason  : Installed as a dependency for another package
Install Script  : No
Validated By    : Signature

quiche/0.22.0: System requirements:  already installed

======== Installing packages ========
quiche/0.22.0: Calling source() in /home/Timur/.conan2/p/quichb9418c7a88e54/s
quiche/0.22.0: Unzipping 4.6MB, this can take a while
Unzipping 100 %                                                       
quiche/0.22.0: Cloning git repo
quiche/0.22.0: RUN: git clone "<hidden>"  "src/quiche/deps/boringssl"

-------- Installing package quiche/0.22.0 (1 of 1) --------
quiche/0.22.0: Building from source
quiche/0.22.0: Package quiche/0.22.0:da39a3ee5e6b4b0d3255bfef95601890afd80709
quiche/0.22.0: Copying sources to build folder
quiche/0.22.0: Building your package in /home/Timur/.conan2/p/b/quich23f5fb0ae15f0/b
quiche/0.22.0: Calling generate()
quiche/0.22.0: Generators folder: /home/Timur/.conan2/p/b/quich23f5fb0ae15f0/b
/usr/bin/cargo
quiche/0.22.0: Generating aggregated env files
quiche/0.22.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
quiche/0.22.0: Calling build()
    Updating crates.io index
     Locking 118 packages to latest compatible versions
      Adding bindgen v0.68.1 (latest: v0.69.4)
      Adding env_logger v0.10.2 (latest: v0.11.3)
      Adding hermit-abi v0.3.9 (latest: v0.4.0)
      Adding idna v0.1.5 (latest: v1.0.2)
      Adding idna v0.5.0 (latest: v1.0.2)
      Adding mio v0.8.11 (latest: v1.0.0)
      Adding nix v0.27.1 (latest: v0.29.0)
      Adding peeking_take_while v0.1.2 (latest: v1.0.0)
      Adding percent-encoding v1.0.1 (latest: v2.3.1)
      Adding rustc-hash v1.1.0 (latest: v2.0.0)
      Adding strsim v0.10.0 (latest: v0.11.1)
      Adding url v1.7.2 (latest: v2.5.2)
      Adding wasi v0.11.0+wasi-snapshot-preview1 (latest: v0.13.1+wasi-0.2.0)
      Adding windows-sys v0.48.0 (latest: v0.52.0)
      Adding windows-targets v0.48.5 (latest: v0.52.6)
      Adding windows_aarch64_gnullvm v0.48.5 (latest: v0.52.6)
      Adding windows_aarch64_msvc v0.48.5 (latest: v0.52.6)
      Adding windows_i686_gnu v0.48.5 (latest: v0.52.6)
      Adding windows_i686_msvc v0.48.5 (latest: v0.52.6)
      Adding windows_x86_64_gnu v0.48.5 (latest: v0.52.6)
      Adding windows_x86_64_gnullvm v0.48.5 (latest: v0.52.6)
      Adding windows_x86_64_msvc v0.48.5 (latest: v0.52.6)
   Compiling proc-macro2 v1.0.86
   Compiling unicode-ident v1.0.12
   Compiling autocfg v1.3.0
   Compiling libc v0.2.155
   Compiling serde v1.0.204
   Compiling cc v1.1.5
   Compiling ident_case v1.0.1
   Compiling fnv v1.0.7
   Compiling strsim v0.11.1
   Compiling equivalent v1.0.1
   Compiling hashbrown v0.14.5
   Compiling memchr v2.7.4
   Compiling regex-syntax v0.8.4
   Compiling serde_json v1.0.120
   Compiling rust_decimal v1.35.0
   Compiling tinyvec_macros v0.1.1
   Compiling cfg-if v1.0.0
   Compiling tinyvec v1.8.0
   Compiling log v0.4.22
   Compiling cdylib-link-lines v0.1.5
   Compiling arrayvec v0.7.4
   Compiling ryu v1.0.18
   Compiling itoa v1.0.11
   Compiling libm v0.2.8
   Compiling untrusted v0.9.0
   Compiling data-encoding v2.6.0
   Compiling matches v0.1.10
   Compiling unicode-bidi v0.3.15
   Compiling spin v0.9.8
   Compiling bitflags v2.6.0
   Compiling once_cell v1.19.0
   Compiling percent-encoding v1.0.1
   Compiling memoffset v0.9.1
   Compiling num-traits v0.2.19
   Compiling slab v0.4.9
   Compiling lazy_static v1.5.0
   Compiling aho-corasick v1.1.3
   Compiling strsim v0.10.0
   Compiling cmake v0.1.50
   Compiling intrusive-collections v0.9.6
   Compiling quote v1.0.36
   Compiling indexmap v2.2.6
   Compiling humantime v2.1.0
   Compiling unicode-normalization v0.1.23
   Compiling syn v2.0.71
   Compiling termcolor v1.4.1
   Compiling octets v0.3.0 (/home/Timur/.conan2/p/b/quich23f5fb0ae15f0/b/src/octets)
   Compiling getrandom v0.2.15
   Compiling ring v0.17.8
   Compiling quiche v0.22.0 (/home/Timur/.conan2/p/b/quich23f5fb0ae15f0/b/src/quiche)
   Compiling is-terminal v0.4.12
   Compiling idna v0.1.5
   Compiling either v1.13.0
   Compiling mio v0.8.11
   Compiling nix v0.27.1
   Compiling regex-automata v0.4.7
   Compiling sfv v0.9.4
   Compiling url v1.7.2
   Compiling darling_core v0.20.10
   Compiling regex v1.10.5
   Compiling env_logger v0.10.2
   Compiling serde_derive v1.0.204
   Compiling darling_macro v0.20.10
   Compiling darling v0.20.10
   Compiling serde_with_macros v3.9.0
   Compiling serde_with v3.9.0
   Compiling smallvec v1.13.2
   Compiling docopt v1.1.1
   Compiling qlog v0.13.0 (/home/Timur/.conan2/p/b/quich23f5fb0ae15f0/b/src/qlog)
   Compiling quiche_apps v0.1.0 (/home/Timur/.conan2/p/b/quich23f5fb0ae15f0/b/src/apps)
    Finished `release` profile [optimized + debuginfo] target(s) in 39.11s
quiche/0.22.0: Package 'da39a3ee5e6b4b0d3255bfef95601890afd80709' built
quiche/0.22.0: Build folder /home/Timur/.conan2/p/b/quich23f5fb0ae15f0/b
quiche/0.22.0: Generating the package
quiche/0.22.0: Packaging in folder /home/Timur/.conan2/p/b/quich23f5fb0ae15f0/p
quiche/0.22.0: Calling package()
quiche/0.22.0: package(): Packaged 4 '.rlib' files: liboctets.rlib, libqlog.rlib, libquiche.rlib, libquiche_apps.rlib
quiche/0.22.0: package(): Packaged 1 '.a' file: libquiche.a
quiche/0.22.0: package(): Packaged 1 '.so' file: libquiche.so
quiche/0.22.0: package(): Packaged 1 '.0' file: libquiche.so.0
quiche/0.22.0: package(): Packaged 4 '.d' files: liboctets.d, libqlog.d, libquiche.d, libquiche_apps.d
quiche/0.22.0: package(): Packaged 1 '.h' file: quiche.h
quiche/0.22.0: package(): Packaged 2 files: COPYING, LICENSE
quiche/0.22.0: Created package revision 87af1739749b8d0f9d27819d36f75783
quiche/0.22.0: Package 'da39a3ee5e6b4b0d3255bfef95601890afd80709' created
quiche/0.22.0: Full package reference: quiche/0.22.0#dc4f88abcfeefb1896bf21d4a261f09c:da39a3ee5e6b4b0d3255bfef95601890afd80709#87af1739749b8d0f9d27819d36f75783
quiche/0.22.0: Package folder /home/Timur/.conan2/p/b/quich23f5fb0ae15f0/p

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    quiche/0.22.0 (test package): /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/conanfile.py
Requirements
    quiche/0.22.0#dc4f88abcfeefb1896bf21d4a261f09c - Cache

======== Computing necessary packages ========
Requirements
    quiche/0.22.0#dc4f88abcfeefb1896bf21d4a261f09c:da39a3ee5e6b4b0d3255bfef95601890afd80709#87af1739749b8d0f9d27819d36f75783 - Cache
Name            : rust
Version         : 1:1.79.0-1
Description     : Systems programming language focused on safety, speed and concurrency
Architecture    : x86_64
URL             : https://www.rust-lang.org/
Licenses        : Apache-2.0 OR MIT
Groups          : None
Provides        : cargo  rustfmt
Depends On      : bash  curl  gcc  gcc-libs  glibc  libssh2  llvm-libs  openssl  zlib
Optional Deps   : gdb: rust-gdb script [installed]
                  lldb: rust-lldb script
Required By     : None
Optional For    : None
Conflicts With  : cargo  rust-docs<1:1.56.1-3  rustfmt
Replaces        : cargo  cargo-tree  rust-docs<1:1.56.1-3  rustfmt
Installed Size  : 256.65 MiB
Packager        : Jan Alexander Steffens (heftig) <heftig@archlinux.org>
Build Date      : Fri 14 Jun 2024 07:26:50 AM +05
Install Date    : Thu 27 Jun 2024 08:01:42 PM +05
Install Reason  : Installed as a dependency for another package
Install Script  : No
Validated By    : Signature

quiche/0.22.0: System requirements:  already installed

======== Installing packages ========
quiche/0.22.0: Already installed! (1 of 1)

======== Testing the package ========
Removing previously existing 'test_package' build folder: /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/build/gcc-14-x86_64-gnu17-release
quiche/0.22.0 (test package): Test package build: build/gcc-14-x86_64-gnu17-release
quiche/0.22.0 (test package): Test package build folder: /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/build/gcc-14-x86_64-gnu17-release
quiche/0.22.0 (test package): Writing generators to /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/build/gcc-14-x86_64-gnu17-release/generators
quiche/0.22.0 (test package): Generator 'CMakeDeps' calling 'generate()'
quiche/0.22.0 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(quiche)
    target_link_libraries(... quiche::quiche)
quiche/0.22.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
quiche/0.22.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
quiche/0.22.0 (test package): CMakeToolchain generated: /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/build/gcc-14-x86_64-gnu17-release/generators/CMakePresets.json
quiche/0.22.0 (test package): CMakeToolchain generated: /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/CMakeUserPresets.json
quiche/0.22.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
quiche/0.22.0 (test package): Generating aggregated env files
quiche/0.22.0 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
quiche/0.22.0 (test package): Calling build()
quiche/0.22.0 (test package): Running CMake.configure()
quiche/0.22.0 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package"
-- Using Conan toolchain: /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/build/gcc-14-x86_64-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The CXX compiler identification is GNU 14.1.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'quiche::quiche'
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/build/gcc-14-x86_64-gnu17-release

quiche/0.22.0 (test package): Running CMake.build()
quiche/0.22.0 (test package): RUN: cmake --build "/home/Timur/Desktop/WorkSpace/conan-center-index/recipes/quiche/all/test_package/build/gcc-14-x86_64-gnu17-release" -- -j16
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
quiche/0.22.0 (test package): Running test()
quiche/0.22.0 (test package): RUN: ./test_package
WELL DONE
</details>

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
