### PR TITLE
libpq: Avoid broken symlinks in include/catalog #24895

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -183,20 +183,20 @@ class LibpqConan(ConanFile):
                     self.run("perl build.pl libpgport")
         else:
             autotools = Autotools(self)
-            with chdir(self, os.path.join(self.source_folder)):
+            with chdir(self, os.path.join(self.build_folder)):
                 autotools.configure()
-            with chdir(self, os.path.join(self.source_folder, "src", "backend")):
+            with chdir(self, os.path.join(self.build_folder, "src", "backend")):
                 autotools.make(target="generated-headers")
-            with chdir(self, os.path.join(self.source_folder, "src", "common")):
+            with chdir(self, os.path.join(self.build_folder, "src", "common")):
                 autotools.make()
-            with chdir(self, os.path.join(self.source_folder, "src", "include")):
+            with chdir(self, os.path.join(self.build_folder, "src", "include")):
                 autotools.make()
-            with chdir(self, os.path.join(self.source_folder, "src", "interfaces", "libpq")):
+            with chdir(self, os.path.join(self.build_folder, "src", "interfaces", "libpq")):
                 autotools.make()
             if Version(self.version) >= 12:
-                with chdir(self, os.path.join(self.source_folder, "src", "port")):
+                with chdir(self, os.path.join(self.build_folder, "src", "port")):
                     autotools.make()
-            with chdir(self, os.path.join(self.source_folder, "src", "bin", "pg_config")):
+            with chdir(self, os.path.join(self.build_folder, "src", "bin", "pg_config")):
                 autotools.make()
 
     def _remove_unused_libraries_from_package(self):
@@ -233,16 +233,16 @@ class LibpqConan(ConanFile):
                 copy(self, pattern="*.lib", dst=os.path.join(self.package_folder, "lib"), src=self.source_folder, keep_path=False)
         else:
             autotools = Autotools(self)
-            with chdir(self, os.path.join(self.source_folder, "src", "common")):
+            with chdir(self, os.path.join(self.build_folder, "src", "common")):
                 autotools.install()
-            with chdir(self, os.path.join(self.source_folder, "src", "include")):
+            with chdir(self, os.path.join(self.build_folder, "src", "include")):
                 autotools.install()
-            with chdir(self, os.path.join(self.source_folder, "src", "interfaces", "libpq")):
+            with chdir(self, os.path.join(self.build_folder, "src", "interfaces", "libpq")):
                 autotools.install()
             if Version(self.version) >= 12:
-                with chdir(self, os.path.join(self.source_folder, "src", "port")):
+                with chdir(self, os.path.join(self.build_folder, "src", "port")):
                     autotools.install()
-            with chdir(self, os.path.join(self.source_folder, "src", "bin", "pg_config")):
+            with chdir(self, os.path.join(self.build_folder, "src", "bin", "pg_config")):
                 autotools.install()
             copy(self, "*.h", src=os.path.join(self.source_folder, "src", "include", "catalog"),
                               dst=os.path.join(self.package_folder, "include", "catalog"))
@@ -251,7 +251,7 @@ class LibpqConan(ConanFile):
             rmdir(self, os.path.join(self.package_folder, "include", "postgresql", "server"))
             self._remove_unused_libraries_from_package()
             fix_apple_shared_install_name(self)
-        copy(self, "*.h", src=os.path.join(self.build_folder, "src", "backend", "catalog"),
+        copy(self, "*.h", src=os.path.join(self.source_folder, "src", "backend", "catalog"),
                           dst=os.path.join(self.package_folder, "include", "catalog"))
 
     def package_info(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpq/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
See https://github.com/conan-io/conan-center-index/issues/24895

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
To avoid broken symlinks, do out of source build.
Change `build()` and `package()` method to do out of source build.
Copy the backend catalog from the source tree.
Note: the `MSVC` part is ignored in this PR.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

I ran the tests for some configurations:
https://gitlab.com/scandyna/conan-center-index-partialbasicci-sandbox/-/pipelines/1463949508

Notes about the Windows builds:
- For MSVC, the `test_v1_package` fails. Probably something missing in my environment (I don't use the `cmake` generator anymore)
- For MinGW, the `test_package` fails due to undefined references. This is also the case without the changes in this PR (I opened another issue for this case, 25282)