### PR TITLE
iguana: add version 1.0.6

### DIFF
--- a/recipes/iguana/all/conandata.yml
+++ b/recipes/iguana/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.6":
+    url: "https://github.com/qicosmos/iguana/archive/refs/tags/1.0.6.tar.gz"
+    sha256: "cfacf1cce4ebe49b947ec823f93a23c2a7fd220f67f6847e9f449e7c469deb9e"
   "1.0.5":
     url: "https://github.com/qicosmos/iguana/archive/refs/tags/1.0.5.tar.gz"
     sha256: "b7a7385c49574a60f9f6bf887c1addbc08f557a0117bf18cf7eec532ac2536b1"

--- a/recipes/iguana/all/test_package/CMakeLists.txt
+++ b/recipes/iguana/all/test_package/CMakeLists.txt
@@ -3,6 +3,10 @@ project(test_package LANGUAGES CXX)
 
 find_package(iguana REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+if(iguana_VERSION VERSION_GREATER_EQUAL "1.0.6")
+    add_executable(${PROJECT_NAME} test_package.cpp)
+else()
+    add_executable(${PROJECT_NAME} test_package_1_0_5.cpp)
+endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE iguana::iguana)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/iguana/all/test_package/test_package_1_0_5.cpp
+++ b/recipes/iguana/all/test_package/test_package_1_0_5.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <iguana/json_reader.hpp>
 #include <iguana/json_writer.hpp>
 
@@ -8,26 +7,20 @@ struct person {
   int64_t age;
 };
 
-#if __cplusplus < 202002L
-YLT_REFL(person, name, age);
-#endif
+REFLECTION(person, name, age);
 } // namespace client
 
 struct MyStruct {
   uint64_t a;
 };
-#if __cplusplus < 202002L
-YLT_REFL(MyStruct, a);
-#endif
+REFLECTION(MyStruct, a);
 
 struct student {
   int id;
   std::string name;
   int age;
 };
-#if __cplusplus < 202002L
-YLT_REFL(student, id, name, age);
-#endif
+REFLECTION(student, id, name, age);
 
 void test() {
   MyStruct p = {5566777755311};

--- a/recipes/iguana/config.yml
+++ b/recipes/iguana/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.6":
+    folder: all
   "1.0.5":
     folder: all
   "1.0.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **iguana/1.0.6**

#### Motivation
There are lots of improvements in 1.0.6.

#### Details
https://github.com/qicosmos/iguana/compare/1.0.5...1.0.6
The name of macro has been renamed from `REFLECTION` to `YLT_REFL` in 1.0.6.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
