### PR TITLE
Add au recipe

### DIFF
--- a/recipes/au/all/conandata.yml
+++ b/recipes/au/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "0.3.5":
+    url: "https://github.com/aurora-opensource/au/archive/refs/tags/0.3.5.tar.gz"
+    sha256: "7ec826dc42968dc1633de56e4f9d06e70de73e820d2ac4788e8453343a622c9b"
+patches:
+  "0.3.5":
+    - patch_file: "patches/0001-v0.3.5-disable-gtest.patch"
+      patch_description: "Remove GTest dependency and disable tests build"
+      patch_type: "conan"

--- a/recipes/au/all/conanfile.py
+++ b/recipes/au/all/conanfile.py
@@ -39,6 +39,9 @@ class PackageConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def package_id(self):
+        self.info.clear()
+
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)

--- a/recipes/au/all/conanfile.py
+++ b/recipes/au/all/conanfile.py
@@ -48,6 +48,9 @@ class PackageConan(ConanFile):
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.24 <4]")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/au/all/conanfile.py
+++ b/recipes/au/all/conanfile.py
@@ -75,8 +75,6 @@ class PackageConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.libs = ["package_lib"]
-
         self.cpp_info.set_property("cmake_file_name", "Au")
         self.cpp_info.set_property("cmake_target_name", "Au::au")
 

--- a/recipes/au/all/conanfile.py
+++ b/recipes/au/all/conanfile.py
@@ -1,0 +1,86 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
+from conan.tools.scm import Version
+import os
+
+
+required_conan_version = ">=1.53.0"
+
+class PackageConan(ConanFile):
+    name = "au"
+    description = "A C++14-compatible physical units library"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/aurora-opensource/au"
+    topics = ("units", "C++14")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "10",
+            "clang": "7",
+            "gcc": "7",
+            "msvc": "191",
+            "Visual Studio": "15",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["package_lib"]
+
+        self.cpp_info.set_property("cmake_file_name", "Au")
+        self.cpp_info.set_property("cmake_target_name", "Au::au")
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.append("dl")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "Au"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "Au"
+        self.cpp_info.names["cmake_find_package"] = "Au::au"
+        self.cpp_info.names["cmake_find_package_multi"] = "Au::au"

--- a/recipes/au/all/patches/0001-v0.3.5-disable-gtest.patch
+++ b/recipes/au/all/patches/0001-v0.3.5-disable-gtest.patch
@@ -1,0 +1,58 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b18407f..dbd35af 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,23 +37,23 @@ set(AU_EXPORT_SET_NAME AuHeaders)
+ 
+ enable_testing()
+ 
+-# Bring in GoogleTest so we can build and run the tests.
+-include(FetchContent)
+-FetchContent_Declare(
+-   googletest
+-   GIT_REPOSITORY https://github.com/google/googletest.git
+-   GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # Release 1.12.1
+-   FIND_PACKAGE_ARGS
+-      1.12.1
+-      NAMES GTest
+-)
+-
+-# https://google.github.io/googletest/quickstart-cmake.html
+-# For Windows: Prevent overriding the parent project's compiler/linker settings
+-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+-
+-FetchContent_MakeAvailable(googletest)
+-include(GoogleTest)
++## Bring in GoogleTest so we can build and run the tests.
++#include(FetchContent)
++#FetchContent_Declare(
++#   googletest
++#   GIT_REPOSITORY https://github.com/google/googletest.git
++#   GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # Release 1.12.1
++#   FIND_PACKAGE_ARGS
++#      1.12.1
++#      NAMES GTest
++#)
++#
++## https://google.github.io/googletest/quickstart-cmake.html
++## For Windows: Prevent overriding the parent project's compiler/linker settings
++#set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
++#
++#FetchContent_MakeAvailable(googletest)
++#include(GoogleTest)
+ 
+ add_subdirectory(au)
+ 
+diff --git a/cmake/HeaderOnlyLibrary.cmake b/cmake/HeaderOnlyLibrary.cmake
+index 28daf00..fbf0fab 100644
+--- a/cmake/HeaderOnlyLibrary.cmake
++++ b/cmake/HeaderOnlyLibrary.cmake
+@@ -75,7 +75,7 @@ function(header_only_library)
+   )
+ 
+   # Add the test, if requested.
+-  if (DEFINED ARG_GTEST_SRCS)
++  if (OFF)
+     add_executable("${ARG_NAME}_test")
+     target_sources("${ARG_NAME}_test" PRIVATE ${ARG_GTEST_SRCS})
+     target_link_libraries(

--- a/recipes/au/all/test_package/CMakeLists.txt
+++ b/recipes/au/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package LANGUAGES CXX)
+
+find_package(Au REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE Au::au)

--- a/recipes/au/all/test_package/CMakeLists.txt
+++ b/recipes/au/all/test_package/CMakeLists.txt
@@ -6,3 +6,4 @@ find_package(Au REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE Au::au)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/au/all/test_package/conanfile.py
+++ b/recipes/au/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/au/all/test_package/test_package.cpp
+++ b/recipes/au/all/test_package/test_package.cpp
@@ -7,9 +7,9 @@
 using namespace au;
 
 int main(void) {
-    constexpr auto lenght = meters(100.0);
+    constexpr auto length = meters(100.0);
 
-    std::cout << lenght << " == " << lenght.in(kilo(meters)) <<" km" << std::endl;
+    std::cout << length << " == " << length.in(kilo(meters)) <<" km" << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/recipes/au/all/test_package/test_package.cpp
+++ b/recipes/au/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+
+#include "au/au.hh"
+#include "au/io.hh"
+#include "au/units/meters.hh"
+
+using namespace au;
+
+int main(void) {
+    constexpr auto lenght = meters(100.0);
+
+    std::cout << lenght << " == " << lenght.in(kilo(meters)) <<" km" << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/au/config.yml
+++ b/recipes/au/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.5":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **au/[0.3.5]**

#### Motivation
Add recipe for https://github.com/aurora-opensource/au

This is an incomplete recipe, it only exposes the main `Au::au` target and not the `io` component (which is used for the `<<` operator).

I'm not sure why it is needed since it works anyway? Their CMake is a bit weird.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
