### PR TITLE
aws-sdk-cpp: fix an ignored validate_build()

### DIFF
--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -554,7 +554,6 @@ class AwsSdkCppConan(ConanFile):
         if self._settings_build.os == "Windows" and self.settings.os == "Android":
             raise ConanInvalidConfiguration("Cross-building from Windows to Android is not supported")
 
-    def validate_build(self):
         if (self.options.shared
                 and self.settings.compiler == "gcc"
                 and Version(self.settings.compiler.version) < "6.0"):


### PR DESCRIPTION
`validate_build()` is defined twice, causing the first one to be ignored.