### PR TITLE
gstreamer: add v1.24.7, drop old versions

### DIFF
--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -1,28 +1,19 @@
 sources:
+  "1.24.7":
+    url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.24.7.tar.xz"
+    sha256: "c0e75b124c52bb7a0c3dcdb734b2ad260ea7286a8745cf2ea629d4c849e6a958"
   "1.22.6":
     url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.22.6.tar.xz"
     sha256: "f500e6cfddff55908f937711fc26a0840de28a1e9ec49621c0b6f1adbd8f818e"
-  "1.22.3":
-    url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.22.3.tar.xz"
-    sha256: "9ffeab95053f9f6995eb3b3da225e88f21c129cd60da002d3f795db70d6d5974"
   "1.20.6":
     url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.20.6.tar.xz"
     sha256: "0545b030960680f71a95f9d39c95daae54b4d317d335e8f239d81138773c9b90"
   "1.19.2":
     url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.19.2/gstreamer-1.19.2.tar.gz"
     sha256: "6ec8494867d9b58f145c0c357da631faf21c2c72c7cd8b637b440188fe904ab8"
-  "1.19.1":
-    url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.19.1/gstreamer-1.19.1.tar.gz"
-    sha256: "2e51f61e59564e48883b5f1996871b0d1c404406aadb9aa1b306de8a2a331a90"
   "1.18.4":
     url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.18.4/gstreamer-1.18.4.tar.gz"
     sha256: "f0956c2056281f5909d030945a9896810e55084f29b6bcfc401b53e91ddf1c7f"
-  "1.18.3":
-    url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.18.3/gstreamer-1.18.3.tar.gz"
-    sha256: "d7e3917b5d3d9c3bd9bb70b7500314a5725377cff39bcd818df13c1fda0f60ba"
-  "1.18.0":
-    sha256: "f072da67b6dad9b4aecf2cb594aaaa66f86c22af9ba80503b90f957d47015ef8"
-    url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.18.0/gstreamer-1.18.0.tar.bz2"
   "1.16.2":
-    sha256: "dac037ab84d557f5d4e6e66e833f6bf8cf4f84671a311e0b2df99f9b30a9d693"
     url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.16.2/gstreamer-1.16.2.tar.bz2"
+    sha256: "dac037ab84d557f5d4e6e66e833f6bf8cf4f84671a311e0b2df99f9b30a9d693"

--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
   "1.19.2":
     url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.19.2/gstreamer-1.19.2.tar.gz"
     sha256: "6ec8494867d9b58f145c0c357da631faf21c2c72c7cd8b637b440188fe904ab8"
+  "1.19.1":
+    url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.19.1/gstreamer-1.19.1.tar.gz"
+    sha256: "2e51f61e59564e48883b5f1996871b0d1c404406aadb9aa1b306de8a2a331a90"
   "1.18.4":
     url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.18.4/gstreamer-1.18.4.tar.gz"
     sha256: "f0956c2056281f5909d030945a9896810e55084f29b6bcfc401b53e91ddf1c7f"

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -1,19 +1,13 @@
 versions:
-  "1.22.6":
+  "1.24.7":
     folder: all
-  "1.22.3":
+  "1.22.6":
     folder: all
   "1.20.6":
     folder: all
   "1.19.2":
     folder: all
-  "1.19.1":
-    folder: all
   "1.18.4":
-    folder: all
-  "1.18.3":
-    folder: all
-  "1.18.0":
     folder: all
   "1.16.2":
     folder: all

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -7,6 +7,8 @@ versions:
     folder: all
   "1.19.2":
     folder: all
+  "1.19.1":
+    folder: all
   "1.18.4":
     folder: all
   "1.16.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gstreamer/1.24.7**

#### Motivation
Adds the latest version of GStreamer.

Would like to make progress with the Conan 2.x migration GStreamer and its related packages.

#### Details
I compared the pkgconfig output of the latest version and previous ones and identified some minor changes. Updated the recipe accordingly.

The `gio-unix-2.0` dependency was added in https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/b004464ac6c9e9a59ebf51139a835dd1fac33201?page=4#5ef7fd2d4f67cb80c17ceb3e596e5f75bdd35838

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
