### PR TITLE
openvino: fix empty patches field in conandata.yml

### DIFF
--- a/recipes/openvino/all/conandata.yml
+++ b/recipes/openvino/all/conandata.yml
@@ -31,4 +31,3 @@ sources:
     "onednn_gpu":
       url: "https://github.com/oneapi-src/oneDNN/archive/cb77937ffcf5e83b5d1cf2940c94e8b508d8f7b4.tar.gz"
       sha256: "2ca304c033786aa5c3ec1ec6f8fc3936ae5c6874d5964b586311da11bec2ec4a"
-patches:


### PR DESCRIPTION
This was picked up by the linter but not reported.

This is not an error - that is, the recipe exports and build file, and the syntax of the yaml passes validation

This will skip CI as it does not result in any versions being exported.