### PR TITLE
cpython: avoid invalid configurations

### DIFF
--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -66,7 +66,7 @@ class CPythonConan(ConanFile):
 
     @property
     def _supports_modules(self):
-        return not is_msvc(self) or self.options.get_safe("shared")
+        return not is_msvc(self) or self.options.get_safe("shared", default=True)
 
     @property
     def _version_suffix(self):
@@ -159,7 +159,7 @@ class CPythonConan(ConanFile):
         del self.info.options.env_vars
 
     def validate(self):
-        if self.options.get_safe("shared"):
+        if self.options.get_safe("shared", default=True):
             if is_msvc_static_runtime(self):
                 raise ConanInvalidConfiguration(
                     "cpython does not support MT(d) runtime when building a shared cpython library"
@@ -443,7 +443,7 @@ class CPythonConan(ConanFile):
                             "$(RUNSHARED) CC='$(CC) $(CONFIGURE_CFLAGS) $(CONFIGURE_CPPFLAGS)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)'")
 
         # Enable static MSVC cpython
-        if not self.options.get_safe("shared"):
+        if not self.options.get_safe("shared", default=True):
             replace_in_file(self, os.path.join(self.source_folder, "PCbuild", "pythoncore.vcxproj"),
                 "<PreprocessorDefinitions>",
                 "<PreprocessorDefinitions>Py_NO_BUILD_SHARED;")
@@ -480,7 +480,7 @@ class CPythonConan(ConanFile):
 
     @property
     def _solution_projects(self):
-        if self.options.get_safe("shared"):
+        if self.options.get_safe("shared", default=True):
             solution_path = os.path.join(self.source_folder, "PCbuild", "pcbuild.sln")
             projects = set(m.group(1) for m in re.finditer('"([^"]+)\\.vcxproj"', open(solution_path).read()))
 
@@ -660,7 +660,7 @@ class CPythonConan(ConanFile):
         prefix = "" if self.settings.os == "Windows" else "lib"
         if self.settings.os == "Windows":
             extension = "lib"
-        elif not self.options.get_safe("shared"):
+        elif not self.options.get_safe("shared", default=True):
             extension = "a"
         elif is_apple_os(self):
             extension = "dylib"
@@ -724,7 +724,7 @@ class CPythonConan(ConanFile):
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         if is_msvc(self):
-            if self.options.get_safe("shared"):
+            if self.options.get_safe("shared", default=True):
                 self._msvc_package_layout()
             else:
                 self._msvc_package_copy()
@@ -822,7 +822,7 @@ class CPythonConan(ConanFile):
                 os.path.join("include", f"python{self._version_suffix}{self._abi_suffix}")
             )
             libdir = "lib"
-        if self.options.get_safe("shared"):
+        if self.options.get_safe("shared", default=True):
             self.cpp_info.components["python"].defines.append("Py_ENABLE_SHARED")
         else:
             self.cpp_info.components["python"].defines.append("Py_NO_ENABLE_SHARED")

--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -5,6 +5,7 @@ import textwrap
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
+from conan.tools.build import cross_building
 from conan.tools.env import VirtualRunEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, load, mkdir, replace_in_file, rm, rmdir, save, unzip
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
@@ -86,6 +87,10 @@ class CPythonConan(ConanFile):
             del self.options.with_curses
             del self.options.with_gdbm
             del self.options.with_nis
+        if is_apple_os(self) and cross_building(self):
+            # FIXME: The corresponding recipes currently don't support cross building
+            self.options.with_tkinter = False
+            self.options.with_curses = False
 
         self.settings.compiler.rm_safe("libcxx")
         self.settings.compiler.rm_safe("cppstd")

--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -107,7 +107,7 @@ class CPythonConan(ConanFile):
             # Static CPython on Windows is only loosely supported, see https://github.com/python/cpython/issues/110234
             # 3.10 fails during the test, 3.11 fails during the build (missing symbol that seems to be DLL specific: PyWin_DLLhModule)
             # Disabling static MSVC builds (>=3.10) due to "AttributeError: module 'sys' has no attribute 'winver'"
-            self.package_type = "static-library"
+            self.package_type = "shared-library"
             del self.options.shared
 
     def layout(self):

--- a/recipes/cpython/all/test_package/CMakeLists.txt
+++ b/recipes/cpython/all/test_package/CMakeLists.txt
@@ -1,13 +1,17 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package C)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module Development.Embed)
+find_package(Python3 REQUIRED COMPONENTS Development.Module Development.Embed)
 
-message("Python3_EXECUTABLE: ${Python3_EXECUTABLE}")
-message("Python3_INTERPRETER_ID: ${Python3_INTERPRETER_ID}")
 message("Python3_VERSION: ${Python3_VERSION}")
 message("Python3_INCLUDE_DIRS: ${Python3_INCLUDE_DIRS}")
 message("Python3_LIBRARIES: ${Python3_LIBRARIES}")
+
+if(CAN_RUN)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    message("Python3_EXECUTABLE: ${Python3_EXECUTABLE}")
+    message("Python3_INTERPRETER_ID: ${Python3_INTERPRETER_ID}")
+endif()
 
 option(BUILD_MODULE "Build python module")
 if(BUILD_MODULE)

--- a/recipes/cpython/all/test_package/conanfile.py
+++ b/recipes/cpython/all/test_package/conanfile.py
@@ -80,6 +80,7 @@ class TestPackageConan(ConanFile):
 
         # The build also needs access to the run environment to run the python executable
         VirtualRunEnv(self).generate(scope="run")
+        # Required for find_package() work with shared=True
         VirtualRunEnv(self).generate(scope="build")
 
         if self._test_setuptools:

--- a/recipes/cpython/all/test_package/conanfile.py
+++ b/recipes/cpython/all/test_package/conanfile.py
@@ -66,6 +66,7 @@ class TestPackageConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["BUILD_MODULE"] = self._supports_modules
+        tc.cache_variables["CAN_RUN"] = can_run(self)
         tc.generate()
 
         deps = CMakeDeps(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpython/[*]**

#### Motivation
The cpython recipe is currently marked as invalid on
- macOS x86_64 due to tk and ncurses not supporting cross-building.
  `tk/8.6.10: Invalid: The tk conan recipe does not currently support Macos cross-builds. A contribution to add this functionality would be welcome.`
  `ncurses/6.4: Invalid: Cross building to/from arm is (currently) not supported`
- cpython/*:shared=False on MSVC for v3.10 and greater due to build errors.
  `cpython/3.12.7: Invalid ID: Static msvc build disabled (>=3.10) due to "AttributeError: module 'sys' has no attribute 'winver'"`

Both of these are avoidable.

This affects the build of these configurations for `nanobind`, for example: https://github.com/conan-io/conan-center-index/pull/20297#issuecomment-2390819786

/cc @Ahajha

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
