### PR TITLE
sdl: add version 2.30.8, remove older versions

### DIFF
--- a/recipes/sdl/all/conandata.yml
+++ b/recipes/sdl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.30.8":
+    url: "https://www.libsdl.org/release/SDL2-2.30.8.tar.gz"
+    sha256: "2508c80438cd5ff3bbeb8fe36b8f3ce7805018ff30303010b61b03bb83ab9694"
   "2.30.7":
     url: "https://www.libsdl.org/release/SDL2-2.30.7.tar.gz"
     sha256: "2508c80438cd5ff3bbeb8fe36b8f3ce7805018ff30303010b61b03bb83ab9694"
@@ -11,39 +14,12 @@ sources:
   "2.30.4":
     url: "https://www.libsdl.org/release/SDL2-2.30.4.tar.gz"
     sha256: "59c89d0ed40d4efb23b7318aa29fe7039dbbc098334b14f17f1e7e561da31a26"
-  "2.30.3":
-    url: "https://www.libsdl.org/release/SDL2-2.30.3.tar.gz"
-    sha256: "820440072f8f5b50188c1dae104f2ad25984de268785be40c41a099a510f0aec"
-  "2.30.2":
-    url: "https://www.libsdl.org/release/SDL2-2.30.2.tar.gz"
-    sha256: "891d66ac8cae51361d3229e3336ebec1c407a8a2a063b61df14f5fdf3ab5ac31"
-  "2.30.1":
-    url: "https://www.libsdl.org/release/SDL2-2.30.1.tar.gz"
-    sha256: "01215ffbc8cfc4ad165ba7573750f15ddda1f971d5a66e9dcaffd37c587f473a"
   "2.28.5":
     url: "https://www.libsdl.org/release/SDL2-2.28.5.tar.gz"
     sha256: "332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4"
   "2.28.3":
     url: "https://www.libsdl.org/release/SDL2-2.28.3.tar.gz"
     sha256: "7acb8679652701a2504d734e2ba7543ec1a83e310498ddd22fd44bf965eb5518"
-  "2.28.2":
-    url: "https://www.libsdl.org/release/SDL2-2.28.2.tar.gz"
-    sha256: "64b1102fa22093515b02ef33dd8739dee1ba57e9dbba6a092942b8bbed1a1c5e"
-  "2.26.5":
-    url: "https://www.libsdl.org/release/SDL2-2.26.5.tar.gz"
-    sha256: "ad8fea3da1be64c83c45b1d363a6b4ba8fd60f5bde3b23ec73855709ec5eabf7"
-  "2.26.1":
-    url: "https://www.libsdl.org/release/SDL2-2.26.1.tar.gz"
-    sha256: "02537cc7ebd74071631038b237ec4bfbb3f4830ba019e569434da33f42373e04"
-  "2.26.0":
-    url: "https://www.libsdl.org/release/SDL2-2.26.0.tar.gz"
-    sha256: "8000d7169febce93c84b6bdf376631f8179132fd69f7015d4dadb8b9c2bdb295"
-  "2.24.1":
-    url: "https://www.libsdl.org/release/SDL2-2.24.1.tar.gz"
-    sha256: "bc121588b1105065598ce38078026a414c28ea95e66ed2adab4c44d80b309e1b"
-  "2.24.0":
-    url: "https://www.libsdl.org/release/SDL2-2.24.0.tar.gz"
-    sha256: "91e4c34b1768f92d399b078e171448c6af18cafda743987ed2064a28954d6d97"
   "2.0.20":
     url: "https://www.libsdl.org/release/SDL2-2.0.20.tar.gz"
     sha256: "c56aba1d7b5b0e7e999e4a7698c70b63a3394ff9704b5f6e1c57e0c16f04dd06"

--- a/recipes/sdl/all/conandata.yml
+++ b/recipes/sdl/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.30.8":
     url: "https://www.libsdl.org/release/SDL2-2.30.8.tar.gz"
-    sha256: "2508c80438cd5ff3bbeb8fe36b8f3ce7805018ff30303010b61b03bb83ab9694"
+    sha256: "380c295ea76b9bd72d90075793971c8bcb232ba0a69a9b14da4ae8f603350058"
   "2.30.7":
     url: "https://www.libsdl.org/release/SDL2-2.30.7.tar.gz"
     sha256: "2508c80438cd5ff3bbeb8fe36b8f3ce7805018ff30303010b61b03bb83ab9694"

--- a/recipes/sdl/config.yml
+++ b/recipes/sdl/config.yml
@@ -1,33 +1,21 @@
 versions:
+  "2.30.8":
+    folder: all
   "2.30.7":
     folder: all
   "2.30.6":
     folder: all
+  # keep 2.30.5 for sdl_mixer
   "2.30.5":
     folder: all
   "2.30.4":
     folder: all
-  "2.30.3":
-    folder: all
-  "2.30.2":
-    folder: all
-  "2.30.1":
-    folder: all
+  # keep 2.28.5 for pdcurses, ffmpeg, sdl_net, sdl_mixer
   "2.28.5":
     folder: all
+  # keep 2.28.3 for sdl_image, sdl_ttf
   "2.28.3":
     folder: all
-  "2.28.2":
-    folder: all
-  "2.26.5":
-    folder: all
-  "2.26.1":
-    folder: all
-  "2.26.0":
-    folder: all
-  "2.24.1":
-    folder: all
-  "2.24.0":
-    folder: all
+  # keep 2.0.20 for magnum, ogre
   "2.0.20":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl/***

#### Motivation
There are several bugfixes in 2.30.8.

#### Details
https://github.com/libsdl-org/SDL/compare/release-2.30.7...release-2.30.8

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
