### PR TITLE
orc: add version 2.0.3 (and other stable releases)

### DIFF
--- a/recipes/orc/all/conandata.yml
+++ b/recipes/orc/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "2.0.3":
     url: "https://archive.apache.org/dist/orc/orc-2.0.3/orc-2.0.3.tar.gz"
     sha256: "082cba862b5a8a0d14c225404d0b51cd8d1b64ca81b8f1e500322ce8922cb86d"
+  "2.0.0":
+    url: "https://archive.apache.org/dist/orc/orc-2.0.0/orc-2.0.0.tar.gz"
+    sha256: "9107730919c29eb39efaff1b9e36166634d1d4d9477e5fee76bfd6a8fec317df"
   "1.9.5":
     url: "https://archive.apache.org/dist/orc/orc-1.9.5/orc-1.9.5.tar.gz"
     sha256: "6900b4e8a2e4e49275f4067bd0f838ad68330204305fd3f13a5ec519e9d71547"

--- a/recipes/orc/all/conandata.yml
+++ b/recipes/orc/all/conandata.yml
@@ -1,19 +1,40 @@
 sources:
+  "2.0.3":
+    url: "https://archive.apache.org/dist/orc/orc-2.0.3/orc-2.0.3.tar.gz"
+    sha256: "082cba862b5a8a0d14c225404d0b51cd8d1b64ca81b8f1e500322ce8922cb86d"
+  "2.0.2":
+    url: "https://archive.apache.org/dist/orc/orc-2.0.2/orc-2.0.2.tar.gz"
+    sha256: "fabdee3e8acd64dae1e8b8987149a7188121b40b025de46d15cc9d0becee2279"
+  "2.0.1":
+    url: "https://archive.apache.org/dist/orc/orc-2.0.1/orc-2.0.1.tar.gz"
+    sha256: "1ffac0228aa83f04a1b1cf2788a3af5953e82587ae3a77c41900e99f2557132d"
   "2.0.0":
     url: "https://archive.apache.org/dist/orc/orc-2.0.0/orc-2.0.0.tar.gz"
     sha256: "9107730919c29eb39efaff1b9e36166634d1d4d9477e5fee76bfd6a8fec317df"
+  "1.9.5":
+    url: "https://archive.apache.org/dist/orc/orc-1.9.5/orc-1.9.5.tar.gz"
+    sha256: "6900b4e8a2e4e49275f4067bd0f838ad68330204305fd3f13a5ec519e9d71547"
+  "1.9.4":
+    url: "https://archive.apache.org/dist/orc/orc-1.9.4/orc-1.9.4.tar.gz"
+    sha256: "d9a6bcc00e07a6e54d81ce380134e495ed0fc0d9dc1988d4d52125c9def097fd"
   "1.9.3":
     url: "https://archive.apache.org/dist/orc/orc-1.9.3/orc-1.9.3.tar.gz"
     sha256: "f737d005d0c4deb65688ac3c0223ed530b0ba6258552555b2774dcdb77359b0f"
   "1.9.2":
     url: "https://archive.apache.org/dist/orc/orc-1.9.2/orc-1.9.2.tar.gz"
     sha256: "7f46f2c184ecefd6791f1a53fb062286818bd8710c3f08b94dd3cac365e240ee"
+  "1.8.8":
+    url: "https://archive.apache.org/dist/orc/orc-1.8.8/orc-1.8.8.tar.gz"
+    sha256: "eca12a9139c0889d11ef1ecc8f273ccb0ef5d19df70d61cb732194d806db026b"
   "1.8.7":
     url: "https://archive.apache.org/dist/orc/orc-1.8.7/orc-1.8.7.tar.gz"
     sha256: "57c9d12bf74b2752b1ce1039c15035c3b6f6531d865df962a99b3e079b3dfdb7"
   "1.8.6":
     url: "https://archive.apache.org/dist/orc/orc-1.8.6/orc-1.8.6.tar.gz"
     sha256: "5675b18118df4dd7f86cc6ba859ed75b425ea1b7ddff805e1d671a17fd57d7f7"
+  "1.7.11":
+    url: "https://archive.apache.org/dist/orc/orc-1.7.11/orc-1.7.11.tar.gz"
+    sha256: "ff62f0b882470529b3e2507daa4092ffdb34818c220abefb11cac443e5757236"
   "1.7.10":
     url: "https://archive.apache.org/dist/orc/orc-1.7.10/orc-1.7.10.tar.gz"
     sha256: "85aef9368dc9bcdffaaf10010b66dfe053ce22f30b64854f63852248164686a3"

--- a/recipes/orc/all/conandata.yml
+++ b/recipes/orc/all/conandata.yml
@@ -2,39 +2,6 @@ sources:
   "2.0.3":
     url: "https://archive.apache.org/dist/orc/orc-2.0.3/orc-2.0.3.tar.gz"
     sha256: "082cba862b5a8a0d14c225404d0b51cd8d1b64ca81b8f1e500322ce8922cb86d"
