### PR TITLE
libxml2: add 2.11.9, 2.12.9 and remove unused versions

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.12.9":
+    url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.9.tar.xz"
+    sha256: "59912db536ab56a3996489ea0299768c7bcffe57169f0235e7f962a91f483590"
   "2.12.7":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.tar.xz"
     sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56"
@@ -14,6 +17,9 @@ sources:
   "2.12.3":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.3.tar.xz"
     sha256: "8c8f1092340a89ff32bc44ad5c9693aff9bc8a7a3e161bb239666e5d15ac9aaa"
+  "2.11.9":
+    url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.9.tar.xz"
+    sha256: "780157a1efdb57188ec474dca87acaee67a3a839c2525b2214d318228451809f"
   "2.11.8":
     url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.8.tar.xz"
     sha256: "53961af1721b72246180cd844b7ddae36ea8e1e4e27b683567990a1ee78b02c1"

--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -2,15 +2,6 @@ sources:
   "2.12.9":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.9.tar.xz"
     sha256: "59912db536ab56a3996489ea0299768c7bcffe57169f0235e7f962a91f483590"
-  "2.12.7":
-    url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.7.tar.xz"
-    sha256: "24ae78ff1363a973e6d8beba941a7945da2ac056e19b53956aeb6927fd6cfb56"
-  "2.12.6":
-    url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.6.tar.xz"
-    sha256: "889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb"
-  "2.12.5":
-    url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.5.tar.xz"
-    sha256: "a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21"
   "2.12.4":
     url: "https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.4.tar.xz"
     sha256: "497360e423cf0bd99eacdb7c6215dea92e6d6e89ee940393c2bae0e77cb9b7d0"
@@ -20,12 +11,6 @@ sources:
   "2.11.9":
     url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.9.tar.xz"
     sha256: "780157a1efdb57188ec474dca87acaee67a3a839c2525b2214d318228451809f"
-  "2.11.8":
-    url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.8.tar.xz"
-    sha256: "53961af1721b72246180cd844b7ddae36ea8e1e4e27b683567990a1ee78b02c1"
-  "2.11.7":
-    url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.7.tar.xz"
-    sha256: "fb27720e25eaf457f94fd3d7189bcf2626c6dccf4201553bc8874d50e3560162"
   "2.11.6":
     url: "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.6.tar.xz"
     sha256: "c90eee7506764abbe07bb616b82da452529609815aefef423d66ef080eb0c300"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,21 +1,11 @@
 versions:
   "2.12.9":
     folder: all
-  "2.12.7":
-    folder: all
-  "2.12.6":
-    folder: all
-  "2.12.5":
-    folder: all
   "2.12.4":
     folder: all
   "2.12.3":
     folder: all
   "2.11.9":
-    folder: all
-  "2.11.8":
-    folder: all
-  "2.11.7":
     folder: all
   "2.11.6":
     folder: all

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.12.9":
+    folder: all
   "2.12.7":
     folder: all
   "2.12.6":
@@ -8,6 +10,8 @@ versions:
   "2.12.4":
     folder: all
   "2.12.3":
+    folder: all
+  "2.11.9":
     folder: all
   "2.11.8":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2/***

#### Motivation
2.11.9 and 2.12.9 contain fix for [CVE-2024-40896] Fix XXE protection in downstream code
https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.11.9
https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.9

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
I've also removed bugfix versions that aren't present in current master

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
