### PR TITLE
freetype: add version 2.13.3

### DIFF
--- a/recipes/freetype/config.yml
+++ b/recipes/freetype/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.13.3":
+    folder: meson
   "2.13.2":
     folder: meson
   "2.13.0":

--- a/recipes/freetype/meson/conandata.yml
+++ b/recipes/freetype/meson/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "2.13.3":
+    url:
+      - "https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz"
+      - "https://sourceforge.net/projects/freetype/files/freetype2/2.13.3/freetype-2.13.3.tar.xz"
+    sha256: "0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289"
   "2.13.2":
     url:
       - "https://download.savannah.gnu.org/releases/freetype/freetype-2.13.2.tar.xz"

--- a/recipes/freetype/meson/conanfile.py
+++ b/recipes/freetype/meson/conanfile.py
@@ -177,6 +177,7 @@ class FreetypeConan(ConanFile):
 
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
         self._create_cmake_module_variables(
             os.path.join(self.package_folder, self._module_vars_rel_path)
         )


### PR DESCRIPTION
### Summary
Changes to recipe:  **freetype/2.13.3**

#### Motivation
"The B/W rasterizer has become much faster; besides that, it is a maintenance release."

#### Details
https://sourceforge.net/projects/freetype/files/freetype2/2.13.3/

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
