### PR TITLE
krb5: set pkg_config_name, add cross-compilation support

### DIFF
--- a/recipes/krb5/all/conanfile.py
+++ b/recipes/krb5/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.0"
 
 class Krb5Conan(ConanFile):
     name = "krb5"
@@ -51,15 +51,10 @@ class Krb5Conan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} Conan recipe is not prepared for Windows yet. Contributions are welcome!")
         if self.settings.os == "Macos":
             raise ConanInvalidConfiguration(f"{self.ref} Conan recipe is not prepared for Macos yet. Contributions are welcome!")
-        if self.options.with_tls == "openssl" and not self.dependencies["openssl"].options.shared:
-            # k5tls does not respect linkage order, it passes krb5 and krb5support before openssl to the linker, which causes linking errors
-            # gcc -shared -fPIC -Wl,-h,k5tls.so.0 -Wl,--no-undefined -o k5tls.so openssl.so notls.so -L../../../lib -lkrb5 -lkrb5support ...
-            # /usr/bin/ld: /.../lib/libssl.a(libssl-lib-ssl_cert_comp.o): in function `OSSL_COMP_CERT_from_uncompressed_data':
-            #     ssl_cert_comp.c:(.text+0x3d1): undefined reference to `COMP_CTX_free'
-            raise ConanInvalidConfiguration(f"{self.ref} building with static OpenSSL generates linking errors. Please use '-o openssl/*:shared=True'")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         env = VirtualBuildEnv(self)
@@ -112,11 +107,10 @@ class Krb5Conan(ConanFile):
     def build_requirements(self):
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/[>=2.2 <3]")
-        self.build_requires("automake/1.16.5")
-        self.build_requires("bison/3.8.2")
+        self.tool_requires("automake/1.16.5")
+        self.tool_requires("bison/3.8.2")
 
     def build(self):
-        apply_conandata_patches(self)
         with chdir(self, os.path.join(self.source_folder, "src")):
             self.run("autoreconf -vif")
         autotools = Autotools(self)

--- a/recipes/krb5/all/conanfile.py
+++ b/recipes/krb5/all/conanfile.py
@@ -105,7 +105,7 @@ class Krb5Conan(ConanFile):
 
     def build_requirements(self):
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/1.9.3")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
         self.build_requires("automake/1.16.5")
         self.build_requires("bison/3.8.2")
 
@@ -129,37 +129,37 @@ class Krb5Conan(ConanFile):
         self.cpp_info.components["mit-krb5"].libs = ["krb5", "k5crypto", "com_err"]
         if self.options.get_safe('with_tls') == "openssl":
             self.cpp_info.components["mit-krb5"].requires = ["openssl::crypto"]
-        self.cpp_info.components["mit-krb5"].names["pkg_config"] = "mit-krb5"
+        self.cpp_info.components["mit-krb5"].set_property("pkg_config_name", "mit-krb5")
         if self.settings.os == "Linux":
             self.cpp_info.components["mit-krb5"].system_libs = ["resolv"]
 
         self.cpp_info.components["libkrb5"].libs = []
         self.cpp_info.components["libkrb5"].requires = ["mit-krb5"]
-        self.cpp_info.components["libkrb5"].names["pkg_config"] = "krb5"
+        self.cpp_info.components["libkrb5"].set_property("pkg_config_name", "krb5")
 
         self.cpp_info.components["mit-krb5-gssapi"].libs = ["gssapi_krb5"]
         self.cpp_info.components["mit-krb5-gssapi"].requires = ["mit-krb5"]
-        self.cpp_info.components["mit-krb5-gssapi"].names["pkg_config"] = "mit-krb5-gssapi"
+        self.cpp_info.components["mit-krb5-gssapi"].set_property("pkg_config_name", "mit-krb5-gssapi")
 
         self.cpp_info.components["krb5-gssapi"].libs = []
         self.cpp_info.components["krb5-gssapi"].requires = ["mit-krb5-gssapi"]
-        self.cpp_info.components["krb5-gssapi"].names["pkg_config"] = "krb5-gssapi"
+        self.cpp_info.components["krb5-gssapi"].set_property("pkg_config_name", "krb5-gssapi")
 
         self.cpp_info.components["gssrpc"].libs = ["gssrpc"]
         self.cpp_info.components["gssrpc"].requires = ["mit-krb5-gssapi"]
-        self.cpp_info.components["gssrpc"].names["pkg_config"] = "gssrpc"
+        self.cpp_info.components["gssrpc"].set_property("pkg_config_name", "gssrpc")
 
         self.cpp_info.components["kadm-client"].libs = ["kadm5clnt_mit"]
         self.cpp_info.components["kadm-client"].requires = ["mit-krb5-gssapi", "gssrpc"]
-        self.cpp_info.components["kadm-client"].names["pkg_config"] = "kadm-client"
+        self.cpp_info.components["kadm-client"].set_property("pkg_config_name", "kadm-client")
 
         self.cpp_info.components["kdb"].libs = ["kdb5"]
         self.cpp_info.components["kdb"].requires = ["mit-krb5-gssapi", "mit-krb5", "gssrpc"]
-        self.cpp_info.components["kdb"].names["pkg_config"] = "kdb-client"
+        self.cpp_info.components["kdb"].set_property("pkg_config_name", "kdb-client")
 
         self.cpp_info.components["kadm-server"].libs = ["kadm5srv_mit"]
         self.cpp_info.components["kadm-server"].requires = ["kdb", "mit-krb5-gssapi"]
-        self.cpp_info.components["kadm-server"].names["pkg_config"] = "kadm-server"
+        self.cpp_info.components["kadm-server"].set_property("pkg_config_name", "kadm-server")
 
         self.cpp_info.components["krad"].libs = ["krad"]
         self.cpp_info.components["krad"].requires = ["libkrb5", "libverto::libverto"]

--- a/recipes/krb5/all/test_package/CMakeLists.txt
+++ b/recipes/krb5/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package C)
 
 find_package(krb5 REQUIRED CONFIG)

--- a/recipes/krb5/all/test_package/conanfile.py
+++ b/recipes/krb5/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,6 +21,6 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **krb5/[*]**

#### Motivation
Setting `cpp_info.names["pkg_config"]` is not compatible with Conan v2 and fails to be found in `libpq`, for example.

#### Details

Also moved `libverto::libverto` requires to the root component (`mit-krb5`) based on `objdump -p | grep NEEDED` info and an associated linker error when using krb5 as a libpq dependency.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
