### PR TITLE
c-ares: add version 1.32.3

### DIFF
--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.32.3":
+    url: "https://github.com/c-ares/c-ares/releases/download/v1.32.3/c-ares-1.32.3.tar.gz"
+    sha256: "5f02cc809aac3f6cc5edc1fac6c4423fd5616d7406ce47b904c24adf0ff2cd0f"
   "1.32.2":
     url: "https://github.com/c-ares/c-ares/releases/download/v1.32.2/c-ares-1.32.2.tar.gz"
     sha256: "072ff6b30b9682d965b87eb9b77851dc1cd8e6d8090f6821a56bd8fa89595061"

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.32.3":
+    folder: all
   "1.32.2":
     folder: all
   "1.32.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **c-ares/1.32.3**

#### Motivation
There are several improvements and bugfixes(including memory leak) in 1.32.3.

#### Details
https://github.com/c-ares/c-ares/compare/v1.32.2...v1.32.3#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
