### PR TITLE
aws-c-cal: Bump dependency for aws-c-common to avoid conflict

### DIFF
--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -51,7 +51,7 @@ class AwsCCal(ConanFile):
         if Version(self.version) <= "0.5.20":
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         elif Version(self.version) <= "0.6.1":
-            self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-common/0.9.12", transitive_headers=True, transitive_libs=True)
         else:
             # [>=0.9.7]
             self.requires("aws-c-common/0.9.12", transitive_headers=True, transitive_libs=True)


### PR DESCRIPTION
### Summary
Bumps version of aws-c-common to 0.9.12

#### Motivation
Fix version conflict that appeared here https://github.com/conan-io/conan-center-index/pull/24526

#### Details
 0.9.12 is the latest version of aws-c-common in config.yml

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
