### PR TITLE
[sentry-native] Remove old versions

### DIFF
--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -8,12 +8,6 @@ sources:
   "0.7.8":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.7.8/sentry-native.zip"
     sha256: "7cfde453866edf4ae7991f4300fc08a5cb4e6d679d31011ff93b4cfe5e3e5d8a"
-  "0.7.6":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.7.6/sentry-native.zip"
-    sha256: "42180ad933a3a2bd86a1649ed0f1a41df20e783ce17c5cb1f86775f7caf06bc1"
-  "0.7.5":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.7.5/sentry-native.zip"
-    sha256: "d9f1b44753fae3e9462aa1e6fd3021cb0ff2f51c1a1fa02b34510e3bc311f429"
   "0.6.6":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.6.6/sentry-native.zip"
     sha256: "7a98467c0b2571380a3afc5e681cb13aa406a709529be12d74610b0015ccde0c"

--- a/recipes/sentry-native/config.yml
+++ b/recipes/sentry-native/config.yml
@@ -5,10 +5,6 @@ versions:
     folder: all
   "0.7.8":
     folder: all
-  "0.7.6":
-    folder: all
-  "0.7.5":
-    folder: all
   "0.6.6":
     folder: all
   "0.5.4":


### PR DESCRIPTION
### Summary

Changes to recipe: **sentry-native**

- Remove 0.7.5 and 0.7.6 versions according to https://github.com/conan-io/conan-center-index/blob/5b58888878c588cc2803c11b0845a3ee89dfd237/docs/adding_packages/sources_and_patches.md#removing-old-versions

#### Motivation

<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details

<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
