### PR TITLE
bitsery: add version 5.2.4

### DIFF
--- a/recipes/bitsery/all/conandata.yml
+++ b/recipes/bitsery/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.2.4":
+    url: "https://github.com/fraillt/bitsery/archive/v5.2.4.tar.gz"
+    sha256: "ff741a3fee5420b31af31c7a8cefbcc3aaaf6f7f8c3ac49aa020f99b21d96020"
   "5.2.3":
     url: "https://github.com/fraillt/bitsery/archive/v5.2.3.tar.gz"
     sha256: "896d82ab4ccea9899ff2098aa69ad6d25e524ee1d4c747ce3232d0afe3cd05a5"

--- a/recipes/bitsery/all/conanfile.py
+++ b/recipes/bitsery/all/conanfile.py
@@ -13,10 +13,10 @@ class BitseryConan(ConanFile):
         "Header only C++ binary serialization library. It is designed around "
         "the networking requirements for real-time data delivery, especially for games."
     )
-    topics = ("serialization", "binary", "header-only")
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/fraillt/bitsery"
-    license = "MIT"
+    topics = ("serialization", "binary", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True

--- a/recipes/bitsery/config.yml
+++ b/recipes/bitsery/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.2.4":
+    folder: all
   "5.2.3":
     folder: all
   "5.2.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **bitsery/5.2.4**

#### Motivation
There are minor improvements in 5.2.4, but it is the first release in 1.5 years.

#### Details
https://github.com/fraillt/bitsery/compare/v5.2.3...v5.2.4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
