### PR TITLE
librdkafka: bump lz4 version & use version range for zstd & pkgconf

### DIFF
--- a/recipes/librdkafka/all/conanfile.py
+++ b/recipes/librdkafka/all/conanfile.py
@@ -66,11 +66,11 @@ class LibrdkafkaConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("lz4/1.9.4")
+        self.requires("lz4/1.10.0")
         if self.options.zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.zstd:
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/[>=1.5 <1.6]")
         if self.options.ssl:
             self.requires("openssl/[>=1.1 <4]")
         if self._depends_on_cyrus_sasl:
@@ -80,7 +80,7 @@ class LibrdkafkaConan(ConanFile):
 
     def build_requirements(self):
         if self._depends_on_cyrus_sasl:
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
Use version range for zstd & pkgconf since it's now allowed, and bump lz4 version in the meantime.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
