### PR TITLE
vswhere: new recipe

### DIFF
--- a/recipes/vswhere/all/conandata.yml
+++ b/recipes/vswhere/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "3.1.7":
+    exe:
+      url: "https://github.com/microsoft/vswhere/releases/download/3.1.7/vswhere.exe"
+      sha256: "c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662"
+    license:
+      url: "https://raw.githubusercontent.com/microsoft/vswhere/3.1.7/LICENSE.txt"
+      sha256: "a1e41a01dd80dbe3f8ad5edebfd746e64ccff9c2aae3d8f47922746cf83204ef"

--- a/recipes/vswhere/all/conanfile.py
+++ b/recipes/vswhere/all/conanfile.py
@@ -1,0 +1,51 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, download
+from conan.tools.microsoft import is_msvc
+
+required_conan_version = ">=1.47.0"
+
+
+class VswhereConan(ConanFile):
+    name = "vswhere"
+    description = "Locate Visual Studio 2017 and newer installations"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/microsoft/vswhere"
+    topics = ("visual-studio", "pre-built")
+    package_type = "application"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        pass
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    def validate(self):
+        if not is_msvc(self):
+            raise ConanInvalidConfiguration("vswhere is only available for MSVC")
+
+    def source(self):
+        pass
+
+    def build(self):
+        download(self, **self.conan_data["sources"][self.version]["exe"], filename="vswhere.exe")
+        download(self, **self.conan_data["sources"][self.version]["license"], filename="LICENSE.txt")
+
+    def package(self):
+        copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "vswhere.exe", self.source_folder, os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+        self.cpp_info.includedirs = []
+
+        # TODO: Legacy, to be removed on Conan 2.0
+        bin_folder = os.path.join(self.package_folder, "bin")
+        self.env_info.PATH.append(bin_folder)

--- a/recipes/vswhere/all/test_package/conanfile.py
+++ b/recipes/vswhere/all/test_package/conanfile.py
@@ -1,0 +1,13 @@
+from conan import ConanFile
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        self.run("vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath")

--- a/recipes/vswhere/config.yml
+++ b/recipes/vswhere/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.1.7":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **vswhere/3.1.7**

#### Motivation
CLI tool to locate Visual Studio 2017 and newer installations. https://github.com/microsoft/vswhere
[![Packaging status](https://repology.org/badge/tiny-repos/vswhere.svg)](https://repology.org/project/vswhere/versions)

Used by NSS to configure MSVC support in #19262: https://github.com/nss-dev/nss/blob/NSS_3_104_RTM/coreconf/msvc.sh#L47-L48

While the dependency in NSS could probably be patched around, the tool is simple to package and possibly useful in other contexts as well.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
