### PR TITLE
qt refactor option handling and error reporting

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -185,7 +185,7 @@ class QtConan(ConanFile):
 
         for submodule in self._submodules:
             if submodule not in self._get_module_tree:
-                self.output.debug(f"Qt6: Removing {submodule} option as it is not in the module tree for this version, or is marked as obsolete or ignore")
+                self._debug_output(f"Qt6: Removing {submodule} option as it is not in the module tree for this version, or is marked as obsolete or ignore")
                 self.options.rm_safe(submodule)
 
     @property

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -122,9 +122,10 @@ class QtConan(ConanFile):
         "sysroot": None,
         "multiconfiguration": False,
         "disabled_features": "",
-        "essential_modules": not os.getenv('CONAN_CENTER_BUILD_SERVICE')
     }
-    default_options.update({f"{status}_modules": False for status in _module_statuses if status != "essential"})
+    # essential_modules, addon_modules, deprecated_modules, preview_modules:
+    #    these are only provided for convenience, set to False by default
+    default_options.update({f"{status}_modules": False for status in _module_statuses})
 
     short_paths = True
 
@@ -182,9 +183,10 @@ class QtConan(ConanFile):
         if self.settings.os != "Linux":
             self.options.qtwayland = False
 
-        for m in self._submodules:
-            if m not in self._get_module_tree:
-                delattr(self.options, m)
+        for submodule in self._submodules:
+            if submodule not in self._get_module_tree:
+                self.output.debug(f"Qt6: Removing {submodule} option as it is not in the module tree for this version, or is marked as obsolete or ignore")
+                self.options.rm_safe(submodule)
 
     @property
     def _minimum_compilers_version(self):
@@ -213,28 +215,41 @@ class QtConan(ConanFile):
         if self.options.multiconfiguration:
             del self.settings.build_type
 
-        def _enablemodule(mod):
-            if mod != "qtbase":
-                setattr(self.options, mod, True)
-                for req in self._get_module_tree[mod]["depends"]:
-                    _enablemodule(req)
+        # Requested modules:
+        # - any module for non-removed options that have 'True' value
+        # - any enabled via `xxx_modules` that does not have a 'False' value
+        # Note that at this point, the submodule options dont have a value unless one is given externally
+        # to the recipe (e.g. via the command line, a profile, or a consumer)
+        requested_modules = set([module for module in self._submodules if self.options.get_safe(module)])
+        for module in [m for m in self._submodules if m in self._get_module_tree]:
+            status = self._get_module_tree[module]['status']
+            is_disabled = self.options.get_safe(module) == False
+            if self.options.get_safe(f"{status}_modules"):
+                if not is_disabled:
+                    requested_modules.add(module)
+                else:
+                    self.output.debug(f"qt6: {module} requested because {status}_modules=True"
+                                        f" but it has been explicitly disabled with {module}=False")
 
-        # enable all modules which are
-        # - required by a module explicitely enabled by the consumer
-        for module_name, module in self._get_module_tree.items():
-            if getattr(self.options, module_name):
-                _enablemodule(module_name)
-            else:
-                for status in self._module_statuses:
-                    if getattr(self.options, f"{status}_modules") and module['status'] == status:
-                        _enablemodule(module_name)
-                        break
+        self.output.debug(f"qt6: requested modules {requested_modules}")
 
-        # disable all modules which are:
-        # - not explicitely enabled by the consumer and
-        # - not required by a module explicitely enabled by the consumer
-        for module in self._get_module_tree:
-            if getattr(self.options, module).value is None:
+        required_modules = set()
+        for module in requested_modules:
+            required_modules.update(self._get_module_tree[module]["depends"])
+
+        required_but_disabled = [m for m in required_modules if self.options.get_safe(m) == False]
+        self.output.debug(f"qt6: required_modules modules {required_modules}")
+        if required_but_disabled:
+            raise ConanInvalidConfiguration(f"Modules {', '.join(required_but_disabled)} are required by other options, but are explicitly disabled")
+
+        enabled_modules = requested_modules.union(required_modules)
+        enabled_modules.discard("qtbase")
+
+        for module in list(enabled_modules):
+            setattr(self.options, module, True)
+
+        for module in self._submodules:
+            if module in self.options and not self.options.get_safe(module):
                 setattr(self.options, module, False)
 
         if not self.options.get_safe("qtmultimedia"):
