### PR TITLE
Add options for Emscripten platform

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -362,6 +362,43 @@ class OpenCVConan(ConanFile):
         if Version(self.version) < "4.3.0":
             self.options.with_jpeg2000 = "jasper"
 
+        if self.settings.os == "Emscripten":
+            # options taken from `platforms/js/build_js.py`
+            self.options.shared = False
+            self.options.fPIC = False
+            self.options.parallel = False
+            self.options.with_ipp = False
+            self.options.with_eigen = False
+            self.options.with_opencl = False
+            self.options.with_cuda = False
+            self.options.with_cublas = False
+            self.options.with_cufft = False
+            self.options.with_cudnn = False
+            self.options.cuda_arch_bin = False
+            self.options.cpu_baseline = ""
+            self.options.cpu_dispatch = ""
+            self.options.with_vulkan = False
+            self.options.dnn_cuda = False
+            self.options.with_qt = False
+            self.options.with_jpeg = False
+            self.options.with_png = False
+            self.options.with_tiff = False
+            self.options.with_jpeg2000 = False
+            self.options.with_openexr = False
+            self.options.with_webp = False
+            self.options.with_imgcodec_hdr = False
+            self.options.with_imgcodec_pfm = False
+            self.options.with_imgcodec_pxm = False
+            self.options.with_imgcodec_sunraster = False
+            self.options.with_quirc = False
+            self.options.with_ffmpeg = False
+            self.options.gapi = False
+            self.options.calib3d = True
+            self.options.dnn = True
+            self.options.flann = True
+            self.options.imgcodecs = False
+            self.options.videoio = False
+
     @property
     def _opencv_modules(self):
         def imageformats_deps():
@@ -1086,43 +1123,6 @@ class OpenCVConan(ConanFile):
                 self.options["jasper"].with_libjpeg = self.options.with_jpeg
             if self.options.get_safe("with_tiff"):
                 self.options["libtiff"].jpeg = self.options.with_jpeg
-        
-        if self.settings.os == "Emscripten":
-            # options taken from `platforms/js/build_js.py`
-            self.options.shared = False
-            self.options.fPIC = False
-            self.options.parallel = False
-            self.options.with_ipp = False
-            self.options.with_eigen = False
-            self.options.with_opencl = False
-            self.options.with_cuda = False
-            self.options.with_cublas = False
-            self.options.with_cufft = False
-            self.options.with_cudnn = False
-            self.options.cuda_arch_bin = False
-            self.options.cpu_baseline = ""
-            self.options.cpu_dispatch = ""
-            self.options.with_vulkan = False
-            self.options.dnn_cuda = False
-            self.options.with_qt = False
-            self.options.with_jpeg = False
-            self.options.with_png = False
-            self.options.with_tiff = False
-            self.options.with_jpeg2000 = False
-            self.options.with_openexr = False
-            self.options.with_webp = False
-            self.options.with_imgcodec_hdr = False
-            self.options.with_imgcodec_pfm = False
-            self.options.with_imgcodec_pxm = False
-            self.options.with_imgcodec_sunraster = False
-            self.options.with_quirc = False
-            self.options.with_ffmpeg = False
-            self.options.gapi = False
-            self.options.calib3d = True
-            self.options.dnn = True
-            self.options.flann = True
-            self.options.imgcodecs = False
-            self.options.videoio = False
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -1252,7 +1252,7 @@ class OpenCVConan(ConanFile):
             raise ConanInvalidConfiguration(
                 "viz module can't be enabled yet. It requires VTK which is not available in conan-center."
             )
-        if self.options.with_jpeg2000 == "openjpeg" and Version(self.version) < "4.3.0":
+        if self.options.get_safe("with_jpeg2000") == "openjpeg" and Version(self.version) < "4.3.0":
             raise ConanInvalidConfiguration("openjpeg is not available for OpenCV before 4.3.0")
 
 

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -1086,6 +1086,43 @@ class OpenCVConan(ConanFile):
                 self.options["jasper"].with_libjpeg = self.options.with_jpeg
             if self.options.get_safe("with_tiff"):
                 self.options["libtiff"].jpeg = self.options.with_jpeg
+        
+        if self.settings.os == "Emscripten":
+            # options taken from `platforms/js/build_js.py`
+            self.options.shared = False
+            self.options.fPIC = False
+            self.options.parallel = False
+            self.options.with_ipp = False
+            self.options.with_eigen = False
+            self.options.with_opencl = False
+            self.options.with_cuda = False
+            self.options.with_cublas = False
+            self.options.with_cufft = False
+            self.options.with_cudnn = False
+            self.options.cuda_arch_bin = False
+            self.options.cpu_baseline = ""
+            self.options.cpu_dispatch = ""
+            self.options.with_vulkan = False
+            self.options.dnn_cuda = False
+            self.options.with_qt = False
+            self.options.with_jpeg = False
+            self.options.with_png = False
+            self.options.with_tiff = False
+            self.options.with_jpeg2000 = False
+            self.options.with_openexr = False
+            self.options.with_webp = False
+            self.options.with_imgcodec_hdr = False
+            self.options.with_imgcodec_pfm = False
+            self.options.with_imgcodec_pxm = False
+            self.options.with_imgcodec_sunraster = False
+            self.options.with_quirc = False
+            self.options.with_ffmpeg = False
+            self.options.gapi = False
+            self.options.calib3d = True
+            self.options.dnn = True
+            self.options.flann = True
+            self.options.imgcodecs = False
+            self.options.videoio = False
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -1367,7 +1404,7 @@ class OpenCVConan(ConanFile):
         tc.variables["BUILD_opencv_apps"] = False
         tc.variables["BUILD_opencv_java"] = False
         tc.variables["BUILD_opencv_java_bindings_gen"] = False
-        tc.variables["BUILD_opencv_js"] = False
+        tc.variables["BUILD_opencv_js"] = self.settings.os == "Emscripten"
         tc.variables["BUILD_ZLIB"] = False
         tc.variables["BUILD_PNG"] = False
         tc.variables["BUILD_TIFF"] = False
@@ -1550,6 +1587,14 @@ class OpenCVConan(ConanFile):
 
         if self.settings.os == "Android":
             tc.variables["BUILD_ANDROID_EXAMPLES"] = False
+
+        if self.settings.os == "Emscripten":
+            # assume --simd and --build_wasm
+            flags = (
+                "-s WASM=1 -msimd128 -s EXPORTED_FUNCTIONS=\\\"['_malloc', '_free']\\\""
+            )
+            tc.variables["CV_ENABLE_INTRINSICS"] = True
+            tc.variables["CMAKE_CXX_FLAGS"] = flags
 
         tc.generate()
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencv/4.x**

Automatically detects when the user is compiling for `emscripten`.

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Related to https://github.com/conan-io/conan-center-index/issues/13171. The use _can_ set these options themselves. But with the default options when compiling with `emsdk`, the compilation will fail.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
This sets the options found in [`platforms/js/build_js.py`](https://github.com/opencv/opencv/blob/315f85d4f484c1e2fa043c73ac3fdd9fc5997ee7/platforms/js/build_js.py). I didn't want to add more options, so it assumes that the user would have passed the `--build_wasm` and `--simd` flag to that script.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
