### PR TITLE
libqasm: add version 0.6.9

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -3,14 +3,14 @@ sources:
     url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.9.tar.gz"
     sha256: "23c5d0e4e506e1974668408f8018034d1b1303e65c6d2d28639eae9499759c4d"
   "0.6.8":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.8.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.8/libqasm-0.6.8.tar.gz"
     sha256: "b98ff44f0c569a0cc20b3728ba7d4711299aaac07d4dadfe52e638b366b91251"
   "0.6.7":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.7.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.7/libqasm-0.6.7.tar.gz"
     sha256: "3e85be4f433b178b89e32bc738bd4f69266cd1c4ad0ed12b5367381ac6e44eb2"
   "0.6.6":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.6.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.6/libqasm-0.6.6.tar.gz"
     sha256: "b3a2d1670f8865ce22bcc62c6a696ee7e0764a7b76901a4f082efa2287e0cbad"
   "0.6.5":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.5.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.5/libqasm-0.6.5.tar.gz"
     sha256: "0577622a512d1f64892949af02abe3d0b53195ad454045715a0ebf837ecde0d6"

--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.9":
+    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.9.tar.gz"
+    sha256: "23c5d0e4e506e1974668408f8018034d1b1303e65c6d2d28639eae9499759c4d"
   "0.6.8":
     url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.8.tar.gz"
     sha256: "b98ff44f0c569a0cc20b3728ba7d4711299aaac07d4dadfe52e638b366b91251"

--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -3,14 +3,14 @@ sources:
     url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.9.tar.gz"
     sha256: "23c5d0e4e506e1974668408f8018034d1b1303e65c6d2d28639eae9499759c4d"
   "0.6.8":
-    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.8.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.8.tar.gz"
     sha256: "b98ff44f0c569a0cc20b3728ba7d4711299aaac07d4dadfe52e638b366b91251"
   "0.6.7":
-    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.7.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.7.tar.gz"
     sha256: "3e85be4f433b178b89e32bc738bd4f69266cd1c4ad0ed12b5367381ac6e44eb2"
   "0.6.6":
-    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.6.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.6.tar.gz"
     sha256: "b3a2d1670f8865ce22bcc62c6a696ee7e0764a7b76901a4f082efa2287e0cbad"
   "0.6.5":
-    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.5.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.5.tar.gz"
     sha256: "0577622a512d1f64892949af02abe3d0b53195ad454045715a0ebf837ecde0d6"

--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "0.6.9":
-    url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.9.tar.gz"
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.9.tar.gz"
     sha256: "23c5d0e4e506e1974668408f8018034d1b1303e65c6d2d28639eae9499759c4d"
   "0.6.8":
     url: "https://github.com/QuTech-Delft/libqasm/archive/refs/tags/0.6.8.tar.gz"

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.9":
+    folder: all
   "0.6.8":
     folder: all
   "0.6.7":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libqasm/0.6.9**

#### Motivation
Just a version bump.

#### Details
config.yml and conandata.yml point to the newly created libqasm/0.6.9.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
