### PR TITLE
Align opencv image codec option default values to upstream defaults

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -191,7 +191,7 @@ class OpenCVConan(ConanFile):
         "with_jpeg": "libjpeg",
         "with_png": True,
         "with_tiff": True,
-        "with_jpeg2000": "jasper",
+        "with_jpeg2000": "openjpeg",
         "with_openexr": True,
         "with_webp": True,
         "with_gdal": False,
@@ -358,6 +358,9 @@ class OpenCVConan(ConanFile):
             # in a big dependency graph
             if not self._has_with_wayland_option:
                 self.options.with_gtk = True
+
+        if Version(self.version) < "4.3.0":
+            self.options.with_jpeg2000 = "jasper"
 
     @property
     def _opencv_modules(self):
@@ -1212,6 +1215,9 @@ class OpenCVConan(ConanFile):
             raise ConanInvalidConfiguration(
                 "viz module can't be enabled yet. It requires VTK which is not available in conan-center."
             )
+        if self.options.with_jpeg2000 == "openjpeg" and Version(self.version) < "4.3.0":
+            raise ConanInvalidConfiguration("openjpeg is ot available for OpenCV before 4.3.0")
+
 
     def build_requirements(self):
         if self.options.get_safe("with_protobuf"):

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -196,10 +196,10 @@ class OpenCVConan(ConanFile):
         "with_webp": True,
         "with_gdal": False,
         "with_gdcm": False,
-        "with_imgcodec_hdr": False,
+        "with_imgcodec_hdr": True,
         "with_imgcodec_pfm": True,
-        "with_imgcodec_pxm": False,
-        "with_imgcodec_sunraster": False,
+        "with_imgcodec_pxm": True,
+        "with_imgcodec_sunraster": True,
         "with_msmf": True,
         "with_msmf_dxva": True,
         # objdetect module options

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -1216,7 +1216,7 @@ class OpenCVConan(ConanFile):
                 "viz module can't be enabled yet. It requires VTK which is not available in conan-center."
             )
         if self.options.with_jpeg2000 == "openjpeg" and Version(self.version) < "4.3.0":
-            raise ConanInvalidConfiguration("openjpeg is ot available for OpenCV before 4.3.0")
+            raise ConanInvalidConfiguration("openjpeg is not available for OpenCV before 4.3.0")
 
 
     def build_requirements(self):

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -197,7 +197,7 @@ class OpenCVConan(ConanFile):
         "with_gdal": False,
         "with_gdcm": False,
         "with_imgcodec_hdr": False,
-        "with_imgcodec_pfm": False,
+        "with_imgcodec_pfm": True,
         "with_imgcodec_pxm": False,
         "with_imgcodec_sunraster": False,
         "with_msmf": True,


### PR DESCRIPTION
The OpenCV projects sets the default of this value to true, there is no reason to change this. If anything, not enabling this by default can lead to unexpected fails at runtime which can be hard to debug.


### Summary
Changes to recipe:  **lib/opencv**

#### Motivation
The OpenCV projects sets the default of this value to true, there is no reason to change this.
If anything, not enabling this by default can lead to unexpected fails at runtime which can be hard to debug.
See #24813.

#### Details
Changing the default value for option `with_imgcodec_pfm` from `False` to `True`.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
