### PR TITLE
cgal: add cgal/6.0-beta1

### DIFF
--- a/recipes/cgal/all/conandata.yml
+++ b/recipes/cgal/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "5.6.1":
     sha256: cdb15e7ee31e0663589d3107a79988a37b7b1719df3d24f2058545d1bcdd5837
     url: https://github.com/CGAL/cgal/releases/download/v5.6.1/CGAL-5.6.1.tar.xz
+  "6.0-beta1":
+    sha256: 0af1c8e5de91b7aab4c81214b5ac50a9361a36b73b89043533a7c82b287d6c70
+    url: https://github.com/CGAL/cgal/releases/download/v6.0-beta1/CGAL-6.0-beta1.tar.xz
 patches:
   "5.3.2":
     - patch_file: "patches/0001-fix-for-conan.patch"

--- a/recipes/cgal/all/conanfile.py
+++ b/recipes/cgal/all/conanfile.py
@@ -24,7 +24,7 @@ class CgalConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return "14"
+        return "17"
 
     @property
     def _minimum_compilers_version(self):

--- a/recipes/cgal/all/conanfile.py
+++ b/recipes/cgal/all/conanfile.py
@@ -24,7 +24,7 @@ class CgalConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return "17"
+        return "17" if Version(self.version) >= "6.0" else "14"
 
     @property
     def _minimum_compilers_version(self):

--- a/recipes/cgal/config.yml
+++ b/recipes/cgal/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "5.6.1":
     folder: all
+  "6.0-beta1":
+    folder: all


### PR DESCRIPTION
Specify library name and version: **cgal/6.0-beta1**

New upstream version (bug-fix): CGAL 6.0-beta1

* [x]  I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).

* [x]  I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).

* [x]  I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
