### PR TITLE
add socket system library to crowcpp's package

### DIFF
--- a/recipes/crowcpp-crow/all/conanfile.py
+++ b/recipes/crowcpp-crow/all/conanfile.py
@@ -117,6 +117,8 @@ class CrowConan(ConanFile):
 
         if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.system_libs = ["pthread"]
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["wsock32", "ws2_32"]
 
         self.cpp_info.set_property("cmake_file_name", "Crow")
         self.cpp_info.set_property("cmake_target_name", "Crow::Crow")


### PR DESCRIPTION
### Summary
Changes to recipe:  Add "wsock32", "ws2_32" to the package_info when on windows so that linking can function on windows.

#### Motivation
Previously with msys2 clang, the above libraries were missing from the linker args.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
