### PR TITLE
sdl_image: Fix cross-compile issue on static build

### DIFF
--- a/recipes/sdl_image/all/conanfile.py
+++ b/recipes/sdl_image/all/conanfile.py
@@ -66,6 +66,10 @@ class SDLImageConan(ConanFile):
         "wic": False,
     }
 
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
     def export_sources(self):
         if Version(self.version) < "2.6":
             copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
@@ -200,7 +204,7 @@ class SDLImageConan(ConanFile):
     def package_info(self):
         lib_postfix = ""
         if Version(self.version) >= "2.6":
-            if self.settings.os == "Windows" and not self.options.shared:
+            if self._settings_build.os == "Windows" and not self.options.shared:
                 lib_postfix += "-static"
             if self.settings.build_type == "Debug":
                 lib_postfix += "d"


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl_image**

#### Motivation

Close #24695

#### Details

The recipe was not prepared for cross compiling statically from linux to windows.
Fixed by using `setting_build.os` instead of `settings.os` while defining `lib_postfix`

Adapted solution to work both in conan v1 and v2.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
