### PR TITLE
[qt6] Add support for MACOSX_BUNDLE

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -381,7 +381,7 @@ class QtConan(ConanFile):
             else:
                 self.requires("libjpeg/9e")
         if self.options.get_safe("with_libpng", False) and not self.options.multiconfiguration:
-            self.requires("libpng/1.6.42")
+            self.requires("libpng/[>=1.6 <2]")
         if self.options.with_sqlite3 and not self.options.multiconfiguration:
             self.requires("sqlite3/3.45.0")
         if self.options.get_safe("with_mysql", False):
@@ -404,7 +404,7 @@ class QtConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.qtwebengine and self.settings.os in ["Linux", "FreeBSD"]:
-            self.requires("expat/2.6.0")
+            self.requires("expat/[>=2.6.2 <3]")
             self.requires("opus/1.4")
             if not self.options.qtwayland:
                 self.requires("xorg-proto/2022.2")
@@ -445,9 +445,9 @@ class QtConan(ConanFile):
 
     def build_requirements(self):
         if self._settings_build.os == "Windows" and is_msvc(self):
-            self.tool_requires("jom/1.1.3")
+            self.tool_requires("jom/1.1.4")
         if self.options.qtwebengine:
-            self.tool_requires("ninja/1.11.1")
+            self.tool_requires("ninja/1.12.1")
             self.tool_requires("nodejs/18.15.0")
             self.tool_requires("gperf/3.1")
             # gperf, bison, flex, python >= 2.7.5 & < 3

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -445,9 +445,9 @@ class QtConan(ConanFile):
 
     def build_requirements(self):
         if self._settings_build.os == "Windows" and is_msvc(self):
-            self.tool_requires("jom/1.1.4")
+            self.tool_requires("jom/[>=1.1 <2]")
         if self.options.qtwebengine:
-            self.tool_requires("ninja/1.12.1")
+            self.tool_requires("ninja/[>=1.12 <2]")
             self.tool_requires("nodejs/18.15.0")
             self.tool_requires("gperf/3.1")
             # gperf, bison, flex, python >= 2.7.5 & < 3

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -400,9 +400,9 @@ class QtConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.21.1 <4]")
-        self.tool_requires("ninja/1.12.1")
+        self.tool_requires("ninja/[>=1.12 <2]")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.2.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
         if self.settings.os == "Windows":
             self.tool_requires('strawberryperl/5.32.1.1')
 

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -803,6 +803,8 @@ class QtConan(ConanFile):
         if self.settings.os == "Macos":
             save(self, ".qmake.stash", "")
             save(self, ".qmake.super", "")
+            copy(self, "Info.plist.app.in", src=os.path.join(self.package_folder, "lib", "cmake", "Qt6", "macos"),
+                                            dst=os.path.join(self.package_folder, "res", "macos"))
         cmake = CMake(self)
         cmake.install()
         copy(self, "*LICENSE*", self.source_folder, os.path.join(self.package_folder, "licenses"),
@@ -837,6 +839,8 @@ class QtConan(ConanFile):
         filecontents += f"set(QT_VERSION_MAJOR {ver.major})\n"
         filecontents += f"set(QT_VERSION_MINOR {ver.minor})\n"
         filecontents += f"set(QT_VERSION_PATCH {ver.patch})\n"
+        if self.settings.os == "Macos":
+            filecontents += f'set(__qt_internal_cmake_apple_support_files_path "{os.path.join(self.package_folder, "res", "macos")}")\n'
         targets = ["moc", "rcc", "tracegen", "cmake_automoc_parser", "qlalr", "qmake"]
         if self.options.with_dbus:
             targets.extend(["qdbuscpp2xml", "qdbusxml2cpp"])

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -351,7 +351,7 @@ class QtConan(ConanFile):
             else:
                 self.requires("libjpeg/9e")
         if self.options.get_safe("with_libpng", False) and not self.options.multiconfiguration:
-            self.requires("libpng/1.6.42")
+            self.requires("libpng/[>=1.6 <2]")
         if self.options.with_sqlite3 and not self.options.multiconfiguration:
             self.requires("sqlite3/3.45.0")
         if self.options.get_safe("with_mysql", False):
@@ -380,7 +380,7 @@ class QtConan(ConanFile):
         if self.options.with_brotli:
             self.requires("brotli/1.1.0")
         if self.options.get_safe("qtwebengine") and self.settings.os == "Linux":
-            self.requires("expat/2.6.0")
+            self.requires("expat/[>=2.6.2 <3]")
             self.requires("opus/1.4")
             self.requires("xorg-proto/2022.2")
             self.requires("libxshmfence/1.3")
@@ -400,9 +400,9 @@ class QtConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.21.1 <4]")
-        self.tool_requires("ninja/1.11.1")
+        self.tool_requires("ninja/1.12.1")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/2.2.0")
         if self.settings.os == "Windows":
             self.tool_requires('strawberryperl/5.32.1.1')
 

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -840,7 +840,7 @@ class QtConan(ConanFile):
         filecontents += f"set(QT_VERSION_MINOR {ver.minor})\n"
         filecontents += f"set(QT_VERSION_PATCH {ver.patch})\n"
         if self.settings.os == "Macos":
-            filecontents += f'set(__qt_internal_cmake_apple_support_files_path "{os.path.join(self.package_folder, "res", "macos")}")\n'
+            filecontents += f'set(__qt_internal_cmake_apple_support_files_path "${{CMAKE_CURRENT_LIST_DIR}}/../../../res/macos")\n'
         targets = ["moc", "rcc", "tracegen", "cmake_automoc_parser", "qlalr", "qmake"]
         if self.options.with_dbus:
             targets.extend(["qdbuscpp2xml", "qdbusxml2cpp"])


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.7.1**

#### Motivation

The Qt project exports more files and variables than CMakeDeps. The variable `__qt_internal_cmake_apple_support_files_path` is consumed to point where `Info.plist.app.in` should be installed.

