### PR TITLE
libheif: add with_openjph

### DIFF
--- a/recipes/libheif/all/conanfile.py
+++ b/recipes/libheif/all/conanfile.py
@@ -105,6 +105,9 @@ class LibheifConan(ConanFile):
         tc.variables["WITH_OpenJPEG_DECODER"] = self.options.get_safe("with_openjpeg", False)
         tc.variables["WITH_OpenJPEG_ENCODER"] = self.options.get_safe("with_openjpeg", False)
         tc.variables["WITH_OPENJPH_ENCODER"] = self.options.get_safe("with_openjph", False)
+        # Disable finding possible Doxygen in system, so no docs are built
+        tc.variables["CMAKE_DISABLE_FIND_PACKAGE_Doxygen"] = True
+
         tc.generate()
         deps = CMakeDeps(self)
         if Version(self.version) >= "1.18.0":

--- a/recipes/libheif/all/conanfile.py
+++ b/recipes/libheif/all/conanfile.py
@@ -27,6 +27,7 @@ class LibheifConan(ConanFile):
         "with_dav1d": [True, False],
         "with_jpeg": [True, False],
         "with_openjpeg": [True, False],
+        "with_openjph": [True, False],
     }
     default_options = {
         "shared": False,
@@ -37,6 +38,7 @@ class LibheifConan(ConanFile):
         "with_dav1d": False,
         "with_jpeg": False,
         "with_openjpeg": False,
+        "with_openjph": False,
     }
 
     def export_sources(self):
@@ -48,6 +50,8 @@ class LibheifConan(ConanFile):
         if Version(self.version) < "1.17.0":
             del self.options.with_jpeg
             del self.options.with_openjpeg
+        if Version(self.version) < "1.18.0":
+            del self.options.with_openjph
 
     def configure(self):
         if self.options.shared:
@@ -69,6 +73,8 @@ class LibheifConan(ConanFile):
             self.requires("libjpeg/9f")
         if self.options.get_safe("with_openjpeg"):
             self.requires("openjpeg/2.5.2")
+        if self.options.get_safe("with_openjph"):
+            self.requires("openjph/0.16.0", transitive_headers=False)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -98,10 +104,12 @@ class LibheifConan(ConanFile):
         tc.variables["WITH_JPEG_ENCODER"] = self.options.get_safe("with_jpeg", False)
         tc.variables["WITH_OpenJPEG_DECODER"] = self.options.get_safe("with_openjpeg", False)
         tc.variables["WITH_OpenJPEG_ENCODER"] = self.options.get_safe("with_openjpeg", False)
+        tc.variables["WITH_OPENJPH_ENCODER"] = self.options.get_safe("with_openjph", False)
         tc.generate()
         deps = CMakeDeps(self)
         if Version(self.version) >= "1.18.0":
             deps.set_property("libde265", "cmake_file_name", "LIBDE265")
+            deps.set_property("openjph", "cmake_file_name", "OPENJPH")
         deps.generate()
         if Version(self.version) >= "1.18.0":
             venv = VirtualBuildEnv(self)
@@ -153,3 +161,5 @@ class LibheifConan(ConanFile):
             self.cpp_info.components["heif"].requires.append("libjpeg::libjpeg")
         if self.options.get_safe("with_openjpeg"):
             self.cpp_info.components["heif"].requires.append("openjpeg::openjpeg")
