### PR TITLE
sail: Enable jpegxl

### DIFF
--- a/recipes/sail/all/conanfile.py
+++ b/recipes/sail/all/conanfile.py
@@ -66,7 +66,7 @@ class SAILConan(ConanFile):
         if self.options.with_medium_priority_codecs:
             self.requires("libavif/1.0.4")
             self.requires("jasper/4.2.0")
-            self.requires("libjxl/0.10.3")
+            self.requires("libjxl/0.8.2")
             self.requires("libwebp/1.3.2")
 
     def layout(self):

--- a/recipes/sail/all/conanfile.py
+++ b/recipes/sail/all/conanfile.py
@@ -101,8 +101,7 @@ class SAILConan(ConanFile):
         tc.variables["SAIL_INSTALL_PDB"]    = False
         tc.variables["SAIL_THREAD_SAFE"]    = self.options.thread_safe
         # TODO: Remove after fixing https://github.com/conan-io/conan/issues/12012
-        if is_msvc(self):
-            tc.cache_variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)
+        tc.cache_variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/sail/all/conanfile.py
+++ b/recipes/sail/all/conanfile.py
@@ -66,10 +66,7 @@ class SAILConan(ConanFile):
         if self.options.with_medium_priority_codecs:
             self.requires("libavif/1.0.4")
             self.requires("jasper/4.2.0")
-            # TODO Re-enable JPEG XL after merging either of the following:
-            #   - https://github.com/conan-io/conan-center-index/pull/13898
-            #   - https://github.com/conan-io/conan-center-index/pull/18812
-            # self.requires("libjxl/0.10.2")
+            self.requires("libjxl/0.10.3")
             self.requires("libwebp/1.3.2")
 
     def layout(self):
@@ -100,12 +97,9 @@ class SAILConan(ConanFile):
         tc.variables["SAIL_COMBINE_CODECS"] = True
         tc.variables["SAIL_ENABLE_OPENMP"]  = False
         tc.variables["SAIL_ONLY_CODECS"]    = ";".join(only_codecs)
-        # JPEGXL needs porting to Conan2
         # SVG with nanosvg is supported in >= 0.9.1
-        if Version(self.version) >= "0.9.1":
-            tc.variables["SAIL_DISABLE_CODECS"] = "jpegxl"
-        else:
-            tc.variables["SAIL_DISABLE_CODECS"] = "jpegxl;svg"
+        if Version(self.version) < "0.9.1":
+            tc.variables["SAIL_DISABLE_CODECS"] = "svg"
         tc.variables["SAIL_INSTALL_PDB"]    = False
         tc.variables["SAIL_THREAD_SAFE"]    = self.options.thread_safe
         # TODO: Remove after fixing https://github.com/conan-io/conan/issues/12012
@@ -169,7 +163,7 @@ class SAILConan(ConanFile):
         if self.options.with_medium_priority_codecs:
             self.cpp_info.components["sail-codecs"].requires.append("libavif::libavif")
             self.cpp_info.components["sail-codecs"].requires.append("jasper::jasper")
-            # self.cpp_info.components["sail-codecs"].requires.append("libjxl::libjxl")
+            self.cpp_info.components["sail-codecs"].requires.append("libjxl::libjxl")
             self.cpp_info.components["sail-codecs"].requires.append("libwebp::libwebp")
 
         self.cpp_info.components["libsail"].set_property("cmake_target_name", "SAIL::Sail")

--- a/recipes/sail/all/conanfile.py
+++ b/recipes/sail/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, rename, rmdir
+from conan.tools.files import copy, get, rename, rmdir
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
@@ -9,6 +9,7 @@ required_conan_version = ">=1.53.0"
 
 class SAILConan(ConanFile):
     name = "sail"
+    package_type = "library"
     description = "The missing small and fast image decoding library for humans (not for machines)"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://sail.software"
@@ -42,9 +43,6 @@ class SAILConan(ConanFile):
         "with_low_priority_codecs": "Enable codecs: ICO, PCX, PNM, PSD, QOI, TGA",
         "with_lowest_priority_codecs": "Enable codecs: WAL, XBM",
     }
-
-    def export_sources(self):
-        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -111,8 +109,6 @@ class SAILConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
-
         cmake = CMake(self)
         cmake.configure()
         cmake.build()


### PR DESCRIPTION
### Summary
Changes to recipe:  **sail/\***

#### Motivation
Enable JPEGXL as it's now available in Conan. 0.8.2 version is used as 0.10.x fails to compile. The issue needs to be fixed on the SAIL side later.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

Should close https://github.com/conan-io/conan-center-index/pull/25575
---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
