### PR TITLE
exiv2: add version 0.28.3

### DIFF
--- a/recipes/exiv2/all/conandata.yml
+++ b/recipes/exiv2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.28.3":
+    url: "https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.3.tar.gz"
+    sha256: "1315e17d454bf4da3cc0edb857b1d2c143670f3485b537d0f946d9ed31d87b70"
   "0.28.2":
     url: "https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.2.tar.gz"
     sha256: "543bead934135f20f438e0b6d8858c55c5fcb7ff80f5d1d55489965f1aad58b9"

--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -17,9 +17,9 @@ class Exiv2Conan(ConanFile):
     description = "Exiv2 is a C++ library and a command-line utility " \
                   "to read, write, delete and modify Exif, IPTC, XMP and ICC image metadata."
     license = "GPL-2.0"
-    topics = ("image", "exif", "xmp")
-    homepage = "https://www.exiv2.org"
     url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.exiv2.org"
+    topics = ("image", "exif", "xmp")
 
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"

--- a/recipes/exiv2/all/test_package/CMakeLists.txt
+++ b/recipes/exiv2/all/test_package/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(exiv2 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} exiv2lib)
+target_link_libraries(${PROJECT_NAME} PRIVATE exiv2lib)
 
 if(${exiv2_VERSION} VERSION_GREATER_EQUAL "0.28.0")
 	target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/exiv2/config.yml
+++ b/recipes/exiv2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.28.3":
+    folder: all
   "0.28.2":
     folder: all
   "0.28.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **exiv2/0.28.3**

#### Motivation
There is a security fix in 0.28.3.

#### Details
https://github.com/Exiv2/exiv2/compare/v0.28.2...v0.28.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
