### PR TITLE
wiringpi: add version 3.8

### DIFF
--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.8":
+    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.8.tar.gz"
+    sha256: "6159764d3d036486f0a110cd5393b1413c1f334d464b7337117fece59ea04bc9"
   "3.6":
     url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.6.tar.gz"
     sha256: "bec180a14ccd2d6b4eb5248d6553593511e7881348f56f8c98515a6d5d5444ee"

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.8":
+    folder: "all"
   "3.6":
     folder: "all"
   "3.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **wiringpi/3.8**

#### Motivation
There are several improvements in 3.8. (3.7 is not released.)

#### Details
https://github.com/WiringPi/WiringPi/compare/3.6...3.8

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
