### PR TITLE
arrow: fix missing dependency when with_s3 is enabled

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -579,10 +579,8 @@ class ArrowConan(ConanFile):
         if self._requires_rapidjson():
             self.cpp_info.components["libarrow"].requires.append("rapidjson::rapidjson")
         if self.options.with_s3:
-            # Arrow needs the identity-management and sts components when WITH_S3 is enabled, see:
             # https://github.com/apache/arrow/blob/6b268f62a8a172249ef35f093009c740c32e1f36/cpp/src/arrow/CMakeLists.txt#L98
-            # identity-management depends on cognito-identity and sts internally, we don't need to list them here.
-            self.cpp_info.components["libarrow"].requires.extend(["aws-sdk-cpp::identity-management", "aws-sdk-cpp::s3"])
+            self.cpp_info.components["libarrow"].requires.extend([f"aws-sdk-cpp::{x}" for x in ["cognito-identity", "core", "identity-management", "s3", "sts"]])
         if self.options.get_safe("with_gcs"):
             self.cpp_info.components["libarrow"].requires.append("google-cloud-cpp::storage")
         if self.options.with_orc:

--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -579,7 +579,7 @@ class ArrowConan(ConanFile):
         if self._requires_rapidjson():
             self.cpp_info.components["libarrow"].requires.append("rapidjson::rapidjson")
         if self.options.with_s3:
-            self.cpp_info.components["libarrow"].requires.append("aws-sdk-cpp::s3")
+            self.cpp_info.components["libarrow"].requires.extend(["aws-sdk-cpp::identity-management", "aws-sdk-cpp::s3"])
         if self.options.get_safe("with_gcs"):
             self.cpp_info.components["libarrow"].requires.append("google-cloud-cpp::storage")
         if self.options.with_orc:

--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -579,6 +579,9 @@ class ArrowConan(ConanFile):
         if self._requires_rapidjson():
             self.cpp_info.components["libarrow"].requires.append("rapidjson::rapidjson")
         if self.options.with_s3:
+            # Arrow needs the identity-management and sts components when WITH_S3 is enabled, see:
+            # https://github.com/apache/arrow/blob/6b268f62a8a172249ef35f093009c740c32e1f36/cpp/src/arrow/CMakeLists.txt#L98
+            # identity-management depends on cognito-identity and sts internally, we don't need to list them here.
             self.cpp_info.components["libarrow"].requires.extend(["aws-sdk-cpp::identity-management", "aws-sdk-cpp::s3"])
         if self.options.get_safe("with_gcs"):
             self.cpp_info.components["libarrow"].requires.append("google-cloud-cpp::storage")


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow**

#### Motivation
arrow links to `aws-cpp-sdk-identity-management` in addition to `aws-cpp-sdk-s3` when `with_s3` is enabled.

#### Details
See https://github.com/apache/arrow/blob/6b268f62a8a172249ef35f093009c740c32e1f36/cpp/src/arrow/CMakeLists.txt#L98


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
