### PR TITLE
json-c: add version 0.18

### DIFF
--- a/recipes/json-c/all/conandata.yml
+++ b/recipes/json-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.18":
+    url: "https://github.com/json-c/json-c/archive/json-c-0.18-20240915.tar.gz"
+    sha256: "3112c1f25d39eca661fe3fc663431e130cc6e2f900c081738317fba49d29e298"
   "0.17":
     url: "https://github.com/json-c/json-c/archive/json-c-0.17-20230812.tar.gz"
     sha256: "024d302a3aadcbf9f78735320a6d5aedf8b77876c8ac8bbb95081ca55054c7eb"

--- a/recipes/json-c/all/conanfile.py
+++ b/recipes/json-c/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import collect_libs, copy, get, rmdir
+from conan.tools.files import copy, get, rmdir
 from conan.tools.scm import Version
 import os
 
@@ -9,13 +9,13 @@ required_conan_version = ">=1.54.0"
 
 class JSONCConan(ConanFile):
     name = "json-c"
-    package_type = "library"
-    description = "JSON-C - A JSON implementation in C"
-    topics = ("json", "encoding", "decoding", "manipulation")
+    description = "A JSON implementation in C"
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/json-c/json-c"
-    license = "MIT"
+    topics = ("json", "encoding", "decoding", "manipulation")
 
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -64,8 +64,9 @@ class JSONCConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.libs = ["json-c"]
+
         self.cpp_info.set_property("cmake_file_name", "json-c")
         self.cpp_info.set_property("cmake_target_name", "json-c::json-c")
         self.cpp_info.set_property("pkg_config_name", "json-c")
-        self.cpp_info.libs = collect_libs(self)
-        self.cpp_info.includedirs = ["include", "include/json-c"]
+        self.cpp_info.includedirs = ["include", os.path.join("include", "json-c")]

--- a/recipes/json-c/config.yml
+++ b/recipes/json-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.18":
+    folder: all
   "0.17":
     folder: all
   "0.16":


### PR DESCRIPTION
### Summary
Changes to recipe:  **json-c/0.18**

#### Motivation
There are lots of improvements in 0.18.

#### Details
https://github.com/json-c/json-c/compare/json-c-0.17-20230812...json-c-0.18-20240915

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
