### PR TITLE
Revert "opencolorio: Bump lcms requirement to 2.16"

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -18,6 +18,7 @@ class OpenColorIOConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("colors", "visual", "effects", "animation")
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "library"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -66,7 +66,7 @@ class OpenColorIOConan(ConanFile):
             self.requires("minizip-ng/3.0.9")
 
         # for tools only
-        self.requires("lcms/2.16")
+        self.requires("lcms/2.14")
         # TODO: add GLUT (needed for ociodisplay tool)
 
     def validate(self):


### PR DESCRIPTION
Reverts conan-io/conan-center-index#25660

This was not meant to be merged until https://github.com/conan-io/conan-center-index/pull/25672 is ready, as it creates a conflict with its whole tree