### PR TITLE
Fix #16735 and remove sysctl.h from chipmunk/7.0.3

### DIFF
--- a/recipes/chipmunk2d/all/conandata.yml
+++ b/recipes/chipmunk2d/all/conandata.yml
@@ -2,3 +2,10 @@ sources:
   "7.0.3":
     url: "https://chipmunk-physics.net/release/Chipmunk-7.x/Chipmunk-7.0.3.tgz"
     sha256: "048b0c9eff91c27bab8a54c65ad348cebd5a982ac56978e8f63667afbb63491a"
+
+patches:
+  "7.0.3":
+    - patch_file: "patches/0001-remove-sysctl-linux-win.patch"
+      patch_type: bugfix
+      patch_source: https://github.com/slembcke/Chipmunk2D/pull/175
+      patch_description: "Needed to build with glib > 2.30"

--- a/recipes/chipmunk2d/all/conanfile.py
+++ b/recipes/chipmunk2d/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file
+from conan.tools.files import copy, get, replace_in_file, apply_conandata_patches, export_conandata_patches
 import os
 
 required_conan_version = ">=1.53.0"
@@ -52,9 +52,13 @@ class Chipmunk2DConan(ConanFile):
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         tc.generate()
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def _patch_sources(self):
         # The finite-math-only optimization has no effect and can cause linking errors
         # when linked against glibc >= 2.31
+        apply_conandata_patches(self)
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                         "-ffast-math", "-ffast-math -fno-finite-math-only")
 

--- a/recipes/chipmunk2d/all/patches/0001-remove-sysctl-linux-win.patch
+++ b/recipes/chipmunk2d/all/patches/0001-remove-sysctl-linux-win.patch
@@ -1,0 +1,16 @@
+--- a/src/cpHastySpace.c
++++ b/src/cpHastySpace.c
+@@ -7,8 +7,12 @@
+ //TODO: Move all the thread stuff to another file
+ 
+ //#include <sys/param.h >
+-#ifndef _WIN32
++
++#ifdef __APPLE__
+ #include <sys/sysctl.h>
++#endif
++
++#ifndef _WIN32
+ #include <pthread.h>
+ #else
+ #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
### Summary
Changes to recipe:  chipmunk2d/7.0.3

Apply a small patch to exclude `sysctl.h` on Linux/Win (i.e. only include on Mac).

#### Motivation
As per issue #16735 - sysctl has been removed from glib (see <https://sourceware.org/pipermail/libc-announce/2020/000029.html>) thus chipmunk2d no longer builds on (most) Linux toolchains. The development version of chipmunk was updated 5 years ago to address this (see https://github.com/slembcke/Chipmunk2D/commit/9a051e6fb970c7afe09ce2d564c163b81df050a8), however this was after the 7.0.3 release, and there have been no further releases as at 08/2024.

#### Details
The commit indicated above adds pre-processing directives to exclude `sysctl.h` on Linux/Win; the recipe now applies this as a patch for version 7.0.3.

NOTE: My contributor access request is pending.