-  "2.0.2":
-    url: "https://archive.apache.org/dist/orc/orc-2.0.2/orc-2.0.2.tar.gz"
-    sha256: "fabdee3e8acd64dae1e8b8987149a7188121b40b025de46d15cc9d0becee2279"
-  "2.0.1":
-    url: "https://archive.apache.org/dist/orc/orc-2.0.1/orc-2.0.1.tar.gz"
-    sha256: "1ffac0228aa83f04a1b1cf2788a3af5953e82587ae3a77c41900e99f2557132d"
-  "2.0.0":
-    url: "https://archive.apache.org/dist/orc/orc-2.0.0/orc-2.0.0.tar.gz"
-    sha256: "9107730919c29eb39efaff1b9e36166634d1d4d9477e5fee76bfd6a8fec317df"
   "1.9.5":
     url: "https://archive.apache.org/dist/orc/orc-1.9.5/orc-1.9.5.tar.gz"
     sha256: "6900b4e8a2e4e49275f4067bd0f838ad68330204305fd3f13a5ec519e9d71547"
-  "1.9.4":
-    url: "https://archive.apache.org/dist/orc/orc-1.9.4/orc-1.9.4.tar.gz"
-    sha256: "d9a6bcc00e07a6e54d81ce380134e495ed0fc0d9dc1988d4d52125c9def097fd"
-  "1.9.3":
-    url: "https://archive.apache.org/dist/orc/orc-1.9.3/orc-1.9.3.tar.gz"
-    sha256: "f737d005d0c4deb65688ac3c0223ed530b0ba6258552555b2774dcdb77359b0f"
-  "1.9.2":
-    url: "https://archive.apache.org/dist/orc/orc-1.9.2/orc-1.9.2.tar.gz"
-    sha256: "7f46f2c184ecefd6791f1a53fb062286818bd8710c3f08b94dd3cac365e240ee"
-  "1.8.8":
-    url: "https://archive.apache.org/dist/orc/orc-1.8.8/orc-1.8.8.tar.gz"
-    sha256: "eca12a9139c0889d11ef1ecc8f273ccb0ef5d19df70d61cb732194d806db026b"
-  "1.8.7":
-    url: "https://archive.apache.org/dist/orc/orc-1.8.7/orc-1.8.7.tar.gz"
-    sha256: "57c9d12bf74b2752b1ce1039c15035c3b6f6531d865df962a99b3e079b3dfdb7"
-  "1.8.6":
-    url: "https://archive.apache.org/dist/orc/orc-1.8.6/orc-1.8.6.tar.gz"
-    sha256: "5675b18118df4dd7f86cc6ba859ed75b425ea1b7ddff805e1d671a17fd57d7f7"
-  "1.7.11":
-    url: "https://archive.apache.org/dist/orc/orc-1.7.11/orc-1.7.11.tar.gz"
-    sha256: "ff62f0b882470529b3e2507daa4092ffdb34818c220abefb11cac443e5757236"
-  "1.7.10":
-    url: "https://archive.apache.org/dist/orc/orc-1.7.10/orc-1.7.10.tar.gz"
-    sha256: "85aef9368dc9bcdffaaf10010b66dfe053ce22f30b64854f63852248164686a3"

--- a/recipes/orc/config.yml
+++ b/recipes/orc/config.yml
@@ -1,5 +1,7 @@
 versions:
   "2.0.3":
     folder: all
+  "2.0.0":
+    folder: all
   "1.9.5":
     folder: all

--- a/recipes/orc/config.yml
+++ b/recipes/orc/config.yml
@@ -1,27 +1,5 @@
 versions:
   "2.0.3":
     folder: all
-  "2.0.2":
-    folder: all
-  "2.0.1":
-    folder: all
-  "2.0.0":
-    folder: all
   "1.9.5":
-    folder: all
-  "1.9.4":
-    folder: all
-  "1.9.3":
-    folder: all
-  "1.9.2":
-    folder: all
-  "1.8.8":
-    folder: all
-  "1.8.7":
-    folder: all
-  "1.8.6":
-    folder: all
-  "1.7.11":
-    folder: all
-  "1.7.10":
     folder: all

--- a/recipes/orc/config.yml
+++ b/recipes/orc/config.yml
@@ -1,13 +1,27 @@
 versions:
+  "2.0.3":
+    folder: all
+  "2.0.2":
+    folder: all
+  "2.0.1":
+    folder: all
   "2.0.0":
+    folder: all
+  "1.9.5":
+    folder: all
+  "1.9.4":
     folder: all
   "1.9.3":
     folder: all
   "1.9.2":
     folder: all
+  "1.8.8":
+    folder: all
   "1.8.7":
     folder: all
   "1.8.6":
+    folder: all
+  "1.7.11":
     folder: all
   "1.7.10":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **orc/2.0.3**

#### Motivation
Sync recent releases from Apache ORC.

#### Details
Add several news releases from Apache ORC 2.0.x, 1.9.x and 1.8.x major versions.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
