### PR TITLE
libinterpolate: add version 2.7

### DIFF
--- a/recipes/libinterpolate/all/conandata.yml
+++ b/recipes/libinterpolate/all/conandata.yml
@@ -1,13 +1,17 @@
 sources:
-  "2.6.2":
+  "2.7":
     url:
-      - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.2.tar.gz"
-    sha256: "42f40c9b77fda6e0c52ed39b522458456e89fb4981d63f812aa158c6f4be8ab0"
-  "2.6.3":
-    url:
-      - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.3.tar.gz"
-    sha256: "bb2f253c27594b4e56ed9349630086665f529100eac2cd3cba63d198c3a84ff9"
+      - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.7.tar.gz"
+    sha256: "a502a00d6aee13e9b8ae9af6fafbcb783d5380835e353a0fc85a586ca7e31e43"
   "2.6.4":
     url:
       - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.4.tar.gz"
     sha256: "231a39fcc87ffc3e03936f7a21abc78ef309c2f1de79bd3ae72c24d78352d666"
+  "2.6.3":
+    url:
+      - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.3.tar.gz"
+    sha256: "bb2f253c27594b4e56ed9349630086665f529100eac2cd3cba63d198c3a84ff9"
+  "2.6.2":
+    url:
+      - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.2.tar.gz"
+    sha256: "42f40c9b77fda6e0c52ed39b522458456e89fb4981d63f812aa158c6f4be8ab0"

--- a/recipes/libinterpolate/all/test_package/conanfile.py
+++ b/recipes/libinterpolate/all/test_package/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"

--- a/recipes/libinterpolate/config.yml
+++ b/recipes/libinterpolate/config.yml
@@ -1,7 +1,9 @@
 versions:
-  "2.6.2":
+  "2.7":
+    folder: all
+  "2.6.4":
     folder: all
   "2.6.3":
     folder: all
-  "2.6.4":
+  "2.6.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libinterpolate/2.7**

#### Motivation
There are several new features in 2.7.
Sort version numbers.

#### Details
https://github.com/CD3/libInterpolate/compare/2.6.4...2.7

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
