### PR TITLE
Libjpeg: Clang/Windows support

### DIFF
--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -30,7 +30,7 @@ class LibjpegConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-
+    
     @property
     def _is_clang_cl(self):
         return self.settings.os == "Windows" and self.settings.compiler == "clang"
@@ -69,7 +69,7 @@ class LibjpegConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        if is_msvc(self):
+        if is_msvc(self) or self._is_clang_cl:
             tc = MSBuildToolchain(self)
             tc.cflags.append("-DLIBJPEG_BUILDING")
             if not self.options.shared:
@@ -84,7 +84,7 @@ class LibjpegConan(ConanFile):
 
     def build(self):
         apply_conandata_patches(self)
-        if is_msvc(self):
+        if is_msvc(self) or self._is_clang_cl:
             with chdir(self, self.source_folder):
                 self.run("nmake /f makefile.vs setupcopy-v16")
 


### PR DESCRIPTION
This commit adds support for Clang based builds for libjpeg on Windows.


### Summary
Changes to recipe:  **libjpeg/* **

#### Motivation
Currently build fails with Clang on Windows (support only partially implemented)

#### Details
This commit adds support for Clang based builds for libjpeg on Windows.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
