### PR TITLE
opencolorio: Bump lcms dependency to version 2.16

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -67,7 +67,7 @@ class OpenColorIOConan(ConanFile):
             self.requires("minizip-ng/3.0.9")
 
         # for tools only
-        self.requires("lcms/2.14")
+        self.requires("lcms/2.16")
         # TODO: add GLUT (needed for ociodisplay tool)
 
     def validate(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencolorio/all**

#### Motivation
This is a copy of #25660 which was reverted to not introduce unexpected changes in the last week before the freeze. @AbrilRBS suggested we do it afterwards and now with 3.0 released, I'm working on completing the recipe update (#25672).

To prepare OpenImageIO 3.0.0.0 which is currently in beta and added libjxl support, to support both opencolorio & libjxl requirements at the same time, the lcms version needs to match.

(I have a branch for OpenImageIO 3.0.0.0 which currently uses the beta but will be published as an MR once the release has happened. https://github.com/conan-io/conan-center-index/pull/25672 is created to start discussion and try if everything else builds in all CI combinations already)

#### Details
OpenImageIO with the addition of libjxl currently results in a graph error due to libjxl requireing *lcms/2.16* while opencolorio requires *lcms/2.14*

The only user of OpenColorIO in CCI is OpenImageIO so the side effect should hopefully be small.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
