### PR TITLE
dawn: new recipe

### DIFF
--- a/recipes/dawn/all/conan_deps.cmake
+++ b/recipes/dawn/all/conan_deps.cmake
@@ -1,0 +1,6 @@
+find_package(absl REQUIRED CONFIG)
+find_package(glslang REQUIRED CONFIG)
+find_package(glfw3 REQUIRED CONFIG)
+find_package(SPIRV-Headers REQUIRED CONFIG)
+find_package(Vulkan-Headers REQUIRED CONFIG)
+find_package(VulkanUtilityHeaders REQUIRED CONFIG)

--- a/recipes/dawn/all/conandata.yml
+++ b/recipes/dawn/all/conandata.yml
@@ -6,6 +6,9 @@ patches:
   "cci.20240726":
     - patch_file: "patches/0001-unvendor-third-party.patch"
 spirv-tools-sources:
+  "1.3.290.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-1.3.290.0.tar.gz"
+    sha256: "8f8b487e20e062c3abfbc86c4541faf767588d167b395ec94f2a7f996ef40efe"
   "1.3.268.0":
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
     sha256: "4c19fdcffb5fe8ef8dc93d7a65ae78b64edc7a5688893ee381c57f70be77deaf"

--- a/recipes/dawn/all/conandata.yml
+++ b/recipes/dawn/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "cci.20240726":
+    url: "https://dawn.googlesource.com/dawn/+archive/076d076106a07f8a68ea7566f6b9f64fbe0c0687.tar.gz"
+patches:
+  "cci.20240726":
+    - patch_file: "patches/0001-unvendor-third-party.patch"
+spirv-tools-sources:
+  "1.3.268.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
+    sha256: "4c19fdcffb5fe8ef8dc93d7a65ae78b64edc7a5688893ee381c57f70be77deaf"

--- a/recipes/dawn/all/conandata.yml
+++ b/recipes/dawn/all/conandata.yml
@@ -1,6 +1,7 @@
 sources:
   "cci.20240726":
-    url: "https://dawn.googlesource.com/dawn/+archive/076d076106a07f8a68ea7566f6b9f64fbe0c0687.tar.gz"
+    url: "https://github.com/google/dawn/archive/076d076106a07f8a68ea7566f6b9f64fbe0c0687.tar.gz"
+    sha256: "14a4ecc52f7ec5acbbf2156a8b2f1c76a6950a86bb379812923ed1d043893c3d"
 patches:
   "cci.20240726":
     - patch_file: "patches/0001-unvendor-third-party.patch"

--- a/recipes/dawn/all/conanfile.py
+++ b/recipes/dawn/all/conanfile.py
@@ -47,7 +47,7 @@ class DawnConan(ConanFile):
             raise ConanInvalidConfiguration("spirv-tools must be built as a static library (-o spirv-tools/*:shared=False)")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version])
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
         # Dawn uses SPIRV-Tools internals, so we need to provide a vendored version
         get(self, **self.conan_data["spirv-tools-sources"][str(self.dependencies["spirv-tools"].ref.version)], strip_root=True,
             destination=os.path.join(self.source_folder, "third_party", "spirv-tools", "src"))

--- a/recipes/dawn/all/conanfile.py
+++ b/recipes/dawn/all/conanfile.py
@@ -56,7 +56,7 @@ class DawnConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["DAWN_BUILD_MONOLITHIC_LIBRARY"] = True  # TODO: the default behavior, but might want to expose as an option
         tc.variables["DAWN_ENABLE_INSTALL"] = True
-        tc.variables["DAWN_BUILD_SAMPLES"] = True
+        tc.variables["DAWN_BUILD_SAMPLES"] = False
         tc.variables["TINT_ENABLE_INSTALL"] = False
         tc.variables["TINT_BUILD_TESTS"] = False
         tc.variables["SPIRV_TOOLS_BUILD_STATIC"] = True

--- a/recipes/dawn/all/conanfile.py
+++ b/recipes/dawn/all/conanfile.py
@@ -54,7 +54,6 @@ class DawnConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["DAWN_BUILD_MONOLITHIC_LIBRARY"] = True  # TODO: the default behavior, but might want to expose as an option
         tc.variables["DAWN_ENABLE_INSTALL"] = True
         tc.variables["DAWN_BUILD_SAMPLES"] = False
         tc.variables["TINT_ENABLE_INSTALL"] = False

