### PR TITLE
[config] Update Conan client version to 2.7.1 and 1.65.0

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -3,7 +3,7 @@
 id: 'conan-io/conan-center-index'
 
 conan:
-  version: 1.64.1
+  version: 1.65.0
 
 artifactory:
   url: "https://c3i.jfrog.io/c3i"

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -3,7 +3,7 @@
 id: 'conan-io/conan-center-index'
 
 conan:
-  version: 2.5.0
+  version: 2.7.1
   backup_sources:
     upload_url: "https://c3i.jfrog.io/artifactory/conan-center-backup-sources/"
     download_url: "https://c3i.jfrog.io/artifactory/conan-center-backup-sources/"


### PR DESCRIPTION
### Summary

Update Conan client used in ConanCentexIndexCI to the versions 2.7.1 and 1.65.0

