### PR TITLE
cutlass: new recipe

### DIFF
--- a/recipes/cutlass/all/conandata.yml
+++ b/recipes/cutlass/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.5.0":
+    url: "https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.5.0.tar.gz"
+    sha256: "ef6af8526e3ad04f9827f35ee57eec555d09447f70a0ad0cf684a2e426ccbcb6"

--- a/recipes/cutlass/all/conanfile.py
+++ b/recipes/cutlass/all/conanfile.py
@@ -80,7 +80,7 @@ class CutlassConan(ConanFile):
         # Don't look for CUDA, we're only installing the headers
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "include(${CMAKE_CURRENT_SOURCE_DIR}/CUDA.cmake)",
                                                                                  """
-                                                                                 if(CUTLASS_ENABLE_HEADERS_ONLY)
+                                                                                 if(NOT CUTLASS_ENABLE_HEADERS_ONLY)
                                                                                  include(${CMAKE_CURRENT_SOURCE_DIR}/CUDA.cmake)
                                                                                  endif()""")
 

--- a/recipes/cutlass/all/conanfile.py
+++ b/recipes/cutlass/all/conanfile.py
@@ -94,9 +94,6 @@ class CutlassConan(ConanFile):
         copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
-        # https://github.com/microsoft/onnxruntime/blame/bad00a36579eefc64bbf1926d2c403928a518b37/cmake/onnxruntime_providers_cuda.cmake#L225
-        copy(self, "*.h", os.path.join(self.source_folder, "examples"), os.path.join(self.package_folder, "examples"))
-        copy(self, "*.h", os.path.join(self.source_folder, "tools", "util", "include"), os.path.join(self.package_folder, "tools", "util", "include"))
         rmdir(self, os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "test"))
 
@@ -104,6 +101,5 @@ class CutlassConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "NvidiaCutlass")
         self.cpp_info.set_property("cmake_target_name", "nvidia::cutlass::cutlass")
-        self.cpp_info.includedirs.extend([os.path.join("tools", "util", "include"), "examples"])
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []

--- a/recipes/cutlass/all/conanfile.py
+++ b/recipes/cutlass/all/conanfile.py
@@ -94,6 +94,9 @@ class CutlassConan(ConanFile):
         copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
+        # https://github.com/microsoft/onnxruntime/blame/bad00a36579eefc64bbf1926d2c403928a518b37/cmake/onnxruntime_providers_cuda.cmake#L225
+        copy(self, "*.h", os.path.join(self.source_folder, "examples"), os.path.join(self.package_folder, "examples"))
+        copy(self, "*.h", os.path.join(self.source_folder, "tools", "util", "include"), os.path.join(self.package_folder, "tools", "util", "include"))
         rmdir(self, os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "test"))
 
@@ -101,6 +104,6 @@ class CutlassConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "NvidiaCutlass")
         self.cpp_info.set_property("cmake_target_name", "nvidia::cutlass::cutlass")
-
+        self.cpp_info.includedirs.extend([os.path.join("tools", "util", "include"), "examples"])
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []

--- a/recipes/cutlass/all/conanfile.py
+++ b/recipes/cutlass/all/conanfile.py
@@ -1,0 +1,91 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rmdir, save
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.52.0"
+
+
+class CutlassConan(ConanFile):
+    name = "cutlass"
+    description = "CUTLASS: CUDA Templates for Linear Algebra Subroutines"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/project/package"
+    topics = ("linear-algebra", "gpu", "cuda", "deep-learning", "nvidia", "header-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    # TODO: add header_only=False option
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "clang": "7",
+            "apple-clang": "7",
+            "msvc": "192",
+            "Visual Studio": "16",
+        }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.19 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        # Install via CMake to ensure headers are configured correctly
+        tc = CMakeToolchain(self)
+        tc.variables["CUTLASS_ENABLE_HEADERS_ONLY"] = True
+        tc.generate()
+        VirtualBuildEnv(self).generate()
+
+    def _patch_sources(self):
+        # Don't look for CUDA, we're only installing the headers
+        save(self, os.path.join(self.source_folder, "CUDA.cmake"), "")
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "test"))
+
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "NvidiaCutlass")
+        self.cpp_info.set_property("cmake_target_name", "nvidia::cutlass::cutlass")
+
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/cutlass/all/test_package/CMakeLists.txt
+++ b/recipes/cutlass/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(NvidiaCutlass REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE nvidia::cutlass::cutlass)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/cutlass/all/test_package/conanfile.py
+++ b/recipes/cutlass/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cutlass/all/test_package/test_package.cpp
+++ b/recipes/cutlass/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <cutlass/version.h>
+
+#include <iostream>
+
+int main() {
+    std::cout << "CUTLASS version: " <<
+        cutlass::getVersionMajor() << "." <<
+        cutlass::getVersionMinor() << "." <<
+        cutlass::getVersionPatch() << std::endl;
+}

--- a/recipes/cutlass/config.yml
+++ b/recipes/cutlass/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.5.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cutlass/3.5.0**

#### Motivation
CUTLASS is a collection of CUDA C++ template abstractions for implementing high-performance matrix-matrix multiplication (GEMM) and related computations at all levels and scales within CUDA.

Required for FBGEMM (#24749) and libtorch (#24759) when building with CUDA enabled.

https://github.com/NVIDIA/cutlass

#### Details
It's mostly a CUDA library, but can be installed as header-only, which avoids a build-time dependency on CUDA.

`header_only=False` option could be added to build and package library binaries as well, but I think it's better to review and merge the minimal header-only version first.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan