### PR TITLE
Draft: OpenImageIO: Add 3.0.0.0 release

### DIFF
--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -14,6 +14,10 @@ sources:
   "2.5.16.0":
     url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.16.0.tar.gz"
     sha256: "e5438e28d34a5b0a09428ed77ec310edd47c141db1b259364859110847e161e7"
+  # Replace before creating MR
+  "3.0.0.0":
+    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v3.0.0.0-beta1.tar.gz"
+    sha256: "344790867caf7d27d7c72578bb28bd35d85835b717a6ca1eb8875a82fee4dcbf"
 patches:
   "2.4.7.1":
     - patch_file: "patches/2.4.7.1-cmake-targets.patch"

--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -42,3 +42,7 @@ patches:
     - patch_file: "patches/2.5.14.0-cmake-targets.patch"
       patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"
       patch_type: "conan"
+  "3.0.0.0":
+    - patch_file: "patches/3.0.0.0-cmake-targets.patch"
+      patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"
+      patch_type: "conan"

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -32,9 +32,9 @@ class OpenImageIOConan(ConanFile):
         "with_freetype": [True, False],
         "with_giflib": [True, False],
         "with_hdf5": [True, False],
-        "with_jxl": [True, False],
         "with_libheif": [True, False],
         "with_libjpeg": ["libjpeg", "libjpeg-turbo"],
+        "with_libjxl": [True, False],
         "with_libpng": [True, False],
         "with_libwebp": [True, False],
         "with_opencolorio": [True, False],
@@ -53,9 +53,9 @@ class OpenImageIOConan(ConanFile):
         "with_freetype": True,
         "with_giflib": True,
         "with_hdf5": True,
-        "with_jxl": True,
-        "with_libjpeg": "libjpeg",
         "with_libheif": True,
+        "with_libjpeg": "libjpeg",
+        "with_libjxl": False,  # TODO: Currently produces link failues
         "with_libpng": True,
         "with_libwebp": True,
         "with_opencolorio": True,
@@ -78,7 +78,7 @@ class OpenImageIOConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
         if Version(self.version) < "3.0.0.0":
-            self.options.with_jxl = False  #rm_safe("with_jxl")
+            self.options.with_libjxl = False  #rm_safe("with_libjxl")
 
     def requirements(self):
         # Required libraries
@@ -101,7 +101,7 @@ class OpenImageIOConan(ConanFile):
             self.requires("fmt/9.1.0", transitive_headers=True)
 
         # Optional libraries
-        if self.options.with_jxl:
+        if self.options.with_libjxl:
             self.requires("libjxl/0.10.3")
         if self.options.with_libpng:
             self.requires("libpng/1.6.42")
@@ -134,6 +134,10 @@ class OpenImageIOConan(ConanFile):
             self.requires("ptex/2.4.2")
         if self.options.with_libwebp:
             self.requires("libwebp/1.3.2")
+
+        # TODO: Temporary, to be removed
+        # Works with build=missing now, awaiting https://github.com/conan-io/conan-center-index/pull/25660
+        self.requires('lcms/2.16', override=True)
 
         # TODO: R3DSDK dependency
         # TODO: Nuke dependency
@@ -183,9 +187,9 @@ class OpenImageIOConan(ConanFile):
         tc.variables["USE_JPEG"] = True
         # OIIO CMake files are patched to check USE_* flags to require or not use dependencies
         tc.variables["USE_JPEGTURBO"] = (self.options.with_libjpeg == "libjpeg-turbo")
-        if Version(self.version) >= '3.0.0.0':
-            tc.variables["USE_JXS"] = self.options.with_jxl
         tc.variables["USE_LIBHEIF"] = self.options.with_libheif
+        if Version(self.version) >= '3.0.0.0':
+            tc.variables["USE_LIBJXL"] = self.options.with_libjxl
         tc.variables["USE_LIBPNG"] = self.options.with_libpng
         tc.variables["USE_LIBRAW"] = self.options.with_raw
         tc.variables["USE_LIBWEBP"] = self.options.with_libwebp
@@ -285,7 +289,7 @@ class OpenImageIOConan(ConanFile):
                 "boost::regex",
             ]
 
-        if self.options.with_jxl:
+        if self.options.with_libjxl:
             open_image_io.requires.append("libjxl::libjxl")
         if self.options.with_libjpeg == "libjpeg":
             open_image_io.requires.append("libjpeg::libjpeg")

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -137,7 +137,7 @@ class OpenImageIOConan(ConanFile):
 
         # TODO: Temporary, to be removed
         # Works with build=missing now, awaiting https://github.com/conan-io/conan-center-index/pull/25660
-        self.requires('lcms/2.16', override=True)
+        #self.requires('lcms/2.16', override=True)
 
         # TODO: R3DSDK dependency
         # TODO: Nuke dependency

--- a/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
@@ -1,0 +1,463 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 322465767..c88ffdb08 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -42,7 +42,7 @@ endif ()
+ 
+ # Set up module path for our own cmake modules and add some esential ones
+ list (APPEND CMAKE_MODULE_PATH
+-      "${PROJECT_SOURCE_DIR}/src/cmake/modules"
++      #"${PROJECT_SOURCE_DIR}/src/cmake/modules"
+       "${PROJECT_SOURCE_DIR}/src/cmake")
+ 
+ # Utilities
+@@ -233,7 +233,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
+     add_subdirectory (src/iinfo)
+     add_subdirectory (src/maketx)
+     add_subdirectory (src/oiiotool)
+-    add_subdirectory (src/testtex)
++    #add_subdirectory (src/testtex)
+     add_subdirectory (src/iv)
+ endif ()
+ 
+diff --git src/cmake/externalpackages.cmake src/cmake/externalpackages.cmake
+index 612d95a60..d7dd711a4 100644
+--- src/cmake/externalpackages.cmake
++++ src/cmake/externalpackages.cmake
+@@ -73,16 +73,15 @@ set (OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH OFF CACHE BOOL
+      "Exclude find_dependency(Imath) from the exported OpenImageIOConfig.cmake")
+ 
+ # JPEG -- prefer JPEG-Turbo to regular libjpeg
+-checked_find_package (libjpeg-turbo
+-                      VERSION_MIN 2.1
+-                      DEFINITIONS USE_JPEG_TURBO=1)
+-if (TARGET libjpeg-turbo::jpeg) # Try to find the non-turbo version
+-    # Doctor it so libjpeg-turbo is aliased as JPEG::JPEG
+-    alias_library_if_not_exists (JPEG::JPEG libjpeg-turbo::jpeg)
+-    set (JPEG_FOUND TRUE)
+-else ()
+-    # Try to find the non-turbo version
++if (USE_JPEGTURBO)
++    checked_find_package (libjpeg-turbo REQUIRED
++                          DEFINITIONS -DUSE_JPEG_TURBO=1
++                          PRINT libjpeg-turbo_INCLUDES libjpeg-turbo_LIBRARIES)
++    add_library(JPEG::JPEG ALIAS libjpeg-turbo::libjpeg-turbo)
++elseif (USE_JPEG) # Try to find the non-turbo version
+     checked_find_package (JPEG REQUIRED)
++else ()
++    message(FATAL_ERROR "JPEG library was not found!")
+ endif ()
+ 
+ 
+@@ -92,9 +91,10 @@ alias_library_if_not_exists (TIFF::TIFF TIFF::tiff)
+ 
+ # JPEG XL
+ option (USE_JXL "Enable JPEG XL support" ON)
+-checked_find_package (JXL
+-                      VERSION_MIN 0.10.1
+-                      DEFINITIONS USE_JXL=1)
++# TODO
++# checked_find_package (JXL
++#                       VERSION_MIN 0.10.1
++#                       DEFINITIONS USE_JXL=1)
+ 
+ # Pugixml setup.  Normally we just use the version bundled with oiio, but
+ # some linux distros are quite particular about having separate packages so we
+@@ -109,7 +109,7 @@ else ()
+ endif()
+ 
+ # From pythonutils.cmake
+-find_python()
++#find_python()
+ if (USE_PYTHON)
+     checked_find_package (pybind11 REQUIRED VERSION_MIN 2.7)
+ endif ()
+@@ -119,85 +119,117 @@ endif ()
+ # Dependencies for optional formats and features. If these are not found,
+ # we will continue building, but the related functionality will be disabled.
+ 
+-checked_find_package (PNG VERSION_MIN 1.6.0)
+-
+-checked_find_package (BZip2)   # Used by ffmpeg and freetype
+-if (NOT BZIP2_FOUND)
+-    set (BZIP2_LIBRARIES "")  # TODO: why does it break without this?
+-endif ()
++if (USE_PNG)
++    checked_find_package (PNG REQUIRED VERSION_MIN 1.6.0)
++endif()
+ 
+-checked_find_package (Freetype
+-                      VERSION_MIN 2.10.0
+-                      DEFINITIONS USE_FREETYPE=1 )
++# checked_find_package (BZip2)   # Used by ffmpeg and freetype
++# if (NOT BZIP2_FOUND)
++#     set (BZIP2_LIBRARIES "")  # TODO: why does it break without this?
++# endif ()
+ 
+-checked_find_package (OpenColorIO REQUIRED
+-                      VERSION_MIN 2.2
+-                      VERSION_MAX 2.9
+-                     )
+-if (NOT OPENCOLORIO_INCLUDES)
+-    get_target_property(OPENCOLORIO_INCLUDES OpenColorIO::OpenColorIO INTERFACE_INCLUDE_DIRECTORIES)
+-endif ()
+-include_directories(BEFORE ${OPENCOLORIO_INCLUDES})
++if (USE_FREETYPE)
++    checked_find_package (Freetype REQUIRED
++                          VERSION_MIN 2.10.0
++                          DEFINITIONS USE_FREETYPE=1 )
++endif()
+ 
+-checked_find_package (OpenCV 4.0
+-                      DEFINITIONS USE_OPENCV=1)
++if (USE_OPENCOLORIO)
++    checked_find_package (OpenColorIO REQUIRED
++                          VERSION_MIN 2.2
++                          VERSION_MAX 2.9
++                         )
++endif()
++# if (NOT OPENCOLORIO_INCLUDES)
++#     get_target_property(OPENCOLORIO_INCLUDES OpenColorIO::OpenColorIO INTERFACE_INCLUDE_DIRECTORIES)
++# endif ()
++# include_directories(BEFORE ${OPENCOLORIO_INCLUDES})
++
++if (USE_OPENCV)
++    checked_find_package (OpenCV 4.0 REQUIRED
++                          DEFINITIONS USE_OPENCV=1)
++endif()
+ 
+ # Intel TBB
+-set (TBB_USE_DEBUG_BUILD OFF)
+-checked_find_package (TBB 2017
+-                      SETVARIABLES OIIO_TBB
+-                      PREFER_CONFIG)
++if (USE_TBCC)
++    set (TBB_USE_DEBUG_BUILD OFF)
++    checked_find_package (TBB 2017 REQUIRED
++                          SETVARIABLES OIIO_TBB
++                          PREFER_CONFIG)
++endif()
+ 
+ # DCMTK is used to read DICOM images
+-checked_find_package (DCMTK CONFIG VERSION_MIN 3.6.1)
++if (USE_DCMTK)
++    checked_find_package (DCMTK REQUIRED CONFIG VERSION_MIN 3.6.1)
++endif()
+ 
+-checked_find_package (FFmpeg VERSION_MIN 4.0)
++if (USE_FFMPEG)
++    checked_find_package (ffmpeg REQUIRED VERSION_MIN 4.0)
++endif()
+ 
+-checked_find_package (GIF VERSION_MIN 5.0)
++if (USE_GIF)
++    checked_find_package (GIF REQUIRED VERSION_MIN 5.0)
++endif()
+ 
+ # For HEIF/HEIC/AVIF formats
+-checked_find_package (Libheif VERSION_MIN 1.11
+-                      RECOMMEND_MIN 1.16
+-                      RECOMMEND_MIN_REASON "for orientation support")
+-
+-checked_find_package (LibRaw
+-                      VERSION_MIN 0.20.0
+-                      PRINT LibRaw_r_LIBRARIES)
+-
+-checked_find_package (OpenJPEG VERSION_MIN 2.0
+-                      RECOMMEND_MIN 2.2
+-                      RECOMMEND_MIN_REASON "for multithreading support")
+-# Note: Recent OpenJPEG versions have exported cmake configs, but we don't
+-# find them reliable at all, so we stick to our FindOpenJPEG.cmake module.
+-
+-checked_find_package (OpenVDB
+-                      VERSION_MIN  9.0
+-                      DEPS         TBB
+-                      DEFINITIONS  USE_OPENVDB=1)
+-
+-checked_find_package (Ptex PREFER_CONFIG)
+-if (NOT Ptex_FOUND OR NOT Ptex_VERSION)
+-    # Fallback for inadequate Ptex exported configs. This will eventually
+-    # disappear when we can 100% trust Ptex's exports.
+-    unset (Ptex_FOUND)
+-    checked_find_package (Ptex)
++if (USE_LIBHEIF)
++    checked_find_package (libheif REQUIRED VERSION_MIN 1.11
++                          RECOMMEND_MIN 1.16
++                          RECOMMEND_MIN_REASON "for orientation support")
++endif()
++
++if (USE_LIBRAW)
++    checked_find_package (LibRaw REQUIRED
++                          VERSION_MIN 0.20.0
++                          PRINT LibRaw_r_LIBRARIES)
++endif()
++
++if (USE_OPENJPEG)
++    checked_find_package (OpenJPEG REQUIRED
++                          VERSION_MIN 2.0
++                          RECOMMEND_MIN 2.2
++                          RECOMMEND_MIN_REASON "for multithreading support")
++    # Note: Recent OpenJPEG versions have exported cmake configs, but we don't
++    # find them reliable at all, so we stick to our FindOpenJPEG.cmake module.
++endif()
++
++if (USE_OPENVDB)
++    checked_find_package (OpenVDB REQUIRED
++                          VERSION_MIN  9.0
++                          DEPS         TBB
++                          DEFINITIONS  USE_OPENVDB=1)
++endif()
++
++if (USE_PTEX)
++    checked_find_package (ptex REQUIRED PREFER_CONFIG)
++    # if (NOT Ptex_FOUND OR NOT Ptex_VERSION)
++    #     # Fallback for inadequate Ptex exported configs. This will eventually
++    #     # disappear when we can 100% trust Ptex's exports.
++    #     unset (Ptex_FOUND)
++    #     checked_find_package (Ptex)
+ endif ()
+ 
+-checked_find_package (WebP VERSION_MIN 1.1)
++if (USE_LIBWEBP)
++    checked_find_package (WebP REQUIRED VERSION_MIN 1.1)
++endif()
+ 
+ option (USE_R3DSDK "Enable R3DSDK (RED camera) support" OFF)
+-checked_find_package (R3DSDK NO_RECORD_NOTFOUND)  # RED camera
++if (USE_R3DSDK)
++    checked_find_package (R3DSDK NO_RECORD_NOTFOUND)  # RED camera
++endif()
+ 
+ set (NUKE_VERSION "7.0" CACHE STRING "Nuke version to target")
+-checked_find_package (Nuke NO_RECORD_NOTFOUND)
++if (USE_NUKE)
++    checked_find_package (Nuke NO_RECORD_NOTFOUND)
++endif()
+ 
+ 
+ # Qt -- used for iv
+ option (USE_QT "Use Qt if found" ON)
+-if (USE_QT)
+-    checked_find_package (OpenGL)   # used for iv
++if (USE_OPENGL)
++    checked_find_package (OpenGL REQUIRED)   # used for iv
+ endif ()
+-if (USE_QT AND OPENGL_FOUND)
++if (USE_QT AND USE_OPENGL)
+     checked_find_package (Qt6 COMPONENTS Core Gui Widgets OpenGLWidgets)
+     if (NOT Qt6_FOUND)
+         checked_find_package (Qt5 COMPONENTS Core Gui Widgets OpenGL)
+@@ -210,10 +242,7 @@ endif ()
+ 
+ 
+ # Tessil/robin-map
+-checked_find_package (Robinmap REQUIRED
+-                      VERSION_MIN 1.2.0
+-                      BUILD_LOCAL missing
+-                     )
++find_package (tsl-robin-map REQUIRED)
+ 
+ # fmtlib
+ option (OIIO_INTERNALIZE_FMT "Copy fmt headers into <install>/include/OpenImageIO/detail/fmt" ON)
+@@ -222,7 +251,7 @@ checked_find_package (fmt REQUIRED
+                       VERSION_MAX 11.99
+                       BUILD_LOCAL missing
+                      )
+-get_target_property(FMT_INCLUDE_DIR fmt::fmt-header-only INTERFACE_INCLUDE_DIRECTORIES)
++get_target_property(FMT_INCLUDE_DIR fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+ 
+ 
+ ###########################################################################
+diff --git src/ffmpeg.imageio/CMakeLists.txt src/ffmpeg.imageio/CMakeLists.txt
+index c84ef3c90..11da54bc2 100644
+--- src/ffmpeg.imageio/CMakeLists.txt
++++ src/ffmpeg.imageio/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-if (FFmpeg_FOUND)
++if (USE_FFMPEG)
+     if (LINKSTATIC)
+         set (_static_suffixes .lib .a)
+         set (_static_libraries_found 0)
+@@ -26,11 +26,9 @@ if (FFmpeg_FOUND)
+     endif()
+ 
+     add_oiio_plugin (ffmpeginput.cpp
+-                     INCLUDE_DIRS ${FFMPEG_INCLUDES}
+-                     LINK_LIBRARIES ${FFMPEG_LIBRARIES}
+-                                    ${BZIP2_LIBRARIES}
++                     LINK_LIBRARIES ffmpeg::avcodec ffmpeg::avformat ffmpeg::swscale
+                      DEFINITIONS "USE_FFMPEG"
+-                                 "-DOIIO_FFMPEG_VERSION=\"${FFMPEG_VERSION}\"")
++                                 "-DOIIO_FFMPEG_VERSION=\"${ffmpeg_VERSION}\"")
+ else()
+     message (STATUS "FFmpeg not found: ffmpeg plugin will not be built")
+ endif()
+diff --git src/heif.imageio/CMakeLists.txt src/heif.imageio/CMakeLists.txt
+index 25606a139..5f520249a 100644
+--- src/heif.imageio/CMakeLists.txt
++++ src/heif.imageio/CMakeLists.txt
+@@ -2,32 +2,9 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-if (Libheif_FOUND)
+-    if (LINKSTATIC)
+-        set (_static_suffixes .lib .a)    
+-        set (_static_libraries_found 0)
+-
+-        foreach (_libeheif_library IN LISTS LIBHEIF_LIBRARIES)
+-            get_filename_component (_ext ${_libeheif_library} LAST_EXT)
+-            list (FIND _static_suffixes ${_ext} _index)
+-            if (${_index} GREATER -1)
+-                MATH (EXPR _static_libraries_found "${static_libraries_found}+1")
+-            endif()
+-        endforeach()
+-
+-        if (${_static_libraries_found} GREATER 0)
+-            message (STATUS "${ColorYellow}")
+-            message (STATUS "You are linking OpenImageIO against a static version of libheif, which is LGPL")
+-            message (STATUS "licensed. If you intend to redistribute this build of OpenImageIO, we recommend")
+-            message (STATUS "that you review the libheif license terms, or you may wish to switch to using a")
+-            message (STATUS "dynamically-linked libheif.")
+-            message ("${ColorReset}")
+-        endif()
+-    endif()
+-
++if (USE_LIBHEIF)
+     add_oiio_plugin (heifinput.cpp heifoutput.cpp
+-                     INCLUDE_DIRS ${LIBHEIF_INCLUDES}
+-                     LINK_LIBRARIES ${LIBHEIF_LIBRARIES}
++                     LINK_LIBRARIES libheif::heif
+                      DEFINITIONS "USE_HEIF=1")
+ else ()
+     message (WARNING "heif plugin will not be built")
+diff --git src/include/CMakeLists.txt src/include/CMakeLists.txt
+index 3ab45a570..9b6511b78 100644
+--- src/include/CMakeLists.txt
++++ src/include/CMakeLists.txt
+@@ -49,7 +49,7 @@ install (FILES ${detail_headers}
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/detail
+          COMPONENT developer)
+ 
+-if (OIIO_INTERNALIZE_FMT OR fmt_LOCAL_BUILD)
++if (0)
+     set (fmt_headers_base_names)
+     foreach (header_name core.h format-inl.h format.h ostream.h printf.h
+              std.h base.h chrono.h)
+diff --git src/jpeg2000.imageio/CMakeLists.txt src/jpeg2000.imageio/CMakeLists.txt
+index 2bce60968..4492f7550 100644
+--- src/jpeg2000.imageio/CMakeLists.txt
++++ src/jpeg2000.imageio/CMakeLists.txt
+@@ -2,10 +2,9 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-if (OPENJPEG_FOUND)
++if (USE_OPENJPEG)
+     add_oiio_plugin (jpeg2000input.cpp jpeg2000output.cpp
+-                     INCLUDE_DIRS ${OPENJPEG_INCLUDES}
+-                     LINK_LIBRARIES ${OPENJPEG_LIBRARIES}
++                     LINK_LIBRARIES openjp2
+                      DEFINITIONS "USE_OPENJPEG")
+ else()
+     message (WARNING "Jpeg-2000 plugin will not be built")
+diff --git src/jpegxl.imageio/CMakeLists.txt src/jpegxl.imageio/CMakeLists.txt
+index 70d28318a..2f83070a4 100644
+--- src/jpegxl.imageio/CMakeLists.txt
++++ src/jpegxl.imageio/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-if (JXL_FOUND)
++if (USE_JXL)
+     add_oiio_plugin (jxlinput.cpp jxloutput.cpp
+                      INCLUDE_DIRS ${JXL_INCLUDE_DIRS}
+                      LINK_LIBRARIES ${JXL_LIBRARIES}
+diff --git src/libOpenImageIO/CMakeLists.txt src/libOpenImageIO/CMakeLists.txt
+index 1dd60922c..4135f02c6 100644
+--- src/libOpenImageIO/CMakeLists.txt
++++ src/libOpenImageIO/CMakeLists.txt
+@@ -160,11 +160,20 @@ target_link_libraries (OpenImageIO
+             $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIOHeaders>
+             $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
+             $<TARGET_NAME_IF_EXISTS:TBB::tbb>
+-            $<TARGET_NAME_IF_EXISTS:Freetype::Freetype>
+-            ${BZIP2_LIBRARIES}
++            #$<TARGET_NAME_IF_EXISTS:Freetype::Freetype>
++            #${BZIP2_LIBRARIES}
+             ZLIB::ZLIB
++            tsl::robin_map
+             ${CMAKE_DL_LIBS}
+         )
++if (USE_OPENCV)
++    target_link_libraries (OpenImageIO PRIVATE opencv::opencv_core
++                                               opencv::opencv_imgproc
++                                               opencv::opencv_videoio)
++endif()
++if (USE_FREETYPE)
++    target_link_libraries (OpenImageIO PRIVATE Freetype::Freetype)
++endif()
+ 
+ if (WIN32)
+     target_link_libraries (OpenImageIO PRIVATE psapi)
+diff --git src/libutil/CMakeLists.txt src/libutil/CMakeLists.txt
+index 941c1bbc9..3126fd267 100644
+--- src/libutil/CMakeLists.txt
++++ src/libutil/CMakeLists.txt
+@@ -58,6 +58,8 @@ function (setup_oiio_util_library targetname)
+                 ${GCC_ATOMIC_LIBRARIES}
+                 ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
+                 ${OPENIMAGEIO_IMATH_TARGETS}
++                fmt::fmt
++                tsl::robin_map
+             PRIVATE
+                 $<TARGET_NAME_IF_EXISTS:TBB::tbb>
+                 ${CMAKE_DL_LIBS}
+@@ -69,13 +71,6 @@ function (setup_oiio_util_library targetname)
+                                PRIVATE stdc++_libbacktrace)
+     endif ()
+ 
+-    if (OIIO_INTERNALIZE_FMT OR fmt_LOCAL_BUILD)
+-        add_dependencies(${targetname} fmt_internal_target)
+-    else ()
+-        target_link_libraries (${targetname}
+-                               PUBLIC fmt::fmt-header-only)
+-    endif ()
+-
+     if (WIN32)
+         target_compile_definitions(${targetname} PRIVATE
+                                    WIN32_LEAN_AND_MEAN NOMINMAX
+diff --git src/oiiotool/CMakeLists.txt src/oiiotool/CMakeLists.txt
+index 87b6a3e78..279b84b10 100644
+--- src/oiiotool/CMakeLists.txt
++++ src/oiiotool/CMakeLists.txt
+@@ -9,4 +9,5 @@ fancy_add_executable (SYSTEM_INCLUDE_DIRS
+                         OpenImageIO
+                         $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
+                         ${OpenCV_LIBRARIES}
++                        tsl::robin_map
+                      )
+diff --git src/ptex.imageio/CMakeLists.txt src/ptex.imageio/CMakeLists.txt
+index 73e3ad843..da45e8c5f 100644
+--- src/ptex.imageio/CMakeLists.txt
++++ src/ptex.imageio/CMakeLists.txt
+@@ -2,12 +2,9 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-if (Ptex_FOUND)
+-    set(ptex_target Ptex::Ptex_dynamic)
+-    if (TARGET Ptex::Ptex_static AND (NOT TARGET Ptex::Ptex_dynamic OR LINKSTATIC))
+-        set(ptex_target Ptex::Ptex_static)
+-    endif()
++if (USE_PTEX)
+     add_oiio_plugin (ptexinput.cpp
+-                     LINK_LIBRARIES ${ptex_target} ZLIB::ZLIB
++                     LINK_LIBRARIES ${ptex_LIBRARIES} ZLIB::ZLIB
++                     INCLUDE_DIRS ${ptex_INCLUDE_DIRS}
+                      DEFINITIONS "USE_PTEX")
+ endif ()

--- a/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
@@ -335,46 +335,6 @@ index 25606a139..5f520249a 100644
                       DEFINITIONS "USE_HEIF=1")
  else ()
      message (WARNING "heif plugin will not be built")
