### PR TITLE
Qt6: change variable setting from FEATURE_cxx to QT_FEATURE_cxx

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -661,13 +661,13 @@ class QtConan(ConanFile):
         current_cpp_std = self.settings.get_safe("compiler.cppstd", default_cppstd(self))
         current_cpp_std = str(current_cpp_std).replace("gnu", "")
         cpp_std_map = {
-            11: "FEATURE_cxx11",
-            14: "FEATURE_cxx14",
-            17: "FEATURE_cxx17",
-            20: "FEATURE_cxx20"
+            11: "QT_FEATURE_cxx11",
+            14: "QT_FEATURE_cxx14",
+            17: "QT_FEATURE_cxx17",
+            20: "QT_FEATURE_cxx20"
         }
         if Version(self.version) >= "6.5.0":
-            cpp_std_map[23] = "FEATURE_cxx2b"
+            cpp_std_map[23] = "QT_FEATURE_cxx2b"
 
         for std, feature in cpp_std_map.items():
             tc.variables[feature] = "ON" if int(current_cpp_std) >= std else "OFF"


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.x.x**

#### Motivation
See #25651 
With this change the CMAKE_CXX_STANDARD property is propagated correctly to the Qtbase submodule and most likely others aswell.

```
D:\dev\conan-center-index\recipes\qt\6.x.x (fix-qt-cxx-flag -> fork)
λ conan create . --version=6.7.3 -s compiler.cppstd=20
....
qt/6.7.3: RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="D:/conan-cache/b/qtd417356601dd9/b/build/generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="D:/conan-cache/b/qtd417356601dd9/p" -DCMAKE_TRY_COMPILE_CONFIGURATION="Release" -DQT_USE_VCPKG="OFF" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "D:/conan-cache/qt9bbf649b16297/s/src"
conanvcvars.bat: Activating environment Visual Studio 17 - amd64 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'x64'
-- Using Conan toolchain: D:/conan-cache/b/qtd417356601dd9/b/build/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Release>:MultiThreadedDLL>
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The CXX compiler identification is MSVC 19.41.34123.0
-- The C compiler identification is MSVC 19.41.34123.0
-- The ASM compiler identification is MSVC
-- Found assembler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.41.34120/bin/Hostx64/x64/cl.exe
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.41.34120/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.41.34120/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Checking dependencies of submodule 'qtbase'
-- Configuring submodule 'qtbase'
-- [QtBase] CMAKE_BUILD_TYPE was already explicitly set to: 'Release'
            -DCMAKE_C_FLAGS=/DWIN32 /D_WINDOWS
            -DCMAKE_C_FLAGS_DEBUG=/Zi /Ob0 /Od /RTC1
            -DCMAKE_C_FLAGS_RELEASE=/O2 /Ob2 /DNDEBUG
            -DCMAKE_C_FLAGS_RELWITHDEBINFO=/Zi /O2 /Ob1 /DNDEBUG
            -DCMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /EHsc
            -DCMAKE_CXX_FLAGS_DEBUG=/Zi /Ob0 /Od /RTC1
            -DCMAKE_CXX_FLAGS_RELEASE=/O2 /Ob2 /DNDEBUG
            -DCMAKE_CXX_FLAGS_RELWITHDEBINFO=/Zi /O2 /Ob1 /DNDEBUG
            -DCMAKE_EXE_LINKER_FLAGS=/machine:x64
            -DCMAKE_TOOLCHAIN_FILE=D:/conan-cache/b/qtd417356601dd9/b/build/generators/conan_toolchain.cmake
            -DCMAKE_C_STANDARD=11
            -DCMAKE_C_STANDARD_REQUIRED=ON
            -DCMAKE_CXX_STANDARD=20
            -DCMAKE_CXX_STANDARD_REQUIRED=ON
            -DCMAKE_MODULE_PATH:STRING=D:/conan-cache/qt9bbf649b16297/s/src/qtbase/cmake/platforms

-- Configuration summary shown below. It has also been written to D:/conan-cache/b/qtd417356601dd9/b/build/config.summary
-- Configure with --log-level=STATUS or higher to increase CMake's message verbosity. The log level does not persist across reconfigurations.

-- Configure summary:

Building for: win32-msvc (x86_64, CPU features: )
Compiler: msvc 19.41.34123.0
Build options:
```

#### Details
Rename the defined cmake configuration variables for the c++ standard from `FEATURE_cxx` to `QT_FEATURE_cxx`. As far as I see it cannot propagate the CXX_STANDARD correctly with the previous name: https://github.com/qt/qtbase/blob/bab1fd8fc3f8d6af5ad4b603c0dabdca434759a4/cmake/QtFlagHandlingHelpers.cmake#L355-L368.

This flag for cppstd was originally added in #15098, @ericLemanissier I wonder if I missed something in my testing or if there was an upstream change in Qt that introduced or changed this. As far as i see, in version 6.4.0 it was also already named `QT_FEATURE_cxx20` and a while before that.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
