### PR TITLE
opengl: avoid unecessary call to package manager for irrelevant host OS

### DIFF
--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -23,6 +23,9 @@ class SysConfigOpenGLConan(ConanFile):
         self.info.clear()
 
     def system_requirements(self):
+        if self.settings.os not in ["Linux", "FreeBSD", "SunOS"]:
+            return
+
         dnf = package_manager.Dnf(self)
         dnf.install_substitutes(["libglvnd-devel"], ["mesa-libGL-devel"], update=True, check=True)
 
@@ -36,11 +39,14 @@ class SysConfigOpenGLConan(ConanFile):
         pacman.install(["libglvnd"], update=True, check=True)
 
         zypper = package_manager.Zypper(self)
-        zypper.install_substitutes(["Mesa-libGL-devel", "glproto-devel"], 
+        zypper.install_substitutes(["Mesa-libGL-devel", "glproto-devel"],
                                    ["Mesa-libGL-devel", "xorgproto-devel"], update=True, check=True)
 
         pkg = package_manager.Pkg(self)
         pkg.install(["libglvnd"], update=True, check=True)
+
+        pkg_util = package_manager.PkgUtil(self)
+        pkg_util.install(["mesalibs"], update=True, check=True)
 
     def package_info(self):
         # TODO: Workaround for #2311 until a better solution can be found
@@ -57,6 +63,6 @@ class SysConfigOpenGLConan(ConanFile):
             self.cpp_info.frameworks.append("OpenGL")
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["opengl32"]
-        elif self.settings.os in ["Linux", "FreeBSD"]:
+        elif self.settings.os in ["Linux", "FreeBSD", "SunOS"]:
             pkg_config = PkgConfig(self, 'gl')
             pkg_config.fill_cpp_info(self.cpp_info, is_system=self.settings.os != "FreeBSD")


### PR DESCRIPTION
### Summary
Changes to recipe:  **opengl/all**

#### Motivation
Currently, when you cross-build from Linux or FreeBSD to another OS than those 2 ones, this recipe installs an OpenGL lib unrelated to host OS, which is useless. Indeed, there is no early check, just attempt to run a bunch of system package managers. So it tries to call build machine system package manager and... succeeds but it's just build machine lib.

Relates to https://github.com/conan-io/conan-center-index/issues/25391

#### Details
Prevent to call system package manager if not Linux, FreeBSD or SunOS (all these package managers calls in system_requirements() are related to these OS).

Also support SunOS in the meantime by trying installation with PkgUtil (package seems to be mesalibs, see https://www.opencsw.org/packages/CSWmesa/).

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
