### PR TITLE
Flac: don't build programs for Apple non-macOS

### DIFF
--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -20,10 +20,12 @@ class FlacConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_programs": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_programs": True,
     }
 
     def export_sources(self):
@@ -55,6 +57,7 @@ class FlacConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_EXAMPLES"] = False
         tc.variables["BUILD_DOCS"] = False
+        tc.variables["BUILD_PROGRAMS"] = self.options.with_programs
         tc.variables["BUILD_TESTING"] = False
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()

--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, rmdir, replace_in_file
@@ -20,12 +21,10 @@ class FlacConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_programs": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_programs": True,
     }
 
     def export_sources(self):
@@ -57,7 +56,7 @@ class FlacConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_EXAMPLES"] = False
         tc.variables["BUILD_DOCS"] = False
-        tc.variables["BUILD_PROGRAMS"] = self.options.with_programs
+        tc.variables["BUILD_PROGRAMS"] = not is_apple_os_(self) or self.settings.os == "Macos"
         tc.variables["BUILD_TESTING"] = False
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()

--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -56,7 +56,7 @@ class FlacConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_EXAMPLES"] = False
         tc.variables["BUILD_DOCS"] = False
-        tc.variables["BUILD_PROGRAMS"] = not is_apple_os_(self) or self.settings.os == "Macos"
+        tc.variables["BUILD_PROGRAMS"] = not is_apple_os(self) or self.settings.os == "Macos"
         tc.variables["BUILD_TESTING"] = False
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **flac/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Currently Flac can't be built for iOS, disabling this option fixes that

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
When building for iOS, Flac fails at cmake configuration step with an error:

```
CMake Error at src/flac/CMakeLists.txt:23 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "flacapp".


CMake Error at src/metaflac/CMakeLists.txt:16 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "metaflac".
```

The PR disables building supplemental programs for Apple non-macOS.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
