### PR TITLE
catch2: add version 3.7.1

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.7.1":
+    url: "https://github.com/catchorg/Catch2/archive/v3.7.1.tar.gz"
+    sha256: "c991b247a1a0d7bb9c39aa35faf0fe9e19764213f28ffba3109388e62ee0269c"
   "3.7.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.7.0.tar.gz"
     sha256: "5b10cd536fa3818112a82820ce0787bd9f2a906c618429e7c4dea639983c8e88"

--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -13,10 +13,10 @@ required_conan_version = ">=1.54.0"
 class Catch2Conan(ConanFile):
     name = "catch2"
     description = "A modern, C++-native, header-only, framework for unit-tests, TDD and BDD"
-    topics = ("catch2", "unit-test", "tdd", "bdd")
     license = "BSL-1.0"
-    homepage = "https://github.com/catchorg/Catch2"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/catchorg/Catch2"
+    topics = ("catch2", "unit-test", "tdd", "bdd")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.7.1":
+    folder: 3.x.x
   "3.7.0":
     folder: 3.x.x
   "3.6.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **catch2/3.7.1**

#### Motivation
There are several improvements in 3.7.1.

#### Details
https://github.com/catchorg/Catch2/compare/v3.7.0...v3.7.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
