### PR TITLE
eabase: add version 2.09.12.cci.20240818 for eastl

### DIFF
--- a/recipes/eabase/all/conandata.yml
+++ b/recipes/eabase/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.09.12.cci.20240818":
+    url: "https://github.com/electronicarts/EABase/archive/123363eb82e132c0181ac53e43226d8ee76dea12.tar.gz"
+    sha256: "eff0503085ab144f4a24e29ff1d2401aece6e0f680d82bdcc6018182d5d1e0b3"
   "2.09.12":
     url: "https://github.com/electronicarts/EABase/archive/d1be0a1d0fc01a9bf8f3f2cea75018df0d2410ee.zip"
     sha256: "53b72d188aa17c7b23aa6bef9a4767854e82eac46a027dec233d12fd3dfbc677"

--- a/recipes/eabase/all/conanfile.py
+++ b/recipes/eabase/all/conanfile.py
@@ -10,10 +10,10 @@ required_conan_version = ">=1.52.0"
 class EABaseConan(ConanFile):
     name = "eabase"
     description = "EABase is a small set of header files that define platform-independent data types and platform feature macros. "
-    topics = ("eastl", "config")
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/electronicarts/EABase"
+    topics = ("eastl", "config", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True

--- a/recipes/eabase/all/test_package/conanfile.py
+++ b/recipes/eabase/all/test_package/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"

--- a/recipes/eabase/config.yml
+++ b/recipes/eabase/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.09.12.cci.20240818":
+    folder: "all"
   "2.09.12":
     folder: "all"
   "2.09.06":


### PR DESCRIPTION
### Summary
Changes to recipe:  **eabase/2.09.12.cci.20240818**

#### Motivation
EASTL/3.21.23 requires latest EABASE which provides `<EABase/eadeprecated.h>`.

#### Details
EASTL uses `<EABase/eadeprecated.h>`.
https://github.com/electronicarts/EASTL/blob/3.21.23/include/EASTL/internal/config.h#L62

latest EABASE provides `<EABase/eadeprecated.h>`.
https://github.com/electronicarts/EABase/commit/31aaf7c6d0e0373f029247ff630557230caebfec

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
