### PR TITLE
parallel-hashmap: add version 1.4.1

### DIFF
--- a/recipes/parallel-hashmap/all/conandata.yml
+++ b/recipes/parallel-hashmap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.1":
+    url: "https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v1.4.1.tar.gz"
+    sha256: "949874f4207b8735422438b23b884fb1f4b926689bb5eebff38cc4d357d09cd2"
   "1.4.0":
     url: "https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v1.4.0.tar.gz"
     sha256: "766e05d19c27d9c09e6f9a627868daf451f4fbdd1b617f1bb875fb9402bfb78b"

--- a/recipes/parallel-hashmap/all/conanfile.py
+++ b/recipes/parallel-hashmap/all/conanfile.py
@@ -12,9 +12,9 @@ class ParallelHashmapConan(ConanFile):
     name = "parallel-hashmap"
     description = "A family of header-only, very fast and memory-friendly hashmap and btree containers."
     license = "Apache-2.0"
-    topics = ("parallel", "hashmap", "btree")
-    homepage = "https://github.com/greg7mdp/parallel-hashmap"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/greg7mdp/parallel-hashmap"
+    topics = ("parallel", "hashmap", "btree", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
@@ -31,9 +31,6 @@ class ParallelHashmapConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
-    def build(self):
-        pass
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/parallel-hashmap/config.yml
+++ b/recipes/parallel-hashmap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.1":
+    folder: all
   "1.4.0":
     folder: all
   "1.3.12":


### PR DESCRIPTION
### Summary
Changes to recipe:  **parallel-hashmap/1.4.1**

#### Motivation
There are several improvements in 1.4.1.
Add `header-only` to topics.

#### Details
https://github.com/greg7mdp/parallel-hashmap/compare/v1.4.0...v1.4.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
