### PR TITLE
frugen: new recipe for frugen and libfru v2.0

### DIFF
--- a/recipes/frugen/all/conandata.yml
+++ b/recipes/frugen/all/conandata.yml
@@ -1,0 +1,12 @@
+sources:
+  "2.0":
+    url: "https://codeberg.org/IPMITool/frugen/archive/v2.0.tar.gz"
+    sha256: "cb5c59cf3593b162b9faedf1e5ae3b1f7e32fb732a61ada6baf7de69632bff77"
+patches:
+  "2.0":
+    - patch_file: "patches/0001-cmake-use-find_package-to-locate-json-c-library.patch"
+      patch_description: "Upstream prefer to use pkg_check_modules instead of find_package to keep capatibility with old versions"
+      patch_type: "conan"
+    - patch_file: "patches/0002-libfru-fix-build-on-MacOS.patch"
+      patch_description: "Fixes build on MacOS"
+      patch_type: "portability"

--- a/recipes/frugen/all/conandata.yml
+++ b/recipes/frugen/all/conandata.yml
@@ -10,3 +10,6 @@ patches:
     - patch_file: "patches/0002-libfru-fix-build-on-MacOS.patch"
       patch_description: "Fixes build on MacOS"
       patch_type: "portability"
+    - patch_file: "patches/0003-let-conan-choose-optimization-flags.patch"
+      patch_description: "Let Conan choose optimization flags"
+      patch_type: "conan"

--- a/recipes/frugen/all/conanfile.py
+++ b/recipes/frugen/all/conanfile.py
@@ -5,6 +5,8 @@ from conan.tools.files import get, rmdir, apply_conandata_patches, export_conand
 from conan.tools.microsoft import is_msvc
 import os
 
+required_conan_version = ">=2.1"
+
 class FrugenConan(ConanFile):
     name = "frugen"
     description = "IPMI FRU Information generator / editor tool and library"
@@ -28,7 +30,7 @@ class FrugenConan(ConanFile):
 
     def validate(self):
         if is_msvc(self):
-            raise ConanInvalidConfiguration("Unsupported compiler. This package currently does not support MSVC")
+            raise ConanInvalidConfiguration("MSVC not supported by the library")
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -58,6 +60,8 @@ class FrugenConan(ConanFile):
             tc.cache_variables["BINARY_STATIC"] = not self.options.shared
         tc.cache_variables["BINARY_32BIT"] = False
         tc.cache_variables["DEBUG_OUTPUT"] = False
