### PR TITLE
rabbitmq-c: add version 0.15.0

### DIFF
--- a/recipes/rabbitmq-c/all/conandata.yml
+++ b/recipes/rabbitmq-c/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "0.15.0":
     url: "https://github.com/alanxz/rabbitmq-c/archive/v0.15.0.tar.gz"
-    sha256: "839b28eae20075ac58f45925fe991d16a3138cbde015db0ee11df1acb1c493df"
+    sha256: "7b652df52c0de4d19ca36c798ed81378cba7a03a0f0c5d498881ae2d79b241c2"
   "0.14.0":
     url: "https://github.com/alanxz/rabbitmq-c/archive/v0.14.0.tar.gz"
     sha256: "839b28eae20075ac58f45925fe991d16a3138cbde015db0ee11df1acb1c493df"

--- a/recipes/rabbitmq-c/all/conandata.yml
+++ b/recipes/rabbitmq-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.15.0":
+    url: "https://github.com/alanxz/rabbitmq-c/archive/v0.15.0.tar.gz"
+    sha256: "839b28eae20075ac58f45925fe991d16a3138cbde015db0ee11df1acb1c493df"
   "0.14.0":
     url: "https://github.com/alanxz/rabbitmq-c/archive/v0.14.0.tar.gz"
     sha256: "839b28eae20075ac58f45925fe991d16a3138cbde015db0ee11df1acb1c493df"

--- a/recipes/rabbitmq-c/config.yml
+++ b/recipes/rabbitmq-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.15.0":
+    folder: all
   "0.14.0":
     folder: all
   "0.13.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **rabbitmq-c/0.15.0**

#### Motivation
There are several improvements in 0.15.0.

#### Details
https://github.com/alanxz/rabbitmq-c/releases/tag/v0.15.0
https://github.com/alanxz/rabbitmq-c/compare/v0.14.0...v0.15.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
