### PR TITLE
nghttp3: add version 1.6.0

### DIFF
--- a/recipes/nghttp3/all/conandata.yml
+++ b/recipes/nghttp3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/ngtcp2/nghttp3/releases/download/v1.6.0/nghttp3-1.6.0.tar.bz2"
+    sha256: "e49806e1008fe823961616dc61dab7df0f20d3e1f43bc76faecf3e10e541a4b8"
   "1.5.0":
     url: "https://github.com/ngtcp2/nghttp3/releases/download/v1.5.0/nghttp3-1.5.0.tar.bz2"
     sha256: "4d89a3b84dbe2c6e0fe1367a2082f23b3c6e3279536e2436aed1a3785f6716c5"

--- a/recipes/nghttp3/config.yml
+++ b/recipes/nghttp3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.0":
+    folder: all
   "1.5.0":
     folder: all
   "1.4.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **nghttp3/1.6.0**

#### Motivation
There are several improvements in 1.6.0.

#### Details
https://github.com/ngtcp2/nghttp3/compare/v1.5.0...v1.6.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
