### PR TITLE
cutlass: add version 3.5.1, fix homepage url

### DIFF
--- a/recipes/cutlass/all/conandata.yml
+++ b/recipes/cutlass/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.1":
+    url: "https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.5.1.tar.gz"
+    sha256: "20b7247cda2d257cbf8ba59ba3ca40a9211c4da61a9c9913e32b33a2c5883a36"
   "3.5.0":
     url: "https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.5.0.tar.gz"
     sha256: "ef6af8526e3ad04f9827f35ee57eec555d09447f70a0ad0cf684a2e426ccbcb6"

--- a/recipes/cutlass/all/conanfile.py
+++ b/recipes/cutlass/all/conanfile.py
@@ -21,6 +21,7 @@ class CutlassConan(ConanFile):
 
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
+    short_paths = True
     # TODO: add header_only=False option
 
     @property

--- a/recipes/cutlass/all/conanfile.py
+++ b/recipes/cutlass/all/conanfile.py
@@ -16,7 +16,7 @@ class CutlassConan(ConanFile):
     description = "CUTLASS: CUDA Templates for Linear Algebra Subroutines"
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/project/package"
+    homepage = "https://github.com/NVIDIA/cutlass"
     topics = ("linear-algebra", "gpu", "cuda", "deep-learning", "nvidia", "header-only")
 
     package_type = "header-library"

--- a/recipes/cutlass/config.yml
+++ b/recipes/cutlass/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "3.5.1":
+    folder: all
   "3.5.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cutlass/3.5.1**

#### Motivation
There are several improvements in 3.5.1.
Fix homepage url in conanfile.py

#### Details
https://github.com/NVIDIA/cutlass/compare/v3.5.0...v3.5.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
