### PR TITLE
cppserver: add v1.0.4.1, add missing transitive_headers=True

### DIFF
--- a/recipes/cppserver/all/conandata.yml
+++ b/recipes/cppserver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.4.1":
+    url: "https://github.com/chronoxor/CppServer/archive/1.0.4.1.tar.gz"
+    sha256: "252f66d6c245641b9ed73eae77324513e597debd0615523d16b83b043d31035f"
   "1.0.2.0":
     url: "https://github.com/chronoxor/CppServer/archive/1.0.2.0.tar.gz"
     sha256: "512b2ada2ddebcedcfac814e3d0784ccef410506dab5dcf64c56302b40e042d4"
@@ -9,6 +12,16 @@ sources:
     url: "https://github.com/chronoxor/CppServer/archive/1.0.0.0.tar.gz"
     sha256: "dc70fb24231ac4c06e813a0489ff911dd5c48f844b75856b1e753ac8dbd64772"
 patches:
+  "1.0.4.1":
+    - patch_file: "patches/0001-cmake-clean-up-1-0-4-1.patch"
+      patch_description: "use cci packages, disable test/example builds"
+      patch_type: "conan"
+    - patch_file: "patches/0002-define-win32-winnt-1-0-2-0.patch"
+      patch_description: "add win32/winnt defines"
+      patch_type: "portability"
+    - patch_file: "patches/0003-remove-asio-defines-1-0-0-0.patch"
+      patch_description: "remove asio defines"
+      patch_type: "portability"
   "1.0.2.0":
     - patch_file: "patches/0001-cmake-clean-up-1-0-2-0.patch"
       patch_description: "use cci packages, disable test/example builds"

--- a/recipes/cppserver/all/conanfile.py
+++ b/recipes/cppserver/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.env.virtualbuildenv import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, collect_libs
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
@@ -8,7 +9,7 @@ import os
 
 required_conan_version = ">=1.53.0"
 
-class CppServer(ConanFile):
+class CppServerPackage(ConanFile):
     name = "cppserver"
     description = "Ultra fast and low latency asynchronous socket server and" \
         " client C++ library with support TCP, SSL, UDP, HTTP, HTTPS, WebSocket" \
