### PR TITLE
[scip] add v9.2.0

### DIFF
--- a/recipes/scip/all/conandata.yml
+++ b/recipes/scip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "9.2.0":
+    url: "https://github.com/scipopt/scip/archive/refs/tags/v920.tar.gz"
+    sha256: "a22dc20f44e99bfec071889fd5af2bfc57c4af14b76d777d1312006616346f7c"
   "9.0.1":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v901.tar.gz"
     sha256: "08ad3e7ad6f84f457d95bb70ab21fa7fc648dd43103099359ef8a8f30fcce32e"
@@ -11,3 +14,24 @@ sources:
   "8.0.3":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v803.tar.gz"
     sha256: "fe7636f8165a8c9298ff55ed3220d084d4ea31ba9b69d2733beec53e0e4335d6"
+patches:
+  "9.2.0":
+    - patch_file: "patches/0001-bliss-include-dir.patch"
+      patch_description: "Change hard-coded paths to conan includes"
+      patch_type: "conan"
+version_mappings:
+  "9.2.0":
+    soplex: "7.1.2"
+    default_sym: "snauty"
+  "9.0.1":
+    soplex: "7.0.1"
+    default_sym: "bliss"
+  "8.1.0":
+    soplex: "6.0.4"
+    default_sym: "bliss"
+  "8.0.4":
+    soplex: "6.0.4"
+    default_sym: "bliss"
+  "8.0.3":
+    soplex: "6.0.3"
+    default_sym: "bliss"

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -75,10 +75,6 @@ class SCIPConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
     def requirements(self):
         def _mapping_requires(dep, **kwargs):
             required_version = self.conan_data["version_mappings"][self.version][dep]
@@ -92,6 +88,8 @@ class SCIPConan(ConanFile):
         self.requires("zlib/[>=1.2.11 <2]")
 
     def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
         if self.options.with_sym == None:
             self.options.with_sym = self.conan_data["version_mappings"][self.version]["default_sym"]
 

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import copy, get
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get
 from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
 from os.path import join
@@ -25,20 +25,13 @@ class SCIPConan(ConanFile):
         "fPIC": [True, False],
         "with_gmp": [True, False],
         "with_tpi": [False, "omp", "tny"],
-        "with_sym": [False, "bliss"],
+        "with_sym": [False, "bliss", "snauty"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_gmp": True,
-        "with_tpi": False,
-        "with_sym": "bliss",
-    }
-    soplex_version_belonging_to_me = {
-        "9.0.1": "7.0.1",
-        "8.1.0": "6.0.4",
-        "8.0.4": "6.0.4",
-        "8.0.3": "6.0.3"
+        "with_tpi": False
     }
 
     @property
@@ -52,6 +45,9 @@ class SCIPConan(ConanFile):
             "clang": "4",
             "apple-clang": "7",
         }
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def validate(self):
         if self.settings.compiler.cppstd:
@@ -84,12 +80,20 @@ class SCIPConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
+        def _mapping_requires(dep, **kwargs):
+            required_version = self.conan_data["version_mappings"][self.version][dep]
+            self.requires(f"{dep}/{required_version}", **kwargs)
+
         if self.options.with_gmp:
             self.requires("gmp/6.3.0")
         if self.options.with_sym == "bliss":
             self.requires("bliss/0.77")
-        self.requires(f"soplex/{self.soplex_version_belonging_to_me[self.version]}")
+        _mapping_requires("soplex")
         self.requires("zlib/[>=1.2.11 <2]")
+
+    def config_options(self):
+        if self.options.with_sym == None:
+            self.options.with_sym = self.conan_data["version_mappings"][self.version]["default_sym"]
 
     def configure(self):
         self.options["soplex"].with_gmp = self.options.with_gmp
@@ -104,6 +108,7 @@ class SCIPConan(ConanFile):
         return ";".join(item.replace("\\", "/") for sublist in arrays for item in sublist)
 
     def generate(self):
+        apply_conandata_patches(self)
         tc = CMakeToolchain(self)
         tc.variables["SHARED"] = self.options.shared
         tc.variables["READLINE"] = False  # required for interactive stuff

--- a/recipes/scip/all/patches/0001-bliss-include-dir.patch
+++ b/recipes/scip/all/patches/0001-bliss-include-dir.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c23a1a85c9..f288b2b89d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -133,11 +133,10 @@ if(SYM STREQUAL "bliss" OR SYM STREQUAL "sbliss")
+ 
+     find_package(Bliss CONFIG HINTS ${BLISS_DIR})
+     if(Bliss_FOUND)
+-        get_filename_component(BLISS_ABSOLUTE_PATH ${Bliss_DIR}/../../.. REALPATH)
+-        include_directories(${BLISS_ABSOLUTE_PATH}/include)
+-        set(SYM_LIBRARIES ${BLISS_ABSOLUTE_PATH}/lib/libbliss.a)
+-        set(SYM_PIC_LIBRARIES ${BLISS_ABSOLUTE_PATH}/lib/libbliss.a)
+-        message(STATUS "Found Bliss: ${BLISS_ABSOLUTE_PATH}")
++        include_directories("${bliss_INCLUDE_DIRS}")
++        set(SYM_LIBRARIES "bliss::bliss")
++        set(SYM_PIC_LIBRARIES "bliss::bliss")
++        message(STATUS "Found Bliss via Conan")
+     else()
+         # Utilities to automatically download missing dependencies
+         include(cmake/Dependencies.cmake)

--- a/recipes/scip/config.yml
+++ b/recipes/scip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "9.2.0":
+    folder: all
   "9.0.1":
     folder: all
   "8.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **scip/9.2.0**

#### Motivation
SCIP v9.2.0 was released

#### Details
I added scip 9.2.0. SCIP changed one of its default settings, so I moved that to the conandata file. I added a patch as the new upstream CMakeLists contains a wrong path, upstream issue https://github.com/scipopt/scip/issues/117 created

This would make #24682 obsolete

The CI will fail until soplex/7.1.2 is released, see #25871 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
