### PR TITLE
gpu.cpp: new recipe

### DIFF
--- a/recipes/gpu.cpp/all/conandata.yml
+++ b/recipes/gpu.cpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20240726":
+    url: "https://github.com/AnswerDotAI/gpu.cpp/archive/0a2d73474a5fa858fbe2021c33a82bd21bfcef38.tar.gz"
+    sha256: "07dee5c15c9612c627ca03c3a46ff5d92323d646ab54fbd2aaf9e58fcd4b54b2"

--- a/recipes/gpu.cpp/all/conandata.yml
+++ b/recipes/gpu.cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "cci.20240726":
-    url: "https://github.com/AnswerDotAI/gpu.cpp/archive/0a2d73474a5fa858fbe2021c33a82bd21bfcef38.tar.gz"
-    sha256: "07dee5c15c9612c627ca03c3a46ff5d92323d646ab54fbd2aaf9e58fcd4b54b2"
+  "0.1.0":
+    url: "https://github.com/AnswerDotAI/gpu.cpp/archive/refs/tags/0.1.0.tar.gz"
+    sha256: "f976ea24df6c4584bb6770a6376e18766328cde80a34cb5978bb6a3212befafc"

--- a/recipes/gpu.cpp/all/conanfile.py
+++ b/recipes/gpu.cpp/all/conanfile.py
@@ -1,0 +1,74 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, replace_in_file
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
+
+
+class GpuCppConan(ConanFile):
+    name = "gpu.cpp"
+    description = "A lightweight library for portable low-level GPU computation using WebGPU."
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://gpucpp.answer.ai/"
+    topics = ("gpgpu", "webgpu")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12",
+            "msvc": "192",
+            "Visual Studio": "16",
+        }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("dawn/cci.20240726")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        pkg_includes = os.path.join(self.package_folder, "include", "gpu.cpp")
+        copy(self, "gpu.h", self.source_folder, pkg_includes)
+        copy(self, "*.h", os.path.join(self.source_folder, "numeric_types"), os.path.join(pkg_includes, "numeric_types"))
+        copy(self, "*.h", os.path.join(self.source_folder, "utils"), os.path.join(pkg_includes, "utils"))
+
+        # Fix incompatibility with newer Dawn
+        replace_in_file(self, os.path.join(pkg_includes, "gpu.h"),
+                        "WGPUBufferUsageFlags",
+                        "WGPUBufferUsage")
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/gpu.cpp/all/conanfile.py
+++ b/recipes/gpu.cpp/all/conanfile.py
@@ -1,14 +1,11 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, replace_in_file
+from conan.tools.files import copy, get, replace_in_file
 from conan.tools.layout import basic_layout
-from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class GpuCppConan(ConanFile):
@@ -22,20 +19,6 @@ class GpuCppConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
 
-    @property
-    def _min_cppstd(self):
-        return 17
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "8",
-            "clang": "7",
-            "apple-clang": "12",
-            "msvc": "192",
-            "Visual Studio": "16",
-        }
-
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -46,13 +29,7 @@ class GpuCppConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
+        check_min_cppstd(self, 17)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/gpu.cpp/all/test_package/CMakeLists.txt
+++ b/recipes/gpu.cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(gpu.cpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE gpu.cpp::gpu.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/gpu.cpp/all/test_package/conanfile.py
+++ b/recipes/gpu.cpp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gpu.cpp/all/test_package/conanfile.py
+++ b/recipes/gpu.cpp/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/gpu.cpp/all/test_package/test_package.cpp
+++ b/recipes/gpu.cpp/all/test_package/test_package.cpp
@@ -1,0 +1,49 @@
+#include <gpu.cpp/gpu.h>
+
+#include <array>
+#include <cstdio>
+#include <future>
+
+using namespace gpu;
+
+static const char *kGelu = R"(
+const GELU_SCALING_FACTOR: f32 = 0.7978845608028654; // sqrt(2.0 / PI)
+@group(0) @binding(0) var<storage, read_write> inp: array<{{precision}}>;
+@group(0) @binding(1) var<storage, read_write> out: array<{{precision}}>;
+@group(0) @binding(1) var<storage, read_write> dummy: array<{{precision}}>;
+@compute @workgroup_size({{workgroupSize}})
+fn main(
+    @builtin(global_invocation_id) GlobalInvocationID: vec3<u32>) {
+    let i: u32 = GlobalInvocationID.x;
+    if (i < arrayLength(&inp)) {
+        let x: f32 = inp[i];
+        out[i] = select(0.5 * x * (1.0 + tanh(GELU_SCALING_FACTOR
+                 * (x + .044715 * x * x * x))), x, x > 10.0);
+    }
+}
+)";
+
+int main() {
+  Context ctx = createContext();
+  static constexpr size_t N = 10000;
+  std::array<float, N> inputArr, outputArr;
+  for (int i = 0; i < N; ++i) {
+    inputArr[i] = static_cast<float>(i) / 10.0; // dummy input data
+  }
+  Tensor input = createTensor(ctx, Shape{N}, kf32, inputArr.data());
+  Tensor output = createTensor(ctx, Shape{N}, kf32);
+  std::promise<void> promise;
+  std::future<void> future = promise.get_future();
+  Kernel op = createKernel(ctx, {kGelu, 256, kf32},
+                           Bindings{input, output},
+                           /* nWorkgroups */ {cdiv(N, 256), 1, 1});
+  dispatchKernel(ctx, op, promise);
+  wait(ctx, future);
+  toCPU(ctx, output, outputArr.data(), sizeof(outputArr));
+  for (int i = 0; i < 12; ++i) {
+    printf("  gelu(%.2f) = %.2f\n", inputArr[i], outputArr[i]);
+  }
+  printf("  ...\n\n");
+  printf("Computed %zu values of GELU(x)\n", N);
+  return 0;
+}

--- a/recipes/gpu.cpp/config.yml
+++ b/recipes/gpu.cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20240726":
+  "0.1.0":
     folder: all

--- a/recipes/gpu.cpp/config.yml
+++ b/recipes/gpu.cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20240726":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **gpu.cpp/cci.20240726**

#### Motivation
gpu.cpp is a lightweight library that makes portable GPU compute with C++ simple.

It focuses on general purpose native GPU computation, leveraging the WebGPU specification as a portable low-level GPU interface. This means we can drop in GPU code in C++ projects and have it run on Nvidia, Intel, AMD, and other GPUs. The same C++ code can work on a wide variety of laptops, workstations, mobile devices or virtually any hardware with Vulkan, Metal, or DirectX support.

https://gpucpp.answer.ai/

#### Details
The library is not yet very stable in terms of the build system, it seems. It currently does not install any headers or export a CMake config. I opted to place the installed headers under an unofficial `gpu.cpp/` prefix and chose to use the `gpu.cpp` CMake file name and `gpu.cpp::gpu.cpp` CMake target implicitly generated by Conan.

I'll probably have to simplify `test_package.cpp`, but I'd like to see whether the more complex one passes for all CCI configurations first.

- Requires #24735

/cc @AnswerDotAI @austinvhuang

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
