### PR TITLE
OpenColorIO: Add options for SIMD optimization support

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -22,12 +22,36 @@ class OpenColorIOConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "use_sse": [True, False],
+
+        # OCIO supports a number of optimized code paths using different SIMD instruction sets.
+        # By default it will determin the support of the current platform. A setting of none keeps
+        # those defaults, True or False will intentionally set the values.
+        # OCIO_USE_SSE was an option in older versions (< 2.3.2), newer versions support the following
+        # instruction sets OCIO_USE_SSE2 up to OCIO_USE_AVX512 (no pure SSE anymore).
+        "use_sse": [None, True, False],
+        "use_sse2": [None, True, False],
+        "use_sse3": [None, True, False],
+        "use_ssse3": [None, True, False],
+        "use_sse4": [None, True, False],
+        "use_sse42": [None, True, False],
+        "use_avx": [None, True, False],
+        "use_avx2": [None, True, False],
+        "use_avx512": [None, True, False],
+        "use_f16c": [None, True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "use_sse": True,
+        "use_sse2": None,
+        "use_sse3": None,
+        "use_ssse3": None,
+        "use_sse4": None,
+        "use_sse42": None,
+        "use_avx": None,
+        "use_avx2": None,
+        "use_avx512": None,
+        "use_f16c": None,
     }
 
     def export_sources(self):
@@ -117,7 +141,27 @@ class OpenColorIOConan(ConanFile):
             tc.variables["TINYXML_OBJECT_LIB_EMBEDDED"] = False
             tc.variables["USE_EXTERNAL_LCMS"] = True
 
-        tc.variables["OCIO_USE_SSE"] = self.options.get_safe("use_sse", False)
+        # Selection of SIMD Instruction sets
+        if not self.options.get_safe("use_sse", None) is None:
+            tc.variables["OCIO_USE_SSE"] = self.options.use_sse
+        if not self.options.get_safe("use_sse2", None) is None:
+            tc.variables["OCIO_USE_SSE2"] = self.options.use_sse2
+        if not self.options.get_safe("use_sse3", None) is None:
+            tc.variables["OCIO_USE_SSE3"] = self.options.use_sse3
+        if not self.options.get_safe("use_ssse3", None) is None:
+            tc.variables["OCIO_USE_SSSE3"] = self.options.use_ssse3
+        if not self.options.get_safe("use_sse4", None) is None:
+            tc.variables["OCIO_USE_SSE4"] = self.options.use_sse4
+        if not self.options.get_safe("use_sse42", None) is None:
+            tc.variables["OCIO_USE_SSE42"] = self.options.use_sse42
+        if not self.options.get_safe("use_avx", None) is None:
+            tc.variables["OCIO_USE_AVX"] = self.options.use_avx
+        if not self.options.get_safe("use_avx2", None) is None:
+            tc.variables["OCIO_USE_AVX2"] = self.options.use_avx2
+        if not self.options.get_safe("use_avx512", None) is None:
+            tc.variables["OCIO_USE_AVX512"] = self.options.use_avx512
+        if not self.options.get_safe("use_f16c", None) is None:
+            tc.variables["OCIO_USE_F16C"] = self.options.use_f16c
 
         # openexr 2.x provides Half library
         tc.variables["OCIO_USE_OPENEXR_HALF"] = True


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencolorio/2.3.2 and newer**

#### Motivation
It was discovered, that there might be problems when building OpenColorIO for older systems not supporting all the instruction sets despite the build process trying to estimate what is supported on the given platform.
#25765

#### Details
Add options for the new flags supported in OpenColorIO since version 2.3.2. Older versions (I only compared the ones in CCI, so might be since 2.3.0 or so) had only a flag for cmake for `OCIO_USE_SSE`. Since 2.3.2 the pure SSE is no longer supported but `OCIO_USE_SSE2` to `OCIO_USE_AVX512` and `OCIO_USE_F16C`. 

The change is implemented so that it supports the setting None to use the default and keep the current behaviour. Only overrides the automatism when set to True/False.

Open question: Would it make sense to specifically check for the version and only then set the variables? Up to now `OCIO_USE_SSE` is set even for the new versions which doesn't error but should also not have an effect as those variables aren't used in the newer CMakeLists. Assume the same for new variables when building 2.2.1 or some other older version.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
