### PR TITLE
hidapi: use CMake-based build system, define CMake targets

### DIFF
--- a/recipes/hidapi/all/conandata.yml
+++ b/recipes/hidapi/all/conandata.yml
@@ -8,6 +8,3 @@ sources:
   "0.12.0":
     url: "https://github.com/libusb/hidapi/archive/hidapi-0.12.0.tar.gz"
     sha256: "28ec1451f0527ad40c1a4c92547966ffef96813528c8b184a665f03ecbb508bc"
-  "0.11.2":
-    url: "https://github.com/libusb/hidapi/archive/hidapi-0.11.2.tar.gz"
-    sha256: "bc4ac0f32a6b21ef96258a7554c116152e2272dacdec1e4620fc44abeea50c27"

--- a/recipes/hidapi/all/conandata.yml
+++ b/recipes/hidapi/all/conandata.yml
@@ -11,9 +11,3 @@ sources:
   "0.11.2":
     url: "https://github.com/libusb/hidapi/archive/hidapi-0.11.2.tar.gz"
     sha256: "bc4ac0f32a6b21ef96258a7554c116152e2272dacdec1e4620fc44abeea50c27"
-  "0.11.0":
-    url: "https://github.com/libusb/hidapi/archive/hidapi-0.11.0.tar.gz"
-    sha256: "391d8e52f2d6a5cf76e2b0c079cfefe25497ba1d4659131297081fc0cd744632"
-  "0.10.1":
-    url: "https://github.com/libusb/hidapi/archive/hidapi-0.10.1.tar.gz"
-    sha256: "f71dd8a1f46979c17ee521bc2117573872bbf040f8a4750e492271fc141f2644"

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -1,14 +1,12 @@
-from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy, get, replace_in_file, rm, rmdir
-from conan.tools.gnu import Autotools, AutotoolsToolchain, PkgConfigDeps
-from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, MSBuild, MSBuildToolchain
-from conan.tools.apple import is_apple_os
-from conan.tools.scm import Version
 import os
+
+from conan import ConanFile
+from conan.tools.apple import is_apple_os
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake
+from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.54.0"
 
@@ -26,25 +24,22 @@ class HidapiConan(ConanFile):
     options = {
         "fPIC": [True, False],
         "shared": [True, False],
+        "build_hidapi_libusb": [True, False],
+        "build_hidapi_hidraw": [True, False],
     }
     default_options = {
         "fPIC": True,
         "shared": False,
+        "build_hidapi_libusb": True,
+        "build_hidapi_hidraw": False,
     }
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
-    @property
-    def _msbuild_configuration(self):
-        return "Debug" if self.settings.build_type == "Debug" else "Release"
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if is_msvc(self):
-            self.options.shared = True
+        if self.settings.os not in ["Linux", "FreeBSD"]:
+            del self.options.build_hidapi_libusb
+            del self.options.build_hidapi_hidraw
 
     def configure(self):
         if self.options.shared:
@@ -56,102 +51,92 @@ class HidapiConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        if self.settings.os in ["Linux", "FreeBSD"]:
+        if self.options.get_safe("build_hidapi_libusb"):
             self.requires("libusb/1.0.26")
-        if self.settings.os == "Linux":
+            self.requires("libiconv/1.17")
+        if self.settings.os == "Linux" and self.options.build_hidapi_hidraw:
             self.requires("libudev/system")
 
     def validate(self):
-        if is_msvc(self) and not self.options.shared:
-            raise ConanInvalidConfiguration("Static libraries for Visual Studio are currently not available")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            if not self.options.build_hidapi_libusb and not self.options.build_hidapi_hidraw:
+                raise ConanInvalidConfiguration(
+                    "At least one of 'build_hidapi_libusb' or 'build_hidapi_hidraw' must be enabled"
+                )
 
     def build_requirements(self):
