### PR TITLE
meson: add version 1.6.0

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/mesonbuild/meson/archive/1.6.0.tar.gz"
+    sha256: "342300656bfdafb6cc09325bdd0fd507366ecaa6be25fa4525f50889adf7c606"
   "1.5.1":
     url: "https://github.com/mesonbuild/meson/archive/1.5.1.tar.gz"
     sha256: "55f6acd5bf72c14d4aa5a781993633f84a1d117bdf2c2057735902ced9b81390"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.0":
+    folder: all
   "1.5.1":
     folder: all
   "1.5.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **meson/1.6.0**

#### Motivation
There are several new features in 1.6.0.

#### Details
https://github.com/mesonbuild/meson/compare/1.5.1...1.6.0#files_bucket

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
