### PR TITLE
qt6: dont use system libclang

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -377,13 +377,13 @@ class QtConan(ConanFile):
             self.requires("harfbuzz/8.3.0")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
             if self.options.with_libjpeg == "libjpeg-turbo":
-                self.requires("libjpeg-turbo/3.0.1")
+                self.requires("libjpeg-turbo/[>=3.0 <3.1]")
             else:
                 self.requires("libjpeg/9e")
         if self.options.get_safe("with_libpng", False) and not self.options.multiconfiguration:
             self.requires("libpng/[>=1.6 <2]")
         if self.options.with_sqlite3 and not self.options.multiconfiguration:
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.get_safe("with_mysql", False):
             self.requires("libmysqlclient/8.1.0")
         if self.options.with_pq:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -347,13 +347,13 @@ class QtConan(ConanFile):
             self.requires("harfbuzz/8.3.0")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
             if self.options.with_libjpeg == "libjpeg-turbo":
-                self.requires("libjpeg-turbo/3.0.1")
+                self.requires("libjpeg-turbo/[>=3.0 <3.1]")
             else:
                 self.requires("libjpeg/9e")
         if self.options.get_safe("with_libpng", False) and not self.options.multiconfiguration:
             self.requires("libpng/[>=1.6 <2]")
         if self.options.with_sqlite3 and not self.options.multiconfiguration:
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.get_safe("with_mysql", False):
             self.requires("libmysqlclient/8.1.0")
         if self.options.with_pq:
@@ -523,6 +523,11 @@ class QtConan(ConanFile):
 
         if not self.options.with_zstd:
             tc.variables["CMAKE_DISABLE_FIND_PACKAGE_WrapZSTD"] = "ON"
+
+        # Prevent finding LibClang from the system
+        # this is needed by the QDoc tool inside Qt Tools
+        # See: https://github.com/conan-io/conan-center-index/issues/24729#issuecomment-2255291495
+        tc.variables["CMAKE_DISABLE_FIND_PACKAGE_WrapLibClang"] = "ON"
 
         for opt, conf_arg in [("with_glib", "glib"),
                               ("with_icu", "icu"),


### PR DESCRIPTION
### Summary
Changes to recipe:  qt

#### Motivation
The build scripts look for libclang in the system "optionally" - this can cause errors in some systems where the development files for libclang are not fully present. Otherwise it would succeeds if it finds it, or if it doesn't at all.

See https://github.com/conan-io/conan-center-index/issues/24729

#### Details
* Make the recipe for reproducible and do not rely on whether or not libclang is present in the system
* This essentially disables building the QDoc utility, but it would seem that tool is more useful for Qt developers to generate the Qt documentation itself. We will consider other options if it turns out this tool is widely used.


Additionally:
* on a trial basis, use version ranges for libjpeg turbo and sqlite3 - which are known to be stable libraries with a backwards compatible C interface