### PR TITLE
bzip2: use SPDX-compliant license identifier

### DIFF
--- a/recipes/bzip2/all/conanfile.py
+++ b/recipes/bzip2/all/conanfile.py
@@ -12,7 +12,7 @@ class Bzip2Conan(ConanFile):
     name = "bzip2"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://sourceware.org/bzip2"
-    license = "bzip2-1.0.8"
+    license = "bzip2-1.0.6"
     description = "bzip2 is a free and open-source file compression program that uses the Burrows Wheeler algorithm."
     topics = ("data-compressor", "file-compression")
     package_type = "library"


### PR DESCRIPTION
### Summary
Changes to recipe:  **bzip2**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
When preparing for creating an SBoM from conan dependencies, I encountered an issue with bzip2 as _bzip2-1.0.8_ is not a valid license identifier. According to [the documentation](https://github.com/conan-io/conan-center-index/blob/167e8aa5fdf01bb633eae29e6848f42105c1a409/docs/adding_packages/conanfile_attributes.md?plain=1#L50-L58), the _license_ attribute is supposed to be a SPDX-compliant license identifier (or if not available shall start with `LicenseRef-` as a prefix).

According to https://github.com/spdx/license-list-XML/issues/1223 and https://github.com/spdx/license-list-XML/issues/2271, the _bzip-1.0.6_ license was introduced due to some optional paragraphs that were apparently found in some versions of previous bzip2 licenses. Subsequent versions of bzip2 have the same license text (excluding the version number). However, the license itself is not versioned and in my understanding does not change with each new release, which is why _bzip2-1.0.6_ is still the correct SPDX license identifier.

See also https://spdx.org/licenses/bzip2-1.0.5.html and https://spdx.org/licenses/bzip2-1.0.6.html.


#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
n/a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
