### PR TITLE
[libsndfile] Make libsndio optional to avoid ffmpeg breakage

### DIFF
--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -131,21 +131,21 @@ class LibsndfileConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "SndFile")
         self.cpp_info.set_property("cmake_target_name", "SndFile::sndfile")
         self.cpp_info.set_property("pkg_config_name", "sndfile")
-        self.cpp_info.components["sndfile"].libs = ["sndfile"]
+        self.cpp_info.libs = ["sndfile"]
         if self.options.with_sndio:
-            self.cpp_info.components["sndfile"].requires.append("libsndio::libsndio")
+            self.cpp_info.requires.append("libsndio::libsndio")
         if self.options.with_external_libs:
-            self.cpp_info.components["sndfile"].requires.extend([
+            self.cpp_info.requires.extend([
                 "ogg::ogg", "vorbis::vorbismain", "vorbis::vorbisenc",
                 "flac::flac", "opus::opus",
             ])
         if self.options.get_safe("with_mpeg", False):
-            self.cpp_info.components["sndfile"].requires.append("mpg123::mpg123")
-            self.cpp_info.components["sndfile"].requires.append("libmp3lame::libmp3lame")
+            self.cpp_info.requires.append("mpg123::mpg123")
+            self.cpp_info.requires.append("libmp3lame::libmp3lame")
         if self.options.get_safe("with_alsa"):
-            self.cpp_info.components["sndfile"].requires.append("libalsa::libalsa")
+            self.cpp_info.requires.append("libalsa::libalsa")
         if not self.options.shared:
             if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.components["sndfile"].system_libs = ["m", "dl", "pthread", "rt"]
+                self.cpp_info.system_libs = ["m", "dl", "pthread", "rt"]
             elif self.settings.os == "Windows":
-                self.cpp_info.components["sndfile"].system_libs.append("winmm")
+                self.cpp_info.system_libs.append("winmm")

--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -36,7 +36,7 @@ class LibsndfileConan(ConanFile):
         "fPIC": True,
         "programs": True,
         "experimental": False,
-        "with_alsa": True,
+        "with_alsa": False,
         "with_external_libs": True,
         "with_mpeg": True,
         "with_sndio": False,
@@ -131,9 +131,9 @@ class LibsndfileConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "SndFile")
         self.cpp_info.set_property("cmake_target_name", "SndFile::sndfile")
         self.cpp_info.set_property("pkg_config_name", "sndfile")
-        # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["sndfile"].libs = ["sndfile"]
-        self.cpp_info.components["sndfile"].requires.append("libsndio::libsndio")
+        if self.options.with_sndio:
+            self.cpp_info.components["sndfile"].requires.append("libsndio::libsndio")
         if self.options.with_external_libs:
             self.cpp_info.components["sndfile"].requires.extend([
                 "ogg::ogg", "vorbis::vorbismain", "vorbis::vorbisenc",
@@ -149,10 +149,3 @@ class LibsndfileConan(ConanFile):
                 self.cpp_info.components["sndfile"].system_libs = ["m", "dl", "pthread", "rt"]
             elif self.settings.os == "Windows":
                 self.cpp_info.components["sndfile"].system_libs.append("winmm")
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.names["cmake_find_package"] = "SndFile"
-        self.cpp_info.names["cmake_find_package_multi"] = "SndFile"
-        self.cpp_info.components["sndfile"].set_property("cmake_target_name", "SndFile::sndfile")
-        if self.options.programs:
-            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -29,6 +29,7 @@ class LibsndfileConan(ConanFile):
         "with_alsa": [True, False],
         "with_external_libs": [True, False],
         "with_mpeg": [True, False],
+        "with_sndio": [True, False],
     }
     default_options = {
         "shared": False,
@@ -38,6 +39,7 @@ class LibsndfileConan(ConanFile):
         "with_alsa": True,
         "with_external_libs": True,
         "with_mpeg": True,
+        "with_sndio": False,
     }
 
     def export_sources(self):
@@ -57,15 +59,16 @@ class LibsndfileConan(ConanFile):
         self.settings.rm_safe("compiler.libcxx")
 
     def validate(self):
-        if self.dependencies["libsndio"].options.get_safe("with_alsa") and not self.options.get_safe("with_alsa"):
-            raise ConanInvalidConfiguration(f"{self.ref} 'with_alsa' option should be True when the libsndio 'with_alsa' one is True")
+        if self.options.with_sndio:
+            if self.dependencies["libsndio"].options.get_safe("with_alsa") and not self.options.get_safe("with_alsa"):
+                raise ConanInvalidConfiguration(f"{self.ref} 'with_alsa' option should be True when the libsndio 'with_alsa' one is True")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libsndio/1.9.0",
-            options={"with_alsa": self.options.get_safe("with_alsa")})
+        if self.options.with_sndio:
+            self.requires("libsndio/1.9.0", options={"with_alsa": self.options.get_safe("with_alsa")})
         if self.options.get_safe("with_alsa"):
             self.requires("libalsa/1.2.10")
         if self.options.with_external_libs:

--- a/recipes/libsndio/all/conanfile.py
+++ b/recipes/libsndio/all/conanfile.py
@@ -24,7 +24,7 @@ class LibsndioConan(ConanFile):
         "with_alsa": [True, False]
     }
     default_options = {
-        "with_alsa": True,
+        "with_alsa": False,
     }
 
     def configure(self):
