### PR TITLE
tracy: add version 0.11.1

### DIFF
--- a/recipes/tracy/all/conandata.yml
+++ b/recipes/tracy/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.1":
+    url: "https://github.com/wolfpld/tracy/archive/refs/tags/v0.11.1.tar.gz"
+    sha256: "2c11ca816f2b756be2730f86b0092920419f3dabc7a7173829ffd897d91888a1"
   "0.11.0":
     url: "https://github.com/wolfpld/tracy/archive/refs/tags/v0.11.0.tar.gz"
     sha256: "b591ef2820c5575ccbf17e2e7a1dc1f6b9a2708f65bfd00f4ebefad2a1ccf830"

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -96,7 +96,7 @@ class TracyConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("libunwind_backtrace"):
-            self.requires("libunwind/1.8.1", transitive_headers=True)
+            self.requires("libunwind/1.8.1", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -123,12 +123,6 @@ class TracyConan(ConanFile):
             deps.generate()
 
     def build(self):
-        if self.version == "0.11.1":
-            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                """target_include_directories(TracyClient INTERFACE ${unwind_INCLUDE_DIRS})""",
-                """target_include_directories(TracyClient PRIVATE ${unwind_INCLUDE_DIRS})"""
-            )
-
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.files import copy, get, rmdir, replace_in_file
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 import os
@@ -45,6 +46,7 @@ class TracyConan(ConanFile):
         "libunwind_backtrace": ([True, False], False),
         "symbol_offline_resolve": ([True, False], False),
         "libbacktrace_elf_dynload_support": ([True, False], False),
+        "verbose": ([True, False], False),
     }
     options = {
         "shared": [True, False],
@@ -81,12 +83,20 @@ class TracyConan(ConanFile):
             del self._tracy_options["symbol_offline_resolve"]
             del self._tracy_options["libbacktrace_elf_dynload_support"]
 
+        if Version(self.version) < "0.11.1":
+            self.options.rm_safe("verbose")
+            del self._tracy_options["verbose"]
+
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.get_safe("libunwind_backtrace"):
+            self.requires("libunwind/1.8.1", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):
@@ -97,8 +107,7 @@ class TracyConan(ConanFile):
             raise ConanInvalidConfiguration(f"libunwind_backtrace is not supported in {self.ref}")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -109,8 +118,17 @@ class TracyConan(ConanFile):
             opt = f"TRACY_{opt.upper()}"
             tc.variables[opt] = switch
         tc.generate()
+        if self.options.get_safe("libunwind_backtrace"):
+            deps = PkgConfigDeps(self)
+            deps.generate()
 
     def build(self):
+        if self.version == "0.11.1":
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                """target_include_directories(TracyClient INTERFACE ${unwind_INCLUDE_DIRS})""",
+                """target_include_directories(TracyClient PRIVATE ${unwind_INCLUDE_DIRS})"""
+            )
+
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -142,6 +160,8 @@ class TracyConan(ConanFile):
                 "dbghelp",
                 "ws2_32"
             ])
+        if self.options.get_safe("libunwind_backtrace"):
+            self.cpp_info.components["tracyclient"].requires.append("libunwind::libunwind")
 
         # Tracy CMake adds options set to ON as public
         for opt in self._tracy_options.keys():

--- a/recipes/tracy/config.yml
+++ b/recipes/tracy/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.1":
+    folder: all
   "0.11.0":
     folder: all
   "0.10":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
There are several improvements in 0.11.1.

1. add `TRACY_VERBOSE` option.
2. fix `libbacktrace_elf_dynload_support` issue.

#### Details
https://github.com/wolfpld/tracy/compare/v0.11.0...v0.11.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
