### PR TITLE
cryptopp: Add use_openmp option

### DIFF
--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -34,20 +34,6 @@ sources:
     cmake:
       url: "https://github.com/noloader/cryptopp-cmake/archive/CRYPTOPP_8_5_0.tar.gz"
       sha256: "10685209405e676993873fcf638ade5f8f99d7949afa6b2045289ce9cc6d90ac"
-  "8.4.0":
-    source:
-      url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_4_0.tar.gz"
-      sha256: "6687dfc1e33b084aeab48c35a8550b239ee5f73a099a3b6a0918d70b8a89e654"
-    cmake:
-      url: "https://github.com/noloader/cryptopp-cmake/archive/CRYPTOPP_8_4_0.tar.gz"
-      sha256: "b850070141f6724fce640e4e2cfde433ec5b2d99d4386d29ba9255167bc4b4f0"
-  "8.2.0":
-    source:
-      url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_2_0.tar.gz"
-      sha256: "e3bcd48a62739ad179ad8064b523346abb53767bcbefc01fe37303412292343e"
-    cmake:
-      url: "https://github.com/noloader/cryptopp-cmake/archive/CRYPTOPP_8_2_0.tar.gz"
-      sha256: "f41f6a32b1177c094c3ef97423916713c902d0ac26cbee30ec70b1e8ab0e6fba"
 patches:
   "8.9.0":
     - patch_file: "patches/8.9.0-0001-cve-2023-50980.patch"
@@ -63,14 +49,5 @@ patches:
       patch_type: "conan"
   "8.5.0":
     - patch_file: "patches/8.4.0-0001-relocatable-macos.patch"
-      patch_description: "Relocatable shared lib on macOS"
-      patch_type: "conan"
-  "8.4.0":
-    - patch_file: "patches/8.4.0-0001-relocatable-macos.patch"
-      patch_description: "Relocatable shared lib on macOS"
-      patch_type: "conan"
-  "8.2.0":
-    - patch_file: "patches/8.2.0-0001-fix-cmake.patch"
-    - patch_file: "patches/8.2.0-0002-relocatable-macos.patch"
       patch_description: "Relocatable shared lib on macOS"
       patch_type: "conan"

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -189,6 +189,12 @@ class CryptoPPConan(ConanFile):
         elif self.settings.os == "Windows":
             self.cpp_info.components["libcryptopp"].system_libs = ["bcrypt", "ws2_32"]
 
+        if not self.options.shared and self.options.use_openmp:
+            if self.settings.compiler in ("gcc", "clang"):
+                openmp_flag = ["-fopenmp"]
+                self.cpp_info.components["libcryptopp"].cxxflags = openmp_flag
+                self.cpp_info.components["libcryptopp"].exelinkflags = openmp_flag
+
         # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
         self.cpp_info.names["pkg_config"] = "libcryptopp"
         self.cpp_info.components["libcryptopp"].names["cmake_find_package"] = legacy_cmake_target

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -26,10 +26,12 @@ class CryptoPPConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "use_openmp": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "use_openmp": False,
     }
 
     def export_sources(self):
@@ -97,6 +99,7 @@ class CryptoPPConan(ConanFile):
             tc.cache_variables["CRYPTOPP_USE_INTERMEDIATE_OBJECTS_TARGET"] = False
             if self.settings.os == "Android":
                 tc.cache_variables["CRYPTOPP_NATIVE_ARCH"] = True
+            tc.cache_variables["CRYPTOPP_USE_OPENMP"] = self.options.use_openmp
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Git"] = True
         tc.generate()
 

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -192,7 +192,7 @@ class CryptoPPConan(ConanFile):
         if not self.options.shared and self.options.use_openmp:
             if self.settings.compiler in ("gcc", "clang"):
                 openmp_flag = ["-fopenmp"]
-                self.cpp_info.components["libcryptopp"].cxxflags = openmp_flag
+                self.cpp_info.components["libcryptopp"].sharedlinkflags = openmp_flag
                 self.cpp_info.components["libcryptopp"].exelinkflags = openmp_flag
 
         # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -1,5 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import (
     apply_conandata_patches, collect_libs, copy, export_conandata_patches, get,
@@ -48,6 +50,11 @@ class CryptoPPConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def validate_build(self):
+        if is_apple_os(self) and cross_building(self) and Version(self.version) <= "8.6.0":
+            # See https://github.com/abdes/cryptopp-cmake/pull/38
+            raise ConanInvalidConfiguration("cryptopp 8.6.0 and lower do not support cross-building on Apple platforms")
+    
     def validate(self):
         if self.options.shared and Version(self.version) >= "8.7.0":
             raise ConanInvalidConfiguration("cryptopp 8.7.0 and higher do not support shared builds")

--- a/recipes/cryptopp/all/test_package/test_package.cpp
+++ b/recipes/cryptopp/all/test_package/test_package.cpp
@@ -1,13 +1,8 @@
-#include "cryptopp/cryptlib.h"
-#include "cryptopp/osrng.h" // AutoSeededRandomPool
-
-#include <stdio.h>
+#include <cryptopp/cryptlib.h>
+#include <iostream>
 
 int main() {
-  printf("CryptoPP version: %d\n", CRYPTOPP_VERSION);
-
-  CryptoPP::AutoSeededRandomPool rng;
-  printf("This is a random number from CryptoPP: %d\n", rng.GenerateByte());
-
+  std::cout << "CryptoPP LibraryVersion() = " << CryptoPP::LibraryVersion() << std::endl;
+  std::cout << "CryptoPP HeaderVersion() = " << CryptoPP::HeaderVersion() << std::endl;
   return 0;
 }

--- a/recipes/cryptopp/config.yml
+++ b/recipes/cryptopp/config.yml
@@ -9,7 +9,3 @@ versions:
     folder: "all"
   "8.5.0":
     folder: "all"
-  "8.4.0":
-    folder: "all"
-  "8.2.0":
-    folder: "all"


### PR DESCRIPTION
This option is present in Crypto++'s CMakeList.txt but was not exposed in the conanfile.py. Adding exposure for it.


### Summary
Changes to recipe:  **cryptopp/\***

#### Motivation
This is an option that allows enabling OpenMP for the cryptographic algorithms in Crypto++. It will speed up some and slow down other algorithms.

#### Details
Default is `False` since it can have a negative performance impact on some algorithms. But it will speed up others, so it should be up to the caller.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
