### PR TITLE
foxglove-websocket: add version 1.3.1

### DIFF
--- a/recipes/foxglove-websocket/all/conandata.yml
+++ b/recipes/foxglove-websocket/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  1.3.1:
+    url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v1.3.1.tar.gz
+    sha256: 48bae8599603da893e559b952e7fec1392aeb55cc6d59288feac6e6428e61bef
   1.3.0:
     url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v1.3.0.tar.gz
     sha256: 5c1d4cda60a89bf635ef0150e8cd2f4da569f92beb8ac8555795ed7fd47f2a21

--- a/recipes/foxglove-websocket/config.yml
+++ b/recipes/foxglove-websocket/config.yml
@@ -1,4 +1,6 @@
 versions:
+  1.3.1:
+    folder: all
   1.3.0:
     folder: all
   1.2.0:


### PR DESCRIPTION
### Summary
Changes to recipe:  **foxglove-websocket/1.3.1**

#### Motivation
Version bump

#### Details
New version available: https://github.com/foxglove/ws-protocol/releases/tag/releases%2Fcpp%2Fv1.3.1


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
