### PR TITLE
new package: libjuice 1.5.7

### DIFF
--- a/recipes/libjuice/all/conandata.yml
+++ b/recipes/libjuice/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.5.7":
+    url: "https://github.com/paullouisageneau/libjuice/archive/refs/tags/v1.5.7.tar.gz"
+    sha256: "6385c574f3c33f766ed25cddf919625b0ae8ca0d76871f70301e5a0cf2c93dc8"

--- a/recipes/libjuice/all/conanfile.py
+++ b/recipes/libjuice/all/conanfile.py
@@ -1,0 +1,80 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm, rmdir, export_conandata_patches, apply_conandata_patches
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
+from conan.tools.apple import fix_apple_shared_install_name
+
+required_conan_version = ">=2.1"
+
+class libjuiceConan(ConanFile):
+    name = "libjuice"
+    description = "JUICE is a UDP Interactive Connectivity Establishment library."
+    license = "MPL 2.0"
+    topics = ("webrtc", "ice")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/paullouisageneau/libjuice"
+    settings = "os", "compiler", "build_type", "arch"
+    package_type = "library"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    implements = ["auto_shared_fpic"]
+
+    def validate(self):
+        check_min_cppstd(self, 11)
+        if self.settings.os == "Windows" and self.options.shared:
+            # It exports no symbols, so it can't be used as a shared library
+            raise ConanInvalidConfiguration("Does not support shared libraries on Windows")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["NO_TESTS"] = True
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        fix_apple_shared_install_name(self)
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        suffix = ""
+        if is_msvc(self) and self.settings.build_type == "Debug":
+            suffix = "d"
+        self.cpp_info.libs = ["juice" + suffix]
+        self.cpp_info.set_property("cmake_file_name", "LibJuice")
+        self.cpp_info.set_property("cmake_target_name", "LibJuice::LibJuice")
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.append("dl")
+
+        if is_msvc(self):
+            self.cpp_info.cxxflags.append("/bigobj")

--- a/recipes/libjuice/all/test_package/CMakeLists.txt
+++ b/recipes/libjuice/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(test_package LANGUAGES CXX) # if the project uses c++
+
+find_package(libjuice REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE LibJuice::LibJuice)

--- a/recipes/libjuice/all/test_package/conanfile.py
+++ b/recipes/libjuice/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libjuice/all/test_package/test_package.cpp
+++ b/recipes/libjuice/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <cstdlib>
+#include <juice/juice.h>
+
+int main(void) {
+    juice_config config;
+    juice_agent_t * agent = juice_create(&config);
+    juice_destroy(agent);
+    return EXIT_SUCCESS;
+}

--- a/recipes/libjuice/config.yml
+++ b/recipes/libjuice/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.5.7":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjuice/1.5.7**

#### Motivation
This library is a dependency of "libdatachannel". That package is not yet in conan, but I will provide another PR with libdatachannel that will depend on this package.

#### Details
JUICE is a UDP Interactive Connectivity Establishment library, used for setting up connections used in WebRTC.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
