### PR TITLE
[quazip] Use version range for Qt

### DIFF
--- a/recipes/quazip/all/conandata.yml
+++ b/recipes/quazip/all/conandata.yml
@@ -8,9 +8,6 @@ sources:
   "1.2":
     url: "https://github.com/stachenov/quazip/archive/v1.2.tar.gz"
     sha256: "2dfb911d6b27545de0b98798d967c40430312377e6ade57096d6ec80c720cb61"
-  "1.1":
-    url: "https://github.com/stachenov/quazip/archive/v1.1.tar.gz"
-    sha256: "54edce9c11371762bd4f0003c2937b5d8806a2752dd9c0fd9085e90792612ad0"
 patches:
   "1.3":
     - patch_file: "patches/1.3-0001-use-cpp17-for-qt6.patch"

--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -48,7 +48,7 @@ class QuaZIPConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("qt/5.15.9", transitive_headers=True, transitive_libs=True)
+        self.requires("qt/[~5.15]", transitive_headers=True, transitive_libs=True)
         self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True)
         if Version(self.version) >= "1.4":
             self.requires("bzip2/1.0.8")

--- a/recipes/quazip/config.yml
+++ b/recipes/quazip/config.yml
@@ -5,5 +5,3 @@ versions:
     folder: all
   "1.2":
     folder: all
-  "1.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **quazip/1.3**

#### Motivation

The maintained version of Qt-5 is 5.15.14, resulting in missing binary packages when building this package. Using version ranges for Qt solves the current error.

More about current version ranges in CCI: https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/dependencies.md#version-ranges

#### Details

I also remove version 1.1. Quazip is not used in CCI, only consumed externally. Most of issues only mention version: https://github.com/conan-io/conan-center-index/issues?q=is%3Aissue+quazip


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
