### PR TITLE
Magic_enum/0.9.6: Update signature

### DIFF
--- a/recipes/magic_enum/all/conandata.yml
+++ b/recipes/magic_enum/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "0.9.6":
     url: "https://github.com/Neargye/magic_enum/archive/v0.9.6.tar.gz"
-    sha256: "814791ff32218dc869845af7eb89f898ebbcfa18e8d81aa4d682d18961e13731"
+    sha256: "fcda8295256a2084f1f98a63b3d2c66b3d7140eea008e1ef94ea015b2f6d3034"
   "0.9.5":
     url: "https://github.com/Neargye/magic_enum/archive/v0.9.5.tar.gz"
     sha256: "44ad80db5a72f5047e01d90e18315751d9ac90c0ab42cbea7a6f9ec66a4cd679"


### PR DESCRIPTION
### Summary
Changes to recipe:  **magic_enum/0.9.6**

#### Motivation
Trying to conan install the latest magic_enum version would fail with message
`ERROR: magic_enum/0.9.6: Error in source() method, line 57 get(self, **self.conan_data["sources"][self.version], strip_root=True) ConanException: sha256 signature failed for 'v0.9.6.tar.gz' file.  Provided signature: 814791ff32218dc869845af7eb89f898ebbcfa18e8d81aa4d682d18961e13731   Computed signature: fcda8295256a2084f1f98a63b3d2c66b3d7140eea008e1ef94ea015b2f6d3034`


#### Details
Magic_enum updated its 0.9.6 package recently, breaking the package (https://github.com/Neargye/magic_enum/releases/tag/v0.9.6)

Updated the signature for 0.9.6 magic_enum package


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
