### PR TITLE
cuda-api-wrappers recipe: Removed 0.7.0 betas, added 0.7.0 and 0.7.1

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "0.7.0-b2":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.0-b2.tar.gz"
-    sha256: "9439cb2250dd3045a05d43c4ca66b5d49535eeba123b05a2e49169354fdb3123"
-  "0.7-b1":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/0.7b1.tar.gz"
-    sha256: "1ed5912d8f602ccd176865b824de17f462cb57142eb2a685d7cc034831e54a71"
+  "0.7.1":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.1.tar.gz"
+    sha256: "fa30c9fe43a62f5a3fd82a5deb477838fbf0bf455c73a2d2bb5ab6284184900b"
+  "0.7.0":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.0.tar.gz"
+    sha256: "a47d11607ffa0c41cfffe689840a14125520da3f4bb504267e9d232ebb846457"
   "0.6.8":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.8.tar.gz"
     sha256: "a0d1b062dbe41c99d06df4ae7885a053c2ae3815d6fe12df0458bc5277d08ed7"

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "0.7.0-b2":
+  "0.7.1":
     folder: all
-  "0.7-b1":
+  "0.7.0":
     folder: all
   "0.6.8":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cuda-api-wrappers**

#### Motivation
The cuda-api-wrappers has had two releases since the latest available on conan; and for one of them, we had some betas available.

#### Details
This removes the betas and adds the releases: 0.7.0 and 0.7.1 .


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
