### PR TITLE
octo-logger-cpp: add version 2.0.0

### DIFF
--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.0":
+    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v2.0.0.tar.gz"
+    sha256: "2edad6d1cba27019f1f26e562d9d8ff8395fc9ada1e8fb0c226c603ec5e0ed15"
   "1.12.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.12.0.tar.gz"
     sha256: "b4140d31910af128e1d97ae44a564bbad7f7ca889410bbc885691c5e215c0d61"

--- a/recipes/octo-logger-cpp/config.yml
+++ b/recipes/octo-logger-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.0":
+    folder: "all"
   "1.12.0":
     folder: "all"
   "1.11.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **octo-logger-cpp/2.0.0**

#### Motivation
Major version up.

#### Details
https://github.com/ofiriluz/octo-logger-cpp/compare/v1.12.0...v2.0.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
