### PR TITLE
openmpi: add v5.0.5, add optional deps, fix cross-compilation by using GnuToolchain

### DIFF
--- a/recipes/openmpi/all/conandata.yml
+++ b/recipes/openmpi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.0.5":
+    url: "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.bz2"
+    sha256: "6588d57c0a4bd299a24103f4e196051b29e8b55fbda49e11d5b3d32030a32776"
   "4.1.6":
     url: "https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.bz2"
     sha256: "f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415"

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -117,7 +117,7 @@ class OpenMPIConan(ConanFile):
 
         tc = AutotoolsToolchain(self)
         tc.configure_args += [
-            "--with-pic" if self.options.get_safe("fPIC") else "--without-pic",
+            "--with-pic" if self.options.get_safe("fPIC", True) else "--without-pic",
             f"--enable-mpi-fortran={self.options.fortran}",
             f"--with-hwloc={root('hwloc')}",
             f"--with-libevent={root('libevent')}",

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -255,7 +255,7 @@ class OpenMPIConan(ConanFile):
             self.cpp_info.components["prrte"].libs = ["prrte"]
             self.cpp_info.components["prrte"].requires = ["pmix"]
             self.cpp_info.components["ompi"].requires = ["pmix"]
-            main_component = self.cpp_info.components["ompi"]
+            main_component = self.cpp_info.components["pmix"]
         else:
             self.cpp_info.components["orte"].set_property("pkg_config_name", "orte")
             self.cpp_info.components["orte"].libs = ["open-rte"]

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -81,7 +81,7 @@ class OpenMPIConan(ConanFile):
     def requirements(self):
         # OpenMPI public headers don't include anything besides stddef.h.
         # transitive_headers=True is not needed for any dependencies.
-        self.requires("hwloc/2.10.0")
+        self.requires("hwloc/2.11.1")
         self.requires("zlib/[>=1.2.11 <2]")
         self.requires("libevent/2.1.12")
         if self.settings.os == "Linux":
@@ -116,7 +116,7 @@ class OpenMPIConan(ConanFile):
             return "yes" if v else "no"
 
         tc = GnuToolchain(self)
-        tc.configure_args["--with-pic"] = self.options.get_safe("fPIC", True)
+        tc.configure_args["--with-pic"] = self.options.get_safe("fPIC")
         tc.configure_args["--enable-mpi-fortran"] = self.options.fortran
         tc.configure_args["--with-hwloc"] = root("hwloc")
         tc.configure_args["--with-libevent"] = root("libevent")
@@ -173,7 +173,7 @@ class OpenMPIConan(ConanFile):
         # libtool's libltdl is not really needed, OpenMPI provides its own equivalent.
         # Not adding it as it fails to be detected by ./configure in some cases.
         # https://github.com/open-mpi/ompi/blob/v4.1.6/opal/mca/dl/dl.h#L20-L25
-        tc.configure_args.append("--with-libltdl=no")
+        tc.configure_args["--with-libltdl"] = "no"
         tc.generate()
 
         deps = AutotoolsDeps(self)
@@ -249,7 +249,7 @@ class OpenMPIConan(ConanFile):
             self.cpp_info.components["prrte"].libs = ["prrte"]
             self.cpp_info.components["prrte"].requires = ["pmix"]
             self.cpp_info.components["ompi"].requires = ["pmix"]
-            main_component = self.cpp_info.components["pmix"]
+            main_component = self.cpp_info.components["ompi"]
         else:
             self.cpp_info.components["orte"].set_property("pkg_config_name", "orte")
             self.cpp_info.components["orte"].libs = ["open-rte"]
@@ -301,21 +301,3 @@ class OpenMPIConan(ConanFile):
         self.runenv_info.define_path("OPAL_LIBDIR", os.path.join(self.package_folder, "lib"))
         self.runenv_info.define_path("OPAL_DATADIR", os.path.join(self.package_folder, "res"))
         self.runenv_info.define_path("OPAL_DATAROOTDIR", os.path.join(self.package_folder, "res"))
-
-        # TODO: Legacy, to be removed on Conan 2.0
-        self.env_info.PATH.append(bin_folder)
-        self.env_info.MPI_BIN = bin_folder
-        self.env_info.MPI_HOME = self.package_folder
-        self.env_info.OPAL_PREFIX = self.package_folder
-        self.env_info.OPAL_EXEC_PREFIX = self.package_folder
-        self.env_info.OPAL_LIBDIR = os.path.join(self.package_folder, "lib")
-        self.env_info.OPAL_DATADIR = os.path.join(self.package_folder, "res")
-        self.env_info.OPAL_DATAROOTDIR = os.path.join(self.package_folder, "res")
-
-        self.cpp_info.names["cmake_find_package"] = "MPI"
-        self.cpp_info.names["cmake_find_package_multi"] = "MPI"
-        self.cpp_info.components["ompi-c"].names["cmake_find_package"] = "MPI_C"
-        if self.options.get_safe("enable_cxx"):
-            self.cpp_info.components["ompi-cxx"].names["cmake_find_package"] = "MPI_CXX"
-        if self.options.fortran != "no":
-            self.cpp_info.components["ompi-fort"].names["cmake_find_package"] = "MPI_Fortran"

--- a/recipes/openmpi/all/test_package/conanfile.py
+++ b/recipes/openmpi/all/test_package/conanfile.py
@@ -7,8 +7,7 @@ from conan.tools.cmake import cmake_layout, CMake
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/openmpi/all/test_package/conanfile.py
+++ b/recipes/openmpi/all/test_package/conanfile.py
@@ -23,6 +23,7 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
+            self.run("ompi_info", env="conanrun")
             bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             command = f"mpiexec -mca plm_rsh_agent yes {bin_path}"
             self.run(command, env="conanrun")

--- a/recipes/openmpi/config.yml
+++ b/recipes/openmpi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.0.5":
+    folder: all
   "4.1.6":
     folder: all
   "4.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **openmpi/[*]**

#### Motivation
A follow-up to #18980.

- Adds the latest version, a new major release, for OpenMPI.
- Adds a missing non-optional `libevent` dependency. The project otherwise uses a vendored version of libevent if it is not provided or found on the system. This is fragile and silently using the system library is likely to break things in consuming packages, especially when built as as static.
- Added optional support for `libfabric`, now that it has been migrated.
- Added support for optional `libcurl` and `jansson` deps in v5.
- Added `ompi_info` call in test_package, which provides a useful summary of the enabled features for validation and debugging.

#### Details
v5 also added support for `libev` as an alternative to `libevent`. I considered adding it as an option, but `pmix` errors out during `./configure` when `libevent` is disabled.

Dropped `--with-moab=no`, since it's actually enabled by default and does not have external deps.

closes #23503

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
