### PR TITLE
libavrocpp: add version 1.12.0

### DIFF
--- a/recipes/libavrocpp/all/conandata.yml
+++ b/recipes/libavrocpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.12.0":
+    url: "https://github.com/apache/avro/archive/release-1.12.0.tar.gz"
+    sha256: "51832f9c2e81fa95addb74be627dac27b4883ec2c8627ec8471d99cfea787555"
   "1.11.3":
     url: "https://github.com/apache/avro/archive/release-1.11.3.tar.gz"
     sha256: "da377ac1cf8b91458bf702cbcfb214eecb5c399b267f0ca9c0aade6cabaf126e"
@@ -15,6 +18,25 @@ sources:
     url: "https://github.com/apache/avro/archive/release-1.10.1.tar.gz"
     sha256: "8fd1f850ce37e60835e6d8335c0027a959aaa316773da8a9660f7d33a66ac142"
 patches:
+  "1.12.0":
+    - patch_file: "patches/0001-add-iterator-include-1-12-0.patch"
+      patch_description: "include iterator"
+      patch_type: "portability"
+    - patch_file: "patches/0002-disable-tests-1-12-0.patch"
+      patch_description: "disable tests"
+      patch_type: "conan"
+    - patch_file: "patches/0003-allow-static-boost-linkage-1-12-0.patch"
+      patch_description: "remove boost linkage definitions"
+      patch_type: "conan"
+    - patch_file: "patches/0004-fix-windows-shared-installation-1-12-0.patch"
+      patch_description: "fix runtime installation path"
+      patch_type: "portability"
+    - patch_file: "patches/0006-disable-warn-as-error-1-12-0.patch"
+      patch_description: "disable warn as error for boost c++14 breaking change"
+      patch_type: "portability"
+    - patch_file: "patches/0007-use-cci-fmt-1-12-0.patch"
+      patch_description: "use cci fmt"
+      patch_type: "conan"
   "1.11.3":
     - patch_file: "patches/0001-add-iterator-include-1-11-0.patch"
       patch_description: "include iterator"

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, replace_in_file
-from conan.tools.build import check_min_cppstd, valid_min_cppstd
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.54.0"
@@ -22,7 +23,8 @@ class LibavrocppConan(ConanFile):
     }
     default_options = {
         "shared": False,
-        "fPIC": True
+        "fPIC": True,
+        "fmt/*:header_only": True,
     }
     short_paths = True
 
@@ -43,11 +45,13 @@ class LibavrocppConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
-        
+
     def requirements(self):
         # boost upper to 1.81.0 requires C++14 minimum
         self.requires("boost/1.81.0", transitive_headers=True)
         self.requires("snappy/1.1.9")
+        if Version(self.version) >= "1.12.0":
+            self.requires("fmt/10.2.1", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -104,3 +108,5 @@ class LibavrocppConan(ConanFile):
             "boost::headers", "boost::filesystem", "boost::iostreams", "boost::program_options",
             "boost::regex", "boost::system", "snappy::snappy",
         ]
+        if Version(self.version) >= "1.12.0":
+            self.cpp_info.requires.append("fmt::fmt")

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, replace_in_file
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
@@ -30,7 +31,20 @@ class LibavrocppConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return 11
+        # 1.12.0 or later requires C++17 https://github.com/apache/avro/pull/2949
+        return "11" if Version(self.version) < "1.12.0" else "17"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "17": {
+                "gcc": "8",
+                "clang": "7",
+                "apple-clang": "12",
+                "Visual Studio": "16",
+                "msvc": "192",
+            },
+        }.get(self._min_cppstd, {})
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -47,15 +61,22 @@ class LibavrocppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # boost upper to 1.81.0 requires C++14 minimum
-        self.requires("boost/1.81.0", transitive_headers=True)
-        self.requires("snappy/1.1.9")
-        if Version(self.version) >= "1.12.0":
+        if Version(self.version) < "1.12.0":
+            # boost upper to 1.81.0 requires C++14 minimum
+            self.requires("boost/1.81.0", transitive_headers=True)
+        else:
+            self.requires("boost/1.85.0", transitive_headers=True)
             self.requires("fmt/10.2.1", transitive_headers=True)
