### PR TITLE
qt: permit usage of system libjpeg/libjpeg-turbo

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -52,7 +52,7 @@ class QtConan(ConanFile):
         "with_fontconfig": [True, False],
         "with_icu": [True, False],
         "with_harfbuzz": [True, False],
-        "with_libjpeg": ["libjpeg", "libjpeg-turbo", False],
+        "with_libjpeg": ["libjpeg", "libjpeg-turbo", "system", False],
         "with_libpng": [True, False],
         "with_sqlite3": [True, False],
         "with_mysql": [True, False],

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -51,7 +51,7 @@ class QtConan(ConanFile):
         "with_fontconfig": [True, False],
         "with_icu": [True, False],
         "with_harfbuzz": [True, False],
-        "with_libjpeg": ["libjpeg", "libjpeg-turbo", False],
+        "with_libjpeg": ["libjpeg", "libjpeg-turbo", "system", False],
         "with_libpng": [True, False],
         "with_sqlite3": [True, False],
         "with_mysql": [True, False],


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.x.x** and **qt/5.x.x**

#### Motivation
This enables usage, particularly on Linux, of using the system native libjpeg equivalent library, whether the system provides libjpeg or libjpeg-turbo.

#### Details
Adding `system` as an allowed value for the `with_libjpeg` option enables subsequent processing and enabling of the Qt JPEG support, without having to build a specific library within Conan (and presumably vendor it with the application). This approach allows building using the native distribution provided jpeg variant and having it as a system dependency.

The result is not incurring a Conan requires, while still allowing e.g., `FEATURE_system_jpeg` to be enabled and have Qt configuration report jpeg support.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
