### PR TITLE
[mingw-w64] Prioritize PATH to always use package apps first

### DIFF
--- a/recipes/mingw-w64/linux/conanfile.py
+++ b/recipes/mingw-w64/linux/conanfile.py
@@ -118,7 +118,7 @@ class MingwConan(ConanFile):
 
         # Add binutils to path. Required for gcc build.
         env = Environment()
-        env.append_path("PATH", os.path.join(self.package_folder, "bin"))
+        env.prepend_path("PATH", os.path.join(self.package_folder, "bin"))
         env.vars(self).save_script("conanbuild_package_bin_path")
 
         venv = VirtualBuildEnv(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **mingw-w64/8.0.2**

#### Motivation

Fix #25719 reported by @pkoshevoy

#### Details

When building mingw-w64 crt (C Runtime Library), it should use the gcc already built in the same Conan package, one step before. However, when having mingw-w64 installed in the system already, the PATH may find the system's compiler instead. In order to fix it, the PATH should updated to look fist in package folder.

Full build log based on the commit a0498ea: [mingw-w64-8.0.2-gcc9-var-path.log](https://github.com/user-attachments/files/18024584/mingw-w64-8.0.2-gcc9-var-path.log)

The was built using Docker ubuntu:20.04 and with mingw installed in Linux.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
