### PR TITLE
Add history.h as a symlink to readline.h to align with libreadline

### DIFF
--- a/recipes/editline/all/conanfile.py
+++ b/recipes/editline/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualRunEnv
-from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.files import copy, get, rm, rmdir, chdir
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 import os
@@ -83,6 +83,10 @@ class EditlineConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         fix_apple_shared_install_name(self)
+
+        # Create symlink history.h as consumers may expect to find some functions therein instead of editline.h
+        with chdir(self, os.path.join(self.package_folder, "include", "editline")):
+            os.symlink("readline.h", "history.h")
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "libedit")


### PR DESCRIPTION
### Summary
Changes to recipe:  **editline/3.1**

#### Motivation
`editline` is a readline-compatible library, whereas `libreadline` exports its API in two header files: `readline.h` and `history.h`. Some consumers support using any of these readline-compatible libraries, which only works when they expose the same functions as well as headers. Since `editline` only provides a single header `readline.h` the Conan package should provide a symbolic link `history.h` linking to `readline.h` so that consumers find the expected header.

Note that the [`editline` Debian package](https://packages.debian.org/de/bookworm/libedit-dev) does the same thing [here](https://salsa.debian.org/debian/libedit/-/blob/master/debian/libedit-dev.links?ref_type=heads).

#### Details
Add a symbolic link history.h linking to (and next to) readline.h.

---
- [x ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
