### PR TITLE
Fix boost 1.86.0 recipe for x86 arch

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -621,7 +621,7 @@ class BoostConan(ConanFile):
             return not self.options.header_only and not self.options.without_stacktrace and self.settings.os != "Windows"
         elif Version(self.version) >= "1.86.0":
             # https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L148
-            return not self.options.header_only and not self.options.without_stacktrace and self.settings.arch == "x86_64"
+            return not self.options.header_only and not self.options.without_stacktrace and self._b2_architecture() == "x86"
 
     def configure(self):
         if self.options.header_only:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -621,7 +621,7 @@ class BoostConan(ConanFile):
             return not self.options.header_only and not self.options.without_stacktrace and self.settings.os != "Windows"
         elif Version(self.version) >= "1.86.0":
             # https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L148
-            return not self.options.header_only and not self.options.without_stacktrace and self._b2_architecture() == "x86"
+            return not self.options.header_only and not self.options.without_stacktrace and self._b2_architecture == "x86"
 
     def configure(self):
         if self.options.header_only:


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.86.0**

### Motivation
Fix https://github.com/conan-io/conan-center-index/issues/25864.

### Details
We can see the relevant part of the build definition for boost 1.86.0 [here](https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L148).  The token `$(arch:G=)` will evaluate to `x86` in two conan recipe scenarios:
* settings.arch = "x86"
* settings.arch = "x86_64"

We also see an existing helper property `_b2_architecture` in the conan recipe [here](https://github.com/conan-io/conan-center-index/blob/f7a9ac9570e8f7d6fe806e1ca9b9be5dbdf828a5/recipes/boost/all/conanfile.py#L1206).

Therefore this change seems reasonable.

### Testing
#### profile "win32_v192_debug.txt"
VS 2019 16.11.41
```
[settings]
arch=x86
build_type=Debug
compiler=msvc
compiler.runtime=dynamic
compiler.runtime_type=Debug
compiler.version=192
os=Windows
```
#### profile "x64_v192_debug.txt"
VS 2019 16.11.41
```
[settings]
arch=x86_64
build_type=Debug
compiler=msvc
compiler.runtime=dynamic
compiler.runtime_type=Debug
compiler.version=192
os=Windows
```

#### profile "win32_v194_debug.txt"
VS 2022 17.11.5
```
[settings]
arch=x86
build_type=Debug
compiler=msvc
compiler.runtime=dynamic
compiler.runtime_type=Debug
compiler.version=194
os=Windows
```
#### profile "x64_v194_debug.txt"
VS 2022 17.11.5
```
[settings]
arch=x86_64
build_type=Debug
compiler=msvc
compiler.runtime=dynamic
compiler.runtime_type=Debug
compiler.version=194
os=Windows
```

#### cases
Using Conan 2.9.2:
* [x] `conan create ./all --version 1.86.0 --build missing --profile:all "C:\tmp\conan_profiles\win32_v192_debug.txt"`
* [ ] `conan create ./all --version 1.86.0 --build missing --profile:all "C:\tmp\conan_profiles\x64_v192_debug.txt"`
* [x] `conan create ./all --version 1.86.0 --build missing --profile:all "C:\tmp\conan_profiles\win32_v194_debug.txt"`
* [x] `conan create ./all --version 1.86.0 --build missing --profile:all "C:\tmp\conan_profiles\x64_v194_debug.txt"`
---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
