### PR TITLE
grpc: Revert `grpc` component name to `_grpc`

### DIFF
--- a/recipes/grpc/all/target_info/grpc_1.50.0.yml
+++ b/recipes/grpc/all/target_info/grpc_1.50.0.yml
@@ -17,7 +17,7 @@ grpc_targets:
         - abseil::absl_time
         - abseil::absl_optional
         - abseil::absl_variant
-    - name: "grpc"
+    - name: "_grpc"
       lib: "grpc"
       requires:
         - zlib::zlib

--- a/recipes/grpc/all/target_info/grpc_1.50.0.yml
+++ b/recipes/grpc/all/target_info/grpc_1.50.0.yml
@@ -70,7 +70,7 @@ grpc_targets:
       requires:
         - protobuf::libprotobuf
         - abseil::absl_cleanup
-        - grpc
+        - _grpc
     - name: "grpc++_alts"
       lib: "grpc++_alts"
       requires:

--- a/recipes/grpc/all/target_info/grpc_1.50.1.yml
+++ b/recipes/grpc/all/target_info/grpc_1.50.1.yml
@@ -17,7 +17,7 @@ grpc_targets:
         - abseil::absl_time
         - abseil::absl_optional
         - abseil::absl_variant
-    - name: "grpc"
+    - name: "_grpc"
       lib: "grpc"
       requires:
         - zlib::zlib

--- a/recipes/grpc/all/target_info/grpc_1.50.1.yml
+++ b/recipes/grpc/all/target_info/grpc_1.50.1.yml
@@ -70,7 +70,7 @@ grpc_targets:
       requires:
         - protobuf::libprotobuf
         - abseil::absl_cleanup
-        - grpc
+        - _grpc
     - name: "grpc++_alts"
       lib: "grpc++_alts"
       requires:

--- a/recipes/grpc/all/target_info/grpc_1.54.3.yml
+++ b/recipes/grpc/all/target_info/grpc_1.54.3.yml
@@ -76,7 +76,7 @@ grpc_targets:
       requires:
         - protobuf::libprotobuf
         - zlib::zlib
-        - grpc
+        - _grpc
     - name: "grpc++_alts"
       lib: "grpc++_alts"
       requires:

--- a/recipes/grpc/all/target_info/grpc_1.54.3.yml
+++ b/recipes/grpc/all/target_info/grpc_1.54.3.yml
@@ -23,7 +23,7 @@ grpc_targets:
         - abseil::absl_time
         - abseil::absl_optional
         - abseil::absl_variant
-    - name: "grpc"
+    - name: "_grpc"
       lib: "grpc"
       requires:
         - zlib::zlib
@@ -150,4 +150,3 @@ grpc_plugins:
       executable: "grpc_python_plugin"
     - target: "gRPC::grpc_ruby_plugin"
       executable: "grpc_ruby_plugin"
-  

--- a/recipes/grpc/all/target_info/grpc_1.65.0.yml
+++ b/recipes/grpc/all/target_info/grpc_1.65.0.yml
@@ -105,7 +105,7 @@ grpc_targets:
       requires:
         - abseil::absl_absl_check
         - abseil::absl_absl_log
-        - grpc
+        - _grpc
         - protobuf::libprotobuf
     - name: "grpc++_alts"
       lib: "grpc++_alts"

--- a/recipes/grpc/all/target_info/grpc_1.65.0.yml
+++ b/recipes/grpc/all/target_info/grpc_1.65.0.yml
@@ -24,7 +24,7 @@ grpc_targets:
         - abseil::absl_time
         - abseil::absl_optional
         - abseil::absl_variant
-    - name: "grpc"
+    - name: "_grpc"
       lib: "grpc"
       requires:
         - upb_json_lib


### PR DESCRIPTION
### Summary
Changes to recipe:  **grpc/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The `_grpc` component might be used in some recipes (See `google-cloud-cpp`) which breaks when changing the name. For now let's revert it back

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
https://github.com/conan-io/conan-center-index/pull/24215 refactored the recipe to make it more maintainable, but this breaking change was not considered important as there was no expectation for the explicit usage of the component outside the recipe

Closes https://github.com/conan-io/conan-center-index/issues/24698


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
