### PR TITLE
rectanglebinpack: add cci.20230923

### DIFF
--- a/recipes/rectanglebinpack/all/conandata.yml
+++ b/recipes/rectanglebinpack/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20230923":
+    - url: "https://github.com/juj/RectangleBinPack/archive/83e7e1132d93777e3732dfaae26b0f3703be2036.zip"
+      sha256: "ec8f20227fc79467cf7c5b5656e3e520712ee446fb9e449d42e1e5b4565f6bdc"
   "cci.20210901":
     - url: "https://github.com/juj/RectangleBinPack/archive/a40fcaf3871da57b0f6a080655b3387374840877.zip"
       sha256: "88cec105ca8d90d09e9e81f9862caa0cc1cdb851560fb701555eb58b29515748"

--- a/recipes/rectanglebinpack/config.yml
+++ b/recipes/rectanglebinpack/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20230923":
+    folder: "all"
   "cci.20210901":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **rectanglebinpack/cci.20230923**

#### Motivation
New version with fix for newer compilers and Windows build fix.

#### Details
Just a new version, upstream library has only two new commits (one with added `#include` and other one fixing Windows build, so the patch is no longer needed).


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
