### PR TITLE
Update conandata_yml_format.md

### DIFF
--- a/docs/adding_packages/conandata_yml_format.md
+++ b/docs/adding_packages/conandata_yml_format.md
@@ -126,8 +126,9 @@ Usually, `url` has a [https](https://tools.ietf.org/html/rfc2660) scheme, but ot
 #### sha256
 
 [sha256](https://tools.ietf.org/html/rfc6234) is a preferred method to specify hash sum for the released sources. It allows to check the integrity of sources downloaded.
-You may use an [online service](https://hash.online-convert.com/sha256-generator) to compute `sha256` sum for the given `url`.
-Also, you may use [sha256sum](https://linux.die.net/man/1/sha256sum) command ([windows](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-filehash?view=powershell-7.4) you can use PowerShell).
+You may use an [online service](https://hash.online-convert.com/sha256-generator) to compute `sha256` sum for the given file located at `url`.
+
+If you're using linux you can run `wget -q -O - url | sha256sum` to get the hash which uses the [sha256sum](https://linux.die.net/man/1/sha256sum) command ([windows](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-filehash?view=powershell-7.4) you can use PowerShell).
 
 ## patches
 


### PR DESCRIPTION
When reading the documentation here I misread that it was the hash of the file rather than the url, looking back this is an obvious mistake because we care about the files matching not the URL's matching. 

I decided to make it even more obvious for anyone else who might have gotten confused in the moment, I also added in a sample command which can generate the hash.