### PR TITLE
skia: new recipe

### DIFF
--- a/recipes/skia/all/conandata.yml
+++ b/recipes/skia/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "cci.20240727":
+    # Prefer the GitHub mirror because googlesource.com does not have a stable hash
+    url: "https://github.com/google/skia/archive/804999efe4024b8ecf305a5a1bd0271fe4be44b1.tar.gz"
+    sha256: "ce1c02b8b4b36ff4f8d367d6171f75c0467bc8fe12e930945a607bea65c03823"
+patches:
+  "cci.20240727":
+    - patch_file: "patches/0001-use-conan-dependencies.patch"
+      patch_description: "Replace all non-Rust dependencies with ones from Conan"
+      patch_type: "conan"

--- a/recipes/skia/all/conandata.yml
+++ b/recipes/skia/all/conandata.yml
@@ -1,10 +1,11 @@
+# The commit is the head of corresponding milestone branch, e.g. https://github.com/google/skia/tree/chrome/m132
+# Using the GitHub mirror because googlesource.com does not have a stable hash.
 sources:
-  "cci.20240727":
-    # Prefer the GitHub mirror because googlesource.com does not have a stable hash
-    url: "https://github.com/google/skia/archive/804999efe4024b8ecf305a5a1bd0271fe4be44b1.tar.gz"
-    sha256: "ce1c02b8b4b36ff4f8d367d6171f75c0467bc8fe12e930945a607bea65c03823"
+  "132":
+    url: "https://github.com/google/skia/archive/8699f9d8c8ae8c5d390325dbf5a5d9fbadbcc899.tar.gz"
+    sha256: "e0598f82899c1dfd9a03624d350494630588760a72ce0dd9697533e60f4007a8"
 patches:
-  "cci.20240727":
+  "132":
     - patch_file: "patches/0001-use-conan-dependencies.patch"
       patch_description: "Replace all non-Rust dependencies with ones from Conan"
       patch_type: "conan"

--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -3,14 +3,11 @@ import re
 from pathlib import Path
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, load, replace_in_file
 from conan.tools.google import BazelToolchain, BazelDeps, bazel_layout, Bazel
-from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class SkiaConan(ConanFile):
@@ -30,20 +27,6 @@ class SkiaConan(ConanFile):
     default_options = {
         "fPIC": True,
     }
-
-    @property
-    def _min_cppstd(self):
-        return 17
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "7",
-            "clang": "7",
-            "apple-clang": "10",
-            "msvc": "191",
-            "Visual Studio": "15",
-        }
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -66,30 +49,15 @@ class SkiaConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
+            check_min_cppstd(self, 17)
 
     def build_requirements(self):
