### PR TITLE
taskflow: add version 3.8.0, remove older versions

### DIFF
--- a/recipes/taskflow/all/conandata.yml
+++ b/recipes/taskflow/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.8.0":
+    url: "https://github.com/taskflow/taskflow/archive/v3.8.0.tar.gz"
+    sha256: "51316ee5fbf0c8f8f4638eb7428430cadfe6e8910756593884710e99129fa0ab"
   "3.7.0":
     url: "https://github.com/taskflow/taskflow/archive/v3.7.0.tar.gz"
     sha256: "788b88093fb3788329ebbf7c7ee05d1f8960d974985a301798df01e77e04233b"
@@ -20,18 +23,6 @@ sources:
   "3.1.0":
     url: "https://github.com/taskflow/taskflow/archive/v3.1.0.tar.gz"
     sha256: "B83E9A78C254D831B8401D0F8A766E3C5B60D8D20BE5AF6E2D2FAD4AA4A8B980"
-  "3.0.0":
-    url: "https://github.com/taskflow/taskflow/archive/v3.0.0.tar.gz"
-    sha256: "553C88A6E56E115D29AC1520B8A0FEA4557A5FCDA1AF1427BD3BA454926D03A2"
-  "2.7.0":
-    url: "https://github.com/taskflow/taskflow/archive/v2.7.0.tar.gz"
-    sha256: "BC2227DCABEC86ABEBA1FEE56BB357D9D3C0EF0184F7C2275D7008E8758DFC3E"
-  "2.6.0":
-    url: "https://github.com/taskflow/taskflow/archive/v2.6.0.tar.gz"
-    sha256: "2F511F4291653D759AF12A7854BABCEBF57CFBB8B49BF6CD3EB0DD98A1A4039C"
-  "2.5.0":
-    url: "https://github.com/taskflow/taskflow/archive/v2.5.0.tar.gz"
-    sha256: "B7016EE3486458AE401D521EA6BC0403DDE975828038B9734621A6A325ACAC1A"
 patches:
   "3.3.0":
     - patch_file: "patches/3.3.0-immintrin-guard.patch"

--- a/recipes/taskflow/all/conanfile.py
+++ b/recipes/taskflow/all/conanfile.py
@@ -26,28 +26,17 @@ class TaskflowConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        if Version(self.version) >= "3.0.0":
-            return "17"
-        return "14"
+        return "17"
 
     @property
     def _compilers_minimum_version(self):
         return {
-            "17": {
-                "Visual Studio": "16",
-                "msvc": "192",
-                "gcc": "7.3" if Version(self.version) < "3.7.0" else "8.4",
-                "clang": "6.0",
-                "apple-clang": "10.0",
-            },
-            "14": {
-                "Visual Studio": "15",
-                "msvc": "191",
-                "gcc": "5",
-                "clang": "4.0",
-                "apple-clang": "8.0",
-            },
-        }[self._min_cppstd]
+            "Visual Studio": "16",
+            "msvc": "192",
+            "gcc": "7.3" if Version(self.version) < "3.7.0" else "8.4",
+            "clang": "6.0",
+            "apple-clang": "10.0",
+        }
 
     def export_sources(self):
         export_conandata_patches(self)

--- a/recipes/taskflow/config.yml
+++ b/recipes/taskflow/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.8.0":
+    folder: all
   "3.7.0":
     folder: all
   "3.6.0":
@@ -12,12 +14,4 @@ versions:
   "3.2.0":
     folder: all
   "3.1.0":
-    folder: all
-  "3.0.0":
-    folder: all
-  "2.7.0":
-    folder: all
-  "2.6.0":
-    folder: all
-  "2.5.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **taskflow/3.8.0**

#### Motivation
There are lots of improvements in 3.8.0.

#### Details
https://github.com/taskflow/taskflow/compare/v3.7.0...v3.8.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
