### PR TITLE
c-ares: add version 1.32.2

### DIFF
--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.32.2":
+    url: "https://github.com/c-ares/c-ares/releases/download/v1.32.2/c-ares-1.32.2.tar.gz"
+    sha256: "072ff6b30b9682d965b87eb9b77851dc1cd8e6d8090f6821a56bd8fa89595061"
   "1.32.1":
     url: "https://github.com/c-ares/c-ares/releases/download/v1.32.1/c-ares-1.32.1.tar.gz"
     sha256: "63be2c4ee121faa47e9766f735b4cde750fff2c563f81c11e572d3dc6401e5e7"

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.32.2":
+    folder: all
   "1.32.1":
     folder: all
   "1.31.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **c-ares/1.32.2**

#### Motivation
There are several bugfixes in 1.32.2.

#### Details
https://github.com/c-ares/c-ares/compare/v1.32.1...v1.32.2#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
