### PR TITLE
Use `sqlite3/[>=3.45.0 <4]` for compatibility with Qt recipes

### DIFF
--- a/docs/adding_packages/dependencies.md
+++ b/docs/adding_packages/dependencies.md
@@ -74,6 +74,7 @@ version range only when a requirement for a newer version is needed.
 * meson: `[>=1.2.3 <2]`
 * pkgconf: `[>=2.2 <3]`
 * xz_utils: `[>=5.4.5 <6]`
+* sqlite3: `[>=3.45.0 <4]`
 
 Conan maintainers may introduce this for other dependencies over time. Outside of the cases outlined above, version ranges are not allowed in ConanCenter recipes.
 

--- a/recipes/apr-util/all/conanfile.py
+++ b/recipes/apr-util/all/conanfile.py
@@ -88,7 +88,7 @@ class AprUtilConan(ConanFile):
         if self.options.with_mysql:
             self.requires("libmysqlclient/8.1.0")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.with_expat:
             self.requires("expat/[>=2.6.2 <3]")
         if self.options.with_postgresql:

--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -140,7 +140,7 @@ class BehaviorTreeCPPConan(ConanFile):
         if self._with_minitrace:
             self.requires("minitrace/cci.20230905")
         if self._with_sqlite3:
-            self.requires("sqlite3/3.44.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self._with_tinyxml2:
             self.requires("tinyxml2/10.0.0")
         if self._with_zeromq:

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -144,7 +144,7 @@ class BotanConan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.45.1")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.with_boost:
             self.requires("boost/1.84.0")
 

--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -134,7 +134,7 @@ class CPythonConan(ConanFile):
             # TODO: Add nis when available.
             raise ConanInvalidConfiguration("nis is not available on CCI (yet)")
         if self.options.get_safe("with_sqlite3"):
-            self.requires("sqlite3/3.45.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.get_safe("with_tkinter"):
             self.requires("tk/8.6.10")
         if self.options.get_safe("with_curses", False):

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -96,7 +96,7 @@ class CyrusSaslConan(ConanFile):
         if self.options.get_safe("with_mysql"):
             self.requires("libmysqlclient/8.1.0")
         if self.options.get_safe("with_sqlite3"):
-            self.requires("sqlite3/3.44.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
 
     def validate(self):
         if is_msvc(self) and not self.options.shared:

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -96,7 +96,7 @@ class DlibConan(ConanFile):
         if self.options.get_safe("with_webp"):
             self.requires("libwebp/1.3.2")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.with_openblas:
             self.requires("openblas/0.3.26")
 

--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -130,7 +130,7 @@ class DrogonConan(ConanFile):
         if self.options.get_safe("with_mysql"):
             self.requires("libmysqlclient/8.1.0")
         if self.options.get_safe("with_sqlite"):
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.get_safe("with_redis"):
             self.requires("hiredis/1.2.0")
         if self.options.get_safe("with_yaml_cpp", False):

--- a/recipes/elfutils/all/conanfile.py
+++ b/recipes/elfutils/all/conanfile.py
@@ -69,7 +69,7 @@ class ElfutilsConan(ConanFile):
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.44.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.with_bzlib:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:

--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -288,7 +288,7 @@ class GdalConan(ConanFile):
         if self.options.with_spatialite:
             self.requires("libspatialite/5.0.1")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.44.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.with_tiledb:
             self.requires("tiledb/2.17.4")
         if self.options.with_webp:

--- a/recipes/gdal/pre_3.5.0/conanfile.py
+++ b/recipes/gdal/pre_3.5.0/conanfile.py
@@ -284,7 +284,7 @@ class GdalConan(ConanFile):
         # if self.options.with_spatialite:
         #     self.requires("libspatialite/4.3.0a")
         if self.options.get_safe("with_sqlite3"):
-            self.requires("sqlite3/3.44.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         # if self.options.with_rasterlite2:
         #     self.requires("rasterlite2/x.x.x")
         if self.options.get_safe("with_pcre"):

--- a/recipes/librasterlite/all/conanfile.py
+++ b/recipes/librasterlite/all/conanfile.py
@@ -58,7 +58,7 @@ class LibrasterliteConan(ConanFile):
         self.requires("libpng/1.6.40")
         self.requires("libspatialite/5.0.1")
         self.requires("libtiff/4.5.1")
-        self.requires("sqlite3/3.42.0")
+        self.requires("sqlite3/[>=3.45.0 <4]")
 
     def build_requirements(self):
         if not is_msvc(self):

--- a/recipes/librasterlite2/all/conanfile.py
+++ b/recipes/librasterlite2/all/conanfile.py
@@ -78,7 +78,7 @@ class Librasterlite2Conan(ConanFile):
         self.requires("libspatialite/5.0.1")
         self.requires("libtiff/4.5.1")
         self.requires("libxml2/2.11.4")
-        self.requires("sqlite3/3.42.0")
+        self.requires("sqlite3/[>=3.45.0 <4]")
         self.requires("zlib/1.2.13")
         if self.options.with_openjpeg:
             self.requires("openjpeg/2.5.0")

--- a/recipes/libspatialite/all/conanfile.py
+++ b/recipes/libspatialite/all/conanfile.py
@@ -87,7 +87,7 @@ class LibspatialiteConan(ConanFile):
     def requirements(self):
         # Included in public spatialite/sqlite.h
         # https://www.gaia-gis.it/fossil/libspatialite/file?name=src/headers/spatialite/sqlite.h&ci=tip
-        self.requires("sqlite3/3.44.2", transitive_headers=True, transitive_libs=True)
+        self.requires("sqlite3/[>=3.45.0 <4]", transitive_headers=True, transitive_libs=True)
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_proj:
             self.requires("proj/9.3.1")

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -223,7 +223,7 @@ class LibwebsocketsConan(ConanFile):
             self.requires("libmount/2.39.2")
 
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.44.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
 
         if self.options.with_ssl == "openssl":
             self.requires("openssl/[>=1.1.1w <4]", transitive_headers=True)
@@ -440,7 +440,7 @@ class LibwebsocketsConan(ConanFile):
             save(self, project_include_file, 'find_package(OpenSSL REQUIRED)\nset(OPENSSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})')
 
         # Prevent locating and copying OpenSSL binaries (not needed by the recipe)
-        replace_in_file(self, 
+        replace_in_file(self,
                         os.path.join(self.source_folder, "cmake", "FindOpenSSLbins.cmake"),
                         "if(OPENSSL_FOUND)", "if(FALSE)")
 

--- a/recipes/mfast/all/conanfile.py
+++ b/recipes/mfast/all/conanfile.py
@@ -74,7 +74,7 @@ class mFASTConan(ConanFile):
         self.requires("boost/1.75.0", transitive_headers=True)
         self.requires("tinyxml2/9.0.0")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.43.1")
+            self.requires("sqlite3/[>=3.45.0 <4]")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/oatpp-sqlite/all/conanfile.py
+++ b/recipes/oatpp-sqlite/all/conanfile.py
@@ -41,7 +41,7 @@ class OatppsqliteConan(ConanFile):
 
     def requirements(self):
         self.requires(f"oatpp/{self.version}", transitive_headers=True)
-        self.requires("sqlite3/3.45.0")
+        self.requires("sqlite3/[>=3.45.0 <4]")
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/openslide/all/conanfile.py
+++ b/recipes/openslide/all/conanfile.py
@@ -61,7 +61,7 @@ class OpenSlideConan(ConanFile):
         self.requires("libtiff/4.6.0")
         self.requires("libxml2/[>=2.12.5 <3]")
         self.requires("openjpeg/2.5.2")
-        self.requires("sqlite3/3.45.3")
+        self.requires("sqlite3/[>=3.45.0 <4]")
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.jpeg == "libjpeg":
             self.requires("libjpeg/9e")

--- a/recipes/osgearth/all/conanfile.py
+++ b/recipes/osgearth/all/conanfile.py
@@ -126,7 +126,7 @@ class OsgearthConan(ConanFile):
         if self.options.with_geos:
             self.requires("geos/3.11.1")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.42.0")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.with_draco:
             self.requires("draco/1.4.3")
         # if self.options.with_basisu:

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -159,7 +159,7 @@ class PocoConan(ConanFile):
         if self.options.enable_xml:
             self.requires("expat/[>=2.6.2 <3]", transitive_headers=True)
         if self.options.enable_data_sqlite:
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.enable_apacheconnector:
             self.requires("apr/1.7.4")
             self.requires("apr-util/1.6.1")

--- a/recipes/proj/all/conanfile.py
+++ b/recipes/proj/all/conanfile.py
@@ -60,7 +60,7 @@ class ProjConan(ConanFile):
 
     def requirements(self):
         self.requires("nlohmann_json/3.11.3")
-        self.requires("sqlite3/3.44.2")
+        self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.get_safe("with_tiff"):
             self.requires("libtiff/4.6.0")
         if self.options.get_safe("with_curl"):

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -62,7 +62,7 @@ class SociConan(ConanFile):
 
     def requirements(self):
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.44.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.with_odbc and self.settings.os != "Windows":
             self.requires("odbc/2.3.11")
         if self.options.with_mysql:

--- a/recipes/sqlite_orm/all/conanfile.py
+++ b/recipes/sqlite_orm/all/conanfile.py
@@ -40,7 +40,7 @@ class SqliteOrmConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("sqlite3/3.45.0", transitive_headers=True, transitive_libs=True)
+        self.requires("sqlite3/[>=3.45.0 <4]", transitive_headers=True, transitive_libs=True)
 
     def package_id(self):
         self.info.clear()

--- a/recipes/sqlitecpp/all/conanfile.py
+++ b/recipes/sqlitecpp/all/conanfile.py
@@ -43,7 +43,7 @@ class SQLiteCppConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("sqlite3/3.45.0")
+        self.requires("sqlite3/[>=3.45.0 <4]")
 
     def validate(self):
         if Version(self.version) >= "3.0.0" and self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/sqlpp11-connector-sqlite3/all/conanfile.py
+++ b/recipes/sqlpp11-connector-sqlite3/all/conanfile.py
@@ -52,7 +52,7 @@ class sqlpp11Conan(ConanFile):
         if self.options.with_sqlcipher:
             self.requires("sqlcipher/4.5.1", transitive_headers=True, transitive_libs=True)
         else:
-            self.requires("sqlite3/3.44.2", transitive_headers=True, transitive_libs=True)
+            self.requires("sqlite3/[>=3.45.0 <4]", transitive_headers=True, transitive_libs=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -107,7 +107,7 @@ class WtConan(ConanFile):
         if self.options.with_ssl:
             self.requires("openssl/[>=1.1 <4]")
         if self.options.get_safe("with_sqlite"):
-            self.requires("sqlite3/3.44.2")
+            self.requires("sqlite3/[>=3.45.0 <4]")
         if self.options.get_safe("with_mysql"):
             self.requires("libmysqlclient/8.1.0", transitive_headers=True, transitive_libs=True)
         if self.options.get_safe("with_postgres"):
@@ -118,7 +118,7 @@ class WtConan(ConanFile):
             self.requires("libunwind/1.7.2")
         if self.options.with_haru:
             self.requires("libharu/2.4.3")
-            
+
     def validate(self):
         miss_boost_required_comp = any(self.dependencies["boost"].options.get_safe(f"without_{boost_comp}", True)
                                        for boost_comp in self._required_boost_components)


### PR DESCRIPTION
Would be nice to get rid of a major source of version conflicts on CCI.

Both Qt recipes already use the mentioned version range, so I assume it's considered safe?
https://github.com/conan-io/conan-center-index/blob/a7af27e0b555eadb9011747d5078294f6815ab59/recipes/qt/6.x.x/conanfile.py#L394