### PR TITLE
libjpeg-turbo: add version 3.0.4

### DIFF
--- a/recipes/libjpeg-turbo/all/conandata.yml
+++ b/recipes/libjpeg-turbo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.4":
+    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.0.4/libjpeg-turbo-3.0.4.tar.gz"
+    sha256: "99130559e7d62e8d695f2c0eaeef912c5828d5b84a0537dcb24c9678c9d5b76b"
   "3.0.3":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.0.3/libjpeg-turbo-3.0.3.tar.gz"
     sha256: "343e789069fc7afbcdfe44dbba7dbbf45afa98a15150e079a38e60e44578865d"

--- a/recipes/libjpeg-turbo/config.yml
+++ b/recipes/libjpeg-turbo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.4":
+    folder: all
   "3.0.3":
     folder: all
   "3.0.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjpeg-turbo/3.0.4**

#### Motivation
Add version 3.0.4

#### Details
https://github.com/libjpeg-turbo/libjpeg-turbo/compare/3.0.3...3.0.4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
