### PR TITLE
[efsw] Honor fPIC and require Conan 2.x features

### DIFF
--- a/recipes/efsw/all/test_package/conanfile.py
+++ b/recipes/efsw/all/test_package/conanfile.py
@@ -7,7 +7,6 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
Changes to recipe:  **efsw/1.4.0**

#### Motivation

The PR #25448 introduced the new recipe for efsw. However, it missed my review. 

#### Details

- The upstream enforces fPIC always, overriding the recipe option: https://github.com/SpartanJ/efsw/blob/1.4.0/CMakeLists.txt#L5
- The upstream generates a second static library that's packaged, but not listed in cpp_info: 
  - https://github.com/SpartanJ/efsw/blob/1.4.0/CMakeLists.txt#L27
  - https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-25448/11/package_build_logs/build_log_efsw_1_4_0_6542073374ca622afe046e6c97ae7645_13be611585c95453f1cbbd053cea04b3e64470ca.success.txt
- Explicit is no longer required as the require requires Conan 2.x. Using implements feature.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan