### PR TITLE
[docs] Fix auto_shared_fpic usage in CCI recipe templates

### DIFF
--- a/docs/package_templates/autotools_package/all/conanfile.py
+++ b/docs/package_templates/autotools_package/all/conanfile.py
@@ -40,6 +40,7 @@ class PackageConan(ConanFile):
         "fPIC": True,
         "with_foobar": True,
     }
+    # In case having config_options() or configure() method, the logic should be moved to the specific methods.
     implements = ["auto_shared_fpic"]
 
     # no exports_sources attribute, but export_sources(self) method instead
@@ -47,6 +48,10 @@ class PackageConan(ConanFile):
         export_conandata_patches(self)
 
     def configure(self):
+        # Keep this logic only in case configure() is needed e.g pure-c project.
+        # Otherwise remove configure() and auto_shared_fpic will manage it.
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
         # for plain C projects only. Otherwise, remove this method.
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")

--- a/docs/package_templates/cmake_package/all/conanfile.py
+++ b/docs/package_templates/cmake_package/all/conanfile.py
@@ -35,6 +35,7 @@ class PackageConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
+    # In case having config_options() or configure() method, the logic should be moved to the specific methods.
     implements = ["auto_shared_fpic"]
 
     # no exports_sources attribute, but export_sources(self) method instead
@@ -42,6 +43,10 @@ class PackageConan(ConanFile):
         export_conandata_patches(self)
 
     def configure(self):
+        # Keep this logic only in case configure() is needed e.g pure-c project.
+        # Otherwise remove configure() and auto_shared_fpic will manage it.
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
         # for plain C projects only
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")

--- a/docs/package_templates/meson_package/all/conanfile.py
+++ b/docs/package_templates/meson_package/all/conanfile.py
@@ -7,7 +7,6 @@ from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import is_msvc
-from conan.tools.scm import Version
 import os
 
 
@@ -41,6 +40,7 @@ class PackageConan(ConanFile):
         "fPIC": True,
         "feature": True,
     }
+    # In case having config_options() or configure() method, the logic should be moved to the specific methods.
     implements = ["auto_shared_fpic"]
 
     # no exports_sources attribute, but export_sources(self) method instead
@@ -48,6 +48,10 @@ class PackageConan(ConanFile):
         export_conandata_patches(self)
 
     def configure(self):
+        # Keep this logic only in case configure() is needed e.g pure-c project.
+        # Otherwise remove configure() and auto_shared_fpic will manage it.
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
         # for plain C projects only. Otherwise, remove this method.
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")

--- a/docs/package_templates/msbuild_package/all/conanfile.py
+++ b/docs/package_templates/msbuild_package/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import MSBuild, MSBuildDeps, MSBuildToolchain, is_msvc
 import os
@@ -24,13 +24,10 @@ class PackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
-        "fPIC": [True, False],
     }
     default_options = {
         "shared": False,
-        "fPIC": True,
     }
-    implements = ["auto_shared_fpic"]
 
     # no exports_sources attribute, but export_sources(self) method instead
     def export_sources(self):


### PR DESCRIPTION
### Summary

The `auto_shared_fpic` works only when `configure()` or `config_options()` are not declared in the recipe. Otherwise, each method should manage the shared/fPIC as usual.

The `auto_shared_fpic` will act by replacing `configure()` or `config_options()`. In case one of them is defined, it will replace what is missing with the fPIC removal logic. 

I also updated the template for msbuild, as it's focused on Visual Studio, I removed fPIC option as well. 

Reference:

- https://docs.conan.io/2/reference/conanfile/methods/configure.html#auto-shared-fpic
- https://docs.conan.io/2/reference/conanfile/methods/config_options.html#auto-shared-fpic


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
