### PR TITLE
tesseract: add version 5.5.0, fix url of 5.4.1

### DIFF
--- a/recipes/tesseract/all/conandata.yml
+++ b/recipes/tesseract/all/conandata.yml
@@ -34,9 +34,15 @@ patches:
     - patch_file: "patches/0004-control-optimizations-5.4.0.patch"
       patch_description: "fix condition for cpu optimizations"
       patch_type: "portability"
+    - patch_file: "patches/0005-disable-install-pdb-5.5.0.patch"
+      patch_description: "disable installing PDB files"
+      patch_type: "portability"
   "5.4.1":
     - patch_file: "patches/0004-control-optimizations-5.4.0.patch"
       patch_description: "fix condition for cpu optimizations"
+      patch_type: "portability"
+    - patch_file: "patches/0005-disable-install-pdb-5.4.1.patch"
+      patch_description: "disable installing PDB files"
       patch_type: "portability"
   "5.4.0":
     - patch_file: "patches/0004-control-optimizations-5.4.0.patch"

--- a/recipes/tesseract/all/conandata.yml
+++ b/recipes/tesseract/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "5.5.0":
+    url: "https://github.com/tesseract-ocr/tesseract/archive/5.5.0.tar.gz"
+    sha256: "f2fb34ca035b6d087a42875a35a7a5c4155fa9979c6132365b1e5a28ebc3fc11"
   "5.4.1":
-    url: "https://github.com/tesseract-ocr/tesseract/archive/5.4.0.tar.gz"
-    sha256: "30ceffd9b86780f01cbf4eaf9b7fc59abddfcbaf5bbd52f9a633c6528cb183fd"
+    url: "https://github.com/tesseract-ocr/tesseract/archive/5.4.1.tar.gz"
+    sha256: "c4bc2a81c12a472f445b7c2fb4705a08bd643ef467f51ec84f0e148bd368051b"
   "5.4.0":
     url: "https://github.com/tesseract-ocr/tesseract/archive/5.4.0.tar.gz"
     sha256: "30ceffd9b86780f01cbf4eaf9b7fc59abddfcbaf5bbd52f9a633c6528cb183fd"
@@ -27,6 +30,10 @@ sources:
     url: "https://github.com/tesseract-ocr/tesseract/archive/4.1.1.tar.gz"
     sha256: "2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb"
 patches:
+  "5.5.0":
+    - patch_file: "patches/0004-control-optimizations-5.4.0.patch"
+      patch_description: "fix condition for cpu optimizations"
+      patch_type: "portability"
   "5.4.1":
     - patch_file: "patches/0004-control-optimizations-5.4.0.patch"
       patch_description: "fix condition for cpu optimizations"

