### PR TITLE
asio: add version 1.32.0, remove older versions

### DIFF
--- a/recipes/asio/all/conandata.yml
+++ b/recipes/asio/all/conandata.yml
@@ -1,85 +1,30 @@
 sources:
+  "1.32.0":
+    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-32-0.tar.gz"
+    sha256: "f1b94b80eeb00bb63a3c8cef5047d4e409df4d8a3fe502305976965827d95672"
   "1.31.0":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-31-0.tar.gz"
     sha256: "530540f973498c2d297771af1bc852f69b27509bbb56bc7ac3309c928373286f"
   "1.30.2":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-30-2.tar.gz"
     sha256: "755bd7f85a4b269c67ae0ea254907c078d408cce8e1a352ad2ed664d233780e8"
-  "1.30.1":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-30-1.tar.gz"
-    sha256: "94b121cc2016680f2314ef58eadf169c2d34fff97fba01df325a192d502d3a58"
+  # keep 1.29.0 for crowcpp-crow, restinio, fast-dds, asio-grpc
   "1.29.0":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-29-0.tar.gz"
     sha256: "44305859b4e6664dbbf853c1ef8ca0259d694f033753ae309fcb2534ca20f721"
-  "1.28.2":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-28-2.tar.gz"
-    sha256: "5705a0e403017eba276625107160498518838064a6dd7fd8b00b2e30c0ffbdee"
+  # keep 1.28.1 for openscenegraph, restinio, simple-websocket-server, websocketpp
   "1.28.1":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-28-1.tar.gz"
     sha256: "5ff6111ec8cbe73a168d997c547f562713aa7bd004c5c02326f0e9d579a5f2ce"
-  "1.28.0":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-28-0.tar.gz"
-    sha256: "226438b0798099ad2a202563a83571ce06dd13b570d8fded4840dbc1f97fa328"
+  # keep 1.27.0 for cppserver
   "1.27.0":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-27-0.tar.gz"
     sha256: "b31c63867daaba0e460ee2c85dc508a52c81db0a7318e0d2147f444b26f80ed7"
-  "1.26.0":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-26-0.tar.gz"
-    sha256: "935583f86825b7b212479277d03543e0f419a55677fa8cb73a79a927b858a72d"
-  "1.24.0":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-24-0.tar.gz"
-    sha256: "cbcaaba0f66722787b1a7c33afe1befb3a012b5af3ad7da7ff0f6b8c9b7a8a5b"
-  "1.23.0":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-23-0.tar.gz"
-    sha256: "facae7627ce6c716add3f328eee3d78c2e6e133a46ac5ecb80897b37ebacf05e"
-  "1.22.1":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-22-1.tar.gz"
-    sha256: "30cb54a5de5e465d10ec0c2026d6b5917f5e89fffabdbabeb1475846fc9a2cf0"
-  "1.22.0":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-22-0.tar.gz"
-    sha256: "17bfd506f6d55c85a33603277a256b42ca5883bf290930040489ffeeed23724a"
-  "1.21.0":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-21-0.tar.gz"
-    sha256: "5d2d2dcb7bfb39bff941cabbfc8c27ee322a495470bf0f3a7c5238648cf5e6a9"
-  "1.20.0":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-20-0.tar.gz"
-    sha256: "34a8f07be6f54e3753874d46ecfa9b7ab7051c4e3f67103c52a33dfddaea48e6"
-  "1.19.2":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-19-2.tar.gz"
-    sha256: "5ee191aee825dfb1325cbacf643d599b186de057c88464ea98f1bae5ba4ff47a"
-  "1.19.1":
-    url: "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-19-1.tar.gz"
-    sha256: "2555e0a29256de5c77d6a34b14faefd28c76555e094ba0371acb0b91d483520e"
-  "1.19.0":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-19-0.tar.gz"
-    sha256: "11bc0e22fcdfb3f0b77574ac33760a3592c0dac7e7eece7668b823c158243629"
-  "1.18.2":
-    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-18-2.tar.gz"
-    sha256: "8d67133b89e0f8b212e9f82fdcf1c7b21a978d453811e2cd941c680e72c2ca32"
+  # keep 1.18.1 for packio
   "1.18.1":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-18-1.tar.gz"
     sha256: "39c721b987b7a0d2fe2aee64310bd128cd8cc10f43481604d18cb2d8b342fd40"
