### PR TITLE
tree-sitter-c: add version 0.23.2

### DIFF
--- a/recipes/tree-sitter-c/all/conandata.yml
+++ b/recipes/tree-sitter-c/all/conandata.yml
@@ -17,3 +17,9 @@ sources:
   "0.20.1":
     url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.20.1.tar.gz"
     sha256: "ffcc2ef0eded59ad1acec9aec4f9b0c7dd209fc1a85d85f8b0e81298e3dddcc2"
+patches:
+  "0.23.2":
+    - patch_file: "patches/0.23.2-0001-disable-gencode-fpic.patch"
+      patch_description: "disable gencode and fPIC"
+      patch_type: "portability"
+

--- a/recipes/tree-sitter-c/all/conandata.yml
+++ b/recipes/tree-sitter-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.23.2":
+    url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.23.2.tar.gz"
+    sha256: "d8b9c1b2ffb6a42caf9bc76e07c52507d4e60b17175ed9beb0e779be8db1200c"
   "0.23.1":
     url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.23.1.tar.gz"
     sha256: "8f90f481c28a45c7dcba84d05fc07853df043ff813868cdfa074a3835e89467a"

--- a/recipes/tree-sitter-c/all/conanfile.py
+++ b/recipes/tree-sitter-c/all/conanfile.py
@@ -1,6 +1,8 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import get, replace_in_file, copy
+from conan.tools.files import get, replace_in_file, copy, rmdir
+
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -29,11 +31,13 @@ class TreeSitterCConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def export_sources(self):
-        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=(self.export_sources_folder + "/src"))
+        if Version(self.version) < "0.23.2":
+            copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=os.path.join(self.export_sources_folder, "src"))
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["TREE_SITTER_C_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        if Version(self.version) < "0.23.2":
+            tc.variables["TREE_SITTER_C_SRC_DIR"] = self.source_folder.replace("\\", "/")
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
@@ -55,7 +59,7 @@ class TreeSitterCConan(ConanFile):
         self.requires("tree-sitter/0.24.3", transitive_headers=True, transitive_libs=True)
 
     def _patch_sources(self):
-        if not self.options.shared:
+        if Version(self.version) < "0.23.2" and not self.options.shared:
             replace_in_file(
                 self,
                 os.path.join(self.source_folder, "src", "parser.c"),
@@ -77,6 +81,7 @@ class TreeSitterCConan(ConanFile):
         )
         cmake = CMake(self)
         cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.libs = ["tree-sitter-c"]

--- a/recipes/tree-sitter-c/all/conanfile.py
+++ b/recipes/tree-sitter-c/all/conanfile.py
@@ -53,6 +53,13 @@ class TreeSitterCConan(ConanFile):
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
 
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    def requirements(self):
+        self.requires("tree-sitter/0.24.3", transitive_headers=True, transitive_libs=True)
+
     def _patch_sources(self):
         if Version(self.version) < "0.23.2" and not self.options.shared:
             replace_in_file(
@@ -61,15 +68,8 @@ class TreeSitterCConan(ConanFile):
                 "__declspec(dllexport)", ""
             )
 
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        apply_conandata_patches(self)
-        self._patch_sources()
-
-    def requirements(self):
-        self.requires("tree-sitter/0.24.3", transitive_headers=True, transitive_libs=True)
-
     def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/tree-sitter-c/all/patches/0.23.2-0001-disable-gencode-fpic.patch
+++ b/recipes/tree-sitter-c/all/patches/0.23.2-0001-disable-gencode-fpic.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 20754b4..7a2d575 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,7 +14,7 @@ if(NOT ${TREE_SITTER_ABI_VERSION} MATCHES "^[0-9]+$")
+     unset(TREE_SITTER_ABI_VERSION CACHE)
+     message(FATAL_ERROR "TREE_SITTER_ABI_VERSION must be an integer")
+ endif()
+-
++if(0)
+ find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
+ 
+ add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
+@@ -23,7 +23,7 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
+                             --abi=${TREE_SITTER_ABI_VERSION}
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                    COMMENT "Generating parser.c")
+-
++endif()
+ add_library(tree-sitter-c src/parser.c)
+ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
+   target_sources(tree-sitter-c PRIVATE src/scanner.c)
+@@ -37,7 +37,7 @@ target_compile_definitions(tree-sitter-c PRIVATE
+ set_target_properties(tree-sitter-c
+                       PROPERTIES
+                       C_STANDARD 11
+-                      POSITION_INDEPENDENT_CODE ON
++                      # POSITION_INDEPENDENT_CODE ON
+                       SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
+                       DEFINE_SYMBOL "")
+ 

--- a/recipes/tree-sitter-c/all/test_package/CMakeLists.txt
+++ b/recipes/tree-sitter-c/all/test_package/CMakeLists.txt
@@ -5,3 +5,6 @@ find_package(tree-sitter-c REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE tree-sitter-c::tree-sitter-c)
+if(tree-sitter-c_VERSION VERSION_LESS "0.23.2")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE TREE_SITTER_C_API_H)
+endif()

--- a/recipes/tree-sitter-c/all/test_package/test_package.c
+++ b/recipes/tree-sitter-c/all/test_package/test_package.c
@@ -1,5 +1,10 @@
 #include <tree_sitter/api.h>
+
+#ifdef TREE_SITTER_C_API_H
 #include <tree_sitter_c/api.h>
+#else
+#include <tree_sitter/tree-sitter-c.h>
+#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/recipes/tree-sitter-c/config.yml
+++ b/recipes/tree-sitter-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.23.2":
+    folder: all
   "0.23.1":
     folder: all
   "0.20.7":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-sitter-c/0.23.2**

#### Motivation
upstream added official CMakeLists.txt.

#### Details
https://github.com/tree-sitter/tree-sitter-c/compare/v0.23.1...v0.23.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
