### PR TITLE
etl: add version 20.39.3, remove version 20.39.0

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "20.39.2":
-    url: "https://github.com/ETLCPP/etl/archive/20.39.2.tar.gz"
-    sha256: "b1faad1b83382bc7e06df0892b0efe1bd62e8dafe490878b601188f144bef063"
+  "20.39.3":
+    url: "https://github.com/ETLCPP/etl/archive/20.39.3.tar.gz"
+    sha256: "1d596bc47d17959ced8b4586e0ae22348c903df6ab00f47ef900d854ef5e30c8"
   "20.38.17":
     url: "https://github.com/ETLCPP/etl/archive/20.38.17.tar.gz"
     sha256: "5b490aca3faad3796a48bf0980e74f2a67953967fad3c051a6d4981051cb0b9a"

--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,10 +1,7 @@
 sources:
-  "20.39.1":
-    url: "https://github.com/ETLCPP/etl/archive/20.39.1.tar.gz"
-    sha256: "3fb193011450d5d25b9b221d68f74b9baa970c7fb03ff03426cad56fdead93d6"
-  "20.39.0":
-    url: "https://github.com/ETLCPP/etl/archive/20.39.0.tar.gz"
-    sha256: "1553dfaba3ba8a44a592367127b145ba6e413bf2df376808bdb6fe7a7635c197"
+  "20.39.2":
+    url: "https://github.com/ETLCPP/etl/archive/20.39.2.tar.gz"
+    sha256: "b1faad1b83382bc7e06df0892b0efe1bd62e8dafe490878b601188f144bef063"
   "20.38.17":
     url: "https://github.com/ETLCPP/etl/archive/20.38.17.tar.gz"
     sha256: "5b490aca3faad3796a48bf0980e74f2a67953967fad3c051a6d4981051cb0b9a"

--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.39.1":
+    url: "https://github.com/ETLCPP/etl/archive/20.39.1.tar.gz"
+    sha256: "3fb193011450d5d25b9b221d68f74b9baa970c7fb03ff03426cad56fdead93d6"
   "20.39.0":
     url: "https://github.com/ETLCPP/etl/archive/20.39.0.tar.gz"
     sha256: "1553dfaba3ba8a44a592367127b145ba6e413bf2df376808bdb6fe7a7635c197"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.39.1":
+    folder: all
   "20.39.0":
     folder: all
   "20.38.17":

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,7 +1,5 @@
 versions:
-  "20.39.1":
-    folder: all
-  "20.39.0":
+  "20.39.2":
     folder: all
   "20.38.17":
     folder: all

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "20.39.2":
+  "20.39.3":
     folder: all
   "20.38.17":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **etl/***

#### Motivation
There are several new features in 20.39.3.
Removed 20.39.0 because it has been removed.

#### Details
https://github.com/ETLCPP/etl/compare/20.38.17...20.39.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
