### PR TITLE
tracy: add 3 options introduced in 0.11.0

### DIFF
--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -3,6 +3,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.53.0"
@@ -41,6 +42,9 @@ class TracyConan(ConanFile):
         "fibers": ([True, False], False),
         "no_crash_handler": ([True, False], False),
         "timer_fallback": ([True, False], False),
+        "libunwind_backtrace": ([True, False], False),
+        "symbol_offline_resolve": ([True, False], False),
+        "libbacktrace_elf_dynload_support": ([True, False], False),
     }
     options = {
         "shared": [True, False],
@@ -68,6 +72,15 @@ class TracyConan(ConanFile):
             del self._tracy_options["no_crash_handler"]
             del self._tracy_options["timer_fallback"]
 
+        if Version(self.version) < "0.11.0":
+            self.options.rm_safe("libunwind_backtrace")
+            self.options.rm_safe("symbol_offline_resolve")
+            self.options.rm_safe("libbacktrace_elf_dynload_support")
+
+            del self._tracy_options["libunwind_backtrace"]
+            del self._tracy_options["symbol_offline_resolve"]
+            del self._tracy_options["libbacktrace_elf_dynload_support"]
+
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
@@ -78,6 +91,10 @@ class TracyConan(ConanFile):
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 11)
+
+        # libunwind_backtrace is not supported in 0.11.0. https://github.com/wolfpld/tracy/pull/841
+        if self.options.get_safe("libunwind_backtrace"):
+            raise ConanInvalidConfiguration(f"libunwind_backtrace is not supported in {self.ref}")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -131,10 +131,17 @@ class TracyConan(ConanFile):
             self.cpp_info.components["tracyclient"].defines.append(
                 "TRACY_IMPORTS")
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["tracyclient"].system_libs.append(
-                "pthread")
+            self.cpp_info.components["tracyclient"].system_libs.extend([
+                "pthread",
+                "m"
+            ])
         if self.settings.os == "Linux":
             self.cpp_info.components["tracyclient"].system_libs.append("dl")
+        if self.settings.os == "Windows":
+            self.cpp_info.components["tracyclient"].system_libs.extend([
+                "dbghelp",
+                "ws2_32"
+            ])
 
         # Tracy CMake adds options set to ON as public
         for opt in self._tracy_options.keys():

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -93,7 +93,7 @@ class TracyConan(ConanFile):
             check_min_cppstd(self, 11)
 
         # libunwind_backtrace is not supported in 0.11.0. https://github.com/wolfpld/tracy/pull/841
-        if self.options.get_safe("libunwind_backtrace"):
+        if Version(self.version) == "0.11.0" and self.options.get_safe("libunwind_backtrace"):
             raise ConanInvalidConfiguration(f"libunwind_backtrace is not supported in {self.ref}")
 
     def source(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **tracy/***

#### Motivation
This recipe has unsupported options introduced in 0.11.0.
This PR tries to add these.

#### Details
https://github.com/conan-io/conan-center-index/pull/24647#issuecomment-2242493081

- `TRACY_LIBUNWIND_BACKTRACE` has bug which has been solved in upstream.
- Because `TRACY_DEMANGLE` is an experimental options, I think it is not time to add it.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
