### PR TITLE
hdf5: add v1.14.5

### DIFF
--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.14.5":
+    url: "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.5.tar.gz"
+    sha256: "c83996dc79080a34e7b5244a1d5ea076abfd642ec12d7c25388e2fdd81d26350"
   "1.14.4.3":
     url: "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.4.3.tar.gz"
     sha256: "690c1db7ba0fed4ffac61709236675ffd99d95d191e8920ee79c58d7e7ea3361"

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -100,7 +100,7 @@ class Hdf5Conan(ConanFile):
             raise ConanInvalidConfiguration("encoding must be enabled in szip dependency (szip:enable_encoding=True)")
         if self.options.with_zlib and self.options.get_safe("with_zlibng"):
             raise ConanInvalidConfiguration("with_zlib and with_zlibng cannot be enabled at the same time")
-        if self.option.get_safe("with_zlibng") and Version(self.version) < "1.14.5":
+        if self.options.get_safe("with_zlibng") and Version(self.version) < "1.14.5":
             raise ConanInvalidConfiguration("with_zlibng=True is incompatible with versions prior to v1.14.5")
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -28,6 +28,7 @@ class Hdf5Conan(ConanFile):
         "hl": [True, False],
         "threadsafe": [True, False],
         "with_zlib": [True, False],
+        "with_zlibng": [True, False],
         "szip_support": [None, "with_libaec", "with_szip"],
         "szip_encoding": [True, False],
         "parallel": [True, False],
@@ -40,6 +41,7 @@ class Hdf5Conan(ConanFile):
         "hl": True,
         "threadsafe": False,
         "with_zlib": True,
+        "with_zlibng": False,
         "szip_support": None,
         "szip_encoding": False,
         "parallel": False,
@@ -77,6 +79,8 @@ class Hdf5Conan(ConanFile):
     def requirements(self):
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
+        if self.options.with_zlibng:
+            self.requires("zlib-ng/2.2.2")
         if self.options.szip_support == "with_libaec":
             self.requires("libaec/1.0.6")
         elif self.options.szip_support == "with_szip":
@@ -94,6 +98,8 @@ class Hdf5Conan(ConanFile):
                 self.options.szip_encoding and \
                 not self.dependencies["szip"].options.enable_encoding:
             raise ConanInvalidConfiguration("encoding must be enabled in szip dependency (szip:enable_encoding=True)")
+        if self.options.with_zlib and self.options.get_safe("with_zlibng"):
+            raise ConanInvalidConfiguration("with_zlib and with_zlibng cannot be enabled at the same time")
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
 
@@ -150,6 +156,7 @@ class Hdf5Conan(ConanFile):
         tc.variables["HDF5_ENABLE_Z_LIB_SUPPORT"] = self.options.with_zlib
         tc.variables["HDF5_ENABLE_SZIP_SUPPORT"] = bool(self.options.szip_support)
         tc.variables["HDF5_ENABLE_SZIP_ENCODING"] = self.options.get_safe("szip_encoding", False)
+        tc.variables["HDF5_USE_ZLIB_NG"] = self.options.get_safe("with_zlibng", False)
         tc.variables["HDF5_PACKAGE_EXTLIBS"] = False
         tc.variables["HDF5_ENABLE_THREADSAFE"] = self.options.get_safe("threadsafe", False)
         tc.variables["HDF5_ENABLE_DEBUG_APIS"] = False # Option?

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -100,6 +100,8 @@ class Hdf5Conan(ConanFile):
             raise ConanInvalidConfiguration("encoding must be enabled in szip dependency (szip:enable_encoding=True)")
         if self.options.with_zlib and self.options.get_safe("with_zlibng"):
             raise ConanInvalidConfiguration("with_zlib and with_zlibng cannot be enabled at the same time")
+        if self.option.get_safe("with_zlibng") and Version(self.version) < "1.14.5":
+            raise ConanInvalidConfiguration("with_zlibng=True is incompatible with versions prior to v1.14.5")
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._min_cppstd)
 

--- a/recipes/hdf5/config.yml
+++ b/recipes/hdf5/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.14.5":
+    folder: all
   "1.14.4.3":
     folder: all
   "1.14.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **hdf5/all**

Add v.1.14.5 and expose option to link against zlib-ng instead of zlib.

