### PR TITLE
kplot: add package_type, missing transitive_headers, simplify CMakeLists.txt

### DIFF
--- a/recipes/kplot/all/CMakeLists.txt
+++ b/recipes/kplot/all/CMakeLists.txt
@@ -1,49 +1,45 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(kplot LANGUAGES C)
 
 find_package(cairo REQUIRED CONFIG)
 
 set(kplot_src
-    ${KPLOT_SRC_DIR}/colours.c
-    ${KPLOT_SRC_DIR}/array.c
-    ${KPLOT_SRC_DIR}/border.c
-    ${KPLOT_SRC_DIR}/bucket.c
-    ${KPLOT_SRC_DIR}/buffer.c
-    ${KPLOT_SRC_DIR}/draw.c
-    ${KPLOT_SRC_DIR}/grid.c
-    ${KPLOT_SRC_DIR}/hist.c
-    ${KPLOT_SRC_DIR}/label.c
-    ${KPLOT_SRC_DIR}/kdata.c
-    ${KPLOT_SRC_DIR}/kplot.c
-    ${KPLOT_SRC_DIR}/margin.c
-    ${KPLOT_SRC_DIR}/mean.c
-    ${KPLOT_SRC_DIR}/plotctx.c
-    ${KPLOT_SRC_DIR}/reallocarray.c
-    ${KPLOT_SRC_DIR}/stddev.c
-    ${KPLOT_SRC_DIR}/tic.c
-    ${KPLOT_SRC_DIR}/vector.c
+    colours.c
+    array.c
+    border.c
+    bucket.c
+    buffer.c
+    draw.c
+    grid.c
+    hist.c
+    label.c
+    kdata.c
+    kplot.c
+    margin.c
+    mean.c
+    plotctx.c
+    reallocarray.c
+    stddev.c
+    tic.c
+    vector.c
 )
 
 set(kplot_inc
-    ${KPLOT_SRC_DIR}/compat.h
-    ${KPLOT_SRC_DIR}/extern.h
-    ${KPLOT_SRC_DIR}/kplot.h
+    compat.h
+    extern.h
+    kplot.h
 )
 
-include_directories(KPLOT_SRC_DIR)
-
-try_run(HAVE_reallocarray COMPIE_reallocarray ${CMAKE_BINARY_DIR} ${KPLOT_SRC_DIR}/test-reallocarray.c)
-
-file(READ "${KPLOT_SRC_DIR}/compat.pre.h" COMPAT_CONTENTS)
-file(WRITE "${KPLOT_SRC_DIR}/compat.h" "${COMPAT_CONTENTS}")
-if (${COMPIE_reallocarray} AND NOT ${HAVE_reallocarray})
-    file(APPEND "${KPLOT_SRC_DIR}/compat.h" "#define  HAVE_REALLOCARRAY")
+try_run(HAVE_reallocarray COMPIE_reallocarray ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/test-reallocarray.c")
+file(READ compat.pre.h COMPAT_CONTENTS)
+file(WRITE compat.h "${COMPAT_CONTENTS}")
+if (COMPIE_reallocarray AND NOT HAVE_reallocarray)
+    file(APPEND compat.h "#define  HAVE_REALLOCARRAY")
 endif()
-file(READ "${KPLOT_SRC_DIR}/compat.post.h" COMPAT_CONTENTS)
-file(APPEND "${KPLOT_SRC_DIR}/compat.h" "${COMPAT_CONTENTS}")
+file(READ compat.post.h COMPAT_CONTENTS)
+file(APPEND compat.h "${COMPAT_CONTENTS}")
 
 add_library(kplot ${kplot_src})
-
 target_compile_features(kplot PRIVATE c_std_99)
 set_target_properties(kplot PROPERTIES
     PUBLIC_HEADER "${kplot_inc}"
@@ -54,7 +50,6 @@ target_compile_features(kplot PRIVATE c_std_99)
 target_link_libraries(kplot PRIVATE cairo::cairo)
 
 include(GNUInstallDirs)
-
 install(
     TARGETS kplot
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/recipes/kplot/all/test_package/test_package.c
+++ b/recipes/kplot/all/test_package/test_package.c
@@ -1,14 +1,11 @@
-#include <stdlib.h>
+// Both are required by kplot.h
+#include <cairo.h>
 #include <unistd.h>
 
-#include "cairo.h"
-#include "kplot.h"
+#include <kplot.h>
 
 int main() {
     struct kpair points1[50];
     struct kdata* d1 = kdata_array_alloc(points1, 50);
-
     kdata_destroy(d1);
-
-    return 0;
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **kplot/[*]**

#### Motivation
One of the few remaining recipes that does not use `import from conans ...` but is still not Conan 2.x compatible.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
