### PR TITLE
Add minio-cpp package

### DIFF
--- a/recipes/minio-cpp/all/conandata.yml
+++ b/recipes/minio-cpp/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "0.3.0":
+    url:
+    - "https://github.com/minio/minio-cpp/archive/refs/tags/v0.3.0.tar.gz"
+    sha256: "da0f2f54bf169ad9e5e9368cc9143df4db056fc5c05bb55d8c1d9065e7211f7c"
+patches:
+  "0.3.0":
+    - patch_file: "patches/0.3.0-0001-fix-cmake.patch"
+      patch_type: "conan"
+      patch_description: "CMake: dependencies, shared library, cppstd, fPIC"

--- a/recipes/minio-cpp/all/conanfile.py
+++ b/recipes/minio-cpp/all/conanfile.py
@@ -1,0 +1,96 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class MinioCppConan(ConanFile):
+    name = "minio-cpp"
+    description = "The MinIO C++ Client SDK provides simple APIs to access any Amazon S3 compatible object storage"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/minio/minio-cpp"
+    topics = ("aws", "cpp", "storage", "aws-s3", "minio")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "Visual Studio": "15",
+            "msvc": "191",
+            "clang": "5",
+            "apple-clang": "10",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("openssl/3.3.2")
+        self.requires("curlpp/0.8.1.cci.20240530", transitive_headers=True)
+        self.requires("inih/58")
+        self.requires("nlohmann_json/3.11.3", transitive_headers=True)
+        self.requires("pugixml/1.14")
+        self.requires("zlib/1.3.1")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, "17")
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["miniocpp"]
+        self.cpp_info.set_property("cmake_file_name", "miniocpp")
+        self.cpp_info.set_property("cmake_target_name", "miniocpp::miniocpp")
+        self.cpp_info.set_property("pkg_config_name", "miniocpp")

--- a/recipes/minio-cpp/all/patches/0.3.0-0001-fix-cmake.patch
+++ b/recipes/minio-cpp/all/patches/0.3.0-0001-fix-cmake.patch
@@ -1,0 +1,43 @@
+--- minio-cpp-0.3.0/CMakeLists.txt	2024-08-21 18:38:23.000000000 +0200
++++ CMakeLists.txt	2024-11-04 15:49:53.990367855 +0100
+@@ -57,17 +57,17 @@
+ # ------------
+ 
+ find_package(OpenSSL REQUIRED)
+-find_package(unofficial-curlpp CONFIG REQUIRED)
+-find_package(unofficial-inih CONFIG REQUIRED)
++find_package(curlpp CONFIG REQUIRED)
++find_package(inih CONFIG REQUIRED)
+ find_package(nlohmann_json CONFIG REQUIRED)
+ find_package(pugixml CONFIG REQUIRED)
+ find_package(ZLIB REQUIRED)
+ 
+ list(APPEND MINIO_CPP_LIBS
+-  unofficial::curlpp::curlpp
+-  unofficial::inih::inireader
++  curlpp::curlpp
++  inih::inireader
+   nlohmann_json::nlohmann_json
+-  pugixml
++  pugixml::pugixml
+   OpenSSL::SSL OpenSSL::Crypto
+   ZLIB::ZLIB
+ )
+@@ -115,16 +115,14 @@
+   include/miniocpp/utils.h
+ )
+ 
+-add_library(miniocpp STATIC ${MINIO_CPP_SOURCES} ${MINIO_CPP_HEADERS})
++add_library(miniocpp ${MINIO_CPP_SOURCES} ${MINIO_CPP_HEADERS})
+ target_compile_options(miniocpp PRIVATE ${MINIO_CPP_CFLAGS})
+-target_compile_features(miniocpp PUBLIC cxx_std_${MINIO_CPP_STD})
+ target_include_directories(miniocpp PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+ )
+ target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
+ set_target_properties(miniocpp PROPERTIES VERSION "${MINIO_CPP_VERSION_STRING}")
+-set_target_properties(miniocpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ 
+ # Add a cmake alias - this is how users should use minio-cpp in their cmake projects.
+ add_library(miniocpp::miniocpp ALIAS miniocpp)

--- a/recipes/minio-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/minio-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package LANGUAGES CXX)
+
+find_package(miniocpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE miniocpp::miniocpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/minio-cpp/all/test_package/conanfile.py
+++ b/recipes/minio-cpp/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/minio-cpp/all/test_package/test_package.cpp
+++ b/recipes/minio-cpp/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include "miniocpp/client.h"
+
+
+int main() {
+    minio::s3::BaseUrl base_url("play.min.io");
+}

--- a/recipes/minio-cpp/config.yml
+++ b/recipes/minio-cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.0":
+    folder: all


### PR DESCRIPTION
### Summary
Add new recipe: **minio-cpp/0.3.0**

#### Motivation
I'm using Conan at work, and would like to add this missing package.

#### Details
New recipe based on the cmake package template. One patch for the `CMakeLists.txt` file, fixes dependency naming, enable building as a shared library, and removing hardcoded cppstd and fPIC.


---
- [ x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x] Tested locally with at least one configuration using a recent version of Conan
