### PR TITLE
sdl_mixer: link AudioUnit only on macOS

### DIFF
--- a/recipes/sdl_mixer/cmake/conanfile.py
+++ b/recipes/sdl_mixer/cmake/conanfile.py
@@ -62,7 +62,7 @@ class SDLMixerConan(ConanFile):
             del self.options.fPIC
         if self.settings.os not in ["Linux", "FreeBSD"]:
             del self.options.tinymidi
-        if not (self.settings.os == "Windows" or is_apple_os(self)):
+        if not (self.settings.os == "Windows" or self.settings.os == "Macos"):
             del self.options.nativemidi
 
     def configure(self):

--- a/recipes/sdl_mixer/cmake/conanfile.py
+++ b/recipes/sdl_mixer/cmake/conanfile.py
@@ -260,7 +260,7 @@ class SDLMixerConan(ConanFile):
         if self.settings.os == "Windows":
             if self.options.nativemidi:
                 self.cpp_info.system_libs.append("winmm")
-        elif is_apple_os(self):
+        elif is_apple_os(self) and not self.options.shared:
             self.cpp_info.frameworks.extend(["AudioToolbox", "CoreServices", "CoreGraphics", "CoreFoundation"])
             if self.settings.os == "Macos":
                 self.cpp_info.frameworks.extend(["AppKit", "AudioUnit"])

--- a/recipes/sdl_mixer/cmake/conanfile.py
+++ b/recipes/sdl_mixer/cmake/conanfile.py
@@ -261,9 +261,9 @@ class SDLMixerConan(ConanFile):
             if self.options.nativemidi:
                 self.cpp_info.system_libs.append("winmm")
         elif is_apple_os(self):
-            self.cpp_info.frameworks.extend(["AudioToolbox", "AudioUnit", "CoreServices", "CoreGraphics", "CoreFoundation"])
+            self.cpp_info.frameworks.extend(["AudioToolbox", "CoreServices", "CoreGraphics", "CoreFoundation"])
             if self.settings.os == "Macos":
-                self.cpp_info.frameworks.append("AppKit")
+                self.cpp_info.frameworks.extend(["AppKit", "AudioUnit"])
 
         self.cpp_info.names["cmake_find_package"] = "SDL2_mixer"
         self.cpp_info.names["cmake_find_package_multi"] = "SDL2_mixer"


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl_mixer/2.8.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fixes linker error in iOS project that consumes sdl_mixer

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
AudioUnit framework is available only for macOS, on iOS you'd receive

```
ld: framework 'AudioUnit' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
