### PR TITLE
itlib: add version 1.11.2

### DIFF
--- a/recipes/itlib/all/conandata.yml
+++ b/recipes/itlib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.2":
+    url: "https://github.com/iboB/itlib/archive/v1.11.2.tar.gz"
+    sha256: "bbf734f6084af77a1e886e54e4efadab491ada242f5858afa561353db6a0a03f"
   "1.11.1":
     url: "https://github.com/iboB/itlib/archive/v1.11.1.tar.gz"
     sha256: "2c60e02660ea63dfb7a39237e29b30a066670cef228d22e8d0908e1fff2fa7f1"

--- a/recipes/itlib/config.yml
+++ b/recipes/itlib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.11.2":
+    folder: all
   "1.11.1":
     folder: all
   "1.10.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **itlib/1.11.2**

#### Motivation
The ocmpilation errors on MinGW are fixes in 1.11.2.

#### Details
https://github.com/iboB/itlib/compare/v1.11.1...v1.11.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
