### PR TITLE
gperftools: add version 2.16

### DIFF
--- a/recipes/gperftools/all/conandata.yml
+++ b/recipes/gperftools/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.16":
+    url: "https://github.com/gperftools/gperftools/releases/download/gperftools-2.16/gperftools-2.16.tar.gz"
+    sha256: "f12624af5c5987f2cc830ee534f754c3c5961eec08004c26a8b80de015cf056f"
   "2.15":
     url: "https://github.com/gperftools/gperftools/releases/download/gperftools-2.15/gperftools-2.15.tar.gz"
     sha256: "c69fef855628c81ef56f12e3c58f2b7ce1f326c0a1fe783e5cae0b88cbbe9a80"

--- a/recipes/gperftools/config.yml
+++ b/recipes/gperftools/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.16":
+    folder: all
   "2.15":
     folder: all
   "2.14.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gperftools/2.16**

#### Motivation
There are lots of internal improvements in 2.16.
Now C++17 is required.

#### Details
https://github.com/gperftools/gperftools/compare/gperftools-2.15...gperftools-2.16

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
