### PR TITLE
pkgconf: use version range for meson

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -56,7 +56,7 @@ class PkgConfConan(ConanFile):
             del self.info.settings.compiler
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/[>=1.2.3 <2]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **pkgconf/all**

#### Motivation
Use version range for meson build requirement since it's now allowed.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
