### PR TITLE
glaze: add version 4.0.1, 3.6.2

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.2":
+    url: "https://github.com/stephenberry/glaze/archive/v3.6.2.tar.gz"
+    sha256: "74b14656b7a47c0a03d0a857adf5059e8c2351a7a84623593be0dd16b293216c"
   "3.6.1":
     url: "https://github.com/stephenberry/glaze/archive/v3.6.1.tar.gz"
     sha256: "70324ad952adee32d6bbf95a0983f0c1623ce61bd237aa28c8337af2d8bb9ed5"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.0.0":
-    url: "https://github.com/stephenberry/glaze/archive/v4.0.0.tar.gz"
-    sha256: "6114cd6fc2eb39e396e229c7971b2ca5aeb8a670f0dfcd37d6223d766f4afecf"
+  "4.0.1":
+    url: "https://github.com/stephenberry/glaze/archive/v4.0.1.tar.gz"
+    sha256: "0026aca33201ee6d3a820fb5926f36ba8c838bfd3120e2e179b0eee62b5bd231"
   "3.6.2":
     url: "https://github.com/stephenberry/glaze/archive/v3.6.2.tar.gz"
     sha256: "74b14656b7a47c0a03d0a857adf5059e8c2351a7a84623593be0dd16b293216c"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.0":
+    url: "https://github.com/stephenberry/glaze/archive/v4.0.0.tar.gz"
+    sha256: "6114cd6fc2eb39e396e229c7971b2ca5aeb8a670f0dfcd37d6223d766f4afecf"
   "3.6.2":
     url: "https://github.com/stephenberry/glaze/archive/v3.6.2.tar.gz"
     sha256: "74b14656b7a47c0a03d0a857adf5059e8c2351a7a84623593be0dd16b293216c"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.2":
+    folder: all
   "3.6.1":
     folder: all
   "3.4.3":

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.0":
+    folder: all
   "3.6.2":
     folder: all
   "3.6.1":

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.0.0":
+  "4.0.1":
     folder: all
   "3.6.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **glaze/4.0.1,3.6.2**

#### Motivation
There is a major version up (4.0.1).
There are several improvements in 3.6.2

#### Details
https://github.com/stephenberry/glaze/compare/v3.6.1...v3.6.2
https://github.com/stephenberry/glaze/compare/v3.6.2...v4.0.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