-        if not is_msvc(self):
-            self.tool_requires("libtool/2.4.7")
-            if self.settings.os in ["Linux", "FreeBSD"] and not self.conf.get("tools.gnu:pkg_config", check_type=str):
-                self.tool_requires("pkgconf/1.9.3")
-            if self._settings_build.os == "Windows":
-                self.win_bash = True
-                if not self.conf.get("tools.microsoft.bash:path", check_type=str):
-                    self.tool_requires("msys2/cci.latest")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+                self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        if is_msvc(self):
-            tc = MSBuildToolchain(self)
-            tc.configuration = self._msbuild_configuration
-            tc.properties["WholeProgramOptimization"] = "false"
-            tc.generate()
-        else:
-            env = VirtualBuildEnv(self)
-            env.generate()
-            tc = AutotoolsToolchain(self)
-            tc.generate()
-            deps = PkgConfigDeps(self)
-            deps.generate()
+        tc = CMakeToolchain(self)
+        # TODO: Remove after fixing https://github.com/conan-io/conan/issues/12012
+        # Needed for https://github.com/libusb/hidapi/blob/hidapi-0.14.0/libusb/CMakeLists.txt#L34
+        tc.variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+        deps = PkgConfigDeps(self)
+        deps.generate()
 
     def _patch_sources(self):
-        replace_in_file(self, os.path.join(self.source_folder, "configure.ac"),
-                        "AC_CONFIG_MACRO_DIR", "dnl AC_CONFIG_MACRO_DIR")
+        # Move project() right after cmake_minimum_required()
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        "project(hidapi LANGUAGES C)", "")
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        " FATAL_ERROR)", " FATAL_ERROR)\nproject(hidapi LANGUAGES C)")
 
     def build(self):
         self._patch_sources()
