### PR TITLE
sqlcipher: add version 4.6.1

### DIFF
--- a/recipes/sqlcipher/all/conandata.yml
+++ b/recipes/sqlcipher/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.6.1":
+    url: "https://github.com/sqlcipher/sqlcipher/archive/v4.6.1.zip"
+    sha256: "93a7475183d47e2d33f85aefa7518e8730796f103612d36ae191ae56209104e0"
   "4.6.0":
     url: "https://github.com/sqlcipher/sqlcipher/archive/v4.6.0.zip"
     sha256: "2d41ba2bf09c74a488f546551f65f0fa8517413307a0509dd2c87d66df6bff95"
@@ -27,6 +30,10 @@ sources:
     url: "https://github.com/sqlcipher/sqlcipher/archive/v4.3.0.zip"
     sha256: "41e1408465488e9c478ca5b7c5f8410405a10caa73b82db60ac115a76c563c05"
 patches:
+  "4.6.1":
+    - patch_file: patches/Makefile.in-v4.6.1.patch
+    - patch_file: patches/Makefile.msc-v4.6.1.patch
+    - patch_file: patches/fix_configure-v4.5.7.patch
   "4.6.0":
     - patch_file: patches/Makefile.in-v4.5.7.patch
     - patch_file: patches/Makefile.msc-v4.5.7.patch

--- a/recipes/sqlcipher/all/patches/Makefile.in-v4.6.1.patch
+++ b/recipes/sqlcipher/all/patches/Makefile.in-v4.6.1.patch
@@ -1,18 +1,19 @@
 diff --git a/Makefile.in b/Makefile.in
-index ce2617c..77242fc 100644
+index 8431c25..2c1d4fd 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -677,8 +677,7 @@ SQLITE3_SHELL_TARGET   = $(SQLITE3_SHELL_TARGET_@HAVE_WASI_SDK@)
+@@ -676,8 +676,8 @@ SQLITE3_SHELL_TARGET   = $(SQLITE3_SHELL_TARGET_@HAVE_WASI_SDK@)
  # This is the default Makefile target.  The objects listed here
  # are what get build when you type just "make" with no arguments.
  #
 -all:	sqlite3.h libsqlcipher.la $(SQLITE3_SHELL_TARGET) \
 -  $(HAVE_TCL:1=libtclsqlite3.la)
 +all:	sqlite3.h libsqlcipher.la
++
  
  Makefile: $(TOP)/Makefile.in
  	./config.status
-@@ -1579,9 +1578,8 @@ lib_install:	libsqlcipher.la
+@@ -1578,9 +1578,9 @@ lib_install:	libsqlcipher.la
  	$(INSTALL) -d $(DESTDIR)$(libdir)
  	$(LTINSTALL) libsqlcipher.la $(DESTDIR)$(libdir)
  
@@ -20,6 +21,7 @@ index ce2617c..77242fc 100644
 +install:	lib_install sqlite3.h sqlcipher.pc
  	$(INSTALL) -d $(DESTDIR)$(bindir)
 -	$(LTINSTALL) sqlcipher$(TEXE) $(DESTDIR)$(bindir)
++#	$(LTINSTALL) sqlcipher$(TEXE) $(DESTDIR)$(bindir)
  	$(INSTALL) -d $(DESTDIR)$(includedir)
  	$(INSTALL) -m 0644 sqlite3.h $(DESTDIR)$(includedir)
  	$(INSTALL) -m 0644 $(TOP)/src/sqlite3ext.h $(DESTDIR)$(includedir)

