### PR TITLE
vulkan-headers: bump to 1.3.290.0

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.290.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.290.0.tar.gz"
+    sha256: "5b186e1492d97c44102fe858fb9f222b55524a8b6da940a8795c9e326ae6d722"
   "1.3.268.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
     sha256: "94993cbe2b1a604c0d5d9ea37a767e1aba4d771d2bfd4ddceefd66243095164f"

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.290.0":
+    folder: all
   "1.3.268.0":
     folder: all
   "1.3.261.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-headers/1.3.290.0**

#### Motivation
Bump version to allow updating `vulkan-loader` to 1.3.290.0

#### Details
Just simple new sources version bump


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
