### PR TITLE
rapidcsv: add version 8.84

### DIFF
--- a/recipes/rapidcsv/all/conandata.yml
+++ b/recipes/rapidcsv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.84":
+    url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.84.tar.gz"
+    sha256: "213699f46a2a29fc2f45c2f9f66ccbe5383aebe6061445d91ac196e3cf7029c8"
   "8.83":
     url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.83.tar.gz"
     sha256: "9342eeb0ce37e30b778c4c030129d03e99f44a66d4710ac19627187bee774097"

--- a/recipes/rapidcsv/config.yml
+++ b/recipes/rapidcsv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.84":
+    folder: "all"
   "8.83":
     folder: "all"
   "8.82":


### PR DESCRIPTION
### Summary
Changes to recipe:  **rapidcsv/8.84**

#### Motivation
There is an bugfix in 8.84.

#### Details
https://github.com/d99kris/rapidcsv/compare/v8.83...v8.84

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