-diff --git src/iconvert/CMakeLists.txt src/iconvert/CMakeLists.txt
-index 735b88def..8f5bb3b54 100644
---- src/iconvert/CMakeLists.txt
-+++ src/iconvert/CMakeLists.txt
-@@ -2,4 +2,4 @@
- # SPDX-License-Identifier: Apache-2.0
- # https://github.com/AcademySoftwareFoundation/OpenImageIO
- 
--fancy_add_executable (LINK_LIBRARIES OpenImageIO)
-+fancy_add_executable (LINK_LIBRARIES OpenImageIO fmt::fmt)
-diff --git src/idiff/CMakeLists.txt src/idiff/CMakeLists.txt
-index 735b88def..8f5bb3b54 100644
---- src/idiff/CMakeLists.txt
-+++ src/idiff/CMakeLists.txt
-@@ -2,4 +2,4 @@
- # SPDX-License-Identifier: Apache-2.0
- # https://github.com/AcademySoftwareFoundation/OpenImageIO
- 
--fancy_add_executable (LINK_LIBRARIES OpenImageIO)
-+fancy_add_executable (LINK_LIBRARIES OpenImageIO fmt::fmt)
-diff --git src/igrep/CMakeLists.txt src/igrep/CMakeLists.txt
-index 735b88def..8f5bb3b54 100644
---- src/igrep/CMakeLists.txt
-+++ src/igrep/CMakeLists.txt
-@@ -2,4 +2,4 @@
- # SPDX-License-Identifier: Apache-2.0
- # https://github.com/AcademySoftwareFoundation/OpenImageIO
- 
--fancy_add_executable (LINK_LIBRARIES OpenImageIO)
-+fancy_add_executable (LINK_LIBRARIES OpenImageIO fmt::fmt)
-diff --git src/iinfo/CMakeLists.txt src/iinfo/CMakeLists.txt
-index 735b88def..8f5bb3b54 100644
---- src/iinfo/CMakeLists.txt
-+++ src/iinfo/CMakeLists.txt
-@@ -2,4 +2,4 @@
- # SPDX-License-Identifier: Apache-2.0
- # https://github.com/AcademySoftwareFoundation/OpenImageIO
- 
--fancy_add_executable (LINK_LIBRARIES OpenImageIO)
-+fancy_add_executable (LINK_LIBRARIES OpenImageIO fmt::fmt)
 diff --git src/include/CMakeLists.txt src/include/CMakeLists.txt
 index 3ab45a570..9b6511b78 100644
 --- src/include/CMakeLists.txt
