### PR TITLE
metal-cpp: Add version 15

### DIFF
--- a/recipes/metal-cpp/all/conandata.yml
+++ b/recipes/metal-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "15":
+    url: "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15_iOS18.zip"
+    sha256: "0433df1e0ab13c2b0becbd78665071e3fa28381e9714a3fce28a497892b8a184"
   "14.2":
     url: "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS14.2_iOS17.2.zip"
     sha256: "d800ddbc3fccabce3a513f975eeafd4057e07a29e905ad5aaef8c1f4e12d9ada"
@@ -12,6 +15,10 @@ sources:
     url: "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS13_iOS16.zip"
     sha256: "6f741894229e9c750add1afc3797274fc008c7507e2ae726370c17c34b7c6a68"
 minimum_os_version:
+  "15":
+    "Macos": "15"
+    "iOS": "18"
+    "tvOS": "18"
   "14.2":
     "Macos": "14.2"
     "iOS": "17.2"

--- a/recipes/metal-cpp/config.yml
+++ b/recipes/metal-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "15":
+    folder: all
   "14.2":
     folder: all
   "14":


### PR DESCRIPTION
### Summary
Changes to recipe:  **metal-cpp/15**

#### Motivation
New versions supports the API additions of the latest macOS 15/iOS 18 release of Metal.

#### Details
Sadly misses a proper changelog but is the latest release of the Metal wrappers for the new APIs

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
