### PR TITLE
battery-embed: Remove link to battery::embed in test package

### DIFF
--- a/recipes/battery-embed/all/test_package/CMakeLists.txt
+++ b/recipes/battery-embed/all/test_package/CMakeLists.txt
@@ -4,7 +4,6 @@ project(test_package LANGUAGES CXX)
 find_package(battery-embed REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE battery::embed)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 
 b_embed(${PROJECT_NAME} test_package.cpp)


### PR DESCRIPTION
### Summary
Changes to recipe:  **battery-embed/1.2.19**

#### Motivation
The test contains a wrong line, I oversaw it while reviewing the PR for adding the package.
To ensure correct testing and the quality of the package, the line should be removed.

#### Details
The removed line linked to the battery::embed library. However, this should not happen in user code because the function b_embed() already does it automatically, just like it does it for include paths. This is needed, because it is linked on-demand, and only if necessary.

This does not change any functionality.

Since everything already worked before, all test runners should succeed like before.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
