### PR TITLE
abseil: Add STD_ORDERING feature to abi_trick

### DIFF
--- a/recipes/abseil/all/abi_trick/abi.h.in
+++ b/recipes/abseil/all/abi_trick/abi.h.in
@@ -2,4 +2,4 @@
 #cmakedefine01 USE_STD_ANY
 #cmakedefine01 USE_STD_OPTIONAL
 #cmakedefine01 USE_STD_VARIANT
-
+#cmakedefine01 USE_STD_ORDERING

--- a/recipes/abseil/all/abi_trick/conan_abi_test.cmake
+++ b/recipes/abseil/all/abi_trick/conan_abi_test.cmake
@@ -41,4 +41,14 @@ int main() {}
 "
 USE_STD_VARIANT)
 
+check_cxx_source_compiles("
+#include \"absl/base/config.h\"
+#if defined(ABSL_HAVE_STD_ORDERING) && ABSL_HAVE_STD_ORDERING == 1
+int main() {}
+#else
+#error \"no std::(partial|strong|weak)_ordering\"
+#endif
+"
+USE_STD_ORDERING)
+
 configure_file(${CMAKE_CURRENT_LIST_DIR}/abi.h.in ${PROJECT_BINARY_DIR}/abi.h)

--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -258,9 +258,13 @@ class _ABIFile:
 
     def replace_in_options_file(self, options_filepath):
         for name, value in self.abi.items():
-            replace_in_file(self.conanfile, options_filepath,
-                    "#define ABSL_OPTION_{} 2".format(name),
-                    "#define ABSL_OPTION_{} {}".format(name, value))
+            replace_in_file(
+                self.conanfile,
+                options_filepath,
+                "#define ABSL_OPTION_{} 2".format(name),
+                "#define ABSL_OPTION_{} {}".format(name, value),
+                strict=False,
+            )
 
     def cxx_std(self):
         return 17 if any([v == "1" for k, v in self.abi.items()]) else 11


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil**

#### Motivation
This is an additional feature that affects the abseil library's ABI and fits into the recipe's abi_trick mechanism.

#### Details
Add support for the USE_STD_ORDERING abseil ABI parameter to the abi_trick mechanism, same as is done for other features.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
