### PR TITLE
xmlsec: Avoid conflicts with the rest of libxslt

### DIFF
--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -64,7 +64,7 @@ class XmlSecConan(ConanFile):
         if self.options.with_openssl:
             self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
         if self.options.with_xslt:
-            self.requires("libxslt/1.1.39")
+            self.requires("libxslt/1.1.42")
 
     def validate(self):
         if self.options.with_nss:

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -80,7 +80,7 @@ class XmlSecConan(ConanFile):
         if not is_msvc(self):
             self.tool_requires("libtool/2.4.7")
             if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-                self.tool_requires("pkgconf/2.1.0")
+                self.tool_requires("pkgconf/[>=2.2 <3]")
             if self._settings_build.os == "Windows":
                 self.win_bash = True
                 if not self.conf.get("tools.microsoft.bash:path", check_type=str):


### PR DESCRIPTION
Also took the chance to bump pkgconf to a version range 

Successful compilation logs with `-o="&:with_xslt=True"`:

<details>

```
$ conan create . --version=1.3.4 -b=missing -o="&:with_xslt=True" -c="tools.files.download:verify=False"

======== Exporting recipe to the cache ========
xmlsec/1.3.4: Exporting package recipe: /Users/abril/coding/conan-center-index/recipes/xmlsec/all/conanfile.py
xmlsec/1.3.4: exports: File 'conandata.yml' found. Exporting it...
xmlsec/1.3.4: Copied 1 '.py' file: conanfile.py
xmlsec/1.3.4: Copied 1 '.yml' file: conandata.yml
xmlsec/1.3.4: Exported to cache folder: /Users/abril/coding/conan-center-index/recipes/eudev/all/conan_home/p/xmlsea5015bc8e5356/e
xmlsec/1.3.4: Exported: xmlsec/1.3.4#02398c20557217516a34c637a1919d19 (2024-09-25 15:31:21 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=16
os=Macos
[options]
&:with_xslt=True
[platform_tool_requires]
cmake/3.30.3
meson/1.5.2
[replace_tool_requires]
meson/*: meson/[>=1.0 <2]
[conf]
tools.files.download:verify=False

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=16
os=Macos
[platform_tool_requires]
cmake/3.30.3
meson/1.5.2
[replace_tool_requires]
meson/*: meson/[>=1.0 <2]


======== Computing dependency graph ========
Graph root
    cli
Requirements
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd - Cache
    libxml2/2.13.4#72b3bfba0c37dfe22f20c587cc468f4c - Cache
    libxslt/1.1.42#c1b4db9ead063bd275a7227d85cf519e - Cache
    openssl/3.3.2#9f9f130d58e7c13e76bb8a559f0a6a8b - Cache
    xmlsec/1.3.4#02398c20557217516a34c637a1919d19 - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    meson/1.5.2 - Platform
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
Replaced requires
    meson/1.2.2: meson/[>=1.0 <2]
Resolved version ranges
    libxml2/[>=2.12.5 <3]: libxml2/2.13.4
    openssl/[>=1.1 <4]: openssl/3.3.2
    zlib/[>=1.2.11 <2]: zlib/1.3.1

======== Computing necessary packages ========
Requirements
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd:405e382fa7fb6368c140a7f5c5cd71c32b009653#57414433357d972d48cd1a38793e8ac4 - Cache
    libxml2/2.13.4#72b3bfba0c37dfe22f20c587cc468f4c:369200858d3ad3ba8bbe2630b25f226c25956ca4#e992bdd0d1217aa00f3d1c2f7e98578b - Cache
    libxslt/1.1.42#c1b4db9ead063bd275a7227d85cf519e:6d59c33196271a5689ae733d85eb71e9e0b44d7e#72a1c65f6125e51a038df302fd1fb7b5 - Cache
    openssl/3.3.2#9f9f130d58e7c13e76bb8a559f0a6a8b:7ae3c973da08c7a4091a723ab10651cc4c5d5a8b#2ffcd2386e62ae05b5add50b9d071a90 - Cache
    xmlsec/1.3.4#02398c20557217516a34c637a1919d19:470beadbf601e8cd4c8f2a9136cb2fc8b8060e18#9bf60b41420b6c298892d0c72df6bf9b - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2:405e382fa7fb6368c140a7f5c5cd71c32b009653#d32260e9428b0e1610d991b2e0707062 - Cache
Build requirements
Skipped binaries
    autoconf/2.71, automake/1.16.5, gnu-config/cci.20210814, libtool/2.4.7, m4/1.4.19, meson/1.5.2, pkgconf/2.1.0

======== Installing packages ========
libiconv/1.17: Already installed! (1 of 6)
zlib/1.3.1: Already installed! (2 of 6)
openssl/3.3.2: Already installed! (3 of 6)
libxml2/2.13.4: Already installed! (4 of 6)
libxml2/2.13.4: Appending PATH environment variable: /Users/abril/coding/conan-center-index/recipes/eudev/all/conan_home/p/b/libxm7323bf60c9466/p/bin
libxslt/1.1.42: Already installed! (5 of 6)
xmlsec/1.3.4: Already installed! (6 of 6)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: libiconv/1.17, libxml2/2.13.4, libxslt/1.1.42, openssl/3.3.2, zlib/1.3.1
WARN: deprecated:     'env_info' used in: libiconv/1.17, openssl/3.3.2, libxml2/2.13.4, libxslt/1.1.42
WARN: deprecated:     'cpp_info.build_modules' used in: openssl/3.3.2, libxml2/2.13.4
WARN: deprecated:     'cpp_info.filenames' used in: libxml2/2.13.4

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    xmlsec/1.3.4 (test package): /Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/conanfile.py
Requirements
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd - Cache
    libxml2/2.13.4#72b3bfba0c37dfe22f20c587cc468f4c - Cache
    libxslt/1.1.42#c1b4db9ead063bd275a7227d85cf519e - Cache
    openssl/3.3.2#9f9f130d58e7c13e76bb8a559f0a6a8b - Cache
    xmlsec/1.3.4#02398c20557217516a34c637a1919d19 - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    meson/1.5.2 - Platform
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
Replaced requires
    meson/1.2.2: meson/[>=1.0 <2]

======== Computing necessary packages ========
Requirements
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd:405e382fa7fb6368c140a7f5c5cd71c32b009653#57414433357d972d48cd1a38793e8ac4 - Cache
    libxml2/2.13.4#72b3bfba0c37dfe22f20c587cc468f4c:369200858d3ad3ba8bbe2630b25f226c25956ca4#e992bdd0d1217aa00f3d1c2f7e98578b - Cache
    libxslt/1.1.42#c1b4db9ead063bd275a7227d85cf519e:6d59c33196271a5689ae733d85eb71e9e0b44d7e#72a1c65f6125e51a038df302fd1fb7b5 - Cache
    openssl/3.3.2#9f9f130d58e7c13e76bb8a559f0a6a8b:7ae3c973da08c7a4091a723ab10651cc4c5d5a8b#2ffcd2386e62ae05b5add50b9d071a90 - Cache
    xmlsec/1.3.4#02398c20557217516a34c637a1919d19:470beadbf601e8cd4c8f2a9136cb2fc8b8060e18#9bf60b41420b6c298892d0c72df6bf9b - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2:405e382fa7fb6368c140a7f5c5cd71c32b009653#d32260e9428b0e1610d991b2e0707062 - Cache
Build requirements
Skipped binaries
    autoconf/2.71, automake/1.16.5, gnu-config/cci.20210814, libtool/2.4.7, m4/1.4.19, meson/1.5.2, pkgconf/2.1.0

======== Installing packages ========
libiconv/1.17: Already installed! (1 of 6)
zlib/1.3.1: Already installed! (2 of 6)
openssl/3.3.2: Already installed! (3 of 6)
libxml2/2.13.4: Already installed! (4 of 6)
libxml2/2.13.4: Appending PATH environment variable: /Users/abril/coding/conan-center-index/recipes/eudev/all/conan_home/p/b/libxm7323bf60c9466/p/bin
libxslt/1.1.42: Already installed! (5 of 6)
xmlsec/1.3.4: Already installed! (6 of 6)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: libiconv/1.17, libxml2/2.13.4, libxslt/1.1.42, openssl/3.3.2, zlib/1.3.1
WARN: deprecated:     'env_info' used in: libiconv/1.17, openssl/3.3.2, libxml2/2.13.4, libxslt/1.1.42
WARN: deprecated:     'cpp_info.build_modules' used in: openssl/3.3.2, libxml2/2.13.4
WARN: deprecated:     'cpp_info.filenames' used in: libxml2/2.13.4

======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/build/apple-clang-16-armv8-gnu17-release
xmlsec/1.3.4 (test package): Test package build: build/apple-clang-16-armv8-gnu17-release
xmlsec/1.3.4 (test package): Test package build folder: /Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/build/apple-clang-16-armv8-gnu17-release
xmlsec/1.3.4 (test package): Writing generators to /Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/build/apple-clang-16-armv8-gnu17-release/generators
xmlsec/1.3.4 (test package): Generator 'CMakeDeps' calling 'generate()'
xmlsec/1.3.4 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(xmlsec)
    target_link_libraries(... xmlsec::xmlsec)
xmlsec/1.3.4 (test package): Generator 'CMakeToolchain' calling 'generate()'
xmlsec/1.3.4 (test package): CMakeToolchain generated: conan_toolchain.cmake
xmlsec/1.3.4 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/build/apple-clang-16-armv8-gnu17-release/generators/CMakePresets.json
xmlsec/1.3.4 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/CMakeUserPresets.json
xmlsec/1.3.4 (test package): Generator 'VirtualRunEnv' calling 'generate()'
xmlsec/1.3.4 (test package): Generating aggregated env files
xmlsec/1.3.4 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
xmlsec/1.3.4 (test package): Calling build()
xmlsec/1.3.4 (test package): Running CMake.configure()
xmlsec/1.3.4 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package"
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Using Conan toolchain: /Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/build/apple-clang-16-armv8-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'xmlsec::libxmlsec'
-- Conan: Component target declared 'xmlsec::openssl'
-- Conan: Target declared 'xmlsec::xmlsec'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/Users/abril/coding/conan-center-index/recipes/eudev/all/conan_home/p/b/opens0c270420fc473/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Conan: Component target declared 'LibXslt::LibXslt'
-- Conan: Component target declared 'LibXslt::LibExslt'
-- Conan: Target declared 'libxslt::libxslt'
-- Conan: Target declared 'LibXml2::LibXml2'
-- Conan: Target declared 'Iconv::Iconv'
-- Conan: Including build module from '/Users/abril/coding/conan-center-index/recipes/eudev/all/conan_home/p/b/libxm7323bf60c9466/p/lib/cmake/conan-official-libxml2-variables.cmake'
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/build/apple-clang-16-armv8-gnu17-release

xmlsec/1.3.4 (test package): Running CMake.build()
xmlsec/1.3.4 (test package): RUN: cmake --build "/Users/abril/coding/conan-center-index/recipes/xmlsec/all/test_package/build/apple-clang-16-armv8-gnu17-release" -- -j12
[ 50%] Building C object CMakeFiles/test_package.dir/main.c.o
[100%] Linking C executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
xmlsec/1.3.4 (test package): Running test()
xmlsec/1.3.4 (test package): RUN: ./test_package
```

</details>