### PR TITLE
libcurl: add version 8.9.1

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "8.9.0":
+    url:
+      - "https://curl.se/download/curl-8.9.0.tar.xz"
+      - "https://github.com/curl/curl/releases/download/curl-8_9_0/curl-8.9.0.tar.xz"
+    sha256: "ff09b2791ca56d25fd5c3f3a4927dce7c8a9dc4182200c487ca889fba1fdd412"
   "8.8.0":
     url:
       - "https://curl.se/download/curl-8.8.0.tar.xz"

--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "8.9.0":
+  "8.9.1":
     url:
-      - "https://curl.se/download/curl-8.9.0.tar.xz"
-      - "https://github.com/curl/curl/releases/download/curl-8_9_0/curl-8.9.0.tar.xz"
-    sha256: "ff09b2791ca56d25fd5c3f3a4927dce7c8a9dc4182200c487ca889fba1fdd412"
+      - "https://curl.se/download/curl-8.9.1.tar.xz"
+      - "https://github.com/curl/curl/releases/download/curl-8_9_1/curl-8.9.1.tar.xz"
+    sha256: "f292f6cc051d5bbabf725ef85d432dfeacc8711dd717ea97612ae590643801e5"
   "8.8.0":
     url:
       - "https://curl.se/download/curl-8.8.0.tar.xz"

--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -17,6 +17,9 @@ class TestPackageConan(ConanFile):
     def layout(self):
         cmake_layout(self)
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.20 <4]")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -17,9 +17,6 @@ class TestPackageConan(ConanFile):
     def layout(self):
         cmake_layout(self)
 
-    def build_requirements(self):
-        self.tool_requires("cmake/[>=3.20 <4]")
-
     def build(self):
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.9.0":
+    folder: all
   "8.8.0":
     folder: all
   "8.6.0":

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "8.9.0":
+  "8.9.1":
     folder: all
   "8.8.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcurl/8.9.1**

#### Motivation
There are lots of bugfixes in 8.9.1.

#### Details
https://github.com/curl/curl/compare/curl-8_8_0...curl-8_9_1#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
