### PR TITLE
swig: add version 4.2.1

### DIFF
--- a/recipes/swig/all/conandata.yml
+++ b/recipes/swig/all/conandata.yml
@@ -16,10 +16,10 @@ sources:
     sha256: "2eaf6fb89d071d1be280bf995c63360b3729860c0da64948123b5d7e4cfb6cb7"
 patches:
   "4.2.1":
-    - patch_file: "patches/0001-4.1.0-swig-linux-library-path.patch"
+    - patch_file: "patches/0001-4.2.1-swig-linux-library-path.patch"
       patch_type: "portability"
       patch_description: "swig -swiglib should return the correct path next to the binary even when relocated"
-    - patch_file: "patches/0002-4.1.0-do-not-define-SWIG_LIB_WIN_UNIX.patch"
+    - patch_file: "patches/0002-4.2.1-do-not-define-SWIG_LIB_WIN_UNIX.patch"
       patch_type: "portability"
       patch_description: "swig -swiglib should return the correct path next to the binary even when relocated"
   "4.1.1":

--- a/recipes/swig/all/conandata.yml
+++ b/recipes/swig/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.2.1":
+    url: "https://github.com/swig/swig/archive/refs/tags/v4.2.1.tar.gz"
+    sha256: "8895878b9215612e73611203dc8f5232c626e4d07ffc4532922f375518f067ca"
   "4.1.1":
     url: "https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz"
     sha256: "4d97f9528dda8ced8b762e405dff2da38cc4603ef5f868f7287c94872f693265"
@@ -12,6 +15,13 @@ sources:
     url: "https://github.com/swig/swig/archive/rel-4.0.1.tar.gz"
     sha256: "2eaf6fb89d071d1be280bf995c63360b3729860c0da64948123b5d7e4cfb6cb7"
 patches:
+  "4.2.1":
+    - patch_file: "patches/0001-4.1.0-swig-linux-library-path.patch"
+      patch_type: "portability"
+      patch_description: "swig -swiglib should return the correct path next to the binary even when relocated"
+    - patch_file: "patches/0002-4.1.0-do-not-define-SWIG_LIB_WIN_UNIX.patch"
+      patch_type: "portability"
+      patch_description: "swig -swiglib should return the correct path next to the binary even when relocated"
   "4.1.1":
     - patch_file: "patches/0001-4.1.0-swig-linux-library-path.patch"
       patch_type: "portability"

--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -62,10 +62,13 @@ class SwigConan(ConanFile):
                 self.tool_requires("msys2/cci.latest")
             if is_msvc(self):
                 self.tool_requires("cccl/1.3")
-        if is_msvc(self):
-            self.tool_requires("winflexbison/2.5.25")
-        else:
+        if Version(self.version) >= "4.2":
             self.tool_requires("bison/3.8.2")
+        else:
+            if is_msvc(self):
+                self.tool_requires("winflexbison/2.5.25")
+            else:
+                self.tool_requires("bison/3.8.2")
         self.tool_requires("automake/1.16.5")
 
     def source(self):

--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -63,7 +63,11 @@ class SwigConan(ConanFile):
             if is_msvc(self):
                 self.tool_requires("cccl/1.3")
         if Version(self.version) >= "4.2":
-            self.tool_requires("bison/3.8.2")
+            if is_msvc(self):
+                # bison 3.8.2 is not ready for msvc
+                self.tool_requires("bison/3.7.6")
+            else:
+                self.tool_requires("bison/3.8.2")
         else:
             if is_msvc(self):
                 self.tool_requires("winflexbison/2.5.25")

--- a/recipes/swig/all/patches/0001-4.2.1-swig-linux-library-path.patch
+++ b/recipes/swig/all/patches/0001-4.2.1-swig-linux-library-path.patch
@@ -1,0 +1,51 @@
+--- Source/Modules/main.cxx
++++ Source/Modules/main.cxx
+@@ -861,6 +861,32 @@
+
+ static void SWIG_exit_handler(int status);
+
++#if defined(HAVE_UNISTD_H) && !defined(_WIN32)
++#include <libgen.h>
++#include <unistd.h>
++#include <dlfcn.h>
++
++static String *get_exe_path(void) {
++    Dl_info info;
++    if (dladdr("main", &info)) {
++        char realp_buffer[PATH_MAX];
++        char* res = NULL;
++
++        res = realpath(info.dli_fname, realp_buffer);
++        if (!res) {
++         return NewString(SWIG_LIB);
++        }
++
++        const char* dir = dirname(realp_buffer);
++        char dest_buf[PATH_MAX];
++        strcpy(dest_buf, dir);
++        strcat(dest_buf, "/swiglib");
++        return NewStringWithSize(dest_buf, strlen(dest_buf));
++    }
++    return NewString(SWIG_LIB);
++}
++#endif
++
+ int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
+   char *c;
+
+@@ -900,12 +926,14 @@
+     char *p;
+     if (!(GetModuleFileName(0, buf, MAX_PATH) == 0 || (p = strrchr(buf, '\\')) == 0)) {
+       *(p + 1) = '\0';
+-      SwigLib = NewStringf("%sLib", buf); // Native windows installation path
++      SwigLib = NewStringf("%sswiglib", buf); // Native windows installation path
+     } else {
+       SwigLib = NewStringf("");	// Unexpected error
+     }
+     if (Len(SWIG_LIB_WIN_UNIX) > 0)
+       SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX); // Unix installation path using a drive letter (for msys/mingw)
++#elif defined(HAVE_UNISTD_H) && !defined(_WIN32)
++    SwigLib = get_exe_path();
+ #else
+     SwigLib = NewString(SWIG_LIB);
+ #endif

--- a/recipes/swig/all/patches/0002-4.2.1-do-not-define-SWIG_LIB_WIN_UNIX.patch
+++ b/recipes/swig/all/patches/0002-4.2.1-do-not-define-SWIG_LIB_WIN_UNIX.patch
@@ -1,0 +1,11 @@
+--- configure.ac
++++ configure.ac
+@@ -2803,7 +2803,7 @@
+   *-*-cygwin*) SWIG_LIB_WIN_UNIX=`cygpath --mixed "$SWIG_LIB"`;;
+   *) SWIG_LIB_WIN_UNIX="";;
+ esac
+-AC_DEFINE_UNQUOTED(SWIG_LIB_WIN_UNIX, ["$SWIG_LIB_WIN_UNIX"], [Directory for SWIG system-independent libraries (Unix install on native Windows)])
++AC_DEFINE_UNQUOTED(SWIG_LIB_WIN_UNIX, [""], [Directory for SWIG system-independent libraries (Unix install on native Windows)])
+
+ SWIG_LIB_PREINST=$ABS_SRCDIR/Lib
+ AC_SUBST(SWIG_LIB_PREINST)

--- a/recipes/swig/config.yml
+++ b/recipes/swig/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.2.1":
+    folder: "all"
   "4.1.1":
     folder: "all"
   "4.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **swig/4.2.1**

fixes #24842 

#### Motivation
adding swig 4.2.1 for support of the python stable abi and further bug fixing

#### Details
Added the missing version 
updated the patches and added bison as required build tool

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: https://github.com/conan-io/conan-center-index/discussions/24240
- [x] Tested locally with at least one configuration using a recent version of Conan