#### Details

To validate the current change, I modified the test package to use `qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE test_package.cpp)`:

```
diff --git a/recipes/qt/6.x.x/test_package/CMakeLists.txt b/recipes/qt/6.x.x/test_package/CMakeLists.txt
index d12764c12f..14825f5ae6 100644
--- a/recipes/qt/6.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/6.x.x/test_package/CMakeLists.txt
@@ -1,9 +1,12 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(Qt6 COMPONENTS Core Network Sql Concurrent Xml REQUIRED CONFIG)
+find_package(Qt6 COMPONENTS Core REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} WIN32 test_package.cpp greeter.h example.qrc)
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core Qt6::Network Qt6::Sql Qt6::Concurrent Qt6::Xml Qt6::Widgets)
+qt_standard_project_setup()
+
+qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE test_package.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTORCC ON)
diff --git a/recipes/qt/6.x.x/test_package/conanfile.py b/recipes/qt/6.x.x/test_package/conanfile.py
index 01ccf4f452..a3a8c44001 100644
--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -39,5 +39,6 @@ Prefix = {path}""")
     def test(self):
         if can_run(self):
             copy(self, "qt.conf", src=self.generators_folder, dst=os.path.join(self.cpp.build.bindirs[0]))
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            # bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package.app/Contents/MacOS/test_package")
             self.run(bin_path, env="conanrun")
diff --git a/recipes/qt/6.x.x/test_package/test_package.cpp b/recipes/qt/6.x.x/test_package/test_package.cpp
index 5374ecf402..1745ff5c33 100644
--- a/recipes/qt/6.x.x/test_package/test_package.cpp
+++ b/recipes/qt/6.x.x/test_package/test_package.cpp
@@ -1,48 +1,11 @@
 #include <QCoreApplication>
-#include <QObject>
-#include <QString>
-#include <QTimer>
-#include <QFile>
+#include <QDebug>
 
-#include <QNetworkAccessManager>
-#include <QSqlDatabase>
-#include <qtconcurrentfilter.h>
-#include <QDomText>
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
 
-#include "greeter.h"
+    qDebug() << "Hello World";
 
-int main(int argc, char *argv[]){
-    QCoreApplication app(argc, argv);
-    QCoreApplication::setApplicationName("Application Example");
-    QCoreApplication::setApplicationVersion("1.0.0");
-
-    QString name = argc > 0 ? argv[1] : "";
-    if (name.isEmpty()) {
-        name = "World";
-    }
-
-    Greeter* greeter = new Greeter(name, &app);
-    QObject::connect(greeter, SIGNAL(finished()), &app, SLOT(quit()));
-    QTimer::singleShot(0, greeter, SLOT(run()));
-
-    QFile f(":/resource.txt");
-    if(!f.open(QIODevice::ReadOnly))
-        qFatal("Could not open resource file");
-    qDebug() << "Resource content:" << f.readAll();
-    f.close();
-
-    QNetworkAccessManager networkTester;
-
-    QSqlDatabase sqlTester;
-
-    QVector<int> v;
-    v << 1 << 2 << 3 << 4;
-    QtConcurrent::blockingFilter(v, [](int i)
-    {
-        return i % 2;
-    });
-
-    QDomText xmlTester;
-
-    return app.exec();
+    return a.exec();
 }
```

----

Content of `Info.plist.app.in`

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>CFBundleInfoDictionaryVersion</key>
	<string>6.0</string>
	<key>CFBundlePackageType</key>
	<string>APPL</string>

	<key>CFBundleName</key>
	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
	<key>CFBundleIdentifier</key>
	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
	<key>CFBundleExecutable</key>
	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>

	<key>CFBundleVersion</key>
	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
	<key>CFBundleShortVersionString</key>
	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>

	<key>LSMinimumSystemVersion</key>
	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>

	<key>NSHumanReadableCopyright</key>
	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>

	<key>CFBundleIconFile</key>
	<string>${MACOSX_BUNDLE_ICON_FILE}</string>

	<key>CFBundleDevelopmentRegion</key>
	<string>en</string>
	<key>CFBundleAllowMixedLocalizations</key>
	<true/>

	<key>NSPrincipalClass</key>
	<string>NSApplication</string>

	<key>NSSupportsAutomaticGraphicsSwitching</key>
	<true/>
</dict>
</plist>
```

Build test log:

```
conan test 6.x.x/test_package/ qt/6.7.1                                                                                                                                                                                           13:42:42

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=17
compiler.libcxx=libc++
compiler.version=15
os=Macos
[conf]
tools.build:verbosity=verbose
tools.cmake.cmaketoolchain:generator=Ninja
tools.compilation:verbosity=verbose

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=17
compiler.libcxx=libc++
compiler.version=15
os=Macos
[conf]
tools.build:verbosity=verbose
tools.cmake.cmaketoolchain:generator=Ninja
tools.compilation:verbosity=verbose


