### PR TITLE
entt: add version 3.14.0

### DIFF
--- a/recipes/entt/3.x.x/conandata.yml
+++ b/recipes/entt/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.14.0":
+    url: "https://github.com/skypjack/entt/archive/refs/tags/v3.14.0.tar.gz"
+    sha256: "e31f6e95a30e2977a50449ef9a607a9ff40febe6f9da2a8144a183f8606f7719"
   "3.13.2":
     url: "https://github.com/skypjack/entt/archive/refs/tags/v3.13.2.tar.gz"
     sha256: "cb556aa543d01177b62de41321759e02d96078948dda72705b3d7fe68af88489"

--- a/recipes/entt/config.yml
+++ b/recipes/entt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.14.0":
+    folder: 3.x.x
   "3.13.2":
     folder: 3.x.x
   "3.12.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **entt/3.14.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
- A new release (entt v3.14.0) has been published.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
- Add recipe for entt v3.14.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