@@ -57,17 +58,15 @@ class CppServer(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("asio/1.27.0")
-        self.requires("openssl/[>=1.1 <4]")
-        self.requires("cppcommon/1.0.3.0")
+        self.requires("asio/1.27.0", transitive_headers=True, transitive_libs=True)
+        self.requires("openssl/[>=1.1 <4]", transitive_headers=True, transitive_libs=True)
+        self.requires("cppcommon/1.0.3.0", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if not minimum_version:
-            self.output.warn(f"{self.ref} requires C++17. Your compiler is unknown. Assuming it supports C++17.")
-        elif Version(self.settings.compiler.version) < minimum_version:
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(f"{self.ref} requires a compiler that supports at least C++17")
 
     def build_requirements(self):
@@ -78,13 +77,13 @@ class CppServer(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        VirtualBuildEnv(self).generate()
         tc = CMakeToolchain(self)
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         tc.variables["CPPSERVER_MODULE"] = False
         tc.generate()
-
-        dpes = CMakeDeps(self)
-        dpes.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/cppserver/all/conanfile.py
+++ b/recipes/cppserver/all/conanfile.py
@@ -63,7 +63,7 @@ class CppServerPackage(ConanFile):
         # Used in transitive asio/ssl.hpp header from asio
         self.requires("openssl/[>=1.1 <4]", transitive_headers=True, transitive_libs=True)
         # threads/thread.h used in asio/service.h public header
-        self.requires("cppcommon/1.0.3.0", transitive_headers=True, transitive_libs=True)
+        self.requires("cppcommon/1.0.4.0", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/cppserver/all/conanfile.py
+++ b/recipes/cppserver/all/conanfile.py
@@ -58,8 +58,11 @@ class CppServerPackage(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
+        # Used in asio/asio.h public header
         self.requires("asio/1.27.0", transitive_headers=True, transitive_libs=True)
+        # Used in transitive asio/ssl.hpp header from asio
         self.requires("openssl/[>=1.1 <4]", transitive_headers=True, transitive_libs=True)
+        # threads/thread.h used in asio/service.h public header
         self.requires("cppcommon/1.0.3.0", transitive_headers=True, transitive_libs=True)
 
     def validate(self):

--- a/recipes/cppserver/all/patches/0001-cmake-clean-up-1-0-4-1.patch
+++ b/recipes/cppserver/all/patches/0001-cmake-clean-up-1-0-4-1.patch
@@ -1,0 +1,113 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,53 +17,24 @@
+   endif()
+ endif()
+ 
+-# CMake module path
+-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+-
+-# Compiler features
+-include(SetCompilerFeatures)
+-include(SetCompilerWarnings)
+-include(SetPlatformFeatures)
+-include(SystemInformation)
+-
+ # External packages
+-if(APPLE)
+-  set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl@1.1")
+-elseif(CYGWIN)
+-  set(OPENSSL_ROOT_DIR "/usr/lib")
+-  set(OPENSSL_INCLUDE_DIR "/usr/include")
+-  set(OPENSSL_CRYPTO_LIBRARY "/usr/lib/libcrypto.dll.a")
+-  set(OPENSSL_SSL_LIBRARY "/usr/lib/libssl.dll.a")
+-elseif(MINGW)
+-  set(OPENSSL_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/modules/OpenSSL/MinGW")
+-  set(OPENSSL_USE_STATIC_LIBS TRUE)
+-elseif(MSVC)
+-  set(OPENSSL_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/modules/OpenSSL/VS")
+-  set(OPENSSL_USE_STATIC_LIBS TRUE)
+-  set(OPENSSL_MSVC_STATIC_RT TRUE)
+-endif()
+ find_package(OpenSSL REQUIRED)
+-if(WIN32)
++if(0)
+   find_package(Crypt)
+   find_package(WinSock)
+ endif()
+ 
+-# Modules
+-add_subdirectory("modules")
+-
+ # Link libraries
+-list(APPEND LINKLIBS ${OPENSSL_LIBRARIES})
++list(APPEND LINKLIBS OpenSSL::SSL)
+ if(WIN32)
+-  list(APPEND LINKLIBS ${CRYPT_LIBRARIES})
+-  list(APPEND LINKLIBS ${WINSOCK_LIBRARIES})
++  list(APPEND LINKLIBS crypt32)
++  list(APPEND LINKLIBS ws2_32)
+ endif()
+-list(APPEND LINKLIBS cppcommon)
++find_package(cppcommon REQUIRED)
++list(APPEND LINKLIBS cppcommon::cppcommon)
+ 
+ # OpenSSL libraries
+ message(STATUS "OpenSSL version: ${OPENSSL_VERSION} ${OPENSSL_INCLUDE_DIR} ${OPENSSL_LIBRARIES}")
+-
+-# System directories
+-include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/modules")
+ 
+ # Library
+ file(GLOB_RECURSE LIB_HEADER_FILES "include/*.h" "source/*.h")
+@@ -72,7 +43,9 @@
+ add_library(cppserver ${LIB_HEADER_FILES} ${LIB_INLINE_FILES} ${LIB_SOURCE_FILES})
+ set_target_properties(cppserver PROPERTIES COMPILE_FLAGS "${PEDANTIC_COMPILE_FLAGS}" FOLDER "libraries")
+ target_include_directories(cppserver PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+-target_link_libraries(cppserver ${LINKLIBS} asio)
++find_package(asio REQUIRED)
++target_link_libraries(cppserver ${LINKLIBS} asio::asio)
++target_compile_features(cppserver PUBLIC cxx_std_17)
+ list(APPEND INSTALL_TARGETS cppserver)
+ list(APPEND LINKLIBS cppserver)
+ 
+@@ -91,6 +64,7 @@
+   list(APPEND LINKLIBS proto)
+ 
+   # Examples
++  if(0)
+   file(GLOB EXAMPLE_HEADER_FILES "examples/*.h")
+   file(GLOB EXAMPLE_INLINE_FILES "examples/*.inl")
+   file(GLOB EXAMPLE_SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/examples" "examples/*.cpp")
+@@ -117,8 +91,10 @@
+     list(APPEND INSTALL_TARGETS ${BENCHMARK_TARGET})
+     list(APPEND INSTALL_TARGETS_PDB ${BENCHMARK_TARGET})
+   endforeach()
++  endif()
+ 
+   # Tests
++  if(0)
+   file(GLOB TESTS_HEADER_FILES "tests/*.h")
+   file(GLOB TESTS_INLINE_FILES "tests/*.inl")
+   file(GLOB TESTS_SOURCE_FILES "tests/*.cpp")
+@@ -132,15 +108,16 @@
+   # CTest
+   enable_testing()
+   add_test(cppserver-tests cppserver-tests --durations yes --order lex)
++  endif()
+ 
+   # Install
+   install(TARGETS ${INSTALL_TARGETS}
+-    RUNTIME DESTINATION "${PROJECT_SOURCE_DIR}/bin"
+-    LIBRARY DESTINATION "${PROJECT_SOURCE_DIR}/bin"
+-    ARCHIVE DESTINATION "${PROJECT_SOURCE_DIR}/bin")
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib)
+ 
+   # Install *.pdb files
+-  if(MSVC)
++  if(0)
+     foreach(INSTALL_TARGET_PDB ${INSTALL_TARGETS_PDB})
+       install(FILES $<TARGET_PDB_FILE:${INSTALL_TARGET_PDB}> DESTINATION "${PROJECT_SOURCE_DIR}/bin")
+     endforeach()

--- a/recipes/cppserver/config.yml
+++ b/recipes/cppserver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.4.1":
+    folder: all
   "1.0.2.0":
     folder: all
   "1.0.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cppserver/1.0.4.1**

#### Motivation
Updates the recipe to the latest version and fixes minor remaining issues on Conan v2.

https://github.com/chronoxor/CppServer/compare/1.0.2.0...1.0.4.1

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan