### PR TITLE
wayland: bump libffi & use version range for meson & pkgconf

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -48,7 +48,7 @@ class WaylandConan(ConanFile):
 
     def requirements(self):
         if self.options.enable_libraries:
-            self.requires("libffi/3.4.4")
+            self.requires("libffi/3.4.6")
         if self.options.enable_dtd_validation:
             self.requires("libxml2/[>=2.12.5 <3]")
         self.requires("expat/[>=2.6.2 <3]")
@@ -58,9 +58,9 @@ class WaylandConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} only supports Linux")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.4.0")
+        self.tool_requires("meson/[>=1.2.3 <2]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
         if not can_run(self):
             self.tool_requires(str(self.ref))
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **wayland/all**

#### Motivation
Use version range for meson & pkgconf since it's now allowed, and bump libffi in the meantime.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
