### PR TITLE
libsodium: add version 1.0.20

### DIFF
--- a/recipes/libsodium/all/conandata.yml
+++ b/recipes/libsodium/all/conandata.yml
@@ -1,6 +1,9 @@
 # To update the version on CCI, add a new cci.date entry from the stable branch:
 # https://github.com/jedisct1/libsodium/commits/stable
 sources:
+  "1.0.20":
+    url: "https://github.com/jedisct1/libsodium/archive/1.0.20-RELEASE.tar.gz"
+    sha256: "8e5aeca07a723a27bbecc3beef14b0068d37e7fc0e97f51b3f1c82d2a58005c1"
   "1.0.19":
     url: "https://github.com/jedisct1/libsodium/releases/download/1.0.19-RELEASE/libsodium-1.0.19.tar.gz"
     sha256: "018d79fe0a045cca07331d37bd0cb57b2e838c51bc48fd837a1472e50068bbea"

--- a/recipes/libsodium/config.yml
+++ b/recipes/libsodium/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.20":
+    folder: all
   "1.0.19":
     folder: all
   "1.0.18":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsodium/1.0.20**
fork from [qchateau](https://github.com/conan-io/conan-center-index/commit/ebc1900d197d229a168cd02e37bc481e3c93bb47)

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
mainly addressing compilation issues

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
