### PR TITLE
subunit: add version 1.4.4

### DIFF
--- a/recipes/subunit/all/conandata.yml
+++ b/recipes/subunit/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.4":
+    url: "https://github.com/testing-cabal/subunit/archive/refs/tags/1.4.4.tar.gz"
+    sha256: "395787f52b8b36830c331faca546ea6c248b6cbd8de95989c2f64d432cc90531"
   "1.4.0":
     url: "https://launchpad.net/subunit/trunk/1.4.0/+download/subunit-1.4.0.tar.gz"
     sha256: "00792096e96cbf1d5f9394dadd0ea73309a4f8b2214822949f1888ce5c2cf1c0"

--- a/recipes/subunit/all/conanfile.py
+++ b/recipes/subunit/all/conanfile.py
@@ -137,6 +137,7 @@ class SubunitConan(ConanFile):
         apply_conandata_patches(self)
         with chdir(self, self.source_folder):
             autotools = Autotools(self)
+            autotools.autoreconf()
             autotools.configure()
             autotools.make()
 

--- a/recipes/subunit/all/conanfile.py
+++ b/recipes/subunit/all/conanfile.py
@@ -165,4 +165,4 @@ class SubunitConan(ConanFile):
         self.cpp_info.components["libcppunit_subunit"].set_property("pkg_config_name", "libcppunit_subunit")
 
         bin_path = os.path.join(self.package_folder, "bin")
-        self.env_info.PATH.append(bin_path)
+        self.runenv_info.append_path("PATH", bin_path)

--- a/recipes/subunit/config.yml
+++ b/recipes/subunit/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.4.4":
+    folder: "all"
   "1.4.0":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/1.4.4**. Fixes: #24732

#### Motivation
Version 1.4.0 which is the current subunit version in Conan repo is not compatible with Python 3.12 (see [subunit bug #2052948](https://bugs.launchpad.net/subunit/+bug/2052948)). Version 1.4.4 has compatibility issues fixed.

#### Details
Changes in PR:
- add new version and add autoreconf() step because new version requires it https://github.com/conan-io/conan-center-index/commit/f0329525508be55f0f838ffe3ea7e1523cab1dc5
- replace `ConanFile.env_info` (which is deprecated) by `ConanFile.runenv_info` https://github.com/conan-io/conan-center-index/commit/37a10d45757b568216fa801923e55ece9e55a9be
Changed are tested with both 1.4.0 and 1.4.4 version using both Conan 1 and 2.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan