### PR TITLE
libxml2: bump deps & use version range for xz_utils & pkgconf

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -97,17 +97,17 @@ class Libxml2Conan(ConanFile):
         if self.options.zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.lzma:
-            self.requires("xz_utils/5.4.5")
+            self.requires("xz_utils/[>=5.4.5 <6]")
         if self.options.iconv:
             self.requires("libiconv/1.17", transitive_headers=True, transitive_libs=True)
         if self.options.icu:
-            self.requires("icu/73.2")
+            self.requires("icu/75.1")
 
     def build_requirements(self):
         if not (is_msvc(self) or self._is_mingw_windows):
             if self.options.zlib or self.options.lzma or self.options.icu:
                 if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-                    self.tool_requires("pkgconf/2.1.0")
+                    self.tool_requires("pkgconf/[>=2.2 <3]")
             if self._settings_build.os == "Windows":
                 self.win_bash = True
                 if not self.conf.get("tools.microsoft.bash:path", check_type=str):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2/all**

#### Motivation
Use version range for xz_utils & pkgconf dependencies since it's now allowed, and bump icu version in the meantime.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
