### PR TITLE
cspice: Add Linux armv8 support for N0067

### DIFF
--- a/recipes/cspice/all/conandata.yml
+++ b/recipes/cspice/all/conandata.yml
@@ -17,8 +17,8 @@ sources:
           url: "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
           sha256: "60a95b51a6472f1afe7e40d77ebdee43c12bb5b8823676ccc74692ddfede06ce"
         "armv8":
-          url: "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/MacM1_OSX_clang_64bit/packages/cspice.tar.Z"
-          sha256: "0deae048443e11ca4d093cac651d9785d4f2594631a183d85a3d58949f4d0aa9"
+          url: "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
+          sha256: "60a95b51a6472f1afe7e40d77ebdee43c12bb5b8823676ccc74692ddfede06ce"
     "Windows":
       "Visual Studio":
         "x86":

--- a/recipes/cspice/all/conandata.yml
+++ b/recipes/cspice/all/conandata.yml
@@ -16,6 +16,9 @@ sources:
         "x86_64":
           url: "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
           sha256: "60a95b51a6472f1afe7e40d77ebdee43c12bb5b8823676ccc74692ddfede06ce"
+        "armv8":
+          url: "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/MacM1_OSX_clang_64bit/packages/cspice.tar.Z"
+          sha256: "0deae048443e11ca4d093cac651d9785d4f2594631a183d85a3d58949f4d0aa9"
     "Windows":
       "Visual Studio":
         "x86":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cspice/0067**

#### Motivation
The current cspice recipe rejects building on Linux armv8 as it cannot find the correct source package to download, however it is possible to build cspice for Linux armv8 even if it is not officially released on the platform by NASA, and is even packaged for Linux armv8 by conda-forge.

#### Details
The patches to build for Apple Silicon macOS (essentially removal of `-m64`) are the same for Linux armv8 and appear to what conda-forge uses for their Linux armv8 cspice package.

https://naif.jpl.nasa.gov/pipermail/spice_discussion/2021-April/000466.html

This adds the Linux armv8 to the sources data via the Apple Silicon macOS tarball from NASA.

This was tested using a Linux virtual machine running on an M1 Pro Mac.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
