### PR TITLE
openexr: Add version 3.3.1

### DIFF
--- a/recipes/openexr/3.x/conandata.yml
+++ b/recipes/openexr/3.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.3.1":
+    url: "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.3.1.tar.gz"
+    sha256: "58aad2b32c047070a52f1205b309bdae007442e0f983120e4ff57551eb6f10f1"
   "3.3.0":
     url: "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.3.0.tar.gz"
     sha256: "58b00f50d2012f3107573c4b7371f70516d2972c2b301a50925e1b4a60a7be6f"

--- a/recipes/openexr/config.yml
+++ b/recipes/openexr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.3.1":
+    folder: "3.x"
   "3.3.0":
     folder: "3.x"
   "3.2.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **openexr/3.3.1**

#### Motivation
Contains a few fixes for performance regression in the latest 3.3.1 release.

#### Details
Besides a fix of performance regressions only contains some changes in documentation and small build system cleanups. None of those seem relevant for us according to the diff:
https://github.com/AcademySoftwareFoundation/openexr/compare/v3.3.0...v3.3.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