+        self.requires("snappy/1.1.9")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libavrocpp/all/patches/0001-add-iterator-include-1-12-0.patch
+++ b/recipes/libavrocpp/all/patches/0001-add-iterator-include-1-12-0.patch
@@ -1,0 +1,65 @@
+diff --git a/lang/c++/impl/DataFile.cc b/lang/c++/impl/DataFile.cc
+index 66281ae..7f58033 100644
+--- a/lang/c++/impl/DataFile.cc
++++ b/lang/c++/impl/DataFile.cc
+@@ -19,7 +19,7 @@
+ #include "DataFile.hh"
+ #include "Compiler.hh"
+ #include "Exception.hh"
+-
++#include <iterator>
+ #include <sstream>
+ 
+ #include <boost/crc.hpp> // for boost::crc_32_type
+diff --git a/lang/c++/impl/Stream.cc b/lang/c++/impl/Stream.cc
+index 738b1e4..507a15e 100644
+--- a/lang/c++/impl/Stream.cc
++++ b/lang/c++/impl/Stream.cc
+@@ -18,7 +18,7 @@
+ 
+ #include "Stream.hh"
+ #include <vector>
+-
++#include <iterator>
+ namespace avro {
+ 
+ using std::vector;
+diff --git a/lang/c++/impl/parsing/JsonCodec.cc b/lang/c++/impl/parsing/JsonCodec.cc
+index 84b3666..841b7f8 100644
+--- a/lang/c++/impl/parsing/JsonCodec.cc
++++ b/lang/c++/impl/parsing/JsonCodec.cc
+@@ -21,7 +21,7 @@
+ #include <map>
+ #include <memory>
+ #include <string>
+-
++#include <iterator>
+ #include "Decoder.hh"
+ #include "Encoder.hh"
+ #include "Symbol.hh"
+diff --git a/lang/c++/impl/parsing/ResolvingDecoder.cc b/lang/c++/impl/parsing/ResolvingDecoder.cc
+index 1553b8a..22bd8cb 100644
+--- a/lang/c++/impl/parsing/ResolvingDecoder.cc
++++ b/lang/c++/impl/parsing/ResolvingDecoder.cc
+@@ -23,7 +23,7 @@
+ #include <set>
+ #include <string>
+ #include <utility>
+-
++#include <iterator>
+ #include "Decoder.hh"
+ #include "Encoder.hh"
+ #include "Generic.hh"
+diff --git a/lang/c++/impl/parsing/ValidatingCodec.cc b/lang/c++/impl/parsing/ValidatingCodec.cc
+index 7a1f8d9..e0db54a 100644
+--- a/lang/c++/impl/parsing/ValidatingCodec.cc
++++ b/lang/c++/impl/parsing/ValidatingCodec.cc
+@@ -23,7 +23,7 @@
+ #include <map>
+ #include <memory>
+ #include <utility>
+-
++#include <iterator>
+ #include "Decoder.hh"
+ #include "Encoder.hh"
+ #include "NodeImpl.hh"

--- a/recipes/libavrocpp/all/patches/0002-disable-tests-1-12-0.patch
+++ b/recipes/libavrocpp/all/patches/0002-disable-tests-1-12-0.patch
@@ -1,0 +1,41 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 19059a4..e1f23c0 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -197,10 +197,10 @@ target_include_directories(avrocpp PUBLIC
+ enable_testing()
+ 
+ macro (unittest name)
+-    add_executable (${name} test/${name}.cc)
+-    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+-    add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
++    # add_executable (${name} test/${name}.cc)
++    # target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
++    # add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
++    #     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
+ endmacro (unittest)
+ 
+ unittest (buffertest)
+@@ -217,14 +217,14 @@ unittest (CompilerTests)
+ unittest (AvrogencppTestReservedWords)
+ unittest (CommonsSchemasTests)
+ 
+-add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh)
++# add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh)
+ 
+-add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
+-    tweet_hh
+-    union_array_union_hh union_map_union_hh union_conflict_hh
+-    recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
+-    primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh
+-    union_empty_record_hh)
++# add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
++#     tweet_hh
++#     union_array_union_hh union_map_union_hh union_conflict_hh
++#     recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
++#     primitivetypes_hh empty_record_hh cpp_reserved_words_union_typedef_hh
++#     union_empty_record_hh)
+ 
+ include (InstallRequiredSystemLibraries)
+ 

--- a/recipes/libavrocpp/all/patches/0003-allow-static-boost-linkage-1-12-0.patch
+++ b/recipes/libavrocpp/all/patches/0003-allow-static-boost-linkage-1-12-0.patch
@@ -1,0 +1,24 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index e1f23c0..6de3e35 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -59,12 +59,13 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
+     add_definitions (/EHa)
+     add_definitions (
+         -DNOMINMAX
+-        -DBOOST_REGEX_DYN_LINK
+-        -DBOOST_FILESYSTEM_DYN_LINK
+-        -DBOOST_SYSTEM_DYN_LINK
+-        -DBOOST_IOSTREAMS_DYN_LINK
+-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
+-        -DBOOST_ALL_NO_LIB)
++        # -DBOOST_REGEX_DYN_LINK
++        # -DBOOST_FILESYSTEM_DYN_LINK
++        # -DBOOST_SYSTEM_DYN_LINK
++        # -DBOOST_IOSTREAMS_DYN_LINK
++        # -DBOOST_PROGRAM_OPTIONS_DYN_LINK
++        # -DBOOST_ALL_NO_LIB)
++    )
+ endif()
+ 
+ if (CMAKE_COMPILER_IS_GNUCXX)

