### PR TITLE
libheif: add version 0.18.2

### DIFF
--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.18.2":
+    url: "https://github.com/strukturag/libheif/releases/download/v1.18.2/libheif-1.18.2.tar.gz"
+    sha256: "c4002a622bec9f519f29d84bfdc6024e33fd67953a5fb4dc2c2f11f67d5e45bf"
   "1.18.1":
     url: "https://github.com/strukturag/libheif/releases/download/v1.18.1/libheif-1.18.1.tar.gz"
     sha256: "8702564b0f288707ea72b260b3bf4ba9bf7abfa7dac01353def3a86acd6bbb76"

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.18.2":
+    folder: all
   "1.18.1":
     folder: all
   "1.16.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libheif/0.18.2**

#### Motivation
There are several bugfixes in 1.18.2.

#### Details
https://github.com/strukturag/libheif/compare/v1.18.1...v1.18.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
