### PR TITLE
duckdb: add version 1.1.2

### DIFF
--- a/recipes/duckdb/all/conandata.yml
+++ b/recipes/duckdb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.2":
+    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v1.1.2.tar.gz"
+    sha256: "a3319a64c390ed0454c869b2e4fc0af2413cd49f55cd0f1400aaed9069cdbc4c"
   "1.1.1":
     url: "https://github.com/duckdb/duckdb/archive/refs/tags/v1.1.1.tar.gz"
     sha256: "a764cef80287ccfd8555884d8facbe962154e7c747043c0842cd07873b4d6752"
@@ -21,6 +24,13 @@ sources:
     url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.9.0.tar.gz"
     sha256: "3dbf3326a831bf0797591572440e81a3d6d668f8e33a25ce04efae19afc3a23d"
 patches:
+  "1.1.2":
+    - patch_file: "patches/1.1.1-0001-fix-cmake.patch"
+      patch_description: "install static of shared library, add installation for odbc extention"
+      patch_type: "portability"
+    - patch_file: "patches/1.1.1-0002-msvc-bicobj.patch"
+      patch_description: "add /bigobj flag"
+      patch_type: "portability"
   "1.1.1":
     - patch_file: "patches/1.1.1-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"

--- a/recipes/duckdb/config.yml
+++ b/recipes/duckdb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.2":
+    folder: "all"
   "1.1.1":
     folder: "all"
   "1.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **duckdb/1.1.2**

#### Motivation
There are lots of bug fixes in 1.1.2.

#### Details
https://github.com/duckdb/duckdb/compare/v1.1.1...v1.1.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
