### PR TITLE
rusty-cpp: new recipe

### DIFF
--- a/recipes/rusty-cpp/all/conandata.yml
+++ b/recipes/rusty-cpp/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "0.1.11":
+    url:
+    - "https://github.com/seekstar/rusty-cpp/archive/refs/tags/v0.1.11.tar.gz"
+    sha256: "313b13c2df256ea46c98702c05080c1433d1c7f3b4378b083dea21491f55ac8f"

--- a/recipes/rusty-cpp/all/conandata.yml
+++ b/recipes/rusty-cpp/all/conandata.yml
@@ -3,7 +3,3 @@ sources:
     url:
     - "https://github.com/seekstar/rusty-cpp/archive/refs/tags/v0.1.12.tar.gz"
     sha256: "18397dfb9aaea6eef9217f749fe4d1ad55715c519fa0df3173eabfd8d418160f"
-  "0.1.11":
-    url:
-    - "https://github.com/seekstar/rusty-cpp/archive/refs/tags/v0.1.11.tar.gz"
-    sha256: "313b13c2df256ea46c98702c05080c1433d1c7f3b4378b083dea21491f55ac8f"

--- a/recipes/rusty-cpp/all/conandata.yml
+++ b/recipes/rusty-cpp/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
+  "0.1.12":
+    url:
+    - "https://github.com/seekstar/rusty-cpp/archive/refs/tags/v0.1.12.tar.gz"
+    sha256: "18397dfb9aaea6eef9217f749fe4d1ad55715c519fa0df3173eabfd8d418160f"
   "0.1.11":
     url:
     - "https://github.com/seekstar/rusty-cpp/archive/refs/tags/v0.1.11.tar.gz"

--- a/recipes/rusty-cpp/all/conanfile.py
+++ b/recipes/rusty-cpp/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
@@ -24,6 +25,9 @@ class RustyCppConan(ConanFile):
 
     def layout(self):
         basic_layout(self, src_folder="src")
+    
+    def validate(self):
+        check_min_cppstd(self, 17)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/rusty-cpp/all/conanfile.py
+++ b/recipes/rusty-cpp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain
-from conan.tools.files import copy, export_conandata_patches, get
+from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 import os
 
@@ -19,8 +19,8 @@ class RustyCppConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    def export_sources(self):
-        export_conandata_patches(self)
+    def package_id(self):
+        self.info.clear()
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/rusty-cpp/all/conanfile.py
+++ b/recipes/rusty-cpp/all/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=2.0"
 class RustyCppConan(ConanFile):
     name = "rusty-cpp"
     description = "Write C++ code like Rust!"
-    license = "Apache-2.0 OR MIT"
+    license = "Apache-2.0", "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/seekstar/rusty-cpp"
     topics = ("C++", "Rust", "header-only")

--- a/recipes/rusty-cpp/all/conanfile.py
+++ b/recipes/rusty-cpp/all/conanfile.py
@@ -1,0 +1,50 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.files import copy, export_conandata_patches, get
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=2.0"
+
+
+class RustyCppConan(ConanFile):
+    name = "rusty-cpp"
+    description = "Write C++ code like Rust!"
+    # dual licensed under the Apache License v2.0 and the MIT License
+    license = "Apache-2.0", "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/seekstar/rusty-cpp"
+    topics = ("C++", "Rust", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE-APACHE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "LICENSE-MIT", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_target_name", "rusty-cpp")
+        self.cpp_info.libdirs = []
+        self.cpp_info.bindirs = []

--- a/recipes/rusty-cpp/all/conanfile.py
+++ b/recipes/rusty-cpp/all/conanfile.py
@@ -11,8 +11,7 @@ required_conan_version = ">=2.0"
 class RustyCppConan(ConanFile):
     name = "rusty-cpp"
     description = "Write C++ code like Rust!"
-    # dual licensed under the Apache License v2.0 and the MIT License
-    license = "Apache-2.0", "MIT"
+    license = "Apache-2.0 OR MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/seekstar/rusty-cpp"
     topics = ("C++", "Rust", "header-only")

--- a/recipes/rusty-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/rusty-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(rusty-cpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE rusty-cpp)

--- a/recipes/rusty-cpp/all/test_package/conanfile.py
+++ b/recipes/rusty-cpp/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/rusty-cpp/all/test_package/test_package.cpp
+++ b/recipes/rusty-cpp/all/test_package/test_package.cpp
@@ -1,8 +1,10 @@
-#include <cstdlib>
-#include <rusty/macro.h>
+#include <iostream>
+#include <rusty/primitive.h>
 
 int main(void) {
-  rusty_assert_eq(233, 233);
+  size_t x = 233;
+  std::cout << "The next power of two of " << x << " is "
+            << rusty::next_power_of_two(x) << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/recipes/rusty-cpp/all/test_package/test_package.cpp
+++ b/recipes/rusty-cpp/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <cstdlib>
+#include <rusty/macro.h>
+
+int main(void) {
+  rusty_assert_eq(233, 233);
+
+  return EXIT_SUCCESS;
+}

--- a/recipes/rusty-cpp/all/test_package/test_package.cpp
+++ b/recipes/rusty-cpp/all/test_package/test_package.cpp
@@ -1,10 +1,13 @@
-#include <iostream>
+#include <cstdio>
+#include <rusty/macro.h>
 #include <rusty/primitive.h>
 
 int main(void) {
-  size_t x = 233;
-  std::cout << "The next power of two of " << x << " is "
-            << rusty::next_power_of_two(x) << std::endl;
+  rusty_assert(1);
+  rusty_assert_eq(rusty::next_power_of_two((size_t)42), 64,
+                  "Math doesn't exist anymore");
+  rusty_assert_eq(rusty::next_power_of_two((size_t)233), 256);
+  printf("All tests passed.\n");
 
   return EXIT_SUCCESS;
 }

--- a/recipes/rusty-cpp/config.yml
+++ b/recipes/rusty-cpp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.1.12":
+    folder: all
   "0.1.11":
     folder: all

--- a/recipes/rusty-cpp/config.yml
+++ b/recipes/rusty-cpp/config.yml
@@ -1,5 +1,3 @@
 versions:
   "0.1.12":
     folder: all
-  "0.1.11":
-    folder: all

--- a/recipes/rusty-cpp/config.yml
+++ b/recipes/rusty-cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.11":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **rusty-cpp**

#### Motivation

This is a library I find handy to use, and others may find it useful, too.

It is currently header-only. If I make it non-header-only in the future, should I modify the existing `conanfile.py`, or should I create a new folder and write a new `conanfile.py` there?
