### PR TITLE
Fix: incorrect headers in prebuilt package

### DIFF
--- a/recipes/bitserializer/all/conanfile.py
+++ b/recipes/bitserializer/all/conanfile.py
@@ -131,7 +131,7 @@ class BitserializerConan(ConanFile):
             deps.generate()
 
     def _patch_sources(self):
-        if Version(self.version) >= "0.50" and self.options.with_rapidyaml:
+        if Version(self.version) >= "0.50":
             # Remove 'ryml' subdirectory from #include
             replace_in_file(
                 self, os.path.join(self.source_folder, "include", "bitserializer", "rapidyaml_archive.h"),


### PR DESCRIPTION
### Summary
Changes to recipe:  **bitserializer/0.50**, **bitserializer/0.65**, **bitserializer/0.70**

#### Motivation
Broken recipe and prebuilt packages.

#### Details
Due to how `package_id` is implemented, when `_is_header_only()` returns True, the package_id will be the same for both values of `with_rapidyaml`. In addition to that, it seems conan-center contains prebuild version of the package_id that was created with `with_rapidyaml=False`. In effect, it contains broken headers for builds with `with_rapidyaml=True`

This fix makes sure we always patch header related to rapidyaml (it is harmless if this functionality is disabled).

NOTE TO CONAN-CENTER MAINTAINERS: To properly complete the fix, the current prebuild packages in conan-center must be replaced with fresh versions build with updated conanfile.py.

Fixes #25516

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
