### PR TITLE
ninja: prevent locating and using re2c executable during build

### DIFF
--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile, conan_version
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, replace_in_file
 from conan.tools.scm import Version
 import os
 
@@ -25,6 +25,10 @@ class NinjaConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
+
+        #prevent re2c (which is optional and not needed) from being used
+        replace_in_file(self, cmakelists, "if(RE2C)", "if(FALSE)")
 
     def generate(self):
         tc = CMakeToolchain(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  ninja (all versions)

#### Motivation
Ninja tries to locate the `re2c` executable, which is useful when the `.in` files are being changed - to have cmake re-render certain files. These .in files are not changed by us and we can use the already generated files directly. This fixes issues when building older versions of ninja on systems where `re2c` is found but does not behave as expected.

#### Details
From https://cpplang.slack.com/archives/C41CWV9HA/p1723843030327379

```
Question: the meson conan package seems to require ninja through a call to self.requires() but the ninja package is showing up as a "build requirement" in the output of conan install. I am trying to override the version of ninja being used by this version of meson but seem unsuccessful in my attempts. I have tried specifying the newer version of ninja as both a requirement and tool_requirement but the best I've been able to get it is conan trying to pull in both packages https://github.com/conan-io/conan/issues/11010 this issue seems similar to what I'm running into but not sure if it is the exact scenario or if there is even a work around? TL;DR the version of re2c we have on our boxes is too low for the version of ninja that ultimately gets pulled in by ncurses (side note: not sure why that recipe checks the tools.gnu:pkg_config value, seems like there should be a better way for package developers to check for the presence of a tool) (edited
```
