### PR TITLE
libheif: add version 1.19.5

### DIFF
--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.19.3":
-    url: "https://github.com/strukturag/libheif/releases/download/v1.19.3/libheif-1.19.3.tar.gz"
-    sha256: "1e6d3bb5216888a78fbbf5fd958cd3cf3b941aceb002d2a8d635f85cc59a8599"
+  "1.19.4":
+    url: "https://github.com/strukturag/libheif/releases/download/v1.19.4/libheif-1.19.4.tar.gz"
+    sha256: "44c35b80596561ab531556175309f5f0ab3fcf7a7517dd933940574063f2af85"
   "1.19.0":
     url: "https://github.com/strukturag/libheif/releases/download/v1.19.0/libheif-1.19.0.tar.gz"
     sha256: "c0323638557994791c7bf939ee9752e8a0f3f5ce4f07328daefa0159e3530eb4"

--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.19.4":
-    url: "https://github.com/strukturag/libheif/releases/download/v1.19.4/libheif-1.19.4.tar.gz"
-    sha256: "44c35b80596561ab531556175309f5f0ab3fcf7a7517dd933940574063f2af85"
+  "1.19.5":
+    url: "https://github.com/strukturag/libheif/releases/download/v1.19.5/libheif-1.19.5.tar.gz"
+    sha256: "d3cf0a76076115a070f9bc87cf5259b333a1f05806500045338798486d0afbaf"
   "1.19.0":
     url: "https://github.com/strukturag/libheif/releases/download/v1.19.0/libheif-1.19.0.tar.gz"
     sha256: "c0323638557994791c7bf939ee9752e8a0f3f5ce4f07328daefa0159e3530eb4"

--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.19.3":
+    url: "https://github.com/strukturag/libheif/releases/download/v1.19.3/libheif-1.19.3.tar.gz"
+    sha256: "1e6d3bb5216888a78fbbf5fd958cd3cf3b941aceb002d2a8d635f85cc59a8599"
   "1.19.0":
     url: "https://github.com/strukturag/libheif/releases/download/v1.19.0/libheif-1.19.0.tar.gz"
     sha256: "c0323638557994791c7bf939ee9752e8a0f3f5ce4f07328daefa0159e3530eb4"

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.19.4":
+  "1.19.5":
     folder: all
   "1.19.0":
     folder: all

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.19.3":
+    folder: all
   "1.19.0":
     folder: all
   "1.18.2":

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.19.3":
+  "1.19.4":
     folder: all
   "1.19.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libheif/1.19.5**

#### Motivation
There are several bugfixes since 1.19.0.

#### Details
https://github.com/strukturag/libheif/releases/tag/v1.19.5
https://github.com/strukturag/libheif/compare/v1.19.0...v1.19.5

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
