### PR TITLE
libxml2: Add version 2.13.4, fixes a few CVE issues

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.13.4":
+    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.4.tar.xz"
+    sha256: "65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650"
   "2.12.9":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.9.tar.xz"
     sha256: "59912db536ab56a3996489ea0299768c7bcffe57169f0235e7f962a91f483590"

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -83,6 +83,8 @@ class Libxml2Conan(ConanFile):
             del self.options.docbook
         if Version(self.version) >= "2.11.0":
             self.options.rm_safe("run-debug")
+        if Version(self.version) >= "2.13.0":
+            self.options.rm_safe("mem-debug")
 
     def configure(self):
         if self.options.shared:

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -400,6 +400,10 @@ class Libxml2Conan(ConanFile):
         elif self.settings.os == "Windows":
             if self.options.ftp or self.options.http:
                 self.cpp_info.system_libs.extend(["ws2_32", "wsock32"])
+            if Version(self.version) >= "2.13.4":
+                # https://gitlab.gnome.org/GNOME/libxml2/-/issues/791
+                # https://gitlab.gnome.org/GNOME/libxml2/-/blob/2.13/win32/Makefile.msvc?ref_type=heads#L84
+                self.cpp_info.system_libs.append("bcrypt")
 
         # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
         self.cpp_info.filenames["cmake_find_package"] = "LibXml2"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.13.4":
+    folder: all
   "2.12.9":
     folder: all
   "2.12.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2**

#### Motivation
Stay up to date with somewhat recent releases of upstream, fix CVE issues. Update to latest patch version.

See also: <https://gitlab.gnome.org/GNOME/libxml2/-/releases>

#### Details
Version bump

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
