### PR TITLE
pybind11: add version 2.13.4

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.13.4":
+    url: "https://github.com/pybind/pybind11/archive/v2.13.4.tar.gz"
+    sha256: "efc901aa0aab439a3fea6efeaf930b5a349fb06394bf845c64ce15a9cf8f0240"
   "2.13.2":
     url: "https://github.com/pybind/pybind11/archive/v2.13.2.tar.gz"
     sha256: "50eebef369d28f07ce1fe1797f38149e5928817be8e539239f2aadfd95b227f3"

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.13.4":
+    folder: all
   "2.13.2":
     folder: all
   "2.13.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **pybind11/2.13.4**

#### Motivation
There are several bugfixes since 2.13.2.

#### Details
https://github.com/pybind/pybind11/compare/v2.13.2...v2.13.4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
