### PR TITLE
catch2: add version 3.7.0

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.7.0":
+    url: "https://github.com/catchorg/Catch2/archive/v3.7.0.tar.gz"
+    sha256: "5b10cd536fa3818112a82820ce0787bd9f2a906c618429e7c4dea639983c8e88"
   "3.6.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.6.0.tar.gz"
     sha256: "485932259a75c7c6b72d4b874242c489ea5155d17efa345eb8cc72159f49f356"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.7.0":
+    folder: 3.x.x
   "3.6.0":
     folder: 3.x.x
   "3.5.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **catch2/3.7.0**

#### Motivation
There are several improvements in 3.7.0.

#### Details
https://github.com/catchorg/Catch2/compare/v3.6.0...v3.7.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
