### PR TITLE
cppfront: add version 0.8.0, remove cci snapshots

### DIFF
--- a/recipes/cppfront/all/conandata.yml
+++ b/recipes/cppfront/all/conandata.yml
@@ -1,13 +1,4 @@
 sources:
-  "cci.20231017":
-    url: "https://github.com/hsutter/cppfront/archive/789cd382ed4c2fb1a9e306e73b6876228d22207d.tar.gz"
-    sha256: "a004c27bbc732f7a60735cee45aa89f066b79266ccc2c881f4723afee2ad1d8d"
-  "cci.20230103":
-    url: "https://github.com/hsutter/cppfront/archive/808db2bd6ae92f869166827dfda66cfa42dde0ab.zip"
-    sha256: "479252c99d66db477c4cd98a6e1707a8929a70afdf000c75589841d944c539f4"
-  "cci.20221024":
-    url: "https://github.com/hsutter/cppfront/archive/b1754dbd53a496a9104b43ecde6064c9980246bd.zip"
-    sha256: "8668bddbd7fc06d4975c867521c005f898eca8f83f018e7c28b54dbcf9aa3ab9"
-  "cci.20220924":
-    url: "https://github.com/hsutter/cppfront/archive/98f6dd46957e100f813245241f183c8aedbcb36f.zip"
-    sha256: "db51c1ac634d45c6047c7eec5c29993ff215443edadf334370f53d09a11cc5b1"
+  "0.8.0":
+    url: "https://github.com/hsutter/cppfront/archive/refs/tags/v0.8.0.tar.gz"
+    sha256: "7fb573599960bc0a46a71ed103ff97adbf938d4a0df754dc952a44fdcacfc571"

--- a/recipes/cppfront/all/conanfile.py
+++ b/recipes/cppfront/all/conanfile.py
@@ -29,7 +29,8 @@ class CppfrontConan(ConanFile):
             "Visual Studio": "16.9",
             "msvc": "192.9",
             "clang": "12",
-            "apple-clang": "13",
+            # cppfront requires <ranges> which is available on apple-clang 14.3 or later..
+            "apple-clang": "14.3",
         }
 
     def export_sources(self):

--- a/recipes/cppfront/all/conanfile.py
+++ b/recipes/cppfront/all/conanfile.py
@@ -26,8 +26,9 @@ class CppfrontConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "gcc": "11",
-            "Visual Studio": "16.9",
-            "msvc": "192.9",
+            # cppfront requires constexpr source_location
+            "Visual Studio": "17",
+            "msvc": "193",
             "clang": "12",
             # cppfront requires <ranges> which is available on apple-clang 14.3 or later..
             "apple-clang": "14.3",

--- a/recipes/cppfront/all/conanfile.py
+++ b/recipes/cppfront/all/conanfile.py
@@ -11,10 +11,11 @@ required_conan_version = ">=1.50.0"
 class CppfrontConan(ConanFile):
     name = "cppfront"
     description = "Cppfront is a experimental compiler from a potential C++ 'syntax 2' (Cpp2) to today's 'syntax 1' (Cpp1)"
-    topics = ("cpp2", "compiler")
+    license = "CC-BY-NC-ND-4.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/hsutter/cppfront"
-    license = "CC-BY-NC-ND-4.0"
+    topics = ("cpp2", "compiler")
+    package_type = "application"
     settings = "os", "arch", "compiler", "build_type"
 
     @property

--- a/recipes/cppfront/all/test_package/conanfile.py
+++ b/recipes/cppfront/all/test_package/conanfile.py
@@ -6,18 +6,17 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualBuildEnv"
-    test_type = "explicit"
+    generators = "VirtualRunEnv"
 
     def layout(self):
         basic_layout(self)
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         copy(self, "pure2-hello.cpp2", src=self.recipe_folder, dst=self.build_folder)
-        self.run("cppfront {}".format(os.path.join(self.build_folder, "pure2-hello.cpp2")))
+        self.run("cppfront {}".format(os.path.join(self.build_folder, "pure2-hello.cpp2")), env="conanrun")
 
     def test(self):
         self.run("cppfront -h")

--- a/recipes/cppfront/all/test_package/conanfile.py
+++ b/recipes/cppfront/all/test_package/conanfile.py
@@ -19,5 +19,5 @@ class TestPackageConan(ConanFile):
         self.run("cppfront {}".format(os.path.join(self.build_folder, "pure2-hello.cpp2")), env="conanrun")
 
     def test(self):
-        self.run("cppfront -h")
+        self.run("cppfront -h", env="conanrun")
         assert os.path.isfile(os.path.join(self.build_folder, "pure2-hello.cpp"))

--- a/recipes/cppfront/config.yml
+++ b/recipes/cppfront/config.yml
@@ -1,9 +1,3 @@
 versions:
-  "cci.20231017":
-    folder: all
-  "cci.20230103":
-    folder: all
-  "cci.20221024":
-    folder: all
-  "cci.20220924":
+  "0.8.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cppfront/0.8.0**

#### Motivation
There are already official releases.
Try to close https://github.com/conan-io/conan-center-index/issues/25787.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
