### PR TITLE
Add correct pkfconfig name for libnl components

### DIFF
--- a/recipes/libnl/all/conanfile.py
+++ b/recipes/libnl/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.env import VirtualBuildEnv
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -16,6 +17,7 @@ class LibNlConan(ConanFile):
     homepage = "https://github.com/thom311/libnl"
     topics = ("netlink")
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "library"
     options = {
         "fPIC": [True, False],
         "shared": [True, False],
@@ -92,6 +94,7 @@ class LibNlConan(ConanFile):
         self.cpp_info.components["nl-idiag"].requires = ["nl"]
         self.cpp_info.components["nl-idiag"].set_property("pkg_config_name", "libnl-idiag-3.0.pc")
 
-        self.cpp_info.components["nl-xfrm"].libs = ["nl-xfrm-3"]
-        self.cpp_info.components["nl-idiag"].requires = ["nl"]
-        self.cpp_info.components["nl-idiag"].set_property("pkg_config_name", "libnl-xfrm-3.0.pc")
+        if Version(self.version) >= "3.3.0":
+            self.cpp_info.components["nl-xfrm"].libs = ["nl-xfrm-3"]
+            self.cpp_info.components["nl-idiag"].requires = ["nl"]
+            self.cpp_info.components["nl-idiag"].set_property("pkg_config_name", "libnl-xfrm-3.0.pc")

--- a/recipes/libnl/all/conanfile.py
+++ b/recipes/libnl/all/conanfile.py
@@ -3,6 +3,7 @@ from conan.tools.files import get, rmdir, copy, rm
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
 import os
 
 required_conan_version = ">=1.53.0"
@@ -45,6 +46,8 @@ class LibNlConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
         tc = AutotoolsToolchain(self)
         tc.generate()
 
@@ -66,14 +69,29 @@ class LibNlConan(ConanFile):
         self.cpp_info.components["nl"].libs = ["nl-3"]
         self.cpp_info.components["nl"].includedirs = [os.path.join('include', 'libnl3')]
         self.cpp_info.components["nl"].system_libs = ["pthread", "m"]
+        self.cpp_info.components["nl"].set_property("pkg_config_name", "libnl-3.0")
+
         self.cpp_info.components["nl-route"].libs = ["nl-route-3"]
         self.cpp_info.components["nl-route"].requires = ["nl"]
+        self.cpp_info.components["nl-route"].set_property("pkg_config_name", "libnl-route-3.0")
+
         self.cpp_info.components["nl-genl"].libs = ["nl-genl-3"]
         self.cpp_info.components["nl-genl"].requires = ["nl"]
+        self.cpp_info.components["nl-genl"].set_property("pkg_config_name", "libnl-genl-3.0.pc")
+
         self.cpp_info.components["nl-nf"].libs = ["nl-nf-3"]
         self.cpp_info.components["nl-nf"].requires = ["nl-route"]
+        self.cpp_info.components["nl-nf"].set_property("pkg_config_name", "libnl-nf-3.0.pc")
+
         self.cpp_info.components["nl-cli"].libs = ["nl-cli-3"]
         self.cpp_info.components["nl-cli"].requires = ["nl-nf", "nl-genl"]
         self.cpp_info.components["nl-cli"].system_libs = ["dl"]
+        self.cpp_info.components["nl-cli"].set_property("pkg_config_name", "libnl-cli-3.0.pc")
+
         self.cpp_info.components["nl-idiag"].libs = ["nl-idiag-3"]
         self.cpp_info.components["nl-idiag"].requires = ["nl"]
+        self.cpp_info.components["nl-idiag"].set_property("pkg_config_name", "libnl-idiag-3.0.pc")
+
+        self.cpp_info.components["nl-xfrm"].libs = ["nl-xfrm-3"]
+        self.cpp_info.components["nl-idiag"].requires = ["nl"]
+        self.cpp_info.components["nl-idiag"].set_property("pkg_config_name", "libnl-xfrm-3.0.pc")

--- a/recipes/libnl/all/test_package/CMakeLists.txt
+++ b/recipes/libnl/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(test_package LANGUAGES C)
 find_package(libnl REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE libnl::nl libnl::nl-route libnl::nl-genl libnl::nl-nf libnl::nl-cli libnl::nl-idiag libnl::nl-xfrm)
+target_link_libraries(${PROJECT_NAME} PRIVATE libnl::nl libnl::nl-route libnl::nl-genl libnl::nl-nf libnl::nl-cli libnl::nl-idiag $<$<TARGET_EXISTS:libnl::nl-xfrm>:libnl::nl-xfrm>)

--- a/recipes/libnl/all/test_package/CMakeLists.txt
+++ b/recipes/libnl/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(test_package LANGUAGES C)
 find_package(libnl REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE libnl::nl libnl::nl-route libnl::nl-genl libnl::nl-nf libnl::nl-cli libnl::nl-idiag)
+target_link_libraries(${PROJECT_NAME} PRIVATE libnl::nl libnl::nl-route libnl::nl-genl libnl::nl-nf libnl::nl-cli libnl::nl-idiag libnl::nl-xfrm)


### PR DESCRIPTION
### Summary

Changes to recipe:  **libnl/[*]**

#### Motivation

The PR https://github.com/conan-io/conan-center-index/pull/23383, when building with libnl support, libpcap failed to find libnl-genl-3.0.pc

/cc @valgur 


#### Details

The libnl uses specific names for its components, using 3.0 as suffix:

```
 /bin/mkdir -p '/home/conan/.conan2/p/b/libnlef6c99bdd2af2/p//lib/pkgconfig'
 /usr/bin/install -c -m 644 /home/conan/.conan2/p/b/libnlef6c99bdd2af2/b/src/man/genl-ctrl-list.8 /home/conan/.conan2/p/b/libnlef6c99bdd2af2/b/src/man/nl-classid-lookup.8 /home/conan/.conan2/p/b/libnlef6c99bdd2af2/b/src/man/nl-pktloc-lookup.8 /home/conan/.conan2/p/b/libnlef6c99bdd2af2/b/src/man/nl-qdisc-add.8 /home/conan/.conan2/p/b/libnlef6c99bdd2af2/b/src/man/nl-qdisc-delete.8 /home/conan/.conan2/p/b/libnlef6c99bdd2af2/b/src/man/nl-qdisc-list.8 '/home/conan/.conan2/p/b/libnlef6c99bdd2af2/p//share/man/man8'
 /usr/bin/install -c -m 644 libnl-3.0.pc libnl-genl-3.0.pc libnl-idiag-3.0.pc libnl-nf-3.0.pc libnl-route-3.0.pc libnl-xfrm-3.0.pc libnl-cli-3.0.pc '/home/conan/.conan2/p/b/libnlef6c99bdd2af2/p//lib/pkgconfig'
```

https://archlinux.org/packages/core/x86_64/libnl/files/ (BTW, I use Arch)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
