### PR TITLE
fix: Added mingw patch

### DIFF
--- a/recipes/onnx/all/conandata.yml
+++ b/recipes/onnx/all/conandata.yml
@@ -20,3 +20,10 @@ sources:
   "1.13.1":
     url: "https://github.com/onnx/onnx/archive/refs/tags/v1.13.1.tar.gz"
     sha256: "090d3e10ec662a98a2a72f1bf053f793efc645824f0d4b779e0ce47468a0890e"
+
+
+patches:
+  "1.16.2":
+    - patch_file: "1.16.2-0001-undef-optional.patch"
+      patch_description: "#undef OPTIONAL macro from windows.h, mingw header in onnx/onnx-data_pb.h"
+      patch_type: "portability"

--- a/recipes/onnx/all/patches/1.16.2-0001-undef-optional.patch
+++ b/recipes/onnx/all/patches/1.16.2-0001-undef-optional.patch
@@ -1,0 +1,7 @@
+--- a/onnx/onnx-data_pb.h
++++ b/onnx/onnx-data_pb.h
+@@ -5,3 +5,3 @@
+ #pragma once
+-
++#undef OPTIONAL 
+ // clang-format off


### PR DESCRIPTION
### Summary
Changes to recipe:  **onnx/1.16.2**

#### Motivation
See #25468 

#### Details
I added `#undef OPTIONAL` to the lib header which undefs the predefined macro from `windows.h`.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
