### PR TITLE
[libpcap] fix: #25700 - enable proper packet capture on Android using pcap-linux.c

### DIFF
--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -130,7 +130,7 @@ class LibPcapConan(ConanFile):
             if Version(self.version) < "1.10":
                 tc.configure_args.append("--disable-packet-ring")
             if cross_building(self):
-                target_os = "linux" if self.settings.os == "Linux" else "null"
+                target_os = "linux" if self.settings.os in ["Linux", "Android"] else "null"
                 tc.configure_args.append(f"--with-pcap={target_os}")
             elif "arm" in self.settings.arch and self.settings.os == "Linux":
                 tc.configure_args.append("--host=arm-linux")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpcap/1.10.4**

#### Motivation
Fixing: #25700 

Previously, libpcap (on Android) defaulted to pcap-null.c, preventing live packet capture. Now correctly uses pcap-linux.c, enabling capture.

#### Details
Results:

Before:
```
Available interfaces:
nflog - Linux netfilter log (NFLOG) interface
nfqueue - Linux netfilter queue (NFQUEUE) interface 

Error creating handle: live packet capture not supported on this system
```

After (this PR):
Recipe for testing created with:
```
~/projects/conan-center-index/recipes/libpcap$ conan create --user=nikita --channel=dev --profile:host=~/projects/redacted/profiles/android_api21_arm64-v8a.jinja --settings:host=build_type=RelWithDebInfo --build=missing --version=1.10.4 all/
```

```
Available interfaces:
eth0:LL - No description
eth0 - No description
any - Pseudo-device that captures on all interfaces lo - No description
nflog - Linux netfilter log (NFLOG) interface
nfqueue - Linux netfilter queue (NFQUEUE) interface

Starting packet capture on can0...
Captured packet with length: 16
ID: 0x1106ff8d
DLC: 8
Data: 60 0F 13 99 FF 01 00 13
```

refs:
- https://github.com/conan-io/conan-center-index/blob/master/recipes/libpcap/all/conanfile.py#L133 
- https://github.com/the-tcpdump-group/libpcap/blob/5d71e580d946a8b7cf95933f64c527dafbda35db/pcap-null.c 
- https://github.com/the-tcpdump-group/libpcap/blob/5d71e580d946a8b7cf95933f64c527dafbda35db/configure.ac#L988-L992C18 
- https://github.com/the-tcpdump-group/libpcap/blob/5d71e580d946a8b7cf95933f64c527dafbda35db/configure.ac#L1183-L1189

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
