### PR TITLE
Updated libgit2 to 1.8.4

### DIFF
--- a/recipes/libgit2/all/conandata.yml
+++ b/recipes/libgit2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.4":
+    url: "https://github.com/libgit2/libgit2/archive/v1.8.4.tar.gz"
+    sha256: "49d0fc50ab931816f6bfc1ac68f8d74b760450eebdb5374e803ee36550f26774"
   "1.8.3":
     url: "https://github.com/libgit2/libgit2/archive/v1.8.3.tar.gz"
     sha256: "868810a5508d41dd7033d41bdc55312561f3f916d64f5b7be92bc1ff4dcae02a"
@@ -30,6 +33,10 @@ sources:
     url: "https://github.com/libgit2/libgit2/archive/v1.0.1.tar.gz"
     sha256: "1775427a6098f441ddbaa5bd4e9b8a043c7401e450ed761e69a415530fea81d2"
 patches:
+  "1.8.4":
+    - patch_file: "patches/1.8.1-0001-fix-cmake.patch"
+      patch_description: "use cci's packages"
+      patch_type: "conan"
   "1.8.3":
     - patch_file: "patches/1.8.1-0001-fix-cmake.patch"
       patch_description: "use cci's packages"

--- a/recipes/libgit2/config.yml
+++ b/recipes/libgit2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.4":
+    folder: "all"
   "1.8.3":
     folder: "all"
   "1.8.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libgit2/1.8.2**

#### Motivation
Making `libgit2/1.8.4` available on Conan Center.

#### Details
Very minimal changes necessary to update the version.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