--- a/recipes/dawn/all/conanfile.py
+++ b/recipes/dawn/all/conanfile.py
@@ -1,0 +1,102 @@
+import os
+from pathlib import Path
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir, export_conandata_patches, apply_conandata_patches
+
+required_conan_version = ">=1.53.0"
+
+
+class DawnConan(ConanFile):
+    name = "dawn"
+    description = ("Dawn is an open-source and cross-platform implementation of the work-in-progress WebGPU standard."
+                   " It exposes a C/C++ API that maps almost one-to-one to the WebGPU IDL and"
+                   " can be managed as part of a larger system such as a Web browser.")
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://dawn.googlesource.com/dawn"
+    topics = ("webgpu", "graphics", "gpgpu")
+
+    package_type = "shared-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("abseil/20240116.2")
+        self.requires("spirv-headers/1.3.268.0", transitive_headers=True)
+        self.requires("spirv-tools/1.3.268.0")
+        self.requires("glslang/1.3.268.0")
+        self.requires("glfw/3.4")
+        self.requires("vulkan-headers/1.3.268.0")
+        self.requires("vulkan-utility-libraries/1.3.268.0")
+        self.requires("opengl-registry/20240721")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
+
+        if self.dependencies["spirv-tools"].options.shared:
+            raise ConanInvalidConfiguration("spirv-tools must be built as a static library (-o spirv-tools/*:shared=False)")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version])
+        # Dawn uses SPIRV-Tools internals, so we need to provide a vendored version
+        get(self, **self.conan_data["spirv-tools-sources"][str(self.dependencies["spirv-tools"].ref.version)], strip_root=True,
+            destination=os.path.join(self.source_folder, "third_party", "spirv-tools", "src"))
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["DAWN_BUILD_MONOLITHIC_LIBRARY"] = True  # TODO: the default behavior, but might want to expose as an option
+        tc.variables["DAWN_ENABLE_INSTALL"] = True
+        tc.variables["DAWN_BUILD_SAMPLES"] = True
+        tc.variables["TINT_ENABLE_INSTALL"] = False
+        tc.variables["TINT_BUILD_TESTS"] = False
+        tc.variables["SPIRV_TOOLS_BUILD_STATIC"] = True
+        tc.variables["SPIRV-Headers_SOURCE_DIR"] = self.dependencies["spirv-headers"].package_folder.replace("\\", "/")
+        tc.variables["OPENGL_REGISTRY_DATA_DIR"] = self.dependencies["opengl-registry"].cpp_info.resdirs[0].replace("\\", "/")
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.set_property("spirv-headers", "cmake_target_name", "SPIRV-Headers")
+        deps.set_property("glslang", "cmake_target_name", "glslang")
+        deps.set_property("glslang::glslang-default-resource-limits", "cmake_target_name", "glslang-default-resource-limits")
+        deps.set_property("glfw", "cmake_target_name", "glfw")
+        deps.set_property("vulkan-headers", "cmake_file_name", "Vulkan-Headers")
+        deps.set_property("vulkan-headers", "cmake_target_name", "Vulkan-Headers")
+        deps.set_property("vulkan-utility-libraries::VulkanUtilityHeaders", "cmake_target_name", "VulkanUtilityHeaders")
+        # Hide the spirv-tools components transitively exposed by glslang to avoid conflicts with the vendored version
+        for component in ["core", "diff", "link", "lint", "opt", "reduce"]:
+            deps.set_property(f"spirv-tools::spirv-tools-{component}", "cmake_target_name", f"SPIRV-Tools-{component}_private")
+        deps.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+        # Make sure everything is unvendored
+        for path in Path(self.source_folder, "third_party").iterdir():
+            if path.is_dir() and path.name != "spirv-tools":
+                rmdir(self, path)
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "Dawn")
+        self.cpp_info.set_property("cmake_target_name", "dawn::webgpu_dawn")
+        self.cpp_info.libs = ["webgpu_dawn"]

--- a/recipes/dawn/all/conanfile.py
+++ b/recipes/dawn/all/conanfile.py
@@ -100,3 +100,19 @@ class DawnConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "Dawn")
         self.cpp_info.set_property("cmake_target_name", "dawn::webgpu_dawn")
         self.cpp_info.libs = ["webgpu_dawn"]
+        self.cpp_info.requires = [
+            "abseil::absl_flat_hash_map",
+            "abseil::absl_flat_hash_set",
+            "abseil::absl_inlined_vector",
+            "abseil::absl_span",
+            "abseil::absl_str_format_internal",
+            "abseil::absl_string_view",
+            "abseil::absl_strings",
+            "spirv-headers::spirv-headers",
+            "glslang::glslang",
+            "glfw::glfw",
+            "vulkan-headers::vulkan-headers",
+            "vulkan-utility-libraries::vulkan-utility-libraries",
+            "opengl-registry::opengl-registry",
+            "spirv-tools::spirv-tools",
+        ]

