### PR TITLE
rocksdb: add version 9.7.3

### DIFF
--- a/recipes/rocksdb/all/conandata.yml
+++ b/recipes/rocksdb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "9.7.3":
+    url: "https://github.com/facebook/rocksdb/archive/refs/tags/v9.7.3.tar.gz"
+    sha256: "acfabb989cbfb5b5c4d23214819b059638193ec33dad2d88373c46448d16d38b"
   "9.7.2":
     url: "https://github.com/facebook/rocksdb/archive/refs/tags/v9.7.2.tar.gz"
     sha256: "13e9c41d290199ee0185590d4fa9d327422aaf75765b3193945303c3c314e07d"

--- a/recipes/rocksdb/config.yml
+++ b/recipes/rocksdb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "9.7.3":
+    folder: all
   "9.7.2":
     folder: all
   "9.5.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **rocksdb/9.7.3**

#### Motivation
There is a behavior change in 9.7.3.

#### Details
https://github.com/facebook/rocksdb/compare/v9.7.2...v9.7.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
