### PR TITLE
xnnpack: add newer version

### DIFF
--- a/recipes/xnnpack/all/conandata.yml
+++ b/recipes/xnnpack/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20240229":
+    url: "https://github.com/google/XNNPACK/archive/fcbf55af6cf28a4627bcd1f703ab7ad843f0f3a2.tar.gz"
+    sha256: "96b2800652a605f0bd289faa09865792d139cadde89f681c79e1b2a08a7e0498"
   "cci.20231026":
     url: "https://github.com/google/XNNPACK/archive/ab16a544c1cbc5ee4ec105a2f35f8adca22e94c1.tar.gz"
     sha256: "11c7e0555d2c2c14d812b3fba2a277d59121cfb898dcc99de1c76477ff2055a0"

--- a/recipes/xnnpack/config.yml
+++ b/recipes/xnnpack/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20240229":
+    folder: all
   "cci.20231026":
     folder: all
   "cci.20230715":


### PR DESCRIPTION
### Summary
Changes to recipe:  **xnnpack/cci.20240229**

#### Motivation
recent versions of libtorch need a xnnpack newer than what we had previously available
this library is not versioned, so taking the exact commit libtorch is currently referencing: https://github.com/pytorch/pytorch/tree/v2.3.1/third_party


