### PR TITLE
libjpeg: fix build with clang-cl

### DIFF
--- a/recipes/libjpeg/all/test_package/conanfile.py
+++ b/recipes/libjpeg/all/test_package/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjpeg/all**

#### Motivation
Fix build of libjpeg with clang-cl (might be a regression coming from https://github.com/conan-io/conan-center-index/pull/23840)

#### Details
Use MSBuild branch when we detect a msvc or clang-cl profile (what I call a cl like profile). I don't know if these MSBuild files can work with clang-cl, I'm not sure that replacing NMake by MSBuild in https://github.com/conan-io/conan-center-index/pull/23840 was a good move.

closes https://github.com/conan-io/conan-center-index/issues/24933

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
