### PR TITLE
OpenImageIO: Add version 2.5.15.0

### DIFF
--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "2.5.14.0":
     url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.14.0.tar.gz"
     sha256: "0e74372c658f083820872311d126867f10d59b526a856672746de7b2c772034d"
+  "2.5.15.0":
+    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.15.0.tar.gz"
+    sha256: "7779ef2c3d03c5ed95e13ff292de85c3f8cee301cd46baad0d2dc83c93bfe85c"
 patches:
   "2.4.7.1":
     - patch_file: "patches/2.4.7.1-cmake-targets.patch"
@@ -49,6 +52,10 @@ patches:
       patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"
       patch_type: "conan"
   "2.5.14.0":
+    - patch_file: "patches/2.5.14.0-cmake-targets.patch"
+      patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"
+      patch_type: "conan"
+  "2.5.15.0":
     - patch_file: "patches/2.5.14.0-cmake-targets.patch"
       patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"
       patch_type: "conan"

--- a/recipes/openimageio/config.yml
+++ b/recipes/openimageio/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "2.5.14.0":
     folder: all
+  "2.5.15.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/2.5.15.0**

#### Motivation
Just bumping the monthly released openimageio with several small updates.

#### Details
Adding the new version and just applying the patch from 2.5.14.0 (for the cmake project) that is still valid.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
