### PR TITLE
libdeflate: add version 1.21

### DIFF
--- a/recipes/libdeflate/all/conandata.yml
+++ b/recipes/libdeflate/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.21":
+    url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.21.tar.gz"
+    sha256: "50827d312c0413fbd41b0628590cd54d9ad7ebf88360cba7c0e70027942dbd01"
   "1.20":
     url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.20.tar.gz"
     sha256: "ed1454166ced78913ff3809870a4005b7170a6fd30767dc478a09b96847b9c2a"

--- a/recipes/libdeflate/config.yml
+++ b/recipes/libdeflate/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.21":
+    folder: "all"
   "1.20":
     folder: "all"
   "1.19":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdeflate/1.21**

#### Motivation
There are several fixes for compilation errors on specific environments in 1.21.

#### Details
https://github.com/ebiggers/libdeflate/compare/v1.20...v1.21

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
