### PR TITLE
libqasm: add version 0.6.7

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.7":
+    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.7.tar.gz"
+    sha256: "3e85be4f433b178b89e32bc738bd4f69266cd1c4ad0ed12b5367381ac6e44eb2"
   "0.6.6":
     url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.6.tar.gz"
     sha256: "b3a2d1670f8865ce22bcc62c6a696ee7e0764a7b76901a4f082efa2287e0cbad"

--- a/recipes/libqasm/all/conanfile.py
+++ b/recipes/libqasm/all/conanfile.py
@@ -70,7 +70,7 @@ class LibqasmConan(ConanFile):
         if self.settings.arch == "wasm":
             self.tool_requires("emsdk/3.1.50")
         if self._should_build_test:
-            self.test_requires("gtest/1.14.0")
+            self.test_requires("gtest/1.15.0")
         if self.options.build_python:
             self.tool_requires("cpython/3.12.2")
 
@@ -91,7 +91,7 @@ class LibqasmConan(ConanFile):
         else:
             self.requires("fmt/11.0.2", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
-        self.requires("tree-gen/1.0.7", transitive_headers=True, transitive_libs=True)
+        self.requires("tree-gen/1.0.8", transitive_headers=True, transitive_libs=True)
         if not self.settings.arch == "wasm":
             self.requires("antlr4-cppruntime/4.13.1", transitive_headers=True)
 

--- a/recipes/libqasm/all/conanfile.py
+++ b/recipes/libqasm/all/conanfile.py
@@ -88,10 +88,11 @@ class LibqasmConan(ConanFile):
     def requirements(self):
         if Version(self.version) < "0.6.7":
             self.requires("fmt/10.2.1", transitive_headers=True)
+            self.requires("tree-gen/1.0.7", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("fmt/11.0.2", transitive_headers=True)
+            self.requires("tree-gen/1.0.8", transitive_headers=True, transitive_libs=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
-        self.requires("tree-gen/1.0.8", transitive_headers=True, transitive_libs=True)
         if not self.settings.arch == "wasm":
             self.requires("antlr4-cppruntime/4.13.1", transitive_headers=True)
 

--- a/recipes/libqasm/all/conanfile.py
+++ b/recipes/libqasm/all/conanfile.py
@@ -86,7 +86,10 @@ class LibqasmConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} requires antlr4-cppruntime to be built with the same shared option value.")
 
     def requirements(self):
-        self.requires("fmt/10.2.1", transitive_headers=True)
+        if Version(self.version) < "0.6.7":
+            self.requires("fmt/10.2.1", transitive_headers=True)
+        else:
+            self.requires("fmt/11.0.2", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
         self.requires("tree-gen/1.0.7", transitive_headers=True, transitive_libs=True)
         if not self.settings.arch == "wasm":

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.7":
+    folder: all
   "0.6.6":
     folder: all
   "0.6.5":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libqasm/0.6.7**

#### Motivation
Just an  update of dependencies.

#### Details
config.yml and conandata.yml point to the newly created libqasm/0.6.7.
conanfile.py updates fmt conan package version to 11.0.2, gtest to 1.15.0, and tree-gen to 1.0.8.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan