### PR TITLE
[premake] Build with Conan 1.x again

### DIFF
--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -55,10 +55,6 @@ class PremakeConan(ConanFile):
     def validate(self):
         if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")
-        if conan_version.major == 1 and self.settings.build_type == "Debug":
-            # This configuration fails without any error messages in C3I.
-            # https://c3i.jfrog.io/artifactory/misc/logs/pr/18844/15-linux-clang/premake/5.0.0-alpha15/
-            raise ConanInvalidConfiguration("Debug build not supported with Conan 1.x")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -3,7 +3,7 @@ import os
 import re
 import shutil
 
-from conan import ConanFile, conan_version
+from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, replace_in_file

--- a/recipes/premake/5.x/test_package/conanfile.py
+++ b/recipes/premake/5.x/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.cmake import cmake_layout
+from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
@@ -10,8 +10,6 @@ class TestPackageConan(ConanFile):
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
 
-    def layout(self):
-        cmake_layout(self)
-
     def test(self):
-        self.run("premake5 --version")
+        if can_run(self):
+            self.run("premake5 --version")


### PR DESCRIPTION
### Summary
Changes to recipe:  **premake/alpha-15**

#### Motivation

So far, Conan 1.x is still mandatory for recipes that are present in ConanCenterIndex since before Conan 2.x migration. 

The premake failed previously, but I can not reproduce that same error by running it in an equal docker container.

#### Details

Using the Docker image `conanio/clang13-ubuntu16.04:1.65.0`, I see no errors when building in Debug mode:

[premake-alpha15-clang13-debug.log](https://github.com/user-attachments/files/16862706/premake-alpha15-clang13-debug.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
