### PR TITLE
Change default disable_static_registration to True for onnx

### DIFF
--- a/recipes/onnx/all/conanfile.py
+++ b/recipes/onnx/all/conanfile.py
@@ -32,7 +32,7 @@ class OnnxConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "disable_static_registration": False,
+        "disable_static_registration": True,
     }
 
     @property


### PR DESCRIPTION
onnxruntime forces this to be True for building: https://github.com/microsoft/onnxruntime/blob/be76e1e1b8e2914e448d12a0cc683c00014c0490/cmake/external/onnxruntime_external_deps.cmake#L542

The problem is that we can't do this right now in Conan Center Index for the onnxruntime recipe:

```
    def configure(self):
        if self.options.shared:
            self.options.rm_safe("fPIC")
        self.options["onnx"].disable_static_registration = True
```

Because we would get missing binaries, and if we raise Invalid Configuration then we won't actually build onnxruntime.

As the only recipe that uses onnx y Conan Center Index is onnxruntime and for that case we need to set this. I think it's better to change the default for the upstream and use `True` for this option.

Also related with: https://github.com/conan-io/conan-center-index/pull/22557