### PR TITLE
Boost: correct address model for "s390x" architecture

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1181,7 +1181,7 @@ class BoostConan(ConanFile):
 
     @property
     def _b2_address_model(self):
-        if self.settings.arch in ("x86_64", "ppc64", "ppc64le", "mips64", "armv8", "armv8.3", "sparcv9"):
+        if self.settings.arch in ("x86_64", "ppc64", "ppc64le", "mips64", "armv8", "armv8.3", "sparcv9", "s390x"):
             return "64"
 
         return "32"


### PR DESCRIPTION
Added "s390x" to the  _b2_address_model function to return "64".


### Summary
Changes to recipe:  **lib/all**

#### Motivation
Boost library fails to build on IBM Z and IBM LinuxONE processors due to recipe defaulting to 32-bits architecture due to the following function: 
```
def _b2_address_model(self):
        if self.settings.arch in ("x86_64", "ppc64", "ppc64le", "mips64", "armv8", "armv8.3", "sparcv9"):
             return "64"

        return "32"
```

#### Details
Added "s390x" to the architecture tuple returning "64": 
```
def _b2_address_model(self):
       if self.settings.arch in ("x86_64", "ppc64", "ppc64le", "mips64", "armv8", "armv8.3", "sparcv9", "s390x"):
            return "64"

        return "32"
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
