### PR TITLE
[glfw] do not link explicitly to opengl

### DIFF
--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -61,6 +61,8 @@ class GlfwConan(ConanFile):
 
         if self.options.get_safe("with_wayland"):
             self.options["xkbcommon"].with_wayland = True
+            self.options["wayland"].shared = True
+            self.options["xkbcommon"].shared = True
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -76,8 +78,14 @@ class GlfwConan(ConanFile):
             self.requires("xkbcommon/1.6.0")
 
     def validate(self):
-        if self.options.get_safe("with_wayland") and not self.dependencies["xkbcommon"].options.with_wayland:
-            raise ConanInvalidConfiguration(f"{self.ref} requires the with_wayland option in xkbcommon to be enabled when the with_wayland option is enabled")
+        if self.options.get_safe("with_wayland"):
+            xkbcommon_options = self.dependencies["xkbcommon"].options
+            if not xkbcommon_options.with_wayland:
+                raise ConanInvalidConfiguration(f"{self.ref} requires the with_wayland option in xkbcommon to be enabled when the with_wayland option is enabled")
+            if not xkbcommon_options.shared:
+                raise ConanInvalidConfiguration(f"{self.ref} always loads xkbcommon dependencies dynamically and does not support static linkage")
+            if not self.dependencies["wayland"].options.shared:
+                raise ConanInvalidConfiguration(f"{self.ref} always loads wayland dependencies dynamically and does not support static linkage")
 
     def build_requirements(self):
         if self.options.get_safe("with_wayland"):

--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -66,7 +66,6 @@ class GlfwConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("opengl/system")
         if self.options.vulkan_static:
             self.requires("vulkan-loader/1.3.268.0")
         if self.settings.os in ["Linux", "FreeBSD"]:
@@ -215,7 +214,6 @@ class GlfwConan(ConanFile):
                 "CoreServices", "Foundation", "IOKit",
             ])
 
-        self.cpp_info.requires = ["opengl::opengl"]
         if self.options.vulkan_static:
             self.cpp_info.requires.append("vulkan-loader::vulkan-loader")
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/glfw/all/test_package/CMakeLists.txt
+++ b/recipes/glfw/all/test_package/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
+find_package(OpenGL REQUIRED)
 find_package(glfw3 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
+target_link_libraries(${PROJECT_NAME} PRIVATE glfw OpenGL::GL)

--- a/recipes/glfw/all/test_package/conanfile.py
+++ b/recipes/glfw/all/test_package/conanfile.py
@@ -13,6 +13,7 @@ class TestPackageConan(ConanFile):
         cmake_layout(self)
 
     def requirements(self):
+        self.requires("opengl/system")
         self.requires(self.tested_reference_str)
 
     def build(self):

--- a/recipes/glfw/all/test_v1_package/conanfile.py
+++ b/recipes/glfw/all/test_v1_package/conanfile.py
@@ -6,6 +6,9 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
+    def requirements(self):
+        self.requires("opengl/system")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
### Summary
Changes to recipe:  **glfw**

#### Motivation

Projects using GLFW cannot be cross compiled to targets that depend on OpenGLES rather than OpenGL, as the recipe introduces an explicit dependency on `libGL`

#### Details
Remove the explicit dependency on `opengl/system`. From [Building applications](https://github.com/glfw/glfw/blob/master/docs/build.md)

Additionally, GLFW always loads wayland and xkbcommon dynamically via `dlopen` or equivalent - so disable static linkage.

> _Note that the glfw target does not depend on OpenGL, as GLFW loads any OpenGL, OpenGL ES or Vulkan libraries it needs at runtime. If your application calls OpenGL directly, instead of using a modern extension loader library, use the OpenGL CMake package._


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
