### PR TITLE
yaml linter: patch description is optional - reduce noise in pull requests

### DIFF
--- a/linter/conandata_yaml_linter.py
+++ b/linter/conandata_yaml_linter.py
@@ -31,7 +31,7 @@ def main():
     patch_fields = MapCombined(
         {
             "patch_file": Str(),
-            "patch_description": Str(),
+            Optional("patch_description"): Str(),
             Optional("patch_type"): Enum(
                 ["official", "conan", "portability", "bugfix", "vulnerability"]
             ),


### PR DESCRIPTION
the "description" field is optional, that is, it is not required by `apply_conandata_patches()` 

while useful, this should have never been added without addressing existing "violations" of this linter rule, or at least filtering out violations that predated the PR and are not part of a PR changeset.

It is unacceptable that PR contributors are alerted by things unrelated to their PR, that pre-date the PR and is not their responsibility to fix. It also adds unnecessary noise to reviewers - the focus should be on the changes in the PR, not something pre-existing.

On the other hand, for _some_ PRs that only add new versions, CI knows to only build the version that is added if the recipe is not modified. Well intentioned contributors may choose to address these linter warnings, which would cause all versions to be rebuilt, unnecessarily.

It should be on the _reviewers_ to ask for a clarification when patches are introduced in a conandata.yml, and all patches should be traceable all the way to the PR description.


Avoids things like this, which impedes reviewing and contributing: 

<img width="977" alt="Screenshot 2024-07-24 at 10 37 00" src="https://github.com/user-attachments/assets/4a87379e-d52a-4cf7-a684-c9655d15eaca">

