### PR TITLE
xerces-c: fix handling of nsl library

### DIFF
--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -120,6 +120,10 @@ class XercesCConan(ConanFile):
         tc = CMakeToolchain(self)
         # Because upstream overrides BUILD_SHARED_LIBS as a CACHE variable
         tc.cache_variables["BUILD_SHARED_LIBS"] = "ON" if self.options.shared else "OFF"
+
+        # Prevent linking against unused found library
+        tc.cache_variables["NSL_LIBRARY"] = "NSL_LIBRARY-NOTFOUND"
+        
         # https://xerces.apache.org/xerces-c/build-3.html
         tc.variables["network"] =  self.options.network
         if self.options.network:
@@ -172,7 +176,7 @@ class XercesCConan(ConanFile):
         if self.settings.os == "Macos":
             self.cpp_info.frameworks = ["CoreFoundation", "CoreServices"]
         elif self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.extend(["pthread", "nsl"])
+            self.cpp_info.system_libs.extend(["pthread"])
 
         if Version(conan_version).major < 2:
             self.cpp_info.names["cmake_find_package"] = "XercesC"


### PR DESCRIPTION
### Summary
Changes to recipe: xerces-c all

#### Motivation
nsl is not a system library that is installed by default or found in all distros - so it shouldn't be listed as a system dependency without further safeguards.



#### Details
However, nsl appears to be completely unused even when found by the build system (there are no evaluations of the `HAVE_LIBNSL` macro, and no uses of any headers in the `rpcsvc/*` folder. 
On systms where gcc is configured to pass `--as-needed` to the linker, the dependency is never encoded even if libnsl was found.


