### PR TITLE
cnats: add version 3.8.3

### DIFF
--- a/recipes/cnats/all/conandata.yml
+++ b/recipes/cnats/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "3.8.2":
     url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.8.2.tar.gz"
     sha256: "083ee03cf5a413629d56272e88ad3229720c5006c286e8180c9e5b745c10f37d"
+  "3.8.3":
+    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.8.3.tar.gz"
+    sha256: "fe7e9ce7636446cc3fe0f47f6a235c4783299e00d5e5c4a1f8689d20707871db"

--- a/recipes/cnats/config.yml
+++ b/recipes/cnats/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "3.8.2":
     folder: all
+  "3.8.3":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cnats/3.8.2**

#### Motivation
v3.8.3 is released with some fixes: https://github.com/nats-io/nats.c/releases/tag/v3.8.3

#### Details
No build changes: https://github.com/nats-io/nats.c/compare/v3.8.2...v3.8.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
