### PR TITLE
rosx_introspection: new recipe

### DIFF
--- a/recipes/rosx_introspection/all/conandata.yml
+++ b/recipes/rosx_introspection/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.0.1":
+    url: "https://github.com/facontidavide/rosx_introspection/archive/refs/tags/1.0.1.zip"
+    sha256: "fe11c6593d1b1096e5646867baeca6a5aba36f097fbbe56ad610c58be65eb0fa"
+patches:
+  "1.0.1":
+    - patch_file: "patches/0001-cmake-fixes.patch"

--- a/recipes/rosx_introspection/all/conanfile.py
+++ b/recipes/rosx_introspection/all/conanfile.py
@@ -1,0 +1,95 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
+
+
+class RosxIntrospectionConan(ConanFile):
+    name = "rosx_introspection"
+    description = "Deserialize any ROS message, without compilation time information."
+    license = "MPL-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/facontidavide/rosx_introspection"
+    topics = ("ros", "serialization", "introspection")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "16",
+            "msvc": "192",
+            "gcc": "8",
+            "clang": "8",
+            "apple-clang": "10",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("rapidjson/cci.20230929")
+        self.requires("fast-cdr/2.2.0")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["CMAKE_DISABLE_FIND_PACKAGE_ament_cmake"] = True
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["rosx_introspection"]

--- a/recipes/rosx_introspection/all/patches/0001-cmake-fixes.patch
+++ b/recipes/rosx_introspection/all/patches/0001-cmake-fixes.patch
@@ -1,0 +1,36 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,11 +1,10 @@
+-cmake_minimum_required(VERSION 3.10)
++cmake_minimum_required(VERSION 3.15)
+ 
+ project(rosx_introspection LANGUAGES CXX VERSION 1.0.1)
+ 
+ 
+ option(CMAKE_POSITION_INDEPENDENT_CODE "Set -fPIC" ON)
+ 
+-include(cmake/CPM.cmake)
+ 
+ find_package(ament_cmake QUIET)
+ 
+@@ -48,7 +47,7 @@
+         rclcpp
+         rosbag2_cpp
+         fastcdr)
+-else()
++elseif(FALSE)
+     message(STATUS "Downloading FastCDR with CPM and building as static library")
+     # Override Fast-CDR option: compile as static lib
+     # set(BUILD_SHARED_LIBS OFF CACHE BOOL "Create static libraries by default")
+@@ -60,8 +59,10 @@
+     target_link_libraries(rosx_introspection fastcdr)
+ endif()
+ 
++find_package(fastcdr REQUIRED)
++find_package(RapidJSON REQUIRED)
+ 
+-find_package(RapidJSON QUIET)
++target_link_libraries(rosx_introspection PRIVATE rapidjson fastcdr)
+ 
+ if(NOT RapidJSON_FOUND)
+     message(STATUS "Downloading RapidJSON with CPM")    

--- a/recipes/rosx_introspection/all/test_package/CMakeLists.txt
+++ b/recipes/rosx_introspection/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(rosx_introspection REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE rosx_introspection::rosx_introspection)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/rosx_introspection/all/test_package/conanfile.py
+++ b/recipes/rosx_introspection/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/rosx_introspection/all/test_package/test_package.cpp
+++ b/recipes/rosx_introspection/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <rosx_introspection/ros_message.hpp>
+
+#include <iostream>
+#include <string>
+
+int main() {
+    const std::string vector_def = "float64 x\n";
+    RosMsgParser::ROSMessage msg(vector_def);
+    std::cout << "The name of the first message field is: " << msg.field(0).name() << std::endl;
+}

--- a/recipes/rosx_introspection/config.yml
+++ b/recipes/rosx_introspection/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **rosx_introspection/1.0.1**

#### Motivation
Deserialize any ROS message, without compilation time information.

https://github.com/facontidavide/rosx_introspection

/cc @facontidavide

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
