### PR TITLE
ouster_sdk: add version 0.13.0

### DIFF
--- a/recipes/ouster_sdk/all/conandata.yml
+++ b/recipes/ouster_sdk/all/conandata.yml
@@ -1,25 +1,24 @@
 sources:
-  # The C++ library uses a separate versioning scheme from the overall releases
   "0.13.0":
     url: "https://github.com/ouster-lidar/ouster-sdk/archive/refs/tags/release-0.13.0.tar.gz"
     sha256: "baf65fbf547375fe73fdaee89c6c1246fdf9f0cabe4f4bd16391d3a06d0117a1"
   "0.12.0":
-    url: "https://github.com/ouster-lidar/ouster_example/archive/refs/tags/20240703.tar.gz"
-    sha256: "aac9f82d8b8376bd11366204a57ab4e2a27e92a1a758238f2d3859e570be4914"
+    url: "https://github.com/ouster-lidar/ouster-sdk/archive/refs/tags/20240703.tar.gz"
+    sha256: "7edff33451e99fe094aeafc4c10081d77bfe02d2f2ab16da93a44a5e61473af7"
   "0.11.0":
-    url: "https://github.com/ouster-lidar/ouster_example/archive/refs/tags/20240425.tar.gz"
-    sha256: "f4f38f6787021e697633f2c290c95b544af81d388a18cb9f790234d4f592caf0"
+    url: "https://github.com/ouster-lidar/ouster-sdk/archive/refs/tags/20240425.tar.gz"
+    sha256: "8141abf4caef8a175a48c35c47bd841b34f8a7d758cb3ad66cf948a7042adbf9"
   "0.10.0":
-    url: "https://github.com/ouster-lidar/ouster_example/archive/refs/tags/20231031.tar.gz"
-    sha256: "150482d28930308ef089233f3d4eb15d1330727a167aad3f9b2190078dcecfbf"
+    url: "https://github.com/ouster-lidar/ouster-sdk/archive/refs/tags/20231031.tar.gz"
+    sha256: "c45dfd42ff11e171b605ffd0a98d8094ec88ecbbccb923d396e1e73cba7737f3"
 patches:
   "0.11.0":
     - patch_file: "patches/001-579-fix-cpp20-string-error.patch"
       patch_type: "portability"
       patch_description: "Fix non-const string issue with C++20"
-      patch_source: "https://github.com/ouster-lidar/ouster_example/pull/579"
+      patch_source: "https://github.com/ouster-lidar/ouster-sdk/pull/579"
   "0.10.0":
     - patch_file: "patches/001-579-fix-cpp20-string-error.patch"
       patch_type: "portability"
       patch_description: "Fix non-const string issue with C++20"
-      patch_source: "https://github.com/ouster-lidar/ouster_example/pull/579"
+      patch_source: "https://github.com/ouster-lidar/ouster-sdk/pull/579"

--- a/recipes/ouster_sdk/all/conandata.yml
+++ b/recipes/ouster_sdk/all/conandata.yml
@@ -1,5 +1,8 @@
 sources:
   # The C++ library uses a separate versioning scheme from the overall releases
+  "0.13.0":
+    url: "https://github.com/ouster-lidar/ouster-sdk/archive/refs/tags/release-0.13.0.tar.gz"
+    sha256: "baf65fbf547375fe73fdaee89c6c1246fdf9f0cabe4f4bd16391d3a06d0117a1"
   "0.12.0":
     url: "https://github.com/ouster-lidar/ouster_example/archive/refs/tags/20240703.tar.gz"
     sha256: "aac9f82d8b8376bd11366204a57ab4e2a27e92a1a758238f2d3859e570be4914"

--- a/recipes/ouster_sdk/all/conanfile.py
+++ b/recipes/ouster_sdk/all/conanfile.py
@@ -15,7 +15,7 @@ class OusterSdkConan(ConanFile):
     description = "Ouster SDK - tools for working with Ouster Lidars"
     license = "BSD 3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/ouster-lidar/ouster_example"
+    homepage = "https://github.com/ouster-lidar/ouster-sdk"
     topics = ("ouster", "lidar", "driver", "hardware", "point cloud", "3d", "robotics", "automotive")
 
     package_type = "library"

--- a/recipes/ouster_sdk/all/conanfile.py
+++ b/recipes/ouster_sdk/all/conanfile.py
@@ -98,8 +98,6 @@ class OusterSdkConan(ConanFile):
         if self.options.build_viz:
             self.requires("glad/0.1.36")
             self.requires("glfw/3.4")
-            if self.settings.os != "Windows":
-                self.requires("xorg/system")
 
     def validate(self):
         if conan_version.major < 2 and self.settings.os == "Windows":
@@ -212,8 +210,6 @@ class OusterSdkConan(ConanFile):
                 "glad::glad",
                 "glfw::glfw",
             ]
-            if self.settings.os != "Windows":
-                self.cpp_info.components["ouster_viz"].requires.append("xorg::xorg")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "OusterSDK"

--- a/recipes/ouster_sdk/config.yml
+++ b/recipes/ouster_sdk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.13.0":
+    folder: all
   "0.12.0":
     folder: all
   "0.11.0":


### PR DESCRIPTION
### Summary
Adding new version of `ouster_sdk`: **ouster_sdk/0.13.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Ouster has released a new version of their C++ SDK for their lidars. I would like to have it in `conan-center`.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
This is just a version bump, no recipe changes.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
