### PR TITLE
tree-sitter-c: add version 0.23.1, update tree-sitter

### DIFF
--- a/recipes/tree-sitter-c/all/CMakeLists.txt
+++ b/recipes/tree-sitter-c/all/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.0)
-project(tree-sitter-c C)
+project(tree-sitter-c LANGUAGES C)
 
 find_package(tree-sitter REQUIRED CONFIG)
 include(GenerateExportHeader)
 
 file(WRITE api.h [[
 #pragma once
-#include <tree_sitter/parser.h>
 #include "tree_sitter_c_export.h"
 
 #ifdef __cplusplus

--- a/recipes/tree-sitter-c/all/conandata.yml
+++ b/recipes/tree-sitter-c/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "0.23.1":
     url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.23.1.tar.gz"
     sha256: "8f90f481c28a45c7dcba84d05fc07853df043ff813868cdfa074a3835e89467a"
+  "0.20.7":
+    url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.20.7.tar.gz"
+    sha256: "00abd71259093983fc7e2b51f3efc724ccab3e69af3a37d3cdd0a2a01d703061"
   "0.20.3":
     url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.20.3.tar.gz"
     sha256: "8c72a765230324f2b64e9ed66e027daf1a2ed24dde5fbf21398ad8ff7fca2a2d"

--- a/recipes/tree-sitter-c/all/conandata.yml
+++ b/recipes/tree-sitter-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.23.1":
+    url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.23.1.tar.gz"
+    sha256: "8f90f481c28a45c7dcba84d05fc07853df043ff813868cdfa074a3835e89467a"
   "0.20.3":
     url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.20.3.tar.gz"
     sha256: "8c72a765230324f2b64e9ed66e027daf1a2ed24dde5fbf21398ad8ff7fca2a2d"

--- a/recipes/tree-sitter-c/all/conanfile.py
+++ b/recipes/tree-sitter-c/all/conanfile.py
@@ -9,10 +9,10 @@ required_conan_version = ">=1.53.0"
 class TreeSitterCConan(ConanFile):
     name = "tree-sitter-c"
     description = "C grammar for tree-sitter."
-    topics = ("parser", "grammar", "tree", "c", "ide")
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/tree-sitter/tree-sitter-c"
-    license = "MIT"
+    topics = ("parser", "grammar", "tree", "c", "ide")
     settings = "os", "arch", "compiler", "build_type"
     package_type = "library"
 
@@ -24,9 +24,6 @@ class TreeSitterCConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-
-
-    exports_sources = "CMakeLists.txt"
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -55,7 +52,7 @@ class TreeSitterCConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def requirements(self):
-        self.requires("tree-sitter/0.20.8", transitive_headers=True, transitive_libs=True)
+        self.requires("tree-sitter/0.24.3", transitive_headers=True, transitive_libs=True)
 
     def _patch_sources(self):
         if not self.options.shared:

--- a/recipes/tree-sitter-c/all/test_package/CMakeLists.txt
+++ b/recipes/tree-sitter-c/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+project(test_package LANGUAGES C)
 
 find_package(tree-sitter-c REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} tree-sitter-c::tree-sitter-c)
+target_link_libraries(${PROJECT_NAME} PRIVATE tree-sitter-c::tree-sitter-c)

--- a/recipes/tree-sitter-c/all/test_package/test_package.c
+++ b/recipes/tree-sitter-c/all/test_package/test_package.c
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 int main() {
     TSParser *parser = ts_parser_new();

--- a/recipes/tree-sitter-c/config.yml
+++ b/recipes/tree-sitter-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.23.1":
+    folder: all
   "0.20.3":
     folder: all
   "0.20.2":

--- a/recipes/tree-sitter-c/config.yml
+++ b/recipes/tree-sitter-c/config.yml
@@ -1,6 +1,8 @@
 versions:
   "0.23.1":
     folder: all
+  "0.20.7":
+    folder: all
   "0.20.3":
     folder: all
   "0.20.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-sitter-c/0.23.1**

#### Motivation
There are lots of improvements in 0.23.1 and 0.20.7.
0.20.7 is the latest official version.

#### Details
https://github.com/tree-sitter/tree-sitter-c/compare/v0.20.3...v0.23.1
https://github.com/tree-sitter/tree-sitter-c/compare/v0.20.3...v0.20.7

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
