### PR TITLE
Add src folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ graph_info.json
 build/
 .conanrunner/
 .conanrc
+src/
 
 # CMake
 CMakeUserPresets.json


### PR DESCRIPTION
All recipes define this in their layout (Guess who almost just commits the whole src of a library!)