--- a/recipes/libavrocpp/all/patches/0004-fix-windows-shared-installation-1-12-0.patch
+++ b/recipes/libavrocpp/all/patches/0004-fix-windows-shared-installation-1-12-0.patch
@@ -1,0 +1,13 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 6de3e35..dfd62e6 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -236,7 +236,7 @@ include (CPack)
+ install (TARGETS avrocpp avrocpp_s
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib
+-    RUNTIME DESTINATION lib)
++    RUNTIME DESTINATION bin)
+ 
+ install (TARGETS avrogencpp RUNTIME DESTINATION bin)
+ 

--- a/recipes/libavrocpp/all/patches/0006-disable-warn-as-error-1-12-0.patch
+++ b/recipes/libavrocpp/all/patches/0006-disable-warn-as-error-1-12-0.patch
@@ -1,0 +1,13 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index dfd62e6..096c509 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -69,7 +69,7 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
+ endif()
+ 
+ if (CMAKE_COMPILER_IS_GNUCXX)
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Wconversion -pedantic -Werror")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Wconversion -pedantic")
+ if (AVRO_ADD_PROTECTOR_FLAGS)
+     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
+     # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options

--- a/recipes/libavrocpp/all/patches/0006-disable-warn-as-error-1-12-0.patch
+++ b/recipes/libavrocpp/all/patches/0006-disable-warn-as-error-1-12-0.patch
@@ -7,7 +7,7 @@ index dfd62e6..096c509 100644
  
  if (CMAKE_COMPILER_IS_GNUCXX)
 -    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Wconversion -pedantic -Werror")
-+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -Wconversion -pedantic")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wlogical-op -Wuseless-cast -Wconversion -pedantic")
  if (AVRO_ADD_PROTECTOR_FLAGS)
      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
      # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options

--- a/recipes/libavrocpp/all/patches/0007-use-cci-fmt-1-12-0.patch
+++ b/recipes/libavrocpp/all/patches/0007-use-cci-fmt-1-12-0.patch
@@ -1,0 +1,55 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index dfd62e6..096c509 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -83,16 +83,7 @@ endif ()
+ find_package (Boost 1.38 REQUIRED
+     COMPONENTS filesystem iostreams program_options regex system)
+ 
+-include(FetchContent)
+-FetchContent_Declare(
+-        fmt
+-        GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
+-        GIT_TAG         10.2.1
+-        GIT_PROGRESS    TRUE
+-        USES_TERMINAL_DOWNLOAD TRUE
+-)
+-FetchContent_MakeAvailable(fmt)
+-
++find_package(fmt REQUIRED)
+ find_package(Snappy)
+ if (SNAPPY_FOUND)
+     set(SNAPPY_PKG libsnappy)
+@@ -136,7 +127,7 @@ set_property (TARGET avrocpp
+ 
+ add_library (avrocpp_s STATIC ${AVRO_SOURCE_FILES})
+ target_include_directories(avrocpp_s PRIVATE ${SNAPPY_INCLUDE_DIR})
+-target_link_libraries(avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} fmt::fmt-header-only)
++target_link_libraries(avrocpp_s PRIVATE ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} fmt::fmt-header-only)
+ 
+ set_property (TARGET avrocpp avrocpp_s
+     APPEND PROPERTY COMPILE_DEFINITIONS AVRO_SOURCE)
+@@ -147,12 +138,12 @@ set_target_properties (avrocpp PROPERTIES
+ set_target_properties (avrocpp_s PROPERTIES
+     VERSION ${AVRO_VERSION_MAJOR}.${AVRO_VERSION_MINOR}.${AVRO_VERSION_PATCH})
+ 
+-target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} fmt::fmt-header-only)
++target_link_libraries (avrocpp PRIVATE ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES} fmt::fmt-header-only)
+ target_include_directories(avrocpp PRIVATE ${SNAPPY_INCLUDE_DIR})
+ 
+ add_executable (precompile test/precompile.cc)
+ 
+-target_link_libraries (precompile avrocpp_s)
++target_link_libraries (precompile avrocpp_s fmt::fmt-header-only)
+ 
+ macro (gen file ns)
+     add_custom_command (OUTPUT ${file}.hh
+@@ -184,7 +175,7 @@ gen (cpp_reserved_words cppres)
+ gen (cpp_reserved_words_union_typedef cppres_union)
+ 
+ add_executable (avrogencpp impl/avrogencpp.cc)
+-target_link_libraries (avrogencpp avrocpp_s)
++target_link_libraries (avrogencpp avrocpp_s fmt::fmt-header-only)
+ 
+ target_include_directories(avrocpp_s PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/recipes/libavrocpp/config.yml
+++ b/recipes/libavrocpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  1.12.0:
+    folder: all
   1.11.3:
     folder: all
   1.11.1:


### PR DESCRIPTION
### Summary
Changes to recipe:  **libavrocpp/1.12.0**

#### Motivation
There are lots of improvements and bugfixes in 1.12.0.

#### Details
https://github.com/apache/avro/compare/release-1.11.3...release-1.12.0#diff-8b7a00e2b0a48716d8140820dc7c44f17466c5ffde508ce3ab092dfb1507e6c3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
