### PR TITLE
gtest: require CMake for building gtest

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -109,6 +109,12 @@ class GTestConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def build_requirements(self):
+        if Version(self.version) >= "1.14.0":
+            self.tool_requires("cmake/[>=3.13]")
+        else:
+            self.tool_requires("cmake/[>=3.5]")
+
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_GMOCK"] = bool(self.options.build_gmock)


### PR DESCRIPTION
### Summary
Changes to recipe:  **gtest/***

Fixes #25582

#### Motivation
Currently gtest does not require CMake for building, but in fact it is required. If CMake is not installed on the system the build will fail.

#### Details
CMake is added as a required tool for building. Following CMake version are required by gtest:
* 1.12.0: 3.5, see https://github.com/google/googletest/blob/v1.12.0/CMakeLists.txt
* 1.13.0: 3.5, see https://github.com/google/googletest/blob/v1.13.0/CMakeLists.txt
* 1.14.0: 3.13, see https://github.com/google/googletest/blob/v1.14.0/CMakeLists.txt
* current main: 3.13, see https://github.com/google/googletest/blob/main/CMakeLists.txt

This is covered by the change.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
