### PR TITLE
daw_header_libraries: add version 2.110.0

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.109.0":
-    url: "https://github.com/beached/header_libraries/archive/v2.109.0.tar.gz"
-    sha256: "62b7e344afbcddf37359a673fccf918a61c776d76ce306357873910ef62cac7a"
+  "2.110.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.110.0.tar.gz"
+    sha256: "6515bb7a130656adff9f1f17d6be69dbd7c40dbcebbe418e9d0cf15bbc71bffc"
   "2.107.0":
     url: "https://github.com/beached/header_libraries/archive/v2.107.0.tar.gz"
     sha256: "b84f7666d004da466d0035e9f475797395e90b6e8f23e000816b45aa13d4fc35"

--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.109.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.109.0.tar.gz"
+    sha256: "62b7e344afbcddf37359a673fccf918a61c776d76ce306357873910ef62cac7a"
   "2.107.0":
     url: "https://github.com/beached/header_libraries/archive/v2.107.0.tar.gz"
     sha256: "b84f7666d004da466d0035e9f475797395e90b6e8f23e000816b45aa13d4fc35"

--- a/recipes/daw_header_libraries/all/test_package/CMakeLists.txt
+++ b/recipes/daw_header_libraries/all/test_package/CMakeLists.txt
@@ -4,6 +4,10 @@ project(test_package LANGUAGES CXX)
 
 find_package(daw-header-libraries REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+if(daw-header-libraries_VERSION VERSION_LESS "2.109.0")
+    add_executable(${PROJECT_NAME} test_package_old.cpp)
+else()
+    add_executable(${PROJECT_NAME} test_package.cpp)
+endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE daw::daw-header-libraries)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/daw_header_libraries/all/test_package/test_package.cpp
+++ b/recipes/daw_header_libraries/all/test_package/test_package.cpp
@@ -1,7 +1,7 @@
-#include "daw/deprecated/daw_carray.h"
+#include "daw/daw_bounded_array.h"
 
 int main() {
-    daw::carray<int, 6> t = { 1, 2, 3, 4, 5, 6 };
+    daw::array<int, 6> t = { 1, 2, 3, 4, 5, 6 };
 
     auto val = t[3];
 

--- a/recipes/daw_header_libraries/all/test_package/test_package_old.cpp
+++ b/recipes/daw_header_libraries/all/test_package/test_package_old.cpp
@@ -1,4 +1,4 @@
-#include "daw/deprecated/daw_carray.h"
+#include "daw/daw_carray.h"
 
 int main() {
     daw::carray<int, 6> t = { 1, 2, 3, 4, 5, 6 };

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.109.0":
+    folder: all
   "2.107.0":
     folder: all
   "2.106.2":

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.109.0":
+  "2.110.0":
     folder: all
   "2.107.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **daw_header_libraries/2.110.0**

#### Motivation
In 2.110.0, there are lots of breaking changes.

#### Details
https://github.com/beached/header_libraries/compare/v2.107.0...v2.110.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
