### PR TITLE
add yaml-cpp  0.6.2-0f9a586-p1 for cpp-libp2p

### DIFF
--- a/recipes/yaml-cpp/all/conandata.yml
+++ b/recipes/yaml-cpp/all/conandata.yml
@@ -8,6 +8,10 @@ sources:
   "0.6.3":
     url: "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.3.tar.gz"
     sha256: "77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed"
+  "0.6.2-0f9a586-p1":
+    url: "https://github.com/hunter-packages/yaml-cpp/archive/refs/tags/v0.6.2-0f9a586-p1.tar.gz"
+    sha256: "b416ab3f1b018e55755dafe6af0ed59150e7bcfadef59425195a8814c9a19bed"
+
 patches:
   "0.7.0":
     - patch_file: "patches/0001-install-0.7.0.patch"

--- a/recipes/yaml-cpp/config.yml
+++ b/recipes/yaml-cpp/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "0.6.3":
     folder: all
+  "0.6.2-0f9a586-p1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **yaml-cpp/0.6.2-0f9a586-p1**

#### Motivation
This version has been modified by cpp libP2P developers. Without this version, cpp libP2P cannot run.

https://github.com/libp2p/cpp-libp2p/issues/264
https://github.com/xDimon/soralog/issues/11
