### PR TITLE
[bugfix] tensorflow-lite and gcc-13

### DIFF
--- a/recipes/tensorflow-lite/all/conandata.yml
+++ b/recipes/tensorflow-lite/all/conandata.yml
@@ -30,6 +30,10 @@ patches:
     - patch_file: "patches/2.12.0-0003-use-cci-dependencies.patch"
       patch_description: "Dependency compatibility: Patch CMakeLists.txt, updating package names, target names, etc"
       patch_type: "conan"
+    - patch_file: "patches/2.12.0-0004-use-add-stdint-for-int-types.patch"
+      patch_description: "Add stdint.h for int types in internal::Spectrogram"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/tensorflow/tensorflow/pull/60299"
   "2.10.0":
     - patch_file: "patches/2.10.0-0001-remove_simple_memory_arena_debug_dump.patch"
       patch_description: "Shared build fails on Windows with error LNK2005. Resolve the conflict by removing the conflicting implementation for now."
@@ -39,3 +43,7 @@ patches:
     - patch_file: "patches/2.10.0-0003-use-cci-dependencies.patch"
       patch_description: "Dependency compatibility: Patch CMakeLists.txt, updating package names, target names, etc"
       patch_type: "conan"
+    - patch_file: "patches/2.10.0-0004-use-add-stdint-for-int-types.patch"
+      patch_description: "Add stdint.h for int types in internal::Spectrogram"
+      patch_type: "bugfix"
+      patch_source: "https://github.com/tensorflow/tensorflow/pull/60299"

--- a/recipes/tensorflow-lite/all/patches/2.10.0-0004-use-add-stdint-for-int-types.patch
+++ b/recipes/tensorflow-lite/all/patches/2.10.0-0004-use-add-stdint-for-int-types.patch
@@ -1,0 +1,12 @@
+diff --git a/tensorflow/lite/kernels/internal/spectrogram.cc b/tensorflow/lite/kernels/internal/spectrogram.cc
+index a832962a..919eebeb 100644
+--- a/tensorflow/lite/kernels/internal/spectrogram.cc
++++ b/tensorflow/lite/kernels/internal/spectrogram.cc
+@@ -17,6 +17,7 @@ limitations under the License.
+
+ #include <assert.h>
+ #include <math.h>
++#include <stdint.h>
+
+ #include "third_party/fft2d/fft.h"
+

--- a/recipes/tensorflow-lite/all/patches/2.12.0-0004-use-add-stdint-for-int-types.patch
+++ b/recipes/tensorflow-lite/all/patches/2.12.0-0004-use-add-stdint-for-int-types.patch
@@ -1,0 +1,12 @@
+diff --git a/tensorflow/lite/kernels/internal/spectrogram.cc b/tensorflow/lite/kernels/internal/spectrogram.cc
+index a832962a..919eebeb 100644
+--- a/tensorflow/lite/kernels/internal/spectrogram.cc
++++ b/tensorflow/lite/kernels/internal/spectrogram.cc
+@@ -17,6 +17,7 @@ limitations under the License.
+
+ #include <assert.h>
+ #include <math.h>
++#include <stdint.h>
+
+ #include "third_party/fft2d/fft.h"
+


### PR DESCRIPTION
### Summary
Changes to recipe:  **tensorflow-lite/[< 2.15.0]**

#### Motivation

Compilation fails due to missing `<stdint>` header when using GCC-13.

Fix: https://github.com/conan-io/conan-center-index/issues/24538

#### Details
Bugfix source: https://github.com/tensorflow/tensorflow/pull/60299

Profile host/build:

```ini
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux


[conf]
tools.build:compiler_executables={"c": "gcc-13", "cpp": "g++-13"}
```

Error log:

```bash
[ 21%] Building CXX object CMakeFiles/tensorflow-lite.dir/kernels/internal/spectrogram.cc.o
[ 21%] Building CXX object CMakeFiles/tensorflow-lite.dir/kernels/internal/tensor_utils.cc.o
/root/.conan2/p/b/tensoe72a22e4ba1f5/b/src/tensorflow/lite/kernels/internal/spectrogram.cc:46:22: error: ‘uint32_t’ was not declared in this scope
   46 | inline int Log2Floor(uint32_t n) {
      |                      ^~~~~~~~
/root/.conan2/p/b/tensoe72a22e4ba1f5/b/src/tensorflow/lite/kernels/internal/spectrogram.cc:20:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   19 | #include <math.h>
  +++ |+#include <cstdint>
   20 |
/root/.conan2/p/b/tensoe72a22e4ba1f5/b/src/tensorflow/lite/kernels/internal/spectrogram.cc:61:24: error: ‘uint32_t’ was not declared in this scope
   61 | inline int Log2Ceiling(uint32_t n) {
      |                        ^~~~~~~~
/root/.conan2/p/b/tensoe72a22e4ba1f5/b/src/tensorflow/lite/kernels/internal/spectrogram.cc:61:24: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/root/.conan2/p/b/tensoe72a22e4ba1f5/b/src/tensorflow/lite/kernels/internal/spectrogram.cc:69:8: error: ‘uint32_t’ does not name a type
   69 | inline uint32_t NextPowerOfTwo(uint32_t value) {
      |        ^~~~~~~~
/root/.conan2/p/b/tensoe72a22e4ba1f5/b/src/tensorflow/lite/kernels/internal/spectrogram.cc:69:8: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/root/.conan2/p/b/tensoe72a22e4ba1f5/b/src/tensorflow/lite/kernels/internal/spectrogram.cc: In member function ‘bool tflite::internal::Spectrogram::Initialize(const std::vector<double>&, int)’:
/root/.conan2/p/b/tensoe72a22e4ba1f5/b/src/tensorflow/lite/kernels/internal/spectrogram.cc:92:17: error: ‘NextPowerOfTwo’ was not declared in this scope
   92 |   fft_length_ = NextPowerOfTwo(window_length_);
      |                 ^~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/tensorflow-lite.dir/build.make:692: CMakeFiles/tensorflow-lite.dir/kernels/internal/spectrogram.cc.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/Makefile2:119: CMakeFiles/tensorflow-lite.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```

After applying this patch, everything runs OK:

```bash
tensorflow-lite/2.12.0 (test package): Running CMake.build()
tensorflow-lite/2.12.0 (test package): RUN: cmake --build "/home/develop/conan-center-index/recipes/tensorflow-lite/all/test_package/build/gcc-13-x86_64-gnu17-release" -- -j2
tensorflow-lite/2.12.0 (test package): Full command: . "/home/develop/conan-center-index/recipes/tensorflow-lite/all/test_package/build/gcc-13-x86_64-gnu17-release/generators/conanbuild.sh" && cmake --build "/home/develop/conan-center-index/recipes/tensorflow-lite/all/test_package/build/gcc-13-x86_64-gnu17-release" -- -j2
gmake: Warning: File 'Makefile' has modification time 0.46 s in the future
gmake[1]: Warning: File 'CMakeFiles/Makefile2' has modification time 0.39 s in the future
gmake[2]: Warning: File 'CMakeFiles/test_package.dir/flags.make' has modification time 0.36 s in the future
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: Warning: File 'CMakeFiles/test_package.dir/flags.make' has modification time 0.32 s in the future
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[100%] Built target test_package
gmake[1]: warning:  Clock skew detected.  Your build may be incomplete.
gmake: warning:  Clock skew detected.  Your build may be incomplete.
```