--- a/recipes/dawn/all/conanfile.py
+++ b/recipes/dawn/all/conanfile.py
@@ -44,6 +44,9 @@ class DawnConan(ConanFile):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.17.2 <4]")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         # Dawn uses SPIRV-Tools internals, so we need to provide a vendored version

--- a/recipes/dawn/all/conanfile.py
+++ b/recipes/dawn/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, export_conandata_patches, apply_conandata_patches, save
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class DawnConan(ConanFile):
@@ -41,8 +41,7 @@ class DawnConan(ConanFile):
         self.requires("spirv-tools/1.3.290.0", headers=False, libs=False, visible=False)
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, 11)
+        check_min_cppstd(self, 11)
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.17.2 <4]")
@@ -52,6 +51,7 @@ class DawnConan(ConanFile):
         # Dawn uses SPIRV-Tools internals, so we need to provide a vendored version
         get(self, **self.conan_data["spirv-tools-sources"][str(self.dependencies["spirv-tools"].ref.version)], strip_root=True,
             destination=os.path.join(self.source_folder, "third_party", "spirv-tools", "src"))
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -80,7 +80,6 @@ class DawnConan(ConanFile):
         save(self, "SPIRV-ToolsConfig.cmake", "set(SPIRV-Tools_FOUND TRUE)")
 
     def _patch_sources(self):
-        apply_conandata_patches(self)
         # Make sure everything is unvendored
         for path in Path(self.source_folder, "third_party").iterdir():
             if path.is_dir() and path.name != "spirv-tools":

--- a/recipes/dawn/all/patches/0001-unvendor-third-party.patch
+++ b/recipes/dawn/all/patches/0001-unvendor-third-party.patch
@@ -13,31 +13,7 @@ diff --git a/src/dawn/native/CMakeLists.txt b/src/dawn/native/CMakeLists.txt
 diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
 --- a/third_party/CMakeLists.txt
 +++ b/third_party/CMakeLists.txt