@@ -485,15 +445,14 @@ index 941c1bbc9..3126fd267 100644
          target_compile_definitions(${targetname} PRIVATE
                                     WIN32_LEAN_AND_MEAN NOMINMAX
 diff --git src/oiiotool/CMakeLists.txt src/oiiotool/CMakeLists.txt
-index 87b6a3e78..acd0cb985 100644
+index 87b6a3e78..279b84b10 100644
 --- src/oiiotool/CMakeLists.txt
 +++ src/oiiotool/CMakeLists.txt
-@@ -9,4 +9,6 @@ fancy_add_executable (SYSTEM_INCLUDE_DIRS
+@@ -9,4 +9,5 @@ fancy_add_executable (SYSTEM_INCLUDE_DIRS
                          OpenImageIO
                          $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
                          ${OpenCV_LIBRARIES}
 +                        tsl::robin_map
-+                        fmt::fmt
                       )
 diff --git src/ptex.imageio/CMakeLists.txt src/ptex.imageio/CMakeLists.txt
 index 73e3ad843..da45e8c5f 100644

--- a/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
@@ -335,6 +335,46 @@ index 25606a139..5f520249a 100644
                       DEFINITIONS "USE_HEIF=1")
  else ()
      message (WARNING "heif plugin will not be built")
+diff --git src/iconvert/CMakeLists.txt src/iconvert/CMakeLists.txt
+index 735b88def..8f5bb3b54 100644
+--- src/iconvert/CMakeLists.txt
++++ src/iconvert/CMakeLists.txt
+@@ -2,4 +2,4 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-fancy_add_executable (LINK_LIBRARIES OpenImageIO)
++fancy_add_executable (LINK_LIBRARIES OpenImageIO fmt::fmt)
+diff --git src/idiff/CMakeLists.txt src/idiff/CMakeLists.txt
+index 735b88def..8f5bb3b54 100644
+--- src/idiff/CMakeLists.txt
++++ src/idiff/CMakeLists.txt
+@@ -2,4 +2,4 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-fancy_add_executable (LINK_LIBRARIES OpenImageIO)
++fancy_add_executable (LINK_LIBRARIES OpenImageIO fmt::fmt)
+diff --git src/igrep/CMakeLists.txt src/igrep/CMakeLists.txt
+index 735b88def..8f5bb3b54 100644
+--- src/igrep/CMakeLists.txt
++++ src/igrep/CMakeLists.txt
+@@ -2,4 +2,4 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-fancy_add_executable (LINK_LIBRARIES OpenImageIO)
++fancy_add_executable (LINK_LIBRARIES OpenImageIO fmt::fmt)
+diff --git src/iinfo/CMakeLists.txt src/iinfo/CMakeLists.txt
+index 735b88def..8f5bb3b54 100644
+--- src/iinfo/CMakeLists.txt
++++ src/iinfo/CMakeLists.txt
+@@ -2,4 +2,4 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # https://github.com/AcademySoftwareFoundation/OpenImageIO
+ 
+-fancy_add_executable (LINK_LIBRARIES OpenImageIO)
++fancy_add_executable (LINK_LIBRARIES OpenImageIO fmt::fmt)
 diff --git src/include/CMakeLists.txt src/include/CMakeLists.txt
 index 3ab45a570..9b6511b78 100644
 --- src/include/CMakeLists.txt
@@ -445,14 +485,15 @@ index 941c1bbc9..3126fd267 100644
          target_compile_definitions(${targetname} PRIVATE
                                     WIN32_LEAN_AND_MEAN NOMINMAX
 diff --git src/oiiotool/CMakeLists.txt src/oiiotool/CMakeLists.txt
-index 87b6a3e78..279b84b10 100644
+index 87b6a3e78..acd0cb985 100644
 --- src/oiiotool/CMakeLists.txt
 +++ src/oiiotool/CMakeLists.txt
-@@ -9,4 +9,5 @@ fancy_add_executable (SYSTEM_INCLUDE_DIRS
+@@ -9,4 +9,6 @@ fancy_add_executable (SYSTEM_INCLUDE_DIRS
                          OpenImageIO
                          $<TARGET_NAME_IF_EXISTS:OpenEXR::OpenEXR>
                          ${OpenCV_LIBRARIES}
 +                        tsl::robin_map
++                        fmt::fmt
                       )
 diff --git src/ptex.imageio/CMakeLists.txt src/ptex.imageio/CMakeLists.txt
 index 73e3ad843..da45e8c5f 100644

--- a/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
@@ -21,7 +21,7 @@ index 322465767..c88ffdb08 100644
  endif ()
  
 diff --git src/cmake/externalpackages.cmake src/cmake/externalpackages.cmake
-index 612d95a60..fb80f1404 100644
+index 612d95a60..b09e8ec87 100644
 --- src/cmake/externalpackages.cmake
 +++ src/cmake/externalpackages.cmake
 @@ -73,16 +73,15 @@ set (OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH OFF CACHE BOOL
@@ -49,26 +49,22 @@ index 612d95a60..fb80f1404 100644
  endif ()
  
  
-@@ -92,9 +91,15 @@ alias_library_if_not_exists (TIFF::TIFF TIFF::tiff)
+@@ -92,9 +91,11 @@ alias_library_if_not_exists (TIFF::TIFF TIFF::tiff)
  
  # JPEG XL
  option (USE_JXL "Enable JPEG XL support" ON)
 -checked_find_package (JXL
 -                      VERSION_MIN 0.10.1
 -                      DEFINITIONS USE_JXL=1)
-+if (USE_JXL)
-+    checked_find_package (libjxl REQUIRED
++if (USE_LIBJXL)
++    checked_find_package (libjxl REQUIRED CONFIG
 +                          VERSION_MIN 0.10.1
 +                          DEFINITIONS USE_JXL=1)
 +endif()
-+# TODO
-+# checked_find_package (JXL
-+#                       VERSION_MIN 0.10.1
-+#                       DEFINITIONS USE_JXL=1)
  
  # Pugixml setup.  Normally we just use the version bundled with oiio, but
  # some linux distros are quite particular about having separate packages so we
-@@ -109,7 +114,7 @@ else ()
+@@ -109,7 +110,7 @@ else ()
  endif()
  
  # From pythonutils.cmake
@@ -77,7 +73,7 @@ index 612d95a60..fb80f1404 100644
  if (USE_PYTHON)
      checked_find_package (pybind11 REQUIRED VERSION_MIN 2.7)
  endif ()
-@@ -119,85 +124,117 @@ endif ()
+@@ -119,85 +120,117 @@ endif ()
  # Dependencies for optional formats and features. If these are not found,
  # we will continue building, but the related functionality will be disabled.
  
@@ -252,7 +248,7 @@ index 612d95a60..fb80f1404 100644
      checked_find_package (Qt6 COMPONENTS Core Gui Widgets OpenGLWidgets)
      if (NOT Qt6_FOUND)
          checked_find_package (Qt5 COMPONENTS Core Gui Widgets OpenGL)
-@@ -210,10 +247,7 @@ endif ()
+@@ -210,10 +243,7 @@ endif ()
  
  
  # Tessil/robin-map
@@ -264,7 +260,7 @@ index 612d95a60..fb80f1404 100644
  
  # fmtlib
  option (OIIO_INTERNALIZE_FMT "Copy fmt headers into <install>/include/OpenImageIO/detail/fmt" ON)
-@@ -222,7 +256,7 @@ checked_find_package (fmt REQUIRED
+@@ -222,7 +252,7 @@ checked_find_package (fmt REQUIRED
                        VERSION_MAX 11.99
                        BUILD_LOCAL missing
                       )
@@ -370,18 +366,22 @@ index 2bce60968..4492f7550 100644
  else()
      message (WARNING "Jpeg-2000 plugin will not be built")
 diff --git src/jpegxl.imageio/CMakeLists.txt src/jpegxl.imageio/CMakeLists.txt
-index 70d28318a..2f83070a4 100644
+index 70d28318a..e0e29d4c7 100644
 --- src/jpegxl.imageio/CMakeLists.txt
 +++ src/jpegxl.imageio/CMakeLists.txt
-@@ -2,7 +2,7 @@
+@@ -2,10 +2,9 @@
  # SPDX-License-Identifier: Apache-2.0
  # https://github.com/AcademySoftwareFoundation/OpenImageIO
  
 -if (JXL_FOUND)
-+if (USE_JXL)
++if (USE_LIBJXL)
      add_oiio_plugin (jxlinput.cpp jxloutput.cpp
-                      INCLUDE_DIRS ${JXL_INCLUDE_DIRS}
-                      LINK_LIBRARIES ${JXL_LIBRARIES}
+-                     INCLUDE_DIRS ${JXL_INCLUDE_DIRS}
+-                     LINK_LIBRARIES ${JXL_LIBRARIES}
++                     LINK_LIBRARIES libjxl::libjxl
+                      DEFINITIONS "USE_JXL")
+ else()
+     message (WARNING "JPEG XL plugin will not be built")
 diff --git src/libOpenImageIO/CMakeLists.txt src/libOpenImageIO/CMakeLists.txt
 index 1dd60922c..406c0f8a1 100644
 --- src/libOpenImageIO/CMakeLists.txt

--- a/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/3.0.0.0-cmake-targets.patch
@@ -21,7 +21,7 @@ index 322465767..c88ffdb08 100644
  endif ()
  
 diff --git src/cmake/externalpackages.cmake src/cmake/externalpackages.cmake
-index 612d95a60..d7dd711a4 100644
+index 612d95a60..fb80f1404 100644
 --- src/cmake/externalpackages.cmake
 +++ src/cmake/externalpackages.cmake
 @@ -73,16 +73,15 @@ set (OPENIMAGEIO_CONFIG_DO_NOT_FIND_IMATH OFF CACHE BOOL
@@ -49,13 +49,18 @@ index 612d95a60..d7dd711a4 100644
  endif ()
  
  
-@@ -92,9 +91,10 @@ alias_library_if_not_exists (TIFF::TIFF TIFF::tiff)
+@@ -92,9 +91,15 @@ alias_library_if_not_exists (TIFF::TIFF TIFF::tiff)
  
  # JPEG XL
  option (USE_JXL "Enable JPEG XL support" ON)
 -checked_find_package (JXL
 -                      VERSION_MIN 0.10.1
 -                      DEFINITIONS USE_JXL=1)
++if (USE_JXL)
++    checked_find_package (libjxl REQUIRED
++                          VERSION_MIN 0.10.1
++                          DEFINITIONS USE_JXL=1)
++endif()
 +# TODO
 +# checked_find_package (JXL
 +#                       VERSION_MIN 0.10.1
@@ -63,7 +68,7 @@ index 612d95a60..d7dd711a4 100644
  
  # Pugixml setup.  Normally we just use the version bundled with oiio, but
  # some linux distros are quite particular about having separate packages so we
-@@ -109,7 +109,7 @@ else ()
+@@ -109,7 +114,7 @@ else ()
  endif()
  
  # From pythonutils.cmake
@@ -72,7 +77,7 @@ index 612d95a60..d7dd711a4 100644
  if (USE_PYTHON)
      checked_find_package (pybind11 REQUIRED VERSION_MIN 2.7)
  endif ()
-@@ -119,85 +119,117 @@ endif ()
+@@ -119,85 +124,117 @@ endif ()
  # Dependencies for optional formats and features. If these are not found,
  # we will continue building, but the related functionality will be disabled.
  
@@ -247,7 +252,7 @@ index 612d95a60..d7dd711a4 100644
      checked_find_package (Qt6 COMPONENTS Core Gui Widgets OpenGLWidgets)
      if (NOT Qt6_FOUND)
          checked_find_package (Qt5 COMPONENTS Core Gui Widgets OpenGL)
-@@ -210,10 +242,7 @@ endif ()
+@@ -210,10 +247,7 @@ endif ()
  
  
  # Tessil/robin-map
@@ -259,7 +264,7 @@ index 612d95a60..d7dd711a4 100644
  
  # fmtlib
  option (OIIO_INTERNALIZE_FMT "Copy fmt headers into <install>/include/OpenImageIO/detail/fmt" ON)
-@@ -222,7 +251,7 @@ checked_find_package (fmt REQUIRED
+@@ -222,7 +256,7 @@ checked_find_package (fmt REQUIRED
                        VERSION_MAX 11.99
                        BUILD_LOCAL missing
                       )
@@ -378,10 +383,18 @@ index 70d28318a..2f83070a4 100644
                       INCLUDE_DIRS ${JXL_INCLUDE_DIRS}
                       LINK_LIBRARIES ${JXL_LIBRARIES}
 diff --git src/libOpenImageIO/CMakeLists.txt src/libOpenImageIO/CMakeLists.txt
-index 1dd60922c..4135f02c6 100644
+index 1dd60922c..406c0f8a1 100644
 --- src/libOpenImageIO/CMakeLists.txt
 +++ src/libOpenImageIO/CMakeLists.txt
-@@ -160,11 +160,20 @@ target_link_libraries (OpenImageIO
+@@ -153,6 +153,7 @@ target_link_libraries (OpenImageIO
+             OpenImageIO_Util
+             ${OPENIMAGEIO_IMATH_DEPENDENCY_VISIBILITY}
+             ${OPENIMAGEIO_IMATH_TARGETS}
++            fmt::fmt
+         PRIVATE
+             ${OPENIMAGEIO_OPENEXR_TARGETS}
+             ${format_plugin_libs} # Add all the target link libraries from the plugins
+@@ -160,11 +161,20 @@ target_link_libraries (OpenImageIO
              $<TARGET_NAME_IF_EXISTS:OpenColorIO::OpenColorIOHeaders>
              $<TARGET_NAME_IF_EXISTS:pugixml::pugixml>
              $<TARGET_NAME_IF_EXISTS:TBB::tbb>

--- a/recipes/openimageio/config.yml
+++ b/recipes/openimageio/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "2.5.16.0":
     folder: all
+  "3.0.0.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/3.0.0.0**

**NOTE:** Right now this is a draft using the beta-tag to prepare the MR to be updated once the release is ready.

#### Motivation
OpenImageIO 3.0.0.0 brings a larger update of the infrastructure, new file formats (especially Jpeg XL which now becomes popular) etc.

#### Details
Larger changes in the build system introducing the need to adapt a few things, especially:
- libjxl/JpegXS support only being available in 3.0.0.0 and newer
- boost no longer needed beginning with 3.0.0.0
- C++17 now the required standard for Version >= 3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x ] Tested locally with at least one configuration using a recent version of Conan
