### PR TITLE
[boost] Add version 1.86.0

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "1.86.0":
+    url:
+      - "https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2"
+      - "https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2"
+    sha256: "1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b"
   "1.85.0":
     url:
       - "https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.bz2"

--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -78,6 +78,10 @@ sources:
     url: "https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2"
     sha256: "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee"
 patches:
+  "1.86.0":
+    - patch_file: "patches/1.82.0-locale-iconv-library-option.patch"
+      patch_description: "Optional flag to specify iconv from either libc of libiconv"
+      patch_type: "conan"
   "1.85.0":
     - patch_file: "patches/1.82.0-locale-iconv-library-option.patch"
       patch_description: "Optional flag to specify iconv from either libc of libiconv"

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, to_apple_arch, XCRun
-from conan.tools.build import build_jobs, check_min_cppstd, cross_building, valid_min_cppstd, supported_cppstd
+from conan.tools.build import build_jobs, cross_building, valid_min_cppstd, supported_cppstd
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import (
     apply_conandata_patches, chdir, collect_libs, copy, export_conandata_patches,

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -614,7 +614,7 @@ class BoostConan(ConanFile):
             return not self.options.header_only and not self.options.without_stacktrace and self.settings.os != "Windows"
         elif Version(self.version) >= "1.86.0":
             # https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L148
-            return not self.options.header_only and self.settings.arch == "x86_64"
+            return not self.options.header_only and not self.options.without_stacktrace and self.settings.arch == "x86_64"
 
     def configure(self):
         if self.options.header_only:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -609,8 +609,12 @@ class BoostConan(ConanFile):
 
     @property
     def _stacktrace_from_exception_available(self):
-        if Version(self.version) >= "1.85.0":
+        if Version(self.version) == "1.85.0":
+            # https://github.com/boostorg/stacktrace/blob/boost-1.85.0/build/Jamfile.v2#L143
             return not self.options.header_only and not self.options.without_stacktrace and self.settings.os != "Windows"
+        elif Version(self.version) >= "1.86.0":
+            # https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L148
+            return not self.options.header_only and self.settings.arch != "x86_64"
 
     def configure(self):
         if self.options.header_only:
@@ -1913,7 +1917,9 @@ class BoostConan(ConanFile):
                         continue
                     if name in ("boost_math_c99l", "boost_math_tr1l") and str(self.settings.arch).startswith("ppc"):
                         continue
-                    if name in ("boost_stacktrace_addr2line", "boost_stacktrace_backtrace", "boost_stacktrace_basic", "boost_stacktrace_from_exception",) and self.settings.os == "Windows":
+                    if name in ("boost_stacktrace_addr2line", "boost_stacktrace_backtrace", "boost_stacktrace_basic") and self.settings.os == "Windows":
+                        continue
+                    if name == "boost_stacktrace_from_exception" and not self._stacktrace_from_exception_available:
                         continue
                     if name == "boost_stacktrace_addr2line" and not self._stacktrace_addr2line_available:
                         continue

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -614,7 +614,7 @@ class BoostConan(ConanFile):
             return not self.options.header_only and not self.options.without_stacktrace and self.settings.os != "Windows"
         elif Version(self.version) >= "1.86.0":
             # https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L148
-            return not self.options.header_only and self.settings.arch != "x86_64"
+            return not self.options.header_only and self.settings.arch == "x86_64"
 
     def configure(self):
         if self.options.header_only:

--- a/recipes/boost/all/dependencies/dependencies-1.86.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.86.0.yml
@@ -1,0 +1,291 @@
+configure_options:
+- atomic
+- charconv
+- chrono
+- cobalt
+- container
+- context
+- contract
+- coroutine
+- date_time
+- exception
+- fiber
+- filesystem
+- graph
+- graph_parallel
+- iostreams
+- json
+- locale
+- log
+- math
+- mpi
+- nowide
+- program_options
+- python
+- random
+- regex
+- serialization
+- stacktrace
+- system
+- test
+- thread
+- timer
+- type_erasure
+- url
+- wave
+dependencies:
+  atomic: []
+  charconv: []
+  chrono:
+  - system
+  cobalt:
+  - container
+  - system
+  container: []
+  context: []
+  contract:
+  - exception
+  - thread
+  coroutine:
+  - context
+  - exception
+  - system
+  date_time: []
+  exception: []
+  fiber:
+  - context
+  - filesystem
+  fiber_numa:
+  - fiber
+  filesystem:
+  - atomic
+  - system
+  graph:
+  - math
+  - random
+  - regex
+  - serialization
+  graph_parallel:
+  - filesystem
+  - graph
+  - mpi
+  - random
+  - serialization
+  iostreams:
+  - random
+  - regex
+  json:
+  - container
+  - system
+  locale:
+  - thread
+  log:
+  - atomic
+  - date_time
+  - exception
+  - filesystem
+  - random
+  - regex
+  - system
+  - thread
+  log_setup:
+  - log
+  math: []
+  math_c99:
+  - math
+  math_c99f:
+  - math
+  math_c99l:
+  - math
+  math_tr1:
+  - math
+  math_tr1f:
+  - math
+  math_tr1l:
+  - math
+  mpi:
+  - graph
+  - serialization
+  mpi_python:
+  - mpi
+  - python
+  nowide:
+  - filesystem
+  numpy:
+  - python
+  prg_exec_monitor:
+  - test
+  program_options: []
+  python: []
+  random:
+  - system
+  regex: []
+  serialization: []
+  stacktrace: []
+  stacktrace_addr2line:
+  - stacktrace
+  stacktrace_backtrace:
+  - stacktrace
+  stacktrace_basic:
+  - stacktrace
+  stacktrace_from_exception:
+  - stacktrace
+  stacktrace_noop:
+  - stacktrace
+  stacktrace_windbg:
+  - stacktrace
+  stacktrace_windbg_cached:
+  - stacktrace
+  system: []
+  test:
+  - exception
+  test_exec_monitor:
+  - test
+  thread:
+  - atomic
+  - chrono
+  - container
+  - date_time
+  - exception
+  - system
+  timer: []
+  type_erasure:
+  - thread
+  unit_test_framework:
+  - prg_exec_monitor
+  - test
+  - test_exec_monitor
+  url:
+  - system
+  wave:
+  - filesystem
+  - serialization
+  wserialization:
+  - serialization
+libs:
+  atomic:
+  - boost_atomic
+  charconv:
+  - boost_charconv
+  chrono:
+  - boost_chrono
+  cobalt:
+  - boost_cobalt
+  container:
+  - boost_container
+  context:
+  - boost_context
+  contract:
+  - boost_contract
+  coroutine:
+  - boost_coroutine
+  date_time:
+  - boost_date_time
+  exception:
+  - boost_exception
+  fiber:
+  - boost_fiber
+  fiber_numa:
+  - boost_fiber_numa
+  filesystem:
+  - boost_filesystem
+  graph:
+  - boost_graph
+  graph_parallel:
+  - boost_graph_parallel
+  iostreams:
+  - boost_iostreams
+  json:
+  - boost_json
+  locale:
+  - boost_locale
+  log:
+  - boost_log
+  log_setup:
+  - boost_log_setup
+  math: []
+  math_c99:
+  - boost_math_c99
+  math_c99f:
+  - boost_math_c99f
+  math_c99l:
+  - boost_math_c99l
+  math_tr1:
+  - boost_math_tr1
+  math_tr1f:
+  - boost_math_tr1f
+  math_tr1l:
+  - boost_math_tr1l
+  mpi:
+  - boost_mpi
+  mpi_python:
+  - boost_mpi_python
+  nowide:
+  - boost_nowide
+  numpy:
+  - boost_numpy{py_major}{py_minor}
+  prg_exec_monitor:
+  - boost_prg_exec_monitor
+  program_options:
+  - boost_program_options
+  python:
+  - boost_python{py_major}{py_minor}
+  random:
+  - boost_random
+  regex:
+  - boost_regex
+  serialization:
+  - boost_serialization
+  stacktrace: []
+  stacktrace_addr2line:
+  - boost_stacktrace_addr2line
+  stacktrace_backtrace:
+  - boost_stacktrace_backtrace
+  stacktrace_basic:
+  - boost_stacktrace_basic
+  stacktrace_from_exception:
+  - boost_stacktrace_from_exception
+  stacktrace_noop:
+  - boost_stacktrace_noop
+  stacktrace_windbg:
+  - boost_stacktrace_windbg
+  stacktrace_windbg_cached:
+  - boost_stacktrace_windbg_cached
+  system:
+  - boost_system
+  test: []
+  test_exec_monitor:
+  - boost_test_exec_monitor
+  thread:
+  - boost_thread
+  timer:
+  - boost_timer
+  type_erasure:
+  - boost_type_erasure
+  unit_test_framework:
+  - boost_unit_test_framework
+  url:
+  - boost_url
+  wave:
+  - boost_wave
+  wserialization:
+  - boost_wserialization
+requirements:
+  iostreams:
+  - bzip2
+  - lzma
+  - zlib
+  - zstd
+  locale:
+  - iconv
+  - icu
+  python:
+  - python
+  regex:
+  - icu
+  stacktrace:
+  - backtrace
+static_only:
+- boost_exception
+- boost_test_exec_monitor
+version: 1.85.0

--- a/recipes/boost/all/dependencies/dependencies-1.86.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.86.0.yml
@@ -134,6 +134,8 @@ dependencies:
   - stacktrace
   stacktrace_windbg_cached:
   - stacktrace
+  stacktrace_from_exception:
+  - stacktrace
   system: []
   test:
   - exception
@@ -286,4 +288,4 @@ requirements:
 static_only:
 - boost_exception
 - boost_test_exec_monitor
-version: 1.85.0
+version: 1.86.0

--- a/recipes/boost/all/dependencies/dependencies-1.86.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.86.0.yml
@@ -128,8 +128,6 @@ dependencies:
   - stacktrace
   stacktrace_basic:
   - stacktrace
-  stacktrace_from_exception:
-  - stacktrace
   stacktrace_noop:
   - stacktrace
   stacktrace_windbg:

--- a/recipes/boost/config.yml
+++ b/recipes/boost/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.86.0":
+    folder: all
   "1.85.0":
     folder: all
   "1.84.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.86.0**

#### Motivation

New Boost version 1.86.0 has been released and there is a related PR: #25030

#### Details

The version 1.86.0 brings updates related to required C++ standard. However, most of those components are not exposed as an option.

https://www.boost.org/users/history/version_1_86_0.html

- No new libraries.
- Boost CRC requires C++11
- Boost Format requires C++11
- Boost Graph requires C++14. This one has an option.
- Boost UUID requires C++11
- Boost Heap requires C++14
- Boost Lockfree requires C++14


closes #25030

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
