### PR TITLE
msgpack-cxx: add version 7.0.0

### DIFF
--- a/recipes/msgpack-cxx/all/conandata.yml
+++ b/recipes/msgpack-cxx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.0.0":
+    url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-7.0.0/msgpack-cxx-7.0.0.tar.gz"
+    sha256: "7504b7af7e7b9002ce529d4f941e1b7fb1fb435768780ce7da4abaac79bb156f"
   "6.1.1":
     url: "https://github.com/msgpack/msgpack-c/releases/download/cpp-6.1.1/msgpack-cxx-6.1.1.tar.gz"
     sha256: "5fd555742e37bbd58d166199e669f01f743c7b3c6177191dd7b31fb0c37fa191"

--- a/recipes/msgpack-cxx/config.yml
+++ b/recipes/msgpack-cxx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.0.0":
+    folder: all
   "6.1.1":
     folder: all
   "6.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **msgpack-cxx/7.0.0**

#### Motivation
There is a breaking change in 7.0.0.

#### Details
https://github.com/msgpack/msgpack-c/compare/cpp-6.1.1...cpp-7.0.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
