### PR TITLE
mpdecimal/2.5.x: fix build on MSVC

### DIFF
--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -63,7 +63,8 @@ class MpdecimalConan(ConanFile):
                     "A shared libmpdec++ is not possible on Windows (due to non-exportable thread local storage)")
 
     def build_requirements(self):
-        if is_msvc(self):
+        # Use MSYS2 only for MSVC
+        if not is_msvc(self):
             self.tool_requires("automake/1.16.5")
         else:
             # required to support windows as a build machine


### PR DESCRIPTION
### Summary
Changes to recipe:  **mpdecimal/2.5.x**

#### Motivation
Fix mdpecimal cross-compilation on MSVC. The problem occurs because it requires an unnecessary library automake/1.16.5 (m4), which should be in the MSYS2 installation. Fix after found bug https://github.com/conan-io/conan-center-index/issues/24794

#### Details
conan create 2.5.x/conanfile.py --version 2.5.1 -pr default32

======== Exporting recipe to the cache ========
mpdecimal/2.5.1: Exporting package recipe: C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\conanfile.py
mpdecimal/2.5.1: exports: File 'conandata.yml' found. Exporting it...
mpdecimal/2.5.1: Calling export_sources()
mpdecimal/2.5.1: Copied 1 '.yml' file: conandata.yml
mpdecimal/2.5.1: Copied 1 '.py' file: conanfile.py
mpdecimal/2.5.1: Copied 3 '.patch' files: 2.5.1-0001-msvc-fixes.patch, 2.5.1-0002-add-mingw-to-configure-ac.patch, 2.5.1-0003-use-MPDECIMAL_DLL.patch
mpdecimal/2.5.1: Exported to cache folder: C:\.conan\p\mpdec8bafe688515fe\e
mpdecimal/2.5.1: Exported: mpdecimal/2.5.1#e097fcbe12d4465fce626769b0d18708 (2024-09-22 05:29:24 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86
build_type=Release
compiler=msvc
compiler.cppstd=17
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows
[conf]
tools.microsoft.bash:path=C:\msys64\usr\bin\bash.exe
tools.microsoft.bash:subsystem=msys2

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=msvc
compiler.cppstd=17
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows
[conf]
tools.microsoft.bash:path=C:\msys64\usr\bin\bash.exe
tools.microsoft.bash:subsystem=msys2


======== Computing dependency graph ========
Graph root
    cli
Requirements
    mpdecimal/2.5.1#e097fcbe12d4465fce626769b0d18708 - Cache

======== Computing necessary packages ========
mpdecimal/2.5.1: Forced build from source
Requirements
    mpdecimal/2.5.1#e097fcbe12d4465fce626769b0d18708:53d2e4a04c901e84b20cd7462c901253af4b6aac - Build

======== Installing packages ========
mpdecimal/2.5.1: Calling source() in C:\.conan\p\mpdec8bafe688515fe\s\src
mpdecimal/2.5.1: Unzipping mpdecimal-2.5.1.tar.gz to .

-------- Installing package mpdecimal/2.5.1 (1 of 1) --------
mpdecimal/2.5.1: Building from source
mpdecimal/2.5.1: Package mpdecimal/2.5.1:53d2e4a04c901e84b20cd7462c901253af4b6aac
mpdecimal/2.5.1: Copying sources to build folder
mpdecimal/2.5.1: Building your package in C:\.conan\p\b\mpdecbd1e87e4f2f41\b
mpdecimal/2.5.1: Calling generate()
mpdecimal/2.5.1: Generators folder: C:\.conan\p\b\mpdecbd1e87e4f2f41\b\build-release\conan
mpdecimal/2.5.1: Generating aggregated env files
mpdecimal/2.5.1: Generated aggregated env files: ['conanbuild.sh', 'conanbuild.bat', 'conanrun.bat']
mpdecimal/2.5.1: Calling build()
mpdecimal/2.5.1: Apply patch (file): patches/2.5.1-0001-msvc-fixes.patch
mpdecimal/2.5.1: Apply patch (file): patches/2.5.1-0002-add-mingw-to-configure-ac.patch
mpdecimal/2.5.1: Apply patch (file): patches/2.5.1-0003-use-MPDECIMAL_DLL.patch
mpdecimal/2.5.1: WARN: deprecated: Use of 'source_path' is deprecated, please use 'source_folder' instead
mpdecimal/2.5.1: WARN: deprecated: Use of 'source_path' is deprecated, please use 'source_folder' instead
mpdecimal/2.5.1: WARN: deprecated: Use of 'build_path' is deprecated, please use 'build_folder' instead
mpdecimal/2.5.1: WARN: deprecated: Use of 'build_path' is deprecated, please use 'build_folder' instead
mpdecimal/2.5.1: RUN: nmake -f Makefile.vc libmpdec-2.5.1.lib MACHINE=ppro DEBUG=0 DLL=0
conanvcvars.bat: Activating environment Visual Studio 17 - amd64_x86 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'x64_x86'

