### PR TITLE
tree-gen: add version 1.0.9

### DIFF
--- a/recipes/tree-gen/all/conandata.yml
+++ b/recipes/tree-gen/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.9":
+    url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.9.tar.gz"
+    sha256: "4ae8bd44f281ec76f25ac6f8228586467f7c7b2b9f67c4dc38ca524fb4e94d3a"
   "1.0.8":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.8.tar.gz"
     sha256: "a840f1da2fa377d2d791885d83b95dc15f081b308208d3497c395721488a4130"

--- a/recipes/tree-gen/config.yml
+++ b/recipes/tree-gen/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.9":
+    folder: all
   "1.0.8":
     folder: all
   "1.0.7":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-gen/1.0.9**

#### Motivation
Just a version bump.

#### Details
config.yml and conandata.yml point to the newly created tree-gen/1.0.9.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
