### PR TITLE
curlpp: add recipe

### DIFF
--- a/recipes/curlpp/all/conandata.yml
+++ b/recipes/curlpp/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "0.8.1.cci.20240530":
+    url: "https://github.com/jpbarrette/curlpp/archive/8840ec806a75a6def9ed07845a620f6d170e5821.tar.gz"
+    sha256: "1260326d966ec75a50feccb5411268f9aeca667d97f8132973bdb0783ecceb3c"
+patches:
+  "0.8.1.cci.20240530":
+    - patch_file: "patches/0001-disable-static-on-shared.patch"
+      patch_description: "disable building static library on shared=True"
+      patch_type: "conan"

--- a/recipes/curlpp/all/conandata.yml
+++ b/recipes/curlpp/all/conandata.yml
@@ -10,3 +10,6 @@ patches:
     - patch_file: "patches/0002-disable-cpp11.patch"
       patch_description: "disable specifying C++11"
       patch_type: "conan"
+    - patch_file: "patches/0003-replace-project-declaration.patch"
+      patch_description: "switch positions between project() and cmake_minimum_required()"
+      patch_type: "conan"

--- a/recipes/curlpp/all/conandata.yml
+++ b/recipes/curlpp/all/conandata.yml
@@ -7,3 +7,6 @@ patches:
     - patch_file: "patches/0001-disable-static-on-shared.patch"
       patch_description: "disable building static library on shared=True"
       patch_type: "conan"
+    - patch_file: "patches/0002-disable-cpp11.patch"
+      patch_description: "disable specifying C++11"
+      patch_type: "conan"

--- a/recipes/curlpp/all/conanfile.py
+++ b/recipes/curlpp/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, rm
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 import os
 
 required_conan_version = ">=1.53.0"
