### PR TITLE
trantor: add version 1.5.22

### DIFF
--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.22":
+    url: "https://github.com/an-tao/trantor/archive/v1.5.22.tar.gz"
+    sha256: "2f870b016a592228d617ef51eec4e9a9ab7dc56c066923af9bf6dd42fefb63de"
   "1.5.21":
     url: "https://github.com/an-tao/trantor/archive/v1.5.21.tar.gz"
     sha256: "c267e8d3657a85751554a6877efd1199f6766a9fd6418d2c72839ad0a8943988"
@@ -21,6 +24,10 @@ sources:
     url: "https://github.com/an-tao/trantor/archive/v1.5.13.tar.gz"
     sha256: "36f02302bff3ffa8d2b1bff29f451d7a11d215a43963fb95aa543b555de2f9bf"
 patches:
+  "1.5.22":
+    - patch_file: "patches/1.5.19-0001-disable-werror.patch"
+      patch_description: "disable -Werror for gcc5"
+      patch_type: "portability"
   "1.5.21":
     - patch_file: "patches/1.5.19-0001-disable-werror.patch"
       patch_description: "disable -Werror for gcc5"

--- a/recipes/trantor/config.yml
+++ b/recipes/trantor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.22":
+    folder: "all"
   "1.5.21":
     folder: "all"
   "1.5.20":


### PR DESCRIPTION
### Summary
Changes to recipe:  **trantor/1.5.22**

#### Motivation
There are several bugfixes in 1.5.22.

#### Details
https://github.com/an-tao/trantor/compare/v1.5.21...v1.5.22

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
