### PR TITLE
xmlsec: add version 1.3.6

### DIFF
--- a/recipes/xmlsec/all/conandata.yml
+++ b/recipes/xmlsec/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.6":
+    url: "https://github.com/lsh123/xmlsec/releases/download/1.3.6/xmlsec1-1.3.6.tar.gz"
+    sha256: "952b626ad3f3be1a4598622dab52fdab2a8604d0837c1b00589f3637535af92f"
   "1.3.4":
     url: "https://github.com/lsh123/xmlsec/releases/download/1.3.4/xmlsec1-1.3.4.tar.gz"
     sha256: "45ad9078d41ae76844ad2f8651600ffeec0fdd128ead988a8d69e907c57aee75"

--- a/recipes/xmlsec/config.yml
+++ b/recipes/xmlsec/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.6":
+    folder: all
   "1.3.4":
     folder: all
   "1.3.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **xmlsec/1.3.6**

#### Motivation
There are several improvements since 1.3.4.

#### Details
https://github.com/lsh123/xmlsec/compare/xmlsec_1_3_4...1.3.6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