======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    qt/6.7.1 (test package): /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/conanfile.py
Requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    brotli/1.1.0#d56d7bb9ca722942aba17369cb5c0519 - Cache
    bzip2/1.0.8#457c272f7da34cb9c67456dd217d36c4 - Cache
    double-conversion/3.3.0#33321c201741cc32b51169c6d2d05e60 - Cache
    freetype/2.13.2#7934d59c447d72edcd56025dc60e1aeb - Cache
    glib/2.78.3#298e03077934a696f094272c745c2316 - Cache
    harfbuzz/8.3.0#c83405ed297bad6c9e9587e2a19c686a - Cache
    libelf/0.8.13#4f70a3555809ae50cc8add44f0f84288 - Cache
    libffi/3.4.4#72cccac6139293b6e97ec9cd676547ff - Cache
    libgettext/0.22#35d2811b2dd27a98f69e4daa86ca2000 - Cache
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd - Cache
    libpng/1.6.42#fdba4ebf89df3c55d6db0145a2a66a24 - Cache
    libpq/15.4#f0bd46b7559165ceb6a090529fc729b9 - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    md4c/0.4.8#9b5da52e0c0b803bb0d1a4b9fdfe10b1 - Cache
    odbc/2.3.11#84d32d803c970271eb2fc58d3e3cc2b5 - Cache
    opengl/system#4df6fecde4084386beded3ed0e56e4ea - Cache
    openssl/3.2.2#899583c694f9deccec74dbe0bbc65a15 - Cache
    pcre2/10.42#a7a2c122056510509a7525c83d6a6695 - Cache
    qt/6.7.1#081c51c222e0200a67748b44d8553624 - Cache
    sqlite3/3.45.0#3a7911478ffd14e7acc694ac113449b6 - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    bzip2/1.0.8#457c272f7da34cb9c67456dd217d36c4 - Cache
    cmake/3.29.5#56dbff3ff8af6bcd4b9c170fbd4da068 - Cache
    gettext/0.21#a2bd3513f212013764c9040f4c70ed69 - Cache
    glib/2.78.3#298e03077934a696f094272c745c2316 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    libelf/0.8.13#4f70a3555809ae50cc8add44f0f84288 - Cache
    libffi/3.4.4#72cccac6139293b6e97ec9cd676547ff - Cache
    libgettext/0.22#35d2811b2dd27a98f69e4daa86ca2000 - Cache
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    meson/1.2.2#04bdfb85d665c82b08a3510aee3ffd19 - Cache
    meson/1.3.2#d1125ba555ec1a94f165a3412fdf7f88 - Cache
    meson/1.4.0#024dfac41ea5570cb1aec3ea6fe34d0a - Cache
    ninja/1.11.1#77587f8c8318662ac8e5a7867eb4be21 - Cache
    pcre2/10.42#a7a2c122056510509a7525c83d6a6695 - Cache
    pkgconf/2.0.3#f996677e96e61e6552d85e83756c328b - Cache
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2 - Cache
Resolved version ranges
    cmake/[>=3.21.1 <4]: cmake/3.29.5
    openssl/[>=1.1 <4]: openssl/3.2.2
    zlib/[>=1.2.11 <2]: zlib/1.3.1

======== Computing necessary packages ========
Requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809:da39a3ee5e6b4b0d3255bfef95601890afd80709#5b77f70c17ad1741f5845d4e468a347e - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50:9e5323c65b94ae38c3c733fe12637776db0119a5#53e724e4596a55dd2b2a3931d36256dc - Cache
    brotli/1.1.0#d56d7bb9ca722942aba17369cb5c0519:27c3eb48256dc5d2ec50ae887081dd85434e5755#d900a07edf8ac9e300a5105e46e95dd8 - Cache
    bzip2/1.0.8#457c272f7da34cb9c67456dd217d36c4:bd47875fc25b97398a4030f4060ef8ef3539584a#8496bd2ef430954493e1f454a057c2ae - Cache
    double-conversion/3.3.0#33321c201741cc32b51169c6d2d05e60:f3c011171e27f251044f2d9d6c96f710e7b11116#b1ab9a4912ac93ded1707e7683552710 - Cache
    freetype/2.13.2#7934d59c447d72edcd56025dc60e1aeb:b4870ffee4add54f8c0802d2f844e0b2960d8167#374402cb5b32cdfc812a543dc0a46d7d - Cache
    glib/2.78.3#298e03077934a696f094272c745c2316:809ad11dca7631334092e6fd8ac10fc4ab13d046#866db777b57cfede3899011a7568420c - Cache
    harfbuzz/8.3.0#c83405ed297bad6c9e9587e2a19c686a:71bd60f99625f0406a06074fbca90446cf99892b#31543895a2bec6d87824c537355d05da - Cache
    libelf/0.8.13#4f70a3555809ae50cc8add44f0f84288:b117a9060cd3cd9e1fab132b9eda3173f84743bd#d9045a577b336abaa3c89410832c91e9 - Cache
    libffi/3.4.4#72cccac6139293b6e97ec9cd676547ff:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#731fa926db9c0e50276c00f65daa5a9f - Cache
    libgettext/0.22#35d2811b2dd27a98f69e4daa86ca2000:50beeb0af7d06901e44de287d86534d4592f2583#ff4bf8ecf6f56088632dea1e9a778326 - Cache
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#fc73ee0f45832b31ea39ddac665eef3f - Cache
    libpng/1.6.42#fdba4ebf89df3c55d6db0145a2a66a24:110170895f97fd2467430f5b1f7482bcfb6ba38b#6464859c23e13822481f1357a6f7baa0 - Cache
    libpq/15.4#f0bd46b7559165ceb6a090529fc729b9:f0b000c509a4fac0d67f486d07efc67f25653547#564ae2d72442ad24230a5c8fe887143d - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#404108e2f60ca6c8dbf5698ab47f5e46 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2:617cae191537b47386c088e07b1822d8606b7e67#af3bb664b82c4f616d3146625c5b4bd5 - Cache
    md4c/0.4.8#9b5da52e0c0b803bb0d1a4b9fdfe10b1:b5c3671c8e8f51c21784d0e7c3d3f6beaaed98a5#a90d34674306a29a6e067f0179b8c5b1 - Cache
    odbc/2.3.11#84d32d803c970271eb2fc58d3e3cc2b5:ea24a61a3a5c42c3c117e5a507bed5fe857f834b#fc5c6fb0fa308556d0a5f33b585559f5 - Cache
    opengl/system#4df6fecde4084386beded3ed0e56e4ea:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Cache
    openssl/3.2.2#899583c694f9deccec74dbe0bbc65a15:7833c7c48ca5681090256e36ed675b071307c45a#df7ad22cfac9e92700aa9207fc77e126 - Cache
    pcre2/10.42#a7a2c122056510509a7525c83d6a6695:17867723f5118ac06c0e40c6780f191fc7f9489d#5383d43d3ec97fa8aaae59df128d10d9 - Cache
    qt/6.7.1#081c51c222e0200a67748b44d8553624:23f3b93052a0d90b521542969187076ef962cb13#9c15fb167436b72e18e2c44cbea36f39 - Cache
    sqlite3/3.45.0#3a7911478ffd14e7acc694ac113449b6:dc4b586c4203330fce9008cb16c26d25219e4944#c12836486108c4fe7eaefc239f50abf7 - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#1a0af64d22ca28cc11822f1c483dde56 - Cache
