### PR TITLE
zoe: add version 3.6

### DIFF
--- a/recipes/zoe/all/conandata.yml
+++ b/recipes/zoe/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.5":
-    url: "https://github.com/winsoft666/zoe/archive/refs/tags/v3.5.tar.gz"
-    sha256: "6b1716975baddb432ef600e061ba13bb0528d8fb2bb7756fe1763baf7db024ee"
+  "3.6":
+    url: "https://github.com/winsoft666/zoe/archive/refs/tags/v3.6.tar.gz"
+    sha256: "5cae2a51bbac0bfa54aab78a4d2b534a66bea7bc2d72764cfb5bc8e02a751927"
   "3.3":
     url: "https://github.com/winsoft666/zoe/archive/refs/tags/v3.3.tar.gz"
     sha256: "e75d24690d16feff8bf1fc57d1943d545a5203ba769ff94034dc1f35f89927a5"

--- a/recipes/zoe/all/conandata.yml
+++ b/recipes/zoe/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5":
+    url: "https://github.com/winsoft666/zoe/archive/refs/tags/v3.5.tar.gz"
+    sha256: "6b1716975baddb432ef600e061ba13bb0528d8fb2bb7756fe1763baf7db024ee"
   "3.3":
     url: "https://github.com/winsoft666/zoe/archive/refs/tags/v3.3.tar.gz"
     sha256: "e75d24690d16feff8bf1fc57d1943d545a5203ba769ff94034dc1f35f89927a5"

--- a/recipes/zoe/config.yml
+++ b/recipes/zoe/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.5":
+  "3.6":
     folder: all
   "3.3":
     folder: all

--- a/recipes/zoe/config.yml
+++ b/recipes/zoe/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5":
+    folder: all
   "3.3":
     folder: all
   "3.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **zoe/3.6**

#### Motivation
- disable SHA1
- support macOS without patch

#### Details
https://github.com/winsoft666/zoe/compare/v3.3...v3.6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
