### PR TITLE
range-v3: add version cci.20240905.

### DIFF
--- a/recipes/range-v3/all/conandata.yml
+++ b/recipes/range-v3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20240905":
+    url: https://github.com/ericniebler/range-v3/archive/a33616bfdb642744acaa937a3f258fba384b7fd4.tar.gz
+    sha256: d5cc3bf42825097c55c1c6a1f0158eb8fbceb0653935f2f7d2b5286c827dd834
   "0.12.0":
     url: https://github.com/ericniebler/range-v3/archive/refs/tags/0.12.0.tar.gz
     sha256: 015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb

--- a/recipes/range-v3/config.yml
+++ b/recipes/range-v3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20240905":
+    folder: all
   "0.12.0":
     folder: all
   "0.11.0":


### PR DESCRIPTION
### Summary
Added newest `range-v3` `master` as `cci.20240905`.  
`range-v3` didn't see a release for over 2 years, despite numerous bug fixes and improvements being implemented. This new version adds support for new versions of GCC.

#### Motivation
This version fixes compilation issues in newer versions of GCC.  
See this issue: https://github.com/ericniebler/range-v3/issues/1672

#### Details
Just added a version, that is not an official release of `range-v3`.  
I've chosen `cci.20240905` as a version number, as I've seen this format used in other packages.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
