### PR TITLE
libssh2: add version 1.11.1

### DIFF
--- a/recipes/libssh2/all/conandata.yml
+++ b/recipes/libssh2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.1":
+    sha256: 9954cb54c4f548198a7cbebad248bdc87dd64bd26185708a294b2b50771e3769
+    url: https://github.com/libssh2/libssh2/releases/download/libssh2-1.11.1/libssh2-1.11.1.tar.xz
   "1.11.0":
     sha256: a488a22625296342ddae862de1d59633e6d446eff8417398e06674a49be3d7c2
     url: https://github.com/libssh2/libssh2/releases/download/libssh2-1.11.0/libssh2-1.11.0.tar.xz

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -90,6 +90,9 @@ class Libssh2Conan(ConanFile):
             else:
                 self.requires("mbedtls/2.28.4")
 
+    def build_requirements(self):
+        self.tool_requires("cmake/3.20.6")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         apply_conandata_patches(self)

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -91,7 +91,7 @@ class Libssh2Conan(ConanFile):
                 self.requires("mbedtls/2.28.4")
 
     def build_requirements(self):
-        self.tool_requires("cmake/3.20.6")
+        self.tool_requires("cmake/[>=3.20 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libssh2/config.yml
+++ b/recipes/libssh2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.11.1":
+    folder: all
   "1.11.0":
     folder: all
   "1.10.0":


### PR DESCRIPTION
### Summary
Changes to recipe: libssh2/1.11.1

#### Motivation
There are several bugfixes since 1.11.0 including a fix for [terrapin attack](https://terrapin-attack.com/).

#### Details
https://github.com/libssh2/libssh2/compare/libssh2-1.11.0...libssh2-1.11.1


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
