### PR TITLE
joltphysics: add version 5.0.0

### DIFF
--- a/recipes/joltphysics/all/conandata.yml
+++ b/recipes/joltphysics/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.0.0":
+    url: "https://github.com/jrouwe/JoltPhysics/archive/refs/tags/v5.0.0.tar.gz"
+    sha256: "5231953d1b1d5b9cb617facf86341a11337e1cd04456949af6911b917a1646cb"
   "3.0.1":
     url: "https://github.com/jrouwe/JoltPhysics/archive/refs/tags/v3.0.1.tar.gz"
     sha256: "7ebb40bf2dddbcf0515984582aaa197ddd06e97581fd55b98cb64f91b243b8a6"

--- a/recipes/joltphysics/all/test_package/CMakeLists.txt
+++ b/recipes/joltphysics/all/test_package/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
+add_definitions(-DJPH_PROFILE_ENABLED=0 -DJPH_DEBUG_RENDERER=0)
+
 find_package(joltphysics REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/joltphysics/config.yml
+++ b/recipes/joltphysics/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.0.0":
+    folder: all
   "3.0.1":
     folder: all
   "2.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **joltphysics/[5.0.0]**
These changes allow for users to install jolt5.0.0 with conan

#### Motivation
Many new features were added in jolt 5.0.0, these pertain to soft body, vehicles, character, constraint, collision detection, and can be read more about here: https://github.com/jrouwe/JoltPhysics/releases/tag/v5.0.0

#### Details
I am still not an authorized user, so I don't think this will be able to be merged in until I am, but I thought I would start the merge request a bit earlier, because it's my first time doing this and thought that there might be things that I have to change after review, by the time it's correct I'd probably have authorization.

**WARNING**: This merge request is most likely incorrect because I don't fully understand what the previous patch was doing and so I didn't include a patch in this commit, even though running `conan . create --version=5.0.0` works just fine.

So far I have:
* Followed the conan2 guide on consuming packages and creating packages
* Gone through: https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md#two-creating-a-package

#### Questions

* I am the least familiar with patching, notice that in my commit I have added the following line to the `CMakeLists.txt` in `test_package`: 
```
add_definitions(-DJPH_PROFILE_ENABLED=0 -DJPH_DEBUG_RENDERER=0)
```

I added this because when it was not there and I tried to run `conan create . --version=5.0.0` I got the error: 
```
======== Testing the package: Executing test ========
joltphysics/5.0.0 (test package): Running test()
joltphysics/5.0.0 (test package): RUN: ./test_package
Version mismatch, make sure you compile the client code with the same Jolt version and compiler definitions!
Mismatching define JPH_PROFILE_ENABLED.
Mismatching define JPH_DEBUG_RENDERER.
```

From what I understand this is because we build the `joltphysics` package in isolation from the test package, since they both use jolt, they must have matching compiler definitions or else the code is not compatible. When I inspect the previous version patches they have lines like this: 

https://github.com/conan-io/conan-center-index/blob/1bbf24347d4528ecdcd1c13dd63258fb03c96ca7/recipes/joltphysics/all/patches/3.0.1-0001-fix-cmake.patch#L104-L108

Is my method of changing the `CMakeLists.txt` incorrect? Should I be using patching for this? [Also I have read the corresponding section on [patches](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/sources_and_patches.md#policy-about-patching)]

* Another question I had comes from the previous patch that looks like this: 

https://github.com/conan-io/conan-center-index/blob/1bbf24347d4528ecdcd1c13dd63258fb03c96ca7/recipes/joltphysics/all/patches/3.0.1-0001-fix-cmake.patch#L87-L102

What is the purpose of this modification? Do I need create a patch that does that in my version here?

@toge I know that you created the previous patches, would you be able to help answer a few of my questions?

---

Apologies for asking so many questions, but I really want to help contribute to conan center index. I think once I complete my first merge request I will have far less questions.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
