### PR TITLE
spirv-headers: Add version 1.3.296.0

### DIFF
--- a/recipes/spirv-headers/all/conandata.yml
+++ b/recipes/spirv-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.296.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
+    sha256: "1423d58a1171611d5aba2bf6f8c69c72ef9c38a0aca12c3493e4fda64c9b2dc6"
   "1.3.268.0":
     url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
     sha256: "1022379e5b920ae21ccfb5cb41e07b1c59352a18c3d3fdcbf38d6ae7733384d4"

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.50.0"
@@ -28,6 +29,8 @@ class SpirvheadersConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["SPIRV_HEADERS_SKIP_EXAMPLES"] = True
+        if Version(self.version) > "1.3.275.0":
+            tc.variables["SPIRV_HEADERS_ENABLE_TESTS"] = False
         tc.generate()
 
     def build(self):

--- a/recipes/spirv-headers/config.yml
+++ b/recipes/spirv-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.296.0":
+    folder: all
   "1.3.268.0":
     folder: all
   "1.3.261.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **spirv-headers/1.3.296.0**

#### Motivation
Version bump
https://github.com/KhronosGroup/SPIRV-Headers/compare/vulkan-sdk-1.3.268.0...vulkan-sdk-1.3.296.0

#### Details
config.yml and conandata.yml point to the newly created spirv-headers/1.3.296.0.

conanfile.py additionaly disables building of a test project, option to disable this has been introduced in [commit](https://github.com/KhronosGroup/SPIRV-Headers/commit/3b11b02093a959bba57d960f6c28a12e56df9559), which was after 1.3.275.0 release

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
