### PR TITLE
assimp: add v5.4.2

### DIFF
--- a/recipes/assimp/5.x/conandata.yml
+++ b/recipes/assimp/5.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.4.2":
+    url: "https://github.com/assimp/assimp/archive/refs/tags/v5.4.2.tar.gz"
+    sha256: "7414861a7b038e407b510e8b8c9e58d5bf8ca76c9dfe07a01d20af388ec5086a"
   "5.4.1":
     url: "https://github.com/assimp/assimp/archive/refs/tags/v5.4.1.tar.gz"
     sha256: "a1bf71c4eb851ca336bba301730cd072b366403e98e3739d6a024f6313b8f954"

--- a/recipes/assimp/config.yml
+++ b/recipes/assimp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.4.2":
+    folder: "5.x"
   "5.4.1":
     folder: "5.x"
   "5.3.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **assimp/5.4.2**

#### Motivation
Adds many minor fixes.
https://github.com/assimp/assimp/releases/tag/v5.4.2
https://github.com/assimp/assimp/compare/v5.4.1...v5.4.2

Also hopefully fixes the missing binary issue in #24669.

#### Details
No changes to the build system that would affect the recipe in this release.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
