### PR TITLE
mold: add version 2.34.1, remove older versions

### DIFF
--- a/recipes/mold/all/conandata.yml
+++ b/recipes/mold/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.34.0":
-    url: "https://github.com/rui314/mold/archive/refs/tags/v2.34.0.tar.gz"
-    sha256: "6067f41f624c32cb0f4e959ae7fabee5dd71dd06771e2c069c2b3a6a8eca3c8c"
+  "2.34.1":
+    url: "https://github.com/rui314/mold/archive/refs/tags/v2.34.1.tar.gz"
+    sha256: "a8cf638045b4a4b2697d0bcc77fd96eae93d54d57ad3021bf03b0333a727a59d"
   "2.33.0":
     url: "https://github.com/rui314/mold/archive/refs/tags/v2.33.0.tar.gz"
     sha256: "37b3aacbd9b6accf581b92ba1a98ca418672ae330b78fe56ae542c2dcb10a155"

--- a/recipes/mold/all/conandata.yml
+++ b/recipes/mold/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.34.0":
+    url: "https://github.com/rui314/mold/archive/refs/tags/v2.34.0.tar.gz"
+    sha256: "6067f41f624c32cb0f4e959ae7fabee5dd71dd06771e2c069c2b3a6a8eca3c8c"
   "2.33.0":
     url: "https://github.com/rui314/mold/archive/refs/tags/v2.33.0.tar.gz"
     sha256: "37b3aacbd9b6accf581b92ba1a98ca418672ae330b78fe56ae542c2dcb10a155"
@@ -20,15 +23,3 @@ sources:
   "1.11.0":
     url: "https://github.com/rui314/mold/archive/refs/tags/v1.11.0.tar.gz"
     sha256: "99318eced81b09a77e4c657011076cc8ec3d4b6867bd324b8677974545bc4d6f"
-  "1.4.2":
-    url: "https://github.com/rui314/mold/archive/refs/tags/v1.4.2.tar.gz"
-    sha256: "47e6c48d20f49e5b47dfb8197dd9ffcb11a8833d614f7a03bd29741c658a69cd"
-  "1.5.1":
-    url: "https://github.com/rui314/mold/archive/refs/tags/v1.5.1.tar.gz"
-    sha256: "ec94aa74758f1bc199a732af95c6304ec98292b87f2f4548ce8436a7c5b054a1"
-  "1.7.1":
-    url: "https://github.com/rui314/mold/archive/refs/tags/v1.7.1.tar.gz"
-    sha256: "fa2558664db79a1e20f09162578632fa856b3cde966fbcb23084c352b827dfa9"
-  "1.8.0":
-    url: "https://github.com/rui314/mold/archive/refs/tags/v1.8.0.tar.gz"
-    sha256: "7210225478796c2528aae30320232a5a3b93a640292575a8c55aa2b140041b5c"

--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -1,5 +1,6 @@
 import os
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.files import copy, get, rmdir
 from conan.errors import ConanInvalidConfiguration
@@ -29,6 +30,20 @@ class MoldConan(ConanFile):
         "with_mimalloc": False,
     }
 
+    @property
+    def _min_cppstd(self):
+        return 20
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "11",
+            "clang": "12",
+            "apple-clang": "13",
+            "Visual Studio": "16",
+            "msvc": "192",
+        }
+
     def configure(self):
         if Version(self.version) < "2.0.0":
             self.license = "AGPL-3.0"
@@ -51,6 +66,17 @@ class MoldConan(ConanFile):
         del self.info.settings.compiler
 
     def validate(self):
+        # mold has required C+20 since 1.4.1. However, C++20 features are used for the first time in 2.34.0.
+        if Version(self.version) >= "2.34.0":
+            # validate the minimum cpp standard supported. For C++ projects only
+            if self.settings.compiler.cppstd:
+                check_min_cppstd(self, self._min_cppstd)
+            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+            if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+                )
+
         # TODO most of these checks should run on validate_build, but the conan-center hooks are broken and fail the PR because they
         # think we're raising on the build() method
         if self.settings.build_type == "Debug":

--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -39,7 +39,7 @@ class MoldConan(ConanFile):
         return {
             "gcc": "11",
             "clang": "12",
-            "apple-clang": "13",
+            "apple-clang": "14",
             "Visual Studio": "16",
             "msvc": "192",
         }

--- a/recipes/mold/config.yml
+++ b/recipes/mold/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.34.0":
+    folder: all
   "2.33.0":
     folder: all
   "2.32.1":
@@ -12,12 +14,4 @@ versions:
   "2.0.0":
     folder: all
   "1.11.0":
-    folder: all
-  "1.4.2":
-    folder: all
-  "1.5.1":
-    folder: all
-  "1.7.1":
-    folder: all
-  "1.8.0":
     folder: all

--- a/recipes/mold/config.yml
+++ b/recipes/mold/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.34.0":
+  "2.34.1":
     folder: all
   "2.33.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **mold/2.34.1**

#### Motivation
There are new features since 2.33.0.
DEC Alpha is no longer supported in 2.34.0.

#### Details
https://github.com/rui314/mold/compare/v2.33.0...v2.34.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
