### PR TITLE
octo-logger-cpp: add version 2.1.2, update aws-sdk-cpp for 2.x.x

### DIFF
--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.1":
+    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v2.1.1.tar.gz"
+    sha256: "70165a5ed42c1717f3c67566673e31464d260f6e9bf7beade146848dc14a6c93"
   "2.0.2":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v2.0.2.tar.gz"
     sha256: "6aa8ee80a7f7b84df55fa215f22cdf66cbeece8cc60b2097828795194a1e6a40"

--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.1.1":
-    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v2.1.1.tar.gz"
-    sha256: "70165a5ed42c1717f3c67566673e31464d260f6e9bf7beade146848dc14a6c93"
+  "2.1.2":
+    url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v2.1.2.tar.gz"
+    sha256: "d653dc91d17f33f2e7659126ba408b40f8f421def8190ec2b6991713c6a2accf"
   "2.0.2":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v2.0.2.tar.gz"
     sha256: "6aa8ee80a7f7b84df55fa215f22cdf66cbeece8cc60b2097828795194a1e6a40"

--- a/recipes/octo-logger-cpp/all/conandata.yml
+++ b/recipes/octo-logger-cpp/all/conandata.yml
@@ -10,7 +10,7 @@ sources:
     sha256: "2edad6d1cba27019f1f26e562d9d8ff8395fc9ada1e8fb0c226c603ec5e0ed15"
   "1.12.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.12.0.tar.gz"
-    sha256: "b4140d31910af128e1d97ae44a564bbad7f7ca889410bbc885691c5e215c0d61"
+    sha256: "77f351ae4cad973ad7836dae7498419692590f2419b5b569c1f00fc6130d8bbb"
   "1.11.0":
     url: "https://github.com/ofiriluz/octo-logger-cpp/archive/v1.11.0.tar.gz"
     sha256: "73c35ca2a2e0c4be2cd85c5ba1f4061bbc22637fe79570107f1123eff30936db"

--- a/recipes/octo-logger-cpp/all/conanfile.py
+++ b/recipes/octo-logger-cpp/all/conanfile.py
@@ -55,7 +55,10 @@ class OctoLoggerCPPConan(ConanFile):
         self.requires("fmt/10.2.1", transitive_headers=True)
         if self.options.get_safe("with_aws"):
             self.requires("nlohmann_json/3.11.3")
-            self.requires("aws-sdk-cpp/1.9.234")
+            if Version(self.version) >= "2.0.0":
+                self.requires("aws-sdk-cpp/1.11.352")
+            else:
+                self.requires("aws-sdk-cpp/1.9.234")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/octo-logger-cpp/config.yml
+++ b/recipes/octo-logger-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.1":
+    folder: "all"
   "2.0.2":
     folder: "all"
   "2.0.0":

--- a/recipes/octo-logger-cpp/config.yml
+++ b/recipes/octo-logger-cpp/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.1.1":
+  "2.1.2":
     folder: "all"
   "2.0.2":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **octo-logger-cpp/2.1.2**

#### Motivation
There are several improvements since 2.0.2.
octo-logger-logger/2.x.x require aws-cpp-sdk/1.11.x.

#### Details
https://github.com/ofiriluz/octo-logger-cpp/compare/v2.0.2...v2.1.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
