### PR TITLE
Clarify header only library template

### DIFF
--- a/docs/package_templates/README.md
+++ b/docs/package_templates/README.md
@@ -12,7 +12,7 @@ It's listed under [cmake_package](cmake_package) folder. It fits projects which 
 
 ####  Header only
 
-It's listed under [header_only](header_only) folder. It fits projects which only copy header and have the same package ID always.
+It's listed under [header_only](header_only) folder. It fits projects which only copy header and have the same package ID always. Please note that if the library in question does have a build system (e.g. CMake, Meson, Autotools) that contains install logic - that should be the preferred starting point for the recipe. Copying files directly into the package folder should be reserved for header only libraries where the upstream project does not provide this functionality.
 
 #### MSBuild package
 


### PR DESCRIPTION
### Summary


If a header only upstream library has a build system with install targets - this should be preferred if available, for the following reasons:
* the install logic that determines _which files_ and _where_ they are installed, is dictated by the uptream project - and we should follow it where possible. This can avoid issues where the upstream project reorganises their folders, but the conan recipe doesn't follow 

For future capabilities:
* some users very much like to _not_ disable tests during the _creation_ of a package, this continues being a request. It may be not be suitable for Conan Center, but we may have an opt-in in the future to build/run tests during the build/create phase.
* For CMake based projects, in the future we may consider bundling the -config.cmake files - or, better yet, the CPS files once CMake is able to generate them - this would greatly simplify the future proofing

Direct file copy should be reserved for header only libraries that are intended to be "dropped into your project", or where the build system is internal only and does not have "install" logic.