### PR TITLE
dice-template-library: add version 1.6.0

### DIFF
--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.6.0.tar.gz"
+    sha256: "4eb176930beb05dba183d4a48fd9e9716676fe92f0a98a8f527cb8791b0d64fd"
   "1.5.0":
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.5.0.tar.gz"
     sha256: "5ab4155097af5674dc9b34d1643db9ea8b30f78d15c1e547c58396ea31068ffd"

--- a/recipes/dice-template-library/config.yml
+++ b/recipes/dice-template-library/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.0":
+    folder: all
   "1.5.0":
     folder: all
   "1.3.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **dice-template-library/1.6.0**

#### Motivation
There are several new features in 1.6.0.

#### Details
https://github.com/dice-group/dice-template-library/compare/v1.5.0...v1.6.0#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
