### PR TITLE
debug-assert: add version 1.3.4

### DIFF
--- a/recipes/debug_assert/all/conandata.yml
+++ b/recipes/debug_assert/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
-  '1.3.3':
-    url: https://github.com/foonathan/debug_assert/archive/v1.3.3.zip
-    sha256: c0871c7bb8d7e0f36cfae9a5ba526ea0c0fcaa41203ffb4280de27cb030e7383
+  "1.3.4":
+    url: "https://github.com/foonathan/debug_assert/archive/v1.3.4.zip"
+    sha256: "e29925b1b51e10b46e8c4f3d57a86db6a7ebc7cdec53fe30c1b0ca22ef845f43"
+  "1.3.3":
+    url: "https://github.com/foonathan/debug_assert/archive/v1.3.3.zip"
+    sha256: "c0871c7bb8d7e0f36cfae9a5ba526ea0c0fcaa41203ffb4280de27cb030e7383"

--- a/recipes/debug_assert/config.yml
+++ b/recipes/debug_assert/config.yml
@@ -1,3 +1,5 @@
 versions:
-  '1.3.3':
+  "1.3.4":
+    folder: all
+  "1.3.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **debug-assert/1.3.4**

#### Motivation
There are several improvements in 1.3.4.

#### Details
https://github.com/foonathan/debug_assert/compare/v1.3.3...v1.3.4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
