### PR TITLE
msys2: Check if package exists before removing it

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -142,7 +142,8 @@ class MSYS2Conan(ConanFile):
             for package in packages:
                 self.run(f'bash -l -c "pacman -S {package} --noconfirm"')
             for package in ['pkgconf']:
-                self.run(f'bash -l -c "pacman -Rs -d -d $(pacman -Qsq {package}) --noconfirm"')
+                if self.run(f'bash -l -c "pacman -Qq {package}"', ignore_errors=True, quiet=True) == 0:
+                    self.run(f'bash -l -c "pacman -Rs -d -d {package} --noconfirm"')
 
         self._kill_pacman()
 


### PR DESCRIPTION
base-devel 2024.11 does not contain pkgconf any more [1], and the attempt to remove it will resulting in "error: no targets specified (use -h for help)".

[1] https://github.com/msys2/MSYS2-packages/commit/ad465ec8df5813c26505568595658a2303cd3e45

Resolves #25970.


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
