### PR TITLE
tcl: Add 8.6.15 and 9.0.0

### DIFF
--- a/recipes/tcl/all/conandata.yml
+++ b/recipes/tcl/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "9.0.0":
+    url: "https://downloads.sourceforge.net/project/tcl/Tcl/9.0.0/tcl9.0.0-src.tar.gz"
+    sha256: "3bfda6dbaee8e9b1eeacc1511b4e18a07a91dff82d9954cdb9c729d8bca4bbb7"
+  "8.6.15":
+    url: "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.15/tcl8.6.15-src.tar.gz"
+    sha256: "861e159753f2e2fbd6ec1484103715b0be56be3357522b858d3cbb5f893ffef1"
   "8.6.13":
     url: "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.13/tcl8.6.13-src.tar.gz"
     sha256: "43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066"
@@ -9,6 +15,10 @@ sources:
     url: "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.10/tcl8.6.10-src.tar.gz"
     sha256: "5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed"
 patches:
+  "9.0.0":
+    - patch_file: "patches/0001-8.6.11-no-read-only-data.patch"
+  "8.6.15":
+    - patch_file: "patches/0001-8.6.11-no-read-only-data.patch"
   "8.6.13":
     - patch_file: "patches/0001-8.6.11-no-read-only-data.patch"
   "8.6.11":

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -186,6 +186,8 @@ class TclConan(ConanFile):
             for root, _, list_of_files in os.walk(self.build_folder):
                 if "Makefile" in list_of_files:
                     replace_in_file(self, os.path.join(root, "Makefile"), "-Dstrtod=fixstrtod", "", strict=False)
+            # Potentially used by some of the subpackages - make sure it is built first
+            autotools.make(target="minizip")
             # For some reason this target "binaries" may not be built before others
             # on Windows while it's a dependency of many other targets
             autotools.make(target="binaries")

--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -105,13 +105,15 @@ class TclConan(ConanFile):
         unix_config_dir = os.path.join(self.source_folder, "unix")
         # When disabling 64-bit support (in 32-bit), this test must be 0 in order to use "long long" for 64-bit ints
         # (${tcl_type_64bit} can be either "__int64" or "long long")
-        replace_in_file(self, os.path.join(unix_config_dir, "configure"),
-                        "(sizeof(${tcl_type_64bit})==sizeof(long))",
-                        "(sizeof(${tcl_type_64bit})!=sizeof(long))")
+        if Version(self.version) < "9.0.0":
+            replace_in_file(self, os.path.join(unix_config_dir, "configure"),
+                            "(sizeof(${tcl_type_64bit})==sizeof(long))",
+                            "(sizeof(${tcl_type_64bit})!=sizeof(long))")
 
         unix_makefile_in = os.path.join(unix_config_dir, "Makefile.in")
         # Avoid building internal libraries as shared libraries
-        replace_in_file(self, unix_makefile_in, "--enable-shared --enable-threads", "--enable-threads")
+        if Version(self.version) < "9.0.0":
+            replace_in_file(self, unix_makefile_in, "--enable-shared --enable-threads", "--enable-threads")
         # Avoid clearing CFLAGS and LDFLAGS in the makefile
         replace_in_file(self, unix_makefile_in, "\nCFLAGS\t", "\n#CFLAGS\t")
         replace_in_file(self, unix_makefile_in, "\nLDFLAGS\t", "\n#LDFLAGS\t")

--- a/recipes/tcl/all/test_package/library/init.tcl
+++ b/recipes/tcl/all/test_package/library/init.tcl
@@ -1,0 +1,1 @@
+# This file is only necessary for TCL 9.0.0+

--- a/recipes/tcl/config.yml
+++ b/recipes/tcl/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "9.0.0":
+    folder: "all"
+  "8.6.15":
+    folder: "all"
   "8.6.13":
     folder: "all"
   "8.6.11":


### PR DESCRIPTION
New recently released versions

Current issue:
- Mac: `fatal error: the __LINKEDIT segment does not cover the end of the file (can't be processed)` - I have no clue what this means.