### PR TITLE
opentelemetry-cpp: Bump boost to fix old opentelemetry-cpp versions

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -137,7 +137,7 @@ class OpenTelemetryCppConan(ConanFile):
 
         if self.options.get_safe("with_jaeger"):
             self.requires("thrift/0.17.0")
-            self.requires("boost/1.84.0")
+            self.requires("boost/1.85.0")
 
     @property
     def _required_boost_components(self):

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -110,7 +110,7 @@ class OpenTelemetryCppConan(ConanFile):
             self.requires("ms-gsl/4.0.0")
 
         if self.options.with_abseil:
-            self.requires("abseil/20230125.3", transitive_headers=True)
+            self.requires("abseil/20230802.1", transitive_headers=True)
 
         if self.options.with_otlp_grpc or self.options.with_otlp_http:
             self.requires("protobuf/3.21.12", transitive_headers=True, transitive_libs=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentelemetry-cpp/[<1.10]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The recipe for old versions had conflcits on its own graph, fixed those by bumping the boost version. Not done so for the thrift one as that's also used by arrow
