### PR TITLE
[qtxlsxwriter] Use version range for Qt

### DIFF
--- a/recipes/qtxlsxwriter/all/conanfile.py
+++ b/recipes/qtxlsxwriter/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import apply_conandata_patches, copy, download, export_co
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.63.0"
 
 
 class QtXlsxWriterConan(ConanFile):
@@ -45,7 +45,7 @@ class QtXlsxWriterConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("qt/5.15.13", transitive_headers=True, transitive_libs=True)
+        self.requires("qt/[~5.15]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if not self.dependencies["qt"].options.gui:
@@ -56,7 +56,7 @@ class QtXlsxWriterConan(ConanFile):
 
     def build_requirements(self):
         if hasattr(self, "settings_build") and cross_building(self):
-            self.tool_requires("qt/5.15.7")
+            self.tool_requires("qt/<host_version>")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version]["source"],


### PR DESCRIPTION
### Summary
Changes to recipe:  **qtxlsxwriter/0.3.0**

#### Motivation

The maintained version of Qt-5 is 5.15.14, resulting in missing binary packages when building this package. Using version ranges for Qt solves the current error.

More about current version ranges in CCI: [master/docs/adding_packages/dependencies.md#version-ranges](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/dependencies.md?rgh-link-date=2024-09-26T06%3A27%3A05Z#version-ranges)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
