### PR TITLE
Fix: exceptions during build of bitserializer

### DIFF
--- a/recipes/bitserializer/all/conanfile.py
+++ b/recipes/bitserializer/all/conanfile.py
@@ -134,8 +134,11 @@ class BitserializerConan(ConanFile):
         if Version(self.version) >= "0.50":
             # Remove 'ryml' subdirectory from #include
             replace_in_file(
-                self, os.path.join(self.source_folder, "include", "bitserializer", "rapidyaml_archive.h"),
-                "#include <ryml/", "#include <",
+                self, 
+                os.path.join(self.source_folder, "include", "bitserializer", "rapidyaml_archive.h"),
+                "#include <ryml/", 
+                "#include <",
+                strict=False
             )
 
     def build(self):


### PR DESCRIPTION


### Summary
Changes to recipe:  **bitserializer/[>=0.50]**

#### Motivation
The build fails when two variants of the package are build on the same machine (with different `with_rapidaml` option value).

#### Details
The same source location is used to build different variants of package. In effect, the same file is patched more than once, what causes an exception. 

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
