### PR TITLE
Boost: bumping version to 1.86.0

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "1.86.0":
+    url:
+      - "https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2"
+      - "https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2"
+    sha256: "1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b"
   "1.85.0":
     url:
       - "https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.bz2"

--- a/recipes/boost/config.yml
+++ b/recipes/boost/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.86.0":
+    folder: all
   "1.85.0":
     folder: all
   "1.84.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
The latest version of boost solves a critical memory corruption issue with flat_map. It also contains many enhancements and minor fixes. Full changelog here https://www.boost.org/users/history/version_1_86_0.html

#### Details
bumping the version in both the config.yml and conandata.yml.
That hash was copied from https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2.json


Unrelated : the GitFlow link on this page is broken https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md

---
- [ x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
