### PR TITLE
s2n: add version 1.5.5, remove older versions

### DIFF
--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.5":
+    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.5.5.tar.gz"
+    sha256: "6316e1ad2c8ef5807519758bb159d314b9fef31d79ae27bc8f809104b978bb04"
   "1.5.3":
     url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.5.3.tar.gz"
     sha256: "609d4ab5747e592a8749f2db7ff6422ea2e0aff3d2790b6d36defe276f422a71"
@@ -14,53 +17,6 @@ sources:
   "1.4.16":
     url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.4.16.tar.gz"
     sha256: "84fdbaa894c722bf13cac87b8579f494c1c2d66de642e5e6104638fddea76ad9"
-  "1.4.13":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.4.13.tar.gz"
-    sha256: "8b0b36697963d6752e5a1b49e28e393605990d348edf1aef6f39c33164d45edb"
-  "1.4.1":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.4.1.tar.gz"
-    sha256: "d8c1d8e1142441412434feacb4947ce6430a244dcd8f58921af79b29bd901731"
-  "1.4.0":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.4.0.tar.gz"
-    sha256: "3f786cb2f35e0551e120e1747e7b510a8228cd852073afa241313939672046cb"
-  "1.3.56":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.3.56.tar.gz"
-    sha256: "5d7bab81357a564453bc453469b4ae02936f1f35225ad297b8d846d2ecdda521"
-  "1.3.55":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.3.55.tar.gz"
-    sha256: "3b4d51d08326757440a7a134dd4d73c904b700d64837aa7fec0aca908b70fd9b"
-  "1.3.52":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.3.52.tar.gz"
-    sha256: "c8ae02ae427763dcffe10d211ed7a2433803affd9aa5836951ef972c53db0120"
-  "1.3.50":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.3.50.tar.gz"
-    sha256: "19c9a7e9e0ce14aae3fc0c55995759f4eadd5b55f5353de69f82c62ccb3693f8"
-  "1.3.49":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.3.49.tar.gz"
-    sha256: "2bc7b170a750a435ad02ab8e696c3ad6e9bb7a585c02899472793f87670184dd"
-  "1.3.31":
-    url: "https://github.com/aws/s2n-tls/archive/v1.3.31.tar.gz"
-    sha256: "23cfb42f82cbe1ce94b59f3b1c1c8eb9d24af2a1ae4c8f854209ff88fddd3900"
   "1.3.15":
     url: "https://github.com/aws/s2n-tls/archive/v1.3.15.tar.gz"
     sha256: "e3fc3405bb56334cbec90c35cbdf0e8a0f53199749a3f4b8fddb8d8a41e6db8b"
-  "1.3.9":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.3.9.tar.gz"
-    sha256: "09f03600d45cac99b8495f9c7aa5f70a83b5c02867a3018a1ba9975d53184658"
-  "1.2.0":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.2.0.tar.gz"
-    sha256: "90c1b5f4ac2c46774c8f100cac4f2a951715ae0bf2661799b9aaa891e6fb1f30"
-  "1.1.1":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.1.1.tar.gz"
-    sha256: "a17ef1e55b0a6c3d422b8b857bcfd26af7d2f8b33628a540854a6c17b8bed4d8"
-  "1.1.0":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.1.0.tar.gz"
-    sha256: "e094fd1f2044cfaeedb534ef1d7e4fd8745d8c07a247ce383cd8a6a5288e195c"
-  "1.0.11":
-    url: "https://github.com/aws/s2n-tls/archive/refs/tags/v1.0.11.tar.gz"
-    sha256: "dbe886cf8cd6658cce571cdaba81e9a93d8c914fd1eba0d3233fec64ed53224b"
-patches:
-  "1.1.0":
-    - patch_file: "patches/1.1.0/001-try-compile.patch"
-  "1.0.11":
-    - patch_file: "patches/1.0.11/001-try-compile.patch"

--- a/recipes/s2n/all/conanfile.py
+++ b/recipes/s2n/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
+from conan.tools.files import copy, get, rmdir, save
 import os
 import textwrap
 
@@ -28,7 +28,6 @@ class S2nConan(ConanFile):
 
     def export_sources(self):
         copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
-        export_conandata_patches(self)
 
     def configure(self):
         if self.options.shared:
@@ -59,7 +58,6 @@ class S2nConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()

--- a/recipes/s2n/config.yml
+++ b/recipes/s2n/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.5":
+    folder: all
   "1.5.3":
     folder: all
   "1.5.2":
@@ -7,35 +9,9 @@ versions:
     folder: all
   "1.5.0":
     folder: all
+  # keep 1.4.16 for aws-sdk-cpp, aws-c-io
   "1.4.16":
     folder: all
-  "1.4.13":
-    folder: all
-  "1.4.1":
-    folder: all
-  "1.4.0":
-    folder: all
-  "1.3.56":
-    folder: all
-  "1.3.55":
-    folder: all
-  "1.3.52":
-    folder: all
-  "1.3.50":
-    folder: all
-  "1.3.49":
-    folder: all
-  "1.3.31":
-    folder: all
+  # keep 1.3.15 for aws-sdk-cpp, aws-c-io
   "1.3.15":
-    folder: all
-  "1.3.9":
-    folder: all
-  "1.2.0":
-    folder: all
-  "1.1.1":
-    folder: all
-  "1.1.0":
-    folder: all
-  "1.0.11":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **s2n/***

#### Motivation
There are several improvements since 1.5.3.

#### Details
https://github.com/aws/s2n-tls/compare/v1.5.3...v1.5.5

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
