### PR TITLE
onetbb: disable tbbind for Apple non-macOS

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -54,7 +54,7 @@ class OneTBBConan(ConanFile):
     @property
     def _tbbbind_supported(self):
         if is_apple_os(self):
-            return return self.settings.os == "Macos" and Version(self.version) >= "2021.11.0"
+            return self.settings.os == "Macos" and Version(self.version) >= "2021.11.0"
         return True
 
     @property

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
@@ -52,7 +53,9 @@ class OneTBBConan(ConanFile):
 
     @property
     def _tbbbind_supported(self):
-        return self.settings.os != "Macos" or Version(self.version) >= "2021.11.0"
+        if not is_apple_os(self):
+            return True
+        return self.settings.os == "Macos" and Version(self.version) >= "2021.11.0"
 
     @property
     def _tbbbind_build(self):

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -53,9 +53,9 @@ class OneTBBConan(ConanFile):
 
     @property
     def _tbbbind_supported(self):
-        if not is_apple_os(self):
-            return True
-        return self.settings.os == "Macos" and Version(self.version) >= "2021.11.0"
+        if is_apple_os(self):
+            return return self.settings.os == "Macos" and Version(self.version) >= "2021.11.0"
+        return True
 
     @property
     def _tbbbind_build(self):


### PR DESCRIPTION
hwloc can't be built for these platforms


### Summary
Changes to recipe:  **onetbb/***

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
to use the latest version of tbb for iOS, one must explicitly disable tbbind option which is inconvenient

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
hwloc can only be built for macOS among Apple platforms

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
