### PR TITLE
openjdk license: combine the 2 expressions into one for SBOM generator compatibility

### DIFF
--- a/recipes/openjdk/all/conanfile.py
+++ b/recipes/openjdk/all/conanfile.py
@@ -13,7 +13,7 @@ class OpenJDK(ConanFile):
     url = "https://github.com/conan-io/conan-center-index/"
     description = "Java Development Kit builds, from Oracle"
     homepage = "https://jdk.java.net"
-    license = "GPL-2.0-only WITH Classpath-exception-2.0", "GPL-2.0-only WITH OpenJDK-assembly-exception-1.0"
+    license = "GPL-2.0-only WITH Classpath-exception-2.0 AND GPL-2.0-only WITH OpenJDK-assembly-exception-1.0"
     topics = ("java", "jdk", "openjdk")
     settings = "os", "arch", "compiler", "build_type"
     upload_policy = "skip"


### PR DESCRIPTION
### Summary
Changes to recipe:  openjdk all versions, licence attribute

#### Motivation
When using the Conan SBOM generator extension, the CycloneDX library rejects the licence information because it's using SPDX expressions, and in this case, there can be only one element.

#### Details
To allow the license to be valid when using Conan's SBOM generator extension, we have to use only one element when using SPDX expressions. I'm unsure whether multiple WITH operators are valid, so I propose to use a AND operator. WITH has precedence over AND, so no parenthesis is needed.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan

NOTICE: I didn't read any of the CLA text I signed, nor did I read the contributing guidelines.