### PR TITLE
openjph: add version 0.17.0

### DIFF
--- a/recipes/openjph/all/conandata.yml
+++ b/recipes/openjph/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.17.0":
+    url: "https://github.com/aous72/OpenJPH/archive/0.17.0.tar.gz"
+    sha256: "9cd09a5f3a8046b10bded787212afd2410836f9c266964a36f61dc4b63f99b6c"
   "0.16.0":
     url: "https://github.com/aous72/OpenJPH/archive/0.16.0.tar.gz"
     sha256: "94bea4d7057f7a5dcb3f8eee3f854955ce153d98dad99602dd0ba50a560d7cf6"
@@ -6,6 +9,10 @@ sources:
     url: "https://github.com/aous72/OpenJPH/archive/0.15.0.tar.gz"
     sha256: "36601fbd3b4e1fe54eef5e6fa51ac0eca7be94b2a3d7c0967e3c8da66687ff2c"
 patches:
+  "0.17.0":
+    - patch_file: "patches/0.15.0_cmake-cxx-standard.patch"
+      patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan"
+      patch_type: "conan"
   "0.16.0":
     - patch_file: "patches/0.15.0_cmake-cxx-standard.patch"
       patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan"

--- a/recipes/openjph/all/conanfile.py
+++ b/recipes/openjph/all/conanfile.py
@@ -14,9 +14,10 @@ class OpenJPH(ConanFile):
     name = "openjph"
     description = "Open-source implementation of JPEG2000 Part-15 (or JPH or HTJ2K)"
     license = "BSD-2-Clause"
-    homepage = "https://github.com/aous72/OpenJPH"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/aous72/OpenJPH"
     topics = ("ht-j2k", "jpeg2000", "jp2", "openjph", "image", "multimedia", "format", "graphics")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/openjph/config.yml
+++ b/recipes/openjph/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.17.0":
+    folder: all
   "0.16.0":
     folder: all
   "0.15.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **openjph/0.17.0**

#### Motivation
There are several improvements in 0.17.0.

#### Details
https://github.com/aous72/OpenJPH/compare/0.16.0...0.17.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
