### PR TITLE
libarchive: bump deps & use version range for xz_utils & zstd + use correct dependency for with_pcreposix option

### DIFF
--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -93,7 +93,7 @@ class LibarchiveConan(ConanFile):
         if self.options.with_iconv:
             self.requires("libiconv/1.17")
         if self.options.with_pcreposix:
-            self.requires("pcre2/10.42")
+            self.requires("pcre2/10.44")
         if self.options.with_nettle:
             self.requires("nettle/3.9.1")
         if self.options.with_openssl:
@@ -101,17 +101,17 @@ class LibarchiveConan(ConanFile):
         if self.options.with_libb2:
             self.requires("libb2/20190723")
         if self.options.with_lz4:
-            self.requires("lz4/1.9.4")
+            self.requires("lz4/1.10.0")
         if self.options.with_lzo:
             self.requires("lzo/2.10")
         if self.options.with_lzma:
-            self.requires("xz_utils/5.4.5")
+            self.requires("xz_utils/[>=5.4.5 <6]")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/[>=1.5 <1.6]")
         if self.options.get_safe("with_mbedtls"):
-            self.requires("mbedtls/3.5.1")
+            self.requires("mbedtls/3.6.1")
         if self.options.get_safe("with_pcre2"):
-            self.requires("pcre2/10.43")
+            self.requires("pcre2/10.44")
 
     def validate(self):
         if self.settings.os != "Windows" and self.options.with_cng:

--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -101,7 +101,7 @@ class LibarchiveConan(ConanFile):
         if self.options.with_libb2:
             self.requires("libb2/20190723")
         if self.options.with_lz4:
-            self.requires("lz4/1.10.0")
+            self.requires("lz4/1.9.4")
         if self.options.with_lzo:
             self.requires("lzo/2.10")
         if self.options.with_lzma:

--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -93,7 +93,7 @@ class LibarchiveConan(ConanFile):
         if self.options.with_iconv:
             self.requires("libiconv/1.17")
         if self.options.with_pcreposix:
-            self.requires("pcre2/10.44")
+            self.requires("pcre/8.45")
         if self.options.with_nettle:
             self.requires("nettle/3.9.1")
         if self.options.with_openssl:

--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -111,7 +111,7 @@ class LibarchiveConan(ConanFile):
         if self.options.get_safe("with_mbedtls"):
             self.requires("mbedtls/3.6.1")
         if self.options.get_safe("with_pcre2"):
-            self.requires("pcre2/10.44")
+            self.requires("pcre2/10.43")
 
     def validate(self):
         if self.settings.os != "Windows" and self.options.with_cng:


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
Use version range for xz_utils & zstd dependencies since it's now allowed, and bump some other deps in the meantime.
While bumping versions, I've realized that pcre2 was duplicated in requirements: with_pcreposix actually requires pcre, not pcre2 (and with_pcre2 requires pcre2), so it's fixed in the meantime.

#### Details
Proof that `with_pcreposix` (which maps to `ENABLE_PCREPOSIX` CMake option of upstream CMakeLists) requires pcre, not pcre2:
https://github.com/libarchive/libarchive/blob/853bf656ef6d294a4fedc9afc74b262c3c0a6501/CMakeLists.txt#L1306-L1307
https://github.com/libarchive/libarchive/blob/853bf656ef6d294a4fedc9afc74b262c3c0a6501/build/cmake/FindPCREPOSIX.cmake


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
