### PR TITLE
icu: fix build with Emscripten for 74.2

### DIFF
--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -19,6 +19,10 @@ patches:
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
   "74.2":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
+    - patch_file: "patches/0002-74.2-fix-emscripten.patch"
+      patch_description: "Add config file for wasm-emscripten platform"
+      patch_type: "portability"
+      patch_source: "https://gerrit.libreoffice.org/c/core/+/111130/9/external/icu/icu4c-emscripten-cross.patch.1"
   "74.1":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
   "73.2":

--- a/recipes/icu/all/patches/0002-74.2-fix-emscripten.patch
+++ b/recipes/icu/all/patches/0002-74.2-fix-emscripten.patch
@@ -1,0 +1,109 @@
+--- a/source/acinclude.m4
++++ b/source/acinclude.m4
+@@ -85,6 +85,7 @@ powerpc*-apple-darwin*)	icu_cv_host_frag=mh-darwin-ppc ;;
+ *-dec-osf*) icu_cv_host_frag=mh-alpha-osf ;;
+ *-*-nto*)	icu_cv_host_frag=mh-qnx ;;
+ *-ncr-*)	icu_cv_host_frag=mh-mpras ;;
++wasm*-*-emscripten*)	icu_cv_host_frag=mh-emscripten ;;
+ *) 		icu_cv_host_frag=mh-unknown ;;
+ esac
+ 		]
+--- /dev/null
++++ b/source/config/mh-emscripten
+@@ -0,0 +1,86 @@
++## Emscripten-specific setup
++## Copyright (c) 1999-2013, International Business Machines Corporation and
++## others. All Rights Reserved.
++## Commands to generate dependency files
++GEN_DEPS.c=  $(CC) -E -MM $(DEFS) $(CPPFLAGS)
++GEN_DEPS.cc= $(CXX) -E -MM $(DEFS) $(CPPFLAGS) $(CXXFLAGS)
++
++## Flags for position independent code
++SHAREDLIBCFLAGS = -fPIC
++SHAREDLIBCXXFLAGS = -fPIC
++SHAREDLIBCPPFLAGS = -DPIC
++
++## Additional flags when building libraries and with threads
++THREADSCPPFLAGS = -D_REENTRANT
++LIBCPPFLAGS =
++
++## Compiler switch to embed a runtime search path
++LD_RPATH= -Wl,-zorigin,-rpath,'$$'ORIGIN
++LD_RPATH_PRE = -Wl,-rpath,
++
++## Force RPATH=$ORIGIN to locate own dependencies w/o need for LD_LIBRARY_PATH:
++ENABLE_RPATH=YES
++RPATHLDFLAGS=${LD_RPATH_PRE}'$$ORIGIN'
++
++## These are the library specific LDFLAGS
++#LDFLAGSICUDT=-nodefaultlibs -nostdlib
++# Debian change: linking icudata as data only causes too many problems.
++LDFLAGSICUDT=
++
++## Compiler switch to embed a library name
++# The initial tab in the next line is to prevent icu-config from reading it.
++	LD_SONAME = -Wl,-soname -Wl,$(notdir $(MIDDLE_SO_TARGET))
++#SH# # We can't depend on MIDDLE_SO_TARGET being set.
++#SH# LD_SONAME=
++
++## Shared library options
++LD_SOOPTIONS= -Wl,-Bsymbolic-functions
++
++## Shared object suffix
++SO = so
++## Non-shared intermediate object suffix
++STATIC_O = o
++
++## Compilation rules
++# WASM needs -pthread for atomics support
++%.$(STATIC_O): $(srcdir)/%.c
++	$(call SILENT_COMPILE,$(strip $(COMPILE.c) $(STATICCPPFLAGS) $(STATICCFLAGS)) -pthread -o $@ $<)
++
++%.$(STATIC_O): $(srcdir)/%.cpp
++	$(call SILENT_COMPILE,$(strip $(COMPILE.cc) $(STATICCPPFLAGS) $(STATICCXXFLAGS)) -pthread -o $@ $<)
++
++
++## Dependency rules
++%.d: $(srcdir)/%.c
++	$(call ICU_MSG,(deps)) $<
++	@$(SHELL) -ec '$(GEN_DEPS.c) $< \
++		| sed '\''s%\($*\)\.o[ :]*%\1.o $@ : %g'\'' > $@; \
++		[ -s $@ ] || rm -f $@'
++
++%.d: $(srcdir)/%.cpp
++	$(call ICU_MSG,(deps)) $<
++	@$(SHELL) -ec '$(GEN_DEPS.cc) $< \
++		| sed '\''s%\($*\)\.o[ :]*%\1.o $@ : %g'\'' > $@; \
++		[ -s $@ ] || rm -f $@'
++
++## Versioned libraries rules
++
++%.$(SO).$(SO_TARGET_VERSION_MAJOR): %.$(SO).$(SO_TARGET_VERSION)
++	$(RM) $@ && ln -s ${<F} $@
++%.$(SO): %.$(SO).$(SO_TARGET_VERSION_MAJOR)
++	$(RM) $@ && ln -s ${*F}.$(SO).$(SO_TARGET_VERSION) $@
++
++##  Bind internal references
++
++# LDflags that pkgdata will use
++BIR_LDFLAGS= -Wl,-Bsymbolic
++
++# Dependencies [i.e. map files] for the final library
++BIR_DEPS=
++
++## Remove shared library 's'
++STATIC_PREFIX_WHEN_USED =
++STATIC_PREFIX =
++
++## without assembly
++PKGDATA_OPTS = -O $(top_builddir)/data/icupkg.inc -w
+--- a/source/configure
++++ b/source/configure
+@@ -5342,6 +5342,7 @@ powerpc*-apple-darwin*)	icu_cv_host_frag=mh-darwin-ppc ;;
+ *-dec-osf*) icu_cv_host_frag=mh-alpha-osf ;;
+ *-*-nto*)	icu_cv_host_frag=mh-qnx ;;
+ *-ncr-*)	icu_cv_host_frag=mh-mpras ;;
++wasm*-*-emscripten*)	icu_cv_host_frag=mh-emscripten ;;
+ *) 		icu_cv_host_frag=mh-unknown ;;
+ esac
+ 


### PR DESCRIPTION
### Summary
Changes to recipe:  **icu/74.2**

#### Motivation
icu/71.1 was recently removed from CCI and it was the only version that had patch for Emscripten.

#### Details
Patch that adds Emscripten support has been slightly adjusted for 74.2.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
