### PR TITLE
libuv: add version 1.49.1

### DIFF
--- a/recipes/libuv/all/conandata.yml
+++ b/recipes/libuv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.49.1":
+    url: "https://github.com/libuv/libuv/archive/v1.49.1.tar.gz"
+    sha256: "94312ede44c6cae544ae316557e2651aea65efce5da06f8d44685db08392ec5d"
   "1.49.0":
     url: "https://github.com/libuv/libuv/archive/v1.49.0.tar.gz"
     sha256: "a10656a0865e2cff7a1b523fa47d0f5a9c65be963157301f814d1cc5dbd4dc1d"
@@ -33,6 +36,10 @@ sources:
     url: "https://github.com/libuv/libuv/archive/v1.41.0.zip"
     sha256: "cb89a8b9f686c5ccf7ed09a9e0ece151a73ebebc17af3813159c335b02181794"
 patches:
+  "1.49.1":
+    - patch_file: "patches/1.49.0/fix-cmake.patch"
+      patch_description: "separate shared and static library build"
+      patch_type: "conan"
   "1.49.0":
     - patch_file: "patches/1.49.0/fix-cmake.patch"
       patch_description: "separate shared and static library build"

--- a/recipes/libuv/config.yml
+++ b/recipes/libuv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.49.1":
+    folder: all
   "1.49.0":
     folder: all
   "1.48.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libuv/1.49.1**

#### Motivation
There is important bugs in 1.49.1.

#### Details
https://github.com/libuv/libuv/compare/v1.49.0...v1.49.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
