### PR TITLE
vir-simd: add versions 0.3.0, 0.3.1

### DIFF
--- a/recipes/vir-simd/all/conandata.yml
+++ b/recipes/vir-simd/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "0.3.1":
+    url: "https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.3.1.tar.gz"
+    sha256: "552b80773a72db2ec2c82fd8fa70211c0fe8a7a3aa9dd7003541d99ff886a360"
+  "0.3.0":
+    url: "https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.3.0.tar.gz"
+    sha256: "545c8c3254d8369fa01b2a5f8c674a8cb2703340eff63bca352bcd6d7147728f"
   "0.2.0":
     url: "https://github.com/mattkretz/vir-simd/archive/refs/tags/v0.2.0.tar.gz"
     sha256: "197432196ec73009051188ba686124a469d75d639fc5408613b30ed2981f0b70"

--- a/recipes/vir-simd/config.yml
+++ b/recipes/vir-simd/config.yml
@@ -1,4 +1,8 @@
 versions:
   # Newer versions at the top
+  "0.3.1":
+    folder: all
+  "0.3.0":
+    folder: all
   "0.2.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **vir-simd/0.3.1**

#### Motivation
Add releases 0.3.0 and 0.3.1

#### Details
- https://github.com/mattkretz/vir-simd/releases/tag/v0.3.0
- https://github.com/mattkretz/vir-simd/releases/tag/v0.3.1 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
