### PR TITLE
daw_header_libraries: add version 2.106.2

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.106.2":
+    url: "https://github.com/beached/header_libraries/archive/v2.106.2.tar.gz"
+    sha256: "33609d83aec5a6081efebf871627b7a8bddc2b7f0eb8d4ac14756d403d29d089"
   "2.106.1":
     url: "https://github.com/beached/header_libraries/archive/v2.106.1.tar.gz"
     sha256: "393815fbf249ca1220a216899cae3d2672ca193f9db228a0b99925a9b0f90854"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.106.2":
+    folder: all
   "2.106.1":
     folder: all
   "2.106.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **daw_header_libraries/2.106.2**

#### Motivation
There are several bug fixes in 2.106.2.

#### Details
https://github.com/beached/header_libraries/compare/v2.106.1...v2.106.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
