### PR TITLE
Lcc/bugfix/qt6 macos zstd threads

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -521,6 +521,8 @@ class QtConan(ConanFile):
             tc.variables["FEATURE_dbus"] = "OFF"
         tc.variables["CMAKE_FIND_DEBUG_MODE"] = "FALSE"
 
+        if not self.options.with_zstd:
+            tc.variables["CMAKE_DISABLE_FIND_PACKAGE_WrapZSTD"] = "ON"
 
         for opt, conf_arg in [("with_glib", "glib"),
                               ("with_icu", "icu"),
@@ -536,6 +538,8 @@ class QtConan(ConanFile):
                               ("with_gssapi", "gssapi"),
                               ("with_egl", "egl"),
                               ("with_gstreamer", "gstreamer")]:
+            on_or_off = ("ON" if self.options.get_safe(opt, False) else "OFF")
+            self.output.warning(f"FEATURE_{conf_arg}: {on_or_off}")
             tc.variables[f"FEATURE_{conf_arg}"] = ("ON" if self.options.get_safe(opt, False) else "OFF")
 
 

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -538,8 +538,6 @@ class QtConan(ConanFile):
                               ("with_gssapi", "gssapi"),
                               ("with_egl", "egl"),
                               ("with_gstreamer", "gstreamer")]:
-            on_or_off = ("ON" if self.options.get_safe(opt, False) else "OFF")
-            self.output.warning(f"FEATURE_{conf_arg}: {on_or_off}")
             tc.variables[f"FEATURE_{conf_arg}"] = ("ON" if self.options.get_safe(opt, False) else "OFF")
 
 


### PR DESCRIPTION
### Summary
Changes to recipe:  qt/6

#### Motivation
Fix https://github.com/conan-io/conan-center-index/issues/24639

#### Details
the qt build system searches for zstd even when it is not required - the zstd find logic searches for "thread". If zstd is present (outside of conan), it will find it, which causes to search for `Thread::Thread` as a transitive dependency, and when it comes to promoting the target to global, it will fail. 
This prevents cmake from locating zstd when it is not explicitly required by the recipe.


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
