### PR TITLE
Add `.conanrunner` & `.conanrc` to gitignored ignored, alongside `conan_home`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ conanbuildinfo.txt
 conaninfo.txt
 graph_info.json
 build/
-conan_home/
 .conanrunner/
 .conanrc
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ conanbuildinfo.txt
 conaninfo.txt
 graph_info.json
 build/
+conan_home/
+.conanrunner/
 
 # CMake
 CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ graph_info.json
 build/
 conan_home/
 .conanrunner/
+.conanrc
 
 # CMake
 CMakeUserPresets.json


### PR DESCRIPTION
`.conanrunner` is a folder created by the runner feature when using it to create packages from docker, and it's helpful if it's already ignored by git

Alongside it `conan_home` is my (maybe in the docs too?) convention for the value of `CONAN_HOME` env var or the `conan_home` variable in `.conanrc` (Files which for now will also be ignored), which is an useful feature when trying to isolate runner builds, for which creating a separate conan_home for the build is usually the best approach