### PR TITLE
libcroco: new recipe

### DIFF
--- a/recipes/libcroco/all/conandata.yml
+++ b/recipes/libcroco/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.6.13":
+    url: "https://download.gnome.org/sources/libcroco/0.6/libcroco-0.6.13.tar.xz"
+    sha256: "767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4"

--- a/recipes/libcroco/all/conanfile.py
+++ b/recipes/libcroco/all/conanfile.py
@@ -68,6 +68,9 @@ class LibcrocoConan(ConanFile):
         VirtualBuildEnv(self).generate()
 
         tc = AutotoolsToolchain(self)
+        # ./configure fails in C3I otherwise with:
+        # error: -Bsymbolic requested but not supported by ld
+        tc.configure_args.append("--disable-Bsymbolic")
         tc.generate()
 
         deps = PkgConfigDeps(self)

--- a/recipes/libcroco/all/conanfile.py
+++ b/recipes/libcroco/all/conanfile.py
@@ -71,6 +71,9 @@ class LibcrocoConan(ConanFile):
         # ./configure fails in C3I otherwise with:
         # error: -Bsymbolic requested but not supported by ld
         tc.configure_args.append("--disable-Bsymbolic")
+        if is_msvc(self):
+            tc.extra_cflags.append("-FS")
+            tc.extra_cxxflags.append("-FS")
         tc.generate()
 
         deps = PkgConfigDeps(self)

--- a/recipes/libcroco/all/conanfile.py
+++ b/recipes/libcroco/all/conanfile.py
@@ -59,7 +59,7 @@ class LibcrocoConan(ConanFile):
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
         if is_msvc(self):
-            self.tool_requires("automake/x.y.z")
+            self.tool_requires("automake/1.16.5")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libcroco/all/conanfile.py
+++ b/recipes/libcroco/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.files import copy, get, rm, rmdir
@@ -50,6 +51,10 @@ class LibcrocoConan(ConanFile):
         # Both are used in several public headers
         self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
         self.requires("libxml2/[>=2.12.5 <3]", transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if is_msvc(self) and self.options.shared:
+            raise ConanInvalidConfiguration("Shared builds are not supported with MSVC")
 
     def build_requirements(self):
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):

--- a/recipes/libcroco/all/conanfile.py
+++ b/recipes/libcroco/all/conanfile.py
@@ -1,0 +1,113 @@
+import os
+
+from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.env import Environment, VirtualBuildEnv
+from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.gnu import Autotools, PkgConfigDeps, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, unix_path
+
+required_conan_version = ">=1.54.0"
+
+
+class LibcrocoConan(ConanFile):
+    name = "libcroco"
+    description = "A CSS2 parsing and manipulation toolkit for GNOME. Archived and no longer maintained."
+    license = "LGPL-2.1-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://gitlab.com/inkscape/libcroco"
+    topics = ("css", "gnome")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        # Both are used in several public headers
+        self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
+        self.requires("libxml2/[>=2.12.5 <3]", transitive_headers=True, transitive_libs=True)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
+        if is_msvc(self):
+            self.tool_requires("automake/x.y.z")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        VirtualBuildEnv(self).generate()
+
+        tc = AutotoolsToolchain(self)
+        tc.generate()
+
+        deps = PkgConfigDeps(self)
+        deps.generate()
+
+        if is_msvc(self):
+            env = Environment()
+            automake_conf = self.dependencies.build["automake"].conf_info
+            compile_wrapper = unix_path(self, automake_conf.get("user.automake:compile-wrapper", check_type=str))
+            ar_wrapper = unix_path(self, automake_conf.get("user.automake:lib-wrapper", check_type=str))
+            env.define("CC", f"{compile_wrapper} cl -nologo")
+            env.define("CXX", f"{compile_wrapper} cl -nologo")
+            env.define("LD", "link -nologo")
+            env.define("AR", f"{ar_wrapper} lib")
+            env.define("NM", "dumpbin -symbols")
+            env.define("OBJDUMP", ":")
+            env.define("RANLIB", ":")
+            env.define("STRIP", ":")
+            env.vars(self).save_script("conanbuild_msvc")
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "libcroco-0.6")
+        self.cpp_info.libs = ["croco-0.6"]
+        self.cpp_info.includedirs.append(os.path.join("include", "libcroco-0.6"))
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+        self.cpp_info.requires = [
+            "glib::glib-2.0",
+            "libxml2::libxml2",
+        ]

--- a/recipes/libcroco/all/conanfile.py
+++ b/recipes/libcroco/all/conanfile.py
@@ -97,7 +97,8 @@ class LibcrocoConan(ConanFile):
         autotools.make()
 
     def package(self):
-        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "COPYRIGHTS", self.source_folder, os.path.join(self.package_folder, "licenses"))
         autotools = Autotools(self)
         autotools.install()
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))

--- a/recipes/libcroco/all/test_package/CMakeLists.txt
+++ b/recipes/libcroco/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(libcroco REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE libcroco::libcroco)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/libcroco/all/test_package/conanfile.py
+++ b/recipes/libcroco/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libcroco/all/test_package/conanfile.py
+++ b/recipes/libcroco/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/libcroco/all/test_package/test_package.c
+++ b/recipes/libcroco/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <libcroco/libcroco.h>
+#include <string.h>
+
+int main() {
+    const char* css = "body { color: red; }";
+    CRStyleSheet *stylesheet = NULL;
+    enum CRStatus status = cr_om_parser_simply_parse_buf(css, strlen(css), CR_ASCII, &stylesheet);
+}

--- a/recipes/libcroco/config.yml
+++ b/recipes/libcroco/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.6.13":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcroco/0.6.13**

#### Motivation
A CSS2 parsing and manipulation toolkit for GNOME.

https://gitlab.com/inkscape/libcroco

[![Packaging status](https://repology.org/badge/tiny-repos/libcroco.svg)](https://repology.org/project/libcroco/versions)

Required to build the legacy 2.40.x C version of librsvg (#25373).

#### Details
Archived and no longer maintained. Has known vulnerabilities.
- https://repology.org/project/libcroco/cves?version=0.6.13
- https://gitlab.gnome.org/Archive/libcroco/-/issues/8

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
