### PR TITLE
pdf-writer: add version 4.6.7

### DIFF
--- a/recipes/pdf-writer/all/conandata.yml
+++ b/recipes/pdf-writer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.6.7":
+    url: "https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.6.7.tar.gz"
+    sha256: "735c65d4685c5156f0876635f3bc1565700d0f648fbb1f384e46d186796c8bae"
   "4.6.6":
     url: "https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.6.6.tar.gz"
     sha256: "8343820313e553052df68c75fe2bf35353da2719106e81eb2a8b026ff96c7d7c"
@@ -18,6 +21,10 @@ sources:
     url: "https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.5.12.tar.gz"
     sha256: "40fcbaa66fc46fcb588ceda119ba8839ff6d2c886191ac5e68ed702475c7336e"
 patches:
+  "4.6.7":
+    - patch_file: "patches/4.6.6-0001-fix-cmake.patch"
+      patch_description: "disable cpack"
+      patch_type: "conan"
   "4.6.6":
     - patch_file: "patches/4.6.6-0001-fix-cmake.patch"
       patch_description: "disable cpack"

--- a/recipes/pdf-writer/config.yml
+++ b/recipes/pdf-writer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.6.7":
+    folder: all
   "4.6.6":
     folder: all
   "4.6.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **pdf-writer/4.6.7**

#### Motivation
There is a bugfix in 4.6.7.

#### Details
https://github.com/galkahana/PDF-Writer/compare/v4.6.6...v4.6.7

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
