### PR TITLE
pybind11_json: avoid linking pybind11_all_do_not_use

### DIFF
--- a/recipes/pybind11_json/all/conandata.yml
+++ b/recipes/pybind11_json/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.14":
+    url: "https://github.com/pybind/pybind11_json/archive/0.2.14.tar.gz"
+    sha256: "bc4ad7e308add59886a961c21f3ba431e43fe7faa2ef5bd9925c66d042d28cde"
   "0.2.13":
     url: "https://github.com/pybind/pybind11_json/archive/0.2.13.tar.gz"
     sha256: "6b12ddb4930a3135322890318fc15c4a69134f21120ea82163827c11411107a3"

--- a/recipes/pybind11_json/all/conanfile.py
+++ b/recipes/pybind11_json/all/conanfile.py
@@ -41,6 +41,10 @@ class Pybind11JsonConan(ConanFile):
              src=os.path.join(self.source_folder, "include"))
 
     def package_info(self):
+        # By default pybind11::pybind11_all_do_not_use target is used, which is obviously wrong.
+        # Maybe instead pybind11::pybind11 lighter pybind11::headers would be better?
+        self.cpp_info.requires = ["pybind11::pybind11", "nlohmann_json::nlohmann_json"]
+
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
 

--- a/recipes/pybind11_json/all/conanfile.py
+++ b/recipes/pybind11_json/all/conanfile.py
@@ -41,11 +41,8 @@ class Pybind11JsonConan(ConanFile):
              src=os.path.join(self.source_folder, "include"))
 
     def package_info(self):
-        # By default pybind11::pybind11_all_do_not_use target is used, which is obviously wrong.
-        # Maybe instead pybind11::pybind11 lighter pybind11::headers would be better?
-        self.cpp_info.requires = ["pybind11::pybind11", "nlohmann_json::nlohmann_json"]
-
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
 
         self.cpp_info.set_property("cmake_target_aliases", ["pybind11_json"])
+        self.cpp_info.components["pybind11_json"].requires = ["pybind11::pybind11_", "nlohmann_json::nlohmann_json"]

--- a/recipes/pybind11_json/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11_json/all/test_package/CMakeLists.txt
@@ -8,3 +8,4 @@ find_package(pybind11_json REQUIRED CONFIG)
 add_executable(test_package test_package.cpp)
  # FIXME: target should be pybind11_json, replace once Conan v1 has been dropped
 target_link_libraries(test_package PUBLIC pybind11_json::pybind11_json)
+target_link_libraries(test_package PUBLIC pybind11::embed)

--- a/recipes/pybind11_json/config.yml
+++ b/recipes/pybind11_json/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.14":
+    folder: all
   "0.2.13":
     folder: all
   "0.2.12":


### PR DESCRIPTION
### Summary
Changes to recipe:  **pybind11_json/0.2.x**

#### Motivation
`CMakeDeps` incorrectly links to `pybind11_all_do_not_use`. See: https://github.com/conan-io/conan-center-index/issues/25685  
This is technically a breaking change, since `test_package` requires now linking to `pybind11::embed`. But this is how it should be, as the client project should choose whether `pybind11::embed` or `pybind11::module` should be linked.

#### Details
- Linking `pybind11_json` doesn't link to `pybind11_all_do_not_use` any more.
- Added version 0.2.14.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