-        self.tool_requires("bazel/6.2.0")
+        self.tool_requires("bazel/6.5.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
-    def generate(self):
-        VirtualBuildEnv(self).generate()
-
-        tc = BazelToolchain(self)
-        tc.generate()
-
-        deps = BazelDeps(self)
-        deps.generate()
-
-    def _patch_sources(self):
         apply_conandata_patches(self)
+
         # Keep only the external deps that are not available from Conan
         keep_external = [
             "cxx",
@@ -102,8 +70,13 @@ class SkiaConan(ConanFile):
             if path.is_dir() and path.name not in keep_external:
                 rmdir(self, path)
 
+    def generate(self):
+        tc = BazelToolchain(self)
+        tc.generate()
+        deps = BazelDeps(self)
+        deps.generate()
+
     def build(self):
-        self._patch_sources()
         bazel = Bazel(self)
         bazel.build(target="//:skia_public")
 

--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, load, replace_in_file
 from conan.tools.google import BazelToolchain, BazelDeps, bazel_layout, Bazel
 
-required_conan_version = ">=2.0"
+required_conan_version = ">=2.0.9"
 
 
 class SkiaConan(ConanFile):
@@ -27,29 +27,25 @@ class SkiaConan(ConanFile):
     default_options = {
         "fPIC": True,
     }
+    implements = ["auto_shared_fpic"]
 
     def export_sources(self):
         export_conandata_patches(self)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
 
     def layout(self):
         bazel_layout(self, src_folder="src", build_folder="src")
 
     def requirements(self):
         self.requires("dawn/cci.20240726")
-        self.requires("spirv-tools/1.3.268.0")
-        self.requires("spirv-cross/1.3.268.0")
+        self.requires("spirv-tools/1.3.290.0")
+        self.requires("spirv-cross/1.3.290.0")
         self.requires("expat/[>=2.6.2 <3]")
         self.requires("freetype/2.13.2")
         self.requires("fontconfig/2.15.0")
         self.requires("icu/75.1")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, 17)
+        check_min_cppstd(self, 17)
 
     def build_requirements(self):
         self.tool_requires("bazel/6.5.0")

--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -1,0 +1,135 @@
+import os
+import re
+from pathlib import Path
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, load, replace_in_file
+from conan.tools.google import BazelToolchain, BazelDeps, bazel_layout, Bazel
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
+
+
+class SkiaConan(ConanFile):
+    name = "skia"
+    description = ("Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms."
+                   " It serves as the graphics engine for Google Chrome and ChromeOS, Android, Flutter, and many other products.")
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://skia.org/"
+    topics = ("graphics", "2d", "rendering", "chromium")
+
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "clang": "7",
+            "apple-clang": "10",
+            "msvc": "191",
+            "Visual Studio": "15",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        bazel_layout(self, src_folder="src", build_folder="src")
+
+    def requirements(self):
+        self.requires("dawn/cci.20240726")
+        self.requires("spirv-tools/1.3.268.0")
+        self.requires("spirv-cross/1.3.268.0")
+        self.requires("expat/[>=2.6.2 <3]")
+        self.requires("freetype/2.13.2")
+        self.requires("fontconfig/2.15.0")
+        self.requires("icu/75.1")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def build_requirements(self):
+        self.tool_requires("bazel/6.2.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        VirtualBuildEnv(self).generate()
+
+        tc = BazelToolchain(self)
+        tc.generate()
+
+        deps = BazelDeps(self)
+        deps.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+        # Keep only the external deps that are not available from Conan
+        keep_external = [
+            "cxx",
+            "cxxbridge_cmd",
+            "fontations",
+            "icu4x",
+            "vello",
+        ]
+        for path in Path(self.source_folder, "bazel", "external").iterdir():
+            if path.is_dir() and path.name not in keep_external:
+                rmdir(self, path)
+
+    def build(self):
+        self._patch_sources()
+        bazel = Bazel(self)
+        bazel.build(target="//:skia_public")
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+
+        # Copy library file
+        bin_dir = os.path.join(self.source_folder, "bazel-bin")
+        if self.settings.os == "Windows":
+            copy(self, "skia_public.lib", bin_dir, os.path.join(self.package_folder, "lib"))
+        else:
+            copy(self, "libskia_public.a", bin_dir, os.path.join(self.package_folder, "lib"))
+
+        # Copy public headers based on skia_public.cppmap
+        # The project examples use "include/" as the include prefix.
+        # Replace this with a more appropriate "skia/" prefix, which also matches the behavior of Vcpkg and nixpkgs.
+        copy(self, "SkUserConfig.h",
+             os.path.join(self.source_folder, "include", "config"),
+             os.path.join(self.package_folder, "include", "skia", "config"))
+        cppmap = load(self, os.path.join(bin_dir, "skia_public.cppmap"))
+        for m in re.finditer(r'textual header "(?:\.\./)*include/(.+)"', cppmap):
+            copy(self, m.group(1),
+                 os.path.join(self.source_folder, "include"),
+                 os.path.join(self.package_folder, "include", "skia"))
+            replace_in_file(self, os.path.join(self.package_folder, "include", "skia", m.group(1)),
+                            '#include "include/', '#include "skia/', strict=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["skia_public"]

--- a/recipes/skia/all/patches/0001-use-conan-dependencies.patch
+++ b/recipes/skia/all/patches/0001-use-conan-dependencies.patch
@@ -1,28 +1,14 @@
-From 9d212d304afb8c4210503cc38a134a39ac6db8b1 Mon Sep 17 00:00:00 2001
-From: Martin Valgur <martin.valgur@gmail.com>
-Date: Sun, 28 Jul 2024 01:20:41 +0300
-Subject: [PATCH] use conan dependencies
-
----
- WORKSPACE.bazel              | 5 ++++-
- src/ports/BUILD.bazel        | 2 +-
- src/sksl/codegen/BUILD.bazel | 8 +++-----
- 3 files changed, 8 insertions(+), 7 deletions(-)
-
-diff --git a/WORKSPACE.bazel b/WORKSPACE.bazel
-index 08c3136bee..806fe093c0 100644
 --- a/WORKSPACE.bazel
 +++ b/WORKSPACE.bazel
-@@ -1,5 +1,8 @@
+@@ -1,4 +1,7 @@
  workspace(name = "skia")
- 
++
 +load("@//conan:dependencies.bzl", "load_conan_dependencies")
 +load_conan_dependencies()
-+
+ 
  load("//bazel:deps.bzl", "bazel_deps", "c_plus_plus_deps")
  
- bazel_deps()
-@@ -504,7 +507,7 @@ local_repository(
+@@ -488,7 +491,7 @@
  # @wuffs - //bazel/external/wuffs:BUILD.bazel
  # @zlib_skia - //bazel/external/zlib_skia:BUILD.bazel
  #### END GENERATED LIST OF THIRD_PARTY DEPS
@@ -31,24 +17,22 @@ index 08c3136bee..806fe093c0 100644
  
  # In order to copy the Freetype configurations into the checked out Freetype folder,
  # it is easiest to treat them as a third-party dependency from the perspective of Freetype.
-diff --git a/src/ports/BUILD.bazel b/src/ports/BUILD.bazel
-index ab14acf023..67f60ee32f 100644
+
 --- a/src/ports/BUILD.bazel
 +++ b/src/ports/BUILD.bazel
-@@ -302,7 +302,7 @@ skia_cc_deps(
-         ":uses_freetype": ["@freetype"],
-         "//conditions:default": [],
-     }) + select({
--        ":uses_fontconfig": ["//bazel/external/fontconfig"],
-+        ":uses_fontconfig": ["@fontconfig"],
-         "//conditions:default": [],
-     }) + select({
-         "//bazel/common_config_settings:android_fontmgr": ["@expat"],
-diff --git a/src/sksl/codegen/BUILD.bazel b/src/sksl/codegen/BUILD.bazel
-index 75e91d4228..5fd28b2cf5 100644
+@@ -355,7 +355,7 @@
+         ":freetype_support",
+         ":typeface_proxy",
+         "//:core",
+-        "//bazel/external/fontconfig",
++        "@fontconfig",
+         "//src/base",
+         "//src/core:core_priv",
+     ],
+
 --- a/src/sksl/codegen/BUILD.bazel
 +++ b/src/sksl/codegen/BUILD.bazel
-@@ -167,7 +167,7 @@ skia_cc_library(
+@@ -103,7 +103,7 @@
          "//:core",
          "//src/base",
          "//src/core:core_priv",
@@ -57,7 +41,7 @@ index 75e91d4228..5fd28b2cf5 100644
      ],
  )
  
-@@ -232,7 +232,7 @@ skia_cc_library(
+@@ -168,7 +168,7 @@
      deps = [
          "//:core",
          "//src/core:core_priv",
@@ -66,16 +50,15 @@ index 75e91d4228..5fd28b2cf5 100644
      ],
  )
  
-@@ -272,8 +272,6 @@ skia_cc_library(
+@@ -208,8 +208,6 @@
      deps = [
          "//:core",
          "//src/core:core_priv",
 -        "@dawn//:tint",
 -        "@dawn//src/tint/lang/wgsl",
 -        "@dawn//src/tint/lang/wgsl/reader",
+-    ],
+-)
 +        "@dawn",
-     ],
- )
--- 
-2.43.0
-
++    ],
++)