-        if is_msvc(self):
-            # TODO: to remove once https://github.com/conan-io/conan/pull/12817 available in conan client
-            replace_in_file(
-                self, os.path.join(self.source_folder, "windows", "hidapi.vcxproj"),
-                "<WholeProgramOptimization>true</WholeProgramOptimization>",
-                "",
-            )
-            conantoolchain_props = os.path.join(self.generators_folder, MSBuildToolchain.filename)
-            replace_in_file(
-                self, os.path.join(self.source_folder, "windows", "hidapi.vcxproj"),
-                "<Import Project=\"$(VCTargetsPath)\\Microsoft.Cpp.targets\" />",
-                f"<Import Project=\"{conantoolchain_props}\" /><Import Project=\"$(VCTargetsPath)\\Microsoft.Cpp.targets\" />",
-            )
-
-            msbuild = MSBuild(self)
-            msbuild.build_type = self._msbuild_configuration
-            msbuild.platform = "Win32" if self.settings.arch == "x86" else msbuild.platform
-            msbuild.build(os.path.join(self.source_folder, "windows", "hidapi.sln"), targets=["hidapi"])
-        else:
-            autotools = Autotools(self)
-            autotools.autoreconf()
-            autotools.configure()
-            autotools.make()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def package(self):
         copy(self, "LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        if is_msvc(self):
-            copy(self, os.path.join("hidapi", "*.h"), src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
-            output_folder = os.path.join(self.source_folder, "windows")
-            copy(self, "*hidapi.lib", src=output_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
-            copy(self, "*.dll", src=output_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
-        else:
-            autotools = Autotools(self)
-            autotools.install()
-            rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
-            rmdir(self, os.path.join(self.package_folder, "share"))
-            rm(self, "*.la", os.path.join(self.package_folder, "lib"))
-            fix_apple_shared_install_name(self)
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["libusb"].set_property("pkg_config_name", "hidapi-libusb")
-            self.cpp_info.components["libusb"].libs = ["hidapi-libusb"]
-            self.cpp_info.components["libusb"].requires = ["libusb::libusb"]
-            self.cpp_info.components["libusb"].system_libs = ["pthread", "dl", "rt"]
+        self.cpp_info.set_property("cmake_file_name", "hidapi")
 
-            self.cpp_info.components["hidraw"].set_property("pkg_config_name", "hidapi-hidraw")
-            self.cpp_info.components["hidraw"].libs = ["hidapi-hidraw"]
-            if self.settings.os == "Linux":
-                self.cpp_info.components["hidraw"].requires = ["libudev::libudev"]
-            self.cpp_info.components["hidraw"].system_libs = ["pthread", "dl"]
-        else:
+        # See https://github.com/libusb/hidapi/blob/hidapi-0.14.0/src/CMakeLists.txt#L95-L169
+        # for details about the hidapi::hidapi target alias.
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            if self.options.build_hidapi_libusb:
+                self.cpp_info.components["libusb"].set_property("pkg_config_name", "hidapi-libusb")
+                self.cpp_info.components["libusb"].set_property("cmake_target_name", "hidapi::libusb")
+                if not self.options.build_hidapi_hidraw:
+                    self.cpp_info.components["libusb"].set_property("cmake_target_alias", ["hidapi::hidapi"])
+                self.cpp_info.components["libusb"].libs = ["hidapi-libusb"]
+                self.cpp_info.components["libusb"].includedirs.append(os.path.join("include", "hidapi"))
+                self.cpp_info.components["libusb"].requires = ["libusb::libusb", "libiconv::libiconv"]
+                self.cpp_info.components["libusb"].system_libs = ["pthread", "dl", "rt"]
+            if self.options.build_hidapi_hidraw:
+                self.cpp_info.components["hidraw"].set_property("pkg_config_name", "hidapi-hidraw")
+                self.cpp_info.components["hidraw"].set_property("cmake_target_name", "hidapi::hidraw")
+                self.cpp_info.components["hidraw"].set_property("cmake_target_alias", ["hidapi::hidapi"])
+                self.cpp_info.components["hidraw"].libs = ["hidapi-hidraw"]
+                self.cpp_info.components["hidraw"].includedirs.append(os.path.join("include", "hidapi"))
+                if self.settings.os == "Linux":
+                    self.cpp_info.components["hidraw"].requires = ["libudev::libudev"]
+                self.cpp_info.components["hidraw"].system_libs = ["pthread", "dl"]
+        elif is_apple_os(self):
+            self.cpp_info.set_property("cmake_target_name", "hidapi::darwin")
+            self.cpp_info.set_property("cmake_target_alias", ["hidapi::hidapi"])
             self.cpp_info.libs = ["hidapi"]
-            if is_apple_os(self):
-                self.cpp_info.frameworks.extend(["IOKit", "CoreFoundation", "AppKit"])
-            if Version(self.version) == "0.10.1" and self.settings.os == "Windows":
-                self.cpp_info.system_libs = ["setupapi"]
+            self.cpp_info.includedirs.append(os.path.join("include", "hidapi"))
+            self.cpp_info.frameworks.extend(["IOKit", "CoreFoundation"])
+        else:
+            self.cpp_info.set_property("cmake_target_name", "hidapi::winapi")
+            self.cpp_info.set_property("cmake_target_alias", ["hidapi::hidapi"])
+            self.cpp_info.libs = ["hidapi"]
+            self.cpp_info.includedirs.append(os.path.join("include", "hidapi"))

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -115,7 +115,7 @@ class HidapiConan(ConanFile):
                 self.cpp_info.components["libusb"].set_property("pkg_config_name", "hidapi-libusb")
                 self.cpp_info.components["libusb"].set_property("cmake_target_name", "hidapi::libusb")
                 if not self.options.build_hidapi_hidraw:
-                    self.cpp_info.components["libusb"].set_property("cmake_target_alias", ["hidapi::hidapi"])
+                    self.cpp_info.components["libusb"].set_property("cmake_target_aliases", ["hidapi::hidapi"])
                 self.cpp_info.components["libusb"].libs = ["hidapi-libusb"]
                 self.cpp_info.components["libusb"].includedirs.append(os.path.join("include", "hidapi"))
                 self.cpp_info.components["libusb"].requires = ["libusb::libusb", "libiconv::libiconv"]
@@ -123,7 +123,7 @@ class HidapiConan(ConanFile):
             if self.options.build_hidapi_hidraw:
                 self.cpp_info.components["hidraw"].set_property("pkg_config_name", "hidapi-hidraw")
                 self.cpp_info.components["hidraw"].set_property("cmake_target_name", "hidapi::hidraw")
-                self.cpp_info.components["hidraw"].set_property("cmake_target_alias", ["hidapi::hidapi"])
+                self.cpp_info.components["hidraw"].set_property("cmake_target_aliases", ["hidapi::hidapi"])
                 self.cpp_info.components["hidraw"].libs = ["hidapi-hidraw"]
                 self.cpp_info.components["hidraw"].includedirs.append(os.path.join("include", "hidapi"))
                 if self.settings.os == "Linux":
@@ -131,12 +131,12 @@ class HidapiConan(ConanFile):
                 self.cpp_info.components["hidraw"].system_libs = ["pthread", "dl"]
         elif is_apple_os(self):
             self.cpp_info.set_property("cmake_target_name", "hidapi::darwin")
-            self.cpp_info.set_property("cmake_target_alias", ["hidapi::hidapi"])
+            self.cpp_info.set_property("cmake_target_aliases", ["hidapi::hidapi"])
             self.cpp_info.libs = ["hidapi"]
             self.cpp_info.includedirs.append(os.path.join("include", "hidapi"))
             self.cpp_info.frameworks.extend(["IOKit", "CoreFoundation"])
         else:
             self.cpp_info.set_property("cmake_target_name", "hidapi::winapi")
-            self.cpp_info.set_property("cmake_target_alias", ["hidapi::hidapi"])
+            self.cpp_info.set_property("cmake_target_aliases", ["hidapi::hidapi"])
             self.cpp_info.libs = ["hidapi"]
             self.cpp_info.includedirs.append(os.path.join("include", "hidapi"))

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -1,14 +1,14 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake
 from conan.tools.files import copy, get, replace_in_file, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
-from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.0"
 
 
 class HidapiConan(ConanFile):

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -134,7 +134,7 @@ class HidapiConan(ConanFile):
             self.cpp_info.set_property("cmake_target_aliases", ["hidapi::hidapi"])
             self.cpp_info.libs = ["hidapi"]
             self.cpp_info.includedirs.append(os.path.join("include", "hidapi"))
-            self.cpp_info.frameworks.extend(["IOKit", "CoreFoundation"])
+            self.cpp_info.frameworks.extend(["IOKit", "CoreFoundation", "AppKit"])
         else:
             self.cpp_info.set_property("cmake_target_name", "hidapi::winapi")
             self.cpp_info.set_property("cmake_target_aliases", ["hidapi::hidapi"])

--- a/recipes/hidapi/all/test_package/CMakeLists.txt
+++ b/recipes/hidapi/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(hidapi REQUIRED CONFIG)

--- a/recipes/hidapi/all/test_package/conanfile.py
+++ b/recipes/hidapi/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/hidapi/config.yml
+++ b/recipes/hidapi/config.yml
@@ -5,5 +5,3 @@ versions:
     folder: all
   "0.12.0":
     folder: all
-  "0.11.2":
-    folder: all

--- a/recipes/hidapi/config.yml
+++ b/recipes/hidapi/config.yml
@@ -7,7 +7,3 @@ versions:
     folder: all
   "0.11.2":
     folder: all
-  "0.11.0":
-    folder: all
-  "0.10.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **hidapi/[*]**

#### Motivation
HIDAPI supports a CMake-based build system since v0.11.0. This PR replaces the Autotools + MSBuild build systems with it and drops the older versions. The goal is to simplify the recipe and make the behavior across platforms a bit more consistent. Also enables static builds on Windows as a result.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
