### PR TITLE
Add warning for Conan 1.x support

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -54,6 +54,8 @@ tasks:
     detailed_status_checks: false
     update_labels: true
     build_bump_deps_pr: false
+    user_feedback:
+      description: "> [!WARNING]\n> Conan Center will stop receiving updates for Conan 1.x packages soon - please see [announcement](https://github.com/conan-io/conan-center-index/discussions/25461)."
     description_bump_deps_pr: ":vertical_traffic_light: Thank for your Bump dependencies PR. The build service will be triggered soon by a Conan team member."
     wait_for_multibranch:  # CCI jobs should wait for other multibranch job for that same PR
       job_name: "prod-v2/cci"  # e.g. "cci-v2/cci" -> this means waiting for cci-v2/cci/PR-<number>


### PR DESCRIPTION
Add warning for change in Conan 1.x support

Looking for something like this:


<img width="773" alt="Screenshot 2024-10-01 at 11 13 34" src="https://github.com/user-attachments/assets/13ea1fa2-3c80-4a56-8d29-f92b5976c411">
