### PR TITLE
cairo: Fix alloca issue in MSVC cairo

### DIFF
--- a/recipes/cairo/all/conandata.yml
+++ b/recipes/cairo/all/conandata.yml
@@ -14,6 +14,11 @@ sources:
       - "https://mirror.koddos.net/blfs/conglomeration/cairo/cairo-1.17.4.tar.xz"
     sha256: "74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705"
 patches:
+  "1.18.0":
+    - patch_file: "patches/1.18.0-msvc-alloca.patch"
+      patch_type: "backport"
+      patch_description: "Fix alloca undefined with MSVC"
+      patch_source: "https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/520"
   "1.17.4":
     - patch_file: "patches/binutils-2.34-libbfd-fix.patch"
       patch_type: "backport"

--- a/recipes/cairo/all/patches/1.18.0-msvc-alloca.patch
+++ b/recipes/cairo/all/patches/1.18.0-msvc-alloca.patch
@@ -1,0 +1,28 @@
+From 27cdee5e4cf19e7959b80fe1a39e61188de1b654 Mon Sep 17 00:00:00 2001
+From: Dan Yeaw <dan@yeaw.me>
+Date: Sat, 30 Sep 2023 13:30:51 -0400
+Subject: [PATCH] Fix alloca undefined with MSVC
+
+Conditionally includes malloc.h when compiling with
+MSVC so that alloca is defined.
+---
+ src/cairo-colr-glyph-render.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/cairo-colr-glyph-render.c b/src/cairo-colr-glyph-render.c
+index 28254fd51..a9ad84bbf 100644
+--- a/src/cairo-colr-glyph-render.c
++++ b/src/cairo-colr-glyph-render.c
+@@ -43,6 +43,10 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
++#ifdef _MSC_VER
++#include <malloc.h>
++#endif
++
+ #if HAVE_FT_COLR_V1
+ 
+ #include <ft2build.h>
+-- 
+GitLab


### PR DESCRIPTION
### Summary
Changes to recipe:  **cairo/[1.18]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Couldn't compile on my local MSVC setup, but it's interesting to note that the CI did not have the same issue.

This patch is present in most other package managers, seems like we added the version too soon to catch it

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Before:
```
[150/151] Linking target util/cairo-script/csi-exec.exe
FAILED: util/cairo-script/csi-exec.exe
"link"  /MACHINE:x64 /OUT:util/cairo-script/csi-exec.exe util/cairo-script/csi-exec.exe.p/csi-exec.c.obj "/release" "/nologo" "/OPT:REF" "src/libcairo.a" "util/cairo-script/libcairo-script-interpreter.a" "C:/Users/abril/.conan2/p/zlib6f797a4dd16fb/p/lib/zlib.lib" "C:/Users/abril/.conan2/p/libpn214f4edd5a70e/p/lib/libpng16_static.lib" "C:/Users/abril/.conan2/p/fontc74b173433a2a8/p/lib/fontconfig.lib" "C:/Users/abril/.conan2/p/b/freet8f053502a46c4/p/lib/freetype.lib" "C:/Users/abril/.conan2/p/brotl79757a5cae055/p/lib/brotlidec.lib" "C:/Users/abril/.conan2/p/brotl79757a5cae055/p/lib/brotlienc.lib" "C:/Users/abril/.conan2/p/brotl79757a5cae055/p/lib/brotlicommon.lib" "C:/Users/abril/.conan2/p/bzip2e06444d88ab4f/p/lib/bz2.lib" "C:/Users/abril/.conan2/p/expatc090f2293063f/p/lib/libexpatMD.lib" "gdi32.lib" "msimg32.lib" "dwrite.lib" "d2d1.lib" "windowscodecs.lib" "C:/Users/abril/.conan2/p/pixmae425c2c5d0971/p/lib/libpixman-1.lib" "gdi32.lib" "msimg32.lib" "dwrite.lib" "d2d1.lib" "windowscodecs.lib" "gdi32.lib" "msimg32.lib" "dwrite.lib" "d2d1.lib" "windowscodecs.lib" "C:/Users/abril/.conan2/p/lzoaeba5eb052ec5/p/lib/lzo2.lib" "/SUBSYSTEM:CONSOLE" "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "comdlg32.lib" "advapi32.lib"
   Creando biblioteca util\cairo-script\csi-exec.lib y objeto util\cairo-script\csi-exec.exp
libcairo.a(cairo-colr-glyph-render.c.obj) : error LNK2019: símbolo externo alloca sin resolver al que se hace referencia en la función add_sweep_gradient_patches
util\cairo-script\csi-exec.exe : fatal error LNK1120: 1 externos sin resolver
[151/151] Linking target util/cairo-script/csi-replay.exe
FAILED: util/cairo-script/csi-replay.exe
"link"  /MACHINE:x64 /OUT:util/cairo-script/csi-replay.exe util/cairo-script/csi-replay.exe.p/csi-replay.c.obj "/release" "/nologo" "/OPT:REF" "src/libcairo.a" "util/cairo-script/libcairo-script-interpreter.a" "C:/Users/abril/.conan2/p/zlib6f797a4dd16fb/p/lib/zlib.lib" "C:/Users/abril/.conan2/p/libpn214f4edd5a70e/p/lib/libpng16_static.lib" "C:/Users/abril/.conan2/p/fontc74b173433a2a8/p/lib/fontconfig.lib" "C:/Users/abril/.conan2/p/b/freet8f053502a46c4/p/lib/freetype.lib" "C:/Users/abril/.conan2/p/brotl79757a5cae055/p/lib/brotlidec.lib" "C:/Users/abril/.conan2/p/brotl79757a5cae055/p/lib/brotlienc.lib" "C:/Users/abril/.conan2/p/brotl79757a5cae055/p/lib/brotlicommon.lib" "C:/Users/abril/.conan2/p/bzip2e06444d88ab4f/p/lib/bz2.lib" "C:/Users/abril/.conan2/p/expatc090f2293063f/p/lib/libexpatMD.lib" "gdi32.lib" "msimg32.lib" "dwrite.lib" "d2d1.lib" "windowscodecs.lib" "C:/Users/abril/.conan2/p/pixmae425c2c5d0971/p/lib/libpixman-1.lib" "gdi32.lib" "msimg32.lib" "dwrite.lib" "d2d1.lib" "windowscodecs.lib" "gdi32.lib" "msimg32.lib" "dwrite.lib" "d2d1.lib" "windowscodecs.lib" "C:/Users/abril/.conan2/p/lzoaeba5eb052ec5/p/lib/lzo2.lib" "/SUBSYSTEM:CONSOLE" "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "comdlg32.lib" "advapi32.lib"
   Creando biblioteca util\cairo-script\csi-replay.lib y objeto util\cairo-script\csi-replay.exp
libcairo.a(cairo-colr-glyph-render.c.obj) : error LNK2019: símbolo externo alloca sin resolver al que se hace referencia en la función add_sweep_gradient_patches
util\cairo-script\csi-replay.exe : fatal error LNK1120: 1 externos sin resolver
ninja: build stopped: subcommand failed.
```

After: It compiles

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
