### PR TITLE
fontconfig: drop unnecessary util-linux-libuuid dependency

### DIFF
--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -50,8 +50,6 @@ class FontconfigConan(ConanFile):
     def requirements(self):
         self.requires("freetype/2.13.2")
         self.requires("expat/[>=2.6.2 <3]")
-        if self.settings.os == "Linux":
-            self.requires("util-linux-libuuid/2.39.2")
 
     def build_requirements(self):
         self.tool_requires("gperf/3.1")


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
No longer used since v2.13.91:
- https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/500e77a01d00471900755d96ba6ad236d916947a
- https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/acc017e67210ee6d8fed7ffd41a1f55fe04d056b

No includes for `uuid/uuid.h` remain in the codebase: https://gitlab.freedesktop.org/search?group_id=1174&project_id=890&repository_ref=main&scope=blobs&search=uuid.h

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
