### PR TITLE
watcher: add version 0.12.0

### DIFF
--- a/recipes/watcher/all/conandata.yml
+++ b/recipes/watcher/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.12.0":
+    url: "https://github.com/e-dant/watcher/archive/release/0.12.0.tar.gz"
+    sha256: "9dd4758f4c45ae7925619ceee9e3bd5a0b33577aa5ac2cd857eca14d16749723"
   "0.11.0":
     url: "https://github.com/e-dant/watcher/archive/release/0.11.0.tar.gz"
     sha256: "dd92496d77b6bc27e27ed28253faae4d81bc58b19407d154bb49504b2af73664"

--- a/recipes/watcher/config.yml
+++ b/recipes/watcher/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.12.0":
+    folder: all
   "0.11.0":
     folder: all
   "0.10.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
There are internal improvements in 0.12.0.
The c library named watcher-c is provided. I will create seperate recipe for it.

#### Details
https://github.com/e-dant/watcher/compare/release/0.11.0...release/0.12.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
