### PR TITLE
simdutf: add version 5.6.3

### DIFF
--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.6.3":
+    url: "https://github.com/simdutf/simdutf/archive/v5.6.3.tar.gz"
+    sha256: "503070ddf27e26c051b9500dfc7354ec8850e11076f47db32635931c85b630c0"
   "5.6.2":
     url: "https://github.com/simdutf/simdutf/archive/v5.6.2.tar.gz"
     sha256: "c71b5478c9b912e07f75098f3a60920f1c4de3227b5285ea8a90a2fcf8bd6a89"

--- a/recipes/simdutf/config.yml
+++ b/recipes/simdutf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.6.3":
+    folder: all
   "5.6.2":
     folder: all
   "5.6.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **simdutf/5.6.3**

#### Motivation
There is an improvements in 5.6.3.

#### Details
https://github.com/simdutf/simdutf/releases/tag/v5.6.3
https://github.com/simdutf/simdutf/compare/v5.6.2...v5.6.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
