### PR TITLE
opentelemetry-proto: add version 1.3.1, 1.3.2

### DIFF
--- a/recipes/opentelemetry-proto/all/conandata.yml
+++ b/recipes/opentelemetry-proto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.1":
+    url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v1.3.1.tar.gz"
+    sha256: "bed250ceec8e4a83aa5604d7d5595a61945059dc662edd058a9da082283f7a00"
   "1.3.0":
     url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v1.3.0.tar.gz"
     sha256: "73a678b0ff7a29b581381566a2230fe2a00b864608786c99c050a4492e2bbafc"

--- a/recipes/opentelemetry-proto/all/conandata.yml
+++ b/recipes/opentelemetry-proto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.2":
+    url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v1.3.2.tar.gz"
+    sha256: "c069c0d96137cf005d34411fa67dd3b6f1f8c64af1e7fb2fe0089a41c425acd7"
   "1.3.1":
     url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v1.3.1.tar.gz"
     sha256: "bed250ceec8e4a83aa5604d7d5595a61945059dc662edd058a9da082283f7a00"

--- a/recipes/opentelemetry-proto/config.yml
+++ b/recipes/opentelemetry-proto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.2":
+    folder: all
   "1.3.1":
     folder: all
   "1.3.0":

--- a/recipes/opentelemetry-proto/config.yml
+++ b/recipes/opentelemetry-proto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.1":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentelemetry-proto**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
These versions are dependencies for opentelemetry-cpp package, namely:

- opentelemetry-cpp/1.17.0 requires opentelemetry-proto/1.3.2 [(Release v1.17.0)](https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.17.0)
- opentelemetry-cpp/1.16.0 requires opentelemetry-proto/1.3.1 [(Release v1.16.0)](https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.16.0)

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
https://github.com/open-telemetry/opentelemetry-proto/compare/v1.3.1...v1.3.2
https://github.com/open-telemetry/opentelemetry-proto/compare/v1.3.0...v1.3.1



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
