### PR TITLE
opengl-registry: add v20240721

### DIFF
--- a/recipes/opengl-registry/all/conandata.yml
+++ b/recipes/opengl-registry/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20240721":
+    url: "https://github.com/KhronosGroup/OpenGL-Registry/archive/d2fe2072a3aecf3e9ef1568976e805531b50d959.tar.gz"
+    sha256: "0c8295a95e137b0dabd5ad138ad41d96b40e85bcca848b62a3e13378e425a08a"
   "cci.20220929":
     url: "https://github.com/KhronosGroup/OpenGL-Registry/archive/5bae8738b23d06968e7c3a41308568120943ae77.tar.gz"
     sha256: "e69eb5738a517737d91717c4f9bb8da1e1fac7a04afe0fc24532ca92df1da53d"

--- a/recipes/opengl-registry/all/test_package/test_package.c
+++ b/recipes/opengl-registry/all/test_package/test_package.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 int main() {
+    printf("GL_GLEXT_VERSION: %d\n", GL_GLEXT_VERSION);
     GLenum value = GL_UNSIGNED_BYTE_3_3_2;
     printf("GL_UNSIGNED_BYTE_3_3_2: %x\n", value);
     return EXIT_SUCCESS;

--- a/recipes/opengl-registry/config.yml
+++ b/recipes/opengl-registry/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "20240721":
+    folder: all
   "cci.20220929":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **opengl-registry/20240721**

#### Motivation
A simple update to the package for an upcoming [Dawn](https://dawn.googlesource.com/dawn/) PR.
I also switched from the `cci.*` version names to the `GL_GLEXT_VERSION` value set in headers: `20240721`.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
