### PR TITLE
tree-sitter: add version 0.23.1, remove older versions

### DIFF
--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.23.1":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.23.1.tar.gz"
+    sha256: "30ea382bdaea8fc71e3d52850da509398f56d77b7c41e3494da46a1158d37b86"
   "0.23.0":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.23.0.tar.gz"
     sha256: "6403b361b0014999e96f61b9c84d6950d42f0c7d6e806be79382e0232e48a11b"
@@ -17,12 +20,3 @@ sources:
   "0.20.8":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.20.8.tar.gz"
     sha256: "6181ede0b7470bfca37e293e7d5dc1d16469b9485d13f13a605baec4a8b1f791"
-  "0.20.6":
-    url: "https://github.com/tree-sitter/tree-sitter/archive/v0.20.6.tar.gz"
-    sha256: "4d37eaef8a402a385998ff9aca3e1043b4a3bba899bceeff27a7178e1165b9de"
-  "0.20.0":
-    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.20.0.tar.gz"
-    sha256: "4a8070b9de17c3b8096181fe8530320ab3e8cca685d8bee6a3e8d164b5fb47da"
-  "0.17.3":
-    url: "https://github.com/tree-sitter/tree-sitter/archive/0.17.3.tar.gz"
-    sha256: "a897e5c9a7ccb74271d9b20d59121d2d2e9de8b896c4d1cfaac0f8104c1ef9f8"

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -11,5 +11,6 @@ versions:
     folder: all
   "0.21.0":
     folder: all
+  # keep 0.20.8 for tree-sitter-c
   "0.20.8":
     folder: all

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.23.1":
+    folder: all
   "0.23.0":
     folder: all
   "0.22.6":
@@ -10,10 +12,4 @@ versions:
   "0.21.0":
     folder: all
   "0.20.8":
-    folder: all
-  "0.20.6":
-    folder: all
-  "0.20.0":
-    folder: all
-  "0.17.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-sitter/***

#### Motivation
There are several improvements in 0.23.1.

#### Details
https://github.com/tree-sitter/tree-sitter/compare/v0.23.0...v0.23.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
