### PR TITLE
libzip: backport warning suppression for gcc >= 14

### DIFF
--- a/recipes/libzip/all/conanfile.py
+++ b/recipes/libzip/all/conanfile.py
@@ -93,6 +93,11 @@ class LibZipConan(ConanFile):
         tc.variables["BUILD_DOC"] = False
         tc.variables["ENABLE_LZMA"] = self.options.with_lzma
         tc.variables["ENABLE_BZIP2"] = self.options.with_bzip2
+        if self.settings.compiler == "gcc" and Version(self.version) < "1.11":
+            # See https://github.com/conan-io/conan-center-index/issues/26034
+            # It's an error in gcc >= 14
+            # Upstream fixed this silencing this error implicitly from 1.11
+            tc.extra_cflags.append("-Wno-incompatible-pointer-types")
         if self._has_zstd_support:
             tc.variables["ENABLE_ZSTD"] = self.options.with_zstd
         tc.variables["ENABLE_COMMONCRYPTO"] = False  # TODO: We need CommonCrypto package

--- a/recipes/libzip/all/conanfile.py
+++ b/recipes/libzip/all/conanfile.py
@@ -93,7 +93,9 @@ class LibZipConan(ConanFile):
         tc.variables["BUILD_DOC"] = False
         tc.variables["ENABLE_LZMA"] = self.options.with_lzma
         tc.variables["ENABLE_BZIP2"] = self.options.with_bzip2
-        if self.settings.compiler == "gcc" and Version(self.version) < "1.11":
+        if (self.settings.compiler == "gcc"
+                and Version(self.settings.compiler.version) >= "14"
+                and Version(self.version) < "1.11"):
             # See https://github.com/conan-io/conan-center-index/issues/26034
             # It's an error in gcc >= 14
             # Upstream fixed this silencing this error implicitly from 1.11


### PR DESCRIPTION
### Summary
Changes to recipe:  **libzip/[<1.11]**

#### Motivation
On gcc 14, `-Wincompatible-pointer-types` has now become an error by default
To account for this, newer upstream versions suppress that warning altogether https://github.com/nih-at/libzip/issues/440#issuecomment-2185616767

This PR passes the warning suppression as a flag for older versions.

<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
See https://github.com/conan-io/conan-center-index/issues/26034 for additional details

The recipe could get a cleanup, but I'm going for a minimal fix for this diff, another PR will follow once this gets merged
