### PR TITLE
libqasm: add version 0.6.8.

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.8":
+    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.8.tar.gz"
+    sha256: "b98ff44f0c569a0cc20b3728ba7d4711299aaac07d4dadfe52e638b366b91251"
   "0.6.7":
     url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.7.tar.gz"
     sha256: "3e85be4f433b178b89e32bc738bd4f69266cd1c4ad0ed12b5367381ac6e44eb2"

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.8":
+    folder: all
   "0.6.7":
     folder: all
   "0.6.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libqasm/0.6.8**

#### Motivation
Just a version bump.

#### Details
config.yml and conandata.yml point to the newly created libqasm/0.6.8.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
