### PR TITLE
grpc: fix transitive_libs grpc regression

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -101,7 +101,9 @@ class GrpcConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # abseil is public. See https://github.com/conan-io/conan-center-index/pull/17284#issuecomment-1526082638
+        # abseil requires:
+        # transitive_headers=True because grpc headers include abseil headers
+        # transitive_libs=True because generated code (grpc_cpp_plugin) require symbols from abseil
         if Version(self.version) >= "1.62.0":
             self.requires("protobuf/5.27.0", transitive_headers=True)
             self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True, transitive_libs=True)

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -104,9 +104,9 @@ class GrpcConan(ConanFile):
         # abseil is public. See https://github.com/conan-io/conan-center-index/pull/17284#issuecomment-1526082638
         if Version(self.version) >= "1.62.0":
             self.requires("protobuf/5.27.0", transitive_headers=True)
-            self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True)
+            self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True, transitive_libs=True)
         else:
-            self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True)
+            self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True, transitive_libs=True)
             self.requires("protobuf/3.21.12", transitive_headers=True)
         self.requires("c-ares/[>=1.19.1 <2]")
         self.requires("openssl/[>=1.1 <4]")


### PR DESCRIPTION
### Summary
Changes to recipe:  grpc/all

#### Motivation
Fix regression when grpc and abseil are shared - abseil link requirements should be propagated, as generated code will depend on symbols in abseil libraries.

Fix https://github.com/conan-io/conan-center-index/issues/24806
Close https://github.com/conan-io/conan/issues/16911


