### PR TITLE
azure-storage-cpp: mark as deprecated

### DIFF
--- a/recipes/azure-storage-cpp/all/conanfile.py
+++ b/recipes/azure-storage-cpp/all/conanfile.py
@@ -31,6 +31,10 @@ class AzureStorageCppConan(ConanFile):
         "fPIC": True,
     }
 
+    # Use azure-sdk-for-cpp::azure-storage-blobs-cpp instead
+    # https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/MigrationGuide.md
+    deprecated = "azure-sdk-for-cpp"
+
     @property
     def _minimum_cpp_standard(self):
         return 11


### PR DESCRIPTION
### Summary
Changes to recipe:  **azure-storage-cpp/7.5.0**

#### Motivation
The azure-storage-cpp library was deprecated in March 2024: https://azure.microsoft.com/en-us/updates/retirement-notice-the-legacy-azure-storage-c-client-libraries-will-be-retired-on-29-march-2025/

This PR marks the recipe as deprecated accordingly. `azure-sdk-for-cpp::azure-storage-blobs-cpp` should be used instead.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