Build requirements
Skipped binaries
    autoconf/2.71, automake/1.16.5, bzip2/1.0.8, cmake/3.29.5, gettext/0.21, glib/2.78.3, gnu-config/cci.20210814, libelf/0.8.13, libffi/3.4.4, libgettext/0.22, libiconv/1.17, m4/1.4.19, meson/1.2.2, meson/1.3.2, meson/1.4.0, ninja/1.11.1, pcre2/10.42, pkgconf/2.0.3, pkgconf/2.1.0, zlib/1.3.1

======== Installing packages ========
brotli/1.1.0: Already installed! (1 of 24)
bzip2/1.0.8: Already installed! (2 of 24)
double-conversion/3.3.0: Already installed! (3 of 24)
libffi/3.4.4: Already installed! (4 of 24)
libiconv/1.17: Already installed! (5 of 24)
libpq/15.4: Already installed! (6 of 24)
m4/1.4.19: Already installed! (7 of 24)
md4c/0.4.8: Already installed! (8 of 24)
opengl/system: Already installed! (9 of 24)
sqlite3/3.45.0: Already installed! (10 of 24)
zlib/1.3.1: Already installed! (11 of 24)
libelf/0.8.13: Already installed! (12 of 24)
autoconf/2.71: Already installed! (13 of 24)
libgettext/0.22: Already installed! (14 of 24)
libpng/1.6.42: Already installed! (15 of 24)
openssl/3.2.2: Already installed! (16 of 24)
pcre2/10.42: Already installed! (17 of 24)
pcre2/10.42: Appending PATH environment variable: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/bin
automake/1.16.5: Already installed! (18 of 24)
freetype/2.13.2: Already installed! (19 of 24)
glib/2.78.3: Already installed! (20 of 24)
libtool/2.4.7: Already installed! (21 of 24)
libtool/2.4.7: WARN: The use of 'unix_path_legacy_compat' is deprecated in Conan 2.0 and does not perform path conversions. This is retained for compatibility with Conan 1.x and will be removed in a future version.
libtool/2.4.7: WARN: The use of 'unix_path_legacy_compat' is deprecated in Conan 2.0 and does not perform path conversions. This is retained for compatibility with Conan 1.x and will be removed in a future version.
harfbuzz/8.3.0: Already installed! (22 of 24)
odbc/2.3.11: Already installed! (23 of 24)
qt/6.7.1: Already installed! (24 of 24)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: openssl/3.2.2, sqlite3/3.45.0, bzip2/1.0.8, md4c/0.4.8, zlib/1.3.1, libiconv/1.17, pcre2/10.42, qt/6.7.1, odbc/2.3.11, freetype/2.13.2, brotli/1.1.0, libpng/1.6.42, libpq/15.4, libgettext/0.22
WARN: deprecated:     'cpp_info.build_modules' used in: openssl/3.2.2, sqlite3/3.45.0, bzip2/1.0.8, qt/6.7.1, freetype/2.13.2
WARN: deprecated:     'env_info' used in: glib/2.78.3, openssl/3.2.2, sqlite3/3.45.0, bzip2/1.0.8, md4c/0.4.8, pcre2/10.42, libiconv/1.17, libtool/2.4.7, autoconf/2.71, odbc/2.3.11, freetype/2.13.2, libpq/15.4, m4/1.4.19, automake/1.16.5
WARN: deprecated:     'cpp_info.filenames' used in: sqlite3/3.45.0, freetype/2.13.2, opengl/system
WARN: deprecated:     'user_info' used in: freetype/2.13.2, automake/1.16.5

======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release
qt/6.7.1 (test package): Test package build: build/apple-clang-15-armv8-17-release
qt/6.7.1 (test package): Test package build folder: /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release
qt/6.7.1 (test package): Writing generators to /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/generators
qt/6.7.1 (test package): Generator 'CMakeDeps' calling 'generate()'
qt/6.7.1 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(Qt6)
    target_link_libraries(... qt::qt)
qt/6.7.1 (test package): Generator 'CMakeToolchain' calling 'generate()'
qt/6.7.1 (test package): CMakeToolchain generated: conan_toolchain.cmake
qt/6.7.1 (test package): CMakeToolchain generated: /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/generators/CMakePresets.json
qt/6.7.1 (test package): CMakeToolchain generated: /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/CMakeUserPresets.json
qt/6.7.1 (test package): Generator 'VirtualBuildEnv' calling 'generate()'
qt/6.7.1 (test package): Calling generate()
qt/6.7.1 (test package): Generators folder: /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/generators
qt/6.7.1 (test package): Generating aggregated env files
qt/6.7.1 (test package): Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']

