### PR TITLE
[vulkan-validationlayers] Add support for Android

### DIFF
--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -92,7 +92,7 @@ class VulkanValidationLayersConan(ConanFile):
             del self.options.with_wsi_xcb
             del self.options.with_wsi_xlib
             del self.options.with_wsi_wayland
-        elif self.settings.os == "Windows":
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def layout(self):

--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -255,3 +255,6 @@ class VulkanValidationLayersConan(ConanFile):
 
         # TODO: to remove after conan v2, it allows to not break consumers still relying on virtualenv generator
         self.env_info.VK_LAYER_PATH.append(vk_layer_path)
+
+        if self.settings.os == "Android":
+            self.cpp_info.system_libs.extend(["android", "log"])

--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -163,6 +163,7 @@ class VulkanValidationLayersConan(ConanFile):
         elif self.settings.os == "Android":
             tc.variables["BUILD_WSI_XCB_SUPPORT"] = False
             tc.variables["BUILD_WSI_XLIB_SUPPORT"] = False
+            tc.variables["BUILD_WSI_WAYLAND_SUPPORT"] = False
         tc.variables["BUILD_WERROR"] = False
         tc.variables["BUILD_TESTS"] = False
         tc.variables["INSTALL_TESTS"] = False

--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -26,11 +26,13 @@ class VulkanValidationLayersConan(ConanFile):
     package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
+        "fPIC": [True, False],
         "with_wsi_xcb": [True, False],
         "with_wsi_xlib": [True, False],
         "with_wsi_wayland": [True, False],
     }
     default_options = {
+        "fPIC": True,
         "with_wsi_xcb": True,
         "with_wsi_xlib": True,
         "with_wsi_wayland": True,
@@ -90,6 +92,8 @@ class VulkanValidationLayersConan(ConanFile):
             del self.options.with_wsi_xcb
             del self.options.with_wsi_xlib
             del self.options.with_wsi_wayland
+        elif self.settings.os == "Windows":
+            del self.options.fPIC
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -198,6 +202,9 @@ class VulkanValidationLayersConan(ConanFile):
             # https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/a26638ae9fdd8c40b56d4c7b72859a5b9a0952c9
             replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                         "VkLayer_utils PUBLIC Vulkan::Headers", "VkLayer_utils PUBLIC Vulkan::Headers -landroid -llog")
+        if not self.options.get_safe("fPIC"):
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        "CMAKE_POSITION_INDEPENDENT_CODE ON", "CMAKE_POSITION_INDEPENDENT_CODE OFF")
 
     def build(self):
         self._patch_sources()

--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -23,7 +23,7 @@ class VulkanValidationLayersConan(ConanFile):
     topics = ("vulkan", "validation-layers")
     homepage = "https://github.com/KhronosGroup/Vulkan-ValidationLayers"
     url = "https://github.com/conan-io/conan-center-index"
-    package_type = "shared-library"
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "with_wsi_xcb": [True, False],


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-validationlayers/1.3.224.1**

#### Motivation

The `vulkan-validationlayers` Conan recipe is not well supported for Android, this PR fixes the current state.

Current error:

