### PR TITLE
tree-sitter: add version 0.24.4

### DIFF
--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.24.4":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.24.4.tar.gz"
+    sha256: "d704832a6bfaac8b3cbca3b5d773cad613183ba8c04166638af2c6e5dfb9e2d2"
   "0.24.3":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.24.3.tar.gz"
     sha256: "0a8d0cf8e09caba22ed0d8439f7fa1e3d8453800038e43ccad1f34ef29537da1"

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.24.4":
+    folder: all
   "0.24.3":
     folder: all
   "0.23.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-sitter/0.24.4**

#### Motivation
There are several improvements in 0.24.4 for runtime library.

#### Details
https://github.com/tree-sitter/tree-sitter/releases/tag/v0.24.4
https://github.com/tree-sitter/tree-sitter/compare/v0.24.3...v0.24.4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
