### PR TITLE
asmjit: add version cci.20241216 (for blend2d)

### DIFF
--- a/recipes/asmjit/all/conandata.yml
+++ b/recipes/asmjit/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.0.0.cci.20241125":
+    url: "https://github.com/asmjit/asmjit/archive/7bed2b0e1427fab185eea2da8ab4b9fb5b1f45a9.zip"
+    sha256: "3a90f9dc96dee0e9e9dad209f71770288e2c2221de92c1da725c1fde3eb89e6d"
   "cci.20240531":
     url: "https://github.com/asmjit/asmjit/archive/d6c5be2212b9a50ba56ec6d1e9b68693c62136c1.zip"
     sha256: "678549712d4708d0513fb0017d03211df415387aea4c031923d4dd5c07b43db6"

--- a/recipes/asmjit/all/conandata.yml
+++ b/recipes/asmjit/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.0.0.cci.20241125":
-    url: "https://github.com/asmjit/asmjit/archive/7bed2b0e1427fab185eea2da8ab4b9fb5b1f45a9.zip"
-    sha256: "3a90f9dc96dee0e9e9dad209f71770288e2c2221de92c1da725c1fde3eb89e6d"
+  "cci.20241216":
+    url: "https://github.com/asmjit/asmjit/archive/cfc9f813cc6ccda63cad872edb32b38e0662bedb.zip"
+    sha256: "fc1dd360336e271e915808db513128855c2482d3794e4786757ffc0f31013f80"
   "cci.20240531":
     url: "https://github.com/asmjit/asmjit/archive/d6c5be2212b9a50ba56ec6d1e9b68693c62136c1.zip"
     sha256: "678549712d4708d0513fb0017d03211df415387aea4c031923d4dd5c07b43db6"

--- a/recipes/asmjit/all/conanfile.py
+++ b/recipes/asmjit/all/conanfile.py
@@ -59,6 +59,9 @@ class AsmjitConan(ConanFile):
                     f"{self.ref} does not support {self.settings.compiler}/{self.settings.compiler.version}."
                 )
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.19 <4]")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/asmjit/config.yml
+++ b/recipes/asmjit/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.0.0.cci.20241125":
+    folder: all
   "cci.20240531":
     folder: all
   "cci.20230325":

--- a/recipes/asmjit/config.yml
+++ b/recipes/asmjit/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.0.0.cci.20241125":
+  "cci.20241216":
     folder: all
   "cci.20240531":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **asmjit/cci.20241216**

#### Motivation
To update blend2d, we need to update asmjit.
blend2d/0.11.5 on arm requires latest asmjit due to changing namespace of `Inst`.

https://github.com/asmjit/asmjit/commit/514a89f4c47b22328285e445c3298a377b9ce02a
https://github.com/blend2d/blend2d/commit/292c9d339b56ef54edf1879084c3794425f9db45

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
