### PR TITLE
certify: Reduce boost dependencies

### DIFF
--- a/recipes/certify/all/conanfile.py
+++ b/recipes/certify/all/conanfile.py
@@ -38,7 +38,7 @@ class CertifyConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.83.0")
+        self.requires("boost/[>=1.83.0 <2]")
         self.requires("openssl/[>=1.1 <4]")
 
     def package_id(self):
@@ -84,8 +84,15 @@ class CertifyConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "certify")
         self.cpp_info.set_property("cmake_target_name", "certify::core")
+        component_requirements = [
+            "boost::headers",
+            "boost::filesystem",
+            "boost::date_time",
+            "openssl::openssl"
+        ]
 
-        self.cpp_info.components["_certify"].requires = ["boost::boost", "openssl::openssl"]
+        self.cpp_info.requires = component_requirements
+        self.cpp_info.components["_certify"].requires = component_requirements
         self.cpp_info.components["_certify"].names["cmake_find_package"] = "core"
         self.cpp_info.components["_certify"].names["cmake_find_package_multi"] = "core"
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **certify/***

#### Motivation
Reduce the number of boost dependencies in the public interface

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
