### PR TITLE
emsdk: add version used for unity 6

### DIFF
--- a/recipes/emsdk/all/conandata.yml
+++ b/recipes/emsdk/all/conandata.yml
@@ -23,6 +23,9 @@ sources:
   "3.1.44":
     url: "https://github.com/emscripten-core/emsdk/archive/3.1.44.tar.gz"
     sha256: "cb8cded78f6953283429d724556e89211e51ac4d871fcf38e0b32405ee248e91"
+  "3.1.38":
+    url: "https://github.com/emscripten-core/emsdk/archive/3.1.38.tar.gz"
+    sha256: "45ffb273503e48aae28c04549026b9cbdd750a5d36e3da3e22bc9977d2bfd61f"
   "3.1.31":
     url: "https://github.com/emscripten-core/emsdk/archive/3.1.31.tar.gz"
     sha256: "1d38b7375e12e85197165a4c51d76d90e1d9db8c2c593b64cfaec4338af54750"

--- a/recipes/emsdk/config.yml
+++ b/recipes/emsdk/config.yml
@@ -15,6 +15,8 @@ versions:
     folder: all
   "3.1.44":
     folder: all
+  "3.1.38":
+    folder: all
   "3.1.31":
     folder: all
   "3.1.30":


### PR DESCRIPTION
### Summary
Changes to recipe:  **emsdk/3.1.38**

#### Motivation
Version 3.1.38 was added because it is used in the current Unity game engine: https://docs.unity3d.com/6000.0/Documentation/Manual/webgl-native-plugins-with-emscripten.html

#### Details
Additional version was added.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
