### PR TITLE
mbedtls: add version 3.6.2, remove older versions

### DIFF
--- a/recipes/mbedtls/all/conandata.yml
+++ b/recipes/mbedtls/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.2":
+    url: "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.2/mbedtls-3.6.2.tar.bz2"
+    sha256: "8b54fb9bcf4d5a7078028e0520acddefb7900b3e66fec7f7175bb5b7d85ccdca"
   "3.6.1":
     url: "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.1/mbedtls-3.6.1.tar.bz2"
     sha256: "fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3"
@@ -8,42 +11,18 @@ sources:
   "3.5.2":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-3.5.2.tar.gz"
     sha256: "eedecc468b3f8d052ef05a9d42bf63f04c8a1c50d1c5a94c251c681365a2c723"
-  "3.5.1":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-3.5.1.tar.gz"
-    sha256: "0da345cda55ec6f6d71afa84cfae55632a16ba0b8b4644f4d0e8a32c9d1117b0"
   "3.5.0":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.5.0.tar.gz"
     sha256: "bdee0e3e45bbf360541306cac0cc27e00402c7a46b9bdf2d24787d5107f008f2"
-  "3.4.1":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.4.1.tar.gz"
-    sha256: "a420fcf7103e54e775c383e3751729b8fb2dcd087f6165befd13f28315f754f5"
   "3.2.1":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-3.2.1.tar.gz"
     sha256: "5850089672560eeaca03dc36678ee8573bb48ef6e38c94f5ce349af60c16da33"
-  "3.1.0":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-3.1.0.tar.gz"
-    sha256: "64d01a3b22b91cf3a25630257f268f11bc7bfa37981ae6d397802dd4ccec4690"
-  "3.0.0":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-3.0.0.tar.gz"
-    sha256: "377d376919be19f07c7e7adeeded088a525be40353f6d938a78e4f986bce2ae0"
-  "2.28.9":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v2.28.9.tar.gz"
-    sha256: "e4dbcf86a4fb31506482888560f02b161e0ecfb82fee0643abcfc86abee5817e"
-  "2.28.8":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v2.28.8.tar.gz"
-    sha256: "4fef7de0d8d542510d726d643350acb3cdb9dc76ad45611b59c9aa08372b4213"
   "2.28.4":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v2.28.4.tar.gz"
     sha256: "578c4dcd15bbff3f5cd56aa07cd4f850fc733634e3d5947be4f7157d5bfd81ac"
   "2.25.0":
     url: "https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.25.0.tar.gz"
     sha256: "ea2049c2dd4868693998d5a9780e198194be5aea1706ff4a9d4f882f18c0a101"
-  "2.24.0":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-2.24.0.tar.gz"
-    sha256: "b5a779b5f36d5fc4cba55faa410685f89128702423ad07b36c5665441a06a5f3"
-  "2.23.0":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-2.23.0.tar.gz"
-    sha256: "5c8998217402aa1fc734f4afaeac38fad2421470fac4b3abc112bd46391054fe"
   "2.16.12":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/mbedtls-2.16.12.tar.gz"
     sha256: "0afb4a4ce5b771f2fb86daee786362fbe48285f05b73cd205f46a224ec031783"

--- a/recipes/mbedtls/config.yml
+++ b/recipes/mbedtls/config.yml
@@ -1,33 +1,24 @@
 versions:
+  "3.6.2":
+    folder: all
   "3.6.1":
     folder: all
   "3.6.0":
     folder: all
   "3.5.2":
     folder: all
-  "3.5.1":
-    folder: all
+  # keep 3.5.0 for libcurl, libssh2, libwebsockets, libzip
   "3.5.0":
     folder: all
-  "3.4.1":
-    folder: all
+  # keep 3.2.1 for libcoap, libgit2, lief
   "3.2.1":
     folder: all
-  "3.1.0":
-    folder: all
-  "3.0.0":
-    folder: all
-  "2.28.9":
-    folder: all
-  "2.28.8":
-    folder: all
+  # keep 2.28.4 for libssh2
   "2.28.4":
     folder: all
+  # keep 2.25.0 for ixwebsocket, nng, open62541, yojimbo, mdnsresponder
   "2.25.0":
     folder: all
-  "2.24.0":
-    folder: all
-  "2.23.0":
-    folder: all
+  # keep 2.6.12 for cose-c
   "2.16.12":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **mbedtls/***

#### Motivation
There is a securify fix in 3.6.2.

#### Details
https://github.com/Mbed-TLS/mbedtls/compare/v3.6.1...mbedtls-3.6.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
