### PR TITLE
simdjson: add version 3.10.1

### DIFF
--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.10.1":
+    url: "https://github.com/simdjson/simdjson/archive/v3.10.1.tar.gz"
+    sha256: "1e8f881cb2c0f626c56cd3665832f1e97b9d4ffc648ad9e1067c134862bba060"
   "3.10.0":
     url: "https://github.com/simdjson/simdjson/archive/v3.10.0.tar.gz"
     sha256: "9c30552f1dd0ee3d0832bb1c6b7b97d813b18d5ef294c10dcb6fc242e5947de8"

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.10.1":
+    folder: all
   "3.10.0":
     folder: all
   "3.9.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **simdjson/3.10.1**

#### Motivation
Version bump

#### Details
config.yml and conandata.yml point to the newly created simdjson/3.10.1.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
