### PR TITLE
Use version range for libpng in sdl_image recipe

### DIFF
--- a/recipes/sdl_image/all/conanfile.py
+++ b/recipes/sdl_image/all/conanfile.py
@@ -102,7 +102,7 @@ class SDLImageConan(ConanFile):
         if self.options.with_libjpeg:
             self.requires("libjpeg/9e")
         if self.options.with_libpng:
-            self.requires("libpng/1.6.40")
+            self.requires("libpng/[>=1.6 <2]")
         if self.options.with_libwebp:
             self.requires("libwebp/1.3.2")
         if self.options.get_safe("with_avif"):


### PR DESCRIPTION
Closes: https://github.com/conan-io/conan-center-index/issues/24406

Uses the same version range for `sdl_image` for `libpng` [that the one used by freetype](https://github.com/conan-io/conan-center-index/blob/739cf667d599a4d2dcd6a7b53bcc29dc019e38c0/recipes/freetype/all/conanfile.py#L61) that is a requirement of `sdl_ttf` so that we avoid conflicts as much as possible as these libraries are frequently used together.