### PR TITLE
libjxl: disable linking static libgcc and libstdc++

### DIFF
--- a/recipes/libjxl/all/conandata.yml
+++ b/recipes/libjxl/all/conandata.yml
@@ -8,6 +8,3 @@ sources:
   "0.8.2":
     url: "https://github.com/libjxl/libjxl/archive/v0.8.2.zip"
     sha256: "1f2ccc06f07c4f6cf4aa6c7763ba0598f12a7544d597f02beb07f615eb08ccf0"
-  "0.6.1":
-    url: "https://github.com/libjxl/libjxl/archive/v0.6.1.zip"
-    sha256: "3e4877daef07724aa6f490bf80c45ada804f35fe3cce59c27e89c5ae3099535a"

--- a/recipes/libjxl/all/conanfile.py
+++ b/recipes/libjxl/all/conanfile.py
@@ -82,10 +82,10 @@ class LibjxlConan(ConanFile):
             # Fails with a missing DLL error in test_package
             raise ConanInvalidConfiguration(f"{self.ref} does not support shared builds with MSVC")
 
-    # def build_requirements(self):
-    #     # Require newer CMake, which allows INCLUDE_DIRECTORIES to be set on INTERFACE targets
-    #     # Also, v0.9+ require CMake 3.16
-    #     self.tool_requires("cmake/[>=3.19 <4]")
+    def build_requirements(self):
+        # Require newer CMake, which allows INCLUDE_DIRECTORIES to be set on INTERFACE targets
+        # Also, v0.9+ require CMake 3.16
+        self.tool_requires("cmake/[>=3.19 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libjxl/all/conanfile.py
+++ b/recipes/libjxl/all/conanfile.py
@@ -63,10 +63,7 @@ class LibjxlConan(ConanFile):
 
     def requirements(self):
         self.requires("brotli/1.1.0")
-        if Version(self.version) >= "0.7":
-            self.requires("highway/1.1.0")
-        else:
-            self.requires("highway/0.12.2")
+        self.requires("highway/1.1.0")
         self.requires("lcms/2.16")
         if self.options.with_tcmalloc:
             self.requires("gperftools/2.15")
@@ -74,9 +71,6 @@ class LibjxlConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
-        if self.version == "0.6.1" and is_msvc(self) and self.options.shared:
-            # Fails with a missing DLL error in test_package
-            raise ConanInvalidConfiguration(f"{self.ref} does not support shared builds with MSVC")
 
     def build_requirements(self):
         # Require newer CMake, which allows INCLUDE_DIRECTORIES to be set on INTERFACE targets
@@ -160,14 +154,6 @@ class LibjxlConan(ConanFile):
             if os.path.exists(path):
                 fpic = "ON" if self.options.get_safe("fPIC", True) else "OFF"
                 replace_in_file(self, path, "POSITION_INDEPENDENT_CODE ON", f"POSITION_INDEPENDENT_CODE {fpic}")
-
-        if Version(self.version) < "0.7":
-            replace_in_file(self, os.path.join(self.source_folder, "lib", "jxl.cmake"),
-                            "  DESTINATION ${CMAKE_INSTALL_LIBDIR}",
-                            "  RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib")
-            if self.settings.compiler not in ["gcc", "clang"]:
-                replace_in_file(self, os.path.join(self.source_folder, "lib", "jxl.cmake"),
-                                "-Wl,--exclude-libs=ALL", "")
 
     def build(self):
         self._patch_sources()

--- a/recipes/libjxl/all/conanfile.py
+++ b/recipes/libjxl/all/conanfile.py
@@ -30,7 +30,6 @@ class LibjxlConan(ConanFile):
         "avx512_spr": [True, False],
         "avx512_zen4": [True, False],
         "with_tcmalloc": [True, False],
-        "with_jpegli": [True, False],
     }
     default_options = {
         "shared": False,
@@ -39,7 +38,6 @@ class LibjxlConan(ConanFile):
         "avx512_spr": False,
         "avx512_zen4": False,
         "with_tcmalloc": False,
-        "with_jpegli": False,
     }
 
     def export_sources(self):
