### PR TITLE
Fix locating moltenvk headers when with_vulkan=True

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -366,7 +366,11 @@ class QtConan(ConanFile):
         if self.options.with_pcre2:
             self.requires("pcre2/10.42")
         if self.options.get_safe("with_vulkan"):
-            self.requires("vulkan-loader/1.3.268.0")
+            # Note: the versions of vulkan-loader and moltenvk
+            #       must be exactly part of the same Vulkan SDK version
+            #       do not update either without checking both
+            #       require exactly the same version of vulkan-headers
+            self.requires("vulkan-loader/1.3.239.0")
             if is_apple_os(self):
                 self.requires("moltenvk/1.2.2")
         if self.options.with_glib:
@@ -720,6 +724,13 @@ class QtConan(ConanFile):
                         os.path.join(self.source_folder, "qtbase", "cmake", "QtAutoDetect.cmake" if Version(self.version) < "6.6.2" else "QtAutoDetectHelpers.cmake"),
                         "qt_auto_detect_vcpkg()",
                         "# qt_auto_detect_vcpkg()")
+
+        # Handle locating moltenvk headers when vulkan is enabled on macOS
+        replace_in_file(self, os.path.join(self.source_folder, "qtbase", "cmake", "FindWrapVulkanHeaders.cmake"),
+        "if(APPLE)", "if(APPLE)\n"
+                    " find_package(moltenvk REQUIRED QUIET)\n"
+                    " target_include_directories(WrapVulkanHeaders::WrapVulkanHeaders INTERFACE ${moltenvk_INCLUDE_DIR})"
+        )
 
     def _xplatform(self):
         if self.settings.os == "Linux":

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -304,9 +304,6 @@ class QtConan(ConanFile):
         if Version(self.version) >= "6.6.1" and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "13.1":
             raise ConanInvalidConfiguration("apple-clang >= 13.1 is required by qt >= 6.6.1 cf QTBUG-119490")
 
-        if self.settings.os == "Macos" and self.dependencies["double-conversion"].options.shared:
-            raise ConanInvalidConfiguration("Test recipe fails because of Macos' SIP. Contributions are welcome.")
-
         if self.options.get_safe("qtwebengine"):
             if not self.options.shared:
                 raise ConanInvalidConfiguration("Static builds of Qt WebEngine are not supported")
@@ -371,6 +368,7 @@ class QtConan(ConanFile):
             #       do not update either without checking both
             #       require exactly the same version of vulkan-headers
             self.requires("vulkan-loader/1.3.239.0")
+            self.requires("vulkan-headers/1.3.239.0", transitive_headers=True)
             if is_apple_os(self):
                 self.requires("moltenvk/1.2.2")
         if self.options.with_glib:
@@ -1129,6 +1127,7 @@ class QtConan(ConanFile):
                 gui_reqs.append("opengl::opengl")
             if self.options.get_safe("with_vulkan", False):
                 gui_reqs.append("vulkan-loader::vulkan-loader")
+                gui_reqs.append("vulkan-headers::vulkan-headers")
                 if is_apple_os(self):
                     gui_reqs.append("moltenvk::moltenvk")
             if self.options.with_harfbuzz:


### PR DESCRIPTION
### Summary
Changes to recipe:  qt/6

* Fix issue on macOS where building qt fails when `with_vulkan=True` because it does not find the moltenvk headers
* Record direct dependency on vulkan-headers (these are searched _directly_ by Qt, see [here](https://github.com/qt/qtbase/blob/v6.7.1/cmake/FindWrapVulkanHeaders.cmake))
* Record `transitive_headers` for the vulkan-headers when `with_vulkan=True`, these are used here: https://github.com/qt/qtbase/blob/v6.7.1/src/gui/vulkan/qvulkaninstance.h#L19-L21 - if these are not found, including `<QVulkanWindow>` does not properly include the vulkan headers, leading to include errors
* Fix version conflict when `with_vulkan=True` - moltenvk and vulkan have strict version requirements and need to be paired with the right versions

#### Motivation
* Fix version conflict
* Fix compiler error:

```
In file included from /xxx/.conan2/p/qt0cc42066e0980/s/src/qtbase/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm:41:
In file included from /xxx/.conan2/p/qt0cc42066e0980/s/src/qtbase/src/plugins/platforms/cocoa/qcocoaintegration.h:8:
/xxx.conan2/p/qt0cc42066e0980/s/src/qtbase/src/plugins/platforms/cocoa/qcocoawindow.h:19:10: fatal error: 'MoltenVK/mvk_vulkan.h' file not found
#include <MoltenVK/mvk_vulkan.h>
         ^~~~~~~~~~~~~~~~~~~~~~~
```

#### Details
* patch the qt cmake file that handles vulkan headers, to propagate the include path of moltenvk as well



Close https://github.com/conan-io/conan-center-index/issues/24045
Close https://github.com/conan-io/conan-center-index/issues/23684
