### PR TITLE
libvpx: fix redundant -lc++

### DIFF
--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -266,9 +266,5 @@ class LibVPXConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "vpx")
         self.cpp_info.libs = [self._lib_name]
-        if not self.options.get_safe("shared"):
-            libcxx = stdcpp_library(self)
-            if libcxx:
-                self.cpp_info.system_libs.append(libcxx)
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["m", "pthread"])


### PR DESCRIPTION
### Summary
Changes to recipe:  **libvpx**

- fix redundant -lc++

#### Motivation
Consuming libvpx on macOS keep receiving warnings like:

```
ld: warning: ignoring duplicate libraries: '-lc++'
```


#### Details
I guess C++ runtime library would be specified by conan in `-stdlib` flag (such as -stdlib=libc++ for Clang or -stdlib=libstdc++11 for GCC), adding the standard library again with self.cpp_info.system_libs.append(libcxx) result in warnings:

```
ld: warning: ignoring duplicate libraries: '-lc++'
```

Which is complained from clang on macOS, generated verbose link command is like:

```shell
/<path-to-toochain>/c++ -stdlib=libc++ -g -arch arm64 -isysroot /<path-to-xcode-sdk>/MacOSX15.1.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names CMakeFiles/example.dir/src/example.cpp.o -o example   -L/<path-to-conan>/p/b/hello31cb6e20b6eb3/p/lib  -L/<path-to-conan>/p/b/libvp0331582145844/p/lib  -Wl,-rpath,/<path-to-conan>/p/b/hello31cb6e20b6eb3/p/lib -Wl,-rpath,/<path-to-conan>/p/b/libvp0331582145844/p/lib /<path-to-conan>/p/b/hello31cb6e20b6eb3/p/lib/libhello.a /<path-to-conan>/p/b/libvp0331582145844/p/lib/libvpx.a -lc++
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
