### PR TITLE
Fix copy/paste mistake in linter-yaml.yml for  'Run linter (config.yml)'

### DIFF
--- a/.github/workflows/linter-yaml.yml
+++ b/.github/workflows/linter-yaml.yml
@@ -91,7 +91,7 @@ jobs:
           done
           echo "::remove-matcher owner=yamllint_matcher::"
 
-          for file in ${{ steps.changed_files_conandata.outputs.all_changed_files }}; do
+          for file in ${{ steps.changed_files_config.outputs.all_changed_files }}; do
             python3 linter/config_yaml_linter.py ${file}
           done
 


### PR DESCRIPTION
### Summary
Fix list of file to apply linter

#### Motivation
It seems we apply we're doing linting for config to conandata instead of config file

#### Details
Changing to the right set of files


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
