### PR TITLE
[boost] Fix missing stacktrace_backtrace when cross-building

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -613,7 +613,7 @@ class BoostConan(ConanFile):
 
     @property
     def _stacktrace_addr2line_available(self):
-        if (self._is_apple_embedded_platform or self.settings.get_safe("os.subsystem") == "catalyst"):
+        if self._is_apple_embedded_platform or self.settings.get_safe("os.subsystem") == "catalyst":
              # sandboxed environment - cannot launch external processes (like addr2line), system() function is forbidden
             return False
         return not self.options.header_only and not self.options.without_stacktrace and self.settings.os != "Windows"
@@ -1099,7 +1099,9 @@ class BoostConan(ConanFile):
         stacktrace_jamfile = os.path.join(self.source_folder, "libs", "stacktrace", "build", "Jamfile.v2")
         if cross_building(self, skip_x64_x86=True):
             # When cross building, do not attempt to run the test-executable (assume they work)
-            replace_in_file(self, stacktrace_jamfile, "$(>) > $(<)", "echo \"\" > $(<)", strict=False)
+            replace_in_file(self, stacktrace_jamfile, "$(>) > $(<)", "echo \"\" > $(<)", strict=True)
+            if self._with_stacktrace_backtrace and self.settings.os != "Windows" and self.dependencies["libbacktrace"].options.shared:
+                replace_in_file(self, stacktrace_jamfile, "<link>static", "<link>shared", strict=False)
         if self._with_stacktrace_backtrace and self.settings.os != "Windows" and not cross_building(self):
             # When libbacktrace is shared, give extra help to the test-executable
             linker_var = "DYLD_LIBRARY_PATH" if self.settings.os == "Macos" else "LD_LIBRARY_PATH"


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/[>=1.78]**

#### Motivation

The issue #26085 opened by @vithalsm reported that `stacktrace_addr2line` is not available in the package when cross-building.

The original issue shows:

```
- libbacktrace builds      : no [2]
- libbacktrace builds      : no [3]
- addr2line builds         : no [2]
- addr2line builds         : no [3]
```

These 2 important points are required to enable `stacktrace_addr2line` and `stacktrace_backtrace`. Unfortunately, using b2 we have no smart way to detect if `stacktrace_addr2line` and `stacktrace_backtrace` will be built (we would need a post-configure step).

The `addr2line` is configurable, and can be setup by the recipe option `addr2line_location`. For instance: `-o "boost/*:addr2line_location=/opt/arm-gnu-toolchain-13/bin/aarch64-none-linux-gnu-addr2line`. Tested locally and worked.

About the `libbacktrace` is a bit more complicated. When cross-building there is no problems, only when boost is shared (as pointed in the issue). The Boost stacktrace is looking for static library: https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L30 so we need to patch it as well to find shared.

The upstream has a related issue: https://github.com/boostorg/stacktrace/issues/125

fix #26085

#### Details

Full build logs:

Here are my local build logs, using the proposed patch:

- [boost-1.85.0-linux-armv8-shared.log](https://github.com/user-attachments/files/17980620/boost-1.85.0-linux-armv8-shared.log)
- [boost-1.85.0-linux-armv8-static.log](https://github.com/user-attachments/files/17980621/boost-1.85.0-linux-armv8-static.log)

The static library has no changes, as was working as before, only shared needs a help to find the missing libacktrace. 



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
