### PR TITLE
blend2d: add new version 0.11.5

### DIFF
--- a/recipes/blend2d/all/conandata.yml
+++ b/recipes/blend2d/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.5":
+    url: "https://blend2d.com/download/blend2d-0.11.5.tar.gz"
+    sha256: "733ad4f657b478450612bdf73490f3309713076eb30e0f4c55349d698a9d1ec9"
   "0.11.4":
     url: "https://blend2d.com/download/blend2d-0.11.4.tar.gz"
     sha256: "07f7d99d2ebb7b42a707a4f0035745b781faf9083933f944084f66e6246bb01c"

--- a/recipes/blend2d/all/conanfile.py
+++ b/recipes/blend2d/all/conanfile.py
@@ -46,7 +46,7 @@ class Blend2dConan(ConanFile):
 
     def requirements(self):
         if self.options.with_jit:
-            self.requires("asmjit/cci.20240531")
+            self.requires("asmjit/cci.20241216")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/blend2d/config.yml
+++ b/recipes/blend2d/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.5":
+    folder: all
   "0.11.4":
     folder: all
   "0.11.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **blend2d/0.11.5**

#### Motivation
There are several bugfixes in 0.11.5.

There are no official release notes.
The release details are on gitter.
https://matrix.to/#/!QAErhdTeVDsTzJmIhF:gitter.im/$gAdoMsymytlpXGgwJYEnBLnFxEMasylW2a_iN02HWXs?via=gitter.im&via=matrix.org&via=rektagon.com

#### Details
https://github.com/blend2d/blend2d/compare/9a86b2700917ced827c008c3dd488108afb3490c...7eb92c2946fb35c23c09dbdc6e98d835679d7f82

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
