### PR TITLE
SDL: fix Android shared library and expose HIDAPI setting

### DIFF
--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -191,6 +191,7 @@ class SDLConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        self._patch_sources()
 
     def _patch_sources(self):
         apply_conandata_patches(self)
@@ -335,7 +336,6 @@ class SDLConan(ConanFile):
         tc.generate()
 
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -139,8 +139,10 @@ class SDLConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.libcxx")
-        self.settings.rm_safe("compiler.cppstd")
+        # TODO: C++ is also required for WinRT and Haiku
+        if not (self.settings.os == "Android" and self.options.hidapi):
+            self.settings.rm_safe("compiler.libcxx")
+            self.settings.rm_safe("compiler.cppstd")
 
     def requirements(self):
         if self.options.get_safe("iconv", False):

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -191,7 +191,6 @@ class SDLConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        self._patch_sources()
 
     def _patch_sources(self):
         apply_conandata_patches(self)
@@ -336,6 +335,7 @@ class SDLConan(ConanFile):
         tc.generate()
 
     def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -49,6 +49,7 @@ class SDLConan(ConanFile):
         "opengles": [True, False],
         "vulkan": [True, False],
         "libunwind": [True, False],
+        "hidapi": [True, False],
     }
     default_options = {
         "shared": False,
@@ -77,6 +78,7 @@ class SDLConan(ConanFile):
         "opengles": True,
         "vulkan": True,
         "libunwind": True,
+        "hidapi": True,
     }
     generators = "CMakeDeps", "PkgConfigDeps", "VirtualBuildEnv"
 
@@ -243,6 +245,7 @@ class SDLConan(ConanFile):
         tc.variables["SDL_OPENGL"] = self.options.opengl
         tc.variables["SDL_OPENGLES"] = self.options.opengles
         tc.variables["SDL_VULKAN"] = self.options.vulkan
+        tc.variables["SDL_HIDAPI"] = self.options.hidapi
         if self.settings.os == "Linux":
             # See https://github.com/bincrafters/community/issues/696
             tc.variables["SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS"] = 1


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
- fixes building Android shared library
- exposes SDL_HIDAPI setting

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Even though SDL is a C library, on Android it starts requiring C++ only when you build the HIDAPI subsystem, see here: https://github.com/libsdl-org/SDL/blob/bbc9c75618fbc60583123e03f31f4e856f2654bf/cmake/sdlchecks.cmake#L1105-L1106

Without the fix cmake picks the default C++ library from NDK toolchain which is static. This is an issue when your profile requests shared C++ library and could be a source of strange behavior later, like we faced in our project: https://github.com/vcmi/vcmi/issues/4973

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
