### PR TITLE
abseil: Fix build on macOS when using LLVM clang

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -39,6 +39,8 @@ patches:
       patch_description: "Do not build test_allocator target when tests are disabled"
       patch_type: "portability"
       patch_source: "https://github.com/abseil/abseil-cpp/commit/779a3565ac6c5b69dd1ab9183e500a27633117d5"
+    - patch_file: "patches/0006-backport-arm-compilation-fix.patch"
+      patch_source: "https://github.com/abseil/abseil-cpp/pull/1710"
   "20240116.1":
     - patch_file: "patches/0003-absl-string-libm-20240116.patch"
       patch_description: "link libm to absl string"
@@ -52,6 +54,8 @@ patches:
       patch_description: "Do not build test_allocator target when tests are disabled"
       patch_type: "portability"
       patch_source: "https://github.com/abseil/abseil-cpp/commit/779a3565ac6c5b69dd1ab9183e500a27633117d5"
+    - patch_file: "patches/0006-backport-arm-compilation-fix.patch"
+      patch_source: "https://github.com/abseil/abseil-cpp/pull/1710"
   "20230802.1":
     - patch_file: "patches/0003-absl-string-libm-20230802.patch"
       patch_description: "link libm to absl string"
@@ -61,10 +65,14 @@ patches:
       patch_description: "Fix build with MinGW"
       patch_type: "portability"
       patch_source: "https://github.com/abseil/abseil-cpp/commit/2f77684e8dc473a48dbc19167ffe69c40ce8ada4"
+    - patch_file: "patches/0006-backport-arm-compilation-fix.patch"
+      patch_source: "https://github.com/abseil/abseil-cpp/pull/1710"
   "20230125.3":
     - patch_file: "patches/0003-absl-string-libm.patch"
       patch_description: "link libm to absl string"
       patch_type: "portability"
+    - patch_file: "patches/0006-backport-arm-compilation-fix.patch"
+      patch_source: "https://github.com/abseil/abseil-cpp/pull/1710"
   "20220623.1":
     - patch_file: "patches/0003-absl-string-libm.patch"
       patch_description: "link libm to absl string"
@@ -73,6 +81,8 @@ patches:
       patch_description: "Workaround bug in GCC 7.2"
       patch_source: "https://github.com/abseil/abseil-cpp/pull/1250"
       patch_type: "portability"
+    - patch_file: "patches/0006-backport-arm-compilation-fix.patch"
+      patch_source: "https://github.com/abseil/abseil-cpp/pull/1710"
   "20211102.0":
     - patch_file: "patches/0003-absl-string-libm.patch"
       patch_description: "link libm to absl string"

--- a/recipes/abseil/all/patches/0006-backport-arm-compilation-fix.patch
+++ b/recipes/abseil/all/patches/0006-backport-arm-compilation-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/absl/copts/AbseilConfigureCopts.cmake b/absl/copts/AbseilConfigureCopts.cmake
+index 73435e9..f95ea36 100644
+--- a/absl/copts/AbseilConfigureCopts.cmake
++++ b/absl/copts/AbseilConfigureCopts.cmake
+@@ -42,7 +42,7 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES [[Clang]])
+     string(TOUPPER "${_arch}" _arch_uppercase)
+     string(REPLACE "X86_64" "X64" _arch_uppercase ${_arch_uppercase})
+     foreach(_flag IN LISTS ABSL_RANDOM_HWAES_${_arch_uppercase}_FLAGS)
+-      list(APPEND ABSL_RANDOM_RANDEN_COPTS "-Xarch_${_arch}" "${_flag}")
++      list(APPEND ABSL_RANDOM_RANDEN_COPTS "SHELL:-Xarch_${_arch} ${_flag}")
+     endforeach()
+   endforeach()
+   # If a compiler happens to deal with an argument for a currently unused


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil/[*]**

#### Motivation

There is a single file in the abseil build that is built with both x86_64 and armv8. When using LLVM clang (this is *not* an issue on Apple-Clang), some versions fail with this error:

```
clang++: error: unsupported option '-msse4.1' for target 'arm64-apple-darwin23.6.0'
make[2]: *** [absl/random/CMakeFiles/random_internal_randen_hwaes_impl.dir/internal/randen_hwaes.cc.o] Error 1
make[1]: *** [absl/random/CMakeFiles/random_internal_randen_hwaes_impl.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

#### Details
Backport the upstream fix - this is only a fix in the build system to work as intended.


Close https://github.com/conan-io/conan-center-index/issues/25992
Close https://github.com/conan-io/conan-center-index/issues/25747
