### PR TITLE
crashpad: add version cci.20240812  #24929

### DIFF
--- a/recipes/crashpad/all/conandata.yml
+++ b/recipes/crashpad/all/conandata.yml
@@ -1,5 +1,12 @@
 sources:
-  "cci.20220219":
+  "cci.20240812":
+    crashpad:
+      url: "https://github.com/chromium/crashpad/archive/ee8369ffb2bea0343c41edba3bc788ffe720b32c.zip"
+      sha256: "B81DC46A8CB9752063FD5612C6BC2EC2264F614ED3EF805BC9CEFA9F733B639F"
+    mini_chromium:
+      url: "https://github.com/chromium/mini_chromium/archive/7eca85315879ea0ffd4cd83d8e754c8d36248f05.zip"  
+      sha256: "B2B10480FCCE264856EA3603448FDE5092B827E7CE2B8D79EF194FA3AB816FD5"
+"cci.20220219":
     crashpad:
       url: "https://github.com/chromium/crashpad/archive/e9937cb36cd12f24d73a07c4b91168cf1885b5db.tar.gz"
       sha256: "3876ada53bfb35ca58ac4c27fba79ec56d9436046ab28477fb06c9e8d1a97c7e"
@@ -7,6 +14,16 @@ sources:
       url: "https://github.com/chromium/mini_chromium/archive/822fada4a9972e3e2f36a981da770539025beb0a.tar.gz"
       sha256: "2c3bf30d324fcb60eeef84dd6aaf7fb75b70e37bdb3716ab3ea10cda51c4b05c"
 patches:
+  "cci.20240812":
+    - patch_file: "patches/cci.20240812-0001-fix-openssl-link-order.patch"
+    - patch_file: "patches/cci.20220219-0002-remove-fPIC-Werror-LTO.patch"
+    - patch_file: "patches/cci.20240812-0003-compilers-from-env.patch"
+    - patch_file: "patches/cci.20240812-0004-use-conan-linux-syscall-support-package.patch"
+    - patch_file: "patches/cci.20240812-0005-allow-all-archs.patch"
+    #- patch_file: "patches/cci.20240812-0006-mini_chromium-win_helper-py3.patch"
+    # reused patch from cci.20210507
+    - patch_file: "patches/cci.20210507-0007-use-system-zlib.patch"
+    - patch_file: "patches/cci.20220219-0007-static-lib-tool_support.patch"
   "cci.20220219":
     - patch_file: "patches/cci.20220219-0001-fix-openssl-link-order.patch"
     - patch_file: "patches/cci.20220219-0002-remove-fPIC-Werror-LTO.patch"

--- a/recipes/crashpad/all/patches/cci.20240812-0001-fix-openssl-link-order.patch
+++ b/recipes/crashpad/all/patches/cci.20240812-0001-fix-openssl-link-order.patch
@@ -1,0 +1,22 @@
+--- util/BUILD.gn
++++ util/BUILD.gn
+@@ -675,8 +675,8 @@ crashpad_static_library("net") {
+         deps += [ "//third_party/boringssl" ]
+       } else {
+         libs = [
+-          "crypto",
+           "ssl",
++          "crypto",
+         ]
+       }
+     }
+@@ -717,8 +717,8 @@ if (!crashpad_is_android && !crashpad_is_ios) {
+         deps += [ "//third_party/boringssl" ]
+       } else {
+         libs = [
+-          "crypto",
+           "ssl",
++          "crypto",
+         ]
+       }
+     }

