### PR TITLE
keychain: Fixed dependency conflict between libsecret and glib

### DIFF
--- a/recipes/keychain/all/conandata.yml
+++ b/recipes/keychain/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "1.2.0":
-    url: "https://github.com/hrantzsch/keychain/archive/v1.2.0.tar.gz"
-    sha256: "82cc66a7fa12af43f3e2efeb378bacb0a514056617e369430f252da2392acaae"
-  "1.2.1":
-    url: "https://github.com/hrantzsch/keychain/archive/v1.2.1.tar.gz"
-    sha256: "725cc30da0451403713dee648edd06686fdc31b5041e75e3350e6056c78de076"
   "1.3.0":
     url: "https://github.com/hrantzsch/keychain/archive/refs/tags/v1.3.0.tar.gz"
     sha256: "0e2eb3c6ca2c62253f7d28a478d0cb3eeb4b9656b33d2946e1a294361f72809c"
+  "1.2.1":
+    url: "https://github.com/hrantzsch/keychain/archive/v1.2.1.tar.gz"
+    sha256: "725cc30da0451403713dee648edd06686fdc31b5041e75e3350e6056c78de076"
+  "1.2.0":
+    url: "https://github.com/hrantzsch/keychain/archive/v1.2.0.tar.gz"
+    sha256: "82cc66a7fa12af43f3e2efeb378bacb0a514056617e369430f252da2392acaae"

--- a/recipes/keychain/all/conanfile.py
+++ b/recipes/keychain/all/conanfile.py
@@ -86,3 +86,5 @@ class KeychainConan(ConanFile):
             self.cpp_info.frameworks = ["Security", "CoreFoundation"]
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ["crypt32"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m"]

--- a/recipes/keychain/all/conanfile.py
+++ b/recipes/keychain/all/conanfile.py
@@ -1,53 +1,59 @@
+import os
+
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import collect_libs, copy, get, replace_in_file
 from conan.tools.gnu import PkgConfigDeps
 
-import os
-
 
 class KeychainConan(ConanFile):
     name = "keychain"
-    homepage = "https://github.com/hrantzsch/keychain"
-    description = "A cross-platform wrapper for the operating system's credential storage"
-    topics = ("keychain", "security", "credentials", "password", "cpp11")
-    url = "https://github.com/conan-io/conan-center-index"
+    description = (
+        "A cross-platform wrapper for the operating system's credential storage"
+    )
     license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/hrantzsch/keychain"
+    topics = ("keychain", "security", "credentials", "password", "cpp11")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
-    options = {'shared': [False, True], 'fPIC': [False, True]}
+    options = {"shared": [False, True], "fPIC": [False, True]}
     default_options = {"shared": False, "fPIC": True}
 
     def config_options(self):
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
-    def validate(self):
-        if self.settings.get_safe("compiler.cppstd"):
-            check_min_cppstd(self, 11)
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.settings.os == "Linux":
             self.requires("libsecret/0.20.5")
-            self.requires("glib/2.78.1")
+            self.requires("glib/2.78.3")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
 
     def build_requirements(self):
         if self.settings.os == "Linux":
             self.tool_requires("pkgconf/2.0.3")
 
-    def layout(self):
-        cmake_layout(self, src_folder="src")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         # Ensure .dll is installed on Windows
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "TARGETS ${PROJECT_NAME}", "TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin")
+        replace_in_file(
+            self,
+            os.path.join(self.source_folder, "CMakeLists.txt"),
+            "TARGETS ${PROJECT_NAME}",
+            "TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin",
+        )
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -64,14 +70,19 @@ class KeychainConan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="LICENSE",
+            dst=os.path.join(self.package_folder, "licenses"),
+            src=self.source_folder,
+        )
         cmake = CMake(self)
         cmake.install()
 
     def package_info(self):
         self.cpp_info.libs = collect_libs(self)
 
-        if self.settings.os == 'Macos':
-            self.cpp_info.frameworks = ['Security', 'CoreFoundation']
+        if self.settings.os == "Macos":
+            self.cpp_info.frameworks = ["Security", "CoreFoundation"]
         if self.settings.os == "Windows":
-            self.cpp_info.system_libs = ['crypt32']
+            self.cpp_info.system_libs = ["crypt32"]

--- a/recipes/keychain/config.yml
+++ b/recipes/keychain/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "1.2.0":
+  "1.3.0":
     folder: all
   "1.2.1":
     folder: all
-  "1.3.0":
+  "1.2.0":
     folder: all


### PR DESCRIPTION

### Summary
Changes to recipe:  **keychain**

#### Motivation

This recipe had conflicts between its dependencies, causing a graph error exclusively in linux systems.

#### Details
- Fix dependency conflicts -> bump `glib/2.78.1` -> `glib/2.78.3`
- Linted and little refactor of recipe

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
