### PR TITLE
rabbitmq-c: fix a failing try_compile()

### DIFF
--- a/recipes/rabbitmq-c/all/conanfile.py
+++ b/recipes/rabbitmq-c/all/conanfile.py
@@ -67,6 +67,9 @@ class RabbitmqcConan(ConanFile):
         tc.variables["ENABLE_SSL_SUPPORT"] = self.options.ssl
         tc.variables["BUILD_API_DOCS"] = False
         tc.variables["RUN_SYSTEM_TESTS"] = False
+        # Required for https://github.com/alanxz/rabbitmq-c/blob/v0.14.0/CMakeLists.txt#L132-L133
+        # Otherwise fails with "CheckSymbolExists.c:(.text+0x1f): undefined reference to `ENGINE_new'"
+        tc.variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)
         tc.generate()
 
         if self.options.ssl:


### PR DESCRIPTION
### Summary
Changes to recipe:  **librabbitmq-c/[*]**

#### Motivation
Required for https://github.com/alanxz/rabbitmq-c/blob/v0.14.0/CMakeLists.txt#L132-L133
Otherwise the test fails with "CheckSymbolExists.c:(.text+0x1f): undefined reference to `ENGINE_new'".

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
