### PR TITLE
Updates to MSYS2

### DIFF
--- a/recipes/msys2/all/conandata.yml
+++ b/recipes/msys2/all/conandata.yml
@@ -1,7 +1,6 @@
 sources:
   "cci.latest":
     url:
-      - "https://github.com/msys2/msys2-installer/releases/download/2023-10-26/msys2-base-x86_64-20231026.tar.xz"
-      - "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20231026.tar.xz"
-      - "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20231026.tar.xz"
-    sha256: "fa75120560563a311241c05882016978bd35612692c7f0d39815a27837bff27d"
+      - "https://github.com/msys2/msys2-installer/releases/download/2024-07-27/msys2-base-x86_64-20240727.tar.xz"
+      - "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20240727.tar.xz"
+    sha256: "da19afcc9b635967b3bfc0db119bf848ed6c28fdde8e4678d9f838d678939060"

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -47,13 +47,15 @@ class MSYS2Conan(ConanFile):
         "exclude_files": ["ANY"],
         "packages": ["ANY"],
         "additional_packages": [None, "ANY"],
-        "no_kill": [True, False]
+        "no_kill": [True, False],
+        "gpg_dirmngr_honor_http_proxy": [True, False],
     }
     default_options = {
         "exclude_files": "*/link.exe",
         "packages": "base-devel,binutils,gcc",
         "additional_packages": None,
         "no_kill": False,
+        "gpg_dirmngr_honor_http_proxy": False,
     }
 
     short_paths = True
@@ -77,6 +79,12 @@ class MSYS2Conan(ConanFile):
     def _update_pacman(self):
         with chdir(self, os.path.join(self._msys_dir, "usr", "bin")):
             try:
+                if self.options.gpg_dirmngr_honor_http_proxy:
+                    # the following bash lines  must not run with login shells as otherwise the key refresh would be triggered prematurely
+                    self.run('bash -c "PATH=/bin:/usr/bin pacman-key --init"') # creates and initializes /etc/pacman.d/gnupg/
+                    self.run('bash -c "PATH=/bin:/usr/bin echo honor-http-proxy > /etc/pacman.d/gnupg/dirmngr.conf"')
+                    self.run('bash -c "PATH=/bin:/usr/bin pacman-key --populate"')
+
                 self._kill_pacman()
 
                 # https://www.msys2.org/docs/ci/


### PR DESCRIPTION
### Summary
Changes to recipe:  **msys2/cci.latest**

#### Motivation
MSYS2 by default does not work properly behind a corporate proxy. I had created  #25499 originally but then later found out that the option  `honor-http-proxy` must be enabled with GnuPG as used by `pacman`.

#### Details
- version bump to latest release `msys2-base-x86_64-20240727.tar.xz`
- removal of SourceForge download mirror as Sourceforge doesn't receive updates anymore
- added new option `gpg_dirmngr_honor_http_proxy`. When enabled, the gpg dirmngr used by pacman will honor http_proxy et al for the key refreshes and MSYS will no longer hang forever on installation. The option is disabled by default and I successfully tested it locally with my profile having

```ini
[options]
 msys2/*:gpg_dirmngr_honor_http_proxy=True
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
