### PR TITLE
cgal: add cgal/6.0

### DIFF
--- a/recipes/cgal/all/conandata.yml
+++ b/recipes/cgal/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "5.6.1":
     sha256: cdb15e7ee31e0663589d3107a79988a37b7b1719df3d24f2058545d1bcdd5837
     url: https://github.com/CGAL/cgal/releases/download/v5.6.1/CGAL-5.6.1.tar.xz
+  "6.0":
+    sha256: ed53a1498569a22341b482e579c6a3caf9ecbfb6e013f5a90ce780138073b520
+    url: https://github.com/CGAL/cgal/releases/download/v6.0/CGAL-6.0-library.tar.xz
 patches:
   "5.3.2":
     - patch_file: "patches/0001-fix-for-conan.patch"

--- a/recipes/cgal/all/conanfile.py
+++ b/recipes/cgal/all/conanfile.py
@@ -24,7 +24,7 @@ class CgalConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return "14"
+        return "17" if Version(self.version) >= "6.0" else "14"
 
     @property
     def _minimum_compilers_version(self):
@@ -92,82 +92,90 @@ class CgalConan(ConanFile):
 
     def _create_cmake_module_variables(self, module_file):
         '''
-        CGAL requires C++14, and specific compilers flags to enable the possibility to set FPU rounding modes.
+        CGAL requires C++14 or C++17, and specific compilers flags to enable the possibility to set FPU rounding modes.
         This CMake module, from the upstream CGAL pull-request https://github.com/CGAL/cgal/pull/7512, takes
         care of all the known compilers CGAL has ever supported.
         '''
