### PR TITLE
liburing: add version 2.8

### DIFF
--- a/recipes/liburing/all/conandata.yml
+++ b/recipes/liburing/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.8":
+    url: "https://github.com/axboe/liburing/archive/liburing-2.8.tar.gz"
+    sha256: "3ed7891d1b2bbe743ef3fb6d0a4970e630aa02d7c7bd3b0212791fb7be815984"
   "2.7":
     url: "https://github.com/axboe/liburing/archive/liburing-2.7.tar.gz"
     sha256: "56202ad443c50e684dde3692819be3b91bbe003e1c14bf5abfa11973669978c1"
@@ -27,6 +30,10 @@ sources:
     url: "https://github.com/axboe/liburing/archive/liburing-0.7.tar.gz"
     sha256: "8e2842cfe947f3a443af301bdd6d034455536c38a455c7a700d0c1ad165a7543"
 patches:
+  "2.8":
+    - patch_file: "patches/liburing-2.4-disable_samples_and_tests.patch"
+      patch_description: "Disable tests and samples as it might not work while cross-compiling"
+      patch_type: "conan"
   "2.7":
     - patch_file: "patches/liburing-2.4-disable_samples_and_tests.patch"
       patch_description: "Disable tests and samples as it might not work while cross-compiling"

--- a/recipes/liburing/all/conanfile.py
+++ b/recipes/liburing/all/conanfile.py
@@ -13,7 +13,7 @@ class Liburing(ConanFile):
     name = "liburing"
     description = ("helpers to setup and teardown io_uring instances, and also a simplified interface for "
                    "applications that don't need (or want) to deal with the full kernel side implementation.")
-    license = ("GPL-2.0-or-later", "MIT")
+    license = ("GPL-2.0-or-later", "MIT", "LGPL-2.1-or-later")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/axboe/liburing"
     topics = ("asynchronous-io", "async", "kernel")

--- a/recipes/liburing/all/conanfile.py
+++ b/recipes/liburing/all/conanfile.py
@@ -13,7 +13,7 @@ class Liburing(ConanFile):
     name = "liburing"
     description = ("helpers to setup and teardown io_uring instances, and also a simplified interface for "
                    "applications that don't need (or want) to deal with the full kernel side implementation.")
-    license = "GPL-2.0-or-later"
+    license = ("GPL-2.0-or-later", "MIT")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/axboe/liburing"
     topics = ("asynchronous-io", "async", "kernel")

--- a/recipes/liburing/config.yml
+++ b/recipes/liburing/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8":
+    folder: all
   "2.7":
     folder: all
   "2.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **liburing/2.8**

#### Motivation
There are several new features in 2.8.
Adding license list to MIT.

#### Details
https://github.com/axboe/liburing/compare/liburing-2.7...liburing-2.8

LICENSE is described in README.
> All software contained within this repo is dual licensed LGPL and MIT, see
> COPYING and LICENSE, except for a header coming from the kernel which is
> dual licensed GPL with a Linux-syscall-note exception and MIT, see
COPYING.GPL and <https://spdx.org/licenses/Linux-syscall-note.html>.
https://github.com/axboe/liburing/

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
