### PR TITLE
[qwt] Use version range for Qt

### DIFF
--- a/recipes/qwt/all/conanfile.py
+++ b/recipes/qwt/all/conanfile.py
@@ -63,7 +63,7 @@ class QwtConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("qt/5.15.11", transitive_headers=True, transitive_libs=True)
+        self.requires("qt/[~5.15]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if hasattr(self, "settings_build") and cross_building(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **qwt/6.2.0**

#### Motivation

The maintained version of Qt-5 is 5.15.14, resulting in missing binary packages when building this package. Using version ranges for Qt solves the current error.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
