### PR TITLE
fast_float: add version 6.1.3

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.1.3":
+    url: "https://github.com/fastfloat/fast_float/archive/v6.1.3.tar.gz"
+    sha256: "7dd99cc2ff44e07dc2a42bed0c6b8c4a8ee4e3b1c330f77073b6cfdb48724c8e"
   "6.1.1":
     url: "https://github.com/fastfloat/fast_float/archive/v6.1.1.tar.gz"
     sha256: "10159a4a58ba95fe9389c3c97fe7de9a543622aa0dcc12dd9356d755e9a94cb4"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.1.3":
+    folder: all
   "6.1.1":
     folder: all
   "6.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fast_float/6.1.3**

#### Motivation
There are several improvements since 6.1.1.

#### Details
https://github.com/fastfloat/fast_float/compare/v6.1.1...v6.1.3#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
