### PR TITLE
monogo-cxx-driver: add version 4.0.0, update dependencies

### DIFF
--- a/recipes/mongo-cxx-driver/all/conandata.yml
+++ b/recipes/mongo-cxx-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.0":
+    url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r4.0.0/mongo-cxx-driver-r4.0.0.tar.gz"
+    sha256: "d8a254bde203d0fe2df14243ef2c3bab7f12381dc9206d0c1b450f6ae02da7cf"
   "3.11.0":
     url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.11.0/mongo-cxx-driver-r3.11.0.tar.gz"
     sha256: "cb4263229d769ec44aa66563e2dd2d70c6384c85d93840a52fe26b15436c54f1"
@@ -24,6 +27,13 @@ sources:
     url: "https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz"
     sha256: "2c58005d4fe46f1973352fba821f7bb37e818cefc922377ce979a9fd1bff38ac"
 patches:
+  "4.0.0":
+    - patch_file: "patches/4.0.0-0001-dirs.patch"
+      patch_description: "disable documentation features, fix directories"
+      patch_type: "conan"
+    - patch_file: "patches/4.0.0-0002-remove-abi-suffixes.patch"
+      patch_description: "remove abi suffixes for MSVC"
+      patch_type: "conan"
   "3.11.0":
     - patch_file: "patches/3.10.2-0001-dirs.patch"
       patch_description: "disable documentation features, fix directories"

--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -48,9 +48,9 @@ class MongoCxxConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("mongo-c-driver/1.28.0")
+        self.requires("mongo-c-driver/1.29.0")
         if self.options.polyfill == "boost":
-            self.requires("boost/1.82.0", transitive_headers=True)
+            self.requires("boost/1.86.0", transitive_headers=True)
 
     @property
     def _minimal_std_version(self):

--- a/recipes/mongo-cxx-driver/all/patches/4.0.0-0001-dirs.patch
+++ b/recipes/mongo-cxx-driver/all/patches/4.0.0-0001-dirs.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d2af682..acb2f25 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -275,7 +275,7 @@ add_custom_target(hugo
+     COMMAND hugo
+     VERBATIM
+ )
+-
++if(FALSE)
+ add_custom_target(hugo-deploy
+     DEPENDS hugo
+     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+@@ -320,7 +320,7 @@ add_custom_target(format-lint
+ add_custom_target(docs
+     DEPENDS hugo doxygen-current
+ )
+-
++endif()
+ set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
+ set(DATA_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
+ 
+@@ -336,7 +336,7 @@ if(ENABLE_TESTS)
+ endif()
+ 
+ add_subdirectory(src)
+-
++if(FALSE)
+ add_subdirectory(examples EXCLUDE_FROM_ALL)
+ 
+ add_subdirectory(benchmark EXCLUDE_FROM_ALL)
+@@ -462,3 +462,4 @@ endif()
+ if(CMAKE_GENERATOR_TOOLSET)
+     message(STATUS "\tinstance: ${CMAKE_GENERATOR_TOOLSET}")
+ endif()
++endif()
+diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
+index 7e4cade..0a6ce5a 100644
+--- a/src/bsoncxx/CMakeLists.txt
++++ b/src/bsoncxx/CMakeLists.txt
+@@ -66,8 +66,8 @@ if(TARGET bson_shared OR TARGET bson_static)
+     set(BSONCXX_PKG_DEP "find_dependency(bson-${LIBBSON_REQUIRED_ABI_VERSION} REQUIRED)")
+ else()
+     # Attempt to find libbson by new package name (without lib).
+-    find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} QUIET)
+-
++    find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} REQUIRED)
++    set(bson-${LIBBSON_REQUIRED_ABI_VERSION}_FOUND TRUE)
+     if(bson-${LIBBSON_REQUIRED_ABI_VERSION}_FOUND)
+         message(STATUS "found libbson version ${bson-${LIBBSON_REQUIRED_ABI_VERSION}_VERSION}")
+ 

--- a/recipes/mongo-cxx-driver/all/patches/4.0.0-0002-remove-abi-suffixes.patch
+++ b/recipes/mongo-cxx-driver/all/patches/4.0.0-0002-remove-abi-suffixes.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/BsoncxxUtil.cmake b/cmake/BsoncxxUtil.cmake
+index ad8c426..9a7e227 100644
+--- a/cmake/BsoncxxUtil.cmake
++++ b/cmake/BsoncxxUtil.cmake
+@@ -70,7 +70,7 @@ function(bsoncxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
+         endif()
+ 
+         # MSVC-specific ABI tag suffixes.
+-        if(MSVC)
++        if(FALSE)
+             set(vs_suffix "")
+ 
+             # Include the target architecture if applicable (Win32, x64, etc.).
+diff --git a/cmake/MongocxxUtil.cmake b/cmake/MongocxxUtil.cmake
+index de9210c..0c16803 100644
+--- a/cmake/MongocxxUtil.cmake
++++ b/cmake/MongocxxUtil.cmake
+@@ -63,7 +63,7 @@ function(mongocxx_add_library TARGET OUTPUT_NAME LINK_TYPE)
+         endif()
+ 
+         # MSVC-specific ABI tag suffixes. Inherit from bsoncxx.
+-        if(MSVC)
++        if(FALSE)
+             get_target_property(vs_suffix ${bsoncxx_target} BSONCXX_ABI_TAG_VS_SUFFIX)
+             set_target_properties(${TARGET} PROPERTIES
+                 BSONCXX_ABI_TAG_VS_SUFFIX ${vs_suffix}

--- a/recipes/mongo-cxx-driver/config.yml
+++ b/recipes/mongo-cxx-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.0":
+    folder: all
   "3.11.0":
     folder: all
   "3.10.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mongo-cxx-driver/4.0.0**

#### Motivation
Major version up.

#### Details
https://github.com/mongodb/mongo-cxx-driver/compare/r3.11.0...r4.0.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
