### PR TITLE
libftp: add version 1.1.0

### DIFF
--- a/recipes/libftp/all/conandata.yml
+++ b/recipes/libftp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.0.0":
-    url: "https://github.com/deniskovalchuk/libftp/archive/refs/tags/v1.0.0.tar.gz"
-    sha256: "bf019040dc495d477870d6f3df7d29e7efddb3ccc688b26714a442276cf1290a"
+  "1.1.0":
+    url: "https://github.com/deniskovalchuk/libftp/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "8d9ff413436b17eef225c4b12539965cdea786d02bb2c688b153992d36f88f48"
   "0.5.1":
     url: "https://github.com/deniskovalchuk/libftp/archive/refs/tags/v0.5.1.tar.gz"
     sha256: "6cc6e80b50ba425b66175d3b0d22358db4ebeb4941edc33bba47d72442de5645"

--- a/recipes/libftp/all/conandata.yml
+++ b/recipes/libftp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/deniskovalchuk/libftp/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "bf019040dc495d477870d6f3df7d29e7efddb3ccc688b26714a442276cf1290a"
   "0.5.1":
     url: "https://github.com/deniskovalchuk/libftp/archive/refs/tags/v0.5.1.tar.gz"
     sha256: "6cc6e80b50ba425b66175d3b0d22358db4ebeb4941edc33bba47d72442de5645"

--- a/recipes/libftp/config.yml
+++ b/recipes/libftp/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.0.0":
+  "1.1.0":
     folder: all
   "0.5.1":
     folder: all

--- a/recipes/libftp/config.yml
+++ b/recipes/libftp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.5.1":
     folder: all
   "0.5.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libftp/1.1.0**

#### Motivation
There is a new function in 1.1.0.

#### Details
https://github.com/deniskovalchuk/libftp/compare/v0.5.1...v1.1.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
