### PR TITLE
icu: honor compiler.cppstd from profile when compiler is msvc

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -134,6 +134,8 @@ class ICUConan(ConanFile):
         if check_min_vs(self, "180", raise_invalid=False):
             tc.extra_cflags.append("-FS")
             tc.extra_cxxflags.append("-FS")
+        if Version(self.version) >= "75.1" and not self.settings.compiler.cppstd and is_msvc(self):
+            tc.extra_cxxflags.append(f"-std:c++{self._min_cppstd}")
         if not self.options.shared:
             tc.extra_defines.append("U_STATIC_IMPLEMENTATION")
         if is_apple_os(self):
@@ -177,10 +179,7 @@ class ICUConan(ConanFile):
         if is_msvc(self):
             env = Environment()
             env.define("CC", "cl -nologo")
-            if Version(self.version) < "75.1":
-                env.define("CXX", "cl -nologo")
-            else:
-                env.define("CXX", "cl -nologo -std:c++17")
+            env.define("CXX", "cl -nologo")
             if cross_building(self):
                 env.define("icu_cv_host_frag", "mh-msys-msvc")
             env.vars(self).save_script("conanbuild_icu_msvc")


### PR DESCRIPTION
### Summary
Changes to recipe:  **icu/all**

#### Motivation
Honor `compiler.cppstd` from profile for msvc and icu >= 75.1


#### Details
https://github.com/conan-io/conan-center-index/pull/24623 has added a logic forcing C++17 for msvc if icu version is >= 75.1, irrespective of compiler.cppstd in profile.
This PR adds a check for `compiler.cppstd`. If it's set, not need to force C++17 flag, since it's automatically injected by `AutootoolsToolchain` in `CXXFLAGS` with C++ standard from profile (potentially C++20 or C++23).
Moreover, this manual injection was done in `CXX` env var, it's not very neat, it's moved to `tc.extra_cxxflags`.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
