### PR TITLE
openjph: Add 0.18.0, remove 0.15.0

### DIFF
--- a/recipes/openjph/all/conandata.yml
+++ b/recipes/openjph/all/conandata.yml
@@ -1,23 +1,23 @@
 sources:
+  "0.18.0":
+    url: "https://github.com/aous72/OpenJPH/archive/0.18.0.tar.gz"
+    sha256: "2484908bf5a171cda957643d9bc85c39d58ef939016e2d1a00122b1cefbbd4f8"
   "0.17.0":
     url: "https://github.com/aous72/OpenJPH/archive/0.17.0.tar.gz"
     sha256: "9cd09a5f3a8046b10bded787212afd2410836f9c266964a36f61dc4b63f99b6c"
   "0.16.0":
     url: "https://github.com/aous72/OpenJPH/archive/0.16.0.tar.gz"
     sha256: "94bea4d7057f7a5dcb3f8eee3f854955ce153d98dad99602dd0ba50a560d7cf6"
-  "0.15.0":
-    url: "https://github.com/aous72/OpenJPH/archive/0.15.0.tar.gz"
-    sha256: "36601fbd3b4e1fe54eef5e6fa51ac0eca7be94b2a3d7c0967e3c8da66687ff2c"
 patches:
+  "0.18.0":
+    - patch_file: "patches/0.15.0_cmake-cxx-standard.patch"
+      patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan"
+      patch_type: "conan"
   "0.17.0":
     - patch_file: "patches/0.15.0_cmake-cxx-standard.patch"
       patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan"
       patch_type: "conan"
   "0.16.0":
-    - patch_file: "patches/0.15.0_cmake-cxx-standard.patch"
-      patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan"
-      patch_type: "conan"
-  "0.15.0":
     - patch_file: "patches/0.15.0_cmake-cxx-standard.patch"
       patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan"
       patch_type: "conan"

--- a/recipes/openjph/config.yml
+++ b/recipes/openjph/config.yml
@@ -1,7 +1,7 @@
 versions:
+  "0.18.0":
+    folder: all
   "0.17.0":
     folder: all
   "0.16.0":
-    folder: all
-  "0.15.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openjph/0.18** (add), **openjph/0.15** (remove)

#### Motivation
- Contains improvements for lossless compression
- Fixes a bug on some x86 platforms when compiled with Clang and run on non-avx systems.

#### Details
https://github.com/aous72/OpenJPH/releases/tag/0.18.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
