### PR TITLE
[systemc] Re-enable Conan 1.x build

### DIFF
--- a/recipes/systemc/all/conanfile.py
+++ b/recipes/systemc/all/conanfile.py
@@ -1,10 +1,9 @@
-from conan import ConanFile, conan_version
+from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -68,15 +67,6 @@ class SystemcConan(ConanFile):
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration(
                 "Building SystemC as a shared library on Windows is currently not supported"
-            )
-
-        if (
-            conan_version.major == 1
-            and self.settings.compiler == "gcc"
-            and Version(self.settings.compiler.version) <= "5"
-        ):
-            raise ConanInvalidConfiguration(
-                f"GCC {self.settings.compiler.version} is not supported by SystemC on Conan v1"
             )
 
     def source(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **systemc/2.3.4**

#### Motivation

Similar to #25131. The Systemc failed in the past, but looks working now.

#### Details

Locally, is working using the docker image `conanio/gcc5:1.65.0`

[systemc-2.3.3-gcc5-shared.log](https://github.com/user-attachments/files/16868488/systemc-2.3.3-gcc5-shared.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
