### PR TITLE
[libpng/1.6.44] Add a new version of libpng

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.44":
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.44/libpng-1.6.44.tar.xz"
+    sha256: "60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e"
   "1.6.43":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.43/libpng-1.6.43.tar.xz"
     sha256: "6a5ca0652392a2d7c9db2ae5b40210843c0bbc081cbd410825ab00cc59f14a6c"

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -149,6 +149,7 @@ class LibpngConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "libpng"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.cmake", os.path.join(self.package_folder, "lib", "cmake", "PNG"))
 
     def package_info(self):
         major_min_version = f"{Version(self.version).major}{Version(self.version).minor}"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.44":
+    folder: all
   "1.6.43":
     folder: all
   "1.6.42":


### PR DESCRIPTION

Changes from version 1.6.43 to version 1.6.44
---------------------------------------------

 * Hardened calculations in chroma handling to prevent overflows, and
   relaxed a constraint in cHRM validation to accomodate the standard
   ACES AP1 set of color primaries.
   (Contributed by John Bowler)
 * Removed the ASM implementation of ARM Neon optimizations and updated
   the build accordingly. Only the remaining C implementation shall be
   used from now on, thus ensuring the support of the PAC/BTI security
   features on ARM64.
   (Contributed by Ross Burton and John Bowler)
 * Fixed the pickup of the PNG_HARDWARE_OPTIMIZATIONS option in the
   CMake build on FreeBSD/amd64. This is an important performance fix
   on this platform.
 * Applied various fixes and improvements to the CMake build.
   (Contributed by Eric Riff, Benjamin Buch and Erik Scholz)
 * Added fuzzing targets for the simplified read API.
   (Contributed by Mikhail Khachayants)
 * Fixed a build error involving pngtest.c under a custom config.
   This was a regression introduced in a code cleanup in libpng-1.6.43.
   (Contributed by Ben Wagner)
 * Fixed and improved the config files for AppVeyor CI and Travis CI.



### Summary
Changes to recipe:  **libpng/1.6.44*

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
A new release of libpng is available
[libpng 1.6.44 announcement](https://raw.githubusercontent.com/pnggroup/libpng/v1.6.44/ANNOUNCE)

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
