### PR TITLE
s2n: add version 1.5.2

### DIFF
--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.2":
+    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.5.2.tar.gz"
+    sha256: "896d9f8f8e9bd2fdcb9a21b18aede4f7afc65bde279afabc60abf97fa5069dd1"
   "1.5.1":
     url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.5.1.tar.gz"
     sha256: "d79710d6ef089097a3b84fc1e5cec2f08d1ec46e93b1d400df59fcfc859e15a3"

--- a/recipes/s2n/config.yml
+++ b/recipes/s2n/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.2":
+    folder: all
   "1.5.1":
     folder: all
   "1.5.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **s2n/1.5.2**

#### Motivation
There are several bugfixes in 1.5.2.

#### Details
https://github.com/aws/s2n-tls/compare/v1.5.1...v1.5.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
