### PR TITLE
stringzilla: add version 3.10.0

### DIFF
--- a/recipes/stringzilla/all/conandata.yml
+++ b/recipes/stringzilla/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.10.0":
+    url: "https://github.com/ashvardanian/StringZilla/archive/refs/tags/v3.10.0.tar.gz"
+    sha256: "69729a1403c4609256f861a0221e5331f836b4945f6848472e81183726e436e6"
   "3.9.6":
     url: "https://github.com/ashvardanian/StringZilla/archive/refs/tags/v3.9.6.tar.gz"
     sha256: "21577e967d79155f5bcbe9bfd885dd817a79666f384fb2a955c0ac5dbf0657a3"

--- a/recipes/stringzilla/all/test_package/test_package_3_0.cpp
+++ b/recipes/stringzilla/all/test_package/test_package_3_0.cpp
@@ -12,7 +12,7 @@ int main(void) {
   auto substring_position = haystack.find(needle); // Or `rfind`
 
   haystack.end() - haystack.begin() == haystack.size(); // Or `rbegin`, `rend`
-  haystack.find_first_of(" \w\t") == 4; // Or `find_last_of`, `find_first_not_of`, `find_last_not_of`
+  haystack.find_first_of(" \v\t") == 4; // Or `find_last_of`, `find_first_not_of`, `find_last_not_of`
   haystack.starts_with(needle) == true; // Or `ends_with`
   haystack.remove_prefix(needle.size()); // Why is this operation in-place?!
 

--- a/recipes/stringzilla/config.yml
+++ b/recipes/stringzilla/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.10.0":
+    folder: all
   "3.9.6":
     folder: all
   "3.9.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **stringzilla/3.10.0**

#### Motivation
There are several improvements since 3.9.6.

#### Details
https://github.com/ashvardanian/StringZilla/compare/v3.9.6...v3.10.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
