### PR TITLE
xerces-c: Fix clang compilation issue on Windows

### DIFF
--- a/recipes/xerces-c/all/conandata.yml
+++ b/recipes/xerces-c/all/conandata.yml
@@ -14,9 +14,17 @@ sources:
 patches:
   "3.2.5":
     - patch_file: "patches/0002-find-icu-programs.patch"
+      patch_description: "Find ICU programs on environment"
+      patch_type: "conan"
   "3.2.4":
     - patch_file: "patches/0002-find-icu-programs.patch"
+      patch_description: "Find ICU programs on environment"
+      patch_type: "conan"
   "3.2.3":
     - patch_file: "patches/0002-find-icu-programs.patch"
+      patch_description: "Find ICU programs on environment"
+      patch_type: "conan"
   "3.2.2":
     - patch_file: "patches/0002-find-icu-programs.patch"
+      patch_description: "Find ICU programs on environment"
+      patch_type: "conan"

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -134,7 +134,7 @@ class XercesCConan(ConanFile):
 
         # Fix compatibility with Clang on Windows
         # https://issues.apache.org/jira/browse/XERCESC-2252
-        if self.settings.os == "Windows" and self.settings.compiler == "Clang":
+        if self.settings.os == "Windows" and self.settings.compiler == "clang":
             tc.cache_variables["CMAKE_RC_FLAGS"] = "-C 1252"
 
         tc.generate()

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -131,6 +131,12 @@ class XercesCConan(ConanFile):
         # avoid picking up system dependency
         tc.variables["CMAKE_DISABLE_FIND_PACKAGE_CURL"] = self.options.get_safe("network_accessor") != "curl"
         tc.variables["CMAKE_DISABLE_FIND_PACKAGE_ICU"] = "icu" not in (self.options.transcoder, self.options.message_loader)
+
+        # Fix compatibility with Clang on Windows
+        # https://issues.apache.org/jira/browse/XERCESC-2252
+        if self.settings.os == "Windows" and self.settings.compiler == "Clang":
+            tc.cache_variables["CMAKE_RC_FLAGS"] = "-C 1252"
+
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -172,7 +172,7 @@ class XercesCConan(ConanFile):
         if self.settings.os == "Macos":
             self.cpp_info.frameworks = ["CoreFoundation", "CoreServices"]
         elif self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.extend(["pthread", "nsl"])
 
         if Version(conan_version).major < 2:
             self.cpp_info.names["cmake_find_package"] = "XercesC"


### PR DESCRIPTION
### Summary
Changes to recipe:  **xerces-c**

#### Motivation

As explained in #24796, when compiling this package with `clang-cl` in Windows, it will through an error which is easily fixable defining `CMAKE_RC_FLAGS` variable.

#### Details

Close #24796

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
