### PR TITLE
Botan: add version 2.19.5

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -17,6 +17,9 @@ sources:
   "2.19.4":
     url: "https://github.com/randombit/botan/archive/2.19.4.tar.gz"
     sha256: "5754a6b5ddc3c74b0cb8671531feea69d03a4f3b5bdafa5f75e4c73a1242e5b1"
+  "2.19.5":
+    url: "https://github.com/randombit/botan/archive/2.19.5.tar.gz"
+    sha256: "8d4a3826787f9febbdc225172ad2d39d7d3960346c5721fe46cb27d480d7e1de"
   "3.0.0":
     url: "https://github.com/randombit/botan/archive/3.0.0.tar.gz"
     sha256: "8bafe2e965fa9ccf92ef5741165d735c9fbbe6376c373bbf5702495ad2dfb814"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -11,6 +11,8 @@ versions:
     folder: all
   "2.19.4":
     folder: all
+  "2.19.5":
+    folder: all
   "3.0.0":
     folder: all
   "3.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **botan/2.19.5**

#### Motivation

Bugfix release of botan's legacy 2.x branch. This update was missed when it got released back in July.

#### Details

See the release notes: https://github.com/randombit/botan/blob/release-2/news.rst#version-2195-2024-07-08
Also note that Botan 2.x is currently scheduled to reach its end of life by the end of 2024.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
