### PR TITLE
[docs] Keep only patch version compatible for zstd

### DIFF
--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -196,7 +196,7 @@ version range only when a requirement for a newer version is needed.
 * qt5: `[~5.15]`, if your library depends on qt5, only the 5.15 minor version is allowed
 * qt6: `[>=6.x <7]`, where 6.x is the lower bound of your needed qt6 version
 * c-ares: `[>=1.27 <2]`
-* zstd: `[^1.5]` it's equivalent to `[>=1.5 <1.6]`
+* zstd: `[~1.5]` it's equivalent to `[>=1.5 <1.6]`
 * ninja: `[>=1.10.2 <2]`
 * meson: `[>=1.2.3 <2]`
 * pkgconf: `[>=2.2 <3]`


### PR DESCRIPTION
### Summary
Changes documentation only.

#### Motivation

@SpaceIm spotted an incoherence in the documentation, from the PR #24723:

https://github.com/conan-io/conan-center-index/pull/24723/files#r1712973049

#### Details

The `[^1.0.0]` means minor version compatible, and `[~1.0.0]` patch version compatible only:

More references: 

- https://docs.conan.io/1/versioning/version_ranges.html#version-ranges
- https://jubianchi.github.io/semver-check/#/^3.1.5/3.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