Microsoft (R) Program Maintenance Utility Version 14.40.33813.0
Copyright (C) Microsoft Corporation.  All rights reserved.

        1 file(s) copied.
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c basearith.c
basearith.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c context.c
context.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c constants.c
constants.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c convolute.c
convolute.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c crt.c
crt.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c mpdecimal.c
mpdecimal.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c mpsignal.c
mpsignal.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c difradix2.c
difradix2.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c fnt.c
fnt.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c fourstep.c
fourstep.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c io.c
io.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c mpalloc.c
mpalloc.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c numbertheory.c
numbertheory.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c sixstep.c
sixstep.c
        cl /W4 /wd4200 /wd4204 /wd4221 /D_CRT_SECURE_NO_WARNINGS /nologo /DCONFIG_32 /DPPRO /DMASM /Ox /GS /EHsc  -c transpose.c
transpose.c
        lib /out:libmpdec-2.5.1.lib basearith.obj context.obj constants.obj convolute.obj crt.obj  mpdecimal.obj mpsignal.obj difradix2.obj fnt.obj fourstep.obj  io.obj mpalloc.obj numbertheory.obj sixstep.obj transpose.obj
Microsoft (R) Library Manager Version 14.40.33813.0
Copyright (C) Microsoft Corporation.  All rights reserved.


mpdecimal/2.5.1: RUN: nmake -f Makefile.vc libmpdec++-2.5.1.lib MACHINE=ppro DEBUG=0 DLL=0
conanvcvars.bat: Activating environment Visual Studio 17 - amd64_x86 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'x64_x86'

Microsoft (R) Program Maintenance Utility Version 14.40.33813.0
Copyright (C) Microsoft Corporation.  All rights reserved.

        cl "-I." "-I..\libmpdec" /W4 /nologo /Ox /GS /EHsc   -c decimal.cc
decimal.cc
        lib /out:libmpdec++-2.5.1.lib decimal.obj
Microsoft (R) Library Manager Version 14.40.33813.0
Copyright (C) Microsoft Corporation.  All rights reserved.


mpdecimal/2.5.1: WARN: deprecated: Use of 'build_path' is deprecated, please use 'build_folder' instead
mpdecimal/2.5.1: Package '53d2e4a04c901e84b20cd7462c901253af4b6aac' built
mpdecimal/2.5.1: Build folder C:\.conan\p\b\mpdecbd1e87e4f2f41\b\build-release
mpdecimal/2.5.1: Generating the package
mpdecimal/2.5.1: Packaging in folder C:\.conan\p\b\mpdecbd1e87e4f2f41\p
mpdecimal/2.5.1: Calling package()
mpdecimal/2.5.1: WARN: deprecated: Use of 'package_path' is deprecated, please use 'package_folder' instead
mpdecimal/2.5.1: WARN: deprecated: Use of 'build_path' is deprecated, please use 'build_folder' instead
mpdecimal/2.5.1: WARN: deprecated: Use of 'source_path' is deprecated, please use 'source_folder' instead
mpdecimal/2.5.1: package(): Packaged 1 '.hh' file: decimal.hh
mpdecimal/2.5.1: package(): Packaged 1 '.h' file: mpdecimal.h
mpdecimal/2.5.1: package(): Packaged 2 '.lib' files: libmpdec++-2.5.1.lib, libmpdec-2.5.1.lib
mpdecimal/2.5.1: package(): Packaged 1 '.txt' file: LICENSE.txt
mpdecimal/2.5.1: Created package revision 5e9918f6535fb7cab310fa31abffdcdf
mpdecimal/2.5.1: Package '53d2e4a04c901e84b20cd7462c901253af4b6aac' created
mpdecimal/2.5.1: Full package reference: mpdecimal/2.5.1#e097fcbe12d4465fce626769b0d18708:53d2e4a04c901e84b20cd7462c901253af4b6aac#5e9918f6535fb7cab310fa31abffdcdf
mpdecimal/2.5.1: Package folder C:\.conan\p\b\mpdecbd1e87e4f2f41\p

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    mpdecimal/2.5.1 (test package): C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\conanfile.py
Requirements
    mpdecimal/2.5.1#e097fcbe12d4465fce626769b0d18708 - Cache

