### PR TITLE
libdwarf: Add versions 0.9.2 to 0.11.0

### DIFF
--- a/recipes/libdwarf/all/conandata.yml
+++ b/recipes/libdwarf/all/conandata.yml
@@ -1,4 +1,13 @@
 sources:
+  "0.11.0":
+    url: "https://github.com/davea42/libdwarf-code/archive/refs/tags/v0.11.0.tar.gz"
+    sha256: "5135af38dc202206538a3dcdc90675aa8b320e132156849c6855dea5ea0c0729"
+  "0.10.1":
+    url: "https://github.com/davea42/libdwarf-code/archive/refs/tags/v0.10.1.tar.gz"
+    sha256: "4ab8ae7b4b7aa42453725054b348f4fdb2460d5ba644199a1305311c718ff416"
+  "0.9.2":
+    url: "https://github.com/davea42/libdwarf-code/archive/refs/tags/v0.9.2.tar.gz"
+    sha256: "5371c68248c16a4a9cb071284c87c0cdb8f560d5277e0b86893fdc6576062f95"
   "0.9.1":
     url: "https://github.com/davea42/libdwarf-code/archive/refs/tags/v0.9.1.tar.gz"
     sha256: "6da3f46a9f92b4e284c97c733851879d9b91b16642bede90c7614860a946824e"
@@ -15,6 +24,18 @@ sources:
     url: "https://www.prevanders.net/libdwarf-0.5.0.tar.xz"
     sha256: "11fa822c60317fa00e1a01a2ac9e8388f6693e8662ab72d352c5f50c7e0112a9"
 patches:
+  "0.11.0":
+    - patch_file: "patches/0.10.1-0001-fixes.patch"
+      patch_description: "fix DW_API definition and cmake"
+      patch_type: "portability"
+  "0.10.1":
+    - patch_file: "patches/0.10.1-0001-fixes.patch"
+      patch_description: "fix DW_API definition and cmake"
+      patch_type: "portability"
+  "0.9.2":
+    - patch_file: "patches/0.9.2-0001-fixes.patch"
+      patch_description: "fix DW_API definition and cmake"
+      patch_type: "portability"
   "0.9.1":
     - patch_file: "patches/0.9.1-0001-fixes.patch"
       patch_description: "fix DW_API definition and cmake"

