### PR TITLE
mongo-c-driver: add version 1.27.6

### DIFF
--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.27.6":
+    url: "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.27.6.tar.gz"
+    sha256: "7dee166dd106e3074582dd107f62815aa29311520149cda52efb69590b2cae7a"
   "1.27.5":
     url: "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.27.5.tar.gz"
     sha256: "b90dab0856448c5919c1e04fe8d5a4d80d57779ccf8cf08e3981314a5961973d"

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.27.6":
+    folder: all
   "1.27.5":
     folder: all
   "1.27.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mongo-c-driver/1.27.6**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

See https://github.com/mongodb/mongo-c-driver/compare/1.27.5...1.27.6 for full set of changes. Includes bug fixes to large string handling in libbson and a TSan fix in libmongoc.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

PR follows pattern from 1.27.5 in: https://github.com/conan-io/conan-center-index/pull/24853.

Fixes #25123

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
