### PR TITLE
mongo-c-driver: add version 1.28.1

### DIFF
--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.28.1":
+    url: "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.28.1.tar.gz"
+    sha256: "249fd66d8d12aac2aec7dea1456e1bf24908c87971016c391a1a82a636029a87"
   "1.28.0":
     url: "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.28.0.tar.gz"
     sha256: "fc8ef2d081d9388b9016d74826f4a229d213a2813708d26063d771ab12e457cb"

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.28.1":
+    folder: all
   "1.28.0":
     folder: all
   "1.27.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mongo-c-driver/1.28.1**

#### Motivation
There are several bug fixes in 1.28.1.
Try to close https://github.com/conan-io/conan-center-index/issues/25577.

#### Details
https://github.com/mongodb/mongo-c-driver/compare/1.28.0...1.28.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
