### PR TITLE
jsonifier: add version 0.9.97

### DIFF
--- a/recipes/jsonifier/all/conandata.yml
+++ b/recipes/jsonifier/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.97":
+    url: "https://github.com/RealTimeChris/Jsonifier/archive/refs/tags/v0.9.97.tar.gz"
+    sha256: "68828c982a994862b02bcee562ee4e6d7cc461013ac3d4dcb98c0f1581049924"
   "0.9.96":
     url: "https://github.com/RealTimeChris/Jsonifier/archive/refs/tags/v0.9.96.tar.gz"
     sha256: "9f2658282f53680be0121091adacc8f82b2de5b95c31bc6eadb98802c0aa59f0"

--- a/recipes/jsonifier/config.yml
+++ b/recipes/jsonifier/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.97":
+    folder: all
   "0.9.96":
     folder: all
   "0.9.95":


### PR DESCRIPTION
### Summary
Changes to recipe:  **jsonifer/0.9.97**

#### Motivation
There are several improvements in 0.9.97.

#### Details
https://github.com/RealTimeChris/Jsonifier/compare/v0.9.96...v0.9.97

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
