### PR TITLE
libxml2: Add version 2.13.3 and use Meson

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.13.3":
+    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.3.tar.xz"
+    sha256: ""
   "2.12.7":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.tar.xz"
     sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.13.3":
+    folder: meson
   "2.12.7":
     folder: all
   "2.12.6":

--- a/recipes/libxml2/meson/conandata.yml
+++ b/recipes/libxml2/meson/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.13.3":
+    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.3.tar.xz"
+    sha256: "0805d7c180cf09caad71666c7a458a74f041561a532902454da5047d83948138"

--- a/recipes/libxml2/meson/conanfile.py
+++ b/recipes/libxml2/meson/conanfile.py
@@ -102,6 +102,7 @@ class Libxml2Conan(ConanFile):
         env.generate()
 
         tc = MesonToolchain(self)
+        tc.project_options["auto_features"] = "disabled"
         for option in self._boolean_option_names:
             tc.project_options[option] = self.options.get_safe(option)
         for option in self._feature_option_names:

--- a/recipes/libxml2/meson/conanfile.py
+++ b/recipes/libxml2/meson/conanfile.py
@@ -1,0 +1,204 @@
+import os
+import textwrap
+
+from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rm, rmdir, save
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.microsoft import is_msvc
+
+required_conan_version = ">=1.55.0"
+
+
+class Libxml2Conan(ConanFile):
+    name = "libxml2"
+    package_type = "library"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "libxml2 is a software library for parsing XML documents"
+    topics = "xml", "parser", "validation"
+    homepage = "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
+    license = "MIT"
+    settings = "os", "arch", "compiler", "build_type"
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "c14n": True,
+        "catalog": True,
+        "ftp": True,
+        "http": True,
+        "html": True,
+        "iconv": True,
+        "icu": False,
+        "iso8859x": True,
+        "legacy": True,
+        "output": True,
+        "pattern": True,
+        "push": True,
+        "python": False,
+        "reader": True,
+        "regexps": True,
+        "sax1": True,
+        "schemas": True,
+        "schematron": True,
+        "threads": True,
+        "tree": True,
+        "valid": True,
+        "writer": True,
+        "xinclude": True,
+        "xpath": True,
+        "xptr": True,
+        "zlib": True,
+        "lzma": False,
+    }
+    options = {name: [True, False] for name in default_options.keys()}
+
+    @property
+    def _boolean_option_names(self):
+        return ["c14n", "catalog", "ftp", "http", "html", "iso8859x", "legacy", "output", "pattern", "push", "python", "reader", "regexps", "sax1", "schemas", "schematron", "tree", "valid", "writer", "xinclude", "xpath", "xptr"]
+
+    @property
+    def _feature_option_names(self):
+        return ["iconv", "icu", "lzma", "threads", "zlib"]
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.zlib:
+            self.requires("zlib/[>=1.2.11 <2]")
+        if self.options.lzma:
+            self.requires("xz_utils/5.4.5")
+        if self.options.iconv:
+            self.requires("libiconv/1.17", transitive_headers=True, transitive_libs=True)
+        if self.options.icu:
+            self.requires("icu/73.2")
+
+    def build_requirements(self):
+        self.tool_requires("meson/1.5.0")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/2.2.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        def feature(option):
+            return "enabled" if self.options.get_safe(option) else "disabled"
+        env = VirtualBuildEnv(self)
+        env.generate()
+
+        tc = MesonToolchain(self)
+        for option in self._boolean_option_names:
+            tc.project_options[option] = self.options.get_safe(option)
+        for option in self._feature_option_names:
+            tc.project_options[option] = feature(option)
+        tc.generate()
+
+        tc = PkgConfigDeps(self)
+        tc.generate()
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"), ignore_case=True, keep_path=False)
+        copy(self, "Copyright", self.source_folder, os.path.join(self.package_folder, "licenses"), ignore_case=True, keep_path=False)
+        meson = Meson(self)
+        meson.install()
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.sh", os.path.join(self.package_folder, "lib"))
+        rm(self, "run*", os.path.join(self.package_folder, "bin"))
+        rm(self, "test*", os.path.join(self.package_folder, "bin"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        fix_apple_shared_install_name(self)
+
+        for header in ["win32config.h", "wsockcompat.h"]:
+            copy(self, header, os.path.join(self.source_folder, "include"),
+                    os.path.join(self.package_folder, "include", "libxml2"), keep_path=False)
+
+        self._create_cmake_module_variables(
+            os.path.join(self.package_folder, self._module_file_rel_path)
+        )
+
+    def _create_cmake_module_variables(self, module_file):
+        # FIXME: also define LIBXML2_XMLLINT_EXECUTABLE variable
+        content = textwrap.dedent(f"""\
+            set(LibXml2_FOUND TRUE)
+            set(LIBXML2_FOUND TRUE)
+            if(DEFINED LibXml2_INCLUDE_DIRS)
+                set(LIBXML2_INCLUDE_DIR ${{LibXml2_INCLUDE_DIRS}})
+                set(LIBXML2_INCLUDE_DIRS ${{LibXml2_INCLUDE_DIRS}})
+            elseif(DEFINED libxml2_INCLUDE_DIRS)
+                set(LIBXML2_INCLUDE_DIR ${{libxml2_INCLUDE_DIRS}})
+                set(LIBXML2_INCLUDE_DIRS ${{libxml2_INCLUDE_DIRS}})
+            endif()
+            if(DEFINED LibXml2_LIBRARIES)
+                set(LIBXML2_LIBRARIES ${{LibXml2_LIBRARIES}})
+                set(LIBXML2_LIBRARY ${{LibXml2_LIBRARIES}})
+            elseif(DEFINED libxml2_LIBRARIES)
+                set(LIBXML2_LIBRARIES ${{libxml2_LIBRARIES}})
+                set(LIBXML2_LIBRARY ${{libxml2_LIBRARIES}})
+            endif()
+            if(DEFINED LibXml2_DEFINITIONS)
+                set(LIBXML2_DEFINITIONS ${{LibXml2_DEFINITIONS}})
+            elseif(DEFINED libxml2_DEFINITIONS)
+                set(LIBXML2_DEFINITIONS ${{libxml2_DEFINITIONS}})
+            else()
+                set(LIBXML2_DEFINITIONS "")
+            endif()
+            set(LIBXML2_VERSION_STRING "{self.version}")
+        """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")
+
+    def package_info(self):
+        # FIXME: Provide LibXml2::xmllint & LibXml2::xmlcatalog imported target for executables
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.set_property("cmake_module_file_name", "LibXml2")
+        self.cpp_info.set_property("cmake_file_name", "libxml2")
+        self.cpp_info.set_property("cmake_target_name", "LibXml2::LibXml2")
+        self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
+        self.cpp_info.set_property("pkg_config_name", "libxml-2.0")
+        prefix = "lib" if is_msvc(self) else ""
+        suffix = "_a" if is_msvc(self) and not self.options.shared else ""
+        self.cpp_info.libs = [f"{prefix}xml2{suffix}"]
+        self.cpp_info.includedirs.append(os.path.join("include", "libxml2"))
+        if not self.options.shared:
+            self.cpp_info.defines = ["LIBXML_STATIC"]
+        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
+            self.cpp_info.system_libs.append("m")
+            if self.options.threads and self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.system_libs.append("pthread")
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.system_libs.append("dl")
+        elif self.settings.os == "Windows":
+            if self.options.ftp or self.options.http:
+                self.cpp_info.system_libs.extend(["ws2_32", "wsock32"])
+
+        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "LibXml2"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "libxml2"
+        self.cpp_info.names["cmake_find_package"] = "LibXml2"
+        self.cpp_info.names["cmake_find_package_multi"] = "LibXml2"
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.names["pkg_config"] = "libxml-2.0"

--- a/recipes/libxml2/meson/conanfile.py
+++ b/recipes/libxml2/meson/conanfile.py
@@ -87,7 +87,7 @@ class Libxml2Conan(ConanFile):
             self.requires("icu/73.2")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.5.0")
+        self.tool_requires("meson/[>1.5.0 <2]")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/2.2.0")
 
@@ -97,6 +97,7 @@ class Libxml2Conan(ConanFile):
     def generate(self):
         def feature(option):
             return "enabled" if self.options.get_safe(option) else "disabled"
+
         env = VirtualBuildEnv(self)
         env.generate()
 

--- a/recipes/libxml2/meson/conanfile.py
+++ b/recipes/libxml2/meson/conanfile.py
@@ -87,7 +87,7 @@ class Libxml2Conan(ConanFile):
             self.requires("icu/73.2")
 
     def build_requirements(self):
-        self.tool_requires("meson/[>1.5.0 <2]")
+        self.tool_requires("meson/[>=1.5.0 <2]")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/2.2.0")
 

--- a/recipes/libxml2/meson/test_cmake_module_package/CMakeLists.txt
+++ b/recipes/libxml2/meson/test_cmake_module_package/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES C)
+
+find_package(LibXml2 REQUIRED MODULE)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE LibXml2::LibXml2)
+
+# Test whether variables from https://cmake.org/cmake/help/latest/module/FindLibXml2.html
+# are properly defined in conan generators
+set(_custom_vars
+    LibXml2_FOUND # since CMake 3.14
+    LIBXML2_FOUND # until CMake 3.14
+    LIBXML2_INCLUDE_DIR
+    LIBXML2_INCLUDE_DIRS
+    LIBXML2_LIBRARIES
+    LIBXML2_DEFINITIONS
+    LIBXML2_VERSION_STRING
+)
+foreach(_custom_var ${_custom_vars})
+    if(DEFINED ${_custom_var})
+        message(STATUS "${_custom_var}: ${${_custom_var}}")
+    else()
+        message(FATAL_ERROR "${_custom_var} not defined")
+    endif()
+endforeach()

--- a/recipes/libxml2/meson/test_cmake_module_package/conanfile.py
+++ b/recipes/libxml2/meson/test_cmake_module_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            xml_path = os.path.join(self.source_folder, os.pardir, "test_package", "books.xml")
+            self.run(f"{bin_path} {xml_path}", env="conanrun")

--- a/recipes/libxml2/meson/test_package/CMakeLists.txt
+++ b/recipes/libxml2/meson/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+find_package(libxml2 REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE LibXml2::LibXml2)

--- a/recipes/libxml2/meson/test_package/CMakeLists.txt
+++ b/recipes/libxml2/meson/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(libxml2 REQUIRED CONFIG)

--- a/recipes/libxml2/meson/test_package/books.xml
+++ b/recipes/libxml2/meson/test_package/books.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications 
+      with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies, 
+      an evil sorceress, and her own childhood to become queen 
+      of the world.</description>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-11-17</publish_date>
+      <description>After the collapse of a nanotechnology 
+      society in England, the young survivors lay the 
+      foundation for a new society.</description>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-03-10</publish_date>
+      <description>In post-apocalypse England, the mysterious 
+      agent known only as Oberon helps to create a new life 
+      for the inhabitants of London. Sequel to Maeve 
+      Ascendant.</description>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-09-10</publish_date>
+      <description>The two daughters of Maeve, half-sisters, 
+      battle one another for control of England. Sequel to 
+      Oberon's Legacy.</description>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-09-02</publish_date>
+      <description>When Carla meets Paul at an ornithology 
+      conference, tempers fly as feathers get ruffled.</description>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>A deep sea diver finds true love twenty 
+      thousand leagues beneath the sea.</description>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <genre>Horror</genre>
+      <price>4.95</price>
+      <publish_date>2000-12-06</publish_date>
+      <description>An anthology of horror stories about roaches,
+      centipedes, scorpions  and other insects.</description>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems 
+      of being quantum.</description>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in 
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in 
+      detail, with attention to XML DOM interfaces, XSLT processing, 
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are 
+      integrated into a comprehensive development 
+      environment.</description>
+   </book>
+</catalog>

--- a/recipes/libxml2/meson/test_package/conanfile.py
+++ b/recipes/libxml2/meson/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            xml_path = os.path.join(self.source_folder, "books.xml")
+            self.run(f"{bin_path} {xml_path}", env="conanrun")

--- a/recipes/libxml2/meson/test_package/test_package.c
+++ b/recipes/libxml2/meson/test_package/test_package.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <libxml/xmlversion.h>
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+static void print_element_names(xmlNode *a_node)
+{
+    xmlNode *cur_node = NULL;
+    for (cur_node = a_node; cur_node; cur_node = cur_node->next)
+    {
+        if (cur_node->type == XML_ELEMENT_NODE)
+        {
+            printf("node type: Element, name: %s\n", cur_node->name);
+        }
+        print_element_names(cur_node->children);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    xmlDoc *doc = NULL;
+    xmlNode *root_element = NULL;
+
+    if (argc != 2)
+        return (1);
+
+    LIBXML_TEST_VERSION
+
+    /*parse the file and get the DOM */
+    doc = xmlReadFile(argv[1], NULL, 0);
+    
+    if (doc == NULL)
+    {
+        printf("error: could not parse file %s\n", argv[1]);
+        exit(-1);
+    }
+
+    /*Get the root element node */
+    root_element = xmlDocGetRootElement(doc);
+    print_element_names(root_element);
+    xmlFreeDoc(doc);    // free document
+    xmlCleanupParser(); // Free globals
+    return 0;
+}


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2/2.13.3**

#### Motivation

Add the latest release of libxml2, version 2.13.3, using Meson as the build system to simplify the build process.

#### Details

Add version 2.13.3.
Use the Meson build system.
Remove the `include_utils` option for simplicity.
Remove `mem-debug` option as there is no such named option in the `meson_options.txt` file.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
