### PR TITLE
vvdec: add new recipe

### DIFF
--- a/recipes/vvdec/all/conandata.yml
+++ b/recipes/vvdec/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "2.3.0":
+    url: "https://github.com/fraunhoferhhi/vvdec/archive/refs/tags/v2.3.0.tar.gz"
+    sha256: "91ab0c64a6f43627add65cfd2c14d074ad5830105d63fa013af274960efd4e6d"
+patches:
+  "2.3.0":
+    - patch_file: "patches/2.3.0-0001-use-cci.patch"
+      patch_description: "use cci packages"
+      patch_type: "conan"

--- a/recipes/vvdec/all/conanfile.py
+++ b/recipes/vvdec/all/conanfile.py
@@ -103,3 +103,8 @@ class VVdeCConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
             self.cpp_info.system_libs.append("pthread")
+
+        if self.settings.compiler == "gcc" and (self.settings.os == "Windows" or Version(self.settings.compiler.version) <= "7"):
+            self.cpp_info.cxxflags.append("-pthread")
+            self.cpp_info.sharedlinkflags.append("-pthread")
+            self.cpp_info.exelinkflags.append("-pthread")

--- a/recipes/vvdec/all/conanfile.py
+++ b/recipes/vvdec/all/conanfile.py
@@ -99,3 +99,7 @@ class VVdeCConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "vvdec")
         self.cpp_info.set_property("cmake_target_name", "vvdec::vvdec")
         self.cpp_info.set_property("pkg_config_name", "libvvdec")
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/vvdec/all/conanfile.py
+++ b/recipes/vvdec/all/conanfile.py
@@ -1,0 +1,101 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.53.0"
+
+class VVdeCConan(ConanFile):
+    name = "vvdec"
+    description = "the Fraunhofer Versatile Video Decoder"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/fraunhoferhhi/vvdec"
+    topics = ("video", "decoder", "h256", "vvc")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_app": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_app": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "10",
+            "clang": "7",
+            "gcc": "7",
+            "msvc": "191",
+            "Visual Studio": "15",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("simde/0.8.2", transitive_headers=True)
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["VVDEC_ENABLE_WARNINGS_AS_WERROR"] = False
+        tc.variables["VVDEC_INSTALL_VVDECAPP"] = self.options.with_app
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["vvdec"]
+
+        self.cpp_info.set_property("cmake_file_name", "vvdec")
+        self.cpp_info.set_property("cmake_target_name", "vvdec::vvdec")
+        self.cpp_info.set_property("pkg_config_name", "libvvdec")

--- a/recipes/vvdec/all/patches/2.3.0-0001-use-cci.patch
+++ b/recipes/vvdec/all/patches/2.3.0-0001-use-cci.patch
@@ -1,0 +1,40 @@
+diff --git a/source/Lib/vvdec/CMakeLists.txt b/source/Lib/vvdec/CMakeLists.txt
+index 8758189..dad1d67 100644
+--- a/source/Lib/vvdec/CMakeLists.txt
++++ b/source/Lib/vvdec/CMakeLists.txt
+@@ -73,7 +73,7 @@ add_compile_definitions( ${LIB_NAME_UC}_SOURCE )
+ # set PRIVATE include directories for all targets in this directory
+ include_directories( $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../include> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}> )
+ include_directories( . .. ../DecoderLib ../CommonLib ../CommonLib/x86 ../CommonLib/arm ../libmd5 )
+-include_directories( SYSTEM ../../../thirdparty )
++find_package(simde CONFIG REQUIRED)
+ 
+ # don't export all symbols from shared libraries by default (gcc: -fvisibility=hidden), only those marked as VVDEC_DECL
+ #  behavior similar to __declspec(dllexport) on windows
+@@ -112,7 +112,7 @@ if( VVDEC_ENABLE_X86_SIMD )
+ 
+   #add_library( ${LIB_NAME}_x86_simd OBJECT ${X86_SSE41_SRC_FILES} ${X86_SSE42_SRC_FILES} ${X86_AVX_SRC_FILES} ${X86_AVX2_SRC_FILES} )
+   add_library( ${LIB_NAME}_x86_simd OBJECT ${X86_SSE41_SRC_FILES} ${X86_AVX2_SRC_FILES} )
+-  target_link_libraries( ${LIB_NAME}_x86_simd ${INTEL_ITT_LINK_TARGET} )
++  target_link_libraries( ${LIB_NAME}_x86_simd ${INTEL_ITT_LINK_TARGET} simde::simde)
+ 
+   # disble LTO for the files compiled with special architecture flags
+   set_target_properties( ${LIB_NAME}_x86_simd PROPERTIES
+@@ -135,7 +135,7 @@ if( VVDEC_ENABLE_ARM_SIMD )
+   #                                             INTERPROCEDURAL_OPTIMIZATION_RELEASE        OFF
+   #                                             INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO OFF
+   #                                             INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL     OFF )
+-
++  target_link_libraries( ${LIB_NAME}_arm_simd simde::simde)
+   set_target_properties( ${LIB_NAME}_arm_simd PROPERTIES FOLDER lib )
+ endif()
+ 
+@@ -154,7 +154,7 @@ target_compile_definitions( ${LIB_NAME} PUBLIC $<$<STREQUAL:$<TARGET_PROPERTY:${
+ 
+ target_include_directories( ${LIB_NAME} SYSTEM INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../include> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}> )
+ 
+-target_link_libraries( ${LIB_NAME} ${INTEL_ITT_LINK_TARGET} Threads::Threads )
++target_link_libraries( ${LIB_NAME} ${INTEL_ITT_LINK_TARGET} Threads::Threads simde::simde)
+ 
+ set_target_properties( ${LIB_NAME} PROPERTIES
+                                    SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/recipes/vvdec/all/test_package/CMakeLists.txt
+++ b/recipes/vvdec/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(vvdec REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE vvdec::vvdec)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/vvdec/all/test_package/conanfile.py
+++ b/recipes/vvdec/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/vvdec/all/test_package/test_package.cpp
+++ b/recipes/vvdec/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include "vvdec/vvdec.h"
+#include <iostream>
+
+int main() {
+    std::cout << vvdec_get_version() << std::endl;
+
+    return 0;
+}

--- a/recipes/vvdec/config.yml
+++ b/recipes/vvdec/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.3.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **vvdec/2.3.0**

#### Motivation
This library performs the reverse processing of [vvenc](https://conan.io/center/recipes/vvenc
).
Both libraries are required for vvc support in libheif.

#### Details
https://github.com/fraunhoferhhi/vvdec

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