======== Testing the package: Building ========
qt/6.7.1 (test package): Calling build()
qt/6.7.1 (test package): Running CMake.configure()
qt/6.7.1 (test package): RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package" --loglevel=VERBOSE
-- Using Conan toolchain: /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 17 with extensions OFF
-- The CXX compiler identification is AppleClang 15.0.0.15000309
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'Qt6::Core'
-- Conan: Component target declared 'Qt6::Platform'
-- Conan: Component target declared 'qt::QCocoaIntegrationPlugin'
-- Conan: Component target declared 'qt::QODBCDriverPlugin'
-- Conan: Component target declared 'Qt6::LinguistTools'
-- Conan: Component target declared 'Qt6::Gui'
-- Conan: Component target declared 'Qt6::QSQLiteDriverPlugin'
-- Conan: Component target declared 'Qt6::QPSQLDriverPlugin'
-- Conan: Component target declared 'Qt6::QODBCDriverPlugin'
-- Conan: Component target declared 'Qt6::Network'
-- Conan: Component target declared 'Qt6::Sql'
-- Conan: Component target declared 'Qt6::Test'
-- Conan: Component target declared 'Qt6::Concurrent'
-- Conan: Component target declared 'Qt6::Xml'
-- Conan: Component target declared 'Qt6::QCocoaIntegrationPlugin'
-- Conan: Component target declared 'Qt6::QGifPlugin'
-- Conan: Component target declared 'Qt6::QIcoPlugin'
-- Conan: Component target declared 'Qt6::Widgets'
-- Conan: Component target declared 'Qt6::OpenGL'
-- Conan: Component target declared 'Qt6::Qml'
-- Conan: Component target declared 'Qt6::PrintSupport'
-- Conan: Component target declared 'Qt6::OpenGLWidgets'
-- Conan: Component target declared 'Qt6::QmlModels'
-- Conan: Component target declared 'Qt6::QmlImportScanner'
-- Conan: Component target declared 'Qt6::QmlWorkerScript'
-- Conan: Component target declared 'Qt6::UiPlugin'
-- Conan: Component target declared 'Qt6::Help'
-- Conan: Component target declared 'Qt6::UiTools'
-- Conan: Component target declared 'Qt6::Designer'
-- Conan: Target declared 'qt::qt'
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library Qt6Designer found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Designer.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Designer.a
-- Conan: Library Qt6UiTools found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6UiTools.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6UiTools.a
-- Conan: Library Qt6Help found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Help.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Help.a
-- Conan: Library Qt6QmlWorkerScript found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6QmlWorkerScript.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6QmlWorkerScript.a
-- Conan: Library Qt6QmlModels found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6QmlModels.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6QmlModels.a
-- Conan: Library Qt6OpenGLWidgets found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6OpenGLWidgets.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6OpenGLWidgets.a
-- Conan: Library Qt6PrintSupport found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6PrintSupport.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6PrintSupport.a
-- Conan: Library Qt6Qml found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Qml.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Qml.a
-- Conan: Library Qt6OpenGL found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6OpenGL.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6OpenGL.a
-- Conan: Library Qt6Widgets found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Widgets.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Widgets.a
-- Conan: Library qico found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/imageformats/libqico.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/imageformats/libqico.a
-- Conan: Library qgif found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/imageformats/libqgif.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/imageformats/libqgif.a
-- Conan: Library qcocoa found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/platforms/libqcocoa.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/platforms/libqcocoa.a
-- Conan: Library Qt6Xml found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Xml.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Xml.a
-- Conan: Library Qt6Concurrent found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Concurrent.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Concurrent.a
-- Conan: Library Qt6Test found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Test.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Test.a
-- Conan: Library Qt6Sql found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Sql.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Sql.a
-- Conan: Library Qt6Network found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Network.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Network.a
-- Conan: Library qsqlodbc found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlodbc.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlodbc.a
-- Conan: Library qsqlpsql found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlpsql.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlpsql.a
-- Conan: Library qsqlite found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlite.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlite.a
-- Conan: Library Qt6Gui found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Gui.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Gui.a
-- Conan: Library Qt6Core found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Core.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Core.a
-- Conan: Library Qt6Designer found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Designer.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Designer.a
-- Conan: Library Qt6UiTools found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6UiTools.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6UiTools.a
-- Conan: Library Qt6Help found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Help.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Help.a
-- Conan: Library Qt6QmlWorkerScript found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6QmlWorkerScript.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6QmlWorkerScript.a
-- Conan: Library Qt6QmlModels found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6QmlModels.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6QmlModels.a
-- Conan: Library Qt6OpenGLWidgets found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6OpenGLWidgets.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6OpenGLWidgets.a
-- Framework found! qt_Qt6_PrintSupport_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library Qt6PrintSupport found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6PrintSupport.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6PrintSupport.a
-- Conan: Library Qt6Qml found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Qml.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Qml.a
-- Conan: Library Qt6OpenGL found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6OpenGL.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6OpenGL.a
-- Conan: Library Qt6Widgets found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Widgets.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Widgets.a
-- Conan: Library qico found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/imageformats/libqico.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/imageformats/libqico.a
-- Conan: Library qgif found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/imageformats/libqgif.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/imageformats/libqgif.a
-- Conan: Library qcocoa found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/platforms/libqcocoa.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/platforms/libqcocoa.a
-- Conan: Library Qt6Xml found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Xml.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Xml.a
-- Conan: Library Qt6Concurrent found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Concurrent.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Concurrent.a
-- Conan: Library Qt6Test found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Test.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Test.a
-- Conan: Library Qt6Sql found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Sql.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Sql.a
-- Framework found! qt_Qt6_Network_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Network_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Network_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library Qt6Network found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Network.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Network.a
-- Conan: Library qsqlodbc found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlodbc.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlodbc.a
-- Conan: Library qsqlpsql found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlpsql.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlpsql.a
-- Conan: Library qsqlite found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlite.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/plugins/sqldrivers/libqsqlite.a
-- Framework found! qt_Qt6_Gui_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Gui_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Gui_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Gui_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Gui_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Gui_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Gui_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Gui_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library Qt6Gui found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Gui.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Gui.a
-- Framework found! qt_qt_QCocoaIntegrationPlugin_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_qt_QCocoaIntegrationPlugin_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_qt_QCocoaIntegrationPlugin_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_qt_QCocoaIntegrationPlugin_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_qt_QCocoaIntegrationPlugin_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_qt_QCocoaIntegrationPlugin_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_qt_QCocoaIntegrationPlugin_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_qt_QCocoaIntegrationPlugin_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Framework found! qt_Qt6_Core_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library Qt6Core found /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Core.a
-- Conan: Found: /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Core.a
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Library ssl found /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libssl.a
-- Conan: Found: /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libssl.a
-- Conan: Library crypto found /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libcrypto.a
-- Conan: Found: /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libcrypto.a
-- Conan: Library ssl found /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libssl.a
-- Conan: Found: /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libssl.a
-- Conan: Library crypto found /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libcrypto.a
-- Conan: Found: /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libcrypto.a
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Library z found /Users/uilian/.conan2/p/b/zlibfaa15f7ab621a/p/lib/libz.a
-- Conan: Found: /Users/uilian/.conan2/p/b/zlibfaa15f7ab621a/p/lib/libz.a
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Conan: Target declared 'double-conversion::double-conversion'
-- Conan: Library double-conversion found /Users/uilian/.conan2/p/b/doubl010fcf75e57e5/p/lib/libdouble-conversion.a
-- Conan: Found: /Users/uilian/.conan2/p/b/doubl010fcf75e57e5/p/lib/libdouble-conversion.a
-- Conan: Target declared 'harfbuzz::harfbuzz'
-- Framework found! harfbuzz_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library harfbuzz found /Users/uilian/.conan2/p/b/harfbce2320b09d320/p/lib/libharfbuzz.a
-- Conan: Found: /Users/uilian/.conan2/p/b/harfbce2320b09d320/p/lib/libharfbuzz.a
-- Conan: Target declared 'Freetype::Freetype'
-- Conan: Library freetype found /Users/uilian/.conan2/p/b/freet4c605a88e5b0c/p/lib/libfreetype.a
-- Conan: Found: /Users/uilian/.conan2/p/b/freet4c605a88e5b0c/p/lib/libfreetype.a
-- Conan: Target declared 'BZip2::BZip2'
-- Conan: Library bz2 found /Users/uilian/.conan2/p/b/bzip21aadd509484ad/p/lib/libbz2.a
-- Conan: Found: /Users/uilian/.conan2/p/b/bzip21aadd509484ad/p/lib/libbz2.a
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/bzip21aadd509484ad/p/lib/cmake/conan-official-bzip2-variables.cmake'
-- Conan: Target declared 'PNG::PNG'
-- Conan: Library png found /Users/uilian/.conan2/p/b/libpn3d542a19e4e28/p/lib/libpng.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpn3d542a19e4e28/p/lib/libpng.a
-- Conan: Component target declared 'brotli::brotlicommon'
-- Conan: Component target declared 'brotli::brotlidec'
-- Conan: Component target declared 'brotli::brotlienc'
-- Conan: Target declared 'brotli::brotli'
-- Conan: Library brotlienc found /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlienc.a
-- Conan: Found: /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlienc.a
-- Conan: Library brotlidec found /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlidec.a
-- Conan: Found: /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlidec.a
-- Conan: Library brotlicommon found /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlicommon.a
-- Conan: Found: /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlicommon.a
-- Conan: Library brotlienc found /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlienc.a
-- Conan: Found: /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlienc.a
-- Conan: Library brotlidec found /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlidec.a
-- Conan: Found: /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlidec.a
-- Conan: Library brotlicommon found /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlicommon.a
-- Conan: Found: /Users/uilian/.conan2/p/b/brotl3430b44841a20/p/lib/libbrotlicommon.a
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/freet4c605a88e5b0c/p/lib/cmake/conan-official-freetype-variables.cmake'
-- Conan: Component target declared 'glib::glib-2.0'
-- Conan: Component target declared 'glib::gresource'
-- Conan: Component target declared 'glib::gmodule-no-export-2.0'
-- Conan: Component target declared 'glib::gobject-2.0'
-- Conan: Component target declared 'glib::gthread-2.0'
-- Conan: Component target declared 'glib::gmodule-export-2.0'
-- Conan: Component target declared 'glib::gmodule-2.0'
-- Conan: Component target declared 'glib::gio-2.0'
-- Conan: Component target declared 'glib::gio-unix-2.0'
-- Conan: Target declared 'glib::glib'
-- Framework found! glib_FRAMEWORKS_FOUND_RELEASE
-- Framework found! glib_FRAMEWORKS_FOUND_RELEASE
-- Framework found! glib_FRAMEWORKS_FOUND_RELEASE
-- Framework found! glib_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library gio-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgio-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgio-2.0.a
-- Conan: Library gthread-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgthread-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgthread-2.0.a
-- Conan: Library gobject-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgobject-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgobject-2.0.a
-- Conan: Library gmodule-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgmodule-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgmodule-2.0.a
-- Conan: Library glib-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libglib-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libglib-2.0.a
-- Framework found! glib_glib_gio-2.0_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library gio-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgio-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgio-2.0.a
-- Conan: Library gthread-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgthread-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgthread-2.0.a
-- Conan: Library gobject-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgobject-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgobject-2.0.a
-- Conan: Library gmodule-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgmodule-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libgmodule-2.0.a
-- Framework found! glib_glib_glib-2.0_FRAMEWORKS_FOUND_RELEASE
-- Framework found! glib_glib_glib-2.0_FRAMEWORKS_FOUND_RELEASE
-- Framework found! glib_glib_glib-2.0_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library glib-2.0 found /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libglib-2.0.a
-- Conan: Found: /Users/uilian/.conan2/p/b/glibcf7465a8d60a7/p/lib/libglib-2.0.a
-- Conan: Target declared 'libffi::libffi'
-- Conan: Library ffi found /Users/uilian/.conan2/p/b/libff8e7bcf144efec/p/lib/libffi.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libff8e7bcf144efec/p/lib/libffi.a
-- Conan: Component target declared 'PCRE2::8BIT'
-- Conan: Component target declared 'PCRE2::16BIT'
-- Conan: Component target declared 'PCRE2::32BIT'
-- Conan: Component target declared 'PCRE2::POSIX'
-- Conan: Target declared 'pcre2::pcre2'
-- Conan: Library pcre2-posix found /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-posix.a
-- Conan: Found: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-posix.a
-- Conan: Library pcre2-32 found /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-32.a
-- Conan: Found: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-32.a
-- Conan: Library pcre2-16 found /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-16.a
-- Conan: Found: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-16.a
-- Conan: Library pcre2-8 found /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-8.a
-- Conan: Found: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-8.a
-- Conan: Library pcre2-posix found /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-posix.a
-- Conan: Found: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-posix.a
-- Conan: Library pcre2-32 found /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-32.a
-- Conan: Found: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-32.a
-- Conan: Library pcre2-16 found /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-16.a
-- Conan: Found: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-16.a
-- Conan: Library pcre2-8 found /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-8.a
-- Conan: Found: /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-8.a
-- Conan: Target declared 'libelf::libelf'
-- Conan: Library elf found /Users/uilian/.conan2/p/b/libel3be5d54ecfc22/p/lib/libelf.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libel3be5d54ecfc22/p/lib/libelf.a
-- Conan: Target declared 'Intl::Intl'
-- Framework found! libgettext_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library gnuintl found /Users/uilian/.conan2/p/b/libge4a3878bbafdc7/p/lib/libgnuintl.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libge4a3878bbafdc7/p/lib/libgnuintl.a
-- Conan: Target declared 'Iconv::Iconv'
-- Conan: Library iconv found /Users/uilian/.conan2/p/b/libice5a5eb629fb4c/p/lib/libiconv.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libice5a5eb629fb4c/p/lib/libiconv.a
-- Conan: Library charset found /Users/uilian/.conan2/p/b/libice5a5eb629fb4c/p/lib/libcharset.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libice5a5eb629fb4c/p/lib/libcharset.a
-- Conan: Component target declared 'SQLite::SQLite3'
-- Conan: Library sqlite3 found /Users/uilian/.conan2/p/b/sqlit45b60b513563c/p/lib/libsqlite3.a
-- Conan: Found: /Users/uilian/.conan2/p/b/sqlit45b60b513563c/p/lib/libsqlite3.a
-- Conan: Library sqlite3 found /Users/uilian/.conan2/p/b/sqlit45b60b513563c/p/lib/libsqlite3.a
-- Conan: Found: /Users/uilian/.conan2/p/b/sqlit45b60b513563c/p/lib/libsqlite3.a
-- Conan: Component target declared 'libpq::pgport'
-- Conan: Component target declared 'libpq::pgcommon'
-- Conan: Component target declared 'libpq::pq'
-- Conan: Target declared 'PostgreSQL::PostgreSQL'
-- Conan: Library pq found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpq.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpq.a
-- Conan: Library pgcommon found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgcommon.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgcommon.a
-- Conan: Library pgcommon_shlib found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgcommon_shlib.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgcommon_shlib.a
-- Conan: Library pgport found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgport.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgport.a
-- Conan: Library pgport_shlib found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgport_shlib.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgport_shlib.a
-- Conan: Library pq found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpq.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpq.a
-- Conan: Library pgcommon found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgcommon.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgcommon.a
-- Conan: Library pgcommon_shlib found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgcommon_shlib.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgcommon_shlib.a
-- Conan: Library pgport found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgport.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgport.a
-- Conan: Library pgport_shlib found /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgport_shlib.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libpq96288c3ee93c0/p/lib/libpgport_shlib.a
-- Conan: Component target declared 'odbc::_odbc'
-- Conan: Component target declared 'odbc::odbcinst'
-- Conan: Component target declared 'odbc::odbccr'
-- Conan: Target declared 'ODBC::ODBC'
-- Conan: Library odbccr found /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbccr.a
-- Conan: Found: /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbccr.a
-- Conan: Library odbcinst found /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbcinst.a
-- Conan: Found: /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbcinst.a
-- Conan: Library odbc found /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbc.a
-- Conan: Found: /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbc.a
-- Conan: Library odbccr found /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbccr.a
-- Conan: Found: /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbccr.a
-- Conan: Library odbcinst found /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbcinst.a
-- Conan: Found: /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbcinst.a
-- Conan: Library odbc found /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbc.a
-- Conan: Found: /Users/uilian/.conan2/p/b/odbcc51669c9d5f1b/p/lib/libodbc.a
-- Conan: Target declared 'libtool::libtool'
-- Conan: Library ltdl found /Users/uilian/.conan2/p/b/libtoa9f7c053f8133/p/lib/libltdl.a
-- Conan: Found: /Users/uilian/.conan2/p/b/libtoa9f7c053f8133/p/lib/libltdl.a
-- Conan: Target declared 'automake::automake'
-- Conan: Target declared 'autoconf::autoconf'
-- Conan: Target declared 'm4::m4'
-- Conan: Target declared 'opengl::opengl'
-- Framework found! opengl_FRAMEWORKS_FOUND_RELEASE
-- Conan: Component target declared 'md4c::md4c'
-- Conan: Component target declared 'md4c::md4c-html'
-- Conan: Library md4c-html found /Users/uilian/.conan2/p/b/md4ce285846d95786/p/lib/libmd4c-html.a
-- Conan: Found: /Users/uilian/.conan2/p/b/md4ce285846d95786/p/lib/libmd4c-html.a
-- Conan: Library md4c found /Users/uilian/.conan2/p/b/md4ce285846d95786/p/lib/libmd4c.a
-- Conan: Found: /Users/uilian/.conan2/p/b/md4ce285846d95786/p/lib/libmd4c.a
-- Conan: Library md4c-html found /Users/uilian/.conan2/p/b/md4ce285846d95786/p/lib/libmd4c-html.a
-- Conan: Found: /Users/uilian/.conan2/p/b/md4ce285846d95786/p/lib/libmd4c-html.a
-- Conan: Library md4c found /Users/uilian/.conan2/p/b/md4ce285846d95786/p/lib/libmd4c.a
-- Conan: Found: /Users/uilian/.conan2/p/b/md4ce285846d95786/p/lib/libmd4c.a
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Qml/conan_qt_qt6_policies.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Core/conan_qt_executables_variables.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Core/conan_qt_qt6_coreprivate.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Core/Qt6CoreMacros.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Core/Qt6CoreConfigExtras.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/Qt6ConfigExtras.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicExternalProjectHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicCMakeVersionHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicCMakeHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicDependencyHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicAppleHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicTargetHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicFinalizerHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicTestHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicWalkLibsHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicToolHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicPluginHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicFindPackageHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6/QtPublicWasmToolchainHelpers.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Gui/conan_qt_qt6_guiprivate.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Widgets/conan_qt_qt6_widgetsprivate.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Widgets/Qt6WidgetsMacros.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Qml/conan_qt_qt6_qmlprivate.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Qml/Qt6QmlMacros.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6Qml/Qt6QmlConfigExtras.cmake'
-- Conan: Including build module from '/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/cmake/Qt6LinguistTools/Qt6LinguistToolsMacros.cmake'
-- Configuring done (1.1s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release

qt/6.7.1 (test package): Running CMake.build()
qt/6.7.1 (test package): RUN: cmake --build "/Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release" --verbose -- -j10
Change Dir: '/Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release'

Run Build Command(s): /opt/homebrew/bin/ninja -v -j10
[1/4] cd /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release && /Users/uilian/.pyenv/versions/3.10.4/lib/python3.10/site-packages/cmake/data/bin/cmake -E cmake_autogen /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/CMakeFiles/test_package_autogen.dir/AutogenInfo.json Release && /Users/uilian/.pyenv/versions/3.10.4/lib/python3.10/site-packages/cmake/data/bin/cmake -E touch /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/test_package_autogen/timestamp && /Users/uilian/.pyenv/versions/3.10.4/lib/python3.10/site-packages/cmake/data/bin/cmake -E cmake_transform_depfile Ninja gccdepfile /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/test_package_autogen/deps /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/CMakeFiles/d/2f3a5132b4b3626c09b8f0660e33920fee3867bfeb7d5b17d69568891abd1f2f.d
[2/4] /Library/Developer/CommandLineTools/usr/bin/c++ -DPCRE2_STATIC -DQT_CORE_LIB -DQT_NO_DEBUG -I/Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/test_package_autogen/include -isystem /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/include -isystem /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/include/QtCore -stdlib=libc++ -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -fPIC -MD -MT CMakeFiles/test_package.dir/test_package_autogen/mocs_compilation.cpp.o -MF CMakeFiles/test_package.dir/test_package_autogen/mocs_compilation.cpp.o.d -o CMakeFiles/test_package.dir/test_package_autogen/mocs_compilation.cpp.o -c /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/test_package_autogen/mocs_compilation.cpp
[3/4] /Library/Developer/CommandLineTools/usr/bin/c++ -DPCRE2_STATIC -DQT_CORE_LIB -DQT_NO_DEBUG -I/Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/build/apple-clang-15-armv8-17-release/test_package_autogen/include -isystem /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/include -isystem /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/include/QtCore -stdlib=libc++ -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -fPIC -MD -MT CMakeFiles/test_package.dir/test_package.cpp.o -MF CMakeFiles/test_package.dir/test_package.cpp.o.d -o CMakeFiles/test_package.dir/test_package.cpp.o -c /Users/uilian/Development/conan/conan-center-index/recipes/qt/6.x.x/test_package/test_package.cpp
[4/4] : && /Library/Developer/CommandLineTools/usr/bin/c++ -stdlib=libc++ -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/test_package.dir/test_package_autogen/mocs_compilation.cpp.o CMakeFiles/test_package.dir/test_package.cpp.o -o test_package.app/Contents/MacOS/test_package -L/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib   -L/Users/uilian/.conan2/p/b/zlibfaa15f7ab621a/p/lib   -L/Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib   -L/Users/uilian/.conan2/p/b/bzip21aadd509484ad/p/lib   -L/Users/uilian/.conan2/p/b/doubl010fcf75e57e5/p/lib   -L/Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib -Wl,-rpath,/Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib -Wl,-rpath,/Users/uilian/.conan2/p/b/zlibfaa15f7ab621a/p/lib -Wl,-rpath,/Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib -Wl,-rpath,/Users/uilian/.conan2/p/b/bzip21aadd509484ad/p/lib -Wl,-rpath,/Users/uilian/.conan2/p/b/doubl010fcf75e57e5/p/lib -Wl,-rpath,/Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib  /Users/uilian/.conan2/p/b/qtdebe9058650e6/p/lib/libQt6Core.a  -framework CoreFoundation  -framework Foundation  -framework IOKit  -framework Cocoa  -framework AppKit  -framework ApplicationServices  -framework CoreServices  -framework Security  -framework DiskArbitration  /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-posix.a  /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-32.a  /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-16.a  /Users/uilian/.conan2/p/b/pcre23aca6338037d5/p/lib/libpcre2-8.a  /Users/uilian/.conan2/p/b/bzip21aadd509484ad/p/lib/libbz2.a  /Users/uilian/.conan2/p/b/doubl010fcf75e57e5/p/lib/libdouble-conversion.a  /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libssl.a  /Users/uilian/.conan2/p/b/opens8ccd63dc11225/p/lib/libcrypto.a  /Users/uilian/.conan2/p/b/zlibfaa15f7ab621a/p/lib/libz.a && :



======== Testing the package: Executing test ========
qt/6.7.1 (test package): Running test()
qt/6.7.1 (test package): RUN: ./test_package.app/Contents/MacOS/test_package
Hello World
```

fixes #20574

/cc @tamaskenezlego @DoomHammer

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
