### PR TITLE
etl: add version 20.39.0, remove older versions

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.39.0":
+    url: "https://github.com/ETLCPP/etl/archive/20.39.0.tar.gz"
+    sha256: "1553dfaba3ba8a44a592367127b145ba6e413bf2df376808bdb6fe7a7635c197"
   "20.38.17":
     url: "https://github.com/ETLCPP/etl/archive/20.38.17.tar.gz"
     sha256: "5b490aca3faad3796a48bf0980e74f2a67953967fad3c051a6d4981051cb0b9a"
@@ -20,24 +23,3 @@ sources:
   "20.38.10":
     url: "https://github.com/ETLCPP/etl/archive/20.38.10.tar.gz"
     sha256: "562f9b5d9e6786350b09d87be9c5f030073e34d7bf0a975de3e91476ddd471a3"
-  "20.38.7":
-    url: "https://github.com/ETLCPP/etl/archive/20.38.7.tar.gz"
-    sha256: "65cfc033bacab452af05a36bd53b8cdc2bdfd1492b2adc5bb51d2f00e451491f"
-  "20.38.6":
-    url: "https://github.com/ETLCPP/etl/archive/20.38.6.tar.gz"
-    sha256: "95515f2229fe75393d18ee95548998a06e65a02acd5eedae5808dd34f8201462"
-  "20.38.4":
-    url: "https://github.com/ETLCPP/etl/archive/20.38.4.tar.gz"
-    sha256: "4074583bacac17e7944030f099d18a4ea3591d5d58b8d8b85c1b7f080a3e9610"
-  "20.38.3":
-    url: "https://github.com/ETLCPP/etl/archive/20.38.3.tar.gz"
-    sha256: "7d2f384dfa9a50c8e066b716524016d2b62e753b0b75fed09a2b7e2c260759d2"
-  "20.38.0":
-    url: "https://github.com/ETLCPP/etl/archive/20.38.0.tar.gz"
-    sha256: "7e29ce81a2a2d5826286502a2ad5bde1f4b591d2c9e0ef7ccc335e75445223cd"
-  "20.37.3":
-    url: "https://github.com/ETLCPP/etl/archive/20.37.3.tar.gz"
-    sha256: "fbdf60c770772cd96d1eb25bdf56e4f45f23bf4029e18ef1f2af1f2056b9ea41"
-  "20.36.0":
-    url: "https://github.com/ETLCPP/etl/archive/20.36.0.tar.gz"
-    sha256: "bcab607d619008c7e3942ecc9cb429e17deb553c81bc5f1fd013fbc1e17f1344"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.39.0":
+    folder: all
   "20.38.17":
     folder: all
   "20.38.16":
@@ -12,18 +14,4 @@ versions:
   "20.38.11":
     folder: all
   "20.38.10":
-    folder: all
-  "20.38.7":
-    folder: all
-  "20.38.6":
-    folder: all
-  "20.38.4":
-    folder: all
-  "20.38.3":
-    folder: all
-  "20.38.0":
-    folder: all
-  "20.37.3":
-    folder: all
-  "20.36.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **etl/20.39.0**

#### Motivation
There are several improvements in 20.39.0.

#### Details
https://github.com/ETLCPP/etl/compare/20.38.17...20.39.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
