### PR TITLE
vulkan-headers: Add version 1.3.296.0

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.296.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
+    sha256: "1e872a0be3890784bbe68dcd89b7e017fed77ba95820841848718c98bda6dc33"
   "1.3.290.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.290.0.tar.gz"
     sha256: "5b186e1492d97c44102fe858fb9f222b55524a8b6da940a8795c9e326ae6d722"

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.296.0":
+    folder: all
   "1.3.290.0":
     folder: all
   "1.3.268.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-headers/1.3.296.0**

#### Motivation
Version bump

#### Details
config.yml and conandata.yml point to the newly created vulkan-headers/1.3.296.0.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
