### PR TITLE
[docs] Add zstd and ninja to version ranges supported

### DIFF
--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -194,6 +194,7 @@ version range only when a requirement for a newer version is needed.
 * c-ares: `[>=1.27 <2]`
 * zstd: `[^1.5]` it's equivalent to `[>=1.5 <1.6]`
 * ninja: `[>=1.10.2 <2]`
+* meson: `[>=1.2.3 <2]`
 
 > **Warning**: With Conan 1.x, [version ranges](https://docs.conan.io/1/versioning/version_ranges.html) adhere to a much more strict sematic version spec,
 > OpenSSL 1.1.x does not follow this so the client will not resolve to that range and will pick a 3.x version. In order to select a lower version you

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -178,7 +178,11 @@ for consumer, we do impose some limits on Conan features to provide a smoother f
 
 Version ranges are a useful Conan feature, [documentation here](https://docs.conan.io/2/tutorial/versioning/version_ranges.html).
 With the introduction of Conan 2.0, we are currently working to allow the use of version ranges and are allowing this for a handful of dependencies.
-Currently, these are (except if the recipe needs a newer lower/upper version bound for specific reasons):
+
+Version ranges are being progressively introduced by Conan team maintainers and are being rolled out in phases, and we do not intend
+to do it all at once.
+
+Version ranges for the following dependencies will be accepted in pull requests: 
 
 * OpenSSL: `[>=1.1 <4]` for libraries known to be compatible with OpenSSL 1.x and 3.x
 * CMake: `[>3.XX <4]`, where `3.XX` is the minimum version of CMake required by the relevant build scripts. Note that CCI recipes assume 3.15 is installed in the system, so add this
@@ -206,11 +210,14 @@ Conan maintainers may introduce this for other dependencies over time. Outside o
 
 #### Adding Version Ranges
 
-You might also see version ranges in some PR by CCI maintainers.
+You might also see version ranges being added in pull requests by Conan maintainers, that
+are not in the list above. These are being introduced on a case-by-case basis, and are being rolled out 
+in phases to ensure that they do not cause problems to users. Note that version ranges can
+only be used for libraries and tools that have strong compatibility guarantees - and may not
+be suitable in all cases.
 
-These are being done on a case-by-case basis, and are being rolled out in phases to ensure
-that they do not cause problems to users. Please do not open PRs that exclusively add version ranges to dependencies,
-unless they are solving current conflicts, in which case we welcome them and they will be prioritized.
+Please do not open PRs that exclusively add version ranges to dependencies, unless they are solving 
+current conflicts, in which case we welcome them and they will be prioritized.
 
 ## Handling "internal" dependencies
 

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -192,6 +192,8 @@ version range only when a requirement for a newer version is needed.
 * qt5: `[~5.15]`, if your library depends on qt5, only the 5.15 minor version is allowed
 * qt6: `[>=6.x <7]`, where 6.x is the lower bound of your needed qt6 version
 * c-ares: `[>=1.27 <2]`
+* zstd: `[^1.5]` it's equivalent to `[>=1.5 <1.6]`
+* ninja: `[>=1.10.2 <2]`
 
 > **Warning**: With Conan 1.x, [version ranges](https://docs.conan.io/1/versioning/version_ranges.html) adhere to a much more strict sematic version spec,
 > OpenSSL 1.1.x does not follow this so the client will not resolve to that range and will pick a 3.x version. In order to select a lower version you

--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -195,6 +195,7 @@ version range only when a requirement for a newer version is needed.
 * zstd: `[^1.5]` it's equivalent to `[>=1.5 <1.6]`
 * ninja: `[>=1.10.2 <2]`
 * meson: `[>=1.2.3 <2]`
+* pkgconf: `[>=2.2 <3]`
 
 > **Warning**: With Conan 1.x, [version ranges](https://docs.conan.io/1/versioning/version_ranges.html) adhere to a much more strict sematic version spec,
 > OpenSSL 1.1.x does not follow this so the client will not resolve to that range and will pick a 3.x version. In order to select a lower version you


### PR DESCRIPTION
#### Motivation

Both `zstd` and `ninja` looks pretty stable and should be backward compatible to be used in ConanCenterIndex.

#### Details

- Zstd: 
  - https://abi-laboratory.pro/index.php?view=timeline&l=zstd
  - https://github.com/facebook/zstd/issues/731#issuecomment-310264043
  
  Zstd 1.5 is supported since 2023, so keeping 1.5.x is safest, just in case.

- Ninja
  - https://ninja-build.org/manual.html#ref_versioning

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
