### PR TITLE
Fix /usr/bin/x86_64-w64-mingw32-ld: cannot find -lAdvapi32: No such f…

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -2046,7 +2046,7 @@ class BoostConan(ConanFile):
 
             if not self.options.get_safe("without_process"):
                 if self.settings.os == "Windows":
-                    self.cpp_info.components["process"].system_libs.extend(["ntdll", "shell32", "Advapi32", "user32"])
+                    self.cpp_info.components["process"].system_libs.extend(["ntdll", "shell32", "advapi32", "user32"])
                 if self._shared:
                     self.cpp_info.components["process"].defines.append("BOOST_PROCESS_DYN_LINK")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.80.0**

#### Motivation
/usr/bin/x86_64-w64-mingw32-ld: cannot find -lAdvapi32: No such file or directory

#### Details
File names are generally case sensitive on linux.
Boost recipe lists Advapi32 as one of the system_libs, but the file on disk is actually all lower case:
/usr/x86_64-w64-mingw32/lib/libadvapi32.a


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
