### PR TITLE
tree-sitter-cql: add recipe

### DIFF
--- a/recipes/tree-sitter-cql/all/CMakeLists.txt
+++ b/recipes/tree-sitter-cql/all/CMakeLists.txt
@@ -4,7 +4,7 @@ project(tree-sitter-cql LANGUAGES C)
 find_package(tree-sitter REQUIRED CONFIG)
 
 add_library(${PROJECT_NAME}
-    src/parser.c
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/src/parser.c"
 )
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
@@ -12,12 +12,12 @@ target_link_libraries(${PROJECT_NAME}
 )
 target_include_directories(${PROJECT_NAME}
     PRIVATE
-        $<BUILD_INTERFACE:${TREE_SITTER_CQL_SRC_DIR}/src>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
         C_STANDARD 99
-        PUBLIC_HEADER "${TREE_SITTER_CQL_SRC_DIR}/bindings/c/tree-sitter-cql.h"
+        PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/src/bindings/c/tree-sitter-cql.h"
 )
 
 include(GNUInstallDirs)

--- a/recipes/tree-sitter-cql/all/CMakeLists.txt
+++ b/recipes/tree-sitter-cql/all/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.15)
+project(tree-sitter-cql LANGUAGES C)
+
+find_package(tree-sitter REQUIRED CONFIG)
+
+add_library(${PROJECT_NAME}
+    src/parser.c
+)
+target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+        tree-sitter::tree-sitter
+)
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+        $<BUILD_INTERFACE:${TREE_SITTER_CQL_SRC_DIR}/src>
+)
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        C_STANDARD 99
+        PUBLIC_HEADER "${TREE_SITTER_CQL_SRC_DIR}/bindings/c/tree-sitter-cql.h"
+)
+
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME}
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)

--- a/recipes/tree-sitter-cql/all/conandata.yml
+++ b/recipes/tree-sitter-cql/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.2.0":
+    url: "https://github.com/shotover/tree-sitter-cql/archive/refs/tags/v0.2.0.tar.gz"
+    sha256: "fc5aa2c660b6e6daa48e14b4bb7aca0a5a69294229bfae4fdcd9761d288edf07"

--- a/recipes/tree-sitter-cql/all/conanfile.py
+++ b/recipes/tree-sitter-cql/all/conanfile.py
@@ -12,8 +12,8 @@ class TreeSitterCQLConan(ConanFile):
     description = "Tree-sitter parser for Cassandra CQL language"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/tree-sitter/tree-sitter-c"
-    topics = ("parser", "grammar", "tree", "c", "ide")
+    homepage = "https://github.com/shotover/tree-sitter-cql"
+    topics = ("parser", "grammar", "tree", "CQL", "cassandra")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
 
@@ -59,7 +59,7 @@ class TreeSitterCQLConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def _patch_sources(self):
-        if not self.options.shared:
+        if not self.options.get_safe("shared"):
             replace_in_file(
                 self,
                 os.path.join(self.source_folder, "src", "parser.c"),

--- a/recipes/tree-sitter-cql/all/conanfile.py
+++ b/recipes/tree-sitter-cql/all/conanfile.py
@@ -1,0 +1,88 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import get, replace_in_file, copy
+from conan.tools.microsoft import is_msvc
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class TreeSitterCQLConan(ConanFile):
+    name = "tree-sitter-cql"
+    description = "Tree-sitter parser for Cassandra CQL language"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/tree-sitter/tree-sitter-c"
+    topics = ("parser", "grammar", "tree", "c", "ide")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def export_sources(self):
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=(self.export_sources_folder + "/src"))
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if is_msvc(self):
+            del self.options.shared
+            self.package_type = "static-library"
+        if self.options.get_safe("shared"):
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("tree-sitter/0.24.3", transitive_headers=True, transitive_libs=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["TREE_SITTER_CQL_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def _patch_sources(self):
+        if not self.options.shared:
+            replace_in_file(
+                self,
+                os.path.join(self.source_folder, "src", "parser.c"),
+                "__declspec(dllexport)", ""
+            )
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["tree-sitter-cql"]
+        self.cpp_info.set_property("pkg_config_name", "tree-sitter-cql")
+

--- a/recipes/tree-sitter-cql/all/test_package/CMakeLists.txt
+++ b/recipes/tree-sitter-cql/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(PkgConfig)
+pkg_check_modules(TREE_SITTER_CQL IMPORTED_TARGET "tree-sitter-cql")
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::TREE_SITTER_CQL)

--- a/recipes/tree-sitter-cql/all/test_package/CMakeLists.txt
+++ b/recipes/tree-sitter-cql/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
-find_package(PkgConfig)
-pkg_check_modules(TREE_SITTER_CQL IMPORTED_TARGET "tree-sitter-cql")
+find_package(tree-sitter-cql REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::TREE_SITTER_CQL)
+target_link_libraries(${PROJECT_NAME} PRIVATE tree-sitter-cql::tree-sitter-cql)

--- a/recipes/tree-sitter-cql/all/test_package/conanfile.py
+++ b/recipes/tree-sitter-cql/all/test_package/conanfile.py
@@ -1,0 +1,31 @@
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "PkgConfigDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/tree-sitter-cql/all/test_package/conanfile.py
+++ b/recipes/tree-sitter-cql/all/test_package/conanfile.py
@@ -7,18 +7,13 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "PkgConfigDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
 
     def layout(self):
         cmake_layout(self)
-
-    def build_requirements(self):
-        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/tree-sitter-cql/all/test_package/test_package.c
+++ b/recipes/tree-sitter-cql/all/test_package/test_package.c
@@ -1,0 +1,10 @@
+#include <tree_sitter/api.h>
+#include <tree-sitter-cql.h>
+
+int main() {
+    TSParser *parser = ts_parser_new();
+    ts_parser_set_language(parser, tree_sitter_cql());
+    ts_parser_delete(parser);
+    return 0;
+}
+

--- a/recipes/tree-sitter-cql/config.yml
+++ b/recipes/tree-sitter-cql/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.2.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-sitter-cql/***

#### Motivation
CQL(Cassandra Query Language) parser on tree-sitter.

#### Details
https://github.com/shotover/tree-sitter-cql/tree/main/src

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
