### PR TITLE
hwloc: add v2.11.1

### DIFF
--- a/recipes/hwloc/all/conandata.yml
+++ b/recipes/hwloc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.11.1":
+    url: "https://download.open-mpi.org/release/hwloc/v2.11/hwloc-2.11.1.tar.bz2"
+    sha256: "04cdfbffad225ce15f66184f0f4141327dabf288d10a8b84d13f517acb7870c6"
   "2.10.0":
     url: "https://download.open-mpi.org/release/hwloc/v2.10/hwloc-2.10.0.tar.bz2"
     sha256: "0305dd60c9de2fbe6519fe2a4e8fdc6d3db8de574a0ca7812b92e80c05ae1392"

--- a/recipes/hwloc/config.yml
+++ b/recipes/hwloc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.11.1":
+    folder: all
   "2.10.0":
     folder: all
   "2.9.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **hwloc/2.11.1**

#### Motivation
The latest release for hwloc. Might want to upgrade OpenMPI v5 to it in #25162.

#### Details
Release notes: https://www.mail-archive.com/hwloc-announce@lists.open-mpi.org/msg00166.html

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
