### PR TITLE
qt: Fixed Qt uses vulkan-headers from system

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -562,6 +562,9 @@ class QtConan(ConanFile):
         if not self.options.with_zstd:
             tc.variables["CMAKE_DISABLE_FIND_PACKAGE_WrapZSTD"] = "ON"
 
+        if not self.options.get_safe("with_vulkan"):
+            tc.variables["CMAKE_DISABLE_FIND_PACKAGE_WrapVulkanHeaders"] = "ON"
+
         # Prevent finding LibClang from the system
         # this is needed by the QDoc tool inside Qt Tools
         # See: https://github.com/conan-io/conan-center-index/issues/24729#issuecomment-2255291495


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.x.x**

#### Motivation
Fixes: https://github.com/conan-io/conan-center-index/issues/24988

#### Details

OS: macOS

Qt will use vulkan-headers from the system (if installed) even passing `with_vulkan=False`. 

#### Logs

Without the fix and vulkan-headers installed in your system:
```bash
            -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
CMake Error at qtbase/cmake/FindWrapVulkanHeaders.cmake:34 (find_package):
  By not providing "Findmoltenvk.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "moltenvk",
  but CMake did not find one.

  Could not find a package configuration file provided by "moltenvk" with any
  of the following names:

    moltenvkConfig.cmake
    moltenvk-config.cmake

  Add the installation prefix of "moltenvk" to CMAKE_PREFIX_PATH or set
  "moltenvk_DIR" to a directory containing one of the above files.  If
  "moltenvk" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  qtbase/cmake/QtFindPackageHelpers.cmake:156 (find_package)
  qtbase/src/gui/configure.cmake:61 (qt_find_package)
  qtbase/cmake/QtFeature.cmake:678 (include)
  qtbase/src/CMakeLists.txt:13 (qt_feature_evaluate_features)
```

After applying the fix:

```bash
...
-- Configuring done (98.5s)
-- Generating done (1.7s)
-- Build files have been written to: /Users/xxxx/.conan2/p/b/qtfe1f6f6f742e3/b/build/Release

qt/6.7.1: Running CMake.build()
qt/6.7.1: RUN: cmake --build "/Users/xxxxx/.conan2/p/b/qtfe1f6f6f742e3/b/build/Release" -- -j16
```