======== Computing necessary packages ========
Requirements
    mpdecimal/2.5.1#e097fcbe12d4465fce626769b0d18708:53d2e4a04c901e84b20cd7462c901253af4b6aac#5e9918f6535fb7cab310fa31abffdcdf - Cache

======== Installing packages ========
mpdecimal/2.5.1: Already installed! (1 of 1)

======== Testing the package ========
Removing previously existing 'test_package' build folder: C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\build\msvc-194-x86-17-release
mpdecimal/2.5.1 (test package): Test package build: build\msvc-194-x86-17-release
mpdecimal/2.5.1 (test package): Test package build folder: C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\build\msvc-194-x86-17-release
mpdecimal/2.5.1 (test package): Writing generators to C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\build\msvc-194-x86-17-release\generators
mpdecimal/2.5.1 (test package): Generator 'VirtualRunEnv' calling 'generate()'
mpdecimal/2.5.1 (test package): Generator 'CMakeToolchain' calling 'generate()'
mpdecimal/2.5.1 (test package): CMakeToolchain generated: conan_toolchain.cmake
mpdecimal/2.5.1 (test package): CMakeToolchain generated: C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\build\msvc-194-x86-17-release\generators\CMakePresets.json
mpdecimal/2.5.1 (test package): CMakeToolchain generated: C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\CMakeUserPresets.json
mpdecimal/2.5.1 (test package): Generator 'CMakeDeps' calling 'generate()'
mpdecimal/2.5.1 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(mpdecimal)
    target_link_libraries(... mpdecimal::mpdecimal)
mpdecimal/2.5.1 (test package): Generating aggregated env files
mpdecimal/2.5.1 (test package): Generated aggregated env files: ['conanrun.bat', 'conanbuild.bat']

======== Testing the package: Building ========
mpdecimal/2.5.1 (test package): Calling build()
mpdecimal/2.5.1 (test package): Running CMake.configure()
mpdecimal/2.5.1 (test package): RUN: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/Users/Nancy/Develop/ConanCenterIndex/recipes/mpdecimal/2.5.x/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "C:/Users/Nancy/Develop/ConanCenterIndex/recipes/mpdecimal/2.5.x/test_package"
-- Using Conan toolchain: C:/Users/Nancy/Develop/ConanCenterIndex/recipes/mpdecimal/2.5.x/test_package/build/msvc-194-x86-17-release/generators/conan_toolchain.cmake
-- Conan toolchain: CMAKE_GENERATOR_TOOLSET=v143
-- Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Release>:MultiThreadedDLL>
-- Conan toolchain: C++ Standard 17 with extensions OFF
-- Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.22631.
-- The CXX compiler identification is MSVC 19.40.33813.0
-- The C compiler identification is MSVC 19.40.33813.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x86/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x86/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'mpdecimal::libmpdecimal'
-- Conan: Component target declared 'mpdecimal::libmpdecimal++'
-- Conan: Target declared 'mpdecimal::mpdecimal'
-- Configuring done (4.8s)
-- Generating done (0.1s)
-- Build files have been written to: C:/Users/Nancy/Develop/ConanCenterIndex/recipes/mpdecimal/2.5.x/test_package/build/msvc-194-x86-17-release

mpdecimal/2.5.1 (test package): Running CMake.build()
mpdecimal/2.5.1 (test package): RUN: cmake --build "C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\build\msvc-194-x86-17-release" --config Release
MSBuild version 17.10.4+10fbfbf2e for .NET Framework

  1>Checking Build System
  Building Custom Rule C:/Users/Nancy/Develop/ConanCenterIndex/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
  test_package.c
  test_package.vcxproj -> C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\build\msvc-194-x86-17-release\Release\test_package.exe
  Building Custom Rule C:/Users/Nancy/Develop/ConanCenterIndex/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
  test_package.cpp
  test_package_cpp.vcxproj -> C:\Users\Nancy\Develop\ConanCenterIndex\recipes\mpdecimal\2.5.x\test_package\build\msvc-194-x86-17-release\Release\test_package_cpp.exe
  Building Custom Rule C:/Users/Nancy/Develop/ConanCenterIndex/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt


======== Testing the package: Executing test ========
mpdecimal/2.5.1 (test package): Running test()


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
