### PR TITLE
cpp-httplib: add version 0.16.3, remove older versions

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.16.2":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.2.tar.gz"
-    sha256: "75565bcdf12522929a26fb57a2c7f8cc0e175e27a9ecf51616075f3ea960da44"
+  "0.16.3":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.3.tar.gz"
+    sha256: "c1742fc7179aaae2a67ad9bba0740b7e9ffaf4f5e62feef53101ecdef1478716"
   "0.16.0":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.0.tar.gz"
     sha256: "c125022eb85eaa12235518dc4638be93b62c3216d0f87b655af7b17b71b38851"

--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,34 +1,19 @@
 sources:
+  "0.16.1":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.1.tar.gz"
+    sha256: "ffb03d22566e46bec77da4a7ca0b85578d878daeb3ebd0f50fd20ee3219a7423"
   "0.16.0":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.0.tar.gz"
     sha256: "c125022eb85eaa12235518dc4638be93b62c3216d0f87b655af7b17b71b38851"
   "0.15.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.15.3.tar.gz"
     sha256: "2121bbf38871bb2aafb5f7f2b9b94705366170909f434428352187cb0216124e"
-  "0.15.2":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.15.2.tar.gz"
-    sha256: "4afbcf4203249d2cbcb698e46e1f6fb61b479013a84844d6bb1c044e233cab6a"
-  "0.15.1":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.15.1.tar.gz"
-    sha256: "8d6a4a40ee8fd3f553b7e895882e60e674bd910883fc1857587dbbabee3cdb91"
   "0.14.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.14.3.tar.gz"
     sha256: "dcf6486d9030937636d8a4f820ca9531808fd7edb283893dddbaa05f99357e63"
-  "0.14.2":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.14.2.tar.gz"
-    sha256: "dbcf5590e8ed35c6745c2ad659a5ebec92f05187d1506eec24449d6db95e5084"
-  "0.14.1":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.14.1.tar.gz"
-    sha256: "2d4fb5544da643e5d0a82585555d8b7502b4137eb321a4abbb075e21d2f00e96"
-  "0.14.0":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.14.0.tar.gz"
-    sha256: "3a92248ef8cf2c32ad07f910b8e3052ff2427022b2adb871cf326fb620d2438e"
   "0.13.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.13.3.tar.gz"
     sha256: "2a4503f9f2015f6878baef54cd94b01849cc3ed19dfe95f2c9775655bea8b73f"
-  "0.13.1":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.13.1.tar.gz"
-    sha256: "9b837d290b61e3f0c4239da0b23bbf14c382922e2bf2a9bac21c1e3feabe1ff9"
   "0.12.6":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.12.6.tar.gz"
     sha256: "24bc594a9efcc08a5a6f3928e848d046d411a88b07bcd6f7f3851227a1f0133e"

--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -11,6 +11,10 @@ sources:
   "0.14.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.14.3.tar.gz"
     sha256: "dcf6486d9030937636d8a4f820ca9531808fd7edb283893dddbaa05f99357e63"
+  # keep 0.14.1 for enjincppsdk and microservice-essentials
+  "0.14.1":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.14.1.tar.gz"
+    sha256: "2d4fb5544da643e5d0a82585555d8b7502b4137eb321a4abbb075e21d2f00e96"
   "0.13.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.13.3.tar.gz"
     sha256: "2a4503f9f2015f6878baef54cd94b01849cc3ed19dfe95f2c9775655bea8b73f"

--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.16.1":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.1.tar.gz"
-    sha256: "ffb03d22566e46bec77da4a7ca0b85578d878daeb3ebd0f50fd20ee3219a7423"
+  "0.16.2":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.2.tar.gz"
+    sha256: "75565bcdf12522929a26fb57a2c7f8cc0e175e27a9ecf51616075f3ea960da44"
   "0.16.0":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.16.0.tar.gz"
     sha256: "c125022eb85eaa12235518dc4638be93b62c3216d0f87b655af7b17b71b38851"

--- a/recipes/cpp-httplib/all/conanfile.py
+++ b/recipes/cpp-httplib/all/conanfile.py
@@ -11,8 +11,8 @@ class CpphttplibConan(ConanFile):
     name = "cpp-httplib"
     description = "A C++11 single-file header-only cross platform HTTP/HTTPS library."
     license = "MIT"
-    homepage = "https://github.com/yhirose/cpp-httplib"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/yhirose/cpp-httplib"
     topics = ("http", "https", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
@@ -48,9 +48,6 @@ class CpphttplibConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
-    def build(self):
-        pass
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/cpp-httplib/all/test_package/conanfile.py
+++ b/recipes/cpp-httplib/all/test_package/conanfile.py
@@ -7,6 +7,7 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.16.2":
+  "0.16.3":
     folder: all
   "0.16.0":
     folder: all

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.16.1":
+  "0.16.2":
     folder: all
   "0.16.0":
     folder: all

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -7,6 +7,8 @@ versions:
     folder: all
   "0.14.3":
     folder: all
+  "0.14.1":
+    folder: all
   "0.13.3":
     folder: all
   "0.12.6":

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,23 +1,13 @@
 versions:
+  "0.16.1":
+    folder: all
   "0.16.0":
     folder: all
   "0.15.3":
     folder: all
-  "0.15.2":
-    folder: all
-  "0.15.1":
-    folder: all
   "0.14.3":
     folder: all
-  "0.14.2":
-    folder: all
-  "0.14.1":
-    folder: all
-  "0.14.0":
-    folder: all
   "0.13.3":
-    folder: all
-  "0.13.1":
     folder: all
   "0.12.6":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
There are several improvements in 0.16.3

#### Details
https://github.com/yhirose/cpp-httplib/compare/v0.16.0...v0.16.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