@@ -55,8 +53,6 @@ class LibjxlConan(ConanFile):
         # https://github.com/libjxl/libjxl/blob/v0.9.1/CMakeLists.txt#L52-L59
         if self.settings.os in ["Linux", "FreeBSD"] and self.settings.arch == "x86_64":
             self.options.with_tcmalloc = True
-        if Version(self.version) < "0.8.0":
-            del self.options.with_jpegli
 
     def configure(self):
         if self.options.shared:
@@ -91,7 +87,7 @@ class LibjxlConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        # VirtualBuildEnv(self).generate()
+        VirtualBuildEnv(self).generate()
 
         tc = CMakeToolchain(self)
         tc.variables["CMAKE_PROJECT_LIBJXL_INCLUDE"] = "conan_deps.cmake"
@@ -119,9 +115,6 @@ class LibjxlConan(ConanFile):
         tc.variables["JPEGXL_ENABLE_AVX512"] = self.options.get_safe("avx512", False)
         tc.variables["JPEGXL_ENABLE_AVX512_SPR"] = self.options.get_safe("avx512_spr", False)
         tc.variables["JPEGXL_ENABLE_AVX512_ZEN4"] = self.options.get_safe("avx512_zen4", False)
-        if "with_jpegli" in self.options:
-            tc.variables["JPEGXL_ENABLE_JPEGLI"] = self.options.with_jpegli
-            tc.variables["JPEGXL_INSTALL_JPEGLI_LIBJPEG"] = self.options.with_jpegli
         if cross_building(self):
             tc.variables["CMAKE_SYSTEM_PROCESSOR"] = str(self.settings.arch)
         # Allow non-cache_variables to be used

--- a/recipes/libjxl/all/conanfile.py
+++ b/recipes/libjxl/all/conanfile.py
@@ -92,7 +92,7 @@ class LibjxlConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["CMAKE_PROJECT_LIBJXL_INCLUDE"] = "conan_deps.cmake"
         tc.variables["BUILD_TESTING"] = False
-        tc.variables["JPEGXL_STATIC"] = not self.options.shared  # applies to tools only
+        tc.variables["JPEGXL_STATIC"] = False
         tc.variables["JPEGXL_BUNDLE_LIBPNG"] = False
         tc.variables["JPEGXL_ENABLE_BENCHMARK"] = False
         tc.variables["JPEGXL_ENABLE_DOXYGEN"] = False
@@ -168,11 +168,6 @@ class LibjxlConan(ConanFile):
             if self.settings.compiler not in ["gcc", "clang"]:
                 replace_in_file(self, os.path.join(self.source_folder, "lib", "jxl.cmake"),
                                 "-Wl,--exclude-libs=ALL", "")
-
-        # Disable static link for libgcc and libstdc++
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-            '"${CMAKE_EXE_LINKER_FLAGS} -static -static-libgcc -static-libstdc++")',
-            '"${CMAKE_EXE_LINKER_FLAGS}")')
 
     def build(self):
         self._patch_sources()

--- a/recipes/libjxl/config.yml
+++ b/recipes/libjxl/config.yml
@@ -5,5 +5,3 @@ versions:
     folder: all
   "0.8.2":
     folder: all
-  "0.6.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjxl/***

#### Motivation
In some environments, there are compilation errors in static build.
It seems to be caused by linking static libgcc and libcstdc++.
This PR tries to fix it.

#### Details
Compilation error message are following:
```
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - no
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
CMake Error at cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Threads (missing: Threads_FOUND)
Call Stack (most recent call first):
  cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  cmake-3.28/Modules/FindThreads.cmake:226 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:170 (find_package)
```

After applying this PR.
```
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Using -lpthread as --whole-archive
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
