### PR TITLE
OpenCV/4.x: align JPEG codec option with project upstream defaults

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -188,7 +188,7 @@ class OpenCVConan(ConanFile):
         "with_wayland": True,
         # imgcodecs module options
         "with_avif": False,
-        "with_jpeg": "libjpeg",
+        "with_jpeg": "libjpeg-turbo",
         "with_png": True,
         "with_tiff": True,
         "with_jpeg2000": "openjpeg",


### PR DESCRIPTION
### Summary
Changes to recipe:  **OpenCV/4.x:**

#### Motivation
`libjpeg-turbo` is used as the default JPEG codec library since OpenCV 3.4.2. This commit aligns the default set in the conanfile.
https://github.com/opencv/opencv/tree/4.x/3rdparty#readme

#### Details
Set the default option for `"with_jpeg"` to `"libjpeg-turbo"` for OpenCV/4.x.

Closes #25946


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
