### PR TITLE
[ffmpeg] Re-enable Conan 1.x build

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -198,6 +198,7 @@ class FFMpegConan(ConanFile):
         "disable_filters": None,
         "enable_filters": None,
     }
+    short_paths = True
 
     @property
     def _settings_build(self):

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -354,10 +354,6 @@ class FFMpegConan(ConanFile):
                 raise ConanInvalidConfiguration("FFmpeg '{}' option requires '{}' option to be enabled".format(
                     dependency, "' or '".join(features)))
 
-        if Version(self.version) >= "6.1" and conan_version.major == 1 and is_msvc(self) and self.options.shared:
-            # Linking fails with "Argument list too long" for some reason on Conan v1
-            raise ConanInvalidConfiguration("MSVC shared build is not supported for Conan v1")
-
         if Version(self.version) == "7.0.1" and self.settings.build_type == "Debug":
             # FIXME: FFMpeg fails to build in Debug mode with the following error:
             # ld: libavcodec/libavcodec.a(vvcdsp_init.o): in function `ff_vvc_put_pixels2_8_sse4':

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile, conan_version
+from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.build import cross_building


### PR DESCRIPTION
### Summary
Changes to recipe:  **ffmpeg/6.1**

#### Motivation

Similar to PRs #25134 and #25131. The ffmpeg Conan package has a restriction to be built using Conan 1.x on Windows. As the CI received many updates, probably worth checking it.

#### Details

I can build locally using Conan 1.65.0 + Windows 10 + ffmpeg/6.1.1 + ffmpeg:shared=True: 

[ffmpeg-6.1.1-msvc-shared.log](https://github.com/user-attachments/files/16869315/ffmpeg-6.1.1-msvc-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