--- a/recipes/skia/all/patches/0001-use-conan-dependencies.patch
+++ b/recipes/skia/all/patches/0001-use-conan-dependencies.patch
@@ -1,0 +1,81 @@
+From 9d212d304afb8c4210503cc38a134a39ac6db8b1 Mon Sep 17 00:00:00 2001
+From: Martin Valgur <martin.valgur@gmail.com>
+Date: Sun, 28 Jul 2024 01:20:41 +0300
+Subject: [PATCH] use conan dependencies
+
+---
+ WORKSPACE.bazel              | 5 ++++-
+ src/ports/BUILD.bazel        | 2 +-
+ src/sksl/codegen/BUILD.bazel | 8 +++-----
+ 3 files changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/WORKSPACE.bazel b/WORKSPACE.bazel
+index 08c3136bee..806fe093c0 100644
+--- a/WORKSPACE.bazel
++++ b/WORKSPACE.bazel
+@@ -1,5 +1,8 @@
+ workspace(name = "skia")
+ 
++load("@//conan:dependencies.bzl", "load_conan_dependencies")
++load_conan_dependencies()
++
+ load("//bazel:deps.bzl", "bazel_deps", "c_plus_plus_deps")
+ 
+ bazel_deps()
+@@ -504,7 +507,7 @@ local_repository(
+ # @wuffs - //bazel/external/wuffs:BUILD.bazel
+ # @zlib_skia - //bazel/external/zlib_skia:BUILD.bazel
+ #### END GENERATED LIST OF THIRD_PARTY DEPS
+-c_plus_plus_deps()
++# c_plus_plus_deps()
+ 
+ # In order to copy the Freetype configurations into the checked out Freetype folder,
+ # it is easiest to treat them as a third-party dependency from the perspective of Freetype.
+diff --git a/src/ports/BUILD.bazel b/src/ports/BUILD.bazel
+index ab14acf023..67f60ee32f 100644
+--- a/src/ports/BUILD.bazel
++++ b/src/ports/BUILD.bazel
+@@ -302,7 +302,7 @@ skia_cc_deps(
+         ":uses_freetype": ["@freetype"],
+         "//conditions:default": [],
+     }) + select({
+-        ":uses_fontconfig": ["//bazel/external/fontconfig"],
++        ":uses_fontconfig": ["@fontconfig"],
+         "//conditions:default": [],
+     }) + select({
+         "//bazel/common_config_settings:android_fontmgr": ["@expat"],
+diff --git a/src/sksl/codegen/BUILD.bazel b/src/sksl/codegen/BUILD.bazel
+index 75e91d4228..5fd28b2cf5 100644
+--- a/src/sksl/codegen/BUILD.bazel
++++ b/src/sksl/codegen/BUILD.bazel
+@@ -167,7 +167,7 @@ skia_cc_library(
+         "//:core",
+         "//src/base",
+         "//src/core:core_priv",
+-        "@spirv_cross",
++        "@spirv-cross",
+     ],
+ )
+ 
+@@ -232,7 +232,7 @@ skia_cc_library(
+     deps = [
+         "//:core",
+         "//src/core:core_priv",
+-        "@spirv_tools",
++        "@spirv-tools",
+     ],
+ )
+ 
+@@ -272,8 +272,6 @@ skia_cc_library(
+     deps = [
+         "//:core",
+         "//src/core:core_priv",
+-        "@dawn//:tint",
+-        "@dawn//src/tint/lang/wgsl",
+-        "@dawn//src/tint/lang/wgsl/reader",
++        "@dawn",
+     ],
+ )
+-- 
+2.43.0
+

--- a/recipes/skia/all/test_package/CMakeLists.txt
+++ b/recipes/skia/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(skia REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE skia::skia)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/skia/all/test_package/conanfile.py
+++ b/recipes/skia/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/skia/all/test_package/conanfile.py
+++ b/recipes/skia/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/skia/all/test_package/test_package.cpp
+++ b/recipes/skia/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <skia/core/SkPath.h>
+#include <skia/core/SkPathBuilder.h>
+
+int main() {
+    SkPathBuilder pb;
+    pb.moveTo(10, 10);
+    pb.lineTo(15, 5);
+    pb.lineTo(20, 10);
+    pb.close();
+    SkPath path1 = pb.detach();
+}

--- a/recipes/skia/config.yml
+++ b/recipes/skia/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20240727":
+    folder: all

--- a/recipes/skia/config.yml
+++ b/recipes/skia/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20240727":
+  "132":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **skia/cci.20240727**

#### Motivation
Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms. It serves as the graphics engine for Google Chrome and ChromeOS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.

- Closes #2389

[![Packaging status](https://repology.org/badge/tiny-repos/skia.svg)](https://repology.org/project/skia/versions)

#### Details
- he project provides two build systems - an older one based on gn and a newer one based on Bazel that the project is being migrated to. I opted for the latter because it has much better compatibility with Cona.
- The project builds and links against two Rust libraries internally: [icu4x](https://github.com/unicode-org/icu4x) and [vello](https://github.com/linebender/vello).
- The build system also always downloads and uses a Clang toolchain for compilation. Will have to look into replacing it with the C++ toolchain from the Conan profile.
- I opted to build and export only a single bundled library instead of the numerous components it is composed of. The individual components could be added later, if there's interest.
- I'm quite happy with how much simpler the recipe is compared to the equivalent Vcpkg port (currently at least): https://github.com/microsoft/vcpkg/tree/master/ports/skia
- Requires #24735

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
