### PR TITLE
glfw: explicitly list xorg and wayland components

### DIFF
--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -215,6 +215,29 @@ class GlfwConan(ConanFile):
                 "CoreServices", "Foundation", "IOKit",
             ])
 
+        self.cpp_info.requires = ["opengl::opengl"]
+        if self.options.vulkan_static:
+            self.cpp_info.requires.append("vulkan-loader::vulkan-loader")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            if self.options.get_safe("with_x11", True):
+                # https://github.com/glfw/glfw/blob/3.4/src/CMakeLists.txt#L181-L218
+                # https://github.com/glfw/glfw/blob/3.3.2/CMakeLists.txt#L196-L233
+                self.cpp_info.requires.extend([
+                    "xorg::x11", # Also includes Xkb and Xshape
+                    "xorg::xrandr",
+                    "xorg::xinerama",
+                    "xorg::xcursor",
+                    "xorg::xi",
+                ])
+        if self.options.get_safe("with_wayland"):
+            # https://github.com/glfw/glfw/blob/3.4/src/CMakeLists.txt#L163-L167
+            self.cpp_info.requires.extend([
+                "wayland::wayland-client",
+                "wayland::wayland-cursor",
+                "wayland::wayland-egl",
+                "xkbcommon::xkbcommon"
+            ])
+
         # backward support of cmake_find_package, cmake_find_package_multi & pkg_config generators
         self.cpp_info.filenames["cmake_find_package"] = "glfw3"
         self.cpp_info.filenames["cmake_find_package_multi"] = "glfw3"


### PR DESCRIPTION
### Summary
Changes to recipe:  **glfw/[*]**

#### Motivation
To reduce overlinking of X11 libs (there's about 60 additional libs that xorg/system otherwise links against in addition to the 5 listed ones). GLFW is a quite common dependency as well.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
