### PR TITLE
thrift: Remove NOMINMAX definition

### DIFF
--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -175,7 +175,6 @@ class ThriftConan(ConanFile):
         self.cpp_info.components["libthrift"].set_property("pkg_config_name", "thrift")
         self.cpp_info.components["libthrift"].libs = [f"thrift{libsuffix}"]
         if self.settings.os == "Windows":
-            self.cpp_info.components["libthrift"].defines.append("NOMINMAX")
             if Version(self.version) >= "0.15.0":
                 self.cpp_info.components["libthrift"].system_libs.append("shlwapi")
         elif self.settings.os in ["Linux", "FreeBSD"]:


### PR DESCRIPTION
### Summary
Changes to recipe:  **thrift**

#### Motivation
The NOMINMAX macro is leaking from thrift and can easily break code that is relying on min/max from windows.h (including user code and code from the Windows SDK). As the lowest version of thrift that is supposed to need the macro is not supported anymore, this should be removed

#### Details
Since thrift/0.12.0 NOMINMAX is not a requirement anymore ([THRIFT-4680](https://github.com/apache/thrift/commit/9b75e4fe745a9b08e6ccdc0998ec7a69272f5b4c)) 
Remove NOMINMAX define as 0.14.1 is the lowest version supported


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