-  "1.18.0":
-    sha256: 820688d1e0387ff55194ae20036cbae0fb3c7d11b7c3f46492369723c01df96f
-    url: https://github.com/chriskohlhoff/asio/archive/asio-1-18-0.tar.gz
-  "1.17.0":
-    sha256: 46406a830f8334b3789e7352ed7309a39c7c30b685b0499d289eda4fd4ae2067
-    url: https://github.com/chriskohlhoff/asio/archive/asio-1-17-0.tar.gz
+  # keep 1.16.1 for simple-websocket-server
   "1.16.1":
     sha256: e40bbd531530f08318b7c7d7e84e457176d8eae6f5ad2e3714dc27b9131ecd35
     url: https://github.com/chriskohlhoff/asio/archive/asio-1-16-1.tar.gz
-  "1.16.0":
-    sha256: c87410ea62de6245aa239b9ed2057edf01d7f66acc3f5e50add9a29343c87512
-    url: https://github.com/chriskohlhoff/asio/archive/asio-1-16-0.tar.gz
-  "1.14.1":
-    sha256: 5b12ce2cdb658025e67785f954f74b052709cfc9b5941b8fb889c049b0955e1d
-    url: https://github.com/chriskohlhoff/asio/archive/asio-1-14-1.tar.gz
-  "1.14.0":
-    sha256: bdb01a649c24d73ca4a836662e7af442d935313ed6deef6b07f17f3bc5f78d7a
-    url: https://github.com/chriskohlhoff/asio/archive/asio-1-14-0.tar.gz
-  "1.13.0":
-    sha256: 54a1208d20f2104dbd6b7a04a9262f5ab649f4b7a9faf7eac4c2294e9e104c06
-    url: https://github.com/chriskohlhoff/asio/archive/asio-1-13-0.tar.gz
-  "1.12.2":
-    sha256: 1de23266b956674e766cd0b6c929a11259f2284ea8e96b765cc8c67b1689e0fd
-    url: https://github.com/chriskohlhoff/asio/archive/asio-1-12-2.tar.gz

--- a/recipes/asio/config.yml
+++ b/recipes/asio/config.yml
@@ -1,57 +1,17 @@
 versions:
+  "1.32.0":
+    folder: all
   "1.31.0":
     folder: all
   "1.30.2":
     folder: all
-  "1.30.1":
-    folder: all
   "1.29.0":
-    folder: all
-  "1.28.2":
     folder: all
   "1.28.1":
     folder: all
-  "1.28.0":
-    folder: all
   "1.27.0":
-    folder: all
-  "1.26.0":
-    folder: all
-  "1.24.0":
-    folder: all
-  "1.23.0":
-    folder: all
-  "1.22.1":
-    folder: all
-  "1.22.0":
-    folder: all
-  "1.21.0":
-    folder: all
-  "1.20.0":
-    folder: all
-  "1.19.2":
-    folder: all
-  "1.19.1":
-    folder: all
-  "1.19.0":
-    folder: all
-  "1.18.2":
     folder: all
   "1.18.1":
     folder: all
-  "1.18.0":
-    folder: all
-  "1.17.0":
-    folder: all
   "1.16.1":
-    folder: all
-  "1.16.0":
-    folder: all
-  "1.14.1":
-    folder: all
-  "1.14.0":
-    folder: all
-  "1.13.0":
-    folder: all
-  "1.12.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **asio/1.32.0**

#### Motivation
There are several improvements in 1.32.0.

#### Details
https://github.com/chriskohlhoff/asio/compare/asio-1-31-0...asio-1-32-0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
