### PR TITLE
dcmtk: bump deps & use version range for libpng & libxml2

### DIFF
--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -95,15 +95,15 @@ class DCMTKConan(ConanFile):
         if self.options.charset_conversion == "libiconv":
             self.requires("libiconv/1.17")
         elif self.options.charset_conversion == "icu":
-            self.requires("icu/73.2")
+            self.requires("icu/75.1")
         if self.options.with_libxml2:
-            self.requires("libxml2/2.11.4")
+            self.requires("libxml2/[>=2.12.5 <3]")
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_openssl:
             self.requires("openssl/[>=1 <4]")
         if self.options.with_libpng:
-            self.requires("libpng/1.6.40")
+            self.requires("libpng/[>=1.6 <2]")
         if self.options.with_libtiff:
             self.requires("libtiff/4.6.0")
         if self.options.get_safe("with_tcpwrappers"):


### PR DESCRIPTION
### Summary
Changes to recipe:  **dcmtk/all**

#### Motivation
Use version range for libpng & libxml2 dependencies since it's now allowed, and bump icu version in the meantime.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
