### PR TITLE
Bump zstd for libdwarf

### DIFF
--- a/recipes/libdwarf/all/conanfile.py
+++ b/recipes/libdwarf/all/conanfile.py
@@ -56,7 +56,7 @@ class LibdwarfConan(ConanFile):
             self.requires("libelf/0.8.13")
         self.requires("zlib/[>=1.2.11 <2]")
         if  Version(self.version) >= Version("0.9.0"):
-            self.requires("zstd/[^1.5]")
+            self.requires("zstd/[~1.5]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libdwarf/all/conanfile.py
+++ b/recipes/libdwarf/all/conanfile.py
@@ -56,7 +56,7 @@ class LibdwarfConan(ConanFile):
             self.requires("libelf/0.8.13")
         self.requires("zlib/[>=1.2.11 <2]")
         if  Version(self.version) >= Version("0.9.0"):
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/[^1.5]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdwarf/all**

#### Motivation
 #24849 updated mongo-c-driver to use a version range for zstd which causes it to conflict with libdwarf


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
