### PR TITLE
freetype: use version range for meson & pkgconf

### DIFF
--- a/recipes/freetype/meson/conanfile.py
+++ b/recipes/freetype/meson/conanfile.py
@@ -73,9 +73,9 @@ class FreetypeConan(ConanFile):
             self.requires("brotli/1.1.0")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.3.2")
+        self.tool_requires("meson/[>=1.2.3 <2]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **freetype >=2.13.0**

#### Motivation
Use version range for meson & pkgconf build requirements since it's now allowed.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
