### PR TITLE
sqlite3: fix compiling for MSVC with non UTF-8 code page

### DIFF
--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -165,12 +165,6 @@ if(ENABLE_FTS5 OR ENABLE_MATH_FUNCTIONS)
     endif()
 endif()
 
-# The upstream source files're encoded in UTF-8,
-# but some non-ASCII characters may be not be decoded
-# in the user's current code page (e.g. CP936).
-# Thus we need to instruct the MSVC to use UTF-8.
-target_compile_options(${PROJECT_NAME} PRIVATE "$<$<C_COMPILER_ID:MSVC>:/utf-8>")
-
 include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -192,5 +186,10 @@ if(SQLITE3_BUILD_EXECUTABLE)
     if(NOT HAVE_SYSTEM)
         target_compile_definitions(sqlite3-bin PRIVATE SQLITE_NOHAVE_SYSTEM)
     endif()
+    # The upstream source files're encoded in UTF-8,
+    # but some non-ASCII characters may be not be decoded
+    # in the user's current code page (e.g. CP936).
+    # Thus we need to instruct the MSVC to use UTF-8.
+    target_compile_options(sqlite3-bin PRIVATE "$<$<C_COMPILER_ID:MSVC>:/utf-8>")
     install(TARGETS sqlite3-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -169,9 +169,7 @@ endif()
 # but some non-ASCII characters may be not be decoded
 # in the user's current code page (e.g. CP936).
 # Thus we need to instruct the MSVC to use UTF-8.
-if(MSVC)
-    add_compile_options("/utf-8")
-endif()
+target_compile_options(${PROJECT_NAME} PRIVATE "$<$<C_COMPILER_ID:MSVC>:/utf-8>")
 
 include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}

--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -190,6 +190,8 @@ if(SQLITE3_BUILD_EXECUTABLE)
     # but some non-ASCII characters may be not be decoded
     # in the user's current code page (e.g. CP936).
     # Thus we need to instruct the MSVC to use UTF-8.
-    target_compile_options(sqlite3-bin PRIVATE "$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+    if(SQLITE3_VERSION VERSION_LESS "3.47.0")
+        target_compile_options(sqlite3-bin PRIVATE "$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+    endif()
     install(TARGETS sqlite3-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -165,6 +165,14 @@ if(ENABLE_FTS5 OR ENABLE_MATH_FUNCTIONS)
     endif()
 endif()
 
+# The upstream source files're encoded in UTF-8,
+# but some non-ASCII characters may be not be decoded
+# in the user's current code page (e.g. CP936).
+# Thus we need to instruct the MSVC to use UTF-8.
+if(MSVC)
+    add_compile_options("/utf-8")
+endif()
+
 include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3**

#### Motivation
The upstream source files're encoded in UTF-8, but some non-ASCII characters may be not be decoded in the user's current code page (e.g. CP936). Thus we need to instruct the MSVC to use UTF-8.

#### Details
A failed compilation look like this. 

```
sqlite3/3.46.1: RUN: cmake --build "D:\cache\conan\p\b\sqlit063ff4ed98214\b\build" --config Release
MSBuild version 17.11.9+a69bbaaf5 for .NET Framework

  1>Checking Build System
  Building Custom Rule D:/cache/conan/p/b/sqlit063ff4ed98214/b/CMakeLists.txt
  sqlite3.c
  sqlite3.vcxproj -> D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\Release\sqlite3.lib
  Building Custom Rule D:/cache/conan/p/b/sqlit063ff4ed98214/b/CMakeLists.txt
  shell.c
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27256,1): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlit
e3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27709,35): error C2001: newline in constant [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27710,5): error C2143: syntax error: missing ';' before 'const' [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27724,16): error C2065: 'zBom': undeclared identifier [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27724,26): warning C4047: '=': 'int' differs in levels of indirection from 'const char *' [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27791,18): error C2065: 'zBom': undeclared identifier [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27791,20): error C2065: 'zBom': undeclared identifier [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27791,20): warning C4047: 'function': 'const char *' differs in levels of indirection from 'int' [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27791,20): warning C4024: 'oPutsUtf8': different types for formal and actual parameter 1 [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27804,18): error C2065: 'zBom': undeclared identifier [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27804,20): error C2065: 'zBom': undeclared identifier [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27804,20): warning C4047: 'function': 'const char *' differs in levels of indirection from 'int' [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]
D:\cache\conan\p\b\sqlit063ff4ed98214\b\src\shell.c(27804,20): warning C4024: 'oPutsUtf8': different types for formal and actual parameter 1 [D:\cache\conan\p\b\sqlit063ff4ed98214\b\build\sqlite3-bin.vcxproj]

sqlite3/3.46.1: ERROR:
Package 'c258ebf002cfa8d3ee0d78ed530bc27f279541b4' build failed
sqlite3/3.46.1: WARN: Build folder D:\cache\conan\p\b\sqlit063ff4ed98214\b\build
ERROR: sqlite3/3.46.1: Error in build() method, line 160
        cmake.build()
        ConanException: Error 1 while executing
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
