### PR TITLE
xbyak: add version 7.20

### DIFF
--- a/recipes/xbyak/all/conandata.yml
+++ b/recipes/xbyak/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.20":
+    url: "https://github.com/herumi/xbyak/archive/v7.20.tar.gz"
+    sha256: "82824b436751d570f404f9d4598216dfd29596ac149bba8b6b5b4fc555061a12"
   "7.10":
     url: "https://github.com/herumi/xbyak/archive/v7.10.tar.gz"
     sha256: "0f1060c9d14a090615f67391d7790ae596d0580726c79c9db6a249febda7ad63"

--- a/recipes/xbyak/config.yml
+++ b/recipes/xbyak/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.20":
+    folder: all
   "7.10":
     folder: all
   "7.08":


### PR DESCRIPTION
### Summary
Changes to recipe:  **xbyak/7.20**

#### Motivation
7.20 supports AVX-10.2.

#### Details
https://github.com/herumi/xbyak/compare/v7.10...v7.20

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
