### PR TITLE
rapidfuzz: add version 3.1.1

### DIFF
--- a/recipes/rapidfuzz/all/conandata.yml
+++ b/recipes/rapidfuzz/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.1":
+    url: "https://github.com/rapidfuzz/rapidfuzz-cpp/archive/refs/tags/v3.1.1.tar.gz"
+    sha256: "5a72811a9f5a890c69cb479551c19517426fb793a10780f136eb482c426ec3c8"
   "3.0.4":
     url: "https://github.com/rapidfuzz/rapidfuzz-cpp/archive/refs/tags/v3.0.4.tar.gz"
     sha256: "18d1c41575ceddd6308587da8befc98c85d3b5bc2179d418daffed6d46b8cb0a"

--- a/recipes/rapidfuzz/config.yml
+++ b/recipes/rapidfuzz/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.1.1":
+    folder: "all"
   "3.0.4":
     folder: "all"
   "3.0.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **raipdfuzz/3.1.1**

#### Motivation
There are several improvements since 3.0.4.

#### Details
https://github.com/rapidfuzz/rapidfuzz-cpp/compare/v3.0.4...v3.1.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
