### PR TITLE
simfil: Bump 0.3.1 + Fix Recipe

### DIFF
--- a/recipes/simfil/all/conandata.yml
+++ b/recipes/simfil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.3.1":
+    url: "https://github.com/Klebert-Engineering/simfil/archive/refs/tags/v0.3.1.tar.gz"
+    sha256: "caddee2e338041ae5ec56c6a92f14e79ee3d5a0f7eaf327d6b8418fe06dd484e"
   "0.3.0":
     url: "https://github.com/Klebert-Engineering/simfil/archive/refs/tags/v0.3.0.tar.gz"
     sha256: "dea7b063f3f062772fcb49b368954814fc04d66c55db327a53ea008d698cd171"

--- a/recipes/simfil/all/conanfile.py
+++ b/recipes/simfil/all/conanfile.py
@@ -65,7 +65,7 @@ class SimfilRecipe(ConanFile):
         self.requires("fmt/10.0.0", transitive_headers=True)
         self.requires("bitsery/5.2.3", transitive_headers=True)
         if self.options.with_json:
-            self.requires("nlohmann_json/3.11.2")
+            self.requires("nlohmann_json/3.11.2", transitive_headers=True)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -102,3 +102,5 @@ class SimfilRecipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["simfil"]
+        if self.options.with_json:
+            self.cpp_info.defines = ["SIMFIL_WITH_MODEL_JSON=1"]

--- a/recipes/simfil/config.yml
+++ b/recipes/simfil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.3.1":
+    folder: all
   "0.3.0":
     folder: all
   "0.2.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **simfil/0.3.1**

#### Details
The previous conan recipe did not expose the `SIMFIL_WITH_MODEL_JSON` definition to the consumer, which is a bug.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
