### PR TITLE
folly: add version 2024.11.04.00

### DIFF
--- a/recipes/folly/all/conandata.yml
+++ b/recipes/folly/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2024.11.04.00":
+    url: "https://github.com/facebook/folly/releases/download/v2024.11.04.00/folly-v2024.11.04.00.tar.gz"
+    sha256: "55fa5f3f3399fd022a157db8d8144249e8fbe115c13d833d333a719ba2a81216"
   "2024.08.12.00":
     url: "https://github.com/facebook/folly/releases/download/v2024.08.12.00/folly-v2024.08.12.00.tar.gz"
     sha256: "18d7be721721db547cb9c5dd5cc50df05cd88b0a8e683e3126ec6f9ce2c41c4d"


### PR DESCRIPTION
### Summary
Changes to recipe:  **folly/2024.11.04.00**

#### Motivation
There are almost three months since 2024.08.12.00.
Adding `with_libaio` option.

#### Details
https://github.com/facebook/folly/compare/v2024.08.12.00...v2024.11.04.00

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
