### PR TITLE
daw_header_libraries: add version 2.107.0

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.107.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.107.0.tar.gz"
+    sha256: "b84f7666d004da466d0035e9f475797395e90b6e8f23e000816b45aa13d4fc35"
   "2.106.2":
     url: "https://github.com/beached/header_libraries/archive/v2.106.2.tar.gz"
     sha256: "33609d83aec5a6081efebf871627b7a8bddc2b7f0eb8d4ac14756d403d29d089"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.107.0":
+    folder: all
   "2.106.2":
     folder: all
   "2.106.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **daw_header_libraries/2.107.0**

#### Motivation
There are a new features in 2.107.0.

#### Details
https://github.com/beached/header_libraries/compare/v2.106.2...v2.107.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
