### PR TITLE
(#25070) jwt-cpp: Fix missing picojson header

### DIFF
--- a/recipes/jwt-cpp/all/conanfile.py
+++ b/recipes/jwt-cpp/all/conanfile.py
@@ -16,9 +16,12 @@ class JwtCppConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
 
+    options = { "enable_picojson": [True, False] }
+    default_options = { "enable_picojson" : False }
+
     @property
-    def _supports_generic_json(self):
-        return Version(self.version) >= "0.5.0"
+    def _enable_picojson(self):
+        return Version(self.version) < "0.5.0" or self.options.enable_picojson
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -28,7 +31,7 @@ class JwtCppConan(ConanFile):
 
     def requirements(self):
         self.requires("openssl/[>=1.1 <4]")
-        if not self._supports_generic_json:
+        if self._enable_picojson:
             self.requires("picojson/1.3.0")
 
     def package_id(self):
@@ -48,9 +51,11 @@ class JwtCppConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-
+        self.cpp_info.requires = ["openssl::openssl"]
+        if self._enable_picojson:
+            self.cpp_info.requires.append("picojson::picojson")
+        else:
+            self.cpp_info.defines.append("JWT_DISABLE_PICOJSON")
         self.cpp_info.set_property("cmake_file_name", "jwt-cpp")
         self.cpp_info.set_property("cmake_target_name", "jwt-cpp::jwt-cpp")
 
-        if self._supports_generic_json:
-            self.cpp_info.defines.append("JWT_DISABLE_PICOJSON")

--- a/recipes/jwt-cpp/all/conanfile.py
+++ b/recipes/jwt-cpp/all/conanfile.py
@@ -16,12 +16,12 @@ class JwtCppConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
 
-    options = { "enable_picojson": [True, False] }
-    default_options = { "enable_picojson" : False }
+    options = { "with_picojson": [True, False] }
+    default_options = { "with_picojson" : False }
 
     @property
-    def _enable_picojson(self):
-        return Version(self.version) < "0.5.0" or self.options.enable_picojson
+    def _with_picojson(self):
+        return Version(self.version) < "0.5.0" or self.options.with_picojson
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -31,7 +31,7 @@ class JwtCppConan(ConanFile):
 
     def requirements(self):
         self.requires("openssl/[>=1.1 <4]")
-        if self._enable_picojson:
+        if self._with_picojson:
             self.requires("picojson/1.3.0")
 
     def package_id(self):
@@ -52,7 +52,7 @@ class JwtCppConan(ConanFile):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.requires = ["openssl::openssl"]
-        if self._enable_picojson:
+        if self._with_picojson:
             self.cpp_info.requires.append("picojson::picojson")
         else:
             self.cpp_info.defines.append("JWT_DISABLE_PICOJSON")


### PR DESCRIPTION
### Summary
Changes to recipe:  **jwt-cpp/0.7.0**

#### Motivation
Fix #25070

#### Details
Fix missing picojson header by using Conan picojson for all versions.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

© 2024 Morgan Stanley.
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Conan-io project Contributor License Agreement.
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.