### PR TITLE
Botan: add version 3.5.0

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -35,6 +35,9 @@ sources:
   "3.4.0":
     url: "https://github.com/randombit/botan/archive/3.4.0.tar.gz"
     sha256: "6ef2a16a0527b1cfc9648a644877f7b95c4d07e8ef237273b030c623418c5e5b"
+  "3.5.0":
+    url: "https://github.com/randombit/botan/archive/3.5.0.tar.gz"
+    sha256: "7d91d3349e6029e1a6929a50ab587f9fd4e29a9af3f3d698553451365564001f"
 patches:
   "2.18.2":
     - patch_file: "patches/fix-amalgamation-build.patch"

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -53,6 +53,8 @@ class BotanConan(ConanFile):
         "with_powercrypto": [True, False],
         "enable_modules": [None, "ANY"],
         "disable_modules": [None, "ANY"],
+        "enable_experimental_features": [True, False],
+        "enable_deprecated_features": [True, False],
         "system_cert_bundle": [None, "ANY"],
         "module_policy": [None, "bsi", "modern", "nist"],
     }
@@ -81,6 +83,8 @@ class BotanConan(ConanFile):
         "with_powercrypto": True,
         "enable_modules": None,
         "disable_modules": None,
+        "enable_experimental_features": False,
+        "enable_deprecated_features": True,
         "system_cert_bundle": None,
         "module_policy": None,
     }
@@ -335,6 +339,20 @@ class BotanConan(ConanFile):
 
         if self._extra_cxxflags:
             botan_extra_cxx_flags.append(self._extra_cxxflags)
+
+        if Version(self.version) >= '3.4':
+            # Botan 3.4.0 introduced a 'module life cycle' feature, before that
+            # the experimental/deprecated feature switches are ignored.
+
+            if self.options.enable_experimental_features:
+                build_flags.append('--enable-experimental-features')
+            else:
+                build_flags.append('--disable-experimental-features')
+
+            if self.options.enable_deprecated_features:
+                build_flags.append('--enable-deprecated-features')
+            else:
+                build_flags.append('--disable-deprecated-features')
 
         if self.options.enable_modules:
             build_flags.append('--minimized-build')

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -23,3 +23,5 @@ versions:
     folder: all
   "3.4.0":
     folder: all
+  "3.5.0":
+    folder: all


### PR DESCRIPTION
### Summary

Adds Botan's [new release 3.5.0](https://github.com/randombit/botan/blob/master/news.rst#version-350-2024-07-08) and introduces recipe options `enable_experimental_features=False` and `enable_deprecated_features=True`.

#### Details

Botan's module system makes use of a basic 'module lifecycle' starting with version 3.5.0 of the library. Modules can be 'experimental', 'stable' or 'deprecated'. This is reflected by the new recipe options `enable_experimental_features` and `enable_deprecated_features`. Their defaults match the defaults of the upstream library: deprecated modules are built, experimentals are not.

Botan 3.5.0 has deprecated a few modules, namely:

| Module name    | Description                                                                                                             |
| -------------- | ----------------------------------------------------------------------------------------------------------------------- |
| dilithium_aes  | Dilithium (to be ML-DSA) with an AES-based XOF (won't be standardized by NIST)                                          |
| dlies          | Discrete Logarithm Integrated Encryption Scheme                                                                         |
| gost_28147     | Russian/Soviet block cipher "Magma" with 64bit blocks, published in 1989                                                |
| gost_3410      | Russian standard for digital signatures based on Elliptic Curves                                                        |
| kyber_90s      | Kyber (to be ML-KEM) using AES and SHA-2 (won't be standardized by NIST)                                                |
| lion           | Block cipher with variable block sizes                                                                                  |
| mce            | McEliece public key cryptosystem (to be [replaced with Classic McEliece](https://github.com/randombit/botan/pull/3883)) |
| md4            | a vintage hash function                                                                                                 |
| noekeon        | a block cipher submitted to the NESSIE project in 2000                                                                  |
| prf_x942       | pseudo-random function defined in ANSI X9.42                                                                            |
| shake_cipher   | SHAKE XOF exposed as a stream cipher. Superseded by `shake_xof`                                                         |
| streebog       | Russian standard (GOST R 34.11-2012) for a hash function                                                                |

In Botan 3.5.0 there are no modules defined as 'experimental'.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
