### PR TITLE
rapidhash: add new recipe

### DIFF
--- a/recipes/rapidhash/all/conandata.yml
+++ b/recipes/rapidhash/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0":
+    url: "https://github.com/Nicoshev/rapidhash/archive/refs/tags/rapidhash_v1.0.tar.gz"
+    sha256: "d295e66eec6745cc0e0c8c65fb8b5edf08ab3af83b0a503c54c6705144b53848"

--- a/recipes/rapidhash/all/conanfile.py
+++ b/recipes/rapidhash/all/conanfile.py
@@ -1,0 +1,49 @@
+from conan import ConanFile
+
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.52.0"
+
+class RapidHashConan(ConanFile):
+    name = "rapidhash"
+    description = "Very fast, high quality, platform-independent hashing algorithm"
+    license = "BSD-2-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Nicoshev/rapidhash"
+    topics = ("hash", "wyhash", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 11
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(
+            self,
+            "rapidhash.h",
+            self.source_folder,
+            os.path.join(self.package_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/rapidhash/all/test_package/CMakeLists.txt
+++ b/recipes/rapidhash/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(rapidhash REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE rapidhash::rapidhash)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/rapidhash/all/test_package/conanfile.py
+++ b/recipes/rapidhash/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/rapidhash/all/test_package/test_package.cpp
+++ b/recipes/rapidhash/all/test_package/test_package.cpp
@@ -1,10 +1,10 @@
 #include <iostream>
-#include <string_view>
+#include <string>
 
 #include "rapidhash.h"
 
 int main() {
-    std::string_view text = "Hello, rapidhash.";
+    std::string text = "Hello, rapidhash.";
 
     std::cout << rapidhash(text.data(), text.size()) << '\n';
 

--- a/recipes/rapidhash/all/test_package/test_package.cpp
+++ b/recipes/rapidhash/all/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include <string_view>
+
+#include "rapidhash.h"
+
+int main() {
+    std::string_view text = "Hello, rapidhash.";
+
+    std::cout << rapidhash(text.data(), text.size()) << '\n';
+
+    return 0;
+}

--- a/recipes/rapidhash/config.yml
+++ b/recipes/rapidhash/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **rapidhash/1.0**

#### Motivation
rapidhash is the official successor of [wayhash](https://github.com/wangyi-fudan/wyhash).

#### Details
https://github.com/Nicoshev/rapidhash/

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
