### PR TITLE
openh264: add version 2.5.0

### DIFF
--- a/recipes/openh264/all/conandata.yml
+++ b/recipes/openh264/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.0":
+    url: "https://github.com/cisco/openh264/archive/refs/tags/v2.5.0.tar.gz"
+    sha256: "94c8ca364db990047ec4ec3481b04ce0d791e62561ef5601443011bdc00825e3"
   "2.4.1":
     url: "https://github.com/cisco/openh264/archive/refs/tags/v2.4.1.tar.gz"
     sha256: "8ffbe944e74043d0d3fb53d4a2a14c94de71f58dbea6a06d0dc92369542958ea"

--- a/recipes/openh264/config.yml
+++ b/recipes/openh264/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.0":
+    folder: all
   "2.4.1":
     folder: all
   "2.3.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **openh264/2.5.0**

#### Motivation
There are several improvements in 2.5.0.

#### Details
https://github.com/cisco/openh264/compare/v2.4.1...v2.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
