### PR TITLE
minizip-ng: use version range for xz_utils, zstd & pkgconf

### DIFF
--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -83,9 +83,9 @@ class MinizipNgConan(ConanFile):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:
-            self.requires("xz_utils/5.4.5")
+            self.requires("xz_utils/[>=5.4.5 <6]")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/[>=1.5 <1.6]")
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]")
         if self.settings.os != "Windows":
@@ -94,7 +94,7 @@ class MinizipNgConan(ConanFile):
 
     def build_requirements(self):
         if self._needs_pkg_config:
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
         if Version(self.version) >= "4.0.0":
             self.tool_requires("cmake/[>=3.19 <4]")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **minizip-ng/all**

#### Motivation
Use version range for xz_utils, zstd & pkgconf since it's now allowed

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
