### PR TITLE
Fix: Add MBEDTLS to variable prefixes for mbedtls to enable building with encryption=mbedtls

### DIFF
--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -358,6 +358,7 @@ class Open62541Conan(ConanFile):
 
         tc.generate()
         tc = CMakeDeps(self)
+        tc.set_property("mbedtls", "cmake_additional_variables_prefixes", ["MBEDTLS"])
         tc.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
I have tried locally and fixes the not found headers error when using encryption=mbedtls

Closes: https://github.com/conan-io/conan-center-index/issues/23930