### PR TITLE
libid3tag: set pkg_config_name

### DIFF
--- a/recipes/libid3tag/all/conanfile.py
+++ b/recipes/libid3tag/all/conanfile.py
@@ -114,6 +114,8 @@ class LibId3TagConan(ConanFile):
             rm(self, "*.la", self.package_folder, recursive=True)
 
     def package_info(self):
+        # Match the pkg-config name used by Debian and other distros
+        self.cpp_info.set_property("pkg_config_name", "id3tag")
         if is_msvc(self):
             self.cpp_info.libs = ["libid3tag"]
             self.cpp_info.defines.append("ID3TAG_EXPORT=" + ("__declspec(dllimport)" if self.options.shared else ""))


### PR DESCRIPTION
### Summary
Changes to recipe:  **libid3tag/[*]**

#### Motivation
Most if not all package managers install a `id3tag.pc` file for the `libid3tag` package, but not CCI:
- https://packages.debian.org/sid/amd64/libid3tag0-dev/filelist
- https://packages.ubuntu.com/oracular/amd64/libid3tag0-dev/filelist
- https://packages.fedoraproject.org/pkgs/libid3tag/libid3tag-devel/fedora-rawhide.html#files
- https://github.com/microsoft/vcpkg/blob/master/ports/libid3tag/portfile.cmake#L13

Causes `imlib2` configure step to fail.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
