### PR TITLE
[docs] Add missing config.yml for CMake templates

### DIFF
--- a/docs/package_templates/cmake_package/config.yml
+++ b/docs/package_templates/cmake_package/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "1.2.0":
+    folder: all
+  "1.1.0":
+    folder: all


### PR DESCRIPTION
### Summary

Missing config.yml for CMake Conan recipe templates. 

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