--- a/recipes/tesseract/all/patches/0005-disable-install-pdb-5.4.1.patch
+++ b/recipes/tesseract/all/patches/0005-disable-install-pdb-5.4.1.patch
@@ -1,0 +1,179 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0dec189..70a11c0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -927,7 +927,7 @@ install(
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+   RENAME tesseract.pc)
+ install(TARGETS tesseract DESTINATION bin)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION bin OPTIONAL)
+ endif()
+ install(
+@@ -937,7 +937,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:libtesseract> DESTINATION bin OPTIONAL)
+ endif()
+ install(
+diff --git a/src/training/CMakeLists.txt b/src/training/CMakeLists.txt
+index 7fbf021..97fb7a4 100644
+--- a/src/training/CMakeLists.txt
++++ b/src/training/CMakeLists.txt
+@@ -126,7 +126,7 @@ install(
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ generate_export_header(common_training EXPORT_MACRO_NAME
+                        TESS_COMMON_TRAINING_API)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:common_training> DESTINATION bin OPTIONAL)
+ endif()
+ project_group(common_training "Training Tools")
+@@ -144,7 +144,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:ambiguous_words> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -162,7 +162,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:classifier_tester> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -179,7 +179,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:combine_tessdata> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -196,7 +196,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:cntraining> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -213,7 +213,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:dawg2wordlist> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -230,7 +230,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:mftraining> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -248,7 +248,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+      install(FILES $<TARGET_PDB_FILE:shapeclustering> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -265,7 +265,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:wordlist2dawg> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -298,7 +298,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:unicharset_training> DESTINATION bin OPTIONAL)
+   endif()
+   generate_export_header(unicharset_training EXPORT_MACRO_NAME
+@@ -317,7 +317,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:combine_lang_model> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -333,7 +333,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:lstmeval> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -349,7 +349,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:lstmtraining> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -365,7 +365,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:merge_unicharsets> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -381,7 +381,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:set_unicharset_properties> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -398,7 +398,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:unicharset_extractor> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -457,7 +457,7 @@ if(ICU_FOUND)
+       RUNTIME DESTINATION bin
+       LIBRARY DESTINATION lib
+       ARCHIVE DESTINATION lib)
+-    if (MSVC)
++    if (0)
+       install(FILES $<TARGET_PDB_FILE:text2image> DESTINATION bin OPTIONAL)
+     endif()
+   endif()

--- a/recipes/tesseract/all/patches/0005-disable-install-pdb-5.5.0.patch
+++ b/recipes/tesseract/all/patches/0005-disable-install-pdb-5.5.0.patch
@@ -1,0 +1,179 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6cb5a6c..1802e38 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -925,7 +925,7 @@ install(
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+   RENAME tesseract.pc)
+ install(TARGETS tesseract DESTINATION bin)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION bin OPTIONAL)
+ endif()
+ install(
+@@ -935,7 +935,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-if (MSVC AND BUILD_SHARED_LIBS)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:libtesseract> DESTINATION bin OPTIONAL)
+ endif()
+ install(
+diff --git a/src/training/CMakeLists.txt b/src/training/CMakeLists.txt
+index c764442..97fb7a4 100644
+--- a/src/training/CMakeLists.txt
++++ b/src/training/CMakeLists.txt
+@@ -126,7 +126,7 @@ install(
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ generate_export_header(common_training EXPORT_MACRO_NAME
+                        TESS_COMMON_TRAINING_API)
+-if (MSVC AND BUILD_SHARED_LIBS)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:common_training> DESTINATION bin OPTIONAL)
+ endif()
+ project_group(common_training "Training Tools")
+@@ -144,7 +144,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:ambiguous_words> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -162,7 +162,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:classifier_tester> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -179,7 +179,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:combine_tessdata> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -196,7 +196,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:cntraining> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -213,7 +213,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:dawg2wordlist> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -230,7 +230,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:mftraining> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -248,7 +248,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+      install(FILES $<TARGET_PDB_FILE:shapeclustering> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -265,7 +265,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:wordlist2dawg> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -298,7 +298,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  if (MSVC AND BUILD_SHARED_LIBS)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:unicharset_training> DESTINATION bin OPTIONAL)
+   endif()
+   generate_export_header(unicharset_training EXPORT_MACRO_NAME
+@@ -317,7 +317,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:combine_lang_model> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -333,7 +333,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:lstmeval> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -349,7 +349,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:lstmtraining> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -365,7 +365,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:merge_unicharsets> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -381,7 +381,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:set_unicharset_properties> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -398,7 +398,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:unicharset_extractor> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -457,7 +457,7 @@ if(ICU_FOUND)
+       RUNTIME DESTINATION bin
+       LIBRARY DESTINATION lib
+       ARCHIVE DESTINATION lib)
+-    if (MSVC)
++    if (0)
+       install(FILES $<TARGET_PDB_FILE:text2image> DESTINATION bin OPTIONAL)
+     endif()
+   endif()

--- a/recipes/tesseract/config.yml
+++ b/recipes/tesseract/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.5.0":
+    folder: all
   "5.4.1":
     folder: all
   "5.4.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tesseract/5.4.1,5.5.0**

#### Motivation
Fix wrong url of 5.4.1 (Sorry. It's my mistake)
There are several improvements in 5.5.0.

#### Details
https://github.com/tesseract-ocr/tesseract/compare/5.4.1...5.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
