### PR TITLE
autoconf: Do not clear "os" from package info

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -38,7 +38,9 @@ class AutoconfConan(ConanFile):
         self.requires("m4/1.4.19") # Needed at runtime by downstream clients as well
 
     def package_id(self):
-        self.info.clear()
+        del self.info.settings.arch
+        del self.info.settings.compiler
+        del self.info.settings.build_type
 
     def build_requirements(self):
         self.tool_requires("m4/1.4.19")

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -41,6 +41,7 @@ class AutoconfConan(ConanFile):
         del self.info.settings.arch
         del self.info.settings.compiler
         del self.info.settings.build_type
+        self.info.requires.clear()
 
     def build_requirements(self):
         self.tool_requires("m4/1.4.19")


### PR DESCRIPTION
Avoids compatibility issues between Windows and Linux.

### Summary
Changes to recipe:  **autoconf**

#### Motivation
Not including `os` information in the package means that packages built on Linux and Windows mix up, with same package ID and different package revisions. The most recent one will then be pulled from the remote and used, but they might actually not be fully compatible between OSes. In our case the Windows-built version did not have the executable flag set on the scripts in `bin/`, this caused issues when using the package in a Linux environment.
The symptoms were similar to https://github.com/conan-io/conan/issues/14345, so we initially thought the problem happened in decompressing the package files.

#### Details
Just keep the `os` information, it causes minimal duplication and it makes sure the package works in all environments.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