+        # Dont let CMake find doxygen and try to build documentation
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Doxygen"] = True
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/frugen/all/conanfile.py
+++ b/recipes/frugen/all/conanfile.py
@@ -1,0 +1,79 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import get, rmdir, apply_conandata_patches, export_conandata_patches
+from conan.tools.microsoft import is_msvc
+import os
+
+class FrugenConan(ConanFile):
+    name = "frugen"
+    description = "IPMI FRU Information generator / editor tool and library"
+    license = ("Apache-2.0", "GPL-2.0-or-later")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://codeberg.org/IPMITool/frugen"
+    topics = ("hardware", "ipmi", "fru")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_json": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_json": True
+    }
+    implements = ["auto_shared_fpic"]
+
+    def validate(self):
+        if is_msvc(self):
+            raise ConanInvalidConfiguration("Unsupported compiler. This package currently does not support MSVC")
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.with_json:
+            self.requires("json-c/0.18")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_SHARED_LIB"] = self.options.shared
+        tc.cache_variables["ENABLE_JSON"] = self.options.with_json
+        if self.settings.os != "Macos":
+            tc.cache_variables["BINARY_STATIC"] = not self.options.shared
+        tc.cache_variables["BINARY_32BIT"] = False
+        tc.cache_variables["DEBUG_OUTPUT"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        if self.options.shared:
+            self.cpp_info.components["fru-shared"].libs = ["fru"]
+        else:
+            self.cpp_info.components["fru-static"].libs = ["fru"]

--- a/recipes/frugen/all/patches/0001-cmake-use-find_package-to-locate-json-c-library.patch
+++ b/recipes/frugen/all/patches/0001-cmake-use-find_package-to-locate-json-c-library.patch
@@ -1,0 +1,38 @@
+From 00ff4c451deaa70da84fbac8d810d94ef7d59ab9 Mon Sep 17 00:00:00 2001
+From: "Andrei K." <alatarum@gmail.com>
+Date: Sun, 17 Nov 2024 11:32:43 +0400
+Subject: [PATCH] cmake: use find_package to locate json-c library
+
+Signed-off-by: Andrei K. <alatarum@gmail.com>
+---
+ CMakeLists.txt | 13 +++----------
+ 1 file changed, 3 insertions(+), 10 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 086b827..763c0b3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -115,17 +115,10 @@ else(BINARY_STATIC OR NOT BUILD_SHARED_LIB)
+ endif(BINARY_STATIC OR NOT BUILD_SHARED_LIB)
+ 
+ if(ENABLE_JSON)
+-	find_package(PkgConfig)
+-	pkg_check_modules(json-c REQUIRED json-c)
+-
++	find_package(json-c CONFIG REQUIRED)
++	message (STATUS "Using JSON Library found at " ${json-c_DIR})
+ 	add_definitions(-D__HAS_JSON__)
+-	if(JSON_STATIC OR BINARY_STATIC)
+-		target_link_libraries(frugen ${json-c_STATIC_LIBRARIES})
+-	else()
+-		target_link_libraries(frugen ${json-c_LIBRARIES})
+-	endif()
+-
+-	target_include_directories(frugen PRIVATE ${json-c_INCLUDE_DIRS})
++	target_link_libraries(frugen json-c::json-c)
+ else(ENABLE_JSON)
+ 	message (WARNING "JSON library support *disabled*!")
+ endif(ENABLE_JSON)
+-- 
+2.45.2
+

--- a/recipes/frugen/all/patches/0002-libfru-fix-build-on-MacOS.patch
+++ b/recipes/frugen/all/patches/0002-libfru-fix-build-on-MacOS.patch
@@ -1,0 +1,87 @@
+From b31cf1c79730d5f288cd10361a05eb6b01d0698e Mon Sep 17 00:00:00 2001
+From: "Andrei K." <alatarum@gmail.com>
+Date: Sun, 17 Nov 2024 17:29:35 +0400
+Subject: [PATCH] libfru: fix build on MacOS
+
+* remove explicit include of <endian.h>: it should be included in <sys/types.h>
+* redefine endiangs manipulation functions
+* rename uuid_t structure since there is same named type defined on
+  MacOS
+* add type casting for print off_t variable - there is no portable way
+  to pass off_t to printf
+
+Signed-off-by: Andrei K. <alatarum@gmail.com>
+---
+ fru.c    | 21 +++++++++++++++++----
+ frugen.c |  2 +-
+ 2 files changed, 18 insertions(+), 5 deletions(-)
+
+diff --git a/fru.c b/fru.c
+index 01aaef9..c0f79d9 100644
+--- a/fru.c
++++ b/fru.c
+@@ -26,7 +26,20 @@
+ #include "fru-errno.h"
+ 
+ #define _BSD_SOURCE
+-#include <endian.h>
++
++#if defined(__APPLE__)
++#include <libkern/OSByteOrder.h>
++
++#define htobe16(x) OSSwapHostToBigInt16(x)
++#define htole16(x) OSSwapHostToLittleInt16(x)
++#define be16toh(x) OSSwapBigToHostInt16(x)
++#define le16toh(x) OSSwapLittleToHostInt16(x)
++
++#define htobe32(x) OSSwapHostToBigInt32(x)
++#define htole32(x) OSSwapHostToLittleInt32(x)
++#define be32toh(x) OSSwapBigToHostInt32(x)
++#define le32toh(x) OSSwapLittleToHostInt32(x)
++#endif
+ 
+ #ifdef __STANDALONE__
+ #include <stdio.h>
+@@ -1354,7 +1367,7 @@ typedef union __attribute__((packed)) {
+ 		uint8_t clock_seq_low;
+ 		uint8_t node[6];
+ 	};
+-} uuid_t;
++} fru_uuid_t;
+ #pragma pack(pop)
+ 
+ static bool is_mr_rec_valid(fru_mr_rec_t *rec, size_t limit, fru_flags_t flags)
+@@ -1476,7 +1489,7 @@ int fru_mr_mgmt_str2rec(fru_mr_rec_t **rec,
+ int fru_mr_uuid2rec(fru_mr_rec_t **rec, const char *str)
+ {
+ 	size_t len;
+-	uuid_t uuid;
++	fru_uuid_t uuid;
+ 
+ 	if (!str) return -EFAULT;
+ 
+@@ -1531,7 +1544,7 @@ int fru_mr_uuid2rec(fru_mr_rec_t **rec, const char *str)
+ int fru_mr_rec2uuid(char **str, fru_mr_mgmt_rec_t *mgmt, fru_flags_t flags)
+ {
+ 	size_t i;
+-	uuid_t uuid;
++	fru_uuid_t uuid;
+ 
+ 	if (!mgmt || !str) {
+ 		return -EFAULT;
+diff --git a/frugen.c b/frugen.c
+index b0aa76f..36a0c78 100644
+--- a/frugen.c
++++ b/frugen.c
+@@ -314,7 +314,7 @@ void load_from_binary_file(const char *fname,
+ 		fatal("Cannot allocate buffer");
+ 	}
+ 
+-	debug(2, "Reading the template file of size %lu...", statbuf.st_size);
++	debug(2, "Reading the template file of size %ld...", (long) statbuf.st_size);
+ 	if (read(fd, buffer, statbuf.st_size) != statbuf.st_size) {
+ 		fatal("Cannot read file");
+ 	}
+-- 
+2.45.2
+

--- a/recipes/frugen/all/patches/0003-let-conan-choose-optimization-flags.patch
+++ b/recipes/frugen/all/patches/0003-let-conan-choose-optimization-flags.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 763c0b3..0ce32df 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,8 +39,8 @@ option(ENABLE_JSON "enable JSON support" ON)
+ option(JSON_STATIC "link json-c library statically" OFF)
+ option(DEBUG_OUTPUT "show extra debug output" OFF)
+ 
+-set(CMAKE_C_FLAGS_RELEASE "-Os -Wall -Werror -Wfatal-errors")
+-set(CMAKE_C_FLAGS_DEBUG "-g3 -O0 -Wall -Werror -Wfatal-errors")
++# set(CMAKE_C_FLAGS_RELEASE "-Os -Wall -Werror -Wfatal-errors")
++# set(CMAKE_C_FLAGS_DEBUG "-g3 -O0 -Wall -Werror -Wfatal-errors")
+ if(MSVC)
+ 	# warning level 4
+ 	add_compile_options(/W4)

--- a/recipes/frugen/all/test_package/CMakeLists.txt
+++ b/recipes/frugen/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(frugen REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+
+if(BUILD_SHARED_LIB)
+    target_link_libraries(${PROJECT_NAME} PRIVATE frugen::fru-shared)
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE frugen::fru-static)
+endif()

--- a/recipes/frugen/all/test_package/conanfile.py
+++ b/recipes/frugen/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_SHARED_LIB"] = self.dependencies['frugen'].options.shared
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/frugen/all/test_package/test_package.c
+++ b/recipes/frugen/all/test_package/test_package.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include "fru.h"
+
+int main(void) {
+    uint8_t buffer[64] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF};
+    if (!find_fru_header(buffer, sizeof(buffer), FRU_NOFLAGS)) {
+        printf("Failed to find FRU information block");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/frugen/config.yml
+++ b/recipes/frugen/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0":
+    folder: all


### PR DESCRIPTION
### Summary
New recipe:  **frugen/2.0**

#### Motivation
Frugen is a small but useful tool to work with IPMI FRU data widely used in telecom industry to encode hardware inventory information.

#### Details
This adds a new recipe. The recipe mostly focus on `libfru` which is part of frugen and can be used in other projects to encode/decode FRU information but also deploys `frugen` tool itself. 
Includes patch to support macOS: https://codeberg.org/IPMITool/frugen/pulls/8

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
**tested with Conan version 2.7.1**