### PR TITLE
commata: add version 1.0.1

### DIFF
--- a/recipes/commata/all/conandata.yml
+++ b/recipes/commata/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.1":
+    url: "https://github.com/furfurylic/commata/archive/refs/tags/v1.0.1.tar.gz"
+    sha256: "b6e91ede0ec8b7c69ced1e243eba204717e05fcd9ae26163a54425ca800124ef"
   "1.0.0":
     url: "https://github.com/furfurylic/commata/archive/refs/tags/v1.0.0.tar.gz"
     sha256: "ecf0a88f6a4616d10770522b4ef4838e4100511759eb640270f6b932e4b7df69"

--- a/recipes/commata/config.yml
+++ b/recipes/commata/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.1":
+    folder: all
   "1.0.0":
     folder: all
   "0.2.9":


### PR DESCRIPTION
### Summary
Changes to recipe:  **commata/1.0.1**

#### Motivation
There are several bugfixes in 1.0.1.

#### Details
https://github.com/furfurylic/commata/compare/v1.0.0...v1.0.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
