### PR TITLE
tracy: add version 0.11.0

### DIFF
--- a/recipes/tracy/all/conandata.yml
+++ b/recipes/tracy/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.0":
+    url: "https://github.com/wolfpld/tracy/archive/refs/tags/v0.11.0.tar.gz"
+    sha256: "b591ef2820c5575ccbf17e2e7a1dc1f6b9a2708f65bfd00f4ebefad2a1ccf830"
   "0.10":
     url: "https://github.com/wolfpld/tracy/archive/refs/tags/v0.10.tar.gz"
     sha256: "a76017d928f3f2727540fb950edd3b736caa97b12dbb4e5edce66542cbea6600"

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -11,10 +11,11 @@ required_conan_version = ">=1.53.0"
 class TracyConan(ConanFile):
     name = "tracy"
     description = "C++ frame profiler"
-    topics = ("profiler", "performance", "gamedev")
-    homepage = "https://github.com/wolfpld/tracy"
-    url = "https://github.com/conan-io/conan-center-index"
     license = ["BSD-3-Clause"]
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/wolfpld/tracy"
+    topics = ("profiler", "performance", "gamedev")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
 
     # Existing CMake tracy options with default value

--- a/recipes/tracy/config.yml
+++ b/recipes/tracy/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.0":
+    folder: all
   "0.10":
     folder: all
   "0.9.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tracy/0.11.0**

#### Motivation
There are several improvements in 0.11.0.
There are new three cmake options in 0.11.0, but these don't work well in my environments.
I'm investigating.

#### Details
https://github.com/wolfpld/tracy/compare/v0.10...v0.11.0#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
