### PR TITLE
tree-sitter-sql: add version 0.3.7

### DIFF
--- a/recipes/tree-sitter-sql/all/conandata.yml
+++ b/recipes/tree-sitter-sql/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   # As per the official README, the release tarballs don't include the generated codes.
   # > We don't commit the generated parser files to the main branch. Instead, you can find them on the gh-pages branch.
   # We have to obtain the corresponding snapshot of the github-pages branch.
+  "0.3.7":
+    url: "https://github.com/DerekStride/tree-sitter-sql/archive/3d516e6ae778bd41f9d5178823798ff6af96da60.tar.gz"
+    sha256: "273f357389337521823e1af26baba81e6dcff175f133ccf3d9351150c53d1f97"
   "0.3.5":
     url: "https://github.com/DerekStride/tree-sitter-sql/archive/c67ecbd37d8d12f22e4cc7138afd14bc20253e10.tar.gz"
     sha256: "d8cd967ca4daa376614995fe8a439a957a303c7ca5b9858ca15ad243e6b176d3"

--- a/recipes/tree-sitter-sql/all/conandata.yml
+++ b/recipes/tree-sitter-sql/all/conandata.yml
@@ -3,8 +3,13 @@ sources:
   # > We don't commit the generated parser files to the main branch. Instead, you can find them on the gh-pages branch.
   # We have to obtain the corresponding snapshot of the github-pages branch.
   "0.3.7":
-    url: "https://github.com/DerekStride/tree-sitter-sql/archive/3d516e6ae778bd41f9d5178823798ff6af96da60.tar.gz"
-    sha256: "273f357389337521823e1af26baba81e6dcff175f133ccf3d9351150c53d1f97"
+    url: "https://github.com/DerekStride/tree-sitter-sql/archive/f58f33955ea0a3e6a0aa2ef4b90a133ebee02173.tar.gz"
+    sha256: "947f6236251b4e2388441f3748871e4a93884229a05b66c59603b80721c2c1fe"
   "0.3.5":
     url: "https://github.com/DerekStride/tree-sitter-sql/archive/c67ecbd37d8d12f22e4cc7138afd14bc20253e10.tar.gz"
     sha256: "d8cd967ca4daa376614995fe8a439a957a303c7ca5b9858ca15ad243e6b176d3"
+patches:
+  "0.3.7":
+    - patch_file: "patches/0.3.7-0001-fix-cmake.patch"
+      patch_description: "disable generating code and fPIC"
+      patch_type: "conan"

--- a/recipes/tree-sitter-sql/all/conanfile.py
+++ b/recipes/tree-sitter-sql/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 
 
@@ -25,7 +26,11 @@ class TreeSitterSqlConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-    exports_sources = ["CMakeLists.txt"]
+
+    def export_sources(self):
+        if Version(self.version) < "0.3.7":
+            copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -48,23 +53,30 @@ class TreeSitterSqlConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["TREE_SITTER_SQL_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        if Version(self.version) < "0.3.7":
+            tc.variables["TREE_SITTER_SQL_SRC_DIR"] = self.source_folder.replace("\\", "/")
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        if Version(self.version) < "0.3.7":
+            cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        else:
+            cmake.configure()
         cmake.build()
 
     def package(self):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
+        if Version(self.version) >= "0.3.7":
+            rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.libs = ["tree-sitter-sql"]

--- a/recipes/tree-sitter-sql/all/conanfile.py
+++ b/recipes/tree-sitter-sql/all/conanfile.py
@@ -37,7 +37,7 @@ class TreeSitterSqlConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if is_msvc(self):
+        if is_msvc(self) and Version(self.version) < "0.3.7":
             del self.options.shared
             self.package_type = "static-library"
         if self.options.get_safe("shared"):

--- a/recipes/tree-sitter-sql/all/patches/0.3.7-0001-fix-cmake.patch
+++ b/recipes/tree-sitter-sql/all/patches/0.3.7-0001-fix-cmake.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index faaef1e..c939c26 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,7 +14,7 @@ if(NOT ${TREE_SITTER_ABI_VERSION} MATCHES "^[0-9]+$")
+     unset(TREE_SITTER_ABI_VERSION CACHE)
+     message(FATAL_ERROR "TREE_SITTER_ABI_VERSION must be an integer")
+ endif()
+-
++if(0)
+ find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
+ 
+ add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
+@@ -23,9 +23,9 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
+                             --abi=${TREE_SITTER_ABI_VERSION}
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                    COMMENT "Generating parser.c")
+-
++endif()
+ add_library(tree-sitter-sql src/parser.c)
+-if(EXISTS src/scanner.c)
++if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
+   target_sources(tree-sitter-sql PRIVATE src/scanner.c)
+ endif()
+ target_include_directories(tree-sitter-sql PRIVATE src)
+@@ -37,7 +37,7 @@ target_compile_definitions(tree-sitter-sql PRIVATE
+ set_target_properties(tree-sitter-sql
+                       PROPERTIES
+                       C_STANDARD 11
+-                      POSITION_INDEPENDENT_CODE ON
++                      # POSITION_INDEPENDENT_CODE ON
+                       SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
+                       DEFINE_SYMBOL "")
+ 

--- a/recipes/tree-sitter-sql/all/test_package/CMakeLists.txt
+++ b/recipes/tree-sitter-sql/all/test_package/CMakeLists.txt
@@ -6,3 +6,7 @@ pkg_check_modules(TREE_SITTER_SQL IMPORTED_TARGET "tree-sitter-sql")
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::TREE_SITTER_SQL)
+if(TREE_SITTER_SQL_VERSION VERSION_LESS "0.3.7")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE TREE_SITTER_SQL_OLD_PATH)
+endif()
+

--- a/recipes/tree-sitter-sql/all/test_package/test_package.c
+++ b/recipes/tree-sitter-sql/all/test_package/test_package.c
@@ -2,7 +2,11 @@
 #include <string.h>
 
 #include "tree_sitter/api.h"
+#ifdef TREE_SITTER_SQL_OLD_PATH
 #include "tree-sitter-sql.h"
+#else
+#include "tree_sitter/tree-sitter-sql.h"
+#endif
 
 int main() {
     TSParser *parser = ts_parser_new();

--- a/recipes/tree-sitter-sql/config.yml
+++ b/recipes/tree-sitter-sql/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.3.7":
+    folder: all
   "0.3.5":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-sitter-sql/0.3.7**

#### Motivation
There are several improvements in 0.3.7.

#### Details
https://github.com/DerekStride/tree-sitter-sql/releases/tag/v0.3.7
https://github.com/DerekStride/tree-sitter-sql/compare/v0.3.5...v0.3.7

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
