### PR TITLE
volk: Add version 1.3.296.0

### DIFF
--- a/recipes/volk/all/conandata.yml
+++ b/recipes/volk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.296.0":
+    url: "https://github.com/zeux/volk/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
+    sha256: "8ffd0e81e29688f4abaa39e598937160b098228f37503903b10d481d4862ab85"
   "1.3.268.0":
     url: "https://github.com/zeux/volk/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
     sha256: "f1d30fac1cdc17a8fdc8c69f371663547f92db99cfd612962190bb1e2c8ce74d"

--- a/recipes/volk/all/conanfile.py
+++ b/recipes/volk/all/conanfile.py
@@ -59,15 +59,24 @@ class VolkConan(ConanFile):
 
     def _patch_sources(self):
         cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
-        replace_in_file(self, cmakelists, "find_package(Vulkan QUIET)", "find_package(VulkanHeaders REQUIRED)")
+        if Version(self.version) < "1.3.296":
+            replace_in_file(self, cmakelists, "find_package(Vulkan QUIET)", "find_package(VulkanHeaders REQUIRED)")
+
         if Version(self.version) < "1.3.261":
             replace_in_file(self, cmakelists, "Vulkan::Vulkan", "Vulkan::Headers")
-        else:
+        elif Version(self.version) < "1.3.296":
             replace_in_file(
                 self,
                 cmakelists,
                 "if(VULKAN_HEADERS_INSTALL_DIR)",
                 "if(1)\nset(VOLK_INCLUDES ${VulkanHeaders_INCLUDE_DIRS})\nelseif(VULKAN_HEADERS_INSTALL_DIR)",
+            )
+        else:
+            replace_in_file(
+                self,
+                cmakelists,
+                "if(VULKAN_HEADERS_INSTALL_DIR)",
+                "if(1)\nfind_package(VulkanHeaders REQUIRED)\nset(VOLK_INCLUDES ${VulkanHeaders_INCLUDE_DIRS})\nelseif(VULKAN_HEADERS_INSTALL_DIR)",
             )
 
     def build(self):

--- a/recipes/volk/config.yml
+++ b/recipes/volk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.296.0":
+    folder: "all"
   "1.3.268.0":
     folder: "all"
   "1.3.261.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **volk/1.3.296.0**

#### Motivation
Version bump
https://github.com/zeux/volk/compare/vulkan-sdk-1.3.268...vulkan-sdk-1.3.296

#### Details
config.yml and conandata.yml point to the newly created volk/1.3.296.0.

conanfile.py adapts changed include path discovery from this [commit](https://github.com/zeux/volk/commit/01b5e061d44af7cd29e25b5a0b62164ed79e7aeb)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
