### PR TITLE
polyscope: new recipe

### DIFF
--- a/recipes/polyscope/all/conan_deps.cmake
+++ b/recipes/polyscope/all/conan_deps.cmake
@@ -1,0 +1,13 @@
+if(POLYSCOPE_BACKEND_OPENGL3_GLFW)
+    find_package(glfw3 REQUIRED CONFIG)
+    list(APPEND BACKEND_SRCS "${CMAKE_CURRENT_LIST_DIR}/include/backends/imgui_impl_glfw.cpp")
+endif()
+
+if(POLYSCOPE_BACKEND_OPENGL3_GLFW OR POLYSCOPE_BACKEND_OPENGL3_EGL)
+    find_package(glad REQUIRED CONFIG)
+    list(APPEND BACKEND_SRCS "${CMAKE_CURRENT_LIST_DIR}/include/backends/imgui_impl_opengl3.cpp")
+endif()
+
+find_package(glm REQUIRED CONFIG)
+find_package(imgui REQUIRED CONFIG)
+find_package(nlohmann_json REQUIRED CONFIG)

--- a/recipes/polyscope/all/conandata.yml
+++ b/recipes/polyscope/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.2.1":
+    url: "https://github.com/nmwsharp/polyscope/archive/refs/tags/v2.2.1.tar.gz"
+    sha256: "1952d20722cb37c5531e88d5b7f5db88c2827c55fd7ada481c2ac425f3bc4d25"

--- a/recipes/polyscope/all/conanfile.py
+++ b/recipes/polyscope/all/conanfile.py
@@ -1,0 +1,120 @@
+import os
+import textwrap
+
+from conan import ConanFile
+from conan.tools.apple import is_apple_os
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, save
+
+required_conan_version = ">=1.53.0"
+
+
+class PolyscopeConan(ConanFile):
+    name = "polyscope"
+    description = "A viewer for 3D data like meshes and point clouds"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/nmwsharp/polyscope"
+    topics = ("3d", "visualization", "meshes", "point-clouds")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "backend_glfw": [True, False],
+        "backend_egl": [True, False],
+        "backend_mock": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "backend_glfw": True,
+        "backend_egl": True,
+        "backend_mock": True,
+    }
+
+    def export_sources(self):
+        copy(self, "conan_deps.cmake", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+        if self.settings.os != "Linux":
+            del self.options.backend_egl
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.backend_glfw:
+            self.requires("glfw/3.4", transitive_headers=True, transitive_libs=True)
+        if self.options.get_safe("backend_egl"):
+            self.requires("egl/system", transitive_headers=True, transitive_libs=True)
+        if self.options.backend_glfw or self.options.get_safe("backend_egl"):
+            self.requires("glad/0.1.36")
+        self.requires("glm/cci.20230113", transitive_headers=True, transitive_libs=True)
+        self.requires("imgui/1.90.5", transitive_headers=True, transitive_libs=True)
+        self.requires("nlohmann_json/3.11.3")
+        self.requires("stb/cci.20240531")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["CMAKE_PROJECT_polyscope_INCLUDE"] = "conan_deps.cmake"
+        tc.variables["POLYSCOPE_BACKEND_OPENGL3_GLFW"] = self.options.backend_glfw
+        tc.variables["POLYSCOPE_BACKEND_OPENGL3_EGL"] = self.options.get_safe("backend_egl")
+        tc.variables["POLYSCOPE_BACKEND_OPENGL_MOCK"] = self.options.backend_mock
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.set_property("glad", "cmake_target_name", "glad")
+        deps.set_property("glfw", "cmake_target_name", "glfw")
+        deps.set_property("egl", "cmake_target_name", "EGL")
+        deps.set_property("imgui", "cmake_target_name", "imgui")
+        deps.generate()
+
+        copy(self, "*",
+             os.path.join(self.dependencies["imgui"].package_folder, "res", "bindings"),
+             os.path.join(self.source_folder, "include", "backends"))
+
+    def _patch_sources(self):
+        # Adjust the implementation of https://github.com/nmwsharp/polyscope/blob/master/deps/stb/CMakeLists.txt
+        save(self, os.path.join(self.source_folder, "deps", "stb", "CMakeLists.txt"),
+             textwrap.dedent("""\
+                add_library(stb OBJECT stb_impl.cpp)
+                find_package(stb REQUIRED CONFIG)
+                target_link_libraries(stb PUBLIC stb::stb)
+                set_target_properties(stb PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+             """))
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        # The project does not define any CMake targets
+        self.cpp_info.libs = ["polyscope"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m"]
+        elif is_apple_os(self):
+            self.cpp_info.frameworks = ["Cocoa", "OpenGL", "CoreVideo", "IOKit"]

--- a/recipes/polyscope/all/test_package/CMakeLists.txt
+++ b/recipes/polyscope/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(polyscope REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE polyscope::polyscope)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/polyscope/all/test_package/conanfile.py
+++ b/recipes/polyscope/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/polyscope/all/test_package/test_package.cpp
+++ b/recipes/polyscope/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <polyscope/polyscope.h>
+
+#include <iostream>
+
+int main() {
+    std::cout << "A random number: " << polyscope::randomUnit() << std::endl;
+}

--- a/recipes/polyscope/config.yml
+++ b/recipes/polyscope/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.2.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **polyscope/2.2.1**

#### Motivation
Polyscope is a C++/Python viewer and user interface for 3D data such as meshes and point clouds. It allows you to register your data and quickly generate informative and beautiful visualizations, either programmatically or via a dynamic GUI. Polyscope is designed to be lightweight---it does not "take ownership" over your entire program, and it is easy to integrate with existing codebases and popular libraries. The lofty objective of Polyscope is to offer a useful visual interface to your data via a single line of code.

https://github.com/nmwsharp/polyscope

#### Details
I tweaked the project CMake to embed the built `stb` mini-library into the single main library. The `stb` lib was not being installed and this made the packaging a bit simpler and cleaner as well.

/cc @nmwsharp

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