+        if self.options.get_safe("with_openjph"):
+            self.cpp_info.components["heif"].requires.append("openjph::openjph")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libheif/***

#### Motivation
Add with_openjph option. (openjph recipe has been added.)

#### Details
`WITH_OPENJPH_ENCODER` has been added since 1.18.0.

Build log with `with_openjph=True` in apple-clang 16.
<details>
======== Exporting recipe to the cache ========
libheif/1.18.2: Exporting package recipe: /Users/toge/src/conan-center-index/recipes/libheif/all/conanfile.py
libheif/1.18.2: exports: File 'conandata.yml' found. Exporting it...
libheif/1.18.2: Calling export_sources()
libheif/1.18.2: Copied 1 '.py' file: conanfile.py
libheif/1.18.2: Copied 1 '.yml' file: conandata.yml
libheif/1.18.2: Exported to cache folder: /Users/toge/.conan2/p/libhe6595530092c3a/e
libheif/1.18.2: Exported: libheif/1.18.2#f72c842f870e00e68589c2bfd5269e2b (2024-09-30 14:20:54 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=apple-clang
compiler.cppstd=20
compiler.libcxx=libc++
compiler.version=15
os=Macos
[options]
&:with_openjph=True

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=23
compiler.libcxx=libc++
compiler.version=16
os=Macos
[options]
boost/*:without_locale=True
boost/*:without_stacktrace=True


======== Computing dependency graph ========
Graph root
    cli
Requirements
    jbig/20160605#2d29fa02aacd76902e0d2cbbc24631ef - Cache
    libde265/1.0.12#6e7cec8c7e3b1c9bfb6761dfc4d1dbb8 - Cache
    libdeflate/1.19#3ea74a4549efc14d4b1202dc4bfbf602 - Cache
    libheif/1.18.2#f72c842f870e00e68589c2bfd5269e2b - Cache
    libjpeg/9e#3cd27a78643419450ee6d3739514d25c - Cache
    libtiff/4.6.0#51d0e7e15d032aeec1b64e65c44ecd9f - Cache
    libwebp/1.3.2#52f69c4a31c5cf033fdd9230d77a8e38 - Cache
    openjph/0.16.0#859ec8a0c6a11f6ac4e5317e5d2eb5b3 - Cache
    xz_utils/5.4.5#51e5a6e6564f4ea3afd79def01f035ad - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2 - Cache
    zstd/1.5.5#1f239731dc45147c7fc2f54bfbde73df - Cache
Build requirements
    cmake/3.29.3#292a699b66d006bf4c6648608fa7c9e4 - Cache
Resolved version ranges
    cmake/[>=3.16 <4]: cmake/3.29.3
    cmake/[>=3.18 <4]: cmake/3.29.3
    zlib/[>=1.2.11 <2]: zlib/1.3.1

======== Computing necessary packages ========
libheif/1.18.2: Main binary package '8bb00e06634addc523babacfe80ef5269b6c8d3c' missing
libheif/1.18.2: Checking 9 compatible configurations
libheif/1.18.2: Compatible configurations not found in cache, checking servers
libheif/1.18.2: '971aeb7629d01e24d525a7c67fd85249ec675b29': compiler.cppstd=11
libheif/1.18.2: '4b3199aaf89f193976630591267f7185c7b68992': compiler.cppstd=gnu11
libheif/1.18.2: 'cda1c906b4d4c2f8c8310823c699c2fa38cdd463': compiler.cppstd=14
libheif/1.18.2: '25c5f307bc823db5680958ad08ef52c1478bb799': compiler.cppstd=gnu14
libheif/1.18.2: '4c61511ffaf43084910f6c09c1d04f62b4a3dde5': compiler.cppstd=17
libheif/1.18.2: '10ccdd134110f133e47bcca13dc8ecda52a227d4': compiler.cppstd=gnu17
libheif/1.18.2: 'c062c465aa2cd8823a057075dc96f4af334fe19e': compiler.cppstd=gnu20
libheif/1.18.2: 'da54bca30107a3b94e0ac5d332cbf446e00b151e': compiler.cppstd=23
libheif/1.18.2: 'bd1591de4302ef997aca0bae56a4ed234ed20657': compiler.cppstd=gnu23
Requirements
    jbig/20160605#2d29fa02aacd76902e0d2cbbc24631ef:cf6cec528c21acd373f7d38178df3f1c553893c4#ee196f9ce7754dc22d976445de176016 - Cache
    libde265/1.0.12#6e7cec8c7e3b1c9bfb6761dfc4d1dbb8:782a255538fe9012704273bd48abad911317cdce#5425d8749a50cf3e8765d1212ae7e292 - Cache
    libdeflate/1.19#3ea74a4549efc14d4b1202dc4bfbf602:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#2bc3f59b8a3baa511f4b6184845ce37b - Cache
    libheif/1.18.2#f72c842f870e00e68589c2bfd5269e2b:8bb00e06634addc523babacfe80ef5269b6c8d3c - Build
    libjpeg/9e#3cd27a78643419450ee6d3739514d25c:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#9087c3892fde4352adbc98ad9ce3e73e - Cache
    libtiff/4.6.0#51d0e7e15d032aeec1b64e65c44ecd9f:6d15aa7eb0121df86c428d0d3386d3591ca6ad75#f997dd5f79cc8849df116bda058fbe0d - Cache
    libwebp/1.3.2#52f69c4a31c5cf033fdd9230d77a8e38:e45230f84c78b042579daf5f21e3e846e0160028#7f16fade02ceb3a4f9ce6cffc77ae70c - Cache
    openjph/0.16.0#859ec8a0c6a11f6ac4e5317e5d2eb5b3:b4dfcdfd74085087976e5b24f33bb491895d0984#d81ac4e431063bf9335c1567e66ac088 - Cache
    xz_utils/5.4.5#51e5a6e6564f4ea3afd79def01f035ad:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#c0ecc86caef96fe76bc8c33ecd0fde1c - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#e442ade299e68a6f0cc495558351b985 - Cache
    zstd/1.5.5#1f239731dc45147c7fc2f54bfbde73df:3da5102773a28e279c56e1f3943235fce254757e#b62ede115829e2070dfcaece07c9bab6 - Cache
Build requirements
    cmake/3.29.3#292a699b66d006bf4c6648608fa7c9e4:9e5323c65b94ae38c3c733fe12637776db0119a5#bad3e10619d8d846f77de0354874bfd9 - Cache

======== Installing packages ========
cmake/3.29.3: Already installed! (1 of 12)
cmake/3.29.3: Appending PATH environment variable: /Users/toge/.conan2/p/cmake7414e07ab312a/p/CMake.app/Contents/bin
jbig/20160605: Already installed! (2 of 12)
libde265/1.0.12: Already installed! (3 of 12)
libdeflate/1.19: Already installed! (4 of 12)
libjpeg/9e: Already installed! (5 of 12)
libwebp/1.3.2: Already installed! (6 of 12)
xz_utils/5.4.5: Already installed! (7 of 12)
zlib/1.3.1: Already installed! (8 of 12)
zstd/1.5.5: Already installed! (9 of 12)
libtiff/4.6.0: Already installed! (10 of 12)
openjph/0.16.0: Already installed! (11 of 12)
libheif/1.18.2: Calling source() in /Users/toge/.conan2/p/libhe6595530092c3a/s/src
libheif/1.18.2: Unzipping libheif-1.18.2.tar.gz to .

-------- Installing package libheif/1.18.2 (12 of 12) --------
libheif/1.18.2: Building from source
libheif/1.18.2: Package libheif/1.18.2:8bb00e06634addc523babacfe80ef5269b6c8d3c
libheif/1.18.2: Copying sources to build folder
libheif/1.18.2: Building your package in /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b
libheif/1.18.2: Calling generate()
libheif/1.18.2: Generators folder: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/generators
libheif/1.18.2: CMakeToolchain generated: conan_toolchain.cmake
libheif/1.18.2: CMakeToolchain generated: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/generators/CMakePresets.json
libheif/1.18.2: CMakeToolchain generated: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/src/CMakeUserPresets.json
libheif/1.18.2: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(LIBDE265)
    find_package(OPENJPH)
    target_link_libraries(... de265 openjph::openjph)
libheif/1.18.2: Generating aggregated env files
libheif/1.18.2: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
libheif/1.18.2: Calling build()
libheif/1.18.2: Running CMake.configure()
libheif/1.18.2: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/toge/.conan2/p/b/libhe27f3badb90ef6/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/src"
-- Using Conan toolchain: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is AppleClang 16.0.0.16000026
-- The CXX compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Warning: Standard CMAKE_CXX_STANDARD value defined in conan_toolchain.cmake to 20 has been modified to 11 by /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/src/CMakeLists.txt
-- Performing Test has_potentially_evaluated_expression
-- Performing Test has_potentially_evaluated_expression - Success
-- Conan: Target declared 'de265'
-- Conan: Target declared 'openjph::openjph'
-- Conan: Target declared 'TIFF::TIFF'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Component target declared 'libdeflate::libdeflate_static'
-- Conan: Target declared 'LibLZMA::LibLZMA'
-- Conan: Including build module from '/Users/toge/.conan2/p/b/xz_ut0672da6e502bb/p/lib/cmake/conan-official-xz_utils-variables.cmake'
-- Conan: Target declared 'JPEG::JPEG'
-- Conan: Target declared 'jbig::jbig'
-- Conan: Component target declared 'zstd::libzstd_static'
-- Conan: Component target declared 'WebP::webpdecoder'
-- Conan: Component target declared 'WebP::sharpyuv'
-- Conan: Component target declared 'WebP::webp'
-- Conan: Component target declared 'WebP::webpdemux'
-- Conan: Component target declared 'WebP::libwebpmux'
-- Conan: Target declared 'libwebp::libwebp'

=== Summary of compiled codecs ===
libde265 HEVC decoder           : + built-in
FFMPEG HEVC decoder (HW acc)    : - disabled
x265 HEVC encoder               : - disabled
Kvazaar HEVC encoder            : - disabled
AOM AV1 decoder                 : - disabled
AOM AV1 encoder                 : - disabled
Dav1d AV1 decoder               : - disabled
SVT AV1 encoder                 : - disabled
Rav1e AV1 encoder               : - disabled
JPEG decoder                    : + built-in
JPEG encoder                    : + built-in
OpenJPEG J2K decoder            : - disabled
OpenJPEG J2K encoder            : - disabled
OpenJPH HT-J2K encoder          : + separate plugin
uvg266 VVC enc. (experimental)  : - disabled
vvenc VVC enc. (experimental)   : - disabled
vvdec VVC dec. (experimental)   : - disabled

=== Supported formats ===
format        decoding   encoding
HEIC            YES        NO 
AVIF            NO         NO 
VVC             NO         NO 
JPEG            NO         NO 
JPEG2000        NO         NO 
JPEG2000-HT     NO         YES
Uncompressed    NO         NO 

libsharpyuv: disabled
-- Looking for _LIBCPP_VERSION
-- Looking for _LIBCPP_VERSION - found
-- Found Doxygen: /usr/local/bin/doxygen (found version "1.9.5") found components: doxygen missing components: dot
Doxygen build started
Not compiling 'x265' backend
Compiling 'libde265' as built-in backend
Not compiling 'dav1d' backend
Not compiling 'aomdec' backend
Not compiling 'aomenc' backend
Not compiling 'svtenc' backend
Not compiling 'rav1e' backend
Not compiling 'jpegdec' backend
Not compiling 'jpegenc' backend
Not compiling 'j2kdec' backend
Not compiling 'j2kenc' backend
Not compiling 'kvazaar' backend
Not compiling 'ffmpegdec' backend
Compiling 'jphenc' as dynamic plugin
Not compiling 'uvg266' backend
Not compiling 'vvdec' backend
Not compiling 'vvenc' backend
Not compiling 'libsharpyuv'
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Configuring done (5.1s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release

libheif/1.18.2: Running CMake.build()
libheif/1.18.2: RUN: cmake --build "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release" -- -j8
[  2%] Generating API documentation with Doxygen
[  4%] Building CXX object libheif/CMakeFiles/heif.dir/bitstream.cc.o
[  6%] Building CXX object libheif/CMakeFiles/heif.dir/box.cc.o
[  9%] Building CXX object libheif/CMakeFiles/heif.dir/context.cc.o
[ 11%] Building CXX object libheif/CMakeFiles/heif.dir/error.cc.o
[ 13%] Building CXX object libheif/CMakeFiles/heif.dir/file.cc.o
[ 15%] Building CXX object libheif/CMakeFiles/heif.dir/pixelimage.cc.o
warning: Tag 'CLANG_ASSISTED_PARSING' at line 1155 of file '/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/Doxyfile' belongs to an option that was not enabled at compile time.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u", or recompile doxygen with this feature enabled.
warning: Tag 'CLANG_ADD_INC_PATHS' at line 1161 of file '/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/Doxyfile' belongs to an option that was not enabled at compile time.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u", or recompile doxygen with this feature enabled.
warning: Tag 'CLANG_OPTIONS' at line 1169 of file '/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/Doxyfile' belongs to an option that was not enabled at compile time.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u", or recompile doxygen with this feature enabled.
warning: Tag 'CLANG_DATABASE_PATH' at line 1182 of file '/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/Doxyfile' belongs to an option that was not enabled at compile time.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u", or recompile doxygen with this feature enabled.
[ 18%] Building CXX object libheif/CMakeFiles/heif.dir/plugin_registry.cc.o
sh: dot: command not found
sh: dot: command not found
/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/graph_legend.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/graph_legend.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/graph_legend.png"'

/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif_8h__incl.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif_8h__incl.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif_8h__incl.png"'

sh: dot: command not found
sh: dot: command not found
/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/dir_16fa567009e814849454bda1c95ed4d7_dep.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/dir_16fa567009e814849454bda1c95ed4d7_dep.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/dir_16fa567009e814849454bda1c95ed4d7_dep.png"'

/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif_8h__dep__incl.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif_8h__dep__incl.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif_8h__dep__incl.png"'

sh: dot: command not found
sh: dot: command not found
/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/dir_7cedd67459a62855714f3bfc6620e0c4_dep.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/dir_7cedd67459a62855714f3bfc6620e0c4_dep.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/dir_7cedd67459a62855714f3bfc6620e0c4_dep.png"'

/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__encoding__options__coll__graph.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__encoding__options__coll__graph.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__encoding__options__coll__graph.png"'

sh: dot: command not found
/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif__items_8h__incl.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif__items_8h__incl.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif__items_8h__incl.png"'

sh: dot: command not found
/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__decoding__options__coll__graph.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__decoding__options__coll__graph.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__decoding__options__coll__graph.png"'

sh: dot: command not found
sh: dot: command not found
/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__writer__coll__graph.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__writer__coll__graph.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__writer__coll__graph.png"'

/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif__regions_8h__incl.dot:1: error: Problems running dot: exit code=127, command='dot', arguments='"/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif__regions_8h__incl.dot" -Tpng -o "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif__regions_8h__incl.png"'

error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/dir_16fa567009e814849454bda1c95ed4d7_dep.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/dir_7cedd67459a62855714f3bfc6620e0c4_dep.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif_8h__incl.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif_8h__dep__incl.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif__items_8h__incl.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/heif__regions_8h__incl.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__decoding__options__coll__graph.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__encoding__options__coll__graph.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
error: problems opening map file /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release/apidoc/html/structheif__writer__coll__graph.map for inclusion in the docs!
If you installed Graphviz/dot after a previous failing run, 
try deleting the output directory and rerun doxygen.
[ 18%] Built target doc_doxygen
[ 20%] Building CXX object libheif/CMakeFiles/heif.dir/nclx.cc.o
[ 22%] Building CXX object libheif/CMakeFiles/heif.dir/init.cc.o
[ 25%] Building CXX object libheif/CMakeFiles/heif.dir/logging.cc.o
[ 27%] Building CXX object libheif/CMakeFiles/heif.dir/compression_brotli.cc.o
[ 29%] Building CXX object libheif/CMakeFiles/heif.dir/compression_zlib.cc.o
[ 31%] Building CXX object libheif/CMakeFiles/heif.dir/common_utils.cc.o
[ 34%] Building CXX object libheif/CMakeFiles/heif.dir/region.cc.o
[ 36%] Building CXX object libheif/CMakeFiles/heif.dir/api/libheif/heif.cc.o
[ 38%] Building CXX object libheif/CMakeFiles/heif.dir/api/libheif/heif_regions.cc.o
[ 40%] Building CXX object libheif/CMakeFiles/heif.dir/api/libheif/heif_plugin.cc.o
[ 43%] Building CXX object libheif/CMakeFiles/heif.dir/api/libheif/heif_properties.cc.o
[ 45%] Building CXX object libheif/CMakeFiles/heif.dir/api/libheif/heif_items.cc.o
[ 47%] Building CXX object libheif/CMakeFiles/heif.dir/api/libheif/heif_experimental.cc.o
[ 50%] Building CXX object libheif/CMakeFiles/heif.dir/codecs/hevc.cc.o
[ 52%] Building CXX object libheif/CMakeFiles/heif.dir/codecs/avif.cc.o
[ 54%] Building CXX object libheif/CMakeFiles/heif.dir/codecs/jpeg.cc.o
[ 56%] Building CXX object libheif/CMakeFiles/heif.dir/codecs/jpeg2000.cc.o
[ 59%] Building CXX object libheif/CMakeFiles/heif.dir/codecs/vvc.cc.o
[ 61%] Building CXX object libheif/CMakeFiles/heif.dir/codecs/avc.cc.o
[ 63%] Building CXX object libheif/CMakeFiles/heif.dir/codecs/mask_image.cc.o
[ 65%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/colorconversion.cc.o
[ 68%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/rgb2yuv.cc.o
[ 70%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/rgb2yuv_sharp.cc.o
[ 72%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/yuv2rgb.cc.o
[ 75%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/rgb2rgb.cc.o
[ 77%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/monochrome.cc.o
[ 79%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/hdr_sdr.cc.o
[ 81%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/alpha.cc.o
[ 84%] Building CXX object libheif/CMakeFiles/heif.dir/color-conversion/chroma_sampling.cc.o
[ 86%] Building CXX object libheif/CMakeFiles/heif.dir/plugins_unix.cc.o
[ 88%] Building CXX object libheif/CMakeFiles/heif.dir/plugins/decoder_libde265.cc.o
[ 90%] Building CXX object libheif/CMakeFiles/heif.dir/plugins/encoder_mask.cc.o
[ 93%] Linking CXX static library libheif.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libheif.a(compression_brotli.cc.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libheif.a(compression_brotli.cc.o) has no symbols
[ 93%] Built target heif
[ 97%] Building CXX object libheif/plugins/CMakeFiles/heif-jphenc.dir/encoder_openjph.cc.o
[ 97%] Building CXX object libheif/plugins/CMakeFiles/heif-jphenc.dir/__/api/libheif/heif_plugin.cc.o
[100%] Linking CXX shared module libheif-jphenc.so
ld: warning: ignoring duplicate libraries: '-lc++'
[100%] Built target heif-jphenc

libheif/1.18.2: Package '8bb00e06634addc523babacfe80ef5269b6c8d3c' built
libheif/1.18.2: Build folder /Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release
libheif/1.18.2: Generating the package
libheif/1.18.2: Packaging in folder /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p
libheif/1.18.2: Calling package()
libheif/1.18.2: Running CMake.install()
libheif/1.18.2: RUN: cmake --install "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/b/build/Release" --prefix "/Users/toge/.conan2/p/b/libhe27f3badb90ef6/p"
-- Install configuration: "Release"
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/lib/libheif
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/lib/pkgconfig/libheif.pc
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/lib/libheif/libheif-jphenc.so
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/lib/libheif.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/lib/libheif.a(compression_brotli.cc.o) has no symbols
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/include/libheif/heif.h
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/include/libheif/heif_cxx.h
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/include/libheif/heif_plugin.h
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/include/libheif/heif_properties.h
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/include/libheif/heif_regions.h
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/include/libheif/heif_items.h
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/include/libheif/heif_version.h
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/lib/cmake/libheif/libheif-config.cmake
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/lib/cmake/libheif/libheif-config-release.cmake
-- Installing: /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p/lib/cmake/libheif/libheif-config-version.cmake

libheif/1.18.2: package(): Packaged 1 file: COPYING
libheif/1.18.2: package(): Packaged 7 '.h' files
libheif/1.18.2: package(): Packaged 1 '.a' file: libheif.a
libheif/1.18.2: package(): Packaged 1 '.so' file: libheif-jphenc.so
libheif/1.18.2: Created package revision eebe1f254fd30aebe5b666d00ed4f30a
libheif/1.18.2: Package '8bb00e06634addc523babacfe80ef5269b6c8d3c' created
libheif/1.18.2: Full package reference: libheif/1.18.2#f72c842f870e00e68589c2bfd5269e2b:8bb00e06634addc523babacfe80ef5269b6c8d3c#eebe1f254fd30aebe5b666d00ed4f30a
libheif/1.18.2: Package folder /Users/toge/.conan2/p/b/libhe27f3badb90ef6/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'env_info' used in: jbig/20160605, libde265/1.0.12, cmake/3.29.3, zstd/1.5.5
WARN: deprecated:     'cpp_info.build_modules' used in: libde265/1.0.12, xz_utils/5.4.5
WARN: deprecated:     'cpp_info.names' used in: libdeflate/1.19, xz_utils/5.4.5, zstd/1.5.5, libwebp/1.3.2, libjpeg/9e, openjph/0.16.0, libtiff/4.6.0, zlib/1.3.1

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    libheif/1.18.2 (test package): /Users/toge/src/conan-center-index/recipes/libheif/all/test_package/conanfile.py
Requirements
    jbig/20160605#2d29fa02aacd76902e0d2cbbc24631ef - Cache
    libde265/1.0.12#6e7cec8c7e3b1c9bfb6761dfc4d1dbb8 - Cache
    libdeflate/1.19#3ea74a4549efc14d4b1202dc4bfbf602 - Cache
    libheif/1.18.2#f72c842f870e00e68589c2bfd5269e2b - Cache
    libjpeg/9e#3cd27a78643419450ee6d3739514d25c - Cache
    libtiff/4.6.0#51d0e7e15d032aeec1b64e65c44ecd9f - Cache
    libwebp/1.3.2#52f69c4a31c5cf033fdd9230d77a8e38 - Cache
    openjph/0.16.0#859ec8a0c6a11f6ac4e5317e5d2eb5b3 - Cache
    xz_utils/5.4.5#51e5a6e6564f4ea3afd79def01f035ad - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2 - Cache
    zstd/1.5.5#1f239731dc45147c7fc2f54bfbde73df - Cache
Build requirements
    cmake/3.29.3#292a699b66d006bf4c6648608fa7c9e4 - Cache

======== Computing necessary packages ========
Requirements
    jbig/20160605#2d29fa02aacd76902e0d2cbbc24631ef:cf6cec528c21acd373f7d38178df3f1c553893c4#ee196f9ce7754dc22d976445de176016 - Cache
    libde265/1.0.12#6e7cec8c7e3b1c9bfb6761dfc4d1dbb8:782a255538fe9012704273bd48abad911317cdce#5425d8749a50cf3e8765d1212ae7e292 - Cache
    libdeflate/1.19#3ea74a4549efc14d4b1202dc4bfbf602:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#2bc3f59b8a3baa511f4b6184845ce37b - Cache
    libheif/1.18.2#f72c842f870e00e68589c2bfd5269e2b:8bb00e06634addc523babacfe80ef5269b6c8d3c#eebe1f254fd30aebe5b666d00ed4f30a - Cache
    libjpeg/9e#3cd27a78643419450ee6d3739514d25c:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#9087c3892fde4352adbc98ad9ce3e73e - Cache
    libtiff/4.6.0#51d0e7e15d032aeec1b64e65c44ecd9f:6d15aa7eb0121df86c428d0d3386d3591ca6ad75#f997dd5f79cc8849df116bda058fbe0d - Cache
    libwebp/1.3.2#52f69c4a31c5cf033fdd9230d77a8e38:e45230f84c78b042579daf5f21e3e846e0160028#7f16fade02ceb3a4f9ce6cffc77ae70c - Cache
    openjph/0.16.0#859ec8a0c6a11f6ac4e5317e5d2eb5b3:b4dfcdfd74085087976e5b24f33bb491895d0984#d81ac4e431063bf9335c1567e66ac088 - Cache
    xz_utils/5.4.5#51e5a6e6564f4ea3afd79def01f035ad:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#c0ecc86caef96fe76bc8c33ecd0fde1c - Cache
    zlib/1.3.1#f52e03ae3d251dec704634230cd806a2:be7ccd6109b8a8f9da81fd00ee143a1f5bbd5bbf#e442ade299e68a6f0cc495558351b985 - Cache
    zstd/1.5.5#1f239731dc45147c7fc2f54bfbde73df:3da5102773a28e279c56e1f3943235fce254757e#b62ede115829e2070dfcaece07c9bab6 - Cache
Build requirements
Skipped binaries
    cmake/3.29.3

======== Installing packages ========
jbig/20160605: Already installed! (1 of 11)
libde265/1.0.12: Already installed! (2 of 11)
libdeflate/1.19: Already installed! (3 of 11)
libjpeg/9e: Already installed! (4 of 11)
libwebp/1.3.2: Already installed! (5 of 11)
xz_utils/5.4.5: Already installed! (6 of 11)
zlib/1.3.1: Already installed! (7 of 11)
zstd/1.5.5: Already installed! (8 of 11)
libtiff/4.6.0: Already installed! (9 of 11)
openjph/0.16.0: Already installed! (10 of 11)
libheif/1.18.2: Already installed! (11 of 11)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'env_info' used in: jbig/20160605, libde265/1.0.12, zstd/1.5.5
WARN: deprecated:     'cpp_info.build_modules' used in: libde265/1.0.12, xz_utils/5.4.5
WARN: deprecated:     'cpp_info.names' used in: libdeflate/1.19, xz_utils/5.4.5, zstd/1.5.5, libwebp/1.3.2, libjpeg/9e, openjph/0.16.0, libtiff/4.6.0, zlib/1.3.1

======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/toge/src/conan-center-index/recipes/libheif/all/test_package/build/apple-clang-15-x86_64-20-release
libheif/1.18.2 (test package): Test package build: build/apple-clang-15-x86_64-20-release
libheif/1.18.2 (test package): Test package build folder: /Users/toge/src/conan-center-index/recipes/libheif/all/test_package/build/apple-clang-15-x86_64-20-release
libheif/1.18.2 (test package): Writing generators to /Users/toge/src/conan-center-index/recipes/libheif/all/test_package/build/apple-clang-15-x86_64-20-release/generators
libheif/1.18.2 (test package): Generator 'CMakeToolchain' calling 'generate()'
libheif/1.18.2 (test package): CMakeToolchain generated: conan_toolchain.cmake
libheif/1.18.2 (test package): CMakeToolchain generated: /Users/toge/src/conan-center-index/recipes/libheif/all/test_package/build/apple-clang-15-x86_64-20-release/generators/CMakePresets.json
libheif/1.18.2 (test package): CMakeToolchain generated: /Users/toge/src/conan-center-index/recipes/libheif/all/test_package/CMakeUserPresets.json
libheif/1.18.2 (test package): Generator 'CMakeDeps' calling 'generate()'
libheif/1.18.2 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(libheif)
    target_link_libraries(... libheif::heif)
libheif/1.18.2 (test package): Generator 'VirtualRunEnv' calling 'generate()'
libheif/1.18.2 (test package): Generating aggregated env files
libheif/1.18.2 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
libheif/1.18.2 (test package): Calling build()
libheif/1.18.2 (test package): Running CMake.configure()
libheif/1.18.2 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/toge/src/conan-center-index/recipes/libheif/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/toge/src/conan-center-index/recipes/libheif/all/test_package"
-- Using Conan toolchain: /Users/toge/src/conan-center-index/recipes/libheif/all/test_package/build/apple-clang-15-x86_64-20-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- The CXX compiler identification is AppleClang 16.0.0.16000026
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'libheif::heif'
-- Conan: Target declared 'de265'
-- Conan: Target declared 'openjph::openjph'
-- Conan: Target declared 'TIFF::TIFF'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Component target declared 'libdeflate::libdeflate_static'
-- Conan: Target declared 'LibLZMA::LibLZMA'
-- Conan: Including build module from '/Users/toge/.conan2/p/b/xz_ut0672da6e502bb/p/lib/cmake/conan-official-xz_utils-variables.cmake'
-- Conan: Target declared 'JPEG::JPEG'
-- Conan: Target declared 'jbig::jbig'
-- Conan: Component target declared 'zstd::libzstd_static'
-- Conan: Component target declared 'WebP::webpdecoder'
-- Conan: Component target declared 'WebP::sharpyuv'
-- Conan: Component target declared 'WebP::webp'
-- Conan: Component target declared 'WebP::webpdemux'
-- Conan: Component target declared 'WebP::libwebpmux'
-- Conan: Target declared 'libwebp::libwebp'
-- Configuring done (1.3s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/toge/src/conan-center-index/recipes/libheif/all/test_package/build/apple-clang-15-x86_64-20-release

libheif/1.18.2 (test package): Running CMake.build()
libheif/1.18.2 (test package): RUN: cmake --build "/Users/toge/src/conan-center-index/recipes/libheif/all/test_package/build/apple-clang-15-x86_64-20-release" -- -j8
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
ld: warning: ignoring duplicate libraries: '-lc++'
[100%] Built target test_package


======== Testing the package: Executing test ========
libheif/1.18.2 (test package): Running test()
</details>

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
