### PR TITLE
ffmpeg: disable autodetected deps in ./configure, add libsndio support, use non-system libvdpau

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -330,7 +330,7 @@ class FFMpegConan(ConanFile):
         if self.options.get_safe("with_sndio"):
             self.requires("libsndio/1.9.0")
         if self.options.get_safe("with_vaapi"):
-            self.requires("vaapi/system")
+            self.requires("libva/2.21.0")
         if self.options.get_safe("with_vdpau"):
             self.requires("libvdpau/1.5")
         if self.options.get_safe("with_vulkan"):
@@ -931,7 +931,7 @@ class FFMpegConan(ConanFile):
         if self.options.get_safe("with_libdrm"):
             avutil.requires.append("libdrm::libdrm_libdrm")
         if self.options.get_safe("with_vaapi"):
-            avutil.requires.append("vaapi::vaapi")
+            avutil.requires.append("libva::libva")
         if self.options.get_safe("with_xcb"):
             avutil.requires.append("xorg::x11")
 

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -624,17 +624,17 @@ class FFMpegConan(ConanFile):
         # since ffmpeg"s build system ignores CC and CXX
         compilers_from_conf = self.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
         buildenv_vars = VirtualBuildEnv(self).vars()
-        nm = buildenv_vars.get("NM")
+        nm = compilers_from_conf.get("nm", buildenv_vars.get("NM"))
         if nm:
             args.append(f"--nm={unix_path(self, nm)}")
-        ar = buildenv_vars.get("AR")
+        ar = compilers_from_conf.get("ar", buildenv_vars.get("AR"))
         if ar:
             args.append(f"--ar={unix_path(self, ar)}")
         if self.options.with_asm:
             asm = compilers_from_conf.get("asm", buildenv_vars.get("AS"))
             if asm:
                 args.append(f"--as={unix_path(self, asm)}")
-        strip = buildenv_vars.get("STRIP")
+        strip = compilers_from_conf.get("strip", buildenv_vars.get("STRIP"))
         if strip:
             args.append(f"--strip={unix_path(self, strip)}")
         cc = compilers_from_conf.get("c", buildenv_vars.get("CC", self._default_compilers.get("cc")))
@@ -646,7 +646,7 @@ class FFMpegConan(ConanFile):
         ld = buildenv_vars.get("LD")
         if ld:
             args.append(f"--ld={unix_path(self, ld)}")
-        ranlib = buildenv_vars.get("RANLIB")
+        ranlib = compilers_from_conf.get("ranlib", buildenv_vars.get("RANLIB"))
         if ranlib:
             args.append(f"--ranlib={unix_path(self, ranlib)}")
         # for some reason pkgconf from conan can't find .pc files on Linux in the context of ffmpeg configure...

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -332,7 +332,7 @@ class FFMpegConan(ConanFile):
         if self.options.get_safe("with_vaapi"):
             self.requires("vaapi/system")
         if self.options.get_safe("with_vdpau"):
-            self.requires("vdpau/system")
+            self.requires("libvdpau/1.5")
         if self.options.get_safe("with_vulkan"):
             self.requires("vulkan-loader/1.3.243.0")
         if self.options.get_safe("with_libsvtav1"):
@@ -379,7 +379,7 @@ class FFMpegConan(ConanFile):
             else:
                 self.tool_requires("yasm/1.3.0")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
         if self._settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
@@ -936,7 +936,7 @@ class FFMpegConan(ConanFile):
             avutil.requires.append("xorg::x11")
 
         if self.options.get_safe("with_vdpau"):
-            avutil.requires.append("vdpau::vdpau")
+            avutil.requires.append("libvdpau::libvdpau")
 
         if self.options.with_ssl == "openssl":
             avutil.requires.append("openssl::ssl")

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -475,6 +475,7 @@ class FFMpegConan(ConanFile):
         tc = self._create_toolchain()
 
         args = [
+            "--disable-autodetect",
             "--pkg-config-flags=--static",
             "--disable-doc",
             opt_enable_disable("cross-compile", cross_building(self)),

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -61,6 +61,7 @@ class FFMpegConan(ConanFile):
         "with_ssl": [False, "openssl", "securetransport"],
         "with_libalsa": [True, False],
         "with_pulse": [True, False],
+        "with_sndio": [True, False],
         "with_vaapi": [True, False],
         "with_vdpau": [True, False],
         "with_vulkan": [True, False],
@@ -145,6 +146,7 @@ class FFMpegConan(ConanFile):
         "with_ssl": "openssl",
         "with_libalsa": True,
         "with_pulse": True,
+        "with_sndio": False,
         "with_vaapi": True,
         "with_vdpau": True,
         "with_vulkan": False,
@@ -229,6 +231,7 @@ class FFMpegConan(ConanFile):
             "with_libalsa": ["avdevice"],
             "with_xcb": ["avdevice"],
             "with_pulse": ["avdevice"],
+            "with_sndio": ["avdevice"],
             "with_sdl": ["with_programs"],
             "with_libsvtav1": ["avcodec"],
             "with_libaom": ["avcodec"],
@@ -324,6 +327,8 @@ class FFMpegConan(ConanFile):
             self.requires("xorg/system")
         if self.options.get_safe("with_pulse"):
             self.requires("pulseaudio/14.2")
+        if self.options.get_safe("with_sndio"):
+            self.requires("libsndio/1.9.0")
         if self.options.get_safe("with_vaapi"):
             self.requires("vaapi/system")
         if self.options.get_safe("with_vdpau"):
@@ -514,6 +519,7 @@ class FFMpegConan(ConanFile):
             opt_enable_disable("openssl", self.options.with_ssl == "openssl"),
             opt_enable_disable("alsa", self.options.get_safe("with_libalsa")),
             opt_enable_disable("libpulse", self.options.get_safe("with_pulse")),
+            opt_enable_disable("sndio", self.options.get_safe("with_sndio")),
             opt_enable_disable("vaapi", self.options.get_safe("with_vaapi")),
             opt_enable_disable("libdrm", self.options.get_safe("with_libdrm")),
             opt_enable_disable("vdpau", self.options.get_safe("with_vdpau")),
@@ -851,6 +857,8 @@ class FFMpegConan(ConanFile):
                 avdevice.requires.extend(["xorg::x11", "xorg::xext", "xorg::xv"])
             if self.options.get_safe("with_pulse"):
                 avdevice.requires.append("pulseaudio::pulseaudio")
+            if self.options.get_safe("with_sndio"):
+                avdevice.requires.append("libsndio::libsndio")
             if self.options.get_safe("with_appkit"):
                 avdevice.frameworks.append("AppKit")
             if self.options.get_safe("with_avfoundation"):


### PR DESCRIPTION
### Summary
Changes to recipe:  **ffmpeg/[*]**

#### Motivation
Static build of ffmpeg failed for me locally due to libsndio autodetection during ./configure picking up a non-Conan system version of the library.

#### Details
- Disabled all dependency autodetections with `--disable-autodetect` ./configure flag to avoid cases like in the future. The flag is available all the way back to the oldest v4.4.4 on CCI.
- Added support for libsndio. Disabled it by default.
- Replaced `vdpau/system` with `libvdpau/1.5`, which was added a few months ago: #22236.
- Added a version range for pkg-config.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
