### PR TITLE
libxslt: Add new version that supports newer libxml2 versions

### DIFF
--- a/recipes/libxslt/all/conandata.yml
+++ b/recipes/libxslt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.42":
+    sha256: "85ca62cac0d41fc77d3f6033da9df6fd73d20ea2fc18b0a3609ffb4110e1baeb"
+    url: "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.42.tar.xz"
   "1.1.39":
     sha256: "2a20ad621148339b0759c4d4e96719362dee64c9a096dbba625ba053846349f0"
     url: "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.39.tar.xz"

--- a/recipes/libxslt/all/conanfile.py
+++ b/recipes/libxslt/all/conanfile.py
@@ -61,7 +61,7 @@ class LibxsltConan(ConanFile):
 
     def requirements(self):
         if Version(self.version) >= "1.1.42":
-            self.requires("libxml2/[=>2.12.5 <3]", transitive_headers=True, transitive_libs=True)
+            self.requires("libxml2/[>=2.12.5 <3]", transitive_headers=True, transitive_libs=True)
         elif Version(self.version) >= "1.1.39":
             # see https://github.com/conan-io/conan-center-index/pull/16205#discussion_r1149570846
             # Older versions use deprecated functions that were removed in libxml2 2.13

--- a/recipes/libxslt/all/conanfile.py
+++ b/recipes/libxslt/all/conanfile.py
@@ -60,9 +60,12 @@ class LibxsltConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "1.1.39":
+        if Version(self.version) >= "1.1.42":
+            self.requires("libxml2/[=>2.12.5 <3]", transitive_headers=True, transitive_libs=True)
+        elif Version(self.version) >= "1.1.39":
             # see https://github.com/conan-io/conan-center-index/pull/16205#discussion_r1149570846
-            self.requires("libxml2/[>=2.12.5 <3]", transitive_headers=True, transitive_libs=True)
+            # Older versions use deprecated functions that were removed in libxml2 2.13
+            self.requires("libxml2/[>=2.12.5 <2.13]", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("libxml2/2.11.6", transitive_headers=True, transitive_libs=True)
 

--- a/recipes/libxslt/config.yml
+++ b/recipes/libxslt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.42":
+    folder: all
   "1.1.39":
     folder: all
   "1.1.37":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxslt/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
New libxml2 1.13 removed deprecated symbols that were in used by old versions of this recipe
Reported by @gsantner in https://github.com/conan-io/conan-center-index/pull/25322#issuecomment-2373299498
