### PR TITLE
re2: bump abseil dependency to 20240722.0

### DIFF
--- a/recipes/re2/all/conanfile.py
+++ b/recipes/re2/all/conanfile.py
@@ -8,6 +8,12 @@ import os
 
 required_conan_version = ">=1.54.0"
 
+def get_abseil_version(re2_version: str) -> str:
+    if re2_version >= "20241128":
+        return "abseil/20240722.0"
+    if re2_version >= "20230601":
+        return "abseil/20240116.1"
+
 class Re2Conan(ConanFile):
     name = "re2"
     description = "Fast, safe, thread-friendly regular expression library"
@@ -61,8 +67,10 @@ class Re2Conan(ConanFile):
     def requirements(self):
         if self.options.get_safe("with_icu"):
             self.requires("icu/73.2")
-        if Version(self.version) >= "20230601":
-            self.requires("abseil/20240116.1", transitive_headers=True)
+
+        abseil_version = get_abseil_version(Version(self.version))
+        if abseil_version:
+            self.requires(abseil_version, transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/re2/config.yml
+++ b/recipes/re2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20241128":
+    folder: all
   "20240702":
     folder: all
   "20240301":


### PR DESCRIPTION
### Summary
Changes to recipe:  re2

#### Motivation
At the moment you can't build the latest version of re2 on mac arm because it depends on an outdated version of abseil. The latest version doesn't have the problem, so here I just bumped the abseil dependency.

#### Details
fixes #25992


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
