### PR TITLE
jemalloc: Remove unecessary build_type checks

### DIFF
--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -18,7 +18,8 @@ class JemallocConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     license = "BSD-2-Clause"
     homepage = "https://jemalloc.net/"
-    topics = ("conan", "jemalloc", "malloc", "free")
+    topics = ("jemalloc", "malloc", "free")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -119,10 +120,7 @@ class JemallocConan(ConanFile):
             if self.options.enable_cxx and self.settings.compiler.get_safe("libcxx") == "libc++" and \
                     Version(self.settings.compiler.version) < "10":
                 raise ConanInvalidConfiguration("Clang 9 or earlier with libc++ is not supported due to the missing mutex implementation.")
-        # 3. Verify the build type
-        if self.settings.build_type not in ("Release", "Debug", None):
-            raise ConanInvalidConfiguration("Only Release and Debug builds are supported.")
-        # 4: Apple Silicon specific checks
+        # 3: Apple Silicon specific checks
         if self.settings.os == "Macos" and self.settings.arch == "armv8":
             if Version(self.version) < "5.3.0":
                 raise ConanInvalidConfiguration("Support for Apple Silicon is only available as of 5.3.0.")


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Unless someone can point to a specific issue, I have not been able to find a reason for this check, because as shown in https://github.com/conan-io/conan-center-index/issues/25640#issuecomment-2421863626, this compiles just fine with both available versions

Closes #25640