### PR TITLE
s2n: add version 1.5.0, fix url of 1.4.16

### DIFF
--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "1.5.0":
+    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.5.0.tar.gz"
+    sha256: "5e86d97d8f24653ef3dff3abe6165169f0ba59cdf52b5264987125bba070174d"
   "1.4.16":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.4.1.tar.gz"
-    sha256: "d8c1d8e1142441412434feacb4947ce6430a244dcd8f58921af79b29bd901731"
+    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.4.16.tar.gz"
+    sha256: "84fdbaa894c722bf13cac87b8579f494c1c2d66de642e5e6104638fddea76ad9"
   "1.4.13":
     url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.4.13.tar.gz"
     sha256: "8b0b36697963d6752e5a1b49e28e393605990d348edf1aef6f39c33164d45edb"

--- a/recipes/s2n/config.yml
+++ b/recipes/s2n/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.0":
+    folder: all
   "1.4.16":
     folder: all
   "1.4.13":


### PR DESCRIPTION
### Summary
Changes to recipe:  **s2n/***

#### Motivation
- There are several improvents in 1.5.0.
- Fix wrong url of 1.4.16(sorry, It's my fault)

#### Details
https://github.com/aws/s2n-tls/compare/v1.4.16...v1.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
