### PR TITLE
[docs] Add xz_utils in version ranges

### DIFF
--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -182,7 +182,7 @@ With the introduction of Conan 2.0, we are currently working to allow the use of
 Version ranges are being progressively introduced by Conan team maintainers and are being rolled out in phases, and we do not intend
 to do it all at once.
 
-Version ranges for the following dependencies will be accepted in pull requests: 
+Version ranges for the following dependencies will be accepted in pull requests:
 
 * OpenSSL: `[>=1.1 <4]` for libraries known to be compatible with OpenSSL 1.x and 3.x
 * CMake: `[>3.XX <4]`, where `3.XX` is the minimum version of CMake required by the relevant build scripts. Note that CCI recipes assume 3.15 is installed in the system, so add this
@@ -200,6 +200,7 @@ version range only when a requirement for a newer version is needed.
 * ninja: `[>=1.10.2 <2]`
 * meson: `[>=1.2.3 <2]`
 * pkgconf: `[>=2.2 <3]`
+* xz_utils: `[>=5.4.5 <6]`
 
 > **Warning**: With Conan 1.x, [version ranges](https://docs.conan.io/1/versioning/version_ranges.html) adhere to a much more strict sematic version spec,
 > OpenSSL 1.1.x does not follow this so the client will not resolve to that range and will pick a 3.x version. In order to select a lower version you
@@ -211,12 +212,12 @@ Conan maintainers may introduce this for other dependencies over time. Outside o
 #### Adding Version Ranges
 
 You might also see version ranges being added in pull requests by Conan maintainers, that
-are not in the list above. These are being introduced on a case-by-case basis, and are being rolled out 
+are not in the list above. These are being introduced on a case-by-case basis, and are being rolled out
 in phases to ensure that they do not cause problems to users. Note that version ranges can
 only be used for libraries and tools that have strong compatibility guarantees - and may not
 be suitable in all cases.
 
-Please do not open PRs that exclusively add version ranges to dependencies, unless they are solving 
+Please do not open PRs that exclusively add version ranges to dependencies, unless they are solving
 current conflicts, in which case we welcome them and they will be prioritized.
 
 ## Handling "internal" dependencies


### PR DESCRIPTION
### Summary
Changes to recipe:  **xz_utils/[>=5.4.5 <6]**

#### Motivation

The `xz_utils` is used by 23 recipes in CCI right now and most of them are consuming the latest version available in Conan Center: `5.4.5`.

The project looks pretty stable and the backward compatibility is checked until the version 2.3.1: https://abi-laboratory.pro/?view=timeline&l=xz

I didn't find any specific evidence in documentation or in the project repository, ensuring about backward support, so I opened an issue questioning about: https://github.com/tukaani-project/xz/issues/132.

#### Details

Using a grep you can find how many recipes are using `xz_utils`:

    find . -name conanfile.py -exec fgrep xz_utils/ {} +

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
