### PR TITLE
cpp-httplib: add version 0.18.1, remove older versions

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.18.1":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.18.1.tar.gz"
+    sha256: "405abd8170f2a446fc8612ac635d0db5947c0d2e156e32603403a4496255ff00"
   "0.18.0":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.18.0.tar.gz"
     sha256: "6ed5894bbbc4a34a0f4c5e962672d0003d2ea099bbadacc66f6dee2b213ff394"
@@ -24,15 +27,3 @@ sources:
   "0.14.1":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.14.1.tar.gz"
     sha256: "2d4fb5544da643e5d0a82585555d8b7502b4137eb321a4abbb075e21d2f00e96"
-  "0.13.3":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.13.3.tar.gz"
-    sha256: "2a4503f9f2015f6878baef54cd94b01849cc3ed19dfe95f2c9775655bea8b73f"
-  "0.12.6":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.12.6.tar.gz"
-    sha256: "24bc594a9efcc08a5a6f3928e848d046d411a88b07bcd6f7f3851227a1f0133e"
-  "0.11.4":
-    url: "https://github.com/yhirose/cpp-httplib/archive/v0.11.4.tar.gz"
-    sha256: "28f76b875a332fb80972c3212980c963f0a7d2e11a8fe94a8ed0d847b9a2256f"
-  "0.10.9":
-    url: "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.10.9.tar.gz"
-    sha256: "95ac0740ef760829a079c01a44164fd74af3fdc0748a40fc6beefd0276fd2345"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.18.1":
+    folder: all
   "0.18.0":
     folder: all
   "0.17.3":
@@ -14,12 +16,4 @@ versions:
   "0.14.3":
     folder: all
   "0.14.1":
-    folder: all
-  "0.13.3":
-    folder: all
-  "0.12.6":
-    folder: all
-  "0.11.4":
-    folder: all
-  "0.10.9":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-httplib/0.18.1**

#### Motivation
There are several improvements in 0.18.1.

#### Details
https://github.com/yhirose/cpp-httplib/compare/v0.18.0...v0.18.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
