### PR TITLE
hictk: add v2.0.1 and bump deps

### DIFF
--- a/recipes/hictk/all/conandata.yml
+++ b/recipes/hictk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.1":
+    url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v2.0.1.tar.gz"
+    sha256: "bd12f87f6f33ea91f898d6b660e8dcca9f97b0aaf27719e867ab643cd705fced"
   "1.0.0":
     url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v1.0.0.tar.gz"
     sha256: "e337f52658a257eb6265e211dd3cef6b73db40bdc5b5a6433b47ce4faa6006fb"

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -98,6 +98,7 @@ class HictkConan(ConanFile):
         tc.variables["HICTK_BUILD_TOOLS"] = "OFF"
         tc.variables["HICTK_ENABLE_GIT_VERSION_TRACKING"] = "OFF"
         tc.variables["HICTK_ENABLE_TESTING"] = "OFF"
+        tc.variables["HICTK_ENABLE_FUZZY_TESTING"] = "OFF"
         tc.variables["HICTK_WITH_ARROW"] = self.options.get_safe("with_arrow", False)
         tc.variables["HICTK_WITH_EIGEN"] = self.options.with_eigen
         tc.generate()

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -51,16 +51,16 @@ class HictkConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_arrow"):
-            self.requires("arrow/16.1.0")
+            self.requires("arrow/17.0.0")
         self.requires("bshoshany-thread-pool/4.1.0")
-        self.requires("fast_float/6.1.1")
+        self.requires("fast_float/6.1.5")
         if self.options.with_eigen:
             self.requires("eigen/3.4.0")
-        self.requires("fmt/10.2.1")
+        self.requires("fmt/11.0.2")
         self.requires("hdf5/1.14.3")
-        self.requires("highfive/2.9.0")
-        self.requires("libdeflate/1.20")
-        self.requires("parallel-hashmap/1.3.12")  # Note: v1.3.12 is more recent than v1.37
+        self.requires("highfive/2.10.0")
+        self.requires("libdeflate/1.22")
+        self.requires("parallel-hashmap/1.4.0")  # Note: v1.4.0 is more recent than v1.37
         self.requires("span-lite/0.11.0")
         self.requires("spdlog/1.14.1")
         self.requires("zstd/[>=1.5 <1.6]")

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -51,9 +51,9 @@ class HictkConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_arrow"):
-            self.requires("arrow/17.0.0")
+            self.requires("arrow/18.1.0")
         self.requires("bshoshany-thread-pool/4.1.0")
-        self.requires("fast_float/6.1.5")
+        self.requires("fast_float/7.0.0")
         if self.options.with_eigen:
             self.requires("eigen/3.4.0")
         self.requires("fmt/11.0.2")
@@ -62,7 +62,7 @@ class HictkConan(ConanFile):
         self.requires("libdeflate/1.22")
         self.requires("parallel-hashmap/1.4.0")  # Note: v1.4.0 is more recent than v1.37
         self.requires("span-lite/0.11.0")
-        self.requires("spdlog/1.14.1")
+        self.requires("spdlog/1.15.0")
         self.requires("zstd/[>=1.5 <1.6]")
 
         if Version(self.version) == "0.0.3":

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -85,6 +85,11 @@ class HictkConan(ConanFile):
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
+        if self.info.options.get_safe("with_arrow"):
+            arrow = self.dependencies["arrow"]
+            if not arrow.options.compute:
+                raise ConanInvalidConfiguration(f"{self.ref} requires the dependency option arrow/*:compute=True")
+
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.25 <4]")
 

--- a/recipes/hictk/all/test_package/test_package.cpp
+++ b/recipes/hictk/all/test_package/test_package.cpp
@@ -2,9 +2,13 @@
 
 #include "hictk/file.hpp"
 
+#if __has_include("hictk/transformers/to_dataframe.hpp")
 #include "hictk/transformers/to_dataframe.hpp"     // test hictk/*:with_arrow
-#include "hictk/transformers/to_dense_matrix.hpp"  // test hictk/*:with_eigen
+#endif
 
+#if __has_include("hictk/transformers/to_dense_matrix.hpp")
+#include "hictk/transformers/to_dense_matrix.hpp"  // test hictk/*:with_eigen
+#endif
 
 int main(int argc, char** argv) {
   try {

--- a/recipes/hictk/all/test_package/test_package.cpp
+++ b/recipes/hictk/all/test_package/test_package.cpp
@@ -2,6 +2,9 @@
 
 #include "hictk/file.hpp"
 
+#include "hictk/transformers/to_dataframe.hpp"  // test hictk/*:with_arrow
+#include "hictk/transformers/to_dense.hpp"      // test hictk/*:with_eigen
+
 
 int main(int argc, char** argv) {
   try {

--- a/recipes/hictk/all/test_package/test_package.cpp
+++ b/recipes/hictk/all/test_package/test_package.cpp
@@ -2,8 +2,8 @@
 
 #include "hictk/file.hpp"
 
-#include "hictk/transformers/to_dataframe.hpp"  // test hictk/*:with_arrow
-#include "hictk/transformers/to_dense.hpp"      // test hictk/*:with_eigen
+#include "hictk/transformers/to_dataframe.hpp"     // test hictk/*:with_arrow
+#include "hictk/transformers/to_dense_matrix.hpp"  // test hictk/*:with_eigen
 
 
 int main(int argc, char** argv) {

--- a/recipes/hictk/config.yml
+++ b/recipes/hictk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.1":
+    folder: all
   "1.0.0":
     folder: all
   "0.0.12":


### PR DESCRIPTION
### Summary
Changes to recipe:  **hictk/all**

#### Motivation
Add the latest version of hictk and bump a few dependencies to solve current version conflicts and lower the chance of future conflicts.

Note that the recipe does not currently build when `hictk/*:with_arrow=True` because highfive requests boost v1.84.0 while arrow requests v1.85.0.
I've opened https://github.com/conan-io/conan-center-index/pull/26079 to solve the version conflict.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
