### PR TITLE
multiple recipes: align dependency on libdeflate

### DIFF
--- a/recipes/gdal/pre_3.5.0/conanfile.py
+++ b/recipes/gdal/pre_3.5.0/conanfile.py
@@ -208,7 +208,7 @@ class GdalConan(ConanFile):
         if self.options.get_safe("with_zlib", True):
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_libdeflate:
-            self.requires("libdeflate/1.19")
+            self.requires("libdeflate/1.22")
         if self.options.with_libiconv:
             self.requires("libiconv/1.17")
         if self.options.get_safe("with_zstd"):

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -59,7 +59,7 @@ class HictkConan(ConanFile):
         self.requires("fmt/10.2.1")
         self.requires("hdf5/1.14.3")
         self.requires("highfive/2.9.0")
-        self.requires("libdeflate/1.20")
+        self.requires("libdeflate/1.22")
         self.requires("parallel-hashmap/1.3.12")  # Note: v1.3.12 is more recent than v1.37
         self.requires("span-lite/0.11.0")
         self.requires("spdlog/1.14.1")

--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -48,7 +48,7 @@ class UwebsocketsConan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_libdeflate:
-            self.requires("libdeflate/1.19")
+            self.requires("libdeflate/1.22")
         self.requires("usockets/0.8.8")
 
     def package_id(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libtiff/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
libdeflate < v1.20 can't be built for iOS with apple-clang 15, upstream added a workaround only in v1.20, see https://github.com/ebiggers/libdeflate/issues/354

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Now using the latest available version of libdeflate

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