--- a/recipes/crashpad/all/patches/cci.20240812-0003-compilers-from-env.patch
+++ b/recipes/crashpad/all/patches/cci.20240812-0003-compilers-from-env.patch
@@ -1,0 +1,13 @@
+--- third_party/mini_chromium/mini_chromium/build/config/BUILD.gn
++++ third_party/mini_chromium/mini_chromium/build/config/BUILD.gn
+@@ -448,8 +448,8 @@ toolchain("gcc_like_toolchain") {
+     ld = cxx
+     ar = ndk_bin_dir + tool_prefix + "-ar"
+   } else {
+-    cc = "clang"
+-    cxx = "clang++"
++    cc = getenv("CC")
++    cxx = getenv("CXX")
+     asm = cxx
+     ld = cxx
+ 

--- a/recipes/crashpad/all/patches/cci.20240812-0004-use-conan-linux-syscall-support-package.patch
+++ b/recipes/crashpad/all/patches/cci.20240812-0004-use-conan-linux-syscall-support-package.patch
@@ -1,0 +1,14 @@
+--- third_party/lss/lss.h
++++ third_party/lss/lss.h
+@@ -16,9 +16,9 @@
+ #define CRASHPAD_THIRD_PARTY_LSS_LSS_H_
+ 
+ #if defined(CRASHPAD_LSS_SOURCE_EXTERNAL)
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ #elif defined(CRASHPAD_LSS_SOURCE_EMBEDDED)
+-#include "third_party/lss/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ #elif defined(CRASHPAD_LSS_SOURCE_FUCHSIA)
+ #include "../../../../../third_party/linux-syscall-support/src/linux_syscall_support.h"
+ #else

--- a/recipes/crashpad/all/patches/cci.20240812-0005-allow-all-archs.patch
+++ b/recipes/crashpad/all/patches/cci.20240812-0005-allow-all-archs.patch
@@ -1,0 +1,39 @@
+--- third_party/mini_chromium/mini_chromium/build/config/BUILD.gn
++++ third_party/mini_chromium/mini_chromium/build/config/BUILD.gn
+@@ -198,7 +198,7 @@ config("default") {
+           "arm64",
+         ]
+       } else {
+-        assert(false, "Unsupported architecture")
++        print("Unknown architecture -> assume conan knows how to handle it")
+       }
+     }
+ 
+@@ -279,6 +279,6 @@ config("default") {
+       common_flags += [ "--target=riscv64-linux-gnu" ]
+     } else {
+-      assert(false, "Unsupported architecture")
++      print("Unknown architecture -> assume conan knows how to handle it")
+     }
+ 
+     # This is currently required by the clang toolchain build that DEPS uses
+@@ -312,7 +312,7 @@ config("default") {
+     } else if (target_cpu == "x64") {
+       common_flags += [ "--target=x86_64-fuchsia" ]
+     } else {
+-      assert(false, "Unsupported architecture")
++      print("Unknown architecture -> assume conan knows how to handle it")
+     }
+ 
+     # fdio is listed in ldflags instead of libs because it’s important for it to
+--- util/BUILD.gn
++++ util/BUILD.gn
+@@ -137,7 +137,7 @@ if (crashpad_is_mac || crashpad_is_ios) {
+         "arm64",
+       ]
+     } else {
+-      assert(false, "Unsupported architecture")
++      print("Unknown architecture -> assume conan knows how to handle it")
+     }
+   }
+ 

