### PR TITLE
Update to SQLite3 Multiple Ciphers 1.9.0

### DIFF
--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.0":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.9.0.tar.gz"
+    sha256: "b30dcf695ad3a53b32b8907a3920ab2b38670c7d37232839d0fb3148c41166da"
   "1.8.6":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.8.6.tar.gz"
     sha256: "7250e3d9ca4368df00d0ebfaa744add66b458a5de318728b95369d621ebf2028"

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.0":
+    folder: all
   "1.8.6":
     folder: all
   "1.8.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3mc**

#### Motivation

**sqlite3mc version 1.9.0** includes an important bug fix for the SQLCipher cipher scheme.

#### Details

An entry for version 1.9.0 was added to the recipe.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