-@@ -25,6 +25,14 @@
- # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-+find_package(absl REQUIRED CONFIG GLOBAL)
-+find_package(SPIRV-Headers REQUIRED CONFIG GLOBAL)
-+#find_package(SPIRV-Tools REQUIRED CONFIG GLOBAL)
-+find_package(glslang REQUIRED CONFIG GLOBAL)
-+find_package(glfw3 REQUIRED CONFIG GLOBAL)
-+find_package(Vulkan-Headers REQUIRED CONFIG GLOBAL)
-+find_package(VulkanUtilityLibraries REQUIRED CONFIG GLOBAL)
-+
- # Don't build testing in third_party dependencies
- set(BUILD_TESTING OFF)
- 
-@@ -85,7 +93,7 @@
-     add_subdirectory(${DAWN_SPIRV_HEADERS_DIR} "${CMAKE_CURRENT_BINARY_DIR}/spirv-headers")
- endif()
- 
--if (NOT TARGET SPIRV-Tools AND
-+if (
-     (((DAWN_ENABLE_OPENGL OR DAWN_ENABLE_VULKAN)
-         AND DAWN_ENABLE_SPIRV_VALIDATION)
-         OR TINT_BUILD_SPV_READER
-@@ -132,8 +140,8 @@
+@@ -132,8 +132,8 @@
  if (DAWN_ENABLE_DESKTOP_GL OR DAWN_ENABLE_OPENGLES)
      # Header-only library for khrplatform.h
      add_library(dawn_khronos_platform INTERFACE)

--- a/recipes/dawn/all/patches/0001-unvendor-third-party.patch
+++ b/recipes/dawn/all/patches/0001-unvendor-third-party.patch
@@ -1,0 +1,50 @@
+diff --git a/src/dawn/native/CMakeLists.txt b/src/dawn/native/CMakeLists.txt
+--- a/src/dawn/native/CMakeLists.txt
++++ b/src/dawn/native/CMakeLists.txt
+@@ -572,7 +572,7 @@
+         SCRIPT "${Dawn_SOURCE_DIR}/generator/opengl_loader_generator.py"
+         PRINT_NAME "OpenGL function loader"
+         EXTRA_PARAMETERS "--gl-xml"
+-             "${Dawn_SOURCE_DIR}/third_party/khronos/OpenGL-Registry/xml/gl.xml"
++             "${OPENGL_REGISTRY_DATA_DIR}/xml/gl.xml"
+              "--supported-extensions"
+              "${Dawn_SOURCE_DIR}/src/dawn/native/opengl/supported_extensions.json"
+         OUTPUT_HEADERS DAWN_NATIVE_OPENGL_AUTOGEN_HEADERS
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -25,6 +25,14 @@
+ # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
++find_package(absl REQUIRED CONFIG GLOBAL)
++find_package(SPIRV-Headers REQUIRED CONFIG GLOBAL)
++#find_package(SPIRV-Tools REQUIRED CONFIG GLOBAL)
++find_package(glslang REQUIRED CONFIG GLOBAL)
++find_package(glfw3 REQUIRED CONFIG GLOBAL)
++find_package(Vulkan-Headers REQUIRED CONFIG GLOBAL)
++find_package(VulkanUtilityLibraries REQUIRED CONFIG GLOBAL)
++
+ # Don't build testing in third_party dependencies
+ set(BUILD_TESTING OFF)
+ 
+@@ -85,7 +93,7 @@
+     add_subdirectory(${DAWN_SPIRV_HEADERS_DIR} "${CMAKE_CURRENT_BINARY_DIR}/spirv-headers")
+ endif()
+ 
+-if (NOT TARGET SPIRV-Tools AND
++if (
+     (((DAWN_ENABLE_OPENGL OR DAWN_ENABLE_VULKAN)
+         AND DAWN_ENABLE_SPIRV_VALIDATION)
+         OR TINT_BUILD_SPV_READER
+@@ -132,8 +140,8 @@
+ if (DAWN_ENABLE_DESKTOP_GL OR DAWN_ENABLE_OPENGLES)
+     # Header-only library for khrplatform.h
+     add_library(dawn_khronos_platform INTERFACE)
+-    target_sources(dawn_khronos_platform INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/khronos/EGL-Registry/api/KHR/khrplatform.h")
+-    target_include_directories(dawn_khronos_platform INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/khronos/EGL-Registry/api")
++    find_package(opengl-registry REQUIRED CONFIG)
++    target_link_libraries(dawn_khronos_platform INTERFACE opengl-registry::opengl-registry)
+ endif()
+ 
+ if (NOT TARGET Vulkan-Headers AND DAWN_ENABLE_VULKAN)

--- a/recipes/dawn/all/test_package/CMakeLists.txt
+++ b/recipes/dawn/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(Dawn REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE dawn::webgpu_dawn)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/dawn/all/test_package/conanfile.py
+++ b/recipes/dawn/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/dawn/all/test_package/conanfile.py
+++ b/recipes/dawn/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/dawn/all/test_package/test_package.cpp
+++ b/recipes/dawn/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <webgpu/webgpu_cpp.h>
+
+int main() {
+    wgpu::InstanceDescriptor instanceDescriptor{};
+    wgpu::Instance instance = wgpu::CreateInstance(&instanceDescriptor);
+}

--- a/recipes/dawn/config.yml
+++ b/recipes/dawn/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20240726":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **dawn/cci.20240726**

#### Motivation
Dawn is an open-source and cross-platform implementation of the [WebGPU](https://webgpu.dev/) standard. More precisely it implements [webgpu.h](https://github.com/webgpu-native/webgpu-headers/blob/main/webgpu.h) that is a one-to-one mapping with the WebGPU IDL. Dawn is meant to be integrated as part of a larger system and is the underlying implementation of WebGPU in Chromium.

https://dawn.googlesource.com/dawn/

Notably, the WebGPU API is not relevant only for webdev, but is also a vendor-neutral and portable API for both graphics and GPGPU programming in general.

Dawn is a dependency for [Skia](https://skia.org/) and [gpu.cpp](https://github.com/AnswerDotAI/gpu.cpp).

#### Details
I opted to keep the default `DAWN_BUILD_MONOLITHIC_LIBRARY=ON` option, that outputs just a single `webgpu_dawn` shared library, to avoid having to model the complex internals and interdependencies of the individual components in `package_info()`. These can be added later, if needed.

The dependencies of the library are mostly straightforward, except for `spirv-tools`. Dawn uses the internal headers and symbols from `spirv-tools` directly, so it can't be cleanly unvendored. This would not be much of an issue on its own, but `glslang` also depends on and exposes `spirv-tools` (optionally, but enabled by default). I opted to provide the exact same version of `spirv-tools` as used by `glslang` as sources to the library and hide the CMake targets from Conan to avoid conflicts.

I have only tested it with Vulkan on Linux currently. Should also definitely test against DirectX on Windows and Metal on macOS before merging.

- Requires #24734
- Requires #24733
- Requires #21059
- Closes #12726

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
