### PR TITLE
boost-ext-ut: Add version 2.1.0

### DIFF
--- a/recipes/boost-ext-ut/all/conandata.yml
+++ b/recipes/boost-ext-ut/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.0":
+    url: "https://github.com/boost-ext/ut/archive/v2.1.0.tar.gz"
+    sha256: "1c9c35c039ad3a9795a278447db6da0a4ec1a1d223bf7d64687ad28f673b7ae8"
   "2.0.1":
     url: "https://github.com/boost-ext/ut/archive/v2.0.1.tar.gz"
     sha256: "1e43be17045a881c95cedc843d72fe9c1e53239b02ed179c1e39e041ebcd7dad"

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -52,6 +52,11 @@ class UTConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
+        if (Version(self.version) == "2.1.0" and self.settings.os == "Linux" and self.settings.compiler == "clang" and
+                12 <= Version(self.settings.compiler.version) <= 16 and "libstdc++" in self.settings.compiler.libcxx):
+            # https://github.com/boost-ext/ut/issues/637
+            raise ConanInvalidConfiguration(f"{self.ref} does support Clang + libstdc++. Use -s compiler.libcxx=libc++ or Clang >16.")
+
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
         if Version(self.version) <= "1.1.8" and is_msvc(self):

--- a/recipes/boost-ext-ut/config.yml
+++ b/recipes/boost-ext-ut/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.0":
+    folder: "all"
   "2.0.1":
     folder: "all"
   "2.0.0":


### PR DESCRIPTION
### Summary

Add  **boost-ext-ut/2.1.0**.

#### Motivation

To have the latest version of `boost-ext-ut` available.

#### Details

https://github.com/boost-ext/ut/compare/v2.0.1...v2.1.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
