### PR TITLE
mlpack: Add new 4.4.0 version

### DIFF
--- a/recipes/mlpack/all/conandata.yml
+++ b/recipes/mlpack/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.4.0":
+    url: "https://github.com/mlpack/mlpack/archive/refs/tags/4.4.0.tar.gz"
+    sha256: "61c604026d05af26c244b0e47024698bbf150dfcc9d77b64057941d7d64d6cf6"
   "4.3.0":
     url: "https://github.com/mlpack/mlpack/archive/refs/tags/4.3.0.tar.gz"
     sha256: "08cd54f711fde66fc3b6c9db89dc26776f9abf1a6256c77cfa3556e2a56f1a3d"

--- a/recipes/mlpack/all/conanfile.py
+++ b/recipes/mlpack/all/conanfile.py
@@ -24,6 +24,8 @@ class MlpackConan(ConanFile):
 
     @property
     def _min_cppstd(self):
+        if Version(self.version) >= "4.4.0":
+            return 17
         if is_msvc(self):
             return 17
         return 14

--- a/recipes/mlpack/all/conanfile.py
+++ b/recipes/mlpack/all/conanfile.py
@@ -84,23 +84,6 @@ class MlpackConan(ConanFile):
              excludes=["mlpack/bindings/*", "mlpack/tests/*", "mlpack/CMakeLists.txt"])
         self._configure_headers()
 
-    @property
-    def _openmp_flags(self):
-        # Based on https://github.com/Kitware/CMake/blob/v3.28.1/Modules/FindOpenMP.cmake#L104-L135
-        if self.settings.compiler == "clang":
-            return ["-fopenmp=libomp"]
-        elif self.settings.compiler == "apple-clang":
-            return ["-Xclang", "-fopenmp"]
-        elif self.settings.compiler == "gcc":
-            return ["-fopenmp"]
-        elif self.settings.compiler == "intel-cc":
-            return ["-Qopenmp"]
-        elif self.settings.compiler == "sun-cc":
-            return ["-xopenmp"]
-        elif is_msvc(self):
-            return ["-openmp:llvm"]
-        return None
-
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "mlpack")
         self.cpp_info.set_property("cmake_target_name", "mlpack::mlpack")
@@ -115,12 +98,22 @@ class MlpackConan(ConanFile):
         if self.settings.get_safe("compiler.libcxx") in ["libstdc++", "libstdc++11"]:
             self.cpp_info.system_libs.append("atomic")
 
-        self.cpp_info.cflags = self._openmp_flags
-        self.cpp_info.cxxflags = self._openmp_flags
-
+        # FIXME: Review this flags assignment. LLVM-OpenMP is already defining these ones.
+        #        Do we want to depend on llvm-openmp? Only for apple-clang?
+        #        For more info, see this comment https://github.com/conan-io/conan-center-index/pull/22353#issuecomment-2214593855
+        flags = []
+        # Based on https://github.com/Kitware/CMake/blob/v3.28.1/Modules/FindOpenMP.cmake#L104-L135
+        if self.settings.compiler == "clang":
+            flags = ["-fopenmp=libomp"]
+        elif self.settings.compiler == "gcc":
+            flags = ["-fopenmp"]
+            if self.settings.os == "Windows":
+                flags.append("-Wa,-mbig-obj")
+        elif self.settings.compiler == "sun-cc":
+            flags = ["-xopenmp"]
+        elif is_msvc(self):
         # https://github.com/mlpack/mlpack/blob/4.3.0/CMakeLists.txt#L164-L175
-        if is_msvc(self):
-            self.cpp_info.cxxflags.extend(["/bigobj", "/Zm200", "/Zc:__cplusplus"])
-        elif self.settings.os == "Windows" and self.settings.compiler == "gcc":
-            self.cpp_info.cflags.append("-Wa,-mbig-obj")
-            self.cpp_info.cxxflags.append("-Wa,-mbig-obj")
+            flags = ["-openmp:llvm", "/bigobj", "/Zm200", "/Zc:__cplusplus"]
+        if flags:
+            self.cpp_info.cflags = flags
+            self.cpp_info.cxxflags = flags

