### PR TITLE
fast-cdr: add version 2.2.3

### DIFF
--- a/recipes/fast-cdr/all/conandata.yml
+++ b/recipes/fast-cdr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.3":
+    url: "https://github.com/eProsima/Fast-CDR/archive/v2.2.3.tar.gz"
+    sha256: "2501ef0930727d3b3ac1819672a6df8631a58fbcf7f005947046c2de46e8da69"
   "2.2.0":
     url: "https://github.com/eProsima/Fast-CDR/archive/v2.2.0.tar.gz"
     sha256: "8a75ee3aed59f495e95208050920d2c2146df92f073809505a3bd29011c21f20"

--- a/recipes/fast-cdr/config.yml
+++ b/recipes/fast-cdr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.3":
+    folder: all
   "2.2.0":
     folder: all
   "2.1.0":


### PR DESCRIPTION
### Summary
Add point release to recipe:  **fast-cdr/2.2.3**

#### Motivation
The point release contains mostly changes to workflow and documentation, but also fixes a compile warning in the tests.

#### Details
https://github.com/eProsima/Fast-CDR/pull/207
https://github.com/eProsima/Fast-CDR/compare/v2.2.0...v2.2.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
