### PR TITLE
freetype: define DLL_EXPORT for shared library only

### DIFF
--- a/recipes/freetype/meson/conandata.yml
+++ b/recipes/freetype/meson/conandata.yml
@@ -15,13 +15,26 @@ sources:
       - "https://sourceforge.net/projects/freetype/files/freetype2/2.13.0/freetype-2.13.0.tar.xz"
     sha256: "5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c"
 patches:
+  "2.13.3":
+    - patch_file: "patches/2.13.3-0002-meson-Fix-static-windows.patch"
+      patch_description: "meson: define DLL_EXPORT for shared library only"
+      patch_source: "https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/341"
+      patch_type: "portability"
   "2.13.2":
     - patch_file: "patches/2.13.0-0001-meson-Use-the-standard-dependency-mechanism-to-find-.patch"
       patch_description: "meson: Use the standard dependency mechanism to find bzip2"
       patch_source: "https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/318"
       patch_type: "portability"
+    - patch_file: "patches/2.13.0-0002-meson-Fix-static-windows.patch"
+      patch_description: "meson: define DLL_EXPORT for shared library only"
+      patch_source: "https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/341"
+      patch_type: "portability"
   "2.13.0":
     - patch_file: "patches/2.13.0-0001-meson-Use-the-standard-dependency-mechanism-to-find-.patch"
       patch_description: "meson: Use the standard dependency mechanism to find bzip2"
       patch_source: "https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/318"
+      patch_type: "portability"
+    - patch_file: "patches/2.13.0-0002-meson-Fix-static-windows.patch"
+      patch_description: "meson: define DLL_EXPORT for shared library only"
+      patch_source: "https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/341"
       patch_type: "portability"

--- a/recipes/freetype/meson/patches/2.13.0-0002-meson-Fix-static-windows.patch
+++ b/recipes/freetype/meson/patches/2.13.0-0002-meson-Fix-static-windows.patch
@@ -1,0 +1,12 @@
+--- a/meson.build
++++ b/meson.build
+@@ -368,7 +368,8 @@ ftoption_h = custom_target('ftoption.h',
+ ft2_sources += ftoption_h
+ ft2_defines += ['-DFT_CONFIG_OPTIONS_H=<ftoption.h>']
+ 
+-if host_machine.system() == 'windows'
++if host_machine.system() == 'windows' and \
++   get_option('default_library') == 'shared'
+   ft2_defines += ['-DDLL_EXPORT=1']
+ endif
+ 

--- a/recipes/freetype/meson/patches/2.13.3-0002-meson-Fix-static-windows.patch
+++ b/recipes/freetype/meson/patches/2.13.3-0002-meson-Fix-static-windows.patch
@@ -1,0 +1,12 @@
+--- a/meson.build
++++ b/meson.build
+@@ -373,7 +373,8 @@ ftoption_h = custom_target('ftoption.h',
+ ft2_sources += ftoption_h
+ ft2_defines += ['-DFT_CONFIG_OPTIONS_H=<ftoption.h>']
+ 
+-if host_machine.system() == 'windows'
++if host_machine.system() == 'windows' and \
++   get_option('default_library') == 'shared'
+   ft2_defines += ['-DDLL_EXPORT=1']
+ endif
+ 


### PR DESCRIPTION
backport patch from https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/341

### Summary
Changes to recipe:  **freetype/2.13.***

#### Motivation
Without this patch I'm getting link errors in my project.

#### Details
Before patch meson has been injecting DLL_EXPORT compile definition to build process. With this define freetype uses "__declspec(dllexport)" even for static libraries.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
