### PR TITLE
[docs] Remove _settings_build from the autotools template

### DIFF
--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -7,7 +7,6 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path
-from conan.tools.scm import Version
 import os
 
 
@@ -42,10 +41,6 @@ class PackageConan(ConanFile):
         "with_foobar": True,
     }
     implements = ["auto_shared_fpic"]
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
 
     # no exports_sources attribute, but export_sources(self) method instead
     def export_sources(self):
@@ -86,7 +81,7 @@ class PackageConan(ConanFile):
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/[>=2.2 <3]")
         # required to suppport windows as a build machine
-        if self._settings_build.os == "Windows":
+        if self.settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
`self.settings_build` is always defined in Conan 2.x.

#### Details
A small follow-up to #25849.

/cc @uilianries 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
