### PR TITLE
gtest: add 1.15.2

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.15.2":
+    url: "https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"
+    sha256: "7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926"
   "1.15.0":
     url: "https://github.com/google/googletest/releases/download/v1.15.0/googletest-1.15.0.tar.gz"
     sha256: "7315acb6bf10e99f332c8a43f00d5fbb1ee6ca48c52f6b936991b216c586aaad"

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.15.2":
+    folder: all
   "1.15.0":
     folder: all
   "1.14.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gtest/1.15.2**

#### Motivation
I wanted to update to Google Test 1.15 but noticed that a newer patch version is available.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