-        content = textwrap.dedent('''\
-function(CGAL_setup_CGAL_flags target)
-  # CGAL now requires C++14. `decltype(auto)` is used as a marker of
-  # C++14.
-  target_compile_features(${target} INTERFACE cxx_decltype_auto)
+        content = ""
+        if Version(self.version) < "6.0":
+            content = textwrap.dedent('''\
+                function(CGAL_setup_CGAL_flags target)
+                  # CGAL now requires C++14. `decltype(auto)` is used as a marker of
+                  # C++14.
+                  target_compile_features(${target} INTERFACE cxx_decltype_auto)
 
-  if(MSVC)
-    target_compile_options(${target} INTERFACE
-      "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS")
-    if(CMAKE_VERSION VERSION_LESS 3.11)
-      target_compile_options(${target} INTERFACE
-        /fp:strict
-        /fp:except-
-        /wd4503  # Suppress warnings C4503 about "decorated name length exceeded"
-        /bigobj  # Use /bigobj by default
-        )
-    else()
-      # The MSVC generator supports `$<COMPILE_LANGUAGE: >` since CMake 3.11.
-      target_compile_options(${target} INTERFACE
-        $<$<COMPILE_LANGUAGE:CXX>:/fp:strict>
-        $<$<COMPILE_LANGUAGE:CXX>:/fp:except->
-        $<$<COMPILE_LANGUAGE:CXX>:/wd4503>  # Suppress warnings C4503 about "decorated name length exceeded"
-        $<$<COMPILE_LANGUAGE:CXX>:/bigobj>  # Use /bigobj by default
-        )
-    endif()
-  elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0.3)
-      message(STATUS "Apple Clang version ${CMAKE_CXX_COMPILER_VERSION} compiler detected")
-      message(STATUS "Boost MP is turned off for all Apple Clang versions below 11.0.3!")
-      target_compile_options(${target} INTERFACE "-DCGAL_DO_NOT_USE_BOOST_MP")
-    endif()
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    message( STATUS "Using Intel Compiler. Adding -fp-model strict" )
-    if(WIN32)
-      target_compile_options(${target} INTERFACE "/fp:strict")
-    else()
-      target_compile_options(${target} INTERFACE "-fp-model" "strict")
-    endif()
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "SunPro")
-    message( STATUS "Using SunPro compiler, using STLPort 4." )
-    target_compile_options(${target} INTERFACE
-      "-features=extensions;-library=stlport4;-D_GNU_SOURCE")
-    target_link_libraries(${target} INTERFACE "-library=stlport4")
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    if ( RUNNING_CGAL_AUTO_TEST OR CGAL_TEST_SUITE )
-      target_compile_options(${target} INTERFACE "-Wall")
-    endif()
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3)
-      message( STATUS "Using gcc version 4 or later. Adding -frounding-math" )
-      if(CMAKE_VERSION VERSION_LESS 3.3)
-        target_compile_options(${target} INTERFACE "-frounding-math")
-      else()
-        target_compile_options(${target} INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:-frounding-math>")
-      endif()
-    endif()
-    if ( "${GCC_VERSION}" MATCHES "^4.2" )
-      message( STATUS "Using gcc version 4.2. Adding -fno-strict-aliasing" )
-      target_compile_options(${target} INTERFACE "-fno-strict-aliasing" )
-    endif()
-    if ( "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "alpha" )
-      message( STATUS "Using gcc on alpha. Adding -mieee -mfp-rounding-mode=d" )
-      target_compile_options(${target} INTERFACE "-mieee" "-mfp-rounding-mode=d" )
-    endif()
-  endif()
-endfunction()
+                  if(MSVC)
+                    target_compile_options(${target} INTERFACE
+                      "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS")
+                    if(CMAKE_VERSION VERSION_LESS 3.11)
+                      target_compile_options(${target} INTERFACE
+                        /fp:strict
+                        /fp:except-
+                        /wd4503  # Suppress warnings C4503 about "decorated name length exceeded"
+                        /bigobj  # Use /bigobj by default
+                        )
+                    else()
+                      # The MSVC generator supports `$<COMPILE_LANGUAGE: >` since CMake 3.11.
+                      target_compile_options(${target} INTERFACE
+                        $<$<COMPILE_LANGUAGE:CXX>:/fp:strict>
+                        $<$<COMPILE_LANGUAGE:CXX>:/fp:except->
+                        $<$<COMPILE_LANGUAGE:CXX>:/wd4503>  # Suppress warnings C4503 about "decorated name length exceeded"
+                        $<$<COMPILE_LANGUAGE:CXX>:/bigobj>  # Use /bigobj by default
+                        )
+                    endif()
+                  elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+                    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0.3)
+                      message(STATUS "Apple Clang version ${CMAKE_CXX_COMPILER_VERSION} compiler detected")
+                      message(STATUS "Boost MP is turned off for all Apple Clang versions below 11.0.3!")
+                      target_compile_options(${target} INTERFACE "-DCGAL_DO_NOT_USE_BOOST_MP")
+                    endif()
+                  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+                    message( STATUS "Using Intel Compiler. Adding -fp-model strict" )
+                    if(WIN32)
+                      target_compile_options(${target} INTERFACE "/fp:strict")
+                    else()
+                      target_compile_options(${target} INTERFACE "-fp-model" "strict")
+                    endif()
+                  elseif(CMAKE_CXX_COMPILER_ID MATCHES "SunPro")
+                    message( STATUS "Using SunPro compiler, using STLPort 4." )
+                    target_compile_options(${target} INTERFACE
+                      "-features=extensions;-library=stlport4;-D_GNU_SOURCE")
+                    target_link_libraries(${target} INTERFACE "-library=stlport4")
+                  elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+                    if ( RUNNING_CGAL_AUTO_TEST OR CGAL_TEST_SUITE )
+                      target_compile_options(${target} INTERFACE "-Wall")
+                    endif()
+                    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3)
+                      message( STATUS "Using gcc version 4 or later. Adding -frounding-math" )
+                      if(CMAKE_VERSION VERSION_LESS 3.3)
+                        target_compile_options(${target} INTERFACE "-frounding-math")
+                      else()
+                        target_compile_options(${target} INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:-frounding-math>")
+                      endif()
+                    endif()
+                    if ( "${GCC_VERSION}" MATCHES "^4.2" )
+                      message( STATUS "Using gcc version 4.2. Adding -fno-strict-aliasing" )
+                      target_compile_options(${target} INTERFACE "-fno-strict-aliasing" )
+                    endif()
+                    if ( "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "alpha" )
+                      message( STATUS "Using gcc on alpha. Adding -mieee -mfp-rounding-mode=d" )
+                      target_compile_options(${target} INTERFACE "-mieee" "-mfp-rounding-mode=d" )
+                    endif()
+                  endif()
+                endfunction()
+            ''')
 
-CGAL_setup_CGAL_flags(CGAL::CGAL)
+        else:
+            content = textwrap.dedent('''\
+                include(${CMAKE_CURRENT_LIST_DIR}/CGAL_SetupCGALDependencies.cmake)
+            ''')
+        content += textwrap.dedent('''\
+            CGAL_setup_CGAL_flags(CGAL::CGAL)
 
-# CGAL use may rely on the presence of those two variables
-set(CGAL_USE_GMP  TRUE CACHE INTERNAL "CGAL library is configured to use GMP")
-set(CGAL_USE_MPFR TRUE CACHE INTERNAL "CGAL library is configured to use MPFR")
-''')
+            # CGAL use may rely on the presence of those two variables
+            set(CGAL_USE_GMP  TRUE CACHE INTERNAL "CGAL library is configured to use GMP")
+            set(CGAL_USE_MPFR TRUE CACHE INTERNAL "CGAL library is configured to use MPFR")
+        ''')
         save(self, module_file, content)
 
     @property

--- a/recipes/cgal/all/conanfile.py
+++ b/recipes/cgal/all/conanfile.py
@@ -23,16 +23,20 @@ class CgalConan(ConanFile):
     short_paths = True
 
     @property
+    def _requires_cpp17(self):
+        return Version(self.version) >= "6.0"
+
+    @property
     def _min_cppstd(self):
-        return "17" if Version(self.version) >= "6.0" else "14"
+        return "17" if self._requires_cpp17 else "14"
 
     @property
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "15",
             "msvc": "191",
-            "gcc": "5",
-            "clang": "5",
+            "gcc": "7" if self._requires_cpp17 else "5",
+            "clang": "7" if self._requires_cpp17 else "5",
             "apple-clang": "5.1",
         }
 

--- a/recipes/cgal/config.yml
+++ b/recipes/cgal/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "5.6.1":
     folder: all
+  "6.0":
+    folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:  **cgal/6.0**

Resolves #25050.

#### Motivation

New upstream release: CGAL version 6.0, https://github.com/CGAL/cgal/releases/tag/v6.0

#### Details

CGAL 6.0 has a few breaking changes. The major one is that C++17 or later is now required (instead of C++14 for version 5.6).

Also: the PR https://github.com/CGAL/cgal/pull/7512 is merged in CGAL-6.0. That changes the creation of the file `lib/cmake/CGAL/conan-official-cgal-variables.cmake`, that is now simpler:

```cmake
include(${CMAKE_CURRENT_LIST_DIR}/CGAL_SetupCGALDependencies.cmake)
CGAL_setup_CGAL_flags(CGAL::CGAL)

# CGAL use may rely on the presence of those two variables
set(CGAL_USE_GMP  TRUE CACHE INTERNAL "CGAL library is configured to use GMP")
set(CGAL_USE_MPFR TRUE CACHE INTERNAL "CGAL library is configured to use MPFR")
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)... Relates to #25050 (that adds 6.0-beta1)
- [x] Tested locally with at least one configuration using a recent version of Conan
