### PR TITLE
Botan: add version 3.6.1

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -44,6 +44,9 @@ sources:
   "3.6.0":
     url: "https://github.com/randombit/botan/archive/3.6.0.tar.gz"
     sha256: "950199a891fab62dca78780b36e12f89031c37350b2a16a2c35f2e423c041bad"
+  "3.6.1":
+    url: "https://github.com/randombit/botan/archive/3.6.1.tar.gz"
+    sha256: "a6c4e8dcb6c7f4b9b67e2c8b43069d65b548970ca17847e3b1e031d3ffdd874a"
 patches:
   "2.18.2":
     - patch_file: "patches/fix-amalgamation-build.patch"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -29,3 +29,5 @@ versions:
     folder: all
   "3.6.0":
     folder: all
+  "3.6.1":
+    folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:  **botan/3.6.1**

#### Motivation

https://github.com/randombit/botan/blob/master/news.rst#version-361-2024-10-26

When creating a signature using the SLH-DSA algorithm, Botan 3.6.0 did not default to the 'Hedged' mode, but to 'Deterministic'.

Due to a bug in the detection of the CPU's capabilities, 3.6.0 could crash when invoking specific algorithms on certain platforms.

#### Details




---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
