### PR TITLE
mathter: bump xsimd

### DIFF
--- a/recipes/mathter/all/conanfile.py
+++ b/recipes/mathter/all/conanfile.py
@@ -65,7 +65,7 @@ class MathterConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_xsimd"):
-            self.requires("xsimd/11.1.0")
+            self.requires("xsimd/13.0.0")
 
     def package(self):
         if self.version == "1.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mathter/all**

#### Motivation

The main motivation for this bump is so that we can bump `xsimd` in the `arrow` recipe and move on with https://github.com/conan-io/conan-center-index/pull/24044.
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
