### PR TITLE
opentelemetry-cpp/1.14.2: adding missing grpc proto library

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -306,7 +306,8 @@ class OpenTelemetryCppConan(ConanFile):
                 libraries.append("opentelemetry_exporter_otlp_grpc")
                 libraries.append("opentelemetry_exporter_otlp_grpc_metrics")
                 libraries.append("opentelemetry_exporter_otlp_grpc_client")
-                libraries.append("opentelemetry_proto_grpc")
+                if Version(self.version) >= "1.9.1":
+                    libraries.append("opentelemetry_proto_grpc")
                 if Version(self.version) >= "1.11" or self.options.with_logs_preview:
                     libraries.append("opentelemetry_exporter_otlp_grpc_log")
             if self.options.with_otlp_http:
@@ -397,8 +398,10 @@ class OpenTelemetryCppConan(ConanFile):
             self.cpp_info.components["opentelemetry_exporter_otlp_grpc_client"].requires.extend([
                 "grpc::grpc++",
                 "opentelemetry_proto",
-                "opentelemetry_proto_grpc",
             ])
+
+            if Version(self.version) >= "1.9.1":
+                self.cpp_info.components["opentelemetry_exporter_otlp_grpc_client"].requires.append("opentelemetry_proto_grpc")
 
             self.cpp_info.components["opentelemetry_exporter_otlp_grpc"].requires.extend([
                 "opentelemetry_otlp_recordable",

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -111,13 +111,22 @@ class OpenTelemetryCppConan(ConanFile):
             self.requires("ms-gsl/4.0.0")
 
         if self.options.with_abseil:
-            self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True)
+            if Version(self.version) >= "1.12.0":
+                self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True)
+            else:
+                self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True)
 
         if self.options.with_otlp_grpc or self.options.with_otlp_http:
-            self.requires("protobuf/5.27.0", transitive_headers=True, transitive_libs=True)
+            if Version(self.version) >= "1.12.0":
+                self.requires("protobuf/5.27.0", transitive_headers=True, transitive_libs=True)
+            else:
+                self.requires("protobuf/3.21.12", transitive_headers=True, transitive_libs=True)
 
         if self.options.with_otlp_grpc:
-            self.requires("grpc/1.65.0", transitive_headers=True, transitive_libs=True)
+            if Version(self.version) >= "1.12.0":
+                self.requires("grpc/1.65.0", transitive_headers=True, transitive_libs=True)
+            else:
+                self.requires("grpc/1.54.3", transitive_headers=True, transitive_libs=True)
 
         if (self.options.with_zipkin or
            self.options.with_elasticsearch or

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -111,13 +111,13 @@ class OpenTelemetryCppConan(ConanFile):
             self.requires("ms-gsl/4.0.0")
 
         if self.options.with_abseil:
-            self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True)
+            self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True)
 
         if self.options.with_otlp_grpc or self.options.with_otlp_http:
-            self.requires("protobuf/3.21.12", transitive_headers=True, transitive_libs=True)
+            self.requires("protobuf/5.27.0", transitive_headers=True, transitive_libs=True)
 
         if self.options.with_otlp_grpc:
-            self.requires("grpc/1.54.3", transitive_headers=True, transitive_libs=True)
+            self.requires("grpc/1.65.0", transitive_headers=True, transitive_libs=True)
 
         if (self.options.with_zipkin or
            self.options.with_elasticsearch or

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -306,6 +306,7 @@ class OpenTelemetryCppConan(ConanFile):
                 libraries.append("opentelemetry_exporter_otlp_grpc")
                 libraries.append("opentelemetry_exporter_otlp_grpc_metrics")
                 libraries.append("opentelemetry_exporter_otlp_grpc_client")
+                libraries.append("opentelemetry_proto_grpc")
                 if Version(self.version) >= "1.11" or self.options.with_logs_preview:
                     libraries.append("opentelemetry_exporter_otlp_grpc_log")
             if self.options.with_otlp_http:
@@ -396,6 +397,7 @@ class OpenTelemetryCppConan(ConanFile):
             self.cpp_info.components["opentelemetry_exporter_otlp_grpc_client"].requires.extend([
                 "grpc::grpc++",
                 "opentelemetry_proto",
+                "opentelemetry_proto_grpc",
             ])
 
             self.cpp_info.components["opentelemetry_exporter_otlp_grpc"].requires.extend([

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -106,24 +106,33 @@ class OpenTelemetryCppConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def _supports_new_proto_grpc_abseil(self):
+        """Old versions do not support the new proto grpc abseil combo
+        (Usage of old imports etc)
+        This is technically only for protobuf, but we take care to
+        keep abseil range in line, and grpc dependencies in sync so no
+        conflicts arise if using any of the 3 elsewhere
+        """
+        return Version(self.version) >= "1.12.0"
+
     def requirements(self):
         if self.options.with_gsl:
             self.requires("ms-gsl/4.0.0")
 
         if self.options.with_abseil:
-            if Version(self.version) >= "1.12.0":
+            if self._supports_new_proto_grpc_abseil():
                 self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True)
             else:
                 self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True)
 
         if self.options.with_otlp_grpc or self.options.with_otlp_http:
-            if Version(self.version) >= "1.12.0":
+            if self._supports_new_proto_grpc_abseil():
                 self.requires("protobuf/5.27.0", transitive_headers=True, transitive_libs=True)
             else:
                 self.requires("protobuf/3.21.12", transitive_headers=True, transitive_libs=True)
 
         if self.options.with_otlp_grpc:
-            if Version(self.version) >= "1.12.0":
+            if self._supports_new_proto_grpc_abseil():
                 self.requires("grpc/1.65.0", transitive_headers=True, transitive_libs=True)
             else:
                 self.requires("grpc/1.54.3", transitive_headers=True, transitive_libs=True)


### PR DESCRIPTION
grpc proto library is missing when using grpc exporters. This will cause build to fail.
Found in opentelemetry-cpp/1.14.2.


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