--- a/recipes/crashpad/all/patches/cci.20240812-0006-mini_chromium-win_helper-py3.patch
+++ b/recipes/crashpad/all/patches/cci.20240812-0006-mini_chromium-win_helper-py3.patch
@@ -1,0 +1,97 @@
+--- third_party/mini_chromium/mini_chromium/build/win_helper.py
++++ third_party/mini_chromium/mini_chromium/build/win_helper.py
+@@ -39,13 +39,12 @@
+       'systemroot',
+       'temp',
+       'tmp',
+       )
+   env = {}
+   for line in output_of_set.splitlines():
+-    line = line.decode("utf-8")
+     for envvar in envvars_to_save:
+       if re.match(envvar + '=', line.lower()):
+         var, setting = line.split('=', 1)
+         env[var.upper()] = setting
+         break
+   for required in ('SYSTEMROOT', 'TEMP', 'TMP'):
+@@ -77,26 +76,26 @@
+   environment, and then do not prefix the compiler with an absolute path,
+   instead preferring something like "cl.exe" in the rule which will then run
+   whichever the environment setup has put in the path."""
+   archs = ('x86', 'amd64', 'arm64')
+   result = []
+   for arch in archs:
+-    # Extract environment variables for subprocesses.
++    sys.stderr.write("install_dir {} script_path {}".format(install_dir, script_path))
+     args = [os.path.join(install_dir, script_path)]
+     script_arch_name = arch
+     if script_path.endswith('SetEnv.cmd') and arch == 'amd64':
+       script_arch_name = '/x64'
+     if arch == 'arm64':
+       script_arch_name = 'x86_arm64'
+     args.extend((script_arch_name, '&&', 'set'))
+     popen = subprocess.Popen(
+         args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+     variables, _ = popen.communicate()
+     if popen.returncode != 0:
+       raise Exception('"%s" failed with error %d' % (args, popen.returncode))
+-    env = _ExtractImportantEnvironment(variables)
++    env = _ExtractImportantEnvironment(variables.decode())
+ 
+     env_block = _FormatAsEnvironmentBlock(env)
+     basename = 'environment.' + arch
+     with open(os.path.join(out_dir, basename), 'wb') as f:
+       f.write(env_block.encode())
+     result.append(basename)
+@@ -135,30 +134,28 @@
+     env = _GetEnvAsDict(arch)
+     args = list(args)  # *args is a tuple by default, which is read-only.
+     args[0] = args[0].replace('/', '\\')
+     link = subprocess.Popen(args, env=env, shell=True, stdout=subprocess.PIPE)
+     out, _ = link.communicate()
+     for line in out.splitlines():
+-      line = line.decode("utf-8")
+-      if (not line.startswith('   Creating library ') and
+-          not line.startswith('Generating code') and
+-          not line.startswith('Finished generating code')):
++      if (not line.startswith(b'   Creating library ') and
++          not line.startswith(b'Generating code') and
++          not line.startswith(b'Finished generating code')):
+         print(line)
+     return link.returncode
+ 
+   def ExecAsmWrapper(self, arch, *args):
+     """Filter logo banner from invocations of asm.exe."""
+     env = _GetEnvAsDict(arch)
+     popen = subprocess.Popen(args, env=env, shell=True,
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+     out, _ = popen.communicate()
+     for line in out.splitlines():
+-      line = line.decode("utf-8")
+-      if (not line.startswith('Copyright (C) Microsoft Corporation') and
+-          not line.startswith('Microsoft (R) Macro Assembler') and
+-          not line.startswith(' Assembling: ') and
++      if (not line.startswith(b'Copyright (C) Microsoft Corporation') and
++          not line.startswith(b'Microsoft (R) Macro Assembler') and
++          not line.startswith(b' Assembling: ') and
+           line):
+         print(line)
+     return popen.returncode
+ 
+   def ExecGetVisualStudioData(self, outdir, toolchain_path):
+     setenv_paths = [
+@@ -183,13 +180,13 @@
+       # Try vswhere, which will find VS2017.2+. Note that earlier VS2017s will
+       # not be found.
+       vswhere_path = os.path.join(os.environ.get('ProgramFiles(x86)'),
+           'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+       if os.path.exists(vswhere_path):
+         installation_path = subprocess.check_output(
+-            [vswhere_path, '-latest', '-property', 'installationPath']).strip()
++            [vswhere_path, '-latest', '-property', 'installationPath']).strip().decode()
+         if installation_path:
+           return (installation_path.decode("utf-8"),
+                   os.path.join('VC', 'Auxiliary', 'Build', 'vcvarsall.bat'))
+ 
+       # Otherwise, try VS2015.
+       version = '14.0'

--- a/recipes/crashpad/config.yml
+++ b/recipes/crashpad/config.yml
@@ -1,3 +1,5 @@
 versions:
   "cci.20220219":
     folder: all
+  "cci.20240812":
+    folder: all


### PR DESCRIPTION
…s. create crashpad/cci.20240812 package


### Summary
Changes to recipe:  **crashpad/cci.20240812**

#### Motivation
existing crashpad/cci.20220219 does not support c++20 standard.

#### Details
This branch updates the crashpad recipe to include the current https://github.com/chromium/mini_chromium and https://github.com/chromium/crashpad mirror as sources to the crashpad recipes.
Updated patches to handle current files.

---
- [X ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ X] Tested locally with at least one configuration using a recent version of Conan
