### PR TITLE
simdutf: add version 5.6.2

### DIFF
--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.6.2":
+    url: "https://github.com/simdutf/simdutf/archive/v5.6.2.tar.gz"
+    sha256: "325c012e7c29e549779cebfe5a43a3197d9d675b6764f6de547ef19905b56b76"
   "5.6.0":
     url: "https://github.com/simdutf/simdutf/archive/v5.6.0.tar.gz"
     sha256: "98cc5761b638642b018a628b1609f1b2df489b555836fa88706055bb56a4d6fe"

--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "5.6.2":
     url: "https://github.com/simdutf/simdutf/archive/v5.6.2.tar.gz"
-    sha256: "325c012e7c29e549779cebfe5a43a3197d9d675b6764f6de547ef19905b56b76"
+    sha256: "c71b5478c9b912e07f75098f3a60920f1c4de3227b5285ea8a90a2fcf8bd6a89"
   "5.6.0":
     url: "https://github.com/simdutf/simdutf/archive/v5.6.0.tar.gz"
     sha256: "98cc5761b638642b018a628b1609f1b2df489b555836fa88706055bb56a4d6fe"

--- a/recipes/simdutf/config.yml
+++ b/recipes/simdutf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.6.2":
+    folder: all
   "5.6.0":
     folder: all
   "5.5.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **simdutf/5.6.2**

#### Motivation
There are several improvements in 5.6.2.

#### Details
https://github.com/simdutf/simdutf/releases/tag/v5.6.2
https://github.com/simdutf/simdutf/compare/v5.6.0...v5.6.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
