### PR TITLE
simdutf: add version 5.6.0, remove older versions

### DIFF
--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.6.0":
+    url: "https://github.com/simdutf/simdutf/archive/v5.6.0.tar.gz"
+    sha256: "98cc5761b638642b018a628b1609f1b2df489b555836fa88706055bb56a4d6fe"
   "5.5.0":
     url: "https://github.com/simdutf/simdutf/archive/v5.5.0.tar.gz"
     sha256: "47090a770b8eecf610ac4d1fafadde60bb7ba3c9d576d2a3a545aba989a3d749"
@@ -17,24 +20,6 @@ sources:
   "5.3.1":
     url: "https://github.com/simdutf/simdutf/archive/v5.3.1.tar.gz"
     sha256: "373e1e66a1c245817f0aa08ae8693b71d1703f9355d364e0d9d002929738ddcc"
-  "5.2.8":
-    url: "https://github.com/simdutf/simdutf/archive/v5.2.8.tar.gz"
-    sha256: "2706f1bef85a6d8598f82defd3848f1c5100e2e065c5d416d993118b53ea8d77"
-  "5.2.6":
-    url: "https://github.com/simdutf/simdutf/archive/v5.2.6.tar.gz"
-    sha256: "ab9e56facf7cf05f4e9d062a0adef310fc6a0f82a8132e8ec1e1bb7ab5e234df"
-  "5.2.3":
-    url: "https://github.com/simdutf/simdutf/archive/v5.2.3.tar.gz"
-    sha256: "dfa55d85c3ee51e9b52e55c02701b16f83dcf1921e1075b67f99b1036df5adb8"
-  "5.2.2":
-    url: "https://github.com/simdutf/simdutf/archive/v5.2.2.tar.gz"
-    sha256: "6cd905ac7fcf6293e34d7acaa9d5af901d85f182f82ec6ec3ee9f9273881791d"
-  "5.0.0":
-    url: "https://github.com/simdutf/simdutf/archive/v5.0.0.tar.gz"
-    sha256: "088d750466bf3487117cce7f828eb94a0a3474d7e76b45d4902c99a2387212b7"
-  "4.0.9":
-    url: "https://github.com/simdutf/simdutf/archive/v4.0.9.tar.gz"
-    sha256: "599E6558FC8D06F8346E5F210564F8B18751C93D83BCE1A40A0E6A326C57B61E"
   # 4.0.5 is required by scnlib
   "4.0.5":
     url: "https://github.com/simdutf/simdutf/archive/v4.0.5.tar.gz"

--- a/recipes/simdutf/config.yml
+++ b/recipes/simdutf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.6.0":
+    folder: all
   "5.5.0":
     folder: all
   "5.4.15":
@@ -10,18 +12,6 @@ versions:
   "5.3.2":
     folder: all
   "5.3.1":
-    folder: all
-  "5.2.8":
-    folder: all
-  "5.2.6":
-    folder: all
-  "5.2.3":
-    folder: all
-  "5.2.2":
-    folder: all
-  "5.0.0":
-    folder: all
-  "4.0.9":
     folder: all
   "4.0.5":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **simd/5.6.0**

#### Motivation
There are several improvements in 5.6.0.

#### Details
https://github.com/simdutf/simdutf/compare/v5.5.0...v5.6.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
