### PR TITLE
[poselib] Bump PoseLib to version 2.0.4

### DIFF
--- a/recipes/poselib/all/conandata.yml
+++ b/recipes/poselib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.4":
+    url: "https://github.com/PoseLib/PoseLib/archive/refs/tags/v2.0.4.tar.gz"
+    sha256: "caa0c1c9b882f6e36b5ced6f781406ed97d4c1f0f61aa31345ebe54633d67c16"
   "2.0.3":
     url: "https://github.com/PoseLib/PoseLib/archive/refs/tags/v2.0.3.tar.gz"
     sha256: "ec52fe738a803e53c4cedc27f393a38b2dced63da6c73148e98965b338ca0efc"

--- a/recipes/poselib/config.yml
+++ b/recipes/poselib/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.0.4":
+    folder: all
   "2.0.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **poselib/2.0.4**

#### Motivation

There is a PR in PoseLib, documenting how to install it using Conan: https://github.com/PoseLib/PoseLib/pull/106

It would be great if we could have the latest version available in Conan Center as well.

#### Details

The diff in patch version shows a new option for pybind, but is not active by default. I kept it omitted from the recipe:

https://github.com/PoseLib/PoseLib/compare/v2.0.3...v2.0.4#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a

Full build log on local Linux: [poselib-2.0.4-linux.log](https://github.com/user-attachments/files/16506177/poselib-2.0.4-linux.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