--- a/recipes/sqlcipher/all/patches/Makefile.msc-v4.6.1.patch
+++ b/recipes/sqlcipher/all/patches/Makefile.msc-v4.6.1.patch
@@ -1,0 +1,160 @@
+diff --git a/Makefile.msc b/Makefile.msc
+index d46cee1..899ce6a 100644
+--- a/Makefile.msc
++++ b/Makefile.msc
+@@ -306,9 +306,9 @@ SQLITE3H = sqlite3.h
+ #
+ !IFNDEF SQLITE3DLL
+ !IF $(FOR_WIN10)!=0
+-SQLITE3DLL = winsqlite3.dll
++SQLITE3DLL = sqlcipher.dll
+ !ELSE
+-SQLITE3DLL = sqlite3.dll
++SQLITE3DLL = sqlcipher.dll
+ !ENDIF
+ !ENDIF
+ 
+@@ -316,9 +316,9 @@ SQLITE3DLL = sqlite3.dll
+ #
+ !IFNDEF SQLITE3LIB
+ !IF $(FOR_WIN10)!=0
+-SQLITE3LIB = winsqlite3.lib
++SQLITE3LIB = sqlcipher.lib
+ !ELSE
+-SQLITE3LIB = sqlite3.lib
++SQLITE3LIB = sqlcipher.lib
+ !ENDIF
+ !ENDIF
+ 
+@@ -703,7 +703,7 @@ SHELL_CORE_SRC = $(SQLITE3C)
+ SHELL_CORE_DEP = $(SQLITE3DLL)
+ # <<mark>>
+ !ELSEIF $(USE_AMALGAMATION)==0
+-SHELL_CORE_DEP = libsqlite3.lib
++SHELL_CORE_DEP = sqlcipher.lib
+ # <</mark>>
+ !ELSE
+ SHELL_CORE_DEP =
+@@ -726,7 +726,7 @@ TESTFIXTURE_DEP = zlib $(TESTFIXTURE_DEP)
+ SHELL_CORE_LIB = $(SQLITE3LIB)
+ # <<mark>>
+ !ELSEIF $(USE_AMALGAMATION)==0
+-SHELL_CORE_LIB = libsqlite3.lib
++SHELL_CORE_LIB = sqlcipher.lib
+ # <</mark>>
+ !ELSE
+ SHELL_CORE_LIB =
+@@ -761,8 +761,9 @@ RCC = $(RCC) -DWINAPI_FAMILY=WINAPI_FAMILY_APP
+ # C compiler options for the Windows 10 platform (needs MSVC 2015).
+ #
+ !IF $(FOR_WIN10)!=0
+-TCC = $(TCC) /d2guard4 -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
+-BCC = $(BCC) /d2guard4 -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
++# /d2guard4 requires /guard:cf to be present as well, but it doesn't work with /Zi (Debug builds)
++TCC = $(TCC) -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
++BCC = $(BCC) -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
+ !ENDIF
+ 
+ # Also, we need to dynamically link to the correct MSVC runtime
+@@ -1046,8 +1047,9 @@ TLIBS =
+ # default to file, 2 to default to memory, and 3 to force temporary
+ # tables to always be in memory.
+ #
+-TCC = $(TCC) -DSQLITE_TEMP_STORE=1
+-RCC = $(RCC) -DSQLITE_TEMP_STORE=1
++# Allow overriding the value
++TCC = $(TCC) -DSQLITE_TEMP_STORE=$(SQLITE_TEMP_STORE)
++RCC = $(RCC) -DSQLITE_TEMP_STORE=$(SQLITE_TEMP_STORE)
+ 
+ # Enable/disable loadable extensions, and other optional features
+ # based on configuration. (-DSQLITE_OMIT*, -DSQLITE_ENABLE*).
+@@ -1213,14 +1215,15 @@ LTLINKOPTS = $(LTLINKOPTS) "/LIBPATH:$(WP81LIBPATH)"
+ !ENDIF
+ LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE
+ LTLINKOPTS = $(LTLINKOPTS) WindowsPhoneCore.lib RuntimeObject.lib PhoneAppModelHost.lib
+-LTLINKOPTS = $(LTLINKOPTS) /NODEFAULTLIB:kernel32.lib /NODEFAULTLIB:ole32.lib
++# Remove /NODEFAULTLIB:kernel32.lib, required by OpenSSL
+ !ENDIF
+ 
+ # When compiling for UWP or the Windows 10 platform, some extra linker
+ # options are also required.
+ #
+ !IF $(FOR_UWP)!=0 || $(FOR_WIN10)!=0
+-LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE /NODEFAULTLIB:kernel32.lib
++# Remove /NODEFAULTLIB:kernel32.lib, required by OpenSSL
++LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE
+ LTLINKOPTS = $(LTLINKOPTS) mincore.lib
+ !IFDEF PSDKLIBPATH
+ LTLINKOPTS = $(LTLINKOPTS) "/LIBPATH:$(PSDKLIBPATH)"
+@@ -1275,7 +1278,7 @@ LTLIBS = $(LTLIBS) $(LIBICU)
+ #
+ LIBOBJS0 = vdbe.lo parse.lo alter.lo analyze.lo attach.lo auth.lo \
+          backup.lo bitvec.lo btmutex.lo btree.lo build.lo \
+-         callback.lo complete.lo ctime.lo \
++         callback.lo complete.lo crypto.lo crypto_impl.lo crypto_openssl.lo ctime.lo \
+          date.lo dbpage.lo dbstat.lo delete.lo \
+          expr.lo fault.lo fkey.lo \
+          fts3.lo fts3_aux.lo fts3_expr.lo fts3_hash.lo fts3_icu.lo \
+@@ -1786,7 +1789,7 @@ ALL_TCL_TARGETS =
+ # This is the default Makefile target.  The objects listed here
+ # are what get build when you type just "make" with no arguments.
+ #
+-core:	dll libsqlite3.lib shell
++core:	dll sqlcipher.lib shell
+ 
+ # Targets that require the Tcl library.
+ #
+@@ -1805,11 +1808,12 @@ dll:	$(SQLITE3DLL)
+ shell:	$(SQLITE3EXE)
+ 
+ # <<mark>>
+-libsqlite3.lib:	$(LIBOBJ)
+-	$(LTLIB) $(LTLIBOPTS) /OUT:$@ $(LIBOBJ) $(TLIBS)
++# LTLIBPATHS is required to find the openssl/libressl libs
++sqlcipher.lib:	$(LIBOBJ)
++	$(LTLIB) $(LTLIBPATHS) $(LTLIBOPTS) /OUT:$@ $(LIBOBJ) $(TLIBS)
+ 
+-libtclsqlite3.lib:	tclsqlite.lo libsqlite3.lib
+-	$(LTLIB) $(LTLIBOPTS) $(TCLLIBPATHS) $(LTLIBPATHS) /OUT:$@ tclsqlite.lo libsqlite3.lib $(LIBTCLSTUB) $(TLIBS)
++libtclsqlite3.lib:	tclsqlite.lo sqlcipher.lib
++	$(LTLIB) $(LTLIBOPTS) $(TCLLIBPATHS) $(LTLIBPATHS) /OUT:$@ tclsqlite.lo sqlcipher.lib $(LIBTCLSTUB) $(TLIBS)
+ 
+ tclsqlite3.def:	tclsqlite.lo
+ 	echo EXPORTS > tclsqlite3.def
+@@ -1831,9 +1835,9 @@ $(SQLITE3DLL):	$(LIBOBJ) $(LIBRESOBJS) $(CORE_LINK_DEP)
+ 	$(LD) $(LDFLAGS) $(LTLINKOPTS) $(LTLIBPATHS) /DLL $(CORE_LINK_OPTS) /OUT:$@ $(LIBOBJ) $(LIBRESOBJS) $(LTLIBS) $(TLIBS)
+ 
+ # <<block2>>
+-sqlite3.def:	libsqlite3.lib
++sqlite3.def:	sqlcipher.lib
+ 	echo EXPORTS > sqlite3.def
+-	dumpbin /all libsqlite3.lib \
++	dumpbin /all sqlcipher.lib \
+ 		| $(TCLSH_CMD) $(TOP)\tool\replace.tcl include "^\s+1 _?(sqlite3(?:session|changeset|changegroup|rebaser|rbu)?_[^@]*)(?:@\d+)?$$" \1 \
+ 		| sort >> sqlite3.def
+ # <</block2>>
+@@ -2020,6 +2024,15 @@ callback.lo:	$(TOP)\src\callback.c $(HDR)
+ complete.lo:	$(TOP)\src\complete.c $(HDR)
+ 	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\complete.c
+ 
++crypto.lo:	$(TOP)\src\crypto.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto.c
++
++crypto_impl.lo:	$(TOP)\src\crypto_impl.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto_impl.c
++
++crypto_openssl.lo:	$(TOP)\src\crypto_openssl.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto_openssl.c
++
+ ctime.lo:	$(TOP)\src\ctime.c $(HDR)
+ 	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\ctime.c
+ 
+@@ -2444,7 +2457,7 @@ sqlite3rbu.lo:	$(TOP)\ext\rbu\sqlite3rbu.c $(HDR) $(EXTHDR)
+ # Rules to build the 'testfixture' application.
+ #
+ # If using the amalgamation, use sqlite3.c directly to build the test
+-# fixture.  Otherwise link against libsqlite3.lib.  (This distinction is
++# fixture.  Otherwise link against sqlcipher.lib.  (This distinction is
+ # necessary because the test fixture requires non-API symbols which are
+ # hidden when the library is built via the amalgamation).
+ #

--- a/recipes/sqlcipher/config.yml
+++ b/recipes/sqlcipher/config.yml
@@ -1,6 +1,8 @@
 versions:
   "4.6.1":
     folder: all
+  "4.6.0":
+    folder: all
   "4.5.7":
     folder: all
   "4.5.6":

--- a/recipes/sqlcipher/config.yml
+++ b/recipes/sqlcipher/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.6.0":
+  "4.6.1":
     folder: all
   "4.5.7":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlcipher/4.6.1**

#### Motivation
There are several improvements in 4.6.1.

#### Details
https://github.com/sqlcipher/sqlcipher/compare/v4.6.0...v4.6.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
