### PR TITLE
protopuf: add version 3.0.0

### DIFF
--- a/recipes/protopuf/all/conandata.yml
+++ b/recipes/protopuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.0":
+    url: "https://github.com/PragmaTwice/protopuf/archive/v3.0.0.tar.gz"
+    sha256: "62f89b78989eb054bc52e80cc1517274f5621e32eda4758f123c66c7a3521ee3"
   "2.2.1":
     url: "https://github.com/PragmaTwice/protopuf/archive/v2.2.1.tar.gz"
     sha256: "8d4940206d8e8664f75ae1cdfff8c14fa9a196c03967d520725284429744c19c"

--- a/recipes/protopuf/config.yml
+++ b/recipes/protopuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.0":
+    folder: all
   "2.2.1":
     folder: all
   "2.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **protopuf/3.0.0**

#### Motivation
Major version up.
Default mode of `safe_mode` is changed in 3.0.0.

#### Details
https://github.com/PragmaTwice/protopuf/compare/v2.2.1...v3.0.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
