### PR TITLE
daw_header_libraries: add version 2.114.0

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.114.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.114.0.tar.gz"
+    sha256: "c36229424bd68ee8936ad688127303aee69ecd5400a905df75138ed95cbfef53"
   "2.110.0":
     url: "https://github.com/beached/header_libraries/archive/v2.110.0.tar.gz"
     sha256: "6515bb7a130656adff9f1f17d6be69dbd7c40dbcebbe418e9d0cf15bbc71bffc"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.114.0":
+    folder: all
   "2.110.0":
     folder: all
   "2.107.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **daw_header_libraries/2.114.0**

#### Motivation
There are several improvements in 2.114.0.

#### Details
https://github.com/beached/header_libraries/compare/v2.110.0...v2.114.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
