### PR TITLE
watcher-c: add recipe

### DIFF
--- a/recipes/watcher-c/all/conandata.yml
+++ b/recipes/watcher-c/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.12.1":
+    url: "https://github.com/e-dant/watcher/archive/release/0.12.1.tar.gz"
+    sha256: "aab03c11d729b998f16a97fd6f9c6e0579466f4f0d208650117159818a11cf20"

--- a/recipes/watcher-c/all/conanfile.py
+++ b/recipes/watcher-c/all/conanfile.py
@@ -1,0 +1,93 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import check_min_cppstd
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.53.0"
+
+class WatcherCConan(ConanFile):
+    name = "watcher-c"
+    description = "Using the watcher library from C"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/e-dant/watcher"
+    topics = ("watch", "filesystem", "event")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12",
+            "Visual Studio": "16",
+            "msvc": "192",
+        }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def build_requirements(self):
+        self.tool_requires("meson/[>=1.2.3 <2]")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.generate()
+        tc = VirtualBuildEnv(self)
+        tc.generate()
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "license", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.libs = ["watcher-c"]

--- a/recipes/watcher-c/all/test_package/conanfile.py
+++ b/recipes/watcher-c/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("meson/[>=1.2.3 <2]")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/watcher-c/all/test_package/meson.build
+++ b/recipes/watcher-c/all/test_package/meson.build
@@ -1,0 +1,5 @@
+project('test_package', 'c')
+package_dep = dependency('watcher-c')
+executable('test_package',
+            sources : ['test_package.c'],
+            dependencies : [package_dep])

--- a/recipes/watcher-c/all/test_package/test_package.c
+++ b/recipes/watcher-c/all/test_package/test_package.c
@@ -1,0 +1,19 @@
+#include "wtr/watcher-c.h"
+#include <stdio.h>
+
+void callback(struct wtr_watcher_event event, void* _ctx) {
+    printf(
+        "path name: %s, effect type: %d path type: %d, effect time: %ld, associated path name: %s\n",
+        event.path_name,
+        event.effect_type,
+        event.path_type,
+        event.effect_time,
+        event.associated_path_name ? event.associated_path_name : ""
+    );
+}
+
+int main() {
+    void* watcher = wtr_watcher_open(".", callback, NULL);
+    wtr_watcher_close(watcher);
+    return 0;
+}

--- a/recipes/watcher-c/config.yml
+++ b/recipes/watcher-c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.12.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **watcher-c/0.12.1**

#### Motivation
watcher/0.12.0 starts to provide c binding.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
