### PR TITLE
fast_io: add version cci.20240729

### DIFF
--- a/recipes/fast_io/all/conandata.yml
+++ b/recipes/fast_io/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20240729":
+    url: "https://github.com/cppfastio/fast_io/archive/44617e9368b64047fabd00cd98b037c1c2fc7fb2.tar.gz"
+    sha256: "077692f72f2a7e3fed44fa5b37613d058657738c2592addfcb6559cf1ae30716"
   "cci.20240219":
     url: "https://github.com/cppfastio/fast_io/archive/316afccde333721b059a761b25217084e84a9ca0.tar.gz"
     sha256: "9feab7802957c8069b2a112f97bfb885d503ff5d7f433197f47636f40a20188a"

--- a/recipes/fast_io/config.yml
+++ b/recipes/fast_io/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20240729":
+    folder: all
   "cci.20240219":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **fast_io/cci.20240729**

#### Motivation
There are several improvements since cci.20240219.

#### Details
compare/316afccde333721b059a761b25217084e84a9ca0...44617e9368b64047fabd00cd98b037c1c2fc7fb2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
