### PR TITLE
xtr: bump to 2.1.2

### DIFF
--- a/recipes/xtr/all/conandata.yml
+++ b/recipes/xtr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.2":
+    url: "https://github.com/choll/xtr/archive/refs/tags/2.1.2.tar.gz"
+    sha256: "81ff3511e877db68882d01be9e521d317c8222838b0793e48cfd631f405bb3e8"
   "2.1.1":
     url: "https://github.com/choll/xtr/archive/refs/tags/2.1.1.tar.gz"
     sha256: "dbd8d1fbb5308329fe21bbe704206e2e69a5d49696959d43a2504ea1bec00140"

--- a/recipes/xtr/all/conanfile.py
+++ b/recipes/xtr/all/conanfile.py
@@ -133,11 +133,12 @@ class XtrConan(ConanFile):
                             "find_package(liburing REQUIRED NO_DEFAULT_PATH PATHS ${CMAKE_PREFIX_PATH})"
                             if self.options.get_safe("enable_io_uring") else
                             "")
-        # Non-single header installation is broken as of 2.1.0
-        # https://github.com/choll/xtr/pull/4
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "        PUBLIC_HEADER DESTINATION include)",
-                        ")\ninstall(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)")
+        if Version(self.version) < "2.1.2":
+            # Non-single header installation is broken until 2.1.2
+            # https://github.com/choll/xtr/pull/4
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                            "        PUBLIC_HEADER DESTINATION include)",
+                            ")\ninstall(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)")
 
     def build(self):
         self._patch_sources()

--- a/recipes/xtr/config.yml
+++ b/recipes/xtr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.2":
+    folder: all
   "2.1.1":
     folder: all
   "2.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  Bump version to xtr/2.1.2 and guard CMakefiles.txt patch to exclude 2.1.2

#### Motivation
Updates the xtr recipe to the latest version.

#### Details
Bumps version to 2.1.2 and excludes 2.1.2 from having a patch applied, as this patch has been merged into xtr.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
