### PR TITLE
jtckdint: add recipe

### DIFF
--- a/recipes/jtckdint/all/conandata.yml
+++ b/recipes/jtckdint/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.2":
-    url: "https://github.com/jart/jtckdint/archive/refs/tags/0.2.tar.gz"
-    sha256: "bc223afac1b194f1bd51a2a380d0004b00cc7b617273dc9895b96621cf4d3b98"
+  "1.0":
+    url: "https://github.com/jart/jtckdint/archive/refs/tags/1.0.tar.gz"
+    sha256: "a117f12bfe41f17d947c8ccc122d18b162d634c5ae9059391a6d36cee83a000f"

--- a/recipes/jtckdint/all/conandata.yml
+++ b/recipes/jtckdint/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.2":
+    url: "https://github.com/jart/jtckdint/archive/refs/tags/0.2.tar.gz"
+    sha256: "bc223afac1b194f1bd51a2a380d0004b00cc7b617273dc9895b96621cf4d3b98"

--- a/recipes/jtckdint/all/conanfile.py
+++ b/recipes/jtckdint/all/conanfile.py
@@ -1,0 +1,40 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=2.0"
+
+
+class JtckdintConan(ConanFile):
+    name = "jtckdint"
+    description = "C23 Checked Arithmetic"
+    license = "ISC"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/jart/jtckdint"
+    topics = ("integer", "checked", "arithmetic", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        check_min_cppstd(self, 11)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.h", self.source_folder, os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/jtckdint/all/conanfile.py
+++ b/recipes/jtckdint/all/conanfile.py
@@ -25,9 +25,6 @@ class JtckdintConan(ConanFile):
     def package_id(self):
         self.info.clear()
 
-    def validate(self):
-        check_min_cppstd(self, 11)
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/jtckdint/all/test_package/CMakeLists.txt
+++ b/recipes/jtckdint/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(jtckdint REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE jtckdint::jtckdint)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)

--- a/recipes/jtckdint/all/test_package/CMakeLists.txt
+++ b/recipes/jtckdint/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(jtckdint REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE jtckdint::jtckdint)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/jtckdint/all/test_package/conanfile.py
+++ b/recipes/jtckdint/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/jtckdint/all/test_package/test_package.c
+++ b/recipes/jtckdint/all/test_package/test_package.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+#include "jtckdint.h"
+
+int main(void) {
+    uint32_t c;
+    int32_t a = 0x7fffffff;
+    int32_t b = 2;
+    ckd_add(&c, a, b);
+
+    return 0;
+}

--- a/recipes/jtckdint/config.yml
+++ b/recipes/jtckdint/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.2":
+    folder: all

--- a/recipes/jtckdint/config.yml
+++ b/recipes/jtckdint/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.2":
+  "1.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **jtckdint/1.0**

#### Motivation
a portable single-file header-only library that defines C23 three type generic functions.

#### Details
https://github.com/jart/jtckdint

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
