### PR TITLE
xxhash: Add header_only option

### DIFF
--- a/recipes/xxhash/all/conanfile.py
+++ b/recipes/xxhash/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 import os
@@ -17,11 +18,13 @@ class XxHashConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
+        "header_only": [True, False],
         "fPIC": [True, False],
         "utility": [True, False],
     }
     default_options = {
         "shared": False,
+        "header_only": False,
         "fPIC": True,
         "utility": True,
     }
@@ -34,8 +37,14 @@ class XxHashConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.options.shared:
+        if self.options.shared and self.options.header_only:
+            raise ConanException("Options 'shared' and 'header_only' cannot both be true at once.")
+        if self.options.shared or self.options.header_only:
             self.options.rm_safe("fPIC")
+        if self.options.shared:
+            self.options.rm_safe("header_only")
+        elif self.options.header_only:
+            self.options.rm_safe("shared")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
 
@@ -45,36 +54,53 @@ class XxHashConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def _run_cmake(self):
+        return not self.options.get_safe("header_only") or self.options.utility
+
     def generate(self):
-        tc = CMakeToolchain(self)
-        tc.variables["XXHASH_BUNDLED_MODE"] = False
-        tc.variables["XXHASH_BUILD_XXHSUM"] = self.options.utility
-        # Fix CMake configuration if target is iOS/tvOS/watchOS
-        tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
-        # Generate a relocatable shared lib on Macos
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
-        tc.generate()
+        if self._run_cmake():
+            tc = CMakeToolchain(self)
+            tc.variables["XXHASH_BUNDLED_MODE"] = False
+            tc.variables["XXHASH_BUILD_XXHSUM"] = self.options.utility
+            # Fix CMake configuration if target is iOS/tvOS/watchOS
+            tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
+            # Generate a relocatable shared lib on Macos
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+            tc.generate()
 
     def build(self):
-        apply_conandata_patches(self)
-        cmake = CMake(self)
-        cmake.configure(build_script_folder=os.path.join(self.source_folder, "cmake_unofficial"))
-        cmake.build()
+        if self._run_cmake():
+            apply_conandata_patches(self)
+            cmake = CMake(self)
+            cmake.configure(build_script_folder=os.path.join(self.source_folder, "cmake_unofficial"))
+            cmake.build()
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        cmake = CMake(self)
-        cmake.install()
-        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
-        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
-        rmdir(self, os.path.join(self.package_folder, "share"))
+        if self._run_cmake():
+            cmake = CMake(self)
+            cmake.install()
+            if self.options.get_safe("header_only"):
+                rmdir(self, os.path.join(self.package_folder, "lib"))
+            else:
+                rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+                rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+            rmdir(self, os.path.join(self.package_folder, "share"))
+        else:
+            copy(self, "xxhash.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "xxHash")
         self.cpp_info.set_property("cmake_target_name", "xxHash::xxhash")
         self.cpp_info.set_property("pkg_config_name", "libxxhash")
+
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.components["libxxhash"].libs = ["xxhash"]
+        if not self.options.get_safe("shared"):
+            self.cpp_info.components["libxxhash"].defines.append("XXH_STATIC_LINKING_ONLY")
+        if self.options.get_safe("header_only"):
+            self.cpp_info.components["libxxhash"].defines.append("XXH_INLINE_ALL")
+        else:
+            self.cpp_info.components["libxxhash"].libs.append("xxhash")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "xxHash"
@@ -83,5 +109,6 @@ class XxHashConan(ConanFile):
         self.cpp_info.components["libxxhash"].names["cmake_find_package"] = "xxhash"
         self.cpp_info.components["libxxhash"].names["cmake_find_package_multi"] = "xxhash"
         self.cpp_info.components["libxxhash"].set_property("cmake_target_name", "xxHash::xxhash")
+
         if self.options.utility:
             self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/xxhash/all/test_package/CMakeLists.txt
+++ b/recipes/xxhash/all/test_package/CMakeLists.txt
@@ -3,5 +3,5 @@ project(test_package LANGUAGES C)
 
 find_package(xxHash REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} test_package.c test_package_tu.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE xxHash::xxhash)

--- a/recipes/xxhash/all/test_package/test_package.c
+++ b/recipes/xxhash/all/test_package/test_package.c
@@ -1,15 +1,10 @@
-#include "xxhash.h"
-
-#include <stdio.h>
-#include <stdlib.h>
-
+#include "test_package.h"
 
 int main()
 {
-    size_t const bufferSize = 10;
-    void* const buffer = malloc(bufferSize);
-    XXH64_hash_t hash = XXH64(buffer, bufferSize, 0);
-    printf("%llu", hash);
-    free(buffer);
-    return 0;
+    compute_hash();
+
+    // Using the library in both translation units ensures correct linkage with
+    // header-only builds.
+    compute_hash_in_another_tu();
 }

--- a/recipes/xxhash/all/test_package/test_package.h
+++ b/recipes/xxhash/all/test_package/test_package.h
@@ -1,0 +1,15 @@
+#include "xxhash.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static void compute_hash()
+{
+    size_t const bufferSize = 10;
+    void* const buffer = malloc(bufferSize);
+    XXH64_hash_t hash = XXH64(buffer, bufferSize, 0);
+    printf("%llu", hash);
+    free(buffer);
+}
+
+void compute_hash_in_another_tu();

--- a/recipes/xxhash/all/test_package/test_package_tu.c
+++ b/recipes/xxhash/all/test_package/test_package_tu.c
@@ -1,0 +1,6 @@
+#include "test_package.h"
+
+void compute_hash_in_another_tu()
+{
+    compute_hash();
+}


### PR DESCRIPTION
### Summary
Changes to recipe:  **xxhash/0.8.2**

#### Motivation
* `XXH_STATIC_LINKING_ONLY` enables static allocation of hash states. This is important for performance reasons.
* The header-only mode allows inlining the hashing functions in the caller. This is important for performance reasons.

Closes #25778.

#### Details
* Add `header_only` option (default: false), define `XXH_INLINE_ALL` in consumers in header-only mode.
* Define `XXH_STATIC_LINKING_ONLY` in consumers when the package is not a shared library.
* Improve the test package to test linking in header-only mode.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
