### PR TITLE
scip: add version 9.1.1

### DIFF
--- a/recipes/scip/all/conandata.yml
+++ b/recipes/scip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "9.1.0":
+    url: "https://github.com/scipopt/scip/archive/refs/tags/v910.tar.gz"
+    sha256: "0764deae9e96e733febe4c3b03a4370c9eb0edbee94541822af1d9b27d6b51b1"
   "9.0.1":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v901.tar.gz"
     sha256: "08ad3e7ad6f84f457d95bb70ab21fa7fc648dd43103099359ef8a8f30fcce32e"
@@ -11,3 +14,9 @@ sources:
   "8.0.3":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v803.tar.gz"
     sha256: "fe7636f8165a8c9298ff55ed3220d084d4ea31ba9b69d2733beec53e0e4335d6"
+soplex_mapping:
+  "9.1.0": "7.1.0"
+  "9.0.1": "7.0.1"
+  "8.1.0": "6.0.4"
+  "8.0.4": "6.0.4"
+  "8.0.3": "6.0.3"

--- a/recipes/scip/all/conandata.yml
+++ b/recipes/scip/all/conandata.yml
@@ -14,9 +14,15 @@ sources:
   "8.0.3":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v803.tar.gz"
     sha256: "fe7636f8165a8c9298ff55ed3220d084d4ea31ba9b69d2733beec53e0e4335d6"
-soplex_mapping:
-  "9.1.0": "7.1.0"
-  "9.0.1": "7.0.1"
-  "8.1.0": "6.0.4"
-  "8.0.4": "6.0.4"
-  "8.0.3": "6.0.3"
+
+version_mappings:
+  "9.1.0":
+    soplex: "7.1.0"
+  "9.0.1":
+    soplex: "7.0.1"
+  "8.1.0":
+    soplex: "6.0.4"
+  "8.0.4":
+    soplex: "6.0.4"
+  "8.0.3":
+    soplex: "6.0.3"

--- a/recipes/scip/all/conandata.yml
+++ b/recipes/scip/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "9.1.0":
-    url: "https://github.com/scipopt/scip/archive/refs/tags/v910.tar.gz"
-    sha256: "0764deae9e96e733febe4c3b03a4370c9eb0edbee94541822af1d9b27d6b51b1"
+  "9.1.1":
+    url: "https://github.com/scipopt/scip/archive/refs/tags/v911.tar.gz"
+    sha256: "4b4f42fa9521cbcd61efba15b6440130d06434630da049294389f66f95cd35d9"
   "9.0.1":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v901.tar.gz"
     sha256: "08ad3e7ad6f84f457d95bb70ab21fa7fc648dd43103099359ef8a8f30fcce32e"
@@ -16,8 +16,8 @@ sources:
     sha256: "fe7636f8165a8c9298ff55ed3220d084d4ea31ba9b69d2733beec53e0e4335d6"
 
 version_mappings:
-  "9.1.0":
-    soplex: "7.1.0"
+  "9.1.1":
+    soplex: "7.1.1"
   "9.0.1":
     soplex: "7.0.1"
   "8.1.0":

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -57,7 +57,7 @@ class SCIPConan(ConanFile):
                 )
         if is_msvc(self) and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
-        if self.options.shared and self.options.with_sym == "bliss":
+        if self.options.shared and Version(self.version) <= "9.0.1":
             raise ConanInvalidConfiguration("Bliss is not supported in shared mode.")
         comp = self.settings.compiler
         if Version(self.version) <= "9.0.1" and comp == 'clang' and comp.libcxx and comp.libcxx == 'libc++':

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -76,11 +76,15 @@ class SCIPConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
+        def _mapping_requires(dep, **kwargs):
+            required_version = self.conan_data["version_mappings"][self.version][dep]
+            self.requires(f"{dep}/{required_version}", **kwargs)
+
         if self.options.with_gmp:
             self.requires("gmp/6.3.0")
         if Version(self.version) <= "9.0.1":
             self.requires("bliss/0.77")
-        self.requires(f"soplex/{self.conan_data['soplex_mapping'][self.version]}")
+        _mapping_requires("soplex")
         self.requires("zlib/[>=1.2.11 <2]")
 
     def configure(self):

--- a/recipes/scip/config.yml
+++ b/recipes/scip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "9.1.0":
+    folder: all
   "9.0.1":
     folder: all
   "8.1.0":

--- a/recipes/scip/config.yml
+++ b/recipes/scip/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "9.1.0":
+  "9.1.1":
     folder: all
   "9.0.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **scip/9.1.1**

#### Motivation
SCIP released version 9.1.1

#### Details
For symmetry computation, SCIP switched from bliss as default to snauty.
Until version 9.0.1 this recipe had a flag to use bliss or not. All deployed versions always used bliss.
My proposal is to drop the flag and always use the default: until version 9.0.1 bliss, from 9.1.0 on snauty

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
