### PR TITLE
vulkan-loader/headers: bump 1.3.290.0

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.290.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.290.0.tar.gz"
+    sha256: "5b186e1492d97c44102fe858fb9f222b55524a8b6da940a8795c9e326ae6d722"
   "1.3.268.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
     sha256: "94993cbe2b1a604c0d5d9ea37a767e1aba4d771d2bfd4ddceefd66243095164f"

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.290.0":
+    folder: all
   "1.3.268.0":
     folder: all
   "1.3.261.1":

--- a/recipes/vulkan-loader/all/conandata.yml
+++ b/recipes/vulkan-loader/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.290.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.3.290.tar.gz"
+    sha256: "a1f0d80c4ee448d4fa37d1d4a4c4cf1d6d0f5873d3ca6dffe2a9498e6e654142"
   "1.3.268.0":
     url: "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
     sha256: "404fa621f1ab2731bcc68bcbff64d8c6de322faad2d87f9198641bd37255fd39"

--- a/recipes/vulkan-loader/all/conanfile.py
+++ b/recipes/vulkan-loader/all/conanfile.py
@@ -132,12 +132,13 @@ class VulkanLoaderConan(ConanFile):
                                   "if(${configuration} MATCHES \"/MD\")",
                                   "if(FALSE)")
         else:
-            replace_in_file(
-                self,
-                cmakelists,
-                "set(TESTS_STANDARD_CXX_PROPERTIES ${LOADER_STANDARD_CXX_PROPERTIES} MSVC_RUNTIME_LIBRARY \"MultiThreaded$<$<CONFIG:Debug>:Debug>DLL\")",
-                "set(TESTS_STANDARD_CXX_PROPERTIES ${LOADER_STANDARD_CXX_PROPERTIES})",
-            )
+            if Version(self.version) < "1.3.275":
+                replace_in_file(
+                    self,
+                    cmakelists,
+                    "set(TESTS_STANDARD_CXX_PROPERTIES ${LOADER_STANDARD_CXX_PROPERTIES} MSVC_RUNTIME_LIBRARY \"MultiThreaded$<$<CONFIG:Debug>:Debug>DLL\")",
+                    "set(TESTS_STANDARD_CXX_PROPERTIES ${LOADER_STANDARD_CXX_PROPERTIES})",
+                )
             replace_in_file(
                 self,
                 cmakelists,

--- a/recipes/vulkan-loader/config.yml
+++ b/recipes/vulkan-loader/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.290.0":
+    folder: all
   "1.3.268.0":
     folder: all
   "1.3.250.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-loader:13.290.0**
                                **vulkan-headers:13.290.0**

#### Motivation
Current top version `1.3.268.0` doesn't build when using `clang` on Windows and requires https://github.com/KhronosGroup/Vulkan-Loader/commit/a0308b56d851bea6496ed36b088e2d24afd3cb6d

#### Details
I've bumped version to highest available at the moment in `Vulkan-loader` repository. 
Building tests changed in `1.3.275`, thus additional check


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
