### PR TITLE
opentelemetry-cpp: bump grpc to fix unwanted absl log output

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -134,7 +134,7 @@ class OpenTelemetryCppConan(ConanFile):
 
         if self.options.with_otlp_grpc:
             if self._supports_new_proto_grpc_abseil():
-                self.requires("grpc/1.65.0", transitive_headers=True, transitive_libs=True)
+                self.requires("grpc/1.67.1", transitive_headers=True, transitive_libs=True)
             else:
                 self.requires("grpc/1.54.3", transitive_headers=True, transitive_libs=True)
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentelemetry/1.14.2**
fixes #25869

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
gRPC/1.65.0 is affected by a change in absl logging that produces unwanted log output to stdout.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
grpc dependency is bumped from 1.65.0 to 1.67.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
