### PR TITLE
Add rand_seed parameter to openssl 3.x.x

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -89,12 +89,14 @@ class OpenSSLConan(ConanFile):
         "no_zlib": [True, False],
         "openssldir": [None, "ANY"],
         "tls_security_level": [None, 0, 1, 2, 3, 4, 5],
+        "rand_seed": ["none", "getrandom", "devrandom", "os", "egd", "rdcpu"],
     }
     default_options = {key: False for key in options.keys()}
     default_options["fPIC"] = True
     default_options["no_md2"] = True
     default_options["openssldir"] = None
     default_options["tls_security_level"] = None
+    default_options["rand_seed"] = "os"
 
     @property
     def _is_clang_cl(self):
@@ -362,6 +364,7 @@ class OpenSSLConan(ConanFile):
             "--libdir=lib",
             f"--openssldir=\"{openssldir}\"",
             "no-threads" if self.options.no_threads else "threads",
+            f"--with-rand-seed={self.options.rand_seed}",
             f"PERL={self._perl}",
             "no-unit-test",
             "no-tests",
@@ -410,7 +413,7 @@ class OpenSSLConan(ConanFile):
             ])
 
         for option_name in self.default_options.keys():
-            if self.options.get_safe(option_name, False) and option_name not in ("shared", "fPIC", "openssldir", "tls_security_level", "capieng_dialog", "enable_capieng", "zlib", "no_fips", "no_md2"):
+            if self.options.get_safe(option_name, False) and option_name not in ("shared", "fPIC", "openssldir", "tls_security_level", "capieng_dialog", "enable_capieng", "zlib", "no_fips", "no_md2", "rand_seed"):
                 self.output.info(f"Activated option: {option_name}")
                 args.append(option_name.replace("_", "-"))
         return args


### PR DESCRIPTION
### Summary
Changes to recipe:  openssl/3.x.x

#### Motivation
I need to customize this flag for my openssl package.

#### Details
Add option flag to customize the `--with-rand-seed` openssl configuration flag. More info on the flag on the openssl documentation: https://github.com/openssl/openssl/blob/master/INSTALL.md#seeding-the-random-generator


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
