### PR TITLE
thorvg: add version 0.15.4 and removed older versions

### DIFF
--- a/recipes/thorvg/all/conandata.yml
+++ b/recipes/thorvg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.15.4":
+    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.15.4.tar.gz"
+    sha256: "3031a3e070322194fc5368419e996420f05f26ec2ec8137beca17eba5e5e8a58"
   "0.15.3":
     url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.15.3.tar.gz"
     sha256: "c3d57167a54f0ecc3ead8bb33340593acc00bcd8477e784287307bc4e2c82b38"

--- a/recipes/thorvg/all/conandata.yml
+++ b/recipes/thorvg/all/conandata.yml
@@ -5,33 +5,12 @@ sources:
   "0.15.3":
     url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.15.3.tar.gz"
     sha256: "c3d57167a54f0ecc3ead8bb33340593acc00bcd8477e784287307bc4e2c82b38"
-  "0.15.2":
-    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.15.2.tar.gz"
-    sha256: "98fcd73567c003a33fad766a7dbb9244c61e9b4721397d42e7fa04fc2e499dce"
-  "0.15.1":
-    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.15.1.tar.gz"
-    sha256: "4935228bb11e1a5303fc98d2a4b355c94eb82bff10cff581821b0b3c41368049"
   "0.14.10":
     url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.14.10.tar.gz"
     sha256: "e11e2e27ef26ed018807e828cce3bca1fb9a7f25683a152c9cd1f7aac9f3b67a"
   "0.14.6":
     url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.14.6.tar.gz"
     sha256: "13d7778968ce10f4f7dd1ea1f66861d4ee8ff22f669566992b4ac00e050496cf"
-  "0.14.5":
-    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.14.5.tar.gz"
-    sha256: "a007c548e39b0fad5d66ce9cf71244d3d219d9188fd80ccc049a5fa1b7f7aac2"
-  "0.14.4":
-    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.14.4.tar.gz"
-    sha256: "0adabdb61395d9ad126c49ac80aa9c971ad7a37268a77a9712790a556df32838"
-  "0.14.2":
-    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.14.2.tar.gz"
-    sha256: "04202e8f5e17b427c3b16ae3b3d4be5d3f3cdac96d5c64ed3efd7b6db3ad731f"
-  "0.14.1":
-    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.14.1.tar.gz"
-    sha256: "9c0346fda8b62a3b13a764dda5784e0465c8cab54fb5342d0240c7fb40e415bd"
-  "0.14.0":
-    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.14.0.tar.gz"
-    sha256: "6f186b53be3a0bd971dabde7a58022f43303467794e89e3641c774f38cdc2664"
   "0.13.8":
     url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.13.8.tar.gz"
     sha256: "ce49929a94d1686d4f1436da6ef5fa7a8439901c22b5fa0879d7d5879b8ba2bd"

--- a/recipes/thorvg/config.yml
+++ b/recipes/thorvg/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.15.4":
+    folder: all
   "0.15.3":
     folder: all
   "0.15.2":

--- a/recipes/thorvg/config.yml
+++ b/recipes/thorvg/config.yml
@@ -3,23 +3,9 @@ versions:
     folder: all
   "0.15.3":
     folder: all
-  "0.15.2":
-    folder: all
-  "0.15.1":
-    folder: all
   "0.14.10":
     folder: all
   "0.14.6":
-    folder: all
-  "0.14.5":
-    folder: all
-  "0.14.4":
-    folder: all
-  "0.14.2":
-    folder: all
-  "0.14.1":
-    folder: all
-  "0.14.0":
     folder: all
   "0.13.8":
     folder: all


### PR DESCRIPTION
### Summary
Added recipe:  **thorvg/0.15.4**

Removed older patches.

#### Motivation
There are several improvements and bugfixes in 0.15.4.

#### Details
https://github.com/thorvg/thorvg/releases/tag/v0.15.4
https://github.com/thorvg/thorvg/compare/v0.15.3...v0.15.4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