[HDF5 changelog](https://raw.githubusercontent.com/HDFGroup/hdf5/hdf5_1_14_5/release_docs/RELEASE.txt)

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

#### Notes
I've also opened the following PRs to bump the zlib-ng version used throughout cci. Let me know if you prefer instead to make hdf5 depend on v 2.1.6.

https://github.com/conan-io/conan-center-index/pull/25522 https://github.com/conan-io/conan-center-index/pull/25523 https://github.com/conan-io/conan-center-index/pull/25524

Build log for:
```bash
conan create recipes/hdf5/all --version 1.14.5 --name=hdf5 --build=missing -o '*/*:shared=True' -o 'hdf5/*:with_zlibng=True' -o 'hdf5/*:with_zlib=False'
```

<details>
<summary>LOG</summary>

```

======== Exporting recipe to the cache ========
hdf5/1.14.5: Exporting package recipe: /home/devel/github/conan-center-index/recipes/hdf5/all/conanfile.py
hdf5/1.14.5: exports: File 'conandata.yml' found. Exporting it...
hdf5/1.14.5: Calling export_sources()
hdf5/1.14.5: Copied 1 '.py' file: conanfile.py
hdf5/1.14.5: Copied 1 '.yml' file: conandata.yml
hdf5/1.14.5: Exported to cache folder: /home/devel/.conan2/p/hdf50f1ef0e315c38/e
hdf5/1.14.5: Exported: hdf5/1.14.5#ca5eae63bd7cd39c0548869730e04f41 (2024-10-05 12:05:34 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux
[options]
*/*:shared=True
hdf5/*:with_zlib=False
hdf5/*:with_zlibng=True

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    hdf5/1.14.5#ca5eae63bd7cd39c0548869730e04f41 - Cache
    zlib-ng/2.2.2#894a58b509be21a864c41b3bd154e92f - Cache
Build requirements
    cmake/3.30.1#6d832cf2d46f6ec969ca5ed5b41f91eb - Cache
Resolved version ranges
    cmake/[>=3.18 <4]: cmake/3.30.1

======== Computing necessary packages ========
hdf5/1.14.5: Compatible package ID 52c118ba8f2d33288fb6ff4473ba1cdc8100e824 equal to the default package ID: Skipping it.
hdf5/1.14.5: Checking 9 compatible configurations
hdf5/1.14.5: Compatible configurations not found in cache, checking servers
hdf5/1.14.5: '50da24fe2f8c1f9e25fe64d167b025c15e8974b8': compiler.cppstd=11
hdf5/1.14.5: '0feb5b041edca31def0acdd275ff1612f477614e': compiler.cppstd=gnu11
hdf5/1.14.5: '64681929ec5c63cf61809dc517f7a4ed6e9f5b7c': compiler.cppstd=14
hdf5/1.14.5: '720af12818e4bd68ecb6e7f859cd954490c1123a': compiler.cppstd=gnu14
hdf5/1.14.5: 'af664b3b9b8209e68dd8a42ede0053f1e0b1d919': compiler.cppstd=17
hdf5/1.14.5: '7a5b9a45a98dc1feed599fbcf91a1de7efb38ca2': compiler.cppstd=20
hdf5/1.14.5: 'c705c9e68dd3e175f6f2e04eb3ae5231bba5e711': compiler.cppstd=gnu20
hdf5/1.14.5: '56f7269cb3dc12a9638842b4ad26531d6fbbbc35': compiler.cppstd=23
hdf5/1.14.5: 'b4eba7b855665a5c501d825008f6d29c90d95ab9': compiler.cppstd=gnu23
Requirements
    hdf5/1.14.5#ca5eae63bd7cd39c0548869730e04f41:52c118ba8f2d33288fb6ff4473ba1cdc8100e824 - Build
    zlib-ng/2.2.2#894a58b509be21a864c41b3bd154e92f:6613b6885d1e7325456312f712ce6f71c6df1e88#c23b9e6425d6676374c22833f816aa1c - Cache
Build requirements
    cmake/3.30.1#6d832cf2d46f6ec969ca5ed5b41f91eb:63fead0844576fc02943e16909f08fcdddd6f44b#041a38980949bccd356d9142f4e0a2bf - Cache

======== Installing packages ========
cmake/3.30.1: Already installed! (1 of 3)
cmake/3.30.1: Appending PATH environment variable: /home/devel/.conan2/p/cmakefaa1321642d5b/p/bin
zlib-ng/2.2.2: Already installed! (2 of 3)
hdf5/1.14.5: Calling source() in /home/devel/.conan2/p/hdf50f1ef0e315c38/s/src
hdf5/1.14.5: Downloading 37.8MB hdf5_1.14.5.tar.gz
hdf5/1.14.5: Unzipping hdf5_1.14.5.tar.gz to .

-------- Installing package hdf5/1.14.5 (3 of 3) --------
hdf5/1.14.5: Building from source
hdf5/1.14.5: Package hdf5/1.14.5:52c118ba8f2d33288fb6ff4473ba1cdc8100e824
hdf5/1.14.5: Copying sources to build folder
hdf5/1.14.5: Building your package in /home/devel/.conan2/p/b/hdf51731d70c77123/b
hdf5/1.14.5: Calling generate()
hdf5/1.14.5: Generators folder: /home/devel/.conan2/p/b/hdf51731d70c77123/b/build/Release/generators
hdf5/1.14.5: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(zlib-ng)
    target_link_libraries(... zlib-ng::zlib-ng)
hdf5/1.14.5: CMakeToolchain generated: conan_toolchain.cmake
hdf5/1.14.5: CMakeToolchain generated: /home/devel/.conan2/p/b/hdf51731d70c77123/b/build/Release/generators/CMakePresets.json
hdf5/1.14.5: CMakeToolchain generated: /home/devel/.conan2/p/b/hdf51731d70c77123/b/src/CMakeUserPresets.json
hdf5/1.14.5: Generating aggregated env files
hdf5/1.14.5: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
hdf5/1.14.5: Calling build()
hdf5/1.14.5: Running CMake.configure()
hdf5/1.14.5: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/devel/.conan2/p/b/hdf51731d70c77123/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/devel/.conan2/p/b/hdf51731d70c77123/b/src"
-- Using Conan toolchain: /home/devel/.conan2/p/b/hdf51731d70c77123/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is GNU 14.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Final: share
-- Looking for include file sys/file.h
-- Looking for include file sys/file.h - found
-- Looking for include files sys/file.h, sys/ioctl.h
-- Looking for include files sys/file.h, sys/ioctl.h - found
-- Looking for 3 include files sys/file.h, ..., sys/resource.h
-- Looking for 3 include files sys/file.h, ..., sys/resource.h - found
-- Looking for 4 include files sys/file.h, ..., sys/socket.h
-- Looking for 4 include files sys/file.h, ..., sys/socket.h - found
-- Looking for 5 include files sys/file.h, ..., sys/stat.h
-- Looking for 5 include files sys/file.h, ..., sys/stat.h - found
-- Looking for 6 include files sys/file.h, ..., sys/time.h
-- Looking for 6 include files sys/file.h, ..., sys/time.h - found
-- Looking for 7 include files sys/file.h, ..., sys/types.h
-- Looking for 7 include files sys/file.h, ..., sys/types.h - found
-- Looking for 8 include files sys/file.h, ..., features.h
-- Looking for 8 include files sys/file.h, ..., features.h - found
-- Looking for 9 include files sys/file.h, ..., dirent.h
-- Looking for 9 include files sys/file.h, ..., dirent.h - found
-- Looking for 10 include files sys/file.h, ..., unistd.h
-- Looking for 10 include files sys/file.h, ..., unistd.h - found
-- Looking for 11 include files sys/file.h, ..., pwd.h
-- Looking for 11 include files sys/file.h, ..., pwd.h - found
-- Looking for 12 include files sys/file.h, ..., pthread.h
-- Looking for 12 include files sys/file.h, ..., pthread.h - found
-- Looking for 13 include files sys/file.h, ..., dlfcn.h
-- Looking for 13 include files sys/file.h, ..., dlfcn.h - found
-- Looking for 14 include files sys/file.h, ..., netinet/in.h
-- Looking for 14 include files sys/file.h, ..., netinet/in.h - found
-- Looking for 15 include files sys/file.h, ..., netdb.h
-- Looking for 15 include files sys/file.h, ..., netdb.h - found
-- Looking for 16 include files sys/file.h, ..., arpa/inet.h
-- Looking for 16 include files sys/file.h, ..., arpa/inet.h - found
-- Looking for include file quadmath.h
-- Looking for include file quadmath.h - found
-- Looking for ceil in m;
-- Looking for ceil in m; - found
-- Looking for dlopen in dl;m
-- Looking for dlopen in dl;m - found
-- Looking for WSAStartup in ws2_32;m;dl
-- Looking for WSAStartup in ws2_32;m;dl - not found
-- Looking for gethostbyname in wsock32;m;dl
-- Looking for gethostbyname in wsock32;m;dl - not found
-- Looking for gethostname in ucb;m;dl
-- Looking for gethostname in ucb;m;dl - not found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of char
-- Check size of char - done
-- Check size of short
-- Check size of short - done
-- Check size of int
-- Check size of int - done
-- Check size of unsigned
-- Check size of unsigned - done
-- Check size of long
-- Check size of long - done
-- Check size of long long
-- Check size of long long - done
-- Check size of float
-- Check size of float - done
-- Check size of double
-- Check size of double - done
-- Check size of long double
-- Check size of long double - done
-- Check size of int8_t
-- Check size of int8_t - done
-- Check size of uint8_t
-- Check size of uint8_t - done
-- Check size of int_least8_t
-- Check size of int_least8_t - done
-- Check size of uint_least8_t
-- Check size of uint_least8_t - done
-- Check size of int_fast8_t
-- Check size of int_fast8_t - done
-- Check size of uint_fast8_t
-- Check size of uint_fast8_t - done
-- Check size of int16_t
-- Check size of int16_t - done
-- Check size of uint16_t
-- Check size of uint16_t - done
-- Check size of int_least16_t
-- Check size of int_least16_t - done
-- Check size of uint_least16_t
-- Check size of uint_least16_t - done
-- Check size of int_fast16_t
-- Check size of int_fast16_t - done
-- Check size of uint_fast16_t
-- Check size of uint_fast16_t - done
-- Check size of int32_t
-- Check size of int32_t - done
-- Check size of uint32_t
-- Check size of uint32_t - done
-- Check size of int_least32_t
-- Check size of int_least32_t - done
-- Check size of uint_least32_t
-- Check size of uint_least32_t - done
-- Check size of int_fast32_t
-- Check size of int_fast32_t - done
-- Check size of uint_fast32_t
-- Check size of uint_fast32_t - done
-- Check size of int64_t
-- Check size of int64_t - done
-- Check size of uint64_t
-- Check size of uint64_t - done
-- Check size of int_least64_t
-- Check size of int_least64_t - done
-- Check size of uint_least64_t
-- Check size of uint_least64_t - done
-- Check size of int_fast64_t
-- Check size of int_fast64_t - done
-- Check size of uint_fast64_t
-- Check size of uint_fast64_t - done
-- Check size of size_t
-- Check size of size_t - done
-- Check size of ssize_t
-- Check size of ssize_t - done
-- Check size of ptrdiff_t
-- Check size of ptrdiff_t - done
-- Check size of off_t
-- Check size of off_t - done
-- Check size of time_t
-- Check size of time_t - done
-- Check size of _Bool
-- Check size of _Bool - done
-- Looking for CLOCK_MONOTONIC
-- Looking for CLOCK_MONOTONIC - not found
-- Performing Test H5_HAVE_TM_GMTOFF
-- Performing Test H5_HAVE_TM_GMTOFF - Success
-- Performing Test H5_HAVE___TM_GMTOFF
-- Performing Test H5_HAVE___TM_GMTOFF - Failed
-- Performing Test H5_HAVE_STRUCT_TIMEZONE
-- Performing Test H5_HAVE_STRUCT_TIMEZONE - Failed
-- Looking for gettimeofday
-- Looking for gettimeofday - found
-- Performing Test H5_HAVE_STAT_ST_BLOCKS
-- Performing Test H5_HAVE_STAT_ST_BLOCKS - Success
-- Looking for ioctl
-- Looking for ioctl - found
-- Performing Test H5_HAVE_STRUCT_VIDEOCONFIG
-- Performing Test H5_HAVE_STRUCT_VIDEOCONFIG - Failed
-- Performing Test H5_HAVE_STRUCT_TEXT_INFO
-- Performing Test H5_HAVE_STRUCT_TEXT_INFO - Failed
-- Looking for _getvideoconfig
-- Looking for _getvideoconfig - not found
-- Looking for gettextinfo
-- Looking for gettextinfo - not found
-- Looking for _scrsize
-- Looking for _scrsize - not found
-- Looking for GetConsoleScreenBufferInfo
-- Looking for GetConsoleScreenBufferInfo - not found
-- Looking for TIOCGWINSZ
-- Looking for TIOCGWINSZ - found
-- Looking for TIOCGETD
-- Looking for TIOCGETD - found
-- Looking for alarm
-- Looking for alarm - found
-- Looking for fcntl
-- Looking for fcntl - found
-- Looking for flock
-- Looking for flock - found
-- Looking for fork
-- Looking for fork - found
-- Looking for gethostname
-- Looking for gethostname - found
-- Looking for getrusage
-- Looking for getrusage - found
-- Looking for pread
-- Looking for pread - found
-- Looking for pwrite
-- Looking for pwrite - found
-- Looking for rand_r
-- Looking for rand_r - found
-- Looking for random
-- Looking for random - found
-- Looking for strcasestr
-- Looking for strcasestr - found
-- Looking for strdup
-- Looking for strdup - found
-- Looking for symlink
-- Looking for symlink - found
-- Looking for tmpfile
-- Looking for tmpfile - found
-- Looking for asprintf
-- Looking for asprintf - found
-- Looking for vasprintf
-- Looking for vasprintf - found
-- Looking for waitpid
-- Looking for waitpid - found
-- Looking for sigsetjmp
-- Looking for sigsetjmp - found
-- Looking for clock_gettime
-- Looking for clock_gettime - found
-- Looking for clock_gettime in rt
-- Looking for clock_gettime in rt - found
-- Looking for clock_gettime in posix4
-- Looking for clock_gettime in posix4 - not found
-- Check size of CLOCK_MONOTONIC_COARSE
-- Check size of CLOCK_MONOTONIC_COARSE - done
-- Checking if _Float16 support is available
-- Check size of _Float16
-- Check size of _Float16 - done
-- Looking for FLT16_EPSILON
-- Looking for FLT16_EPSILON - found
-- Looking for FLT16_MIN
-- Looking for FLT16_MIN - found
-- Looking for FLT16_MAX
-- Looking for FLT16_MAX - found
-- Looking for FLT16_MIN_10_EXP
-- Looking for FLT16_MIN_10_EXP - found
-- Looking for FLT16_MAX_10_EXP
-- Looking for FLT16_MAX_10_EXP - found
-- Looking for FLT16_MANT_DIG
-- Looking for FLT16_MANT_DIG - found
-- Looking for fabsf16
-- Looking for fabsf16 - not found
-- Found Perl: /usr/bin/perl (found version "5.40.0")
-- ... disable color and URL extended diagnostic messages
-- ....All Warnings are enabled
-- Filter PLUGIN file is /
-- The CXX compiler identification is GNU 14.2.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- ... disable color and URL extended diagnostic messages
-- ....All Warnings are enabled
-- Configuring done (6.3s)
-- Generating done (0.1s)
-- Build files have been written to: /home/devel/.conan2/p/b/hdf51731d70c77123/b/build/Release

hdf5/1.14.5: Running CMake.build()
hdf5/1.14.5: RUN: cmake --build "/home/devel/.conan2/p/b/hdf51731d70c77123/b/build/Release" -- -j32
[  0%] Building C object src/CMakeFiles/hdf5-shared.dir/H5build_settings.c.o
[  0%] Building C object src/CMakeFiles/hdf5-shared.dir/H5.c.o
[  1%] Building C object src/CMakeFiles/hdf5-shared.dir/H5mpi.c.o
[  1%] Building C object src/CMakeFiles/hdf5-shared.dir/H5dbg.c.o
[  1%] Building C object src/CMakeFiles/hdf5-shared.dir/H5checksum.c.o
[  1%] Building C object src/CMakeFiles/hdf5-shared.dir/H5system.c.o
[  1%] Building C object src/CMakeFiles/hdf5-shared.dir/H5timer.c.o
[  2%] Building C object src/CMakeFiles/hdf5-shared.dir/H5trace.c.o
[  2%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Abtree2.c.o
[  2%] Building C object src/CMakeFiles/hdf5-shared.dir/H5A.c.o
[  2%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Adense.c.o
[  2%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Aint.c.o
[  3%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Adeprec.c.o
[  3%] Building C object src/CMakeFiles/hdf5-shared.dir/H5AC.c.o
[  3%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Atest.c.o
[  4%] Building C object src/CMakeFiles/hdf5-shared.dir/H5ACdbg.c.o
[  4%] Building C object src/CMakeFiles/hdf5-shared.dir/H5ACmpio.c.o
[  4%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B.c.o
[  4%] Building C object src/CMakeFiles/hdf5-shared.dir/H5ACproxy_entry.c.o
[  5%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Bcache.c.o
[  5%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Bdbg.c.o
[  5%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2.c.o
[  5%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2cache.c.o
[  6%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2dbg.c.o
[  6%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2hdr.c.o
[  6%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2int.c.o
[  6%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2internal.c.o
[  7%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2leaf.c.o
[  7%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2stat.c.o
[  7%] Building C object src/CMakeFiles/hdf5-shared.dir/H5B2test.c.o
[  7%] Building C object src/CMakeFiles/hdf5-shared.dir/H5C.c.o
[  8%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Cdbg.c.o
[  8%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Cepoch.c.o
[  8%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Centry.c.o
[  8%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Cimage.c.o
[  9%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Cint.c.o
[  9%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Clog.c.o
[  9%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Clog_json.c.o
[  9%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Clog_trace.c.o
[  9%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Cprefetched.c.o
[ 10%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Cmpio.c.o
[ 10%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Cquery.c.o
[ 10%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ctag.c.o
[ 11%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ctest.c.o
[ 11%] Building C object src/CMakeFiles/hdf5-shared.dir/H5CX.c.o
[ 11%] Building C object src/CMakeFiles/hdf5-shared.dir/H5D.c.o
In file included from /home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5B.c:100:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5B.c: In function ‘H5B__remove_helper’:
[ 11%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dbtree.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5B.c:1427:46: warning: potential null pointer dereference [-Wnull-dereference]
 1427 |     if (*lt_key_changed && H5_addr_defined(bt->left)) {
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5private.h:449:36: note: in definition of macro ‘H5_addr_defined’
  449 | #define H5_addr_defined(X)       ((X) != HADDR_UNDEF)
      |                                    ^
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5B.c:1442:51: warning: potential null pointer dereference [-Wnull-dereference]
 1442 |     else if (*rt_key_changed && H5_addr_defined(bt->right)) {
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5private.h:449:36: note: in definition of macro ‘H5_addr_defined’
  449 | #define H5_addr_defined(X)       ((X) != HADDR_UNDEF)
      |                                    ^
[ 12%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dbtree2.c.o
[ 12%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dchunk.c.o
[ 12%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dcompact.c.o
[ 12%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dcontig.c.o
[ 13%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ddbg.c.o
[ 13%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ddeprec.c.o
[ 13%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dearray.c.o
[ 13%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Defl.c.o
[ 14%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dfarray.c.o
[ 14%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dfill.c.o
[ 14%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dint.c.o
[ 15%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dio.c.o
[ 15%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dlayout.c.o
[ 15%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dmpio.c.o
[ 15%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dnone.c.o
[ 15%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Doh.c.o
[ 16%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dscatgath.c.o
[ 16%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dselect.c.o
[ 16%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dsingle.c.o
[ 16%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dtest.c.o
[ 17%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Dvirtual.c.o
[ 17%] Building C object src/CMakeFiles/hdf5-shared.dir/H5E.c.o
[ 17%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Edeprec.c.o
[ 17%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Eint.c.o
[ 18%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EA.c.o
[ 18%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAcache.c.o
[ 18%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAdbg.c.o
[ 18%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAdblkpage.c.o
[ 19%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAdblock.c.o
[ 19%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAhdr.c.o
[ 19%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAiblock.c.o
[ 19%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAint.c.o
[ 20%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAsblock.c.o
[ 20%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAstat.c.o
[ 20%] Building C object src/CMakeFiles/hdf5-shared.dir/H5EAtest.c.o
[ 20%] Building C object src/CMakeFiles/hdf5-shared.dir/H5ES.c.o
[ 21%] Building C object src/CMakeFiles/hdf5-shared.dir/H5ESevent.c.o
[ 21%] Building C object src/CMakeFiles/hdf5-shared.dir/H5ESint.c.o
[ 21%] Building C object src/CMakeFiles/hdf5-shared.dir/H5F.c.o
[ 21%] Building C object src/CMakeFiles/hdf5-shared.dir/H5ESlist.c.o
[ 22%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Faccum.c.o
[ 22%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fcwfs.c.o
[ 22%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fdbg.c.o
[ 22%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fdeprec.c.o
[ 23%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fefc.c.o
[ 23%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ffake.c.o
[ 23%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fint.c.o
[ 23%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fio.c.o
[ 24%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fmount.c.o
[ 24%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fmpi.c.o
[ 24%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fquery.c.o
[ 24%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fsfile.c.o
[ 25%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fspace.c.o
[ 25%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fsuper.c.o
[ 25%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Fsuper_cache.c.o
[ 25%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ftest.c.o
[ 26%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FA.c.o
[ 26%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FAcache.c.o
[ 26%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FAdbg.c.o
[ 26%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FAdblkpage.c.o
[ 27%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FAdblock.c.o
[ 27%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FAhdr.c.o
[ 27%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FAint.c.o
[ 27%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FAstat.c.o
[ 28%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FAtest.c.o
[ 28%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FD.c.o
[ 28%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDcore.c.o
[ 28%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDdirect.c.o
[ 29%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDfamily.c.o
[ 29%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDhdfs.c.o
[ 29%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDint.c.o
[ 30%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDmirror.c.o
[ 30%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDmpi.c.o
[ 30%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDlog.c.o
[ 30%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDmpio.c.o
[ 30%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDmulti.c.o
[ 31%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDonion.c.o
[ 31%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDonion_header.c.o
[ 31%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDonion_history.c.o
[ 31%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDonion_index.c.o
[ 32%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDperform.c.o
[ 32%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDros3.c.o
[ 32%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDs3comms.c.o
[ 33%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDspace.c.o
[ 33%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDsec2.c.o
[ 33%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDsplitter.c.o
[ 33%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDstdio.c.o
[ 33%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDtest.c.o
[ 34%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FDwindows.c.o
[ 34%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FL.c.o
[ 34%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FO.c.o
[ 35%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FScache.c.o
[ 35%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FS.c.o
[ 35%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FSdbg.c.o
[ 35%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FSint.c.o
[ 35%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FSsection.c.o
[ 36%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FSstat.c.o
[ 36%] Building C object src/CMakeFiles/hdf5-shared.dir/H5FStest.c.o
[ 36%] Building C object src/CMakeFiles/hdf5-shared.dir/H5G.c.o
[ 36%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gbtree2.c.o
[ 37%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gcache.c.o
[ 37%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gcompact.c.o
[ 37%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gdense.c.o
[ 37%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gdeprec.c.o
[ 38%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gent.c.o
[ 38%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gint.c.o
[ 38%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Glink.c.o
[ 38%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gloc.c.o
[ 39%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gname.c.o
[ 39%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gnode.c.o
[ 39%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gobj.c.o
[ 39%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Goh.c.o
[ 40%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Groot.c.o
[ 40%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gstab.c.o
[ 40%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gtest.c.o
[ 40%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Gtraverse.c.o
[ 41%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HF.c.o
[ 41%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFbtree2.c.o
[ 41%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFcache.c.o
[ 41%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFdbg.c.o
[ 42%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFdblock.c.o
[ 42%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFdtable.c.o
[ 42%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFhdr.c.o
[ 42%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFhuge.c.o
[ 43%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFiblock.c.o
[ 43%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFiter.c.o
[ 43%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFman.c.o
[ 43%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFsection.c.o
[ 44%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFspace.c.o
[ 44%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFstat.c.o
[ 44%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFtest.c.o
[ 44%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HFtiny.c.o
[ 45%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HG.c.o
[ 45%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HGcache.c.o
[ 45%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HGdbg.c.o
[ 46%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HGquery.c.o
[ 46%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HL.c.o
[ 46%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HLcache.c.o
[ 46%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HLdbg.c.o
[ 46%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HLdblk.c.o
[ 47%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HLint.c.o
[ 47%] Building C object src/CMakeFiles/hdf5-shared.dir/H5HLprfx.c.o
[ 47%] Building C object src/CMakeFiles/hdf5-shared.dir/H5I.c.o
[ 47%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Idbg.c.o
[ 48%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Iint.c.o
[ 48%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Itest.c.o
[ 48%] Building C object src/CMakeFiles/hdf5-shared.dir/H5L.c.o
[ 49%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Lexternal.c.o
[ 49%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ldeprec.c.o
[ 49%] Building C object src/CMakeFiles/hdf5-shared.dir/H5M.c.o
[ 49%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Lint.c.o
[ 49%] Building C object src/CMakeFiles/hdf5-shared.dir/H5MF.c.o
[ 50%] Building C object src/CMakeFiles/hdf5-shared.dir/H5MFaggr.c.o
[ 50%] Building C object src/CMakeFiles/hdf5-shared.dir/H5MFdbg.c.o
[ 50%] Building C object src/CMakeFiles/hdf5-shared.dir/H5MFsection.c.o
[ 50%] Building C object src/CMakeFiles/hdf5-shared.dir/H5MM.c.o
[ 51%] Building C object src/CMakeFiles/hdf5-shared.dir/H5O.c.o
[ 51%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oainfo.c.o
[ 51%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oalloc.c.o
[ 51%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oattr.c.o
[ 52%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oattribute.c.o
[ 52%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Obogus.c.o
[ 52%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Obtreek.c.o
[ 52%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ocache.c.o
[ 53%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ocache_image.c.o
[ 53%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ochunk.c.o
[ 53%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ocont.c.o
[ 53%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ocopy.c.o
[ 54%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ocopy_ref.c.o
[ 54%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Odbg.c.o
[ 54%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Odeprec.c.o
[ 54%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Odrvinfo.c.o
[ 55%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Odtype.c.o
[ 55%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oefl.c.o
[ 55%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ofill.c.o
[ 55%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oflush.c.o
[ 56%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ofsinfo.c.o
[ 56%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oginfo.c.o
[ 56%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oint.c.o
[ 56%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Olayout.c.o
[ 57%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Olinfo.c.o
[ 57%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Olink.c.o
[ 57%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Omessage.c.o
[ 57%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Omtime.c.o
[ 58%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oname.c.o
[ 58%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Onull.c.o
[ 58%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Opline.c.o
[ 58%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Orefcount.c.o
[ 58%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oshared.c.o
[ 59%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Osdspace.c.o
[ 59%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Oshmesg.c.o
[ 59%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ostab.c.o
[ 60%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Otest.c.o
[ 60%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ounknown.c.o
[ 60%] Building C object src/CMakeFiles/hdf5-shared.dir/H5P.c.o
[ 60%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pacpl.c.o
[ 61%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pdapl.c.o
[ 61%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pdcpl.c.o
[ 61%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pdeprec.c.o
[ 62%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pencdec.c.o
[ 62%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pdxpl.c.o
[ 62%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pfapl.c.o
[ 62%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pfcpl.c.o
[ 62%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pfmpl.c.o
[ 63%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pgcpl.c.o
[ 63%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pint.c.o
[ 63%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Plapl.c.o
[ 63%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Plcpl.c.o
[ 64%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pmapl.c.o
[ 64%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pmcpl.c.o
[ 64%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pocpl.c.o
[ 64%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pocpypl.c.o
[ 65%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Pstrcpl.c.o
[ 65%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ptest.c.o
[ 65%] Building C object src/CMakeFiles/hdf5-shared.dir/H5PB.c.o
[ 65%] Building C object src/CMakeFiles/hdf5-shared.dir/H5PL.c.o
[ 66%] Building C object src/CMakeFiles/hdf5-shared.dir/H5PLint.c.o
[ 66%] Building C object src/CMakeFiles/hdf5-shared.dir/H5PLpath.c.o
[ 66%] Building C object src/CMakeFiles/hdf5-shared.dir/H5PLplugin_cache.c.o
[ 66%] Building C object src/CMakeFiles/hdf5-shared.dir/H5R.c.o
[ 67%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Rdeprec.c.o
[ 67%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Rint.c.o
[ 67%] Building C object src/CMakeFiles/hdf5-shared.dir/H5UC.c.o
[ 68%] Building C object src/CMakeFiles/hdf5-shared.dir/H5S.c.o
[ 68%] Building C object src/CMakeFiles/hdf5-shared.dir/H5RS.c.o
[ 68%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Sall.c.o
[ 68%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Sdbg.c.o
[ 69%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Shyper.c.o
[ 69%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Sdeprec.c.o
[ 69%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Smpio.c.o
[ 69%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Snone.c.o
[ 69%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Spoint.c.o
[ 70%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Sselect.c.o
[ 70%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Stest.c.o
[ 70%] Building C object src/CMakeFiles/hdf5-shared.dir/H5SL.c.o
[ 70%] Building C object src/CMakeFiles/hdf5-shared.dir/H5SM.c.o
[ 71%] Building C object src/CMakeFiles/hdf5-shared.dir/H5SMbtree2.c.o
[ 71%] Building C object src/CMakeFiles/hdf5-shared.dir/H5SMcache.c.o
[ 71%] Building C object src/CMakeFiles/hdf5-shared.dir/H5SMmessage.c.o
[ 71%] Building C object src/CMakeFiles/hdf5-shared.dir/H5SMtest.c.o
[ 72%] Building C object src/CMakeFiles/hdf5-shared.dir/H5T.c.o
[ 72%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tarray.c.o
[ 72%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tbit.c.o
[ 72%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tcommit.c.o
[ 73%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tcompound.c.o
[ 73%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv.c.o
[ 73%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_integer.c.o
[ 73%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_float.c.o
[ 74%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_string.c.o
[ 74%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_bitfield.c.o
[ 74%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_compound.c.o
[ 74%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_reference.c.o
[ 75%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_enum.c.o
[ 75%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_vlen.c.o
[ 75%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tconv_array.c.o
[ 75%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tcset.c.o
[ 76%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tdbg.c.o
[ 76%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tdeprec.c.o
[ 76%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tenum.c.o
[ 76%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tfields.c.o
[ 77%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tfixed.c.o
[ 77%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tfloat.c.o
[ 77%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tinit_float.c.o
[ 77%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tnative.c.o
[ 78%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Toffset.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c: In function ‘H5T__conv_float__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 1735 |     H5T_CONV_Ff(FLOAT, FLOAT16, float, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1735:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 78%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Toh.c.o
[ 78%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Topaque.c.o
[ 78%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Torder.c.o
[ 79%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tpad.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c: In function ‘H5T__conv_double__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c: In function ‘H5T__conv_ushort__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 1994 |     H5T_CONV_Ff(DOUBLE, FLOAT16, double, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 1746 |     H5T_CONV_Xf(USHORT, FLOAT16, unsigned short, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:1994:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 79%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tprecis.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1746:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 79%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tref.c.o
[ 79%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tstrpad.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c: In function ‘H5T__conv_int__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 1975 |     H5T_CONV_Xf(INT, FLOAT16, int, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c: In function ‘H5T__conv_ldouble__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 80%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tvlen.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 80%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Tvisit.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 2258 |     H5T_CONV_Ff(LDOUBLE, FLOAT16, long double, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:1975:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_float.c:2258:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 80%] Building C object src/CMakeFiles/hdf5-shared.dir/H5TS.c.o
[ 80%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VL.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c: In function ‘H5T__conv_uint__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 2204 |     H5T_CONV_Xf(UINT, FLOAT16, unsigned int, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2204:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 81%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLcallback.c.o
[ 81%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLdyn_ops.c.o
[ 81%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLint.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c: In function ‘H5T__conv_long__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 2433 |     H5T_CONV_Xf(LONG, FLOAT16, long, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2433:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 81%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative.c.o
[ 82%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_attr.c.o
[ 82%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_blob.c.o
[ 82%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_dataset.c.o
[ 82%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_datatype.c.o
[ 83%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_file.c.o
[ 83%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_group.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c: In function ‘H5T__conv_ulong__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 2662 |     H5T_CONV_Xf(ULONG, FLOAT16, unsigned long, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2662:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 83%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_link.c.o
[ 83%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_introspect.c.o
[ 84%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_object.c.o
[ 84%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLnative_token.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c: In function ‘H5T__conv_llong__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 2891 |     H5T_CONV_Xf(LLONG, FLOAT16, long long, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:2891:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 84%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLpassthru.c.o
[ 84%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VLtest.c.o
[ 85%] Building C object src/CMakeFiles/hdf5-shared.dir/H5VM.c.o
[ 85%] Building C object src/CMakeFiles/hdf5-shared.dir/H5WB.c.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c: In function ‘H5T__conv_ullong__Float16’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
 3122 |     H5T_CONV_Xf(ULLONG, FLOAT16, unsigned long long, H5__Float16, -FLT16_MAX, FLT16_MAX);
      |     ^~~~~~~~~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/src/H5Tconv_integer.c:3122:5: warning: non-standard suffix on floating constant before C23 [-Wc11-c23-compat]
[ 85%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Z.c.o
[ 85%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Zdeflate.c.o
[ 86%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Zfletcher32.c.o
[ 86%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Znbit.c.o
[ 86%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Zscaleoffset.c.o
[ 86%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Zshuffle.c.o
[ 87%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Zszip.c.o
[ 87%] Building C object src/CMakeFiles/hdf5-shared.dir/H5Ztrans.c.o
[ 87%] Linking C shared library libhdf5.so
[ 87%] Built target hdf5-shared
[ 87%] Building C object utils/mirror_vfd/CMakeFiles/mirror_server.dir/mirror_remote.c.o
[ 87%] Building C object utils/mirror_vfd/CMakeFiles/mirror_server_stop.dir/mirror_server_stop.c.o
[ 88%] Building C object utils/mirror_vfd/CMakeFiles/mirror_server.dir/mirror_server.c.o
[ 88%] Building C object utils/mirror_vfd/CMakeFiles/mirror_server.dir/mirror_writer.c.o
[ 88%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5DO.c.o
[ 89%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5DS.c.o
[ 89%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5IM.c.o
[ 89%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5LT.c.o
[ 90%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5ArrayType.cpp.o
[ 90%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5AbstractDs.cpp.o
[ 90%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5LTanalyze.c.o
[ 90%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5AtomType.cpp.o
[ 91%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5LTparse.c.o
[ 91%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5Attribute.cpp.o
[ 92%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5PT.c.o
[ 92%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5CompType.cpp.o
[ 92%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5CommonFG.cpp.o
[ 92%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5TB.c.o
[ 92%] Building C object hl/src/CMakeFiles/hdf5_hl-shared.dir/H5LD.c.o
[ 92%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5DataSet.cpp.o
[ 92%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5DataType.cpp.o
[ 92%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5DataSpace.cpp.o
[ 93%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5DxferProp.cpp.o
[ 93%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5DaccProp.cpp.o
[ 93%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5DcreatProp.cpp.o
[ 93%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5EnumType.cpp.o
[ 94%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5Exception.cpp.o
[ 94%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5FaccProp.cpp.o
[ 94%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5FcreatProp.cpp.o
[ 94%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5File.cpp.o
[ 95%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5FloatType.cpp.o
[ 95%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5Group.cpp.o
[ 96%] Linking C executable mirror_server_stop
[ 96%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5IdComponent.cpp.o
[ 96%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5IntType.cpp.o
[ 96%] Linking C executable mirror_server
[ 96%] Built target mirror_server_stop
[ 97%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5LaccProp.cpp.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/hl/src/H5TB.c: In function ‘H5TB_create_type’:
[ 97%] Built target mirror_server
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/hl/src/H5TB.c:3188:50: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 3188 |     if (NULL == (fnames = (char **)calloc(sizeof(char *), (size_t)nfields)))
      |                                                  ^~~~
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/hl/src/H5TB.c:3188:50: note: earlier argument should specify number of elements, later size of each element
[ 97%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5LcreatProp.cpp.o
[ 97%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5Library.cpp.o
[ 97%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5Location.cpp.o
[ 98%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5Object.cpp.o
[ 98%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5OcreatProp.cpp.o
[ 98%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5PredType.cpp.o
[ 98%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5PropList.cpp.o
[ 99%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5StrType.cpp.o
[ 99%] Building CXX object c++/src/CMakeFiles/hdf5_cpp-shared.dir/H5VarLenType.cpp.o
[100%] Linking C shared library libhdf5_hl.so
[100%] Built target hdf5_hl-shared
[100%] Building CXX object hl/c++/src/CMakeFiles/hdf5_hl_cpp-shared.dir/H5PacketTable.cpp.o
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/c++/src/H5Location.cpp: In member function ‘std::string H5::H5Location::getObjnameByIdx(hsize_t) const’:
/home/devel/.conan2/p/b/hdf51731d70c77123/b/src/c++/src/H5Location.cpp:2001:46: warning: argument 1 range [9223372036854775809, 18446744073709551615] exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
 2001 |     char *name_C = new char[actual_name_len]();
      |                                              ^
In file included from /usr/include/c++/14.2.1/bits/exception_ptr.h:38,
                 from /usr/include/c++/14.2.1/exception:166,
                 from /usr/include/c++/14.2.1/ios:41,
                 from /usr/include/c++/14.2.1/ostream:40,
                 from /usr/include/c++/14.2.1/iostream:41,
                 from /home/devel/.conan2/p/b/hdf51731d70c77123/b/src/c++/src/H5Location.cpp:13:
/usr/include/c++/14.2.1/new:133:26: note: in a call to allocation function ‘void* operator new [](std::size_t)’ declared here
  133 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^~~~~~~~
[100%] Linking CXX shared library libhdf5_hl_cpp.so
[100%] Built target hdf5_hl_cpp-shared
[100%] Linking CXX shared library libhdf5_cpp.so
[100%] Built target hdf5_cpp-shared

hdf5/1.14.5: Package '52c118ba8f2d33288fb6ff4473ba1cdc8100e824' built
hdf5/1.14.5: Build folder /home/devel/.conan2/p/b/hdf51731d70c77123/b/build/Release
hdf5/1.14.5: Generating the package
hdf5/1.14.5: Packaging in folder /home/devel/.conan2/p/b/hdf51731d70c77123/p
hdf5/1.14.5: Calling package()
hdf5/1.14.5: Running CMake.install()
hdf5/1.14.5: RUN: cmake --install "/home/devel/.conan2/p/b/hdf51731d70c77123/b/build/Release" --prefix "/home/devel/.conan2/p/b/hdf51731d70c77123/p"
-- Install configuration: "Release"
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/hdf5.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5api_adpt.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5encode.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5public.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Apublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5ACpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Cpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Dpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Epubgen.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Epublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5ESdevelop.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5ESpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Fpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDcore.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDdevelop.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDdirect.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDfamily.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDhdfs.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDlog.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDmirror.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDmpi.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDmpio.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDmulti.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDonion.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDros3.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDs3comms.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDsec2.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDsplitter.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDstdio.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDwindows.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDsubfiling.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FDioc.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Gpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Idevelop.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Ipublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Ldevelop.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Lpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Mpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5MMpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Opublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Ppublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5PLextern.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5PLpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Rpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Spublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Tdevelop.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Tpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5TSdevelop.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5VLconnector.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5VLconnector_passthru.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5VLnative.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5VLpassthru.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5VLpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Zdevelop.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Zpublic.h
-- Up-to-date: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Epubgen.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5version.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5overflow.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5pubconf.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5.so.310.5.0
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5.so.310
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5.so
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/pkgconfig/hdf5.pc
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/bin/h5cc
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/bin/mirror_server
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/bin/mirror_server_stop
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/bin/h5fuse
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5DOpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5DSpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5IMpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5LTpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5PTpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5TBpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5LDpublic.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/hdf5_hl.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_hl.so.310.0.5
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_hl.so.310
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_hl.so
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/pkgconfig/hdf5_hl.pc
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/bin/h5hlcc
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5AbstractDs.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Alltypes.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5ArrayType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5AtomType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Attribute.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Classes.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5CommonFG.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5CompType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Cpp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5CppDoc.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5DataSet.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5DataSpace.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5DataType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5DaccProp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5DcreatProp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5DxferProp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5EnumType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Exception.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FaccProp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FcreatProp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5File.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5FloatType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Group.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5IdComponent.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Include.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5IntType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5LaccProp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5LcreatProp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Library.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Location.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5Object.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5OcreatProp.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5PredType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5PropList.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5StrType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5VarLenType.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_cpp.so.310.0.5
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_cpp.so.310
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_cpp.so
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/pkgconfig/hdf5_cpp.pc
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/bin/h5c++
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/include/hdf5/H5PacketTable.h
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_hl_cpp.so.310.0.5
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_hl_cpp.so.310
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5_hl_cpp.so
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/pkgconfig/hdf5_hl_cpp.pc
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/bin/h5hlc++
-- Installing: /home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/libhdf5.settings

hdf5/1.14.5: package(): Packaged 104 '.h' files
hdf5/1.14.5: package(): Packaged 8 files
hdf5/1.14.5: package(): Packaged 1 '.0' file: libhdf5.so.310.5.0
hdf5/1.14.5: package(): Packaged 3 '.5' files: libhdf5_cpp.so.310.0.5, libhdf5_hl_cpp.so.310.0.5, libhdf5_hl.so.310.0.5
hdf5/1.14.5: package(): Packaged 4 '.so' files: libhdf5_cpp.so, libhdf5_hl.so, libhdf5.so, libhdf5_hl_cpp.so
hdf5/1.14.5: package(): Packaged 4 '.310' files: libhdf5_hl_cpp.so.310, libhdf5_hl.so.310, libhdf5_cpp.so.310, libhdf5.so.310
hdf5/1.14.5: package(): Packaged 2 '.cmake' files: conan-official-hdf5-variables.cmake, conan-official-hdf5-targets.cmake
hdf5/1.14.5: Created package revision f21b1d7cf6f60d48cfed5e989fa5b407
hdf5/1.14.5: Package '52c118ba8f2d33288fb6ff4473ba1cdc8100e824' created
hdf5/1.14.5: Full package reference: hdf5/1.14.5#ca5eae63bd7cd39c0548869730e04f41:52c118ba8f2d33288fb6ff4473ba1cdc8100e824#f21b1d7cf6f60d48cfed5e989fa5b407
hdf5/1.14.5: Package folder /home/devel/.conan2/p/b/hdf51731d70c77123/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'env_info' used in: cmake/3.30.1
WARN: deprecated:     'cpp_info.names' used in: hdf5/1.14.5
WARN: deprecated:     'cpp_info.build_modules' used in: hdf5/1.14.5

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    hdf5/1.14.5 (test package): /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/conanfile.py
Requirements
    hdf5/1.14.5#ca5eae63bd7cd39c0548869730e04f41 - Cache
    zlib-ng/2.2.2#894a58b509be21a864c41b3bd154e92f - Cache
Build requirements
    cmake/3.30.1#6d832cf2d46f6ec969ca5ed5b41f91eb - Cache

======== Computing necessary packages ========
Requirements
    hdf5/1.14.5#ca5eae63bd7cd39c0548869730e04f41:52c118ba8f2d33288fb6ff4473ba1cdc8100e824#f21b1d7cf6f60d48cfed5e989fa5b407 - Cache
    zlib-ng/2.2.2#894a58b509be21a864c41b3bd154e92f:6613b6885d1e7325456312f712ce6f71c6df1e88#c23b9e6425d6676374c22833f816aa1c - Cache
Build requirements
Skipped binaries
    cmake/3.30.1

======== Installing packages ========
zlib-ng/2.2.2: Already installed! (1 of 2)
hdf5/1.14.5: Already installed! (2 of 2)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: hdf5/1.14.5
WARN: deprecated:     'cpp_info.build_modules' used in: hdf5/1.14.5

======== Testing the package ========
Removing previously existing 'test_package' build folder: /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/build/gcc-13-x86_64-gnu17-release
hdf5/1.14.5 (test package): Test package build: build/gcc-13-x86_64-gnu17-release
hdf5/1.14.5 (test package): Test package build folder: /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/build/gcc-13-x86_64-gnu17-release
hdf5/1.14.5 (test package): Writing generators to /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/build/gcc-13-x86_64-gnu17-release/generators
hdf5/1.14.5 (test package): Generator 'CMakeDeps' calling 'generate()'
hdf5/1.14.5 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(HDF5)
    target_link_libraries(... HDF5::HDF5)
hdf5/1.14.5 (test package): Generator 'VirtualRunEnv' calling 'generate()'
hdf5/1.14.5 (test package): Calling generate()
hdf5/1.14.5 (test package): Generators folder: /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/build/gcc-13-x86_64-gnu17-release/generators
hdf5/1.14.5 (test package): CMakeToolchain generated: conan_toolchain.cmake
hdf5/1.14.5 (test package): CMakeToolchain generated: /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/build/gcc-13-x86_64-gnu17-release/generators/CMakePresets.json
hdf5/1.14.5 (test package): CMakeToolchain generated: /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/CMakeUserPresets.json
hdf5/1.14.5 (test package): Generating aggregated env files
hdf5/1.14.5 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
hdf5/1.14.5 (test package): Calling build()
hdf5/1.14.5 (test package): Running CMake.configure()
hdf5/1.14.5 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/devel/github/conan-center-index/recipes/hdf5/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/devel/github/conan-center-index/recipes/hdf5/all/test_package"
-- Using Conan toolchain: /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/build/gcc-13-x86_64-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is GNU 14.2.1
-- The CXX compiler identification is GNU 14.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'hdf5::hdf5'
-- Conan: Component target declared 'hdf5::hdf5_cpp'
-- Conan: Component target declared 'hdf5::hdf5_hl'
-- Conan: Component target declared 'hdf5::hdf5_hl_cpp'
-- Conan: Target declared 'HDF5::HDF5'
-- Conan: Target declared 'zlib-ng::zlib-ng'
-- Conan: Including build module from '/home/devel/.conan2/p/b/hdf51731d70c77123/p/lib/cmake/conan-official-hdf5-variables.cmake'
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /home/devel/github/conan-center-index/recipes/hdf5/all/test_package/build/gcc-13-x86_64-gnu17-release

hdf5/1.14.5 (test package): Running CMake.build()
hdf5/1.14.5 (test package): RUN: cmake --build "/home/devel/github/conan-center-index/recipes/hdf5/all/test_package/build/gcc-13-x86_64-gnu17-release" -- -j32
[ 33%] Building C object CMakeFiles/test_package.dir/test_package.c.o
[ 66%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
hdf5/1.14.5 (test package): Running test()
hdf5/1.14.5 (test package): RUN: test_package
Testing C API
Testing C++ API


```

</details>

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
