### PR TITLE
trompeloeil: add version 49

### DIFF
--- a/recipes/trompeloeil/all/conandata.yml
+++ b/recipes/trompeloeil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "49":
+    url: "https://github.com/rollbear/trompeloeil/archive/v49.tar.gz"
+    sha256: "2523571fb7920b2813cbc23b46e60294aba8ead7eba434bfec69c24408615593"
   "48":
     url: "https://github.com/rollbear/trompeloeil/archive/v48.tar.gz"
     sha256: "eebd18456975251ea3450b815e241cccfefba5b883e4a36bd309f9cf629bdec6"

--- a/recipes/trompeloeil/all/test_package/test_package.cpp
+++ b/recipes/trompeloeil/all/test_package/test_package.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <trompeloeil.hpp>
 
 struct S

--- a/recipes/trompeloeil/config.yml
+++ b/recipes/trompeloeil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "49":
+    folder: all
   "48":
     folder: all
   "47":


### PR DESCRIPTION
### Summary
Changes to recipe:  **trompeloeil/49**

#### Motivation
This is the 10 years anniversary release.

#### Details
https://github.com/rollbear/trompeloeil/compare/v48...v49

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
