### PR TITLE
Set PNG_INTEL_SSE to 'off' if arch doesn't support intel intrinsics

### DIFF
--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -116,6 +116,8 @@ class LibpngConan(ConanFile):
             tc.variables["PNG_MIPS_MSA"] = self._neon_msa_sse_vsx_mapping[str(self.options.msa)]
         if self._has_sse_support:
             tc.variables["PNG_INTEL_SSE"] = self._neon_msa_sse_vsx_mapping[str(self.options.sse)]
+        else:
+            tc.variables["PNG_INTEL_SSE"] = "off"
         if self._has_vsx_support:
             tc.variables["PNG_POWERPC_VSX"] = self._neon_msa_sse_vsx_mapping[str(self.options.vsx)]
         if Version(self.version) >= "1.6.41":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpng/x**

#### Motivation
The libpng `CMakeLists.txt` sets the default for `PNG_INTEL_SSE` to `on`, so the logic in the `conanfile.py` generate method should be to set it to `off` if the architecture doesn't support intel sse intrinsics. However, it is instead setting it to `on` if the architecture **does** support sse, so the path where arch has no sse instructions currently leaves the flag set to `on`, making CMake compile the intel specific files and breaking builds downstream.

#### Details
To quickfix the issue I added an `else` branch to the `if` block which sets the variable to `off` if no support is detected (which is the safest solution in my opinion, because the CMakeLists.txt could change its default semantics in future versions, so a simple inversion of the condition is not robust enough).

There might be other variables that should be handled the same.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
