### PR TITLE
qt5: fix check for python2 version

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -157,7 +157,6 @@ class QtConan(ConanFile):
             # In any case, check its actual version for compatibility
             command_output = StringIO()
             cmd_v = f"\"{python_exe}\" -c \"import platform;print(platform.python_version())\""
-            
             self.run(cmd_v, command_output)
             verstr = command_output.getvalue().strip()
             version = Version(verstr)

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -10,6 +10,7 @@ from conan.tools.microsoft import is_msvc, msvc_runtime_flag, is_msvc_static_run
 from conan.tools.scm import Version
 import configparser
 import glob
+from io import StringIO
 import itertools
 import os
 import textwrap
@@ -154,20 +155,18 @@ class QtConan(ConanFile):
                 raise ConanInvalidConfiguration(msg)
 
             # In any case, check its actual version for compatibility
-            from six import StringIO  # Python 2 and 3 compatible
-            mybuf = StringIO()
-            cmd_v = f"\"{python_exe}\" --version"
-            self.run(cmd_v, mybuf)
-            verstr = mybuf.getvalue().strip().split("Python ")[1]
-            if verstr.endswith("+"):
-                verstr = verstr[:-1]
+            command_output = StringIO()
+            cmd_v = f"\"{python_exe}\" -c \"import platform;print(platform.python_version())\""
+            
+            self.run(cmd_v, command_output)
+            verstr = command_output.getvalue().strip()
             version = Version(verstr)
             # >= 2.7.5 & < 3
             v_min = "2.7.5"
             v_max = "3.0.0"
             if (version >= v_min) and (version < v_max):
                 msg = ("Found valid Python 2 required for QtWebengine:"
-                       f" version={mybuf.getvalue()}, path={python_exe}")
+                       f" version={verstr}, path={python_exe}")
                 self.output.success(msg)
             else:
                 msg = (f"Found Python 2 in path, but with invalid version {verstr}"


### PR DESCRIPTION
### Summary
Changes to recipe:  qt/5.x.x

#### Motivation
* building qtwebengine requires python2 (still), and the current check in the `validate_build()` method does not work since it checks for stdout

#### Details
* check the python version by passing `-c "import platform;print(platform.python_version())"` instead, which is correctly printed to stdout - avoids other alternative solutions like pipe redirection or calling the underlying process popen

