### PR TITLE
libmount: add 2.40.2

### DIFF
--- a/recipes/libmount/all/conandata.yml
+++ b/recipes/libmount/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.40.2":
+    url: "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.2.tar.xz"
+    sha256: "d78b37a66f5922d70edf3bdfb01a6b33d34ed3c3cafd6628203b2a2b67c8e8b3"
   "2.39.2":
     url: "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-2.39.2.tar.xz"
     sha256: "87abdfaa8e490f8be6dde976f7c80b9b5ff9f301e1b67e3899e1f05a59a1531f"
@@ -11,6 +14,3 @@ sources:
   "2.36":
     url: "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.36/util-linux-2.36.tar.xz"
     sha256: "9e4b1c67eb13b9b67feb32ae1dc0d50e08ce9e5d82e1cccd0ee771ad2fa9e0b1"
-  "2.33.1":
-    url: "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.33/util-linux-2.33.1.tar.xz"
-    sha256: "c14bd9f3b6e1792b90db87696e87ec643f9d63efa0a424f092a5a6b2f2dbef21"

--- a/recipes/libmount/config.yml
+++ b/recipes/libmount/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.40.2":
+    folder: all
   "2.39.2":
     folder: all
   "2.39":
@@ -6,6 +8,4 @@ versions:
   "2.36.2":
     folder: all
   "2.36":
-    folder: all
-  "2.33.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  libmount, add version 2.40.2 and stop publishing revisions for 2.33.1