@@ -83,7 +84,7 @@ class CurlppConan(ConanFile):
         rm(self, "curlpp-config", os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
-        self.cpp_info.libs = ["curlpp"]
+        self.cpp_info.libs = ["libcurlpp" if is_msvc(self) and not self.options.shared else "curlpp"]
 
         self.cpp_info.set_property("cmake_file_name", "curlpp")
         self.cpp_info.set_property("cmake_target_name", "curlpp::curlpp")

--- a/recipes/curlpp/all/conanfile.py
+++ b/recipes/curlpp/all/conanfile.py
@@ -1,7 +1,9 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, rm
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -49,6 +51,8 @@ class CurlppConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
+        elif self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6":
+            raise ConanInvalidConfiguration("${self.ref} requires C++11. Please set 'compiler.cppstd=11'.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/curlpp/all/conanfile.py
+++ b/recipes/curlpp/all/conanfile.py
@@ -51,8 +51,11 @@ class CurlppConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-        elif self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6":
-            raise ConanInvalidConfiguration("${self.ref} requires C++11. Please set 'compiler.cppstd=11'.")
+        else:
+            if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6":
+                raise ConanInvalidConfiguration("${self.ref} requires C++11. Please set 'compiler.cppstd=11'.")
+            if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "14":
+                raise ConanInvalidConfiguration("${self.ref} requires C++11. Please set 'compiler.cppstd=11'.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/curlpp/all/conanfile.py
+++ b/recipes/curlpp/all/conanfile.py
@@ -44,7 +44,7 @@ class CurlppConan(ConanFile):
 
     def requirements(self):
         # As it's a wrapper, it includes curl symbols in its public headers 
-        self.requires("libcurl/8.9.1", transitive_headers=True, transitive_libs=True)
+        self.requires("libcurl/8.10.0", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -56,6 +56,7 @@ class CurlppConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["CURLPP_BUILD_SHARED_LIBS"] = self.options.shared
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/curlpp/all/conanfile.py
+++ b/recipes/curlpp/all/conanfile.py
@@ -43,7 +43,8 @@ class CurlppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libcurl/8.9.1", transitive_headers=True)
+        # As it's a wrapper, it includes curl symbols in its public headers 
+        self.requires("libcurl/8.9.1", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/curlpp/all/conanfile.py
+++ b/recipes/curlpp/all/conanfile.py
@@ -43,8 +43,8 @@ class CurlppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # As it's a wrapper, it includes curl symbols in its public headers 
-        self.requires("libcurl/8.10.0", transitive_headers=True, transitive_libs=True)
+        # As it's a wrapper, it includes curl symbols in its public headers
+        self.requires("libcurl/8.9.1", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -56,7 +56,6 @@ class CurlppConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["CURLPP_BUILD_SHARED_LIBS"] = self.options.shared
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/curlpp/all/conanfile.py
+++ b/recipes/curlpp/all/conanfile.py
@@ -43,7 +43,7 @@ class CurlppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libcurl/8.9.1")
+        self.requires("libcurl/8.9.1", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/curlpp/all/conanfile.py
+++ b/recipes/curlpp/all/conanfile.py
@@ -1,0 +1,81 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, rm
+import os
+
+required_conan_version = ">=1.53.0"
+
+class CurlppConan(ConanFile):
+    name = "curlpp"
+    description = "C++ wrapper around libcURL"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/jpbarrette/curlpp"
+    topics = ("curl", "libcurl")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 11
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("libcurl/8.9.1")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["CURLPP_BUILD_SHARED_LIBS"] = self.options.shared
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", os.path.join(self.source_folder, "doc"), os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "curlpp-config", os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["curlpp"]
+
+        self.cpp_info.set_property("cmake_file_name", "curlpp")
+        self.cpp_info.set_property("cmake_target_name", "curlpp::curlpp")

--- a/recipes/curlpp/all/patches/0001-disable-static-on-shared.patch
+++ b/recipes/curlpp/all/patches/0001-disable-static-on-shared.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4f550b5..ca97e64 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -108,7 +108,7 @@ if(CURLPP_BUILD_SHARED_LIBS)
+    target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+    target_link_libraries(${PROJECT_NAME} PUBLIC CURL::libcurl ${CONAN_LIBS})
+    set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1 VERSION 1.0.0)
+-endif()
++else()
+ 
+ add_library(${PROJECT_NAME}_static STATIC ${HeaderFileList} ${SourceFileList})
+ add_library(${PROJECT_NAME}::${PROJECT_NAME}_static ALIAS ${PROJECT_NAME}_static)
+@@ -126,16 +126,16 @@ SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME ${PROJECT_NA
+ # so we add a "lib" prefix (which is default on other platforms anyway):
+ SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES PREFIX "lib")
+ target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
+-
++endif()
+ # install headers
+ install(FILES "${PROJECT_SOURCE_DIR}/cmake/curlppConfig.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/curlpp")
+ install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
+ if(CURLPP_BUILD_SHARED_LIBS)
+   install(TARGETS curlpp EXPORT curlppTargets INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-endif()
++else()
+   install(TARGETS curlpp_static EXPORT curlppTargets INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-  
++endif()
+ install(
+     EXPORT curlppTargets
+     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/curlpp"

--- a/recipes/curlpp/all/patches/0001-disable-static-on-shared.patch
+++ b/recipes/curlpp/all/patches/0001-disable-static-on-shared.patch
@@ -14,8 +14,9 @@ index 4f550b5..ca97e64 100644
 @@ -126,16 +126,16 @@ SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES OUTPUT_NAME ${PROJECT_NA
  # so we add a "lib" prefix (which is default on other platforms anyway):
  SET_TARGET_PROPERTIES(${PROJECT_NAME}_static PROPERTIES PREFIX "lib")
- target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
+-target_link_libraries(${PROJECT_NAME}_static ${CURL_LIBRARIES} ${CONAN_LIBS})
 -
++target_link_libraries(${PROJECT_NAME}_static CURL::libcurl ${CONAN_LIBS})
 +endif()
  # install headers
  install(FILES "${PROJECT_SOURCE_DIR}/cmake/curlppConfig.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/curlpp")

--- a/recipes/curlpp/all/patches/0002-disable-cpp11.patch
+++ b/recipes/curlpp/all/patches/0002-disable-cpp11.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ca97e64..bdb257e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,7 +22,7 @@ if(WIN32)
+     cmake_minimum_required(VERSION 3.4)
+ 
+     # c++ 11 support from cmake 3.4 or newer
+-    set(CMAKE_CXX_STANDARD 11) # C++11...
++    # set(CMAKE_CXX_STANDARD 11) # C++11...
+     set(CMAKE_CXX_STANDARD_REQUIRED ON) #...is required...
+     set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
+ 
+@@ -43,10 +43,10 @@ if(WIN32)
+         #
+         # for non-windows platform we try to keep cmake 2.8 support
+         # since entreprise distribution tends to have 2.8 version.
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
++        # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+     else()
+         # c++ 11 support from cmake 3.1 or newer
+-        set(CMAKE_CXX_STANDARD 11) # C++11...
++        # set(CMAKE_CXX_STANDARD 11) # C++11...
+         set(CMAKE_CXX_STANDARD_REQUIRED ON) #...is required...
+         set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
+     endif()

--- a/recipes/curlpp/all/patches/0003-replace-project-declaration.patch
+++ b/recipes/curlpp/all/patches/0003-replace-project-declaration.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bfba06b..7f4c6fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,3 @@
+-project(curlpp)
+-
+-
+ # In response to CMake 3.0 generating warnings regarding policy CMP0042,
+ # the OSX RPATH settings have been updated per recommendations found
+ # in the CMake Wiki:
+@@ -52,6 +49,7 @@ if(WIN32)
+     endif()
+ endif()
+ 
++project(curlpp)
+ 
+ # Conan.io integration
+ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)

--- a/recipes/curlpp/all/test_package/CMakeLists.txt
+++ b/recipes/curlpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(curlpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE curlpp::curlpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/curlpp/all/test_package/conanfile.py
+++ b/recipes/curlpp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/curlpp/all/test_package/test_package.cpp
+++ b/recipes/curlpp/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+
+#include <curlpp/cURLpp.hpp>
+#include <curlpp/Easy.hpp>
+#include <curlpp/Options.hpp>
+
+using namespace curlpp::options;
+
+int main(int, char **) {
+    curlpp::Easy myRequest;
+	myRequest.setOpt<curlpp::options::Url>("http://example.com");
+}

--- a/recipes/curlpp/config.yml
+++ b/recipes/curlpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.8.1.cci.20240530":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **curlpp/0.8.1.cci.20240530**

#### Motivation
curlpp is required by [minio-cpp](https://github.com/minio/minio-cpp).
I want to add minio-cpp to cci.

#### Details
https://github.com/jpbarrette/curlpp

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
