### PR TITLE
bgfx: add msvc version 194

### DIFF
--- a/recipes/bgfx/all/conanfile.py
+++ b/recipes/bgfx/all/conanfile.py
@@ -160,7 +160,7 @@ class bgfxConan(ConanFile):
         if is_msvc(self):
             # Conan to Genie translation maps
             vs_ver_to_genie = {"17": "2022", "16": "2019", "15": "2017",
-                            "193": "2022", "192": "2019", "191": "2017"}
+                            "194": "2022", "193": "2022", "192": "2019", "191": "2017"}
 
             # Use genie directly, then msbuild on specific projects based on requirements
             genie_VS = f"vs{vs_ver_to_genie[str(self.settings.compiler.version)]}"


### PR DESCRIPTION
### Summary
Changes to recipe:  **bgfx/cci.20230216**

#### Motivation
The latest version of MSVC 2022 presents as 194; there is no key to handle that number, resulting in a key error when building.

#### Details
Add version 194 that maps to MSVC 2022


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
