### PR TITLE
[Protobuf] Fix crosscompilation error

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -78,7 +78,7 @@ class ProtobufConan(ConanFile):
             self.requires("zlib/[>=1.2.11 <2]")
 
         if self._protobuf_release >= "22.0":
-            self.requires("abseil/20240116.2", transitive_headers=True)
+            self.requires("abseil/20240116.2", transitive_headers=True, transitive_libs=True)
 
     @property
     def _compilers_minimum_version(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuf/ >= 22.0**

#### Motivation
The test package (and any other package that depends on protobuf) fail to link when crosscompiling with undefined references to `libabsl`.

#### Details
I'm going to start by stating that I don't understand why this patch is needed and that I might be doing something wrong.
I'm trying to crosscompile `protobuf` for an arm platform and I get a bunch of link errors when the test package is built. If I skip the test package, then the errors come from other packages that depend on protobuf.
```
[2/2] Linking CXX executable test_package
FAILED: test_package 
: && /opt/arm-sdk/sysroots/x86_64-pokysdk-linux/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-g++ --sysroot=/opt/arm-sdk/sysroots/armv7at2hf-neon-poky-linux-gnueabi -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard -fstack-protector-strong --sysroot=/opt/arm-sdk/sysroots/armv7at2hf-neon-poky-linux-gnueabi -O3 -DNDEBUG  CMakeFiles/test_package.dir/test_package.cpp.o -o test_package -L/home/dev/.conan2/p/b/proto917b804664ee9/p/lib   -L/home/dev/.conan2/p/b/zlib8373429f3ea58/p/lib   -L/home/dev/.conan2/p/b/absei62aa51aa47723/p/lib -Wl,-rpath,/home/dev/.conan2/p/b/proto917b804664ee9/p/lib:/home/dev/.conan2/p/b/zlib8373429f3ea58/p/lib:/home/dev/.conan2/p/b/absei62aa51aa47723/p/lib  /home/dev/.conan2/p/b/proto917b804664ee9/p/lib/libprotoc.so  /home/dev/.conan2/p/b/proto917b804664ee9/p/lib/libprotobuf.so  -lm  -latomic  -lpthread && :
/opt/arm-sdk/sysroots/x86_64-pokysdk-linux/usr/libexec/arm-poky-linux-gnueabi/gcc/arm-poky-linux-gnueabi/11.3.0/real-ld: warning: libabsl_log_internal_check_op.so.2401.0.0, needed by /home/dev/.conan2/p/b/proto917b804664ee9/p/lib/libprotoc.so, not found (try using -rpath or -rpath-link)
/opt/arm-sdk/sysroots/x86_64-pokysdk-linux/usr/libexec/arm-poky-linux-gnueabi/gcc/arm-poky-linux-gnueabi/11.3.0/real-ld: warning: libabsl_leak_check.so.2401.0.0, needed by /home/dev/.conan2/p/b/proto917b804664ee9/p/lib/libprotoc.so, not found (try using -rpath or -rpath-link)

<....>

/opt/arm-sdk/sysroots/x86_64-pokysdk-linux/usr/libexec/arm-poky-linux-gnueabi/gcc/arm-poky-linux-gnueabi/11.3.0/real-ld: /home/dev/.conan2/p/b/proto917b804664ee9/p/lib/libprotoc.so: undefined reference to `bool absl::lts_20240116::str_format_internal::FormatArgImpl::Dispatch<long long>(absl::lts_20240116::str_format_internal::FormatArgImpl::Data, absl::lts_20240116::str_format_internal::FormatConversionSpecImpl, void*)'
/opt/arm-sdk/sysroots/x86_64-pokysdk-linux/usr/libexec/arm-poky-linux-gnueabi/gcc/arm-poky-linux-gnueabi/11.3.0/real-ld: /home/dev/.conan2/p/b/proto917b804664ee9/p/lib/libprotoc.so: undefined reference to `absl::lts_20240116::str_format_internal::FormatPack[abi:cxx11](absl::lts_20240116::str_format_internal::UntypedFormatSpecImpl, absl::lts_20240116::Span<absl::lts_20240116::str_format_internal::FormatArgImpl const>)

<...>
```
This is the profile
```
[settings]
os=Linux
arch=armv7hf
compiler=gcc
compiler.version=11
compiler.libcxx=libstdc++11
build_type=Release

[conf]
tools.system.package_manager:mode=install
tools.system.package_manager:sudo=True
tools.build:compiler_executables = {"cpp": "arm-poky-linux-gnueabi-g++", "c": "arm-poky-linux-gnueabi-gcc"}
tools.build:sysroot = "/opt/arm-sdk/sysroots/armv7at2hf-neon-poky-linux-gnueabi"
tools.build:cflags = ["-march=armv7-a", "-mthumb", "-mfpu=neon", "-mfloat-abi=hard", "-fstack-protector-strong --sysroot=/opt/arm-sdk/sysroots/armv7at2hf-neon-poky-linux-gnueabi"]
tools.build:cxxflags = ["-march=armv7-a", "-mthumb", "-mfpu=neon", "-mfloat-abi=hard", "-fstack-protector-strong --sysroot=/opt/arm-sdk/sysroots/armv7at2hf-neon-poky-linux-gnueabi"]
tools.cmake.cmaketoolchain:generator=Ninja
# We need the toolchain just to set CMAKE_FIND_ROOT_PATH_MODE_PROGRAM and CMAKE_FIND_ROOT_PATH_MODE_PACKAGE
# https://github.com/conan-io/conan/issues/14343
tools.cmake.cmaketoolchain:user_toolchain = ["{{ os.path.join(profile_dir, "rv1126_toolchain.cmake") }}"]

# CMake won't set CMAKE_SYSTEM_PROCESSOR unless SYSTEM_NAME is also set
tools.cmake.cmaketoolchain:system_name = "Linux"
tools.cmake.cmaketoolchain:system_processor = "armv7at2hf"

[options]
*:shared=True
```
And the build command is:
```
 conan create recipes/protobuf/all/ --version 5.27.0 -pr:b x86_64 -pr:h arm
```
I say I don't understand this code because I have set `*:shared=True` on my profile (because I only want to use shared libs across my whole project, is there a better way?) then why do I need to explicitly propagate this library downstream? Shouldn't this be the default for shared libs? The docs say that for shared libs only `run=True` is inferred.

Tagging 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
