### PR TITLE
Fix compilation error on non-msvc compilers without gnu extensions enabled

### DIFF
--- a/recipes/pcapplusplus/cmake/conanfile.py
+++ b/recipes/pcapplusplus/cmake/conanfile.py
@@ -55,7 +55,7 @@ class PcapplusplusConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} does not support Windows shared builds for now")
         if self.settings.compiler.cppstd:
             # popen()/pclose() usage
-            check_min_cppstd(self, self._min_cppstd, gnu_extensions=not is_msvc(self))
+            check_min_cppstd(self, self._min_cppstd)
         if self.settings.os not in ("FreeBSD", "Linux", "Macos", "Windows"):
             raise ConanInvalidConfiguration(f"{self.settings.os} is not supported")
 

--- a/recipes/pcapplusplus/cmake/conanfile.py
+++ b/recipes/pcapplusplus/cmake/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 from conan.tools.files import copy, get, rmdir, replace_in_file
 from conan.tools.scm import Version
-from conan.tools.microsoft import is_msvc
 from conan.errors import ConanInvalidConfiguration
 
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **pcapplusplus/[>=23.09]**

#### Motivation
The package fails to compile on non-msvc compiler when `cppstd` is not set to `gnuXX`.
The error looks like this:
```
pcapplusplus/23.09: Invalid: The cppstd GNU extension is required 
```

Example profile:
```
[settings]
arch=x86_64
os=Linux
compiler=gcc
compiler.version=11
compiler.cppstd=20
compiler.libcxx=libstdc++11
build_type=Debug
```

#### Details
This PR simply removes the requirement for gnu extensions for any compiler.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
