### PR TITLE
qscintilla: new recipe

### DIFF
--- a/recipes/qscintilla/all/CMakeLists.txt
+++ b/recipes/qscintilla/all/CMakeLists.txt
@@ -1,0 +1,97 @@
+# Reproduces https://github.com/brCreate/QScintilla/blob/6cdb1f9876038ad3ce5955ee473b8f8e503aa2d5/src/qscintilla.pro
+cmake_minimum_required(VERSION 3.15)
+project(QScintilla LANGUAGES CXX)
+
+option(QSCINTILLA_BUILD_DESIGNER_PLUGIN "Build the QScintilla designer plugin" OFF)
+option(CMAKE_POSITION_INDEPENDENT_CODE "Generate position-independent code" ON)
+option(CMAKE_CXX_STANDARD "C++ standard to use" 11)
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt6 REQUIRED)
+if(NOT Qt6_FOUND)
+    find_package(Qt5 REQUIRED)
+endif()
+
+set(LIB_NAME "qscintilla2_qt${QT_VERSION_MAJOR}")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(APPLE)
+        string(APPEND LIB_NAME "_debug")
+    elseif(WIN32)
+        string(APPEND LIB_NAME "d")
+    endif()
+endif()
+if(NOT BUILD_SHARED_LIBS)
+    string(APPEND LIB_NAME "_static")
+endif()
+
+file(GLOB SOURCES
+    scintilla/src/*.cpp
+    scintilla/lexlib/*.cpp
+    scintilla/lexers/*.cpp
+    src/*.cpp
+)
+file(GLOB HEADERS
+    scintilla/src/*.h
+    scintilla/lexlib/*.h
+    scintilla/include/*.h
+    src/*.h
+    src/Qsci/*.h
+)
+if(IOS)
+    list(REMOVE_ITEM SOURCES src/qsciprinter.cpp)
+    list(REMOVE_ITEM HEADERS src/Qsci/qsciprinter.h)
+endif()
+
+add_library(QScintilla ${SOURCES} ${HEADERS})
+set_target_properties(QScintilla PROPERTIES OUTPUT_NAME ${LIB_NAME})
+target_include_directories(QScintilla
+    PUBLIC
+        src
+    PRIVATE
+        scintilla/include
+        scintilla/lexlib
+        scintilla/src
+)
+target_compile_definitions(QScintilla PRIVATE
+    SCINTILLA_QT
+    SCI_LEXER
+    INCLUDE_DEPRECATED_FEATURES
+)
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(QScintilla PRIVATE QSCINTILLA_MAKE_DLL)
+endif()
+
+target_link_libraries(QScintilla PUBLIC Qt${QT_VERSION_MAJOR}::Widgets)
+if(NOT IOS)
+    target_link_libraries(QScintilla PUBLIC Qt${QT_VERSION_MAJOR}::PrintSupport)
+endif()
+if(QT_VERSION_MAJOR EQUAL 5 AND APPLE)
+    target_link_libraries(QScintilla PUBLIC Qt5::MacExtras)
+endif()
+
+if(QSCINTILLA_BUILD_DESIGNER_PLUGIN)
+    # Reproduces https://github.com/brCreate/QScintilla/blob/6cdb1f9876038ad3ce5955ee473b8f8e503aa2d5/designer/designer.pro
+    add_library(qscintillaplugin MODULE designer/qscintillaplugin.cpp)
+    target_link_libraries(qscintillaplugin PRIVATE
+        QScintilla
+        Qt${QT_VERSION_MAJOR}::Widgets
+        Qt${QT_VERSION_MAJOR}::Designer
+    )
+    include(GNUInstallDirs)
+    install(TARGETS qscintillaplugin DESTINATION ${CMAKE_INSTALL_LIBDIR}/qt/plugins/designer)
+endif()
+
+include(GNUInstallDirs)
+install(TARGETS QScintilla
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(DIRECTORY src/Qsci DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+file(GLOB TRANSLATION_FILES src/qscintilla_*.qm)
+install(FILES ${TRANSLATION_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/translations)
+if(BUILD_SHARED_LIBS)
+    install(FILES src/features/qscintilla2.prf DESTINATION ${CMAKE_INSTALL_DATADIR}/mkspecs/features)
+else()
+    install(FILES src/features_staticlib/qscintilla2.prf DESTINATION ${CMAKE_INSTALL_DATADIR}/mkspecs/features)
+endif()

--- a/recipes/qscintilla/all/CMakeLists.txt
+++ b/recipes/qscintilla/all/CMakeLists.txt
@@ -3,8 +3,13 @@ cmake_minimum_required(VERSION 3.15)
 project(QScintilla LANGUAGES CXX)
 
 option(QSCINTILLA_BUILD_DESIGNER_PLUGIN "Build the QScintilla designer plugin" OFF)
-option(CMAKE_POSITION_INDEPENDENT_CODE "Generate position-independent code" ON)
-option(CMAKE_CXX_STANDARD "C++ standard to use" 11)
+
+if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
 set(CMAKE_AUTOMOC ON)
 
 find_package(Qt6 REQUIRED)

--- a/recipes/qscintilla/all/CMakeLists.txt
+++ b/recipes/qscintilla/all/CMakeLists.txt
@@ -3,13 +3,8 @@ cmake_minimum_required(VERSION 3.15)
 project(QScintilla LANGUAGES CXX)
 
 option(QSCINTILLA_BUILD_DESIGNER_PLUGIN "Build the QScintilla designer plugin" OFF)
-
-if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-endif()
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-endif()
+option(CMAKE_POSITION_INDEPENDENT_CODE "Generate position-independent code" ON)
+option(CMAKE_CXX_STANDARD "C++ standard to use" 11)
 set(CMAKE_AUTOMOC ON)
 
 find_package(Qt6 REQUIRED)

--- a/recipes/qscintilla/all/conandata.yml
+++ b/recipes/qscintilla/all/conandata.yml
@@ -1,0 +1,14 @@
+sources:
+  "2.14.1":
+    url: "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.14.0/QScintilla_src-2.14.0.tar.gz"
+    sha256: "449353928340300804c47b3785c3e62096f918a723d5eed8a5439764e6507f4c"
+patches:
+  "2.14.1":
+    - patch_file: "patches/0004-remove-logo-privacy-issue.patch"
+      patch_description: "Fix logo privacy issue"
+      patch_type: "conan"
+      patch_source: "https://salsa.debian.org/python-team/packages/qscintilla2/-/blob/debian/2.14.1+dfsg-1/debian/patches/0004-remove-logo-privacy-issue.diff.patch"
+    - patch_file: "patches/0010-Add-import-QUrl.patch"
+      patch_description: "Add QUrl include"
+      patch_type: "bugfix"
+      patch_source: "https://salsa.debian.org/python-team/packages/qscintilla2/-/blob/debian/2.14.1+dfsg-1/debian/patches/0010-Add-import-QUrl.patch"

--- a/recipes/qscintilla/all/conandata.yml
+++ b/recipes/qscintilla/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.14.1":
-    url: "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.14.0/QScintilla_src-2.14.0.tar.gz"
-    sha256: "449353928340300804c47b3785c3e62096f918a723d5eed8a5439764e6507f4c"
+    url: "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.14.1/QScintilla_src-2.14.1.tar.gz"
+    sha256: "dfe13c6acc9d85dfcba76ccc8061e71a223957a6c02f3c343b30a9d43a4cdd4d"
 patches:
   "2.14.1":
     - patch_file: "patches/0004-remove-logo-privacy-issue.patch"

--- a/recipes/qscintilla/all/conanfile.py
+++ b/recipes/qscintilla/all/conanfile.py
@@ -1,0 +1,102 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+
+required_conan_version = ">=1.60.0 <2.0 || >=2.0.5"
+
+
+class QScintillaConan(ConanFile):
+    name = "qscintilla"
+    description = "QScintilla is a Qt port of the Scintilla text editing component"
+    license = "GPL-3.0-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://riverbankcomputing.com/software/qscintilla"
+    topics = ("qt", "scintilla", "text-editor", "widget")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 11
+
+    def export_sources(self):
+        export_conandata_patches(self)
+        copy(self, "CMakeLists.txt", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.options["qt"].widgets = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("qt/[>=6.7.1 <7]", transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        if not self.dependencies["qt"].options.widgets:
+            raise ConanInvalidConfiguration("QScintilla requires -o qt/*:widgets=True")
+
+    def build_requirements(self):
+        self.tool_requires("qt/<host_version>")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        VirtualBuildEnv(self).generate()
+        tc = CMakeToolchain(self)
+        tc.cache_variables["QSCINTILLA_BUILD_DESIGNER_PLUGIN"] = self.dependencies["qt"].options.qttools
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        qt_major = self.dependencies["qt"].ref.version.major
+        lib_name = f"qscintilla2_qt{qt_major}"
+        if self.settings.build_type == "Debug":
+            if is_apple_os(self):
+                lib_name += "_debug"
+            elif self.settings.os == "Windows":
+                lib_name += "d"
+        if not self.options.shared:
+            lib_name += "_static"
+        self.cpp_info.libs = [lib_name]
+
+        self.cpp_info.requires = ["qt::qtWidgets"]
+        if self.settings.os != "iOS":
+            self.cpp_info.requires.append("qt::qtPrintSupport")
+        if qt_major == 5 and is_apple_os(self):
+            self.cpp_info.frameworks.extend(["qtMacExtras"])

--- a/recipes/qscintilla/all/conanfile.py
+++ b/recipes/qscintilla/all/conanfile.py
@@ -3,11 +3,11 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
-from conan.tools.build import check_min_cppstd, can_run
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 
-required_conan_version = ">=2.0.5"
+required_conan_version = ">=2.0.9"
 
 
 class QScintillaConan(ConanFile):
@@ -27,25 +27,17 @@ class QScintillaConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
+    implements = ["auto_shared_fpic"]
 
     def export_sources(self):
         export_conandata_patches(self)
         copy(self, "CMakeLists.txt", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
-        self.options["qt"].widgets = True
-
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("qt/[>=6.7.1 <7]", transitive_headers=True, transitive_libs=True, run=can_run(self))
+        self.requires("qt/[>=6.7.1 <7]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         check_min_cppstd(self, 11)
@@ -53,11 +45,12 @@ class QScintillaConan(ConanFile):
             raise ConanInvalidConfiguration("QScintilla requires -o qt/*:widgets=True")
 
     def build_requirements(self):
-        if not can_run(self):
-            self.tool_requires("qt/<host_version>")
+        self.tool_requires("cmake/[>=3.27 <4]")
+        self.tool_requires("qt/<host_version>")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -67,7 +60,6 @@ class QScintillaConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/qscintilla/all/patches/0004-remove-logo-privacy-issue.patch
+++ b/recipes/qscintilla/all/patches/0004-remove-logo-privacy-issue.patch
@@ -1,0 +1,49 @@
+From: SVN-Git Migration <python-modules-team@lists.alioth.debian.org>
+Date: Thu, 8 Oct 2015 13:39:18 -0700
+Subject: remove-logo-privacy-issue.diff
+
+Remove use of http://www.scintilla.org/SciBreak.jpg when the SCintilla docs
+are accessed to resolve privacy-breach-logo lintian error.  Not forwarded, not
+needed.
+
+Patch-Name: remove-logo-privacy-issue.diff
+---
+ doc/Scintilla/index.html | 12 ++----------
+ 1 file changed, 2 insertions(+), 10 deletions(-)
+
+diff --git a/doc/Scintilla/index.html b/doc/Scintilla/index.html
+index 208b1ce..2831ab5 100644
+--- a/doc/Scintilla/index.html
++++ b/doc/Scintilla/index.html
+@@ -64,13 +64,6 @@
+         </td>
+       </tr>
+     </table>
+-    <table bgcolor="#000000" width="100%" cellspacing="0" cellpadding="0" border="0">
+-      <tr>
+-        <td width="100%" style="background: url(https://www.scintilla.org/SciBreak.jpg) no-repeat;height:150px;">
+-          &nbsp;
+-        </td>
+-      </tr>
+-    </table>
+     <ul id="versionlist">
+       <li>Version 3.7.5 adds a Reverse Selected Lines command.
+       MSVC 2013 is no longer supported.</li>
+@@ -177,15 +170,14 @@ hosted on
+ <!--
+ if (IsRemote()) {
+     document.write('<a href="https://sourceforge.net/projects/scintilla/">');
+-    document.write('<img src="https://sflogo.sourceforge.net/sflogo.php?group_id=2439&amp;type=8" width="80" height="15" alt="Get Scintilla at SourceForge.net. Fast, secure and Free Open Source software downloads" /></a> ');
+ } else {
+     document.write('<a href="https://sourceforge.net/projects/scintilla/">SourceForge<\/a>');
+ }
+ //-->
+ </script>
+ <noscript>
+-<a href="https://sourceforge.net/projects/scintilla/">
+-<img src="https://sflogo.sourceforge.net/sflogo.php?group_id=2439&amp;type=8" width="80" height="15" alt="Get Scintilla at SourceForge.net. Fast, secure and Free Open Source software downloads" /></a>
++<a href="http://sourceforge.net/projects/scintilla">
++Get Scintilla at SourceForge.net. Fast, secure and Free Open Source software downloads</a>
+ </noscript>
+   </body>
+ </html>

--- a/recipes/qscintilla/all/patches/0010-Add-import-QUrl.patch
+++ b/recipes/qscintilla/all/patches/0010-Add-import-QUrl.patch
@@ -1,0 +1,33 @@
+From: "Gudjon I. Gudjonsson" <gudjon@gudjon.org>
+Date: Mon, 26 Aug 2019 06:49:17 +0200
+Subject: Add import QUrl
+
+---
+ src/Qsci/qsciscintilla.h     | 1 +
+ src/Qsci/qsciscintillabase.h | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/Qsci/qsciscintilla.h b/src/Qsci/qsciscintilla.h
+index c8f1eee..31a5529 100644
+--- a/src/Qsci/qsciscintilla.h
++++ b/src/Qsci/qsciscintilla.h
+@@ -22,6 +22,7 @@
+ #ifndef QSCISCINTILLA_H
+ #define QSCISCINTILLA_H
+ 
++#include <QUrl>
+ #include <QByteArray>
+ #include <QList>
+ #include <QObject>
+diff --git a/src/Qsci/qsciscintillabase.h b/src/Qsci/qsciscintillabase.h
+index a253b11..1b1f8b6 100644
+--- a/src/Qsci/qsciscintillabase.h
++++ b/src/Qsci/qsciscintillabase.h
+@@ -23,6 +23,7 @@
+ 
+ #include <qglobal.h>
+ 
++#include <QUrl>
+ #include <QAbstractScrollArea>
+ #include <QByteArray>
+ #include <QPoint>

--- a/recipes/qscintilla/all/test_package/CMakeLists.txt
+++ b/recipes/qscintilla/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(qscintilla REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE qscintilla::qscintilla)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/qscintilla/all/test_package/conanfile.py
+++ b/recipes/qscintilla/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/qscintilla/all/test_package/conanfile.py
+++ b/recipes/qscintilla/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/qscintilla/all/test_package/test_package.cpp
+++ b/recipes/qscintilla/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <Qsci/qsciscintilla.h>
+
+void dummy() {
+    QsciScintilla editor;
+}
+
+int main() { }

--- a/recipes/qscintilla/config.yml
+++ b/recipes/qscintilla/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.14.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **qscintilla/2.14.1**

#### Motivation
QScintilla is a Qt port of the Scintilla text editing component.

https://www.riverbankcomputing.com/software/qscintilla

Source mirror: https://github.com/brCreate/QScintilla

[![Packaging status](https://repology.org/badge/tiny-repos/qscintilla.svg)](https://repology.org/project/qscintilla/versions)

#### Details
I initially tried to make the recipe work with the `src/scintilla.pro` qmake file, but I kept running into issues with the build flags (such as the compiler executable path) not being respected. At the same time, propagating the standard Conan build flags and profile details through an ad-hoc qmake generator was not much simpler or shorter than rewriting it as a CMake project, so I went with the latter option.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan