### PR TITLE
qt6: always set CMAKE_TRY_COMPILE_CONFIGURATION

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -550,8 +550,8 @@ class QtConan(ConanFile):
                 tc.variables["QT_FEATURE_openssl_linked"] = "ON"
 
         # TODO: Remove after fixing https://github.com/conan-io/conan/issues/12012
-        if is_msvc(self):
-            tc.cache_variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)
+        # Required for qt_config_compile_test() calls against CMakeDeps targets to work correctly.
+        tc.cache_variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)
 
         if self.options.with_dbus:
             tc.variables["INPUT_dbus"] = "linked"


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.x**

#### Motivation
Qt6 uses `qt_config_compile_test()` in multiple places against CMake targets potentially defined by CMakeDeps:
- OpenSSL (on MSVC): https://github.com/qt/qtbase/blob/v6.7.3/configure.cmake#L31
- libdrm: https://github.com/qt/qtbase/blob/v6.7.3/src/gui/configure.cmake#L154
- libinput (currently not listed as a dependency): https://github.com/qt/qtbase/blob/v6.7.3/src/gui/configure.cmake#L544
- Possibly the OpenGL, EGL, GLES and GLX targets as well if libglvnd is used.
- X11 and XCB if non-system version of X11 is used.

These are potentially affected by the https://github.com/conan-io/conan/issues/12012 issue.

It's better to always set `CMAKE_TRY_COMPILE_CONFIGURATION` to be safe. Setting it does not have any downsides that I'm aware of (that is, it can affect multi-config CMake generators, but that's only relevant when using a recipe directly, not as a dependency).

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan