### PR TITLE
lielab: add version 0.4.1

### DIFF
--- a/recipes/lielab/all/conandata.yml
+++ b/recipes/lielab/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.1":
+    url: "https://github.com/sandialabs/Lielab/archive/refs/tags/v0.4.1.tar.gz"
+    sha256: "862BEC2114B9E554F77ECB2F7B3D5CEABF7374A9A0E7F80BCB94A868F3D9F51C"
   "0.4.0":
     url: "https://github.com/sandialabs/Lielab/archive/refs/tags/v0.4.0.tar.gz"
     sha256: "5CABF2D31D7D38EEEF525ADEE5D22C0359E9C043884D4AB5FBA219D3CB217A5C"

--- a/recipes/lielab/config.yml
+++ b/recipes/lielab/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.4.1":
+    folder: "all"
   "0.4.0":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  lielab/0.4.x

#### Motivation
Added lielab/0.4.1

#### Details
Uses the existing recipe. Updated for new 0.4.1 tarball.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
