### PR TITLE
aws-sdk-cpp: add missing transitive_headers=True

### DIFF
--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -356,11 +356,14 @@ class AwsSdkCppConan(ConanFile):
             if self.options.get_safe("s3-crt"):
                 self.requires("aws-c-s3/0.1.26")
         if self.settings.os != "Windows":
-            self.requires("openssl/[>=1.1 <4]")
-            self.requires("libcurl/[>=7.78.0 <9]")
+            # Used transitively in core/utils/crypto/openssl/CryptoImpl.h public header
+            self.requires("openssl/[>=1.1 <4]", transitive_headers=True, transitive_libs=True)
+            # Used transitively in core/http/curl/CurlHandleContainer.h public header
+            self.requires("libcurl/[>=7.78.0 <9]", transitive_headers=True, transitive_libs=True)
         if self.settings.os in ["Linux", "FreeBSD"]:
             if self.options.get_safe("text-to-speech"):
-                self.requires("pulseaudio/14.2")
+                # Used transitively in text-to-speech/PulseAudioPCMOutputDriver.h public header
+                self.requires("pulseaudio/14.2", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if (self.options.shared


### PR DESCRIPTION
### Summary
Changes to recipe:  **aws-sdk-cpp/[*]**

#### Motivation
Causes a build failure in #21164 (aws-sdk-cdi) currently.

#### Details
```
[100%] Linking C executable test_package
/opt/conan/binutils/bin/ld: warning: libpulse-simple.so.0, needed by /home/conan/workspace/prod-v2/bsr/40116/efcbc/p/aws-sb19a5683d133d/p/lib/libaws-cpp-sdk-text-to-speech.so, not found (try using -rpath or -rpath-link)
/opt/conan/binutils/bin/ld: warning: libpulse.so.0, needed by /home/conan/workspace/prod-v2/bsr/40116/efcbc/p/aws-sb19a5683d133d/p/lib/libaws-cpp-sdk-text-to-speech.so, not found (try using -rpath or -rpath-link)
/opt/conan/binutils/bin/ld: warning: libpulsecommon-14.2.so, needed by /home/conan/workspace/prod-v2/bsr/40116/efcbc/p/aws-sb19a5683d133d/p/lib/libaws-cpp-sdk-text-to-speech.so, not found (try using -rpath or -rpath-link)
/opt/conan/binutils/bin/ld: /home/conan/workspace/prod-v2/bsr/40116/efcbc/p/aws-sb19a5683d133d/p/lib/libaws-cpp-sdk-text-to-speech.so: undefined reference to `pa_simple_new@PULSE_0'
/opt/conan/binutils/bin/ld: /home/conan/workspace/prod-v2/bsr/40116/efcbc/p/aws-sb19a5683d133d/p/lib/libaws-cpp-sdk-text-to-speech.so: undefined reference to `pa_simple_free@PULSE_0'
/opt/conan/binutils/bin/ld: /home/conan/workspace/prod-v2/bsr/40116/efcbc/p/aws-sb19a5683d133d/p/lib/libaws-cpp-sdk-text-to-speech.so: undefined reference to `pa_strerror@PULSE_0'
/opt/conan/binutils/bin/ld: /home/conan/workspace/prod-v2/bsr/40116/efcbc/p/aws-sb19a5683d133d/p/lib/libaws-cpp-sdk-text-to-speech.so: undefined reference to `pa_simple_write@PULSE_0'
collect2: error: ld returned 1 exit status
CMakeFiles/test_package.dir/build.make:85: recipe for target 'test_package' failed
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
