### PR TITLE
SDL: disable iconv dependency on all Apple platforms by default

### DIFF
--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -103,11 +103,11 @@ class SDLConan(ConanFile):
         export_conandata_patches(self)
 
     def config_options(self):
-        # Don't depend on iconv on macOS by default
+        # Don't depend on iconv on Apple by default
         # SDL2 depends on many system freamworks,
         # which depend on the system-provided iconv
         # and can conflict with the Conan provided one
-        self.options.iconv = self.settings.os != "Macos"
+        self.options.iconv = not is_apple_os(self)
 
         if self.settings.os == "Windows":
             del self.options.fPIC


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Same logic behind disabling iconv for macOS applies to all Apple platforms actually

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
