### PR TITLE
fast_float: add version 6.1.5

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.1.5":
+    url: "https://github.com/fastfloat/fast_float/archive/v6.1.5.tar.gz"
+    sha256: "597126ff5edc3ee59d502c210ded229401a30dafecb96a513135e9719fcad55f"
   "6.1.4":
     url: "https://github.com/fastfloat/fast_float/archive/v6.1.4.tar.gz"
     sha256: "12cb6d250824160ca16bcb9d51f0ca7693d0d10cb444f34f1093bc02acfce704"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.1.5":
+    folder: all
   "6.1.4":
     folder: all
   "6.1.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fast_float/6.1.5**

#### Motivation
There are several improvements in 6.1.5.

#### Details
https://github.com/fastfloat/fast_float/compare/v6.1.4...v6.1.5

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
