### PR TITLE
libraw: Bump lcms dependency to 2.16

### DIFF
--- a/recipes/libraw/all/conanfile.py
+++ b/recipes/libraw/all/conanfile.py
@@ -62,7 +62,7 @@ class LibRawConan(ConanFile):
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.3")
         if self.options.with_lcms:
-            self.requires("lcms/2.14")
+            self.requires("lcms/2.16")
         if self.options.with_jasper:
             self.requires("jasper/4.0.0")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libraw/all**

#### Motivation
I'm currently preparing OpenColorIO 3.0.0 (#25672) which has libraw as an optional dependency but also uses opencolorio and libjxl, both depending on lcms. (libjxl depends on 2.16, opencolorio on 2.14 (see #25899). This MR would ensure that all dependencies use the same version.

#### Details
Only bumping the lcms dependency for compatiblity with the other openimageio requirements.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
