### PR TITLE
Extend test_package code to trigger linkage against upstreams.

### DIFF
--- a/recipes/libarchive/all/test_package/test_package.c
+++ b/recipes/libarchive/all/test_package/test_package.c
@@ -4,5 +4,11 @@
 int main(int argc, char *argv[]) {
     printf("libarchive version: %s\n", archive_version_string());
     printf("libarchive details: %s\n", archive_version_details());
+
+    // Further test correct linkage against upstreams
+    struct archive * a = archive_read_new();
+    archive_read_support_filter_all(a);
+    archive_read_free(a);
+
     return 0;
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **libarchive/[all]**

#### Motivation
This PR extends the test package to reproduce issue #25565 

#### Details
The test_package code calls `archive_read_support_filter_all()` which triggers linkage against upstreams used to support compression formats.
This should trigger the linker error described in #25565 when building on Windows `arch=x86`.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
