### PR TITLE
ouster sdk: add v0.13.1, upgrade spdlog version

### DIFF
--- a/recipes/ouster_sdk/all/conandata.yml
+++ b/recipes/ouster_sdk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.14.0":
+    url: "https://github.com/ouster-lidar/ouster-sdk/archive/refs/tags/release-0.13.1.tar.gz"
+    sha256: "291cdc67a46c2e00bf717a0685f17ed84e159b4d68330b5b51750f410e93ba99"
   "0.13.0":
     url: "https://github.com/ouster-lidar/ouster-sdk/archive/refs/tags/release-0.13.0.tar.gz"
     sha256: "baf65fbf547375fe73fdaee89c6c1246fdf9f0cabe4f4bd16391d3a06d0117a1"

--- a/recipes/ouster_sdk/all/conanfile.py
+++ b/recipes/ouster_sdk/all/conanfile.py
@@ -80,7 +80,7 @@ class OusterSdkConan(ConanFile):
         self.requires("eigen/3.4.0", transitive_headers=True)
         # Used in ouster/sensor_http.h
         self.requires("jsoncpp/1.9.5", transitive_headers=True, transitive_libs=True)
-        self.requires("spdlog/1.13.0")
+        self.requires("spdlog/1.14.1")
         self.requires("fmt/10.2.1")
         self.requires("libcurl/[>=7.78 <9]")
         # Replaces vendored optional-lite

--- a/recipes/ouster_sdk/config.yml
+++ b/recipes/ouster_sdk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.13.1":
+    folder: all
   "0.13.0":
     folder: all
   "0.12.0":


### PR DESCRIPTION
### Summary

This MR adds v.013.1 of the ouster_sdk, and bumps up the version for the spdlog dependency. 

#### Motivation
Ouster SDK team released [v0.13.1](https://github.com/ouster-lidar/ouster-sdk/releases/tag/release-0.13.1) and it would be convenient to have the most recent version on conan-center. 

#### Details
The changes are under `conandata.yml`, `config.yml`, and the `conanfile.py` in the recipe for the package.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
