### PR TITLE
openblas: add v0.3.28, fix a GCC 14 error

### DIFF
--- a/recipes/openblas/all/conandata.yml
+++ b/recipes/openblas/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.3.28":
+    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.28.tar.gz"
+    sha256: "f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1"
   "0.3.27":
     url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.27.tar.gz"
     sha256: "aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897"
@@ -14,18 +17,3 @@ sources:
   "0.3.20":
     url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.20.tar.gz"
     sha256: "8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c"
-  "0.3.17":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.17.tar.gz"
-    sha256: "df2934fa33d04fd84d839ca698280df55c690c86a5a1133b3f7266fce1de279f"
-  "0.3.15":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.15.tar.gz"
-    sha256: "30a99dec977594b387a17f49904523e6bc8dd88bd247266e83485803759e4bbe"
-  "0.3.13":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.13.tar.gz"
-    sha256: "79197543b17cc314b7e43f7a33148c308b0807cd6381ee77f77e15acf3e6459e"
-  "0.3.12":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.12.tar.gz"
-    sha256: "65a7d3a4010a4e3bd5c0baa41a234797cd3a1735449a4a5902129152601dc57b"
-  "0.3.10":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.10.tar.gz"
-    sha256: "0484d275f87e9b8641ff2eecaa9df2830cbe276ac79ad80494822721de6e1693"

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -190,6 +190,11 @@ class OpenblasConan(ConanFile):
             tc.cache_variables["TARGET"] = self.options.target
 
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+
+        # Fix a fatal compiler warning on GCC 14
+        # https://github.com/OpenMathLib/OpenBLAS/pull/4894
+        tc.extra_cflags.append("-Wno-error=incompatible-pointer-types")
+
         tc.generate()
 
     def _patch_sources(self):

--- a/recipes/openblas/all/test_package/CMakeLists.txt
+++ b/recipes/openblas/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package)
 
 find_package(OpenBLAS REQUIRED CONFIG)

--- a/recipes/openblas/all/test_package/conanfile.py
+++ b/recipes/openblas/all/test_package/conanfile.py
@@ -4,11 +4,9 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/openblas/config.yml
+++ b/recipes/openblas/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.3.28":
+    folder: all
   "0.3.27":
     folder: all
   "0.3.26":
@@ -8,14 +10,4 @@ versions:
   "0.3.24":
     folder: all
   "0.3.20":
-    folder: all
-  "0.3.17":
-    folder: all
-  "0.3.15":
-    folder: all
-  "0.3.13":
-    folder: all
-  "0.3.12":
-    folder: all
-  "0.3.10":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openblas/0.3.28**

#### Motivation
Fixes #25655 and adds the latest version.

Drops v0.3.17 and older. v0.3.17 was added in July 2021 and OpenBLAS is very backwards-compatible, so these can probably be safely removed.

#### Details
Overlaps somewhat with #25344 but is more limited in scope.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
