### PR TITLE
freeglut: add v3.6.0, set CMP0077, list exact xorg components

### DIFF
--- a/recipes/freeglut/all/conandata.yml
+++ b/recipes/freeglut/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.0":
+    url: "https://github.com/FreeGLUTProject/freeglut/archive/v3.6.0.tar.gz"
+    sha256: "16de4f51dc1efd663a1a58ba5552e54f8783b77478289c95dca474a4d39ddd02"
   "3.4.0":
     url: "https://github.com/FreeGLUTProject/freeglut/archive/v3.4.0.tar.gz"
     sha256: "3c0bcb915d9b180a97edaebd011b7a1de54583a838644dcd42bb0ea0c6f3eaec"

--- a/recipes/freeglut/all/conanfile.py
+++ b/recipes/freeglut/all/conanfile.py
@@ -142,6 +142,7 @@ class freeglutConan(ConanFile):
         tc.variables["INSTALL_PDB"] = False
         tc.variables["FREEGLUT_REPLACE_GLUT"] = self.options.replace_glut
         tc.preprocessor_definitions["FREEGLUT_LIB_PRAGMAS"] = "0"
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
         cmake_deps = CMakeDeps(self)
         cmake_deps.generate()

--- a/recipes/freeglut/all/conanfile.py
+++ b/recipes/freeglut/all/conanfile.py
@@ -203,7 +203,13 @@ class freeglutConan(ConanFile):
         else:
             self.cpp_info.components["freeglut_"].requires.append("opengl::opengl")
         if self._with_x11:
-            self.cpp_info.components["freeglut_"].requires.append("xorg::xorg")
+            # https://github.com/freeglut/freeglut/blob/v3.4.0/CMakeLists.txt#L261-L278
+            self.cpp_info.components["freeglut_"].requires.extend([
+                "xorg::x11",
+                "xorg::xrandr",
+                "xorg::xxf86vm",
+                "xorg::xinput",
+            ])
         if self.options.get_safe("with_wayland"):
             self.cpp_info.components["freeglut_"].requires.extend(["wayland::wayland-client", "wayland::wayland-cursor", "wayland::wayland-egl", "xkbcommon::xkbcommon"])
         if is_apple_os(self) or self.settings.os == "Windows":

--- a/recipes/freeglut/all/test_package/conanfile.py
+++ b/recipes/freeglut/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/freeglut/all/test_package_module/conanfile.py
+++ b/recipes/freeglut/all/test_package_module/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/freeglut/config.yml
+++ b/recipes/freeglut/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.0":
+    folder: all
   "3.4.0":
     folder: all
   "3.2.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **freeglut/[*]**

#### Motivation
Adds the latest version.

https://github.com/freeglut/freeglut/compare/v3.4.0...v3.6.0?w=1

Explicitly lists X11 components to avoid overlinking.

Set CMP0077 due to the CMake policy version 3.1 in the project being less than the required 3.12.

#### Details
All of the patches have been merged upstream. Thank you for the effort, @jwillikers!

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
