### PR TITLE
daw_header_libraries: add version 2.118.0

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.118.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.118.0.tar.gz"
+    sha256: "2a3e093c2f69db979e7672d33b97f7f24cda23ff753fafe90a3aaf25ac965a70"
   "2.114.0":
     url: "https://github.com/beached/header_libraries/archive/v2.114.0.tar.gz"
     sha256: "c36229424bd68ee8936ad688127303aee69ecd5400a905df75138ed95cbfef53"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.118.0":
+    folder: all
   "2.114.0":
     folder: all
   "2.110.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **daw_header_libraries/2.118.0**

#### Motivation
There are several improvements in 2.118.0.

#### Details
https://github.com/beached/header_libraries/compare/v2.114.0...v2.118.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
