### PR TITLE
add new recipe ann/1.1.2

### DIFF
--- a/recipes/ann/all/CMakeLists.txt
+++ b/recipes/ann/all/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.15)
+project(ANN LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+file(GLOB ANN_SRC_FILES ${ANN_SRC_DIR}/src/*.cpp)
+
+add_library(ANN ${ANN_SRC_FILES})
+target_include_directories(ANN PUBLIC ${ANN_SRC_DIR}/include)
+
+if(WIN32)
+    if(BUILD_SHARED_LIBS)
+        set_target_properties(ANN PROPERTIES
+            CXX_VISIBILITY_PRESET hidden
+            VISIBILITY_INLINES_HIDDEN TRUE
+        )
+        target_compile_definitions(ANN PRIVATE DLL_EXPORTS)
+    else()
+        target_compile_definitions(ANN PUBLIC ANN_STATIC)
+    endif()
+endif()
+
+install(DIRECTORY ${ANN_SRC_DIR}/include/ANN DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(
+    TARGETS ANN
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/recipes/ann/all/conandata.yml
+++ b/recipes/ann/all/conandata.yml
@@ -1,0 +1,12 @@
+sources:
+  "1.1.2":
+    url: "https://www.cs.umd.edu/~mount/ANN/Files/1.1.2/ann_1.1.2.tar.gz"
+    sha256: "eea03f2e224b66813226d775053316675375dcec45bd263674c052d9324a49a5"
+patches:
+  "1.1.2":
+    - patch_file: "patches/1.1.2-0001-fix-windows-static.patch"
+      patch_description: "Fix windows static"
+      patch_type: "portability"
+    - patch_file: "patches/1.1.2-0002-fix-cppstd17+-register-keyword.patch"
+      patch_description: "Fix compilation with C++17 (or above) standard, by removing register keyword"
+      patch_type: "portability"

--- a/recipes/ann/all/conanfile.py
+++ b/recipes/ann/all/conanfile.py
@@ -1,0 +1,69 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class AnnConan(ConanFile):
+    name = "ann"
+    description = (
+        "ANN is a library written in C++, which supports data structures and "
+        "algorithms for both exact and approximate nearest neighbor searching "
+        "in arbitrarily high dimensions."
+    )
+    license = "LGPL-2.1-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.cs.umd.edu/~mount/ANN"
+    topics = ("nns", "nearest-neighbor-search")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def export_sources(self):
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ANN_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        cmake.build()
+
+    def package(self):
+        for license_file in ("Copyright.txt", "License.txt"):
+            copy(self, license_file, src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["ANN"]
+        if self.settings.os == "Windows" and not self.options.shared:
+            self.cpp_info.defines.append("ANN_STATIC")

--- a/recipes/ann/all/conanfile.py
+++ b/recipes/ann/all/conanfile.py
@@ -67,3 +67,5 @@ class AnnConan(ConanFile):
         self.cpp_info.libs = ["ANN"]
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.defines.append("ANN_STATIC")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")

--- a/recipes/ann/all/patches/1.1.2-0001-fix-windows-static.patch
+++ b/recipes/ann/all/patches/1.1.2-0001-fix-windows-static.patch
@@ -1,0 +1,11 @@
+--- a/include/ANN/ANN.h
++++ b/include/ANN/ANN.h
+@@ -59,7 +59,7 @@
+ #ifndef ANN_H
+ #define ANN_H
+ 
+-#ifdef WIN32
++#if defined(_WIN32) && !defined(ANN_STATIC)
+   //----------------------------------------------------------------------
+   // For Microsoft Visual C++, externally accessible symbols must be
+   // explicitly indicated with DLL_API, which is somewhat like "extern."

--- a/recipes/ann/all/patches/1.1.2-0002-fix-cppstd17+-register-keyword.patch
+++ b/recipes/ann/all/patches/1.1.2-0002-fix-cppstd17+-register-keyword.patch
@@ -1,0 +1,141 @@
+--- a/src/ANN.cpp
++++ b/src/ANN.cpp
+@@ -48,9 +48,9 @@ ANNdist annDist(						// interpoint squared distance
+ 	ANNpoint			p,
+ 	ANNpoint			q)
+ {
+-	register int d;
+-	register ANNcoord diff;
+-	register ANNcoord dist;
++	int d;
++	ANNcoord diff;
++	ANNcoord dist;
+ 
+ 	dist = 0;
+ 	for (d = 0; d < dim; d++) {
+--- a/src/kd_fix_rad_search.cpp
++++ b/src/kd_fix_rad_search.cpp
+@@ -147,11 +147,11 @@ void ANNkd_split::ann_FR_search(ANNdist box_dist)
+ 
+ void ANNkd_leaf::ann_FR_search(ANNdist box_dist)
+ {
+-	register ANNdist dist;				// distance to data point
+-	register ANNcoord* pp;				// data coordinate pointer
+-	register ANNcoord* qq;				// query coordinate pointer
+-	register ANNcoord t;
+-	register int d;
++	ANNdist dist;				// distance to data point
++	ANNcoord* pp;				// data coordinate pointer
++	ANNcoord* qq;				// query coordinate pointer
++	ANNcoord t;
++	int d;
+ 
+ 	for (int i = 0; i < n_pts; i++) {	// check points in bucket
+ 
+--- a/src/kd_pr_search.cpp
++++ b/src/kd_pr_search.cpp
+@@ -180,12 +180,12 @@ void ANNkd_split::ann_pri_search(ANNdist box_dist)
+ 
+ void ANNkd_leaf::ann_pri_search(ANNdist box_dist)
+ {
+-	register ANNdist dist;				// distance to data point
+-	register ANNcoord* pp;				// data coordinate pointer
+-	register ANNcoord* qq;				// query coordinate pointer
+-	register ANNdist min_dist;			// distance to k-th closest point
+-	register ANNcoord t;
+-	register int d;
++	ANNdist dist;				// distance to data point
++	ANNcoord* pp;				// data coordinate pointer
++	ANNcoord* qq;				// query coordinate pointer
++	ANNdist min_dist;			// distance to k-th closest point
++	ANNcoord t;
++	int d;
+ 
+ 	min_dist = ANNprPointMK->max_key(); // k-th smallest distance so far
+ 
+--- a/src/kd_search.cpp
++++ b/src/kd_search.cpp
+@@ -171,12 +171,12 @@ void ANNkd_split::ann_search(ANNdist box_dist)
+ 
+ void ANNkd_leaf::ann_search(ANNdist box_dist)
+ {
+-	register ANNdist dist;				// distance to data point
+-	register ANNcoord* pp;				// data coordinate pointer
+-	register ANNcoord* qq;				// query coordinate pointer
+-	register ANNdist min_dist;			// distance to k-th closest point
+-	register ANNcoord t;
+-	register int d;
++	ANNdist dist;				// distance to data point
++	ANNcoord* pp;				// data coordinate pointer
++	ANNcoord* qq;				// query coordinate pointer
++	ANNdist min_dist;			// distance to k-th closest point
++	ANNcoord t;
++	int d;
+ 
+ 	min_dist = ANNkdPointMK->max_key(); // k-th smallest distance so far
+ 
+--- a/src/kd_util.cpp
++++ b/src/kd_util.cpp
+@@ -127,10 +127,10 @@ ANNdist annBoxDistance(			// compute distance from point to box
+ 	const ANNpoint		hi,				// high point of box
+ 	int					dim)			// dimension of space
+ {
+-	register ANNdist dist = 0.0;		// sum of squared distances
+-	register ANNdist t;
++	ANNdist dist = 0.0;		// sum of squared distances
++	ANNdist t;
+ 
+-	for (register int d = 0; d < dim; d++) {
++	for (int d = 0; d < dim; d++) {
+ 		if (q[d] < lo[d]) {				// q is left of box
+ 			t = ANNdist(lo[d]) - ANNdist(q[d]);
+ 			dist = ANN_SUM(dist, ANN_POW(t));
+@@ -238,8 +238,8 @@ void annMedianSplit(
+ 	int l = 0;							// left end of current subarray
+ 	int r = n-1;						// right end of current subarray
+ 	while (l < r) {
+-		register int i = (r+l)/2;		// select middle as pivot
+-		register int k;
++		int i = (r+l)/2;		// select middle as pivot
++		int k;
+ 
+ 		if (PA(i,d) > PA(r,d))			// make sure last > pivot
+ 			PASWAP(i,r)
+--- a/src/pr_queue.h
++++ b/src/pr_queue.h
+@@ -86,9 +86,9 @@ public:
+ 		PQinfo inf)						// item info
+ 		{
+ 			if (++n > max_size) annError("Priority queue overflow.", ANNabort);
+-			register int r = n;
++			int r = n;
+ 			while (r > 1) {				// sift up new item
+-				register int p = r/2;
++				int p = r/2;
+ 				ANN_FLOP(1)				// increment floating ops
+ 				if (pq[p].key <= kv)	// in proper order
+ 					break;
+@@ -105,9 +105,9 @@ public:
+ 		{
+ 			kv = pq[1].key;				// key of min item
+ 			inf = pq[1].info;			// information of min item
+-			register PQkey kn = pq[n--].key;// last item in queue
+-			register int p = 1;			// p points to item out of position
+-			register int r = p<<1;		// left child of p
++			PQkey kn = pq[n--].key;// last item in queue
++			int p = 1;			// p points to item out of position
++			int r = p<<1;		// left child of p
+ 			while (r <= n) {			// while r is still within the heap
+ 				ANN_FLOP(2)				// increment floating ops
+ 										// set r to smaller child of p
+--- a/src/pr_queue_k.h
++++ b/src/pr_queue_k.h
+@@ -100,7 +100,7 @@ public:
+ 		PQKkey kv,						// key value
+ 		PQKinfo inf)					// item info
+ 		{
+-			register int i;
++			int i;
+ 										// slide larger values up
+ 			for (i = n; i > 0; i--) {
+ 				if (mk[i-1].key > kv)

--- a/recipes/ann/all/test_package/CMakeLists.txt
+++ b/recipes/ann/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(ann REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE ann::ann)

--- a/recipes/ann/all/test_package/conanfile.py
+++ b/recipes/ann/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/ann/all/test_package/test_package.cpp
+++ b/recipes/ann/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <ANN/ANN.h>
+
+int main() {
+    ANNpoint queryPt = annAllocPt(2);
+    return 0;
+}

--- a/recipes/ann/config.yml
+++ b/recipes/ann/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.2":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **ann/1.1.2**

#### Motivation
Add ANN library to conancenter.

#### Details

- Upstream there are some raw Makefiles and a vcproj file (only for DLL, not static). I've written a simple CMakeLists instead (library is very simple to compile), so that it can be more portable.
- A small fix is needed for static lib on windows in order to avoid dllexport/dllimport. So a `ANN_STATIC` definition is introduced, it must be defined at build & consume time if windows & static.
- Another fix is needed for compilation with C++17 or above: there are `register` keyword in front of several variables in source code (several cpp files & private headers, no fix required in public headers). It's useless and not supported at all since C++17.
- The latest version is from 2010, so I don't hope any backport of these patches upstream.

Closes https://github.com/conan-io/conan-center-index/issues/25263

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
