### PR TITLE
cli11: Compile by default, add header_only option

### DIFF
--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -82,6 +82,7 @@ class CLI11Conan(ConanFile):
         self.cpp_info.libdirs = []
 
         if self._supports_compilation and not self.options.get_safe("header_only"):
+            self.cpp_info.libdirs = ["lib"]
             self.cpp_info.libs = ["CLI11"]
             self.cpp_info.defines = ["CLI11_COMPILE"]
 

--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -31,7 +31,7 @@ class CLI11Conan(ConanFile):
     
     @property
     def _supports_compilation(self):
-        return Version(self.version) >= 2.3
+        return Version(self.version) >= "2.3"
     
     def config_options(self):
         if not self._supports_compilation:

--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -33,12 +33,11 @@ class CLI11Conan(ConanFile):
     def _supports_compilation(self):
         return Version(self.version) >= "2.3"
     
-    def config_options(self):
-        if not self._supports_compilation:
-            del self.options.header_only
-    
     def configure(self):
-        if self._supports_compilation and not self.options.header_only:
+        if not self._supports_compilation:
+            # TODO: Back to config_options after Conan 1 freeze
+            del self.options.header_only
+        elif not self.options.header_only:
             self.package_type = "static-library"
 
     def layout(self):

--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -14,9 +14,7 @@ class CLI11Conan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/CLIUtils/CLI11"
     topics = "cli-parser", "cpp11", "no-dependencies", "cli"
-    # Correct value not autodetected by Conan as this is always a static-library
-    # config_options/configure set the proper value in this case
-    package_type = "library"
+    package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
@@ -38,20 +36,16 @@ class CLI11Conan(ConanFile):
     def config_options(self):
         if not self._supports_compilation:
             del self.options.header_only
-            self.package_type = "header-library"
     
     def configure(self):
-        if self._supports_compilation:
-            if self.options.header_only:
-                self.package_type = "header-library"
-            else:
-                self.package_type = "static-library"
+        if self._supports_compilation and not self.options.header_only:
+            self.package_type = "static-library"
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def package_id(self):
-        if self.info.options.get_safe("header_only", True):
+        if not self._supports_compilation or self.info.options.header_only:
             self.info.clear()
 
     def validate(self):

--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -28,11 +28,11 @@ class CLI11Conan(ConanFile):
     @property
     def _min_cppstd(self):
         return "11"
-    
+
     @property
     def _supports_compilation(self):
         return Version(self.version) >= "2.3"
-    
+
     def configure(self):
         if not self._supports_compilation:
             # TODO: Back to config_options after Conan 1 freeze
@@ -78,10 +78,10 @@ class CLI11Conan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        if self.options.get_safe("header_only"):
-            self.cpp_info.bindirs = []
-            self.cpp_info.libdirs = []
-        else:
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        if self._supports_compilation and not self.options.get_safe("header_only"):
             self.cpp_info.libs = ["CLI11"]
             self.cpp_info.defines = ["CLI11_COMPILE"]
 

--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -22,7 +22,7 @@ class CLI11Conan(ConanFile):
         "header_only": [True, False]
     }
     default_options = {
-        "header_only": False
+        "header_only": True
     }
 
     @property

--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -12,10 +12,17 @@ class CLI11Conan(ConanFile):
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/CLIUtils/CLI11"
-    topics = "cli-parser", "cpp11", "no-dependencies", "cli", "header-only"
-    package_type = "header-library"
+    topics = "cli-parser", "cpp11", "no-dependencies", "cli"
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+
+    options = {
+        "header_only": [True, False]
+    }
+    default_options = {
+        "header_only": False
+    }
 
     @property
     def _min_cppstd(self):
@@ -25,7 +32,8 @@ class CLI11Conan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def package_id(self):
-        self.info.clear()
+        if self.info.options.header_only:
+            del self.info.options.header_only
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -36,6 +44,7 @@ class CLI11Conan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["CLI11_PRECOMPILED"] = not self.options.header_only
         tc.variables["CLI11_BUILD_EXAMPLES"] = False
         tc.variables["CLI11_BUILD_TESTS"] = False
         tc.variables["CLI11_BUILD_DOCS"] = False
@@ -56,8 +65,12 @@ class CLI11Conan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.bindirs = []
-        self.cpp_info.libdirs = []
+        if self.options.header_only:
+            self.cpp_info.bindirs = []
+            self.cpp_info.libdirs = []
+        else:
+            self.cpp_info.libs = ["CLI11"]
+            self.cpp_info.defines = ["CLI11_COMPILE"]
 
         self.cpp_info.set_property("cmake_file_name", "CLI11")
         self.cpp_info.set_property("cmake_target_name", "CLI11::CLI11")

--- a/recipes/cli11/all/test_package/CMakeLists.txt
+++ b/recipes/cli11/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(CLI11 REQUIRED CONFIG)


### PR DESCRIPTION
### Summary
CLI11 supports static library builds. This PR changes the recipe to build a static library by default and adds a header only option.

#### Motivation
Fixes #25737.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
