### PR TITLE
Update soplex to 7.1.2

### DIFF
--- a/recipes/soplex/all/conandata.yml
+++ b/recipes/soplex/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.1.2":
+    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-712.tar.gz"
+    sha256: "a1a7d7f7e30d1db65548b32f75d6f2ed9bd0bf289f639eb4481d3d141c67a332"
   "7.1.1":
     url: "https://github.com/scipopt/soplex/archive/refs/tags/release-711.tar.gz"
     sha256: "75752dca395e219e350f3b462f1f4c08e9d3c2deb2782414862f546a9489cdeb"

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -73,7 +73,7 @@ class SoPlexConan(ConanFile):
             # see https://github.com/conan-io/conan-center-index/pull/16017#issuecomment-1495688452
             self.requires("gmp/6.3.0", transitive_headers=True, transitive_libs=True)
         if self.options.with_boost:
-            self.requires("boost/1.86.0", transitive_headers=True)  # also update Boost_VERSION_MACRO below!
+            self.requires("boost/1.84.0", transitive_headers=True)  # also update Boost_VERSION_MACRO below!
 
     def validate(self):
         if self.settings.compiler.cppstd:
@@ -93,7 +93,7 @@ class SoPlexConan(ConanFile):
         tc.variables["MPFR"] = False
         tc.variables["GMP"] = self.options.with_gmp
         tc.variables["BOOST"] = self.options.with_boost
-        tc.variables["Boost_VERSION_MACRO"] = "108600"
+        tc.variables["Boost_VERSION_MACRO"] = "108400"
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
         deps = CMakeDeps(self)

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -73,7 +73,7 @@ class SoPlexConan(ConanFile):
             # see https://github.com/conan-io/conan-center-index/pull/16017#issuecomment-1495688452
             self.requires("gmp/6.3.0", transitive_headers=True, transitive_libs=True)
         if self.options.with_boost:
-            self.requires("boost/1.84.0", transitive_headers=True)  # also update Boost_VERSION_MACRO below!
+            self.requires("boost/1.86.0", transitive_headers=True)  # also update Boost_VERSION_MACRO below!
 
     def validate(self):
         if self.settings.compiler.cppstd:
@@ -93,7 +93,7 @@ class SoPlexConan(ConanFile):
         tc.variables["MPFR"] = False
         tc.variables["GMP"] = self.options.with_gmp
         tc.variables["BOOST"] = self.options.with_boost
-        tc.variables["Boost_VERSION_MACRO"] = "108400"
+        tc.variables["Boost_VERSION_MACRO"] = "108600"
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
         deps = CMakeDeps(self)

--- a/recipes/soplex/config.yml
+++ b/recipes/soplex/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.1.2":
+    folder: all
   "7.1.1":
     folder: all
   "7.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **soplex/7.1.2**

#### Motivation
New version released, required dependency for SCIP/9.2.0

#### Details
added v7.1.2 and updated dependency boost to 1.86


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
