### PR TITLE
jsoncons: add version 0.178.0

### DIFF
--- a/recipes/jsoncons/all/conandata.yml
+++ b/recipes/jsoncons/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.178.0":
+    url: "https://github.com/danielaparker/jsoncons/archive/refs/tags/v0.178.0.tar.gz"
+    sha256: "c531b4288bb08c9c2b36fba53f568bc800e93656830bcffc18a87a3af1f46290"
   "0.177.0":
     url: "https://github.com/danielaparker/jsoncons/archive/refs/tags/v0.177.0.tar.gz"
     sha256: "a381d58489f143a3a515484f4ad6e32ae4d977033e1a455fecf8cdc4e2c9a49e"

--- a/recipes/jsoncons/config.yml
+++ b/recipes/jsoncons/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.178.0":
+    folder: "all"
   "0.177.0":
     folder: "all"
   "0.176.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **jsoncons/0.178.0**

#### Motivation
There are several new features in 0.178.0.

#### Details
https://github.com/danielaparker/jsoncons/compare/v0.177.0...v0.178.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
