### PR TITLE
oatpp/1.3.0-latest

### DIFF
--- a/recipes/oatpp/all/conandata.yml
+++ b/recipes/oatpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.0-latest":
+    url: "https://github.com/oatpp/oatpp/archive/1.3.0-latest.tar.gz"
+    sha256: "adc3b88076532838cd0fb8155872d6a9467ac0cb5df319735a2396ce6945d064"
   "1.3.0":
     url: "https://github.com/oatpp/oatpp/archive/1.3.0.tar.gz"
     sha256: "e1f80fa8fd7a74da6737e7fee1a4db68b4d7085a3f40e7d550752d6ff5714583"
@@ -14,3 +17,8 @@ sources:
   "1.0.0":
     url: "https://github.com/oatpp/oatpp/archive/1.0.0.tar.gz"
     sha256: "9ba7c75e3ada8ec894ec10beae712e775774a835fd3de89d8c34e17740202619"
+patches:
+  "1.3.0-latest":
+    - patch_file: "patches/1.3.0-latest/version.patch"
+      patch_description: "Fix build with suffix in version string"
+      patch_type: "conan"

--- a/recipes/oatpp/all/conanfile.py
+++ b/recipes/oatpp/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
@@ -28,6 +28,9 @@ class OatppConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -61,6 +64,7 @@ class OatppConan(ConanFile):
         tc.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -92,7 +96,7 @@ class OatppConan(ConanFile):
         # oatpp-test
         self.cpp_info.components["oatpp-test"].names["cmake_find_package"] = "oatpp-test"
         self.cpp_info.components["oatpp-test"].names["cmake_find_package_multi"] = "oatpp-test"
-        self.cpp_info.components["oatpp-test"].set_property("cmake_target_name", "oatpp-test::oatpp-test")
+        self.cpp_info.components["oatpp-test"].set_property("cmake_target_name", "oatpp::oatpp-test")
         self.cpp_info.components["oatpp-test"].includedirs = [include_dir]
         self.cpp_info.components["oatpp-test"].libdirs = [lib_dir]
         self.cpp_info.components["oatpp-test"].libs = ["oatpp-test"]

--- a/recipes/oatpp/all/patches/1.3.0-latest/version.patch
+++ b/recipes/oatpp/all/patches/1.3.0-latest/version.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d41c8b2..9338d246 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+ 
+-file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/src/oatpp/core/base/Environment.hpp" OATPP_VERSION_MACRO REGEX "#define OATPP_VERSION \"[0-9]+.[0-9]+.[0-9]+\"$")
+-string(REGEX REPLACE "#define OATPP_VERSION \"([0-9]+.[0-9]+.[0-9]+)\"$" "\\1" oatpp_VERSION "${OATPP_VERSION_MACRO}")
++file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/src/oatpp/core/base/Environment.hpp" OATPP_VERSION_MACRO REGEX "#define OATPP_VERSION \"[0-9]+.[0-9]+.[0-9]+.*\"$")
++string(REGEX REPLACE "#define OATPP_VERSION \"([0-9]+.[0-9]+.[0-9]+.*)\"$" "\\1" oatpp_VERSION "${OATPP_VERSION_MACRO}")
+ 
+ ###################################################################################################
+ ## These variables are passed to oatpp-module-install.cmake script
+@@ -12,7 +12,7 @@ set(OATPP_THIS_MODULE_VERSION ${oatpp_VERSION}) ## version of the module (also s
+ 
+ ###################################################################################################
+ 
+-project(oatpp VERSION ${OATPP_THIS_MODULE_VERSION} LANGUAGES CXX)
++project(oatpp VERSION 1.3.0 LANGUAGES CXX)
+ 
+ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+ option(OATPP_INSTALL "Create installation target for oat++" ON)
+diff --git a/src/oatpp/core/base/Environment.hpp b/src/oatpp/core/base/Environment.hpp
+index 05d5c949..0a580b5d 100644
+--- a/src/oatpp/core/base/Environment.hpp
++++ b/src/oatpp/core/base/Environment.hpp
+@@ -39,7 +39,7 @@
+ #include <stdexcept>
+ #include <cstdlib>
+ 
+-#define OATPP_VERSION "1.3.0"
++#define OATPP_VERSION "1.3.0-latest"
+ 
+ typedef unsigned char v_char8;
+ typedef v_char8 *p_char8;

--- a/recipes/oatpp/config.yml
+++ b/recipes/oatpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.0-latest":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.5":


### PR DESCRIPTION
Added version 1.3.0-latest to be in line with Oat++'s [official releases](https://github.com/oatpp/oatpp/releases) instead of just overwriting 1.3.0.


### Summary
Changes to recipe:  **oatpp/1.3.0-latest**

#### Motivation
1.3.0-latest is available and includes bug fixes.

#### Details
- A patch had been added to make the packaging work with the `-latest` suffix in the version.
- `oatpp-test::oatpp-test` was renamed to `oatpp::oatpp-test` for consistency (as other extensions like `oatpp::oatpp-openssl`, `oatpp::oatpp-sqlite` etc.).


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan (Conan 2.7, MSVC2022, GCC10, all 64 bit release).
