### PR TITLE
shader-slang: new recipe

### DIFF
--- a/recipes/shader-slang/all/conandata.yml
+++ b/recipes/shader-slang/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "2024.11.1":
+    url: "https://github.com/shader-slang/slang/archive/refs/tags/v2024.11.1.tar.gz"
+    sha256: "e25bdf63e4cace79ba388e4411eed73495f2046ef53125e42ec5fa36599995a8"
+patches:
+  "2024.11.1":
+    - patch_file: "patches/0001-update-unvendored-includes.patch"
+    - patch_file: "patches/0002-cmake-fixes.patch"
+    - patch_file: "patches/0003-fix-glslang-regression.patch"

--- a/recipes/shader-slang/all/conanfile.py
+++ b/recipes/shader-slang/all/conanfile.py
@@ -1,0 +1,178 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, mkdir
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
+
+
+class ShaderSlangConan(ConanFile):
+    name = "shader-slang"
+    description = (
+        "Slang is a shading language that makes it easier to build and maintain large shader"
+        " codebases in a modular and extensible fashion, while also maintaining the highest possible"
+        " performance on modern GPUs and graphics APIs."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/shader-slang/slang"
+    topics = ("shaders", "vulkan", "glsl", "cuda", "hlsl", "d3d12")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "enable_gfx": [True, False],
+        "with_x11": [True, False],
+        "with_cuda": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "enable_gfx": False,
+        "with_x11": True,
+        "with_cuda": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "10",
+            "clang": "7",
+            "gcc": "8",
+            "msvc": "191",
+            "Visual Studio": "15",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        if not self.options.enable_gfx or self.settings.os not in ["Linux", "FreeBSD"]:
+            del self.options.with_x11
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("glslang/1.3.290.0")
+        self.requires("spirv-headers/1.3.290.0")
+        self.requires("spirv-tools/1.3.290.0")
+        self.requires("lz4/1.10.0")
+        self.requires("miniz/3.0.2")
+        self.requires("unordered_dense/4.4.0")
+        if self.options.enable_gfx:
+            self.requires("vulkan-headers/1.3.290.0")
+            self.requires("imgui/1.91.0")
+            if is_apple_os(self):
+                self.requires("metal-cpp/14.2")
+            if self.options.get_safe("with_x11"):
+                self.requires("xorg/system")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.25 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["SLANG_LIB_TYPE"] = "SHARED" if self.options.shared else "STATIC"
+        tc.cache_variables["SLANG_ENABLE_PREBUILT_BINARIES"] = False
+        tc.cache_variables["SLANG_ENABLE_TESTS"] = False
+        tc.cache_variables["SLANG_ENABLE_EXAMPLES"] = False
+        tc.cache_variables["SLANG_ENABLE_GFX"] = self.options.enable_gfx
+        tc.cache_variables["SLANG_ENABLE_XLIB"] = self.options.get_safe("with_x11", False)
+        tc.cache_variables["SLANG_ENABLE_CUDA"] = self.options.get_safe("with_cuda", False)
+        tc.cache_variables["SLANG_SLANG_LLVM_FLAVOR"] = "USE_SYSTEM_LLVM" if self.options.get_safe("with_llvm") else "DISABLE"
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+        VirtualBuildEnv(self).generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+        # Everything except dxc/dxcapi.h is unvendored
+        mkdir(self, os.path.join(self.source_folder, "external_headers"))
+        os.rename(os.path.join(self.source_folder, "external", "dxc"),
+                  os.path.join(self.source_folder, "external_headers", "dxc"))
+        rmdir(self, os.path.join(self.source_folder, "external"))
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.components["slang_"].libs = ["slang"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["slang_"].system_libs.extend(["m", "pthread", "dl", "rt"])
+        self.cpp_info.components["slang_"].requires = [
+            "miniz::miniz",
+            "lz4::lz4",
+            "glslang::glslang-core",
+            "glslang::spirv",
+            "spirv-tools::spirv-tools-opt",
+            "spirv-headers::spirv-headers",
+            "unordered_dense::unordered_dense"
+        ]
+
+        self.cpp_info.components["slang-glslang"].libs = ["slang-glslang"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["slang-glslang"].system_libs.extend(["m", "pthread", "rt"])
+        self.cpp_info.components["slang-glslang"].requires = [
+            "glslang::glslang-core",
+            "glslang::spirv",
+            "spirv-tools::spirv-tools-opt",
+            "spirv-headers::spirv-headers",
+            "unordered_dense::unordered_dense"
+        ]
+
+        self.cpp_info.components["slang-rt"].libs = ["slang-rt"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["slang-rt"].system_libs.extend(["m", "pthread", "dl"])
+        self.cpp_info.components["slang-rt"].requires = ["miniz::miniz", "lz4::lz4"]
+
+        if self.options.enable_gfx:
+            self.cpp_info.components["gfx"].libs = ["gfx"]
+            self.cpp_info.components["gfx"].requires = ["slang_", "vulkan-headers::vulkan-headers"]
+            if is_apple_os(self):
+                self.cpp_info.components["gfx"].requires.append("metal-cpp::metal-cpp")
+            if self.options.get_safe("with_x11"):
+                self.cpp_info.components["gfx"].requires.append("xorg::x11")
+            if self.options.with_cuda:
+                self.cpp_info.components["gfx"].system_libs.append("cuda")
+
+        self.cpp_info.components["_tools"].requires = ["imgui::imgui"]

--- a/recipes/shader-slang/all/conanfile.py
+++ b/recipes/shader-slang/all/conanfile.py
@@ -130,7 +130,7 @@ class ShaderSlangConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
-        if getattr(self, "settings_target") is not None:
+        if self.settings_target is not None:
             # Build and install native build tools for cross-compilation
             cmake.build(target="generators")
             cmake.build(target="slang-bootstrap")
@@ -139,7 +139,7 @@ class ShaderSlangConan(ConanFile):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
-        if getattr(self, "settings_target") is not None:
+        if self.settings_target is not None:
             cmake.install(component="generators")
         rmdir(self, os.path.join(self.package_folder, "share"))
 

--- a/recipes/shader-slang/all/patches/0001-update-unvendored-includes.patch
+++ b/recipes/shader-slang/all/patches/0001-update-unvendored-includes.patch
@@ -1,0 +1,202 @@
+From 0cf4d7dd8ed237ec954f5579c4e61e5f4867bac6 Mon Sep 17 00:00:00 2001
+From: Martin Valgur <martin.valgur@gmail.com>
+Date: Wed, 18 Sep 2024 14:23:20 +0300
+Subject: [PATCH 1/2] Update unvendored dependency includes
+
+---
+ source/compiler-core/slang-dxc-compiler.cpp     |  4 ++--
+ source/compiler-core/slang-spirv-core-grammar.h |  2 +-
+ source/core/slang-dictionary.h                  |  2 +-
+ source/core/slang-hash.h                        |  2 +-
+ source/core/slang-lz4-compression-system.cpp    |  2 +-
+ source/slang-glslang/slang-glslang.cpp          | 13 +++++++------
+ source/slang/slang-ir-glsl-legalize.cpp         |  2 +-
+ tools/gfx/open-gl/render-gl.cpp                 |  6 +++---
+ tools/platform/gui.h                            |  2 +-
+ tools/platform/model.cpp                        | 12 ++++++------
+ tools/platform/vector-math.h                    |  8 ++++----
+ 17 files changed, 40 insertions(+), 39 deletions(-)
+
+diff --git a/source/compiler-core/slang-dxc-compiler.cpp b/source/compiler-core/slang-dxc-compiler.cpp
+index 3a949b3b..527e5d91 100644
+--- a/source/compiler-core/slang-dxc-compiler.cpp
++++ b/source/compiler-core/slang-dxc-compiler.cpp
+@@ -40,9 +40,9 @@
+ #   ifdef _WIN32
+ #       include <windows.h>
+ #       include <unknwn.h>
+-#       include "../../external/dxc/dxcapi.h"
++#       include "dxc/dxcapi.h"
+ #   else
+-#       include "../../external/dxc/dxcapi.h"
++#       include "dxc/dxcapi.h"
+ 
+ #       ifdef __uuidof
+             // DXC's WinAdapter.h defines __uuidof(T) over types, but the existing
+diff --git a/source/compiler-core/slang-spirv-core-grammar.h b/source/compiler-core/slang-spirv-core-grammar.h
+index 958aaaef..7391b086 100644
+--- a/source/compiler-core/slang-spirv-core-grammar.h
++++ b/source/compiler-core/slang-spirv-core-grammar.h
+@@ -4,7 +4,7 @@
+ #include "../core/slang-string.h"
+ #include "../core/slang-string-slice-pool.h"
+ #include "../core/slang-dictionary.h"
+-#include "../../external/spirv-headers/include/spirv/unified1/spirv.h"
++#include <spirv/unified1/spirv.h>
+ #include <optional>
+ 
+ namespace Slang
+diff --git a/source/core/slang-dictionary.h b/source/core/slang-dictionary.h
+index ba467274..d31e89fc 100644
+--- a/source/core/slang-dictionary.h
++++ b/source/core/slang-dictionary.h
+@@ -8,7 +8,7 @@
+ #include "slang-exception.h"
+ #include "slang-math.h"
+ #include "slang-hash.h"
+-#include "../../external/unordered_dense/include/ankerl/unordered_dense.h"
++#include <ankerl/unordered_dense.h>
+ #include <initializer_list>
+ 
+ namespace Slang
+diff --git a/source/core/slang-hash.h b/source/core/slang-hash.h
+index 784f7fd2..b6884d6a 100644
+--- a/source/core/slang-hash.h
++++ b/source/core/slang-hash.h
+@@ -3,7 +3,7 @@
+ 
+ #include "../../include/slang.h"
+ #include "slang-math.h"
+-#include "../../external/unordered_dense/include/ankerl/unordered_dense.h"
++#include <ankerl/unordered_dense.h>
+ #include <cstring>
+ #include <type_traits>
+ 
+diff --git a/source/core/slang-lz4-compression-system.cpp b/source/core/slang-lz4-compression-system.cpp
+index c20b457d..1e2ab955 100644
+--- a/source/core/slang-lz4-compression-system.cpp
++++ b/source/core/slang-lz4-compression-system.cpp
+@@ -5,7 +5,7 @@
+ 
+ #include "slang-blob.h"
+ 
+-#include "../../external/lz4/lib/lz4.h"
++#include <lz4.h>
+ 
+ namespace Slang
+ {
+diff --git a/source/slang-glslang/slang-glslang.cpp b/source/slang-glslang/slang-glslang.cpp
+index 2dd1b46a..f440c179 100644
+--- a/source/slang-glslang/slang-glslang.cpp
++++ b/source/slang-glslang/slang-glslang.cpp
+@@ -4,8 +4,8 @@
+ 
+ #include "glslang/Public/ResourceLimits.h"
+ #include "glslang/Public/ShaderLang.h"
+-#include "SPIRV/GlslangToSpv.h"
+-#include "SPIRV/disassemble.h"
++#include "glslang/SPIRV/GlslangToSpv.h"
++#include "glslang/SPIRV/disassemble.h"
+ 
+ #include "slang.h"
+ 
+diff --git a/source/slang/slang-ir-glsl-legalize.cpp b/source/slang/slang-ir-glsl-legalize.cpp
+index d8c1aa91..54646e26 100644
+--- a/source/slang/slang-ir-glsl-legalize.cpp
++++ b/source/slang/slang-ir-glsl-legalize.cpp
+@@ -11,7 +11,7 @@
+ #include "slang-ir-clone.h"
+ #include "slang-ir-single-return.h"
+ #include "slang-glsl-extension-tracker.h"
+-#include "../../external/spirv-headers/include/spirv/unified1/spirv.h"
++#include <spirv/unified1/spirv.h>
+ 
+ namespace Slang
+ {
+diff --git a/tools/gfx/open-gl/render-gl.cpp b/tools/gfx/open-gl/render-gl.cpp
+index abb17837..e7970368 100644
+--- a/tools/gfx/open-gl/render-gl.cpp
++++ b/tools/gfx/open-gl/render-gl.cpp
+@@ -9,7 +9,7 @@
+ #include "core/slang-basic.h"
+ #include "core/slang-blob.h"
+ #include "core/slang-secure-crt.h"
+-#include "external/stb/stb_image_write.h"
++#include "stb_image_write.h"
+ 
+ #if SLANG_WIN64 || SLANG_WIN64
+ #define ENABLE_GL_IMPL 1
+@@ -35,8 +35,8 @@
+ #pragma comment(lib, "opengl32")
+ 
+ #include <GL/GL.h>
+-#include "external/glext.h"
+-#include "external/wglext.h"
++#include "glext.h"
++#include "wglext.h"
+ 
+ // We define an "X-macro" for mapping over loadable OpenGL
+ // extension entry point that we will use, so that we can
+diff --git a/tools/platform/gui.h b/tools/platform/gui.h
+index e3975f3f..465ba87b 100644
+--- a/tools/platform/gui.h
++++ b/tools/platform/gui.h
+@@ -5,7 +5,7 @@
+ #include "vector-math.h"
+ #include "window.h"
+ #include "slang-com-ptr.h"
+-#include "external/imgui/imgui.h"
++#include "imgui.h"
+ #include "source/core/slang-basic.h"
+ 
+ namespace platform {
+diff --git a/tools/platform/model.cpp b/tools/platform/model.cpp
+index a48d499b..51803bda 100644
+--- a/tools/platform/model.cpp
++++ b/tools/platform/model.cpp
+@@ -4,17 +4,17 @@
+ #include "window.h"
+ 
+ #define TINYOBJLOADER_IMPLEMENTATION
+-#include "../../external/tinyobjloader/tiny_obj_loader.h"
++#include "tiny_obj_loader.h"
+ 
+ #define STB_IMAGE_IMPLEMENTATION
+-#include "../../external/stb/stb_image.h"
++#include "stb_image.h"
+ 
+ #define STB_IMAGE_RESIZE_IMPLEMENTATION
+-#include "../../external/stb/stb_image_resize.h"
++#include "stb_image_resize.h"
+ 
+-#include "../../external/glm/glm/glm.hpp"
+-#include "../../external/glm/glm/gtc/matrix_transform.hpp"
+-#include "../../external/glm/glm/gtc/constants.hpp"
++#include "glm/glm.hpp"
++#include "glm/gtc/matrix_transform.hpp"
++#include "glm/gtc/constants.hpp"
+ 
+ #include <memory>
+ #include <unordered_map>
+diff --git a/tools/platform/vector-math.h b/tools/platform/vector-math.h
+index e35cb46a..8b59fb91 100644
+--- a/tools/platform/vector-math.h
++++ b/tools/platform/vector-math.h
+@@ -3,10 +3,10 @@
+ 
+ // We will use the GLM library for our vector math types, just for simplicity.
+ 
+-#include "../../external/glm/glm/glm.hpp"
+-#include "../../external/glm/glm/gtc/matrix_transform.hpp"
+-#include "../../external/glm/glm/gtc/constants.hpp"
+-#include "../../external/glm/glm/gtc/quaternion.hpp"
++#include "glm/glm.hpp"
++#include "glm/gtc/matrix_transform.hpp"
++#include "glm/gtc/constants.hpp"
++#include "glm/gtc/quaternion.hpp"
+ 
+ namespace gfx {
+ 
+-- 
+2.25.1
+

--- a/recipes/shader-slang/all/patches/0002-cmake-fixes.patch
+++ b/recipes/shader-slang/all/patches/0002-cmake-fixes.patch
@@ -1,0 +1,155 @@
+From a54fe4b1a9099bbccada6336d3261d6aad03e112 Mon Sep 17 00:00:00 2001
+From: Martin Valgur <martin.valgur@gmail.com>
+Date: Wed, 18 Sep 2024 14:41:18 +0300
+Subject: [PATCH 2/2] CMake fixes
+
+---
+ CMakeLists.txt | 39 +++++++++++++++++++++++++++++++--------
+ 1 file changed, 31 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e1225022..495bd4fe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -198,20 +198,36 @@ if(SLANG_SLANG_LLVM_FLAVOR STREQUAL "USE_SYSTEM_LLVM")
+     find_package(Clang REQUIRED CONFIG)
+ endif()
+ 
+-add_subdirectory(external)
++include_directories(external_headers)
+ 
+ #
+ # Our targets
+ #
+ 
++find_package(glslang REQUIRED)
++find_package(SPIRV-Headers REQUIRED)
++find_package(SPIRV-Tools REQUIRED)
++find_package(miniz REQUIRED)
++find_package(lz4 REQUIRED)
++find_package(unordered_dense REQUIRED)
++find_package(Threads REQUIRED)
++
++link_libraries(unordered_dense::unordered_dense)
++
+ slang_add_target(
+     source/core
+     STATIC
+     EXCLUDE_FROM_ALL
+     USE_EXTRA_WARNINGS
+-    LINK_WITH_PRIVATE miniz lz4_static Threads::Threads ${CMAKE_DL_LIBS}
++    LINK_WITH_PRIVATE miniz::miniz lz4::lz4 Threads::Threads ${CMAKE_DL_LIBS}
+     INCLUDE_DIRECTORIES_PUBLIC source include
+ )
++target_link_libraries(core PUBLIC
++    SPIRV-Tools-opt
++    glslang::glslang
++    glslang::SPIRV
++    SPIRV-Headers::SPIRV-Headers
++)
+ 
+ if(SLANG_ENABLE_SLANGRT)
+     slang_add_target(
+@@ -220,7 +236,7 @@ if(SLANG_ENABLE_SLANGRT)
+         # This compiles 'core' again with the SLANG_RT_DYNAMIC_EXPORT macro defined
+         EXTRA_SOURCE_DIRS source/core
+         USE_EXTRA_WARNINGS
+-        LINK_WITH_PRIVATE miniz lz4_static Threads::Threads ${CMAKE_DL_LIBS}
++        LINK_WITH_PRIVATE miniz::miniz lz4::lz4 Threads::Threads ${CMAKE_DL_LIBS}
+         EXPORT_MACRO_PREFIX SLANG_RT
+         INCLUDE_DIRECTORIES_PUBLIC include
+         INSTALL
+@@ -336,7 +352,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
+         source/slang-glslang
+         MODULE
+         USE_FEWER_WARNINGS
+-        LINK_WITH_PRIVATE glslang SPIRV SPIRV-Tools-opt
++        LINK_WITH_PRIVATE SPIRV-Tools-opt glslang::glslang glslang::SPIRV SPIRV-Headers::SPIRV-Headers
+         INCLUDE_DIRECTORIES_PRIVATE include
+         INSTALL
+     )
+@@ -469,6 +485,12 @@ if(SLANG_ENABLE_PREBUILT_BINARIES)
+ endif()
+ 
+ if(SLANG_ENABLE_GFX)
++    find_package(VulkanHeaders REQUIRED)
++    find_package(imgui REQUIRED)
++    if(APPLE)
++        find_package(metal-cpp REQUIRED)
++    endif()
++
+     #
+     # `platform` contains all the platform abstractions for a GUI application.
+     #
+@@ -479,7 +501,7 @@ if(SLANG_ENABLE_GFX)
+         USE_FEWER_WARNINGS
+         LINK_WITH_PRIVATE
+             core
+-            imgui
++            imgui::imgui
+             $<$<BOOL:${SLANG_ENABLE_XLIB}>:X11::X11>
+             "$<$<PLATFORM_ID:Darwin>:-framework Cocoa>"
+             "$<$<PLATFORM_ID:Darwin>:-framework QuartzCore>"
+@@ -505,8 +527,8 @@ if(SLANG_ENABLE_GFX)
+         LINK_WITH_PRIVATE
+             core
+             slang
+-            Vulkan-Headers
+-            metal-cpp
++            Vulkan::Headers
++            $<$<BOOL:${APPLE}>:metal-cpp::metal-cpp>
+             $<$<BOOL:${SLANG_ENABLE_XLIB}>:X11::X11>
+             $<$<BOOL:${SLANG_ENABLE_CUDA}>:CUDA::cuda_driver>
+         LINK_WITH_FRAMEWORK
+@@ -529,7 +551,7 @@ if(SLANG_ENABLE_GFX)
+         INSTALL
+         FOLDER gfx
+     )
+-    set(modules_dest_dir $<TARGET_FILE_DIR:slang-test>)
++    set(modules_dest_dir ${CMAKE_BINARY_DIR}/slang-test)
+     add_custom_target(
+         copy-gfx-slang-modules
+         COMMAND ${CMAKE_COMMAND} -E make_directory ${modules_dest_dir}
+diff --git a/source/slang/CMakeLists.txt b/source/slang/CMakeLists.txt
+index fd20bbe2..ac0de655 100644
+--- a/source/slang/CMakeLists.txt
++++ b/source/slang/CMakeLists.txt
+@@ -153,7 +153,7 @@ target_include_directories(
+ #
+ 
+ set(SLANG_LOOKUP_GENERATOR_INPUT_JSON
+-    "${slang_SOURCE_DIR}/external/spirv-headers/include/spirv/unified1/extinst.glsl.std.450.grammar.json"
++    "${SPIRV-Headers_INCLUDE_DIR}/spirv/unified1/extinst.glsl.std.450.grammar.json"
+ )
+ set(SLANG_LOOKUP_GENERATOR_OUTPUT_DIR
+     "${CMAKE_CURRENT_BINARY_DIR}/slang-lookup-tables/"
+@@ -179,7 +179,7 @@ add_custom_command(
+ )
+ 
+ set(SLANG_SPIRV_CORE_SOURCE_JSON
+-    "${slang_SOURCE_DIR}/external/spirv-headers/include/spirv/unified1/spirv.core.grammar.json"
++    "${SPIRV-Headers_INCLUDE_DIR}/spirv/unified1/spirv.core.grammar.json"
+ )
+ set(SLANG_SPIRV_CORE_GRAMMAR_SOURCE
+     "${SLANG_LOOKUP_GENERATOR_OUTPUT_DIR}/slang-spirv-core-grammar-embed.cpp"
+@@ -201,7 +201,7 @@ slang_add_target(
+     OBJECT
+     USE_EXTRA_WARNINGS
+     EXPLICIT_SOURCE ${SLANG_LOOKUP_GENERATED_SOURCE} ${SLANG_SPIRV_CORE_GRAMMAR_SOURCE}
+-    LINK_WITH_PRIVATE core SPIRV-Headers
++    LINK_WITH_PRIVATE core SPIRV-Headers::SPIRV-Headers
+     EXCLUDE_FROM_ALL
+     FOLDER generated
+ )
+@@ -253,7 +253,7 @@ set(slang_common_args
+         slang-capability-lookup
+         slang-reflect-headers
+         slang-lookup-tables
+-        SPIRV-Headers
++        SPIRV-Headers::SPIRV-Headers
+     EXTRA_COMPILE_OPTIONS_PRIVATE
+         # a warning is disabled for a memset boundary check.
+         # everything looked fine and it is unclear why the checking fails
+-- 
+2.25.1
+

--- a/recipes/shader-slang/all/patches/0003-fix-glslang-regression.patch
+++ b/recipes/shader-slang/all/patches/0003-fix-glslang-regression.patch
@@ -1,0 +1,29 @@
+TIntermediate type is private in newer versions of glslang.
+
+diff --git a/source/slang-glslang/slang-glslang.cpp b/source/slang-glslang/slang-glslang.cpp
+index 2dd1b46a..f440c179 100644
+--- a/source/slang-glslang/slang-glslang.cpp
++++ b/source/slang-glslang/slang-glslang.cpp
+@@ -16,6 +16,7 @@
+ #   include <windows.h>
+ #endif
+ 
++#include <cassert>
+ #include <memory>
+ #include <mutex>
+ #include <sstream>
+@@ -715,10 +716,10 @@ static int glslang_compileGLSLToSPIRV(glslang_CompileRequest_1_2 request)
+         auto stageIntermediate = program->getIntermediate((EShLanguage)stage);
+         if(!stageIntermediate)
+             continue;
+-        if (debugLevel == SLANG_DEBUG_INFO_LEVEL_MAXIMAL)
+-        {
+-            stageIntermediate->addSourceText(sourceText, sourceTextLength);
+-        }
++        // if (debugLevel == SLANG_DEBUG_INFO_LEVEL_MAXIMAL)
++        // {
++        //     stageIntermediate->addSourceText(sourceText, sourceTextLength);
++        // }
+ 
+         std::vector<unsigned int> spirv;
+         spv::SpvBuildLogger logger;

--- a/recipes/shader-slang/all/test_package/CMakeLists.txt
+++ b/recipes/shader-slang/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(shader-slang REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE shader-slang::shader-slang)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/shader-slang/all/test_package/conanfile.py
+++ b/recipes/shader-slang/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/shader-slang/all/test_package/conanfile.py
+++ b/recipes/shader-slang/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str, run=True)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run("slangc -version", env="conanrun")
+
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            slang_path = os.path.join(self.source_folder, "hello_world.slang")
+            self.run(f"{bin_path} {slang_path}", env="conanrun")

--- a/recipes/shader-slang/all/test_package/hello_world.slang
+++ b/recipes/shader-slang/all/test_package/hello_world.slang
@@ -1,0 +1,12 @@
+// https://github.com/shader-slang/slang/blob/v2024.11.1/examples/hello-world/hello-world.slang
+StructuredBuffer<float> buffer0;
+StructuredBuffer<float> buffer1;
+RWStructuredBuffer<float> result;
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void computeMain(uint3 threadId : SV_DispatchThreadID)
+{
+    uint index = threadId.x;
+    result[index] = buffer0[index] + buffer1[index];
+}

--- a/recipes/shader-slang/all/test_package/test_package.cpp
+++ b/recipes/shader-slang/all/test_package/test_package.cpp
@@ -1,0 +1,32 @@
+#include <slang.h>
+#include <slang-com-ptr.h>
+#include <slang-com-helper.h>
+#include <cstdio>
+
+using Slang::ComPtr;
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        printf("Usage: %s <.slang file>\n", argv[0]);
+        return -1;
+    }
+
+    ComPtr<slang::IGlobalSession> slangGlobalSession;
+    SLANG_RETURN_ON_FAIL(slang::createGlobalSession(slangGlobalSession.writeRef()));
+
+    slang::SessionDesc sessionDesc = {};
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_SHADER_HOST_CALLABLE;
+    targetDesc.flags = SLANG_TARGET_FLAG_GENERATE_WHOLE_PROGRAM;
+    sessionDesc.targets = &targetDesc;
+    sessionDesc.targetCount = 1;
+    ComPtr<slang::ISession> session;
+    SLANG_RETURN_ON_FAIL(slangGlobalSession->createSession(sessionDesc, session.writeRef()));
+
+    slang::IModule* slangModule = session->loadModule(argv[1]);
+    if (!slangModule) {
+        printf("Failed to load %s\n", argv[1]);
+        return -1;
+    }
+    printf("Successfully loaded %s\n", argv[1]);
+}

--- a/recipes/shader-slang/config.yml
+++ b/recipes/shader-slang/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2024.11.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **shader-slang/2024.11.1**

#### Motivation
Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion, while also maintaining the highest possible performance on modern GPUs and graphics APIs. Slang is based on years of collaboration between researchers at NVIDIA, Carnegie Mellon University, Stanford, MIT, UCSD and the University of Washington.

https://github.com/shader-slang/slang

[![Packaging status](https://repology.org/badge/tiny-repos/shader-slang.svg)](https://repology.org/project/shader-slang/versions)

#### Details
Requires `spirv-headers/1.3.290.0`, which is not yet available on CCI.

`slang-llvm` component cannot be built currently.

Closes #20701.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
