### PR TITLE
wiringpi: add version 3.10

### DIFF
--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.10":
+    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.10.tar.gz"
+    sha256: "d0a7b182154e763b4baff1a57a5e0fca093fcf081f663cb2fb17f5ada564e016"
   "3.8":
     url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.8.tar.gz"
     sha256: "6159764d3d036486f0a110cd5393b1413c1f334d464b7337117fece59ea04bc9"

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.10":
+    folder: "all"
   "3.8":
     folder: "all"
   "3.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **wiringpi/3.10**

#### Motivation
There are several improvements in 3.10. (3.9 is not released.)

#### Details
https://github.com/WiringPi/WiringPi/compare/3.8...3.10

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
