### PR TITLE
libdivide: add version 5.1

### DIFF
--- a/recipes/libdivide/all/conandata.yml
+++ b/recipes/libdivide/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.1":
+    url: "https://github.com/ridiculousfish/libdivide/archive/refs/tags/v5.1.tar.gz"
+    sha256: "fec2e4141878c58eb92cfcd478accc3b7f34b39491c1e638566f083d378cc7d4"
   "5.0":
     url: "https://github.com/ridiculousfish/libdivide/archive/refs/tags/5.0.tar.gz"
     sha256: "01ffdf90bc475e42170741d381eb9cfb631d9d7ddac7337368bcd80df8c98356"

--- a/recipes/libdivide/config.yml
+++ b/recipes/libdivide/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.1":
+    folder: all
   "5.0":
     folder: all
   "3.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdivide/5.1**

#### Motivation
There are several improvements in 5.1.
5.1 fixes compilation error on newer gcc.

#### Details
https://github.com/ridiculousfish/libdivide/compare/5.0...v5.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
