### PR TITLE
gobject-introspection: add v2.78.1

### DIFF
--- a/recipes/gobject-introspection/all/conandata.yml
+++ b/recipes/gobject-introspection/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.78.1":
+    url: "https://download.gnome.org/sources/gobject-introspection/1.78/gobject-introspection-1.78.1.tar.xz"
+    sha256: "bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4"
   "1.72.0":
     url: "https://download.gnome.org/sources/gobject-introspection/1.72/gobject-introspection-1.72.0.tar.xz"
     sha256: "02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc"

--- a/recipes/gobject-introspection/config.yml
+++ b/recipes/gobject-introspection/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.78.1":
+    folder: all
   "1.72.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **gobject-introspection/2.78.1**

#### Motivation
To target a newer gobject-introspection version in the updated GTK (#25090) and related recipes (such as harfbuzz #25093).

#### Details
There is a newer v2.80 release available, but it involves a more substantial change to the Python runtime dependencies.
Limiting this one to a simple version bump.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
