### PR TITLE
opentelemetry-cpp: add version 1.18.0, update opentelemetry-proto

### DIFF
--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.18.0":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.18.0.tar.gz"
+    sha256: "b149109d5983cf8290d614654a878899a68b0c8902b64c934d06f47cd50ffe2e"
   "1.17.0":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.17.0.tar.gz"
     sha256: "13542725463f1ea106edaef078c2276065cf3da998cb1d3dcf92630daa3f64d4"

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -216,7 +216,7 @@ class OpenTelemetryCppConan(ConanFile):
 
     def build_requirements(self):
         if self._needs_proto:
-            self.tool_requires("opentelemetry-proto/1.3.2")
+            self.tool_requires("opentelemetry-proto/1.4.0")
             self.tool_requires("protobuf/<host_version>")
 
         if self.options.with_otlp_grpc:

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -216,7 +216,10 @@ class OpenTelemetryCppConan(ConanFile):
 
     def build_requirements(self):
         if self._needs_proto:
-            self.tool_requires("opentelemetry-proto/1.4.0")
+            if Version(self.version) >= "1.18.0":
+                self.tool_requires("opentelemetry-proto/1.4.0")
+            else:
+                self.tool_requires("opentelemetry-proto/1.3.2")
             self.tool_requires("protobuf/<host_version>")
 
         if self.options.with_otlp_grpc:

--- a/recipes/opentelemetry-cpp/config.yml
+++ b/recipes/opentelemetry-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.18.0":
+    folder: all
   "1.17.0":
     folder: all
   "1.16.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentelemetry-cpp/***

#### Motivation
There are several new features and improvements in 1.18.0.
opentelemetry-cpp/1.18.0 requires opentelemetry-proto/1.4.0. [ref](https://github.com/open-telemetry/opentelemetry-cpp/pull/3157)

#### Details
https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.18.0
https://github.com/open-telemetry/opentelemetry-cpp/compare/v1.17.0...v1.18.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
