### PR TITLE
[aws-c-compression] Update require aws-c-common to 0.9.12

### DIFF
--- a/recipes/aws-c-compression/all/conanfile.py
+++ b/recipes/aws-c-compression/all/conanfile.py
@@ -43,7 +43,7 @@ class AwsCCompression(ConanFile):
         if Version(self.version) <= "0.2.15":
             self.requires("aws-c-common/0.8.2", transitive_headers=True, transitive_libs=True)
         else:
-            self.requires("aws-c-common/0.9.6", transitive_headers=True, transitive_libs=True)
+            self.requires("aws-c-common/0.9.12", transitive_headers=True, transitive_libs=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
Update require aws-c-common to 0.9.12

#### Motivation
Removing conflicts from aws recipes 

#### Details
0.9.12 is the latest version of aws-c-common


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
