### PR TITLE
libcap/2.70: Bump version

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.70":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.70.tar.xz"
+    sha256: "23a6ef8aadaf1e3e875f633bb2d116cfef8952dba7bc7c569b13458e1952b30f"
   "2.69":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.69.tar.xz"
     sha256: "f311f8f3dad84699d0566d1d6f7ec943a9298b28f714cae3c931dfd57492d7eb"
@@ -33,6 +36,13 @@ sources:
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.45.tar.xz"
     sha256: "d66639f765c0e10557666b00f519caf0bd07a95f867dddaee131cd284fac3286"
 patches:
+  "2.70":
+    - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+      patch_description: "allow to configure fPIC option from conan recipe"
+      patch_type: "conan"
+    - patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
+      patch_description: "allow to override compiler via environment variables"
+      patch_type: "conan"
   "2.69":
     - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
       patch_description: "allow to configure fPIC option from conan recipe"

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.70":
+    folder: all
   "2.69":
     folder: all
   "2.68":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcap/2.70**

#### Motivation
A new version of libcap is available. It contains only a few cosmetic changes in pam_cap. 

#### Details



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