--- a/recipes/libdwarf/all/patches/0.10.1-0001-fixes.patch
+++ b/recipes/libdwarf/all/patches/0.10.1-0001-fixes.patch
@@ -1,0 +1,65 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f219f078..d8a78136 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -226,6 +226,12 @@ if (ENABLE_DECOMPRESSION)
+     set(HAVE_ZSTD_H TRUE)
+     set(BUILT_WITH_ZLIB_AND_ZSTD TRUE)
+   endif()
++  find_package(zstd CONFIG REQUIRED)
++  if(TARGET zstd::libzstd_shared)
++    set(ZSTD_LIB zstd::libzstd_shared)
++  else()
++    set(ZSTD_LIB zstd::libzstd_static)
++  endif()
+ endif ()
+
+ message(STATUS "CMAKE_SIZEOF_VOID_P ... " ${CMAKE_SIZEOF_VOID_P} )
+diff --git a/src/lib/libdwarf/CMakeLists.txt b/src/lib/libdwarf/CMakeLists.txt
+index 02787555..862c97b8 100644
+--- a/src/lib/libdwarf/CMakeLists.txt
++++ b/src/lib/libdwarf/CMakeLists.txt
+@@ -117,7 +117,7 @@ install(TARGETS dwarf
+         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+         )
+
+-configure_file(libdwarf.pc.in libdwarf.pc @ONLY)
++# configure_file(libdwarf.pc.in libdwarf.pc @ONLY)
+
+ # The install has to be here, not in
+ # another CMakeLists.txt  to make install work properly
+@@ -135,5 +135,5 @@ install(EXPORT libdwarfTargets
+         FILE libdwarf-targets.cmake
+         NAMESPACE libdwarf::
+         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
+-install(FILES "${PROJECT_BINARY_DIR}/src/lib/libdwarf/libdwarf.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++# install(FILES "${PROJECT_BINARY_DIR}/src/lib/libdwarf/libdwarf.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+ install(FILES "${PROJECT_SOURCE_DIR}/cmake/Findzstd.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
+index 380d2ef7..8c62ee7e 100644
+--- a/src/lib/libdwarf/libdwarf.h
++++ b/src/lib/libdwarf/libdwarf.h
+@@ -51,7 +51,7 @@
+ #endif /* DW_API */
+
+ #ifndef LIBDWARF_STATIC
+-# if defined(_WIN32) || defined(__CYGWIN__)
++# if defined(LIBDWARF_SHARED) && (defined(_WIN32) || defined(__CYGWIN__))
+ #  ifdef LIBDWARF_BUILD
+ #   define DW_API __declspec(dllexport)
+ #  else /* !LIBDWARF_BUILD */
+diff --git a/src/lib/libdwarf/libdwarf_private.h b/src/lib/libdwarf/libdwarf_private.h
+index b37ae994..7fa89256 100644
+--- a/src/lib/libdwarf/libdwarf_private.h
++++ b/src/lib/libdwarf/libdwarf_private.h
+@@ -26,11 +26,7 @@
+ #ifdef _MSC_VER /* Macro to select VS compiler */
+ #include <windows.h>
+ typedef SSIZE_T ssize_t;
+-#ifdef _WIN64
+-typedef long long off_t;
+-#else
+ typedef long off_t;
+-#endif
+ #endif /* _MSC_VER */
+
+ #ifndef TRUE

--- a/recipes/libdwarf/all/patches/0.9.2-0001-fixes.patch
+++ b/recipes/libdwarf/all/patches/0.9.2-0001-fixes.patch
@@ -1,0 +1,66 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f219f078..d8a78136 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -225,6 +225,12 @@ if (ENABLE_DECOMPRESSION)
+     set(HAVE_ZSTD_H TRUE)
+     set(BUILT_WITH_ZLIB_AND_ZSTD TRUE)
+   endif()
++  find_package(zstd CONFIG REQUIRED)
++  if(TARGET zstd::libzstd_shared)
++    set(ZSTD_LIB zstd::libzstd_shared)
++  else()
++    set(ZSTD_LIB zstd::libzstd_static)
++  endif()
+ endif ()
+
+ message(STATUS "CMAKE_SIZEOF_VOID_P ... " ${CMAKE_SIZEOF_VOID_P} )
+diff --git a/src/lib/libdwarf/CMakeLists.txt b/src/lib/libdwarf/CMakeLists.txt
+index 6cb0b24e..069343ba 100644
+--- a/src/lib/libdwarf/CMakeLists.txt
++++ b/src/lib/libdwarf/CMakeLists.txt
+@@ -117,7 +117,7 @@ install(TARGETS dwarf
+         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+         )
+
+-configure_file(libdwarf.pc.cmake libdwarf.pc @ONLY)
++# configure_file(libdwarf.pc.cmake libdwarf.pc @ONLY)
+
+ # The install has to be here, not in
+ # another CMakeLists.txt  to make install work properly
+@@ -135,5 +135,5 @@ install(EXPORT libdwarfTargets
+         FILE libdwarf-targets.cmake
+         NAMESPACE libdwarf::
+         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
+-install(FILES "${PROJECT_BINARY_DIR}/src/lib/libdwarf/libdwarf.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++# install(FILES "${PROJECT_BINARY_DIR}/src/lib/libdwarf/libdwarf.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+ install(FILES "${PROJECT_SOURCE_DIR}/cmake/Findzstd.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
+diff --git a/src/lib/libdwarf/libdwarf.h b/src/lib/libdwarf/libdwarf.h
+index 380d2ef7..8c62ee7e 100644
+--- a/src/lib/libdwarf/libdwarf.h
++++ b/src/lib/libdwarf/libdwarf.h
+@@ -51,7 +51,7 @@
+ #endif /* DW_API */
+
+ #ifndef LIBDWARF_STATIC
+-# if defined(_WIN32) || defined(__CYGWIN__)
++# if defined(LIBDWARF_SHARED) && (defined(_WIN32) || defined(__CYGWIN__))
+ #  ifdef LIBDWARF_BUILD
+ #   define DW_API __declspec(dllexport)
+ #  else /* !LIBDWARF_BUILD */
+diff --git a/src/lib/libdwarf/libdwarf_private.h b/src/lib/libdwarf/libdwarf_private.h
+index b37ae994..7fa89256 100644
+--- a/src/lib/libdwarf/libdwarf_private.h
++++ b/src/lib/libdwarf/libdwarf_private.h
+@@ -26,11 +26,7 @@
+ #ifdef _MSC_VER /* Macro to select VS compiler */
+ #include <windows.h>
+ typedef SSIZE_T ssize_t;
+-#ifdef _WIN64
+-typedef long long off_t;
+-#else
+ typedef long off_t;
+-#endif
+ #endif /* _MSC_VER */
+
+ #ifndef TRUE

--- a/recipes/libdwarf/config.yml
+++ b/recipes/libdwarf/config.yml
@@ -1,4 +1,10 @@
 versions:
+  "0.11.0":
+    folder: all
+  "0.10.1":
+    folder: all
+  "0.9.2":
+    folder: all
   "0.9.1":
     folder: all
   "0.9.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdwarf/0.9.2, 0.10.1, 0.11.0**

This PR adds three versions of libdwarf, skipping 0.10.0 as it was defective.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
