### PR TITLE
opentelemetry-proto: add version 1.4.0

### DIFF
--- a/recipes/opentelemetry-proto/all/conandata.yml
+++ b/recipes/opentelemetry-proto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v1.4.0.tar.gz"
+    sha256: "53cd32cedb27762ea2060a9c8d83e4b822de13d73b5d5d37a2db3cf55018d694"
   "1.3.2":
     url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v1.3.2.tar.gz"
     sha256: "c069c0d96137cf005d34411fa67dd3b6f1f8c64af1e7fb2fe0089a41c425acd7"

--- a/recipes/opentelemetry-proto/config.yml
+++ b/recipes/opentelemetry-proto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.0":
+    folder: all
   "1.3.2":
     folder: all
   "1.3.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentelemetry-proto/1.4.0**

#### Motivation
There are several improvements in 1.4.0.

#### Details
https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.4.0
https://github.com/open-telemetry/opentelemetry-proto/compare/v1.3.2...v1.4.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
