### PR TITLE
box2d: Do not force warnings as errors by default

### DIFF
--- a/recipes/box2d/all/conanfile.py
+++ b/recipes/box2d/all/conanfile.py
@@ -78,7 +78,7 @@ class Box2dConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
-	tc.cache_variables["CMAKE_COMPILE_WARNING_AS_ERROR"] = False
+        tc.cache_variables["CMAKE_COMPILE_WARNING_AS_ERROR"] = False
         if Version(self.version) < "3.0.0":
             tc.variables["BOX2D_BUILD_TESTBED"] = False
             tc.variables["BOX2D_BUILD_UNIT_TESTS"] = False

--- a/recipes/box2d/all/conanfile.py
+++ b/recipes/box2d/all/conanfile.py
@@ -78,6 +78,7 @@ class Box2dConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.variables["CMAKE_CXX_FLAGS"] = "-O3 -ftree-vectorize -fopt-info-vec -Wno-pass-failed"
         if Version(self.version) < "3.0.0":
             tc.variables["BOX2D_BUILD_TESTBED"] = False
             tc.variables["BOX2D_BUILD_UNIT_TESTS"] = False

--- a/recipes/box2d/all/conanfile.py
+++ b/recipes/box2d/all/conanfile.py
@@ -78,7 +78,7 @@ class Box2dConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
-        tc.variables["CMAKE_CXX_FLAGS"] = "-O3 -ftree-vectorize -fopt-info-vec -Wno-pass-failed"
+	tc.cache_variables["CMAKE_COMPILE_WARNING_AS_ERROR"] = False
         if Version(self.version) < "3.0.0":
             tc.variables["BOX2D_BUILD_TESTBED"] = False
             tc.variables["BOX2D_BUILD_UNIT_TESTS"] = False


### PR DESCRIPTION
### Summary
Changes to recipe:  **box2d/3.0.0**

#### Motivation
This (hopefully) closes https://github.com/conan-io/conan-center-index/issues/25797

#### Details
Box2D compiles on Linux, Windows, and macOS, but not for WebAssembly using emsdk. This PR attempts to address the compilation error I’m encountering and should not impact other users.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