```
[50/53] /home/uilian/.conan2/p/androc80020a02a776/p/bin/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=aarch64-none-linux-android32 --sysroot=/home/uilian/.conan2/p/androc80020a02a776/p/bin/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DAPI_NAME=\"Vulkan\" -DUSE_ROBIN_HOOD_HASHING -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_ANDROID_KHR -DVK_USE_PLATFORM_ANDROID_KHX -DVkLayer_khronos_validation_EXPORTS -I/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/src/layers -I/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/src/layers/generated -I/home/uilian/.conan2/p/vulka6a51cc1ce5120/p/include -I/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/build/Release -I/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/build/Release/layers -isystem /home/uilian/.conan2/p/spirv3f8db3737707f/p/include -isystem /home/uilian/.conan2/p/robin5ca1e371bc807/p/include -isystem /home/uilian/.conan2/p/b/spirv725ed31ea4b54/p/include -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -Wpointer-arith -Wno-unused-function -Wno-sign-compare -O3 -DNDEBUG  -std=c++11 -fPIC -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -fno-strict-aliasing -fno-builtin-memcmp -fvisibility=hidden -Wno-unused-const-variable -MD -MT layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/parameter_validation.cpp.o -MF layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/parameter_validation.cpp.o.d -o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/parameter_validation.cpp.o -c /home/uilian/.conan2/p/b/vulka645cb56898d3a/b/src/layers/generated/parameter_validation.cpp
[51/53] : && /home/uilian/.conan2/p/androc80020a02a776/p/bin/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=aarch64-none-linux-android32 --sysroot=/home/uilian/.conan2/p/androc80020a02a776/p/bin/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fPIC -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -Wpointer-arith -Wno-unused-function -Wno-sign-compare -O3 -DNDEBUG  -static-libstdc++ -Wl,--build-id=sha1 -Wl,--no-undefined-version -Wl,--fatal-warnings -Wl,--no-undefined -Qunused-arguments  -Wl,--gc-sections  -Wl,--version-script=/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/src/layers/libVkLayer_khronos_validation.map,-Bsymbolic,--exclude-libs,ALL -shared -Wl,-soname,libVkLayer_khronos_validation.so -o layers/libVkLayer_khronos_validation.so layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/chassis.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/layer_chassis_dispatch.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/vk_safe_struct.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/layer_options.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/state_tracker.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/image_layout_map.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/subresource_adapter.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/sync_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/core_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/core_error_location.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/base_node.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/device_memory_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/buffer_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/cmd_buffer_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/image_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/pipeline_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/pipeline_layout_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/pipeline_sub_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/queue_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/render_pass_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/drawdispatch.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/convert_to_renderpass2.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/descriptor_sets.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/descriptor_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/buffer_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/shader_module.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/shader_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/sync_vuid_maps.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/spirv_validation_helper.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/spirv_grammar_helper.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/command_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/synchronization_validation_types.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/gpu_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/corechecks_optick_instrumentation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/xxhash.c.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/object_tracker.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/object_tracker_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/thread_safety.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/parameter_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/parameter_validation_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/best_practices_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/best_practices.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/gpu_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/debug_printf.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/synchronization_validation.cpp.o -L/home/uilian/.conan2/p/b/spirv725ed31ea4b54/p/lib libVkLayer_utils.a  /home/uilian/.conan2/p/b/spirv725ed31ea4b54/p/lib/libSPIRV-Tools-opt.a  /home/uilian/.conan2/p/b/spirv725ed31ea4b54/p/lib/libSPIRV-Tools.a  -lc++_static  -latomic -lm && :
FAILED: layers/libVkLayer_khronos_validation.so 
: && /home/uilian/.conan2/p/androc80020a02a776/p/bin/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=aarch64-none-linux-android32 --sysroot=/home/uilian/.conan2/p/androc80020a02a776/p/bin/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fPIC -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -Wpointer-arith -Wno-unused-function -Wno-sign-compare -O3 -DNDEBUG  -static-libstdc++ -Wl,--build-id=sha1 -Wl,--no-undefined-version -Wl,--fatal-warnings -Wl,--no-undefined -Qunused-arguments  -Wl,--gc-sections  -Wl,--version-script=/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/src/layers/libVkLayer_khronos_validation.map,-Bsymbolic,--exclude-libs,ALL -shared -Wl,-soname,libVkLayer_khronos_validation.so -o layers/libVkLayer_khronos_validation.so layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/chassis.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/layer_chassis_dispatch.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/vk_safe_struct.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/layer_options.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/state_tracker.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/image_layout_map.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/subresource_adapter.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/sync_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/core_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/core_error_location.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/base_node.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/device_memory_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/buffer_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/cmd_buffer_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/image_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/pipeline_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/pipeline_layout_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/pipeline_sub_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/queue_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/render_pass_state.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/drawdispatch.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/convert_to_renderpass2.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/descriptor_sets.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/descriptor_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/buffer_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/shader_module.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/shader_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/sync_vuid_maps.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/spirv_validation_helper.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/spirv_grammar_helper.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/command_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/synchronization_validation_types.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/gpu_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/corechecks_optick_instrumentation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/xxhash.c.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/object_tracker.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/object_tracker_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/thread_safety.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/parameter_validation.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/parameter_validation_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/best_practices_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/generated/best_practices.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/gpu_utils.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/debug_printf.cpp.o layers/CMakeFiles/VkLayer_khronos_validation.dir/synchronization_validation.cpp.o -L/home/uilian/.conan2/p/b/spirv725ed31ea4b54/p/lib libVkLayer_utils.a  /home/uilian/.conan2/p/b/spirv725ed31ea4b54/p/lib/libSPIRV-Tools-opt.a  /home/uilian/.conan2/p/b/spirv725ed31ea4b54/p/lib/libSPIRV-Tools.a  -lc++_static  -latomic -lm && :
ld.lld: error: undefined symbol: AHardwareBuffer_describe
>>> referenced by core_validation.cpp:5249 (/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/src/layers/core_validation.cpp:5249)
>>>               layers/CMakeFiles/VkLayer_khronos_validation.dir/core_validation.cpp.o:(CoreChecks::PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevice_T*, AHardwareBuffer const*, VkAndroidHardwareBufferPropertiesANDROID*) const)
>>> referenced by core_validation.cpp:5310 (/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/src/layers/core_validation.cpp:5310)
>>>               layers/CMakeFiles/VkLayer_khronos_validation.dir/core_validation.cpp.o:(CoreChecks::ValidateAllocateMemoryANDROID(VkMemoryAllocateInfo const*) const)

ld.lld: error: undefined symbol: __android_log_print
>>> referenced by vk_layer_logging.h:835 (/home/uilian/.conan2/p/b/vulka645cb56898d3a/b/src/layers/vk_layer_logging.h:835)
>>>               vk_layer_utils.cpp.o:(messenger_log_callback(VkDebugUtilsMessageSeverityFlagBitsEXT, unsigned int, VkDebugUtilsMessengerCallbackDataEXT const*, void*)) in archive libVkLayer_utils.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.


vulkan-validationlayers/1.3.224.1: ERROR: 
Package 'b834a01895e8710c889b0e7381812c455d0e12d7' build failed
```

#### Details

Full build log for Android: 

[vulkan-validationlayers-1.3.224.1-android-static.log](https://github.com/user-attachments/files/17012496/vulkan-validationlayers-1.3.224.1-android-static.log)

- Add package type as shared library
- Disable xorg when building for Android. It does not work, ffmpeg is a good reference.
- The Current error should be partially fixed to version >=1.3.290.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
