### PR TITLE
wyhash: deprecated (rapidhash is successor)

### DIFF
--- a/recipes/wyhash/all/conanfile.py
+++ b/recipes/wyhash/all/conanfile.py
@@ -16,6 +16,7 @@ class WyhashConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+    deprecated = "rapidhash"
 
     def layout(self):
         basic_layout(self, src_folder="src")


### PR DESCRIPTION
### Summary
Changes to recipe:  **wyhash/***

#### Motivation
rapidhash is released for successor of wyhash.

#### Details
> wyhash has evolved into [rapidhash](https://github.com/Nicoshev/rapidhash) !
> With improved speed, quality and compatibility.
https://github.com/wangyi-fudan/wyhash?tab=readme-ov-file#wyhash-has-evolved-into-rapidhash-with-improved-speed-quality-and-compatibility

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
