### PR TITLE
opencv/4.x: fix building for iOS

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -319,10 +319,13 @@ class OpenCVConan(ConanFile):
         else:
             del self.options.with_ffmpeg
 
-        if "arm" not in self.settings.arch:
-            del self.options.neon
         if not self._has_with_jpeg2000_option:
             del self.options.with_jpeg2000
+        elif Version(self.version) < "4.3.0":
+            self.options.with_jpeg2000 = "jasper"
+
+        if "arm" not in self.settings.arch:
+            del self.options.neon
         if not self._has_with_tiff_option:
             del self.options.with_tiff
         if not self._has_superres_option:
@@ -358,9 +361,6 @@ class OpenCVConan(ConanFile):
             # in a big dependency graph
             if not self._has_with_wayland_option:
                 self.options.with_gtk = True
-
-        if Version(self.version) < "4.3.0":
-            self.options.with_jpeg2000 = "jasper"
 
     @property
     def _opencv_modules(self):
@@ -1215,7 +1215,7 @@ class OpenCVConan(ConanFile):
             raise ConanInvalidConfiguration(
                 "viz module can't be enabled yet. It requires VTK which is not available in conan-center."
             )
-        if self.options.with_jpeg2000 == "openjpeg" and Version(self.version) < "4.3.0":
+        if self.options.get_safe("with_jpeg2000") == "openjpeg" and Version(self.version) < "4.3.0":
             raise ConanInvalidConfiguration("openjpeg is not available for OpenCV before 4.3.0")
 
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencv/4.x**

#### Motivation
After PR #24814 OpenCV could no longer be built for iOS as described in [this comment](https://github.com/conan-io/conan-center-index/pull/24814#issuecomment-2302132602).

#### Details
The option `with_jpeg2000` must not be accessed without `get_safe` or a guard that checks `_has_with_jpeg2000_option`. This PR fixes the regression w/o changing other functionality by safely accessing the `with_jpeg2000` option.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