--- a/recipes/mlpack/all/test_package/CMakeLists.txt
+++ b/recipes/mlpack/all/test_package/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(mlpack REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE mlpack::mlpack)
-if(MSVC)
+if(MSVC OR mlpack_VERSION VERSION_GREATER_EQUAL 4.4.0)
     target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 else()
     target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/mlpack/config.yml
+++ b/recipes/mlpack/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "4.4.0":
+    folder: all
   "4.3.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **mlpack/4.4.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Closes https://github.com/conan-io/conan-center-index/issues/25064

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Currently facing some issues in apple-clang:

<details>

```
$ conan create . --version=4.4.0 -b=missing -c="tools.build:verbosity=verbose" -c="tools.compilation:verbosity=verbose"
ERROR: Error loading custom command audit.cmd_catalog: No module named 'rich'

======== Exporting recipe to the cache ========
mlpack/4.4.0: Exporting package recipe: /Users/abril/coding/conan-center-index/recipes/mlpack/all/conanfile.py
mlpack/4.4.0: exports: File 'conandata.yml' found. Exporting it...
mlpack/4.4.0: Copied 1 '.py' file: conanfile.py
mlpack/4.4.0: Copied 1 '.yml' file: conandata.yml
mlpack/4.4.0: Exported to cache folder: /Users/abril/.conan2/p/mlpac1e5b78f2be1e7/e
mlpack/4.4.0: Exported: mlpack/4.4.0#911f8faaa30d1d50580f7fb9d2bd5d0b (2024-08-29 14:14:02 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=15
os=Macos
[platform_tool_requires]
cmake/3.29.6
[replace_tool_requires]
meson/*: meson/[>=1.0 <2]
[conf]
tools.build:verbosity=verbose
tools.compilation:verbosity=verbose

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=15
os=Macos
[platform_tool_requires]
cmake/3.29.6
[replace_tool_requires]
meson/*: meson/[>=1.0 <2]
[conf]



======== Computing dependency graph ========
Graph root
    cli
Requirements
    armadillo/12.6.4#7d63838db47ae5f43d661b2e6ffd5422 - Cache
    cereal/1.3.2#b94802e904e1129e7fdb46d9bff5321d - Cache
    ensmallen/2.21.0#8cec8b388180597dcd0f4d2af46e68f0 - Cache
    llvm-openmp/17.0.6#776e0fe1ba76d6cbf1cc0a89b1bb13ba - Cache
    mlpack/4.4.0#911f8faaa30d1d50580f7fb9d2bd5d0b - Cache
    stb/cci.20230920#9792498b81cf34a90138d239e36b0bf8 - Cache
Build requirements
    cmake/3.29.6 - Platform

======== Computing necessary packages ========
Requirements
    armadillo/12.6.4#7d63838db47ae5f43d661b2e6ffd5422:c6d1b835e82cf3098168730fe82b25df1b84b56b#19f8a270c21798158a04aef4336981cd - Cache
    cereal/1.3.2#b94802e904e1129e7fdb46d9bff5321d:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ebb9058692e29b6254aad3b967b53b8 - Cache
    ensmallen/2.21.0#8cec8b388180597dcd0f4d2af46e68f0:da39a3ee5e6b4b0d3255bfef95601890afd80709#26518914bf5f3b236be1c450a2684d8f - Cache
    llvm-openmp/17.0.6#776e0fe1ba76d6cbf1cc0a89b1bb13ba:52f4deb179fec4276b1845344f86760780e68492#05003682b83f13a36ccabad273c6ad8e - Cache
    mlpack/4.4.0#911f8faaa30d1d50580f7fb9d2bd5d0b:da39a3ee5e6b4b0d3255bfef95601890afd80709#db6e6c7e0697881723e65280eaec3a9e - Cache
    stb/cci.20230920#9792498b81cf34a90138d239e36b0bf8:24b381c7532f70c284a2a67cc83f779b3c0042fb#72af46794853f74751a3ba685e1c7ef4 - Cache
Build requirements
Skipped binaries
    cmake/3.29.6

======== Installing packages ========
armadillo/12.6.4: Already installed! (1 of 6)
cereal/1.3.2: Already installed! (2 of 6)
stb/cci.20230920: Already installed! (3 of 6)
llvm-openmp/17.0.6: Already installed! (4 of 6)
ensmallen/2.21.0: Already installed! (5 of 6)
mlpack/4.4.0: Already installed! (6 of 6)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: armadillo/12.6.4, llvm-openmp/17.0.6
WARN: deprecated:     'cpp_info.build_modules' used in: armadillo/12.6.4, llvm-openmp/17.0.6, cereal/1.3.2

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    mlpack/4.4.0 (test package): /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/conanfile.py
Requirements
    armadillo/12.6.4#7d63838db47ae5f43d661b2e6ffd5422 - Cache
    cereal/1.3.2#b94802e904e1129e7fdb46d9bff5321d - Cache
    ensmallen/2.21.0#8cec8b388180597dcd0f4d2af46e68f0 - Cache
    llvm-openmp/17.0.6#776e0fe1ba76d6cbf1cc0a89b1bb13ba - Cache
    mlpack/4.4.0#911f8faaa30d1d50580f7fb9d2bd5d0b - Cache
    stb/cci.20230920#9792498b81cf34a90138d239e36b0bf8 - Cache
Build requirements
    cmake/3.29.6 - Platform

======== Computing necessary packages ========
Requirements
    armadillo/12.6.4#7d63838db47ae5f43d661b2e6ffd5422:c6d1b835e82cf3098168730fe82b25df1b84b56b#19f8a270c21798158a04aef4336981cd - Cache
    cereal/1.3.2#b94802e904e1129e7fdb46d9bff5321d:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ebb9058692e29b6254aad3b967b53b8 - Cache
    ensmallen/2.21.0#8cec8b388180597dcd0f4d2af46e68f0:da39a3ee5e6b4b0d3255bfef95601890afd80709#26518914bf5f3b236be1c450a2684d8f - Cache
    llvm-openmp/17.0.6#776e0fe1ba76d6cbf1cc0a89b1bb13ba:52f4deb179fec4276b1845344f86760780e68492#05003682b83f13a36ccabad273c6ad8e - Cache
    mlpack/4.4.0#911f8faaa30d1d50580f7fb9d2bd5d0b:da39a3ee5e6b4b0d3255bfef95601890afd80709#db6e6c7e0697881723e65280eaec3a9e - Cache
    stb/cci.20230920#9792498b81cf34a90138d239e36b0bf8:24b381c7532f70c284a2a67cc83f779b3c0042fb#72af46794853f74751a3ba685e1c7ef4 - Cache
Build requirements
Skipped binaries
    cmake/3.29.6

======== Installing packages ========
armadillo/12.6.4: Already installed! (1 of 6)
cereal/1.3.2: Already installed! (2 of 6)
stb/cci.20230920: Already installed! (3 of 6)
llvm-openmp/17.0.6: Already installed! (4 of 6)
ensmallen/2.21.0: Already installed! (5 of 6)
mlpack/4.4.0: Already installed! (6 of 6)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: armadillo/12.6.4, llvm-openmp/17.0.6
WARN: deprecated:     'cpp_info.build_modules' used in: armadillo/12.6.4, llvm-openmp/17.0.6, cereal/1.3.2

======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release
mlpack/4.4.0 (test package): Test package build: build/apple-clang-15-armv8-gnu17-release
mlpack/4.4.0 (test package): Test package build folder: /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release
mlpack/4.4.0 (test package): Writing generators to /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release/generators
mlpack/4.4.0 (test package): Generator 'CMakeDeps' calling 'generate()'
mlpack/4.4.0 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(mlpack)
    target_link_libraries(... mlpack::mlpack)
mlpack/4.4.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
mlpack/4.4.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
mlpack/4.4.0 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release/generators/CMakePresets.json
mlpack/4.4.0 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/CMakeUserPresets.json
mlpack/4.4.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
mlpack/4.4.0 (test package): Generating aggregated env files
mlpack/4.4.0 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
mlpack/4.4.0 (test package): Calling build()
mlpack/4.4.0 (test package): Running CMake.configure()
mlpack/4.4.0 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package" --loglevel=VERBOSE
-- Using Conan toolchain: /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The CXX compiler identification is AppleClang 15.0.0.15000309
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'mlpack::mlpack'
-- Conan: Target declared 'cereal::cereal'
-- Conan: Target declared 'ensmallen::ensmallen'
-- Conan: Target declared 'Armadillo::Armadillo'
-- Framework found! armadillo_FRAMEWORKS_FOUND_RELEASE
-- Conan: Library armadillo found /Users/abril/.conan2/p/b/armad0861136cf0243/p/lib/libarmadillo.a
-- Conan: Found: /Users/abril/.conan2/p/b/armad0861136cf0243/p/lib/libarmadillo.a
-- Conan: Including build module from '/Users/abril/.conan2/p/b/armad0861136cf0243/p/lib/cmake/conan-official-armadillo-variables.cmake'
-- Conan: Target declared 'stb::stb'
-- Conan: Target declared 'OpenMP::OpenMP'
-- Conan: Library omp found /Users/abril/.conan2/p/b/llvm-13b165d77a919/p/lib/libomp.a
-- Conan: Found: /Users/abril/.conan2/p/b/llvm-13b165d77a919/p/lib/libomp.a
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release

mlpack/4.4.0 (test package): Running CMake.build()
mlpack/4.4.0 (test package): RUN: cmake --build "/Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release" --verbose -- -j12
Change Dir: '/Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release'

Run Build Command(s): /opt/homebrew/Cellar/cmake/3.30.2/bin/cmake -E env VERBOSE=1 /usr/bin/make -f Makefile -j12
/opt/homebrew/Cellar/cmake/3.30.2/bin/cmake -S/Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package -B/Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release --check-build-system CMakeFiles/Makefile.cmake 0
/opt/homebrew/Cellar/cmake/3.30.2/bin/cmake -E cmake_progress_start /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release/CMakeFiles /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release//CMakeFiles/progress.marks
/Library/Developer/CommandLineTools/usr/bin/make  -f CMakeFiles/Makefile2 all
/Library/Developer/CommandLineTools/usr/bin/make  -f CMakeFiles/test_package.dir/build.make CMakeFiles/test_package.dir/depend
cd /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release && /opt/homebrew/Cellar/cmake/3.30.2/bin/cmake -E cmake_depends "Unix Makefiles" /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/build/apple-clang-15-armv8-gnu17-release/CMakeFiles/test_package.dir/DependInfo.cmake "--color="
/Library/Developer/CommandLineTools/usr/bin/make  -f CMakeFiles/test_package.dir/build.make CMakeFiles/test_package.dir/build
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
/Library/Developer/CommandLineTools/usr/bin/c++ -DARMA_DONT_USE_ARPACK -DARMA_DONT_USE_ATLAS -DARMA_DONT_USE_SUPERLU -DARMA_DONT_USE_WRAPPER -DARMA_NO_DEBUG -DARMA_USE_BLAS -DARMA_USE_HDF5 -DARMA_USE_LAPACK -DSTB_TEXTEDIT_KEYTYPE=unsigned -isystem /Users/abril/.conan2/p/b/mlpace2f0c34c42eba/p/include -isystem /Users/abril/.conan2/p/cereab355e3d4f4ed9/p/include -isystem /Users/abril/.conan2/p/ensma45c33cba7ce7e/p/include -isystem /Users/abril/.conan2/p/b/armad0861136cf0243/p/include -isystem /Users/abril/.conan2/p/stbf6cb8d59f52a8/p/include -isystem /Users/abril/.conan2/p/b/llvm-13b165d77a919/p/include -stdlib=libc++ -O3 -DNDEBUG -std=gnu++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -Xclang -fopenmp -Xpreprocessor -MD -MT CMakeFiles/test_package.dir/test_package.cpp.o -MF CMakeFiles/test_package.dir/test_package.cpp.o.d -o CMakeFiles/test_package.dir/test_package.cpp.o -c /Users/abril/coding/conan-center-index/recipes/mlpack/all/test_package/test_package.cpp
clang: warning: argument unused during compilation: '-MT CMakeFiles/test_package.dir/test_package.cpp.o' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-MF CMakeFiles/test_package.dir/test_package.cpp.o.d' [-Wunused-command-line-argument]
error: unknown argument: '-MD'
make[2]: *** [CMakeFiles/test_package.dir/test_package.cpp.o] Error 1
make[1]: *** [CMakeFiles/test_package.dir/all] Error 2
make: *** [all] Error 2


ERROR: mlpack/4.4.0 (test package): Error in build() method, line 21
	cmake.build()
	ConanException: Error 2 while executing
(venv) ~/c/c/r/m/all (ar/mlpack-4.4.0|✔) 1,1s $ 
```

</details>

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
