### PR TITLE
croncpp: add version 2023.03.30, remove cci version

### DIFF
--- a/recipes/croncpp/all/conandata.yml
+++ b/recipes/croncpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-    "cci.20220503":
-        url: "https://github.com/mariusbancila/croncpp/archive/5c28f410db1af9507ef8469c9796a7070e5e8e2e.tar.gz"
-        sha256: "cabc480c78ebf12b11bd9fcd705a7ecb1c85ac88a8c9debe8de67f30abd808a8"
+    "2023.03.30":
+        url: "https://github.com/mariusbancila/croncpp/archive/refs/tags/v2023.03.30.tar.gz"
+        sha256: "0731b7f900a670c009585eb5e9639722aeff6531dbbd5bfc9ce895459733837e"

--- a/recipes/croncpp/all/conanfile.py
+++ b/recipes/croncpp/all/conanfile.py
@@ -1,9 +1,8 @@
-import os
-
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
 
 required_conan_version = ">=1.52.0"
 
@@ -25,7 +24,7 @@ class CroncppConan(ConanFile):
         return 11
 
     def layout(self):
-        cmake_layout(self, src_folder="src")
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()
@@ -37,21 +36,18 @@ class CroncppConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.generate()
-
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.build()
-
     def package(self):
-        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        cmake = CMake(self)
-        cmake.install()
-        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(
+            self,
+            "*.h",
+            os.path.join(self.source_folder, "include"),
+            os.path.join(self.package_folder, "include"),
+        )
 
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+
+        self.cpp_info.set_property("cmake_file_name", "croncpp")
+        self.cpp_info.set_property("cmake_target_name","croncpp::croncpp")

--- a/recipes/croncpp/config.yml
+++ b/recipes/croncpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20220503":
+  "2023.03.30":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **croncpp/2023.03.30**

#### Motivation
This is the first release of croncpp.

#### Details
- delete cci.20220503.
- remove cmake operation to avoid unnecessary C++ version check.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
