### PR TITLE
hwdata: add version 0.385

### DIFF
--- a/recipes/hwdata/all/conandata.yml
+++ b/recipes/hwdata/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.385":
+    url: "https://github.com/vcrhonek/hwdata/archive/v0.385.tar.gz"
+    sha256: "577219d44d9686e8177f6291adbff7bacdd785ad4e8a8d0c4b2a14dbf850d6ac"
   "0.382":
     url: "https://github.com/vcrhonek/hwdata/archive/v0.382.tar.gz"
     sha256: "5e25457b562a5227eb77eac21d5e4344bd1183c7d62b41e7d3e780ae33e053c1"

--- a/recipes/hwdata/config.yml
+++ b/recipes/hwdata/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.385":
+    folder: all
   "0.382":
     folder: all
   "0.378":


### PR DESCRIPTION
### Summary
Changes to recipe:  **hwdata/0.385**

#### Motivation
The internal database has been updated since 0.382.

#### Details
https://github.com/vcrhonek/hwdata/compare/v0.382...v0.385

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
