### PR TITLE
librdkafka: add version 2.5.3

### DIFF
--- a/recipes/librdkafka/all/conandata.yml
+++ b/recipes/librdkafka/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.3":
+    url: "https://github.com/edenhill/librdkafka/archive/v2.5.3.tar.gz"
+    sha256: "eaa1213fdddf9c43e28834d9a832d9dd732377d35121e42f875966305f52b8ff"
   "2.5.0":
     url: "https://github.com/edenhill/librdkafka/archive/v2.5.0.tar.gz"
     sha256: "3dc62de731fd516dfb1032861d9a580d4d0b5b0856beb0f185d06df8e6c26259"
@@ -18,6 +21,13 @@ sources:
     url: "https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz"
     sha256: "3fba157a9f80a0889c982acdd44608be8a46142270a389008b22d921be1198ad"
 patches:
+  "2.5.3":
+    - patch_file: patches/0001-Change-library-names-1-9-1.patch
+      patch_description: "find_package conan packages"
+      patch_type: "conan"
+    - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
+      patch_description: "refer conan package names"
+      patch_type: "conan"
   "2.5.0":
     - patch_file: patches/0001-Change-library-names-1-9-1.patch
       patch_description: "find_package conan packages"

--- a/recipes/librdkafka/config.yml
+++ b/recipes/librdkafka/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.3":
+    folder: all
   "2.5.0":
     folder: all
   "2.4.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **librdkafka/2.5.3**

#### Motivation
2.5.3 fixes the regression which has been introduced in 2.5.0.
https://github.com/confluentinc/librdkafka/releases/tag/v2.5.0

#### Details
https://github.com/confluentinc/librdkafka/compare/v2.5.0...v2.5.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
