### PR TITLE
log4cplus: add version 2.1.2, add package_type

### DIFF
--- a/recipes/log4cplus/all/conandata.yml
+++ b/recipes/log4cplus/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.2":
+    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_1_2/log4cplus-2.1.2.tar.bz2"
+    sha256: "2450dfbb4ab35dd2c9e64d8c750c514bf7293b81d8f32af7ab124417f70adfad"
   "2.1.1":
     url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_1_1/log4cplus-2.1.1.tar.bz2"
     sha256: "6597de782775e4e0fba8fdcad938c3709fd839a8084c4b6edfae3cc5046e2688"
@@ -11,11 +14,14 @@ sources:
   "2.0.7":
     url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_7/log4cplus-2.0.7.tar.bz2"
     sha256: "8fadbafee2ba4e558a0f78842613c9fb239c775d83f23340d091084c0e1b12ab"
-  # v1 is required for the openvdb recipe
   "1.2.2":
     url: "https://github.com/log4cplus/log4cplus/releases/download/REL_1_2_2/log4cplus-1.2.2.tar.bz2"
     sha256: "853efd919f9ca76c518c0944e6b0ced1174523a86b6db046ed4f23fe695167bd"
 patches:
+  "2.1.2":
+    - patch_file: "patches/2.1.2-0001-fix-cmake.patch"
+      patch_description: "disable fPIC"
+      patch_type: "conan"
   "2.1.1":
     - patch_file: "patches/2.0.6-0001-fix-cmake.patch"
       patch_description: "disable fPIC, move cmake_minimum_version to front"

--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.files import apply_conandata_patches, export_conandata_patches,
 from conan.tools.build import check_min_cppstd, valid_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 import os
 
 required_conan_version = ">=1.53.0"
@@ -67,7 +68,7 @@ class Log4cplusConan(ConanFile):
             if Version(self.version) < 2 and valid_min_cppstd(self, 17):
                 raise ConanInvalidConfiguration(f"${self.ref} does not support C++17")
         if Version(self.version) >= "2.1.2" and \
-           self.settings.compiler == "msvc" and Version(self.settings.compiler.version) < 192:
+           is_msvc(self) and Version(self.settings.compiler.version) < 192:
             raise ConanInvalidConfiguration(f"${self.ref} requires Visual Studio 2019 or newer")
 
     def source(self):

--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -11,10 +11,11 @@ required_conan_version = ">=1.53.0"
 class Log4cplusConan(ConanFile):
     name = "log4cplus"
     description = "simple to use C++ logging API, modelled after the Java log4j API"
-    license = ("BSD-2-Clause, Apache-2.0")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/log4cplus/log4cplus"
+    license = ("BSD-2-Clause, Apache-2.0")
     topics = ("logging", "log", "logging-library")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -64,7 +65,10 @@ class Log4cplusConan(ConanFile):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, 11)
             if Version(self.version) < 2 and valid_min_cppstd(self, 17):
-                raise ConanInvalidConfiguration("log4cplus < 2.0.0 does not support C++17")
+                raise ConanInvalidConfiguration(f"${self.ref} does not support C++17")
+        if Version(self.version) >= "2.1.2" and \
+           self.settings.compiler == "msvc" and Version(self.settings.compiler.version) < 192:
+            raise ConanInvalidConfiguration(f"${self.ref} requires Visual Studio 2019 or newer")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/log4cplus/all/patches/2.1.2-0001-fix-cmake.patch
+++ b/recipes/log4cplus/all/patches/2.1.2-0001-fix-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9dcbb8a..f80d3b9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,7 +15,7 @@ cmake_minimum_required (VERSION 3.12)
+ project (log4cplus)
+ 
+ # Use "-fPIC" / "-fPIE" for all targets by default, including static libs.
+-set (CMAKE_POSITION_INDEPENDENT_CODE ON)
++# set (CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+ enable_language (CXX)
+ if (MSVC)

--- a/recipes/log4cplus/config.yml
+++ b/recipes/log4cplus/config.yml
@@ -1,4 +1,7 @@
 versions:
+  "2.1.2":
+    folder: all
+  # 2.1.1 is the last version for Visual Studio 2017
   "2.1.1":
     folder: all
   "2.1.0":
@@ -7,5 +10,6 @@ versions:
     folder: all
   "2.0.7":
     folder: all
+  # v1 is required for the openvdb recipe
   "1.2.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **log4cplus/2.1.2**

#### Motivation
There are several new features in 2.1.2.
2.1.2 drops Visual Studio 2017 support.

#### Details
https://github.com/log4cplus/log4cplus/compare/REL_2_1_1...REL_2_1_2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
