### PR TITLE
luau: add version 0.640

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.640":
+    url: "https://github.com/Roblox/luau/archive/0.640.tar.gz"
+    sha256: "63ada3e4c8c17e5aff8964b16951bfd1b567329dd81c11ae1144b6e95f354762"
   "0.635":
     url: "https://github.com/Roblox/luau/archive/0.635.tar.gz"
     sha256: "b2ec66070bb53ab9c26e41608dd75c9672c942cf0738c4b965c5eb956a954910"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.640":
+    folder: all
   "0.635":
     folder: all
   "0.630":


### PR DESCRIPTION
### Summary
Changes to recipe:  **luau/0.640**

#### Motivation
There are several improvements since 0.635.

#### Details
https://github.com/luau-lang/luau/compare/0.635...0.640

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
