### PR TITLE
Add spirv-cross/1.3.296.0

### DIFF
--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.296.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
+    sha256: "4f7f9a8a643e6694f155712016b9b572c13a9444e65b3f43b27bb464c0ab76e0"  
   "1.3.268.0":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
     sha256: "dd656a51ba4c229c1a0bb220b7470723e8fd4b68abb7f2cf2ca4027df824f4a0"

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.296.0":
+    folder: all  
   "1.3.268.0":
     folder: all
   "1.3.261.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **spirv-cross/1.3.296.0**

#### Motivation
Version bump
https://github.com/KhronosGroup/SPIRV-Cross/compare/vulkan-sdk-1.3.268.0...vulkan-sdk-1.3.296.0

#### Details
config.yml and conandata.yml point to the newly created spirv-cross/1.3.296.0.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
