### PR TITLE
mini: add version 0.9.16

### DIFF
--- a/recipes/mini/all/conandata.yml
+++ b/recipes/mini/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.16":
+    url: "https://github.com/metayeti/mINI/archive/refs/tags/0.9.16.tar.gz"
+    sha256: "ce20e12b1e3bcd79d6eaa47bf8d4bb319e843dfa3585e069e73d581bdf0a81ec"
   "0.9.15":
     url: "https://github.com/metayeti/mINI/archive/refs/tags/0.9.15.tar.gz"
     sha256: "241e105ab074827ab8b40582aa7b04c6191f84b244603969965c0874ad4f942c"

--- a/recipes/mini/config.yml
+++ b/recipes/mini/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.9.16":
+    folder: all
   "0.9.15":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **mini/0.9.16**

#### Motivation
mini/0.9.15 has serial bug, mini/0.9.16 fix it.

#### Details
https://github.com/metayeti/mINI/compare/0.9.15...0.9.16

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