@@ -91,7 +91,7 @@ class LibsndioConan(ConanFile):
         # The original project source has a hand-written `configure` script that does not expose
         # many hooks for specifying additional build flags and library dependencies. Because the script is
         # not auto-generated with Autotools, the standard Conan workflow of using AutoolsDeps is not possible.
-        # The one hook the script does provide is a command line arg: `CC=*|CFLAGS=*|LDFLAGS=*|AR=*)`. 
+        # The one hook the script does provide is a command line arg: `CC=*|CFLAGS=*|LDFLAGS=*|AR=*)`.
         # We use this to inject the various flags, paths, and libraries that the Conan dependency tree specifies.
         dep_cflags = []
         dep_ldflags = []

--- a/recipes/libsndio/all/conanfile.py
+++ b/recipes/libsndio/all/conanfile.py
@@ -122,23 +122,13 @@ class LibsndioConan(ConanFile):
 
     def build(self):
         autotools = Autotools(self)
-        if Version(self.version) > "1.2.4":
-            autotools.configure()
-            autotools.make()
-        else:
-            with chdir(self, self.source_folder):
-                autotools.configure()
-                autotools.make()
+        autotools.configure()
+        autotools.make()
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        if Version(self.version) > "1.2.4":
-            autotools = Autotools(self)
-            autotools.install()
-        else:
-            with chdir(self, self.source_folder):
-                autotools = Autotools(self)
-                autotools.install()
+        autotools = Autotools(self)
+        autotools.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
### Summary

Changes to recipe:  **libsndfile/1.2.2**

#### Motivation

The FFMPEG is being affected by the PR https://github.com/conan-io/conan-center-index/pull/23150, where not libsndio is always required now, but uses ALSA always as well. 

First, libsndio only work on Windows, so it makes FFMPEG not possible to be used in Windows. Second, consuming ALSA by default creates a conflict when consuming FFMPEG as well:

```
ERROR: There are invalid packages:
libsndio/1.9.0: Invalid: libsndio/1.9.0 requires libalsa to be built as a shared library
```

#### Details

The libsndfile has no exported option for sndio, but it's optional:

- https://github.com/libsndfile/libsndfile/blob/v1.0.30/CMakeLists.txt#L82
- https://github.com/libsndfile/libsndfile/blob/v1.0.30/CMakeLists.txt#L466

The libsdnio only has the version 1.9.0 maintained in ConanCenterIndex. The Linter found dead code based on old versions. The code was remove (kudos @perseoGI )

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
