### PR TITLE
libsystemd: use version range for xz_utils, zstd, meson & pkgconf + bump versions of libcap & lz4

### DIFF
--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -60,17 +60,17 @@ class LibsystemdConan(ConanFile):
         }
 
     def requirements(self):
-        self.requires("libcap/2.69")
+        self.requires("libcap/2.70")
         self.requires("libmount/2.39.2")
         self.requires("libxcrypt/4.4.36")
         if self.options.with_selinux:
             self.requires("libselinux/3.6")
         if self.options.with_lz4:
-            self.requires("lz4/1.9.4")
+            self.requires("lz4/1.10.0")
         if self.options.with_xz:
-            self.requires("xz_utils/5.4.5")
+            self.requires("xz_utils/[>=5.4.5 <6]")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/[>=1.5 <1.6]")
 
     def validate(self):
         if self.settings.os != "Linux":
@@ -82,11 +82,11 @@ class LibsystemdConan(ConanFile):
             )
 
     def build_requirements(self):
-        self.tool_requires("meson/1.4.0")
+        self.tool_requires("meson/[>=1.2.3 <2]")
         self.tool_requires("m4/1.4.19")
         self.tool_requires("gperf/3.1")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def source(self):
         # Extract using standard Python tools due to Conan's unzip() not handling backslashes in


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsystemd/all**

#### Motivation
Use version range for xz_utils, zstd, meson & pkgconf

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
