### PR TITLE
rdma-core: add v52.0, enable all modules

### DIFF
--- a/recipes/rdma-core/all/conandata.yml
+++ b/recipes/rdma-core/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "52.0":
+    url: "https://github.com/linux-rdma/rdma-core/releases/download/v52.0/rdma-core-52.0.tar.gz"
+    sha256: "1f0ce5f2462c982b20d21156707076278807a7adf4d10e9142f3be4bec1b2b83"
   "51.0":
     url: "https://github.com/linux-rdma/rdma-core/releases/download/v51.0/rdma-core-51.0.tar.gz"
     sha256: "0a4a55b1351356c2750f26ec9010e8c7370402a13c95799cb8b447cf0134dd61"

--- a/recipes/rdma-core/all/conanfile.py
+++ b/recipes/rdma-core/all/conanfile.py
@@ -36,8 +36,8 @@ class PackageConan(ConanFile):
         "build_libibnetdisc": True,
         "build_libmana": True,
         "build_libmlx4": True,
-        "build_libmlx5": False,
-        "build_librdmacm": False,
+        "build_libmlx5": True,
+        "build_librdmacm": True,
     }
 
     def configure(self):

--- a/recipes/rdma-core/all/conanfile.py
+++ b/recipes/rdma-core/all/conanfile.py
@@ -49,8 +49,7 @@ class PackageConan(ConanFile):
 
     def requirements(self):
         self.requires("libnl/3.8.0")
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.requires("libudev/system")
+        self.requires("libudev/system")
 
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:
@@ -73,6 +72,10 @@ class PackageConan(ConanFile):
         # tc.variables["ENABLE_STATIC"] = not self.options.shared
         tc.variables["NO_PYVERBS"] = True
         tc.variables["NO_MAN_PAGES"] = True
+        # Otherwise get set to ${install_prefix}/car/run and the paths in
+        # https://github.com/linux-rdma/rdma-core/blob/v52.0/buildlib/config.h.in
+        # can exceed the 108-character limit for socket paths on Linux
+        tc.variables["CMAKE_INSTALL_RUNDIR"] = "/var/run"
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/rdma-core/all/conanfile.py
+++ b/recipes/rdma-core/all/conanfile.py
@@ -75,7 +75,8 @@ class PackageConan(ConanFile):
         # Otherwise get set to ${install_prefix}/car/run and the paths in
         # https://github.com/linux-rdma/rdma-core/blob/v52.0/buildlib/config.h.in
         # can exceed the 108-character limit for socket paths on Linux
-        tc.variables["CMAKE_INSTALL_RUNDIR"] = "/var/run"
+        if "CMAKE_INSTALL_RUNDIR" not in self.conf.get("tools.cmake.cmaketoolchain:extra_variables", check_type=dict, default={}):
+            tc.variables["CMAKE_INSTALL_RUNDIR"] = "/var/run"
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/rdma-core/config.yml
+++ b/recipes/rdma-core/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "52.0":
+    folder: all
   "51.0":
     folder: all
   "49.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **rdma-core/52.0**

#### Motivation
#18979 requires `build_librdmacm=True`. Enabled the remaining `build_libmlx5` as well, since it does not add any dependencies or other notable overhead.

#### Details
https://github.com/linux-rdma/rdma-core/releases/tag/v52.0

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