@@ -246,6 +261,16 @@ class QtConan(ConanFile):
         if self.settings.os in ("FreeBSD", "Linux"):
             if self.options.get_safe("qtwebengine"):
                 self.options.with_fontconfig = True
+
+        for status in self._module_statuses:
+            # These are convenience only, should not affect package_id
+            option_name = f"{status}_modules"
+            self.output.debug(f"qt5 removing convenience option: {option_name},"
+                              f" see individual module options")
+            self.options.rm_safe(option_name)
+
+        for option in self.options.items():
+            self.output.debug(f"qt6 option: {option}")
 
     def validate(self):
         if os.getenv('CONAN_CENTER_BUILD_SERVICE') is not None:
@@ -649,8 +674,6 @@ class QtConan(ConanFile):
                 self.info.settings.compiler.runtime_type = "Release/Debug"
         if self.info.settings.os == "Android":
             del self.info.options.android_sdk
-        for status in self._module_statuses:
-            delattr(self.info.options, f"{status}_modules")
 
     def source(self):
         destination = self.source_folder


### PR DESCRIPTION
Recipes: qt5 and qt6

## Summary
- Restore module option defaults  to what they were before https://github.com/conan-io/conan-center-index/pull/23171, that is, set `essential_modules` is False by default in all cases
- Avoid using different option defaults on CI than outside of it - to ensure that users can properly troubleshoot missing binaries with `conan graph explain` (see https://github.com/conan-io/conan/issues/16215)
- Add debug calls and more information - this can help explain which options are enabled and why (conan needs to be invoked with `-vv`)
- Improve handling of errors when options are contradictory:
    - Instead of `"ConanException: Incorrect attempt to modify option 'qtmultimedia' from 'False' to 'True'"`
    - Now we get: `ERROR: qt/5.15.14: Invalid configuration: Modules ['qtgraphicaleffects'] are explicitly disabled, but are required by ['qtquickcontrols2'], enabled by other options`
  

Close https://github.com/conan-io/conan/issues/16215
Close https://github.com/conan-io/conan-center-index/issues/23567

## Details

* This affects the "module" options that control whether specific submodules are built or not.
* Options can be passed either via command line `-o`, inside a profile, or propagated from another recipe that requires this
* In this recipe, these module options *do not have a default value*

### Default behaviour when no options are passed
* None of the submodule options are enabled, and the are all `False` by default
* `gui` and `widgets` are built by default 
* The two above are the baseline and restore the behaviour that the qt recipes had before https://github.com/conan-io/conan-center-index/pull/23171

### When specific submodules are set set to `=True`
* They are enabled explicitly
* Their dependencies will be set to `=True` as well, even if they were not enabled explicitly

### When any submodule is explicitly set to `=False`
* Typically not needed, since they are all False by default
* If a module is set to False is a requirement of another one set to `True`, this will now display a more informative error

### Notes convenience options, e.g `essential_modules=True`
* These were introduced in https://github.com/conan-io/conan-center-index/pull/23171 and provide a "shortcut" to enable multiple options at once, with the behaviour described below:
* All of this modules  in the essential category will be enabled and set to `=True`, _as if_ they had been explicitly requested individually - as per the logic above
* But if ANY module (in a category or a requirement) is set to False, this is respected
* If `essential_modules=True`, but some modules are explicitly set to `False`:
     - This is okay if the modules set to False are not a dependency of something else that is enabled
     - Otherwise, display an informative error

> [!WARNING]  
>  There are some issues with the granularity of `essential_modules=True` and would discourage its use
> Namely: the recipe expresses modules at the level of the Qt repositories, however, as per [Qt's website](https://doc.qt.io/qt.html)) these are expressed directly as modules. We have observed some issues:
>    - `qtdoc` is marked as "essential" by the recipe - but this generates the Qt documentation, which is unlikely to be essential to the recipe consumers
>    - similar case with `qttools` - some tools are arguably not essential, but they're all lumped together
>    - the dependencies are expressed between repositories, but not between actual modules -so for example, the logic in the dependencies are not enough to get a successful configuration of options when `qtwebengine` is enabled 


