### PR TITLE
gn/cci.20210429: add apple arch option

### DIFF
--- a/recipes/gn/all/conanfile.py
+++ b/recipes/gn/all/conanfile.py
@@ -8,6 +8,8 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, XCRun
 from conan.tools.build import check_min_cppstd
+from conan.tools.build.flags import architecture_flag
+from conan.tools.apple import to_apple_arch
 from conan.tools.env import VirtualBuildEnv, Environment
 from conan.tools.files import chdir, copy, get, load, save, replace_in_file
 from conan.tools.layout import basic_layout
@@ -107,6 +109,19 @@ class GnConan(ConanFile):
         # https://gn.googlesource.com/gn/+/refs/heads/main/build/gen.py#386
         env = Environment()
         env.define("CXX", self._cxx)
+
+        arch_flags = ""
+        if is_apple_os(self):
+            if "armv8" in self.settings.arch:
+                arch_flags += "-arch arm64 "
+            if "x86_64" in self.settings.arch:
+                arch_flags += "-arch x86_64 "
+        else:
+            arch_flags = architecture_flag(self.settings)
+
+        env.append("CFLAGS", arch_flags)
+        env.append("LDFLAGS", arch_flags)
+
         env.vars(self).save_script("conanbuild_gn")
 
         if is_msvc(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **gn/cci.20210429**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
This PR fixes #25587. This bugfix allows the creation of binaries for other archs. The generator of gn is ignoring the arch passed when building the package.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
The changes involve adding arch flags to CFLAGS and LDFLAGS, allowing cross-compilation and universal binary support in macOS. They also include a change to allow passing the arch to other platforms, but the focus is on macOS.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
