### PR TITLE
simple_enum: add recipe

### DIFF
--- a/recipes/simple_enum/all/conandata.yml
+++ b/recipes/simple_enum/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.8.0":
+    url: "https://github.com/arturbac/simple_enum/archive/refs/tags/v0.8.0.tar.gz"
+    sha256: "b32e723ddb29b6cb2ab93f2376157ee6fd7a4f3c170edddb6a3fb7186068e6ee"

--- a/recipes/simple_enum/all/conanfile.py
+++ b/recipes/simple_enum/all/conanfile.py
@@ -1,0 +1,74 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, export_conandata_patches, get
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.52.0"
+
+class SimpleEnumConan(ConanFile):
+    name = "simple_enum"
+    description = "SimpleEnum: An Fast, Intuitive and Type-Safe C++ Enumeration Support Library"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/arturbac/simple_enum"
+    topics = ("serialization", "type-safe", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 20
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "11",
+            "clang": "12",
+            "apple-clang": "13",
+            "Visual Studio": "16",
+            "msvc": "192",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(
+            self,
+            "*.hpp",
+            os.path.join(self.source_folder, "include"),
+            os.path.join(self.package_folder, "include"),
+        )
+        copy(
+            self,
+            "*.h",
+            os.path.join(self.source_folder, "include"),
+            os.path.join(self.package_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/simple_enum/all/conanfile.py
+++ b/recipes/simple_enum/all/conanfile.py
@@ -28,7 +28,7 @@ class SimpleEnumConan(ConanFile):
         return {
             "gcc": "11",
             "clang": "12",
-            "apple-clang": "13",
+            "apple-clang": "14", # apple-clang/13 doesn't support std::convertible_to
             "Visual Studio": "16",
             "msvc": "192",
         }

--- a/recipes/simple_enum/all/conanfile.py
+++ b/recipes/simple_enum/all/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.52.0"
 
 class SimpleEnumConan(ConanFile):
     name = "simple_enum"
-    description = "SimpleEnum: An Fast, Intuitive and Type-Safe C++ Enumeration Support Library"
+    description = "An Fast, Intuitive and Type-Safe C++ Enumeration Support Library"
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/arturbac/simple_enum"

--- a/recipes/simple_enum/all/test_package/CMakeLists.txt
+++ b/recipes/simple_enum/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(simple_enum REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE simple_enum::simple_enum)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/recipes/simple_enum/all/test_package/conanfile.py
+++ b/recipes/simple_enum/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/simple_enum/all/test_package/test_package.cpp
+++ b/recipes/simple_enum/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <simple_enum/simple_enum.hpp>
+
+int main() {
+    enum struct enum_bounded  {  v1 = 1,  v2,  v3,  first = v1,  last = v3  };
+    static_assert(simple_enum::enum_name(enum_bounded::v2) == "v2");
+
+    return 0;
+}

--- a/recipes/simple_enum/config.yml
+++ b/recipes/simple_enum/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.8.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **simple_enum/0.8.0**

#### Motivation
simple_enum is a simple and fast enum utility library.
simple_enum requires C++20.

#### Details
https://github.com/arturbac/simple_enum

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
