### PR TITLE
mbedtls: add version 3.6.1

### DIFF
--- a/recipes/mbedtls/all/conandata.yml
+++ b/recipes/mbedtls/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.1":
+    url: "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.1/mbedtls-3.6.1.tar.bz2"
+    sha256: "fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3"
   "3.6.0":
     url: "https://github.com/Mbed-TLS/mbedtls/releases/download/v3.6.0/mbedtls-3.6.0.tar.bz2"
     sha256: "3ecf94fcfdaacafb757786a01b7538a61750ebd85c4b024f56ff8ba1490fcd38"

--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -15,10 +15,10 @@ class MBedTLSConan(ConanFile):
         "mbed TLS makes it trivially easy for developers to include "
         "cryptographic and SSL/TLS capabilities in their (embedded) products"
     )
-    topics = ("polarssl", "tls", "security")
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://tls.mbed.org"
-    license = "Apache-2.0"
+    topics = ("polarssl", "tls", "security")
 
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"

--- a/recipes/mbedtls/config.yml
+++ b/recipes/mbedtls/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.1":
+    folder: all
   "3.6.0":
     folder: all
   "3.5.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mbedtls/3.6.1**

#### Motivation
There are security bugfixes in 3.6.1.

#### Details
https://github.com/Mbed-TLS/mbedtls/compare/v3.6.0...mbedtls-3.6.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
