### PR TITLE
Botan: add version 3.6.0

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -38,6 +38,9 @@ sources:
   "3.5.0":
     url: "https://github.com/randombit/botan/archive/3.5.0.tar.gz"
     sha256: "7d91d3349e6029e1a6929a50ab587f9fd4e29a9af3f3d698553451365564001f"
+  "3.6.0":
+    url: "https://github.com/randombit/botan/archive/3.6.0.tar.gz"
+    sha256: "950199a891fab62dca78780b36e12f89031c37350b2a16a2c35f2e423c041bad"
 patches:
   "2.18.2":
     - patch_file: "patches/fix-amalgamation-build.patch"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -25,3 +25,5 @@ versions:
     folder: all
   "3.5.0":
     folder: all
+  "3.6.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **botan/3.6.0**

#### Motivation

Version bump

#### Details

See the release notes here: https://github.com/randombit/botan/blob/master/news.rst#version-360-2024-10-21

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
