### PR TITLE
Align lcms version across repository

### DIFF
--- a/recipes/imagemagick/all/conanfile.py
+++ b/recipes/imagemagick/all/conanfile.py
@@ -108,7 +108,7 @@ class ImageMagicConan(ConanFile):
         if self.options.with_lzma:
             self.requires("xz_utils/5.2.5")
         if self.options.with_lcms:
-            self.requires("lcms/2.11")
+            self.requires("lcms/2.16")
         if self.options.with_openexr:
             self.requires("openexr/2.5.7")
         if self.options.with_heic:

--- a/recipes/libraw/all/conanfile.py
+++ b/recipes/libraw/all/conanfile.py
@@ -62,7 +62,7 @@ class LibRawConan(ConanFile):
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.3")
         if self.options.with_lcms:
-            self.requires("lcms/2.14")
+            self.requires("lcms/2.16")
         if self.options.with_jasper:
             self.requires("jasper/4.0.0")
 

--- a/recipes/libvips/all/conanfile.py
+++ b/recipes/libvips/all/conanfile.py
@@ -156,7 +156,7 @@ class LibvipsConan(ConanFile):
         if self.options.with_jpeg_xl:
             self.requires("libjxl/0.6.1")
         if self.options.with_lcms:
-            self.requires("lcms/2.14")
+            self.requires("lcms/2.16")
         if self.options.with_magick:
             self.requires("imagemagick/7.0.11-14")
         if self.options.with_matio:

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -67,7 +67,7 @@ class OpenColorIOConan(ConanFile):
             self.requires("minizip-ng/3.0.9")
 
         # for tools only
-        self.requires("lcms/2.14")
+        self.requires("lcms/2.16")
         # TODO: add GLUT (needed for ociodisplay tool)
 
     def validate(self):

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -47,7 +47,7 @@ class PdfiumConan(ConanFile):
     def requirements(self):
         self.requires("freetype/2.13.2")
         self.requires("icu/74.1")
-        self.requires("lcms/2.14")
+        self.requires("lcms/2.16")
         self.requires("openjpeg/2.5.0")
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_libjpeg == "libjpeg":

--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -107,7 +107,7 @@ class PopplerConan(ConanFile):
         if self.options.with_openjpeg:
             self.requires("openjpeg/2.5.0")
         if self.options.with_lcms:
-            self.requires("lcms/2.13.1")
+            self.requires("lcms/2.16")
         if self.options.with_libjpeg == "libjpeg":
             self.requires("libjpeg/9d")
         if self.options.with_png:


### PR DESCRIPTION
Align version of dependency on `lcms` across the entire repository to `lcms/2.16`. The aim is to avoid conflicts.

This affects the following recipes:
* imagemagick
* libraw
* libvips
* opencolorio
* pdfium
* poppler

Note that the following have not yet been migrated to Conan 2 - so this PR will not run checks for those
* `imagemagic/7.0.11-4`
* `poppler/20.09.0` and `poppler/21.07.0`

