### PR TITLE
qt: make "conan test" using the console for stdout

### DIFF
--- a/recipes/qt/5.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/5.x.x/test_package/CMakeLists.txt
@@ -3,7 +3,7 @@ project(test_package LANGUAGES CXX)
 
 find_package(Qt5 COMPONENTS Core Network Sql Concurrent Xml REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} WIN32 test_package.cpp greeter.h example.qrc)
+add_executable(${PROJECT_NAME} test_package.cpp greeter.h example.qrc)
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Network Qt5::Sql Qt5::Concurrent Qt5::Xml)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTORCC ON)

--- a/recipes/qt/5.x.x/test_v1_package/CMakeLists.txt
+++ b/recipes/qt/5.x.x/test_v1_package/CMakeLists.txt
@@ -18,6 +18,6 @@ set(CMAKE_AUTORCC ON)
 
 set(SOURCES ../test_package/test_package.cpp ../test_package/greeter.h ../test_package/example.qrc)
 
-add_executable(${PROJECT_NAME} WIN32 ${SOURCES})
+add_executable(${PROJECT_NAME} ${SOURCES})
 
 target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Network Qt5::Sql Qt5::Concurrent Qt5::Xml)

--- a/recipes/qt/6.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/6.x.x/test_package/CMakeLists.txt
@@ -3,7 +3,7 @@ project(test_package LANGUAGES CXX)
 
 find_package(Qt6 COMPONENTS Core Network Sql Concurrent Xml REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} WIN32 test_package.cpp greeter.h example.qrc)
+add_executable(${PROJECT_NAME} test_package.cpp greeter.h example.qrc)
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core Qt6::Network Qt6::Sql Qt6::Concurrent Qt6::Xml Qt6::Widgets)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTORCC ON)


### PR DESCRIPTION
### Summary

Changes to recipe:  **qt**

The WIN32 option was added to CMake add_executable which prevent from initializing stdout and stderr to the app. This results in no console output of the test on Windows.
* fixes e9bdd352111ec5f462347c8fac170307f1a70ffb for qt6
* fixes 1bca4ac9bc95a012f00ca37ffe0c1e8bbffb6a43 for qt5

No CI run needed, tested on Win10

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
