### PR TITLE
libtiff: bump deps & use version range for xz_utils & zstd

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -65,21 +65,21 @@ class LibtiffConan(ConanFile):
         if self.options.zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.libdeflate:
-            self.requires("libdeflate/1.19")
+            self.requires("libdeflate/1.21")
         if self.options.lzma:
-            self.requires("xz_utils/5.4.5")
+            self.requires("xz_utils/[>=5.4.5 <6]")
         if self.options.jpeg == "libjpeg":
-            self.requires("libjpeg/9e")
+            self.requires("libjpeg/9f")
         elif self.options.jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/3.0.2")
+            self.requires("libjpeg-turbo/3.0.3")
         elif self.options.jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.5")
         if self.options.jbig:
             self.requires("jbig/20160605")
         if self.options.zstd:
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/[>=1.5 <1.6]")
         if self.options.webp:
-            self.requires("libwebp/1.3.2")
+            self.requires("libwebp/1.4.0")
 
     def validate(self):
         if self.options.libdeflate and not self.options.zlib:


### PR DESCRIPTION
### Summary
Changes to recipe:  **libtiff/all**

#### Motivation
Use version range for xz_utils & zstd dependencies since it's now allowed, and bump some other deps in the meantime.

closes https://github.com/conan-io/conan-center-index/issues/25206

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
