### PR TITLE
dice-template-library: add version 1.8.0

### DIFF
--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.0":
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.8.0.tar.gz"
+    sha256: "cb20717cb596b156b098146d043caa158618e055b8edbeb4d3245cd11e1c8276"
   "1.6.0":
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.6.0.tar.gz"
     sha256: "4eb176930beb05dba183d4a48fd9e9716676fe92f0a98a8f527cb8791b0d64fd"

--- a/recipes/dice-template-library/config.yml
+++ b/recipes/dice-template-library/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.0":
+    folder: all
   "1.6.0":
     folder: all
   "1.5.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **dice-template-library/1.8.0**

#### Motivation
There are several new features since 1.6.0.

#### Details
https://github.com/dice-group/dice-template-library/compare/v1.6.0...v1.8.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
