### PR TITLE
krb5: Remove invalid configurations

### DIFF
--- a/recipes/krb5/all/conanfile.py
+++ b/recipes/krb5/all/conanfile.py
@@ -10,13 +10,14 @@ import os
 
 required_conan_version = ">=1.54.0"
 
+
 class Krb5Conan(ConanFile):
     name = "krb5"
     description = "Kerberos is a network authentication protocol. It is designed to provide strong authentication " \
                   "for client/server applications by using secret-key cryptography."
     homepage = "https://web.mit.edu/kerberos"
     topics = ("kerberos", "network", "authentication", "protocol", "client", "server", "cryptography")
-    license = "LicenseRef-NOTICE"
+    license = "DocumentRef-NOTICE:LicenseRef-"
     url = "https://github.com/conan-io/conan-center-index"
     package_type = "shared-library"
     options = {
@@ -45,18 +46,6 @@ class Krb5Conan(ConanFile):
 
     def layout(self):
         basic_layout(self, src_folder="src")
-
-    def validate(self):
-        if is_msvc(self):
-            raise ConanInvalidConfiguration(f"{self.ref} Conan recipe is not prepared for Windows yet. Contributions are welcome!")
-        if self.settings.os == "Macos":
-            raise ConanInvalidConfiguration(f"{self.ref} Conan recipe is not prepared for Macos yet. Contributions are welcome!")
-        if self.options.with_tls == "openssl" and not self.dependencies["openssl"].options.shared:
-            # k5tls does not respect linkage order, it passes krb5 and krb5support before openssl to the linker, which causes linking errors
-            # gcc -shared -fPIC -Wl,-h,k5tls.so.0 -Wl,--no-undefined -o k5tls.so openssl.so notls.so -L../../../lib -lkrb5 -lkrb5support ...
-            # /usr/bin/ld: /.../lib/libssl.a(libssl-lib-ssl_cert_comp.o): in function `OSSL_COMP_CERT_from_uncompressed_data':
-            #     ssl_cert_comp.c:(.text+0x3d1): undefined reference to `COMP_CTX_free'
-            raise ConanInvalidConfiguration(f"{self.ref} building with static OpenSSL generates linking errors. Please use '-o openssl/*:shared=True'")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -105,7 +94,7 @@ class Krb5Conan(ConanFile):
 
     def build_requirements(self):
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/1.9.3")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
         self.build_requires("automake/1.16.5")
         self.build_requires("bison/3.8.2")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **krb5/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
As far as I can tell from local testing, removing both checks leads to successful compilations in Macos, Windows and Linux 

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
