### PR TITLE
libdeflate: add version 1.22

### DIFF
--- a/recipes/libdeflate/all/conandata.yml
+++ b/recipes/libdeflate/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.22":
+    url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.22.tar.gz"
+    sha256: "7f343c7bf2ba46e774d8a632bf073235e1fd27723ef0a12a90f8947b7fe851d6"
   "1.21":
     url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.21.tar.gz"
     sha256: "50827d312c0413fbd41b0628590cd54d9ad7ebf88360cba7c0e70027942dbd01"

--- a/recipes/libdeflate/config.yml
+++ b/recipes/libdeflate/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.22":
+    folder: "all"
   "1.21":
     folder: "all"
   "1.20":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdeflater/1.22**

#### Motivation
There are several improvements in 1.22.

#### Details
https://github.com/ebiggers/libdeflate/compare/v1.21...v1.22

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
