### PR TITLE
libuvc: remove deprecated libjpeg-turbo option

### DIFF
--- a/recipes/libuvc/all/conanfile.py
+++ b/recipes/libuvc/all/conanfile.py
@@ -24,13 +24,11 @@ class LibuvcConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_jpeg": [False, "libjpeg", "libjpeg-turbo", "mozjpeg"],
-        "jpeg_turbo": [True, False, "deprecated"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_jpeg": "libjpeg",
-        "jpeg_turbo": "deprecated",
     }
 
     def export_sources(self):
@@ -46,12 +44,6 @@ class LibuvcConan(ConanFile):
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
 
-        # TODO: to remove once deprecated jpeg_turbo option removed
-        if self.options.jpeg_turbo != "deprecated":
-            self.output.warning("jpeg_turbo option is deprecated, please use with_jpeg option instead")
-            if self.options.jpeg_turbo:
-                self.options.with_jpeg == "libjpeg-turbo"
-
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -63,10 +55,6 @@ class LibuvcConan(ConanFile):
             self.requires("libjpeg-turbo/3.0.0")
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.3")
-
-    def package_id(self):
-        # TODO: to remove once deprecated jpeg_turbo option removed
-        del self.info.options.jpeg_turbo
 
     def validate(self):
         if is_msvc(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libuvc/all**

#### Motivation

We have found an error thanks to the experimental conan linter:
```
recipes/libuvc/all/conanfile.py::53:16 - W0104: Statement seems to have no effect (pointless-statement)
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│    52             if self.options.jpeg_turbo:                                                                                                                              │
│    53                 self.options.with_jpeg == "libjpeg-turbo"                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

We have decided to fully remove this option deprecated two years ago which was incorrectly programmed.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
