### PR TITLE
pybind11: add version 2.13.6

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.13.6":
+    url: "https://github.com/pybind/pybind11/archive/v2.13.6.tar.gz"
+    sha256: "e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20"
   "2.13.5":
     url: "https://github.com/pybind/pybind11/archive/v2.13.5.tar.gz"
     sha256: "b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252"

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.13.6":
+    folder: all
   "2.13.5":
     folder: all
   "2.13.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **pybind11/2.13.6**

#### Motivation
There are several new features in 2.13.6.

#### Details
https://github.com/pybind/pybind11/compare/v2.13.5...v2.13.6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
