### PR TITLE
[luajit] Use Conan Center Backup Sources for sources

### DIFF
--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -1,9 +1,13 @@
+# INFO: Upstream moved to rolling releases and removed all tarballs.
+#       The Github mirror (https://github.com/LuaJIT/LuaJIT) does not match the checksums and have missing header files.
+#       Conan will consume the backup sources from the Conan Center Artifactory instead, which are the original tarballs (same checksums).
+#       Read the issue https://github.com/conan-io/conan-center-index/issues/25032 for more information.
 sources:
   "2.1.0-beta3":
-    url: "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
+    url: "https://c3i.jfrog.io/artifactory/conan-center-backup-sources/1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
     sha256: "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
   "2.0.5":
-    url: "http://luajit.org/download/LuaJIT-2.0.5.tar.gz"
+    url: "https://c3i.jfrog.io/artifactory/conan-center-backup-sources/874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
     sha256: "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
 patches:
   "2.1.0-beta3":

--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -6,9 +6,6 @@ sources:
   "2.1.0-beta3":
     url: "https://c3i.jfrog.io/artifactory/conan-center-backup-sources/1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
     sha256: "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
-  "2.0.5":
-    url: "https://c3i.jfrog.io/artifactory/conan-center-backup-sources/874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
-    sha256: "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
 patches:
   "2.1.0-beta3":
     - patch_file: "patches/2.1.0-beta3-0001-remove-mac-deploy.patch"

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -48,7 +48,8 @@ class LuajitConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} is not supported by Mac M1. Please, try any version >=2.1")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        filename = f"LuaJIT-{self.version}.tar.gz"
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, filename=filename, strip_root=True)
 
     def generate(self):
         if is_msvc(self):

--- a/recipes/luajit/config.yml
+++ b/recipes/luajit/config.yml
@@ -1,5 +1,3 @@
 versions:
   "2.1.0-beta3":
     folder: "all"
-  "2.0.5":
-    folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **luajit/2.1.0-beta3**

#### Motivation

The issue #25032 brought a case where the upstream dropped the download of tags for tarball files, and recommended to use their rolling release approach instead.

After speaking to the Conan team, we considered doing separated moves, first, fixing the broken recipe to use the backup sources. The current state is not only affecting CCI, but also breaks those packages listed in the issue. So we decided to make available old releases in ConanCenterIndex for now.

In a future moment, we should discuss another move to deal with rolling releases in Lua-JIT.

fixes #25032

/cc @uyha

#### Details

Using backup sources is not something new in CCI. The same usage can be found in:

- #24290
- #23329
- #18082

It does not changed sources, they are the backup from the original source that was available in the upstream, the checksum (SHA-256) is the exactly same

UPDATE:

The version 2.0.5 is not available under backup sources, only 2.1.0-beta3. So I removed it from the build. The package `libucl` uses `luajit/2.0.5` as optional requirement, not enabled by default, so it should not break CCI. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
