### PR TITLE
(#25628) [boost] Disable process library on iOS

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -588,6 +588,10 @@ class BoostConan(ConanFile):
                 elif not self._has_cppstd_14_supported:
                     disable_graph()
 
+            if self.settings.os == "iOS":
+                # the process library doesn't build (and doesn't even make sense) on iOS
+                self.options.without_process = True
+
             # TODO: Revisit on Boost 1.87.0
             # It's not possible to disable process only when having shared parsed already.
             # https://github.com/boostorg/process/issues/408


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.86.0**

#### Motivation
iOS does not support subprocesses (all apps have to be a single process), so the operating system APIs this library depends on do not exist on iOS.

fixes #25628

#### Details
Set `without_process` by default on iOS, but only on Boost 1.86+ (the process library is header-only before this version).

#### Testing
Sadly, it is not possible to do iOS builds of Boost in Conan 2 right now, because ios-cmake isn't building (see #21532). I have locally tested:

- a normal macOS (Xcode 15) build on conan 2.9.1
- an iOS build on conan 1.65.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
