### PR TITLE
libzip: Add gnutls support & cleanup recipe

### DIFF
--- a/recipes/libzip/all/conanfile.py
+++ b/recipes/libzip/all/conanfile.py
@@ -23,7 +23,7 @@ class LibZipConan(ConanFile):
         "with_bzip2": [True, False],
         "with_lzma": [True, False],
         "with_zstd": [True, False],
-        "crypto": [False, "win32", "openssl", "mbedtls"],
+        "crypto": [False, "win32", "openssl", "mbedtls", "gnutls"],
         "tools": [True, False],
     }
     default_options = {
@@ -68,15 +68,17 @@ class LibZipConan(ConanFile):
             self.requires("bzip2/1.0.8")
 
         if self.options.with_lzma:
-            self.requires("xz_utils/5.4.5")
-
-        if self.options.get_safe("with_zstd"):
-            self.requires("zstd/1.5.5")
+            self.requires("xz_utils/[>=5.4.5 <6]")
 
         if self.options.crypto == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         elif self.options.crypto == "mbedtls":
             self.requires("mbedtls/3.5.0")
+        elif self.options.crypto == "gnutls":
+            self.requires("gnutls/3.8.2")
+
+        if self.options.get_safe("with_zstd"):
+            self.requires("zstd/[~1.5]")
 
     def validate(self):
         if self.options.crypto == "win32" and self.settings.os != "Windows":
@@ -84,6 +86,7 @@ class LibZipConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -103,7 +106,7 @@ class LibZipConan(ConanFile):
         if self._has_zstd_support:
             tc.variables["ENABLE_ZSTD"] = self.options.with_zstd
         tc.variables["ENABLE_COMMONCRYPTO"] = False  # TODO: We need CommonCrypto package
-        tc.variables["ENABLE_GNUTLS"] = False  # TODO: We need GnuTLS package
+        tc.variables["ENABLE_GNUTLS"] = self.options.crypto == "gnutls"
         tc.variables["ENABLE_MBEDTLS"] = self.options.crypto == "mbedtls"
         tc.variables["ENABLE_OPENSSL"] = self.options.crypto == "openssl"
         tc.variables["ENABLE_WINDOWS_CRYPTO"] = self.options.crypto == "win32"
@@ -113,7 +116,6 @@ class LibZipConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -137,11 +139,6 @@ class LibZipConan(ConanFile):
             if self.options.crypto == "win32":
                 self.cpp_info.components["_libzip"].system_libs.append("bcrypt")
 
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.names["cmake_find_package"] = "libzip"
-        self.cpp_info.names["cmake_find_package_multi"] = "libzip"
-        self.cpp_info.components["_libzip"].names["cmake_find_package"] = "zip"
-        self.cpp_info.components["_libzip"].names["cmake_find_package_multi"] = "zip"
         self.cpp_info.components["_libzip"].set_property("cmake_target_name", "libzip::zip")
         self.cpp_info.components["_libzip"].set_property("pkg_config_name", "libzip")
         self.cpp_info.components["_libzip"].requires = ["zlib::zlib"]
@@ -155,5 +152,5 @@ class LibZipConan(ConanFile):
             self.cpp_info.components["_libzip"].requires.append("openssl::crypto")
         elif self.options.crypto == "mbedtls":
             self.cpp_info.components["_libzip"].requires.append("mbedtls::mbedtls")
-        if self.options.tools:
-            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+        elif self.options.crypto == "gnutls":
+            self.cpp_info.components["_libzip"].requires.append("gnutls::gnutls")


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


Succesful compilation logs:

```
$ conan create . --version=1.11.2 -b=missing -o="&:crypto=gnutls"

======== Exporting recipe to the cache ========
libzip/1.11.2: Exporting package recipe: /Users/abril/coding/conan-center-index/recipes/libzip/all/conanfile.py
libzip/1.11.2: exports: File 'conandata.yml' found. Exporting it...
libzip/1.11.2: Calling export_sources()
libzip/1.11.2: Copied 1 '.py' file: conanfile.py
libzip/1.11.2: Copied 1 '.yml' file: conandata.yml
libzip/1.11.2: Copied 2 '.patch' files: 1.7.3-0001-cmake-install-bundle.patch, 1.11.2-0002-remove-rpath.patch
libzip/1.11.2: Exported to cache folder: /Users/abril/.conan2/p/libzic7c4caa36301c/e
libzip/1.11.2: Exported: libzip/1.11.2#99bad9f93eca0800c372d7e723c1bcb4 (2024-12-09 11:21:55 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=16
os=Macos
[options]
&:crypto=gnutls
[platform_tool_requires]
cmake/3.30.3
meson/1.5.2
[replace_tool_requires]
meson/*: meson/[>=1.0 <2]
[conf]


Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=16
os=Macos
[platform_tool_requires]
cmake/3.30.3
meson/1.5.2
[replace_tool_requires]
meson/*: meson/[>=1.0 <2]
[conf]



======== Computing dependency graph ========
Graph root
    cli
Requirements
    brotli/1.1.0#d56d7bb9ca722942aba17369cb5c0519 - Cache
    bzip2/1.0.8#d00dac990f08d991998d624be81a9526 - Cache
    gmp/6.3.0#df20ffb6d21c34d67704305bcd1dea9e - Cache
    gnutls/3.8.2#e0f4b969ab1676ac533a91dffad28ed2 - Cache
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd - Cache
    libzip/1.11.2#99bad9f93eca0800c372d7e723c1bcb4 - Cache
    nettle/3.9.1#e764066b07b4d951c025795c5af809bf - Cache
    xz_utils/5.4.5#b885d1d79c9d30cff3803f7f551dbe66 - Cache
    zlib/1.3.1#e20364c96c45455608a72543f3a53133 - Cache
    zstd/1.5.5#b87dc3b185caa4b122979ac4ae8ef7e8 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    meson/1.5.2 - Platform
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
Replaced requires
    meson/1.2.2: meson/[>=1.0 <2]
Resolved version ranges
    xz_utils/[>=5.4.5 <6]: xz_utils/5.4.5
    zlib/[>=1.2.11 <2]: zlib/1.3.1

======== Computing necessary packages ========
Requirements
    brotli/1.1.0#d56d7bb9ca722942aba17369cb5c0519:063f98cf19e03d6ad7db1db05444f80065307f33#057374b27417e0ac149a15ef8461a9da - Cache
    bzip2/1.0.8#d00dac990f08d991998d624be81a9526:1b365626531995eab090d0d1b1d474dd9a356923#b1785cad50c9b11ecda525152b088c1e - Cache
    gmp/6.3.0#df20ffb6d21c34d67704305bcd1dea9e:54d2478e2d30d65d558f49d6ed7a5abbd05f22d0#4bb7d21f0d8066b075b07ef4a2a9c36e - Cache
    gnutls/3.8.2#e0f4b969ab1676ac533a91dffad28ed2:8f2c5d3cc51a30a7cbc2dfe9cd1c2b4174e0ef82#2d0af3f72eb9848d800aaa5518ed0e96 - Cache
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd:405e382fa7fb6368c140a7f5c5cd71c32b009653#d792220a2db8d78cc07f324a892260ff - Cache
    libzip/1.11.2#99bad9f93eca0800c372d7e723c1bcb4:e801f4f6596bd8013b64260f66f189743ba0f4e0 - Build
    nettle/3.9.1#e764066b07b4d951c025795c5af809bf:fe81106ecf76e7316874b180267dc98fe324c2d2#5759ef1a1b0a9ceb0fb55fc20b11346b - Cache
    xz_utils/5.4.5#b885d1d79c9d30cff3803f7f551dbe66:405e382fa7fb6368c140a7f5c5cd71c32b009653#5ea646391d65958efee88b799d9db7fa - Cache
    zlib/1.3.1#e20364c96c45455608a72543f3a53133:405e382fa7fb6368c140a7f5c5cd71c32b009653#b7bd0f651c882e73b0b3da240b280c20 - Cache
    zstd/1.5.5#b87dc3b185caa4b122979ac4ae8ef7e8:8eeafb9ab9fd57066c2629ff886059e5941ca64c#a518a96bcdd28146c57d0d6ab9d0e213 - Cache
Build requirements
Skipped binaries
    autoconf/2.71, automake/1.16.5, gnu-config/cci.20210814, libtool/2.4.7, m4/1.4.19, meson/1.5.2, pkgconf/2.1.0

======== Installing packages ========
brotli/1.1.0: Already installed! (1 of 10)
bzip2/1.0.8: Already installed! (2 of 10)
libiconv/1.17: Already installed! (3 of 10)
xz_utils/5.4.5: Already installed! (4 of 10)
zlib/1.3.1: Already installed! (5 of 10)
zstd/1.5.5: Already installed! (6 of 10)
gmp/6.3.0: Already installed! (7 of 10)
nettle/3.9.1: Already installed! (8 of 10)
gnutls/3.8.2: Already installed! (9 of 10)
libzip/1.11.2: Calling source() in /Users/abril/.conan2/p/libzic7c4caa36301c/s/src
libzip/1.11.2: Source ['https://libzip.org/download/libzip-1.11.2.tar.gz', 'https://github.com/nih-at/libzip/releases/download/v1.11.2/libzip-1.11.2.tar.gz'] retrieved from local download cache
libzip/1.11.2: Unzipping libzip-1.11.2.tar.gz to .
libzip/1.11.2: Apply patch (conan): fix installation path of utilities
libzip/1.11.2: WARN: /Users/abril/.conan2/p/libzic7c4caa36301c/s/patches/1.7.3-0001-cmake-install-bundle.patch: file 1/1:	 b'src/CMakeLists.txt'
libzip/1.11.2: WARN: /Users/abril/.conan2/p/libzic7c4caa36301c/s/patches/1.7.3-0001-cmake-install-bundle.patch:  hunk no.1 doesn't match source file at line 7
libzip/1.11.2: WARN: /Users/abril/.conan2/p/libzic7c4caa36301c/s/patches/1.7.3-0001-cmake-install-bundle.patch:   expected: b'    install(TARGETS ${PROGRAM} EXPORT ${PROJECT_NAME}-targets RUNTIME DESTINATION bin)'
libzip/1.11.2: WARN: /Users/abril/.conan2/p/libzic7c4caa36301c/s/patches/1.7.3-0001-cmake-install-bundle.patch:   actual  : b'    install(TARGETS ${PROGRAM} EXPORT ${PROJECT_NAME}-targets DESTINATION bin)'
libzip/1.11.2: WARN: /Users/abril/.conan2/p/libzic7c4caa36301c/s/patches/1.7.3-0001-cmake-install-bundle.patch: already patched  b'src/CMakeLists.txt'
libzip/1.11.2: Apply patch (conan): remove rpath feature

-------- Installing package libzip/1.11.2 (10 of 10) --------
libzip/1.11.2: Building from source
libzip/1.11.2: Package libzip/1.11.2:e801f4f6596bd8013b64260f66f189743ba0f4e0
libzip/1.11.2: Copying sources to build folder
libzip/1.11.2: Building your package in /Users/abril/.conan2/p/b/libzie044a32dbc590/b
libzip/1.11.2: Calling generate()
libzip/1.11.2: Generators folder: /Users/abril/.conan2/p/b/libzie044a32dbc590/b/build/Release/generators
libzip/1.11.2: CMakeToolchain generated: conan_toolchain.cmake
libzip/1.11.2: CMakeToolchain generated: /Users/abril/.conan2/p/b/libzie044a32dbc590/b/build/Release/generators/CMakePresets.json
libzip/1.11.2: CMakeToolchain generated: /Users/abril/.conan2/p/b/libzie044a32dbc590/b/src/CMakeUserPresets.json
libzip/1.11.2: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(BZip2)
    find_package(LibLZMA)
    find_package(GnuTLS)
    find_package(ZLIB)
    find_package(zstd)
    target_link_libraries(... BZip2::BZip2 LibLZMA::LibLZMA GnuTLS::GnuTLS ZLIB::ZLIB zstd::libzstd_static)
libzip/1.11.2: Generating aggregated env files
libzip/1.11.2: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
libzip/1.11.2: Calling build()
libzip/1.11.2: Running CMake.configure()
libzip/1.11.2: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/.conan2/p/b/libzie044a32dbc590/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/abril/.conan2/p/b/libzie044a32dbc590/b/src"
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Using Conan toolchain: /Users/abril/.conan2/p/b/libzie044a32dbc590/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'nettle::libnettle'
-- Conan: Component target declared 'nettle::hogweed'
-- Conan: Target declared 'nettle::nettle'
-- Conan: Component target declared 'gmp::libgmp'
-- Conan: Component target declared 'gmp::gmpxx'
-- Conan: Target declared 'gmp::gmp'
-- Conan: Target declared 'GnuTLS::GnuTLS'
-- Conan: Target declared 'Iconv::Iconv'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Component target declared 'brotli::brotlicommon'
-- Conan: Component target declared 'brotli::brotlidec'
-- Conan: Component target declared 'brotli::brotlienc'
-- Conan: Target declared 'brotli::brotli'
-- Conan: Component target declared 'zstd::libzstd_static'
-- Conan: Including build module from '/Users/abril/.conan2/p/b/gnutlef926e095f917/p/lib/cmake/conan-official-gnutls-variables.cmake'
-- Looking for _close
-- Looking for _close - not found
-- Looking for _dup
-- Looking for _dup - not found
-- Looking for _fdopen
-- Looking for _fdopen - not found
-- Looking for _fileno
-- Looking for _fileno - not found
-- Looking for _fseeki64
-- Looking for _fseeki64 - not found
-- Looking for _fstat64
-- Looking for _fstat64 - not found
-- Looking for _setmode
-- Looking for _setmode - not found
-- Looking for _stat64
-- Looking for _stat64 - not found
-- Looking for _snprintf
-- Looking for _snprintf - not found
-- Looking for _snprintf_s
-- Looking for _snprintf_s - not found
-- Looking for _snwprintf_s
-- Looking for _snwprintf_s - not found
-- Looking for _strdup
-- Looking for _strdup - not found
-- Looking for _stricmp
-- Looking for _stricmp - not found
-- Looking for _strtoi64
-- Looking for _strtoi64 - not found
-- Looking for _strtoui64
-- Looking for _strtoui64 - not found
-- Looking for _unlink
-- Looking for _unlink - not found
-- Looking for arc4random
-- Looking for arc4random - found
-- Looking for clonefile
-- Looking for clonefile - found
-- Looking for explicit_bzero
-- Looking for explicit_bzero - not found
-- Looking for explicit_memset
-- Looking for explicit_memset - not found
-- Looking for fchmod
-- Looking for fchmod - found
-- Looking for fileno
-- Looking for fileno - found
-- Looking for fseeko
-- Looking for fseeko - found
-- Looking for ftello
-- Looking for ftello - found
-- Looking for getprogname
-- Looking for getprogname - found
-- Looking for localtime_r
-- Looking for localtime_r - found
-- Looking for localtime_s
-- Looking for localtime_s - not found
-- Looking for memcpy_s
-- Looking for memcpy_s - not found
-- Looking for random
-- Looking for random - found
-- Looking for setmode
-- Looking for setmode - found
-- Looking for snprintf
-- Looking for snprintf - found
-- Looking for snprintf_s
-- Looking for snprintf_s - not found
-- Looking for strcasecmp
-- Looking for strcasecmp - found
-- Looking for strdup
-- Looking for strdup - found
-- Looking for strerror_s
-- Looking for strerror_s - not found
-- Looking for strerrorlen_s
-- Looking for strerrorlen_s - not found
-- Looking for stricmp
-- Looking for stricmp - not found
-- Looking for strncpy_s
-- Looking for strncpy_s - not found
-- Looking for strtoll
-- Looking for strtoll - found
-- Looking for strtoull
-- Looking for strtoull - found
-- Looking for 3 include files sys/types.h, ..., fts.h
-- Looking for 3 include files sys/types.h, ..., fts.h - found
-- Looking for fts_open
-- Looking for fts_open - found
-- Looking for include file stdbool.h
-- Looking for include file stdbool.h - found
-- Looking for include file strings.h
-- Looking for include file strings.h - found
-- Looking for include file unistd.h
-- Looking for include file unistd.h - found
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Looking for include file stdint.h
-- Looking for include file stdint.h - found
-- Looking for include file sys/types.h
-- Looking for include file sys/types.h - found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of __int8
-- Check size of __int8 - failed
-- Check size of int8_t
-- Check size of int8_t - done
-- Check size of uint8_t
-- Check size of uint8_t - done
-- Check size of __int16
-- Check size of __int16 - failed
-- Check size of int16_t
-- Check size of int16_t - done
-- Check size of uint16_t
-- Check size of uint16_t - done
-- Check size of __int32
-- Check size of __int32 - failed
-- Check size of int32_t
-- Check size of int32_t - done
-- Check size of uint32_t
-- Check size of uint32_t - done
-- Check size of __int64
-- Check size of __int64 - failed
-- Check size of int64_t
-- Check size of int64_t - done
-- Check size of uint64_t
-- Check size of uint64_t - done
-- Check size of short
-- Check size of short - done
-- Check size of int
-- Check size of int - done
-- Check size of long
-- Check size of long - done
-- Check size of long long
-- Check size of long long - done
-- Check size of off_t
-- Check size of off_t - done
-- Check size of size_t
-- Check size of size_t - done
-- Performing Test HAVE_FICLONERANGE
-- Performing Test HAVE_FICLONERANGE - Failed
-- Performing Test HAVE_NULLABLE
-- Performing Test HAVE_NULLABLE - Success
-- Conan: Target declared 'BZip2::BZip2'
-- Conan: Including build module from '/Users/abril/.conan2/p/b/bzip2ea9ce1f033a6a/p/lib/cmake/conan-official-bzip2-variables.cmake'
-- Conan: Target declared 'LibLZMA::LibLZMA'
-- Conan: Including build module from '/Users/abril/.conan2/p/b/xz_ut8370d52c9dc3c/p/lib/cmake/conan-official-xz_utils-variables.cmake'
CMake Warning at CMakeLists.txt:281 (message):
  -- neither Common Crypto, GnuTLS, mbed TLS, OpenSSL, nor Windows
  Cryptography found; AES support disabled


-- Looking for getopt
-- Looking for getopt - found
-- Configuring done (15.7s)
-- Generating done (0.1s)
-- Build files have been written to: /Users/abril/.conan2/p/b/libzie044a32dbc590/b/build/Release

libzip/1.11.2: Running CMake.build()
libzip/1.11.2: RUN: cmake --build "/Users/abril/.conan2/p/b/libzie044a32dbc590/b/build/Release" -- -j12
[  0%] Generating zip_err_str.c
[  1%] Building C object lib/CMakeFiles/zip.dir/zip_add.c.o
[  2%] Building C object lib/CMakeFiles/zip.dir/zip_add_dir.c.o
[  3%] Building C object lib/CMakeFiles/zip.dir/zip_buffer.c.o
[  4%] Building C object lib/CMakeFiles/zip.dir/zip_error.c.o
[  5%] Building C object lib/CMakeFiles/zip.dir/zip_algorithm_deflate.c.o
[  6%] Building C object lib/CMakeFiles/zip.dir/zip_close.c.o
[  6%] Building C object lib/CMakeFiles/zip.dir/zip_delete.c.o
[  7%] Building C object lib/CMakeFiles/zip.dir/zip_dir_add.c.o
[  7%] Building C object lib/CMakeFiles/zip.dir/zip_entry.c.o
[  8%] Building C object lib/CMakeFiles/zip.dir/zip_discard.c.o
[  8%] Building C object lib/CMakeFiles/zip.dir/zip_add_entry.c.o
[  9%] Building C object lib/CMakeFiles/zip.dir/zip_dirent.c.o
[ 10%] Building C object lib/CMakeFiles/zip.dir/zip_error_clear.c.o
[ 10%] Building C object lib/CMakeFiles/zip.dir/zip_error_get.c.o
[ 11%] Building C object lib/CMakeFiles/zip.dir/zip_error_get_sys_type.c.o
[ 12%] Building C object lib/CMakeFiles/zip.dir/zip_error_strerror.c.o
[ 13%] Building C object lib/CMakeFiles/zip.dir/zip_error_to_str.c.o
[ 13%] Building C object lib/CMakeFiles/zip.dir/zip_extra_field.c.o
[ 14%] Building C object lib/CMakeFiles/zip.dir/zip_extra_field_api.c.o
[ 15%] Building C object lib/CMakeFiles/zip.dir/zip_fclose.c.o
[ 16%] Building C object lib/CMakeFiles/zip.dir/zip_fdopen.c.o
[ 16%] Building C object lib/CMakeFiles/zip.dir/zip_file_add.c.o
[ 17%] Building C object lib/CMakeFiles/zip.dir/zip_file_error_clear.c.o
[ 18%] Building C object lib/CMakeFiles/zip.dir/zip_file_error_get.c.o
[ 18%] Building C object lib/CMakeFiles/zip.dir/zip_file_get_comment.c.o
[ 19%] Building C object lib/CMakeFiles/zip.dir/zip_file_get_external_attributes.c.o
[ 20%] Building C object lib/CMakeFiles/zip.dir/zip_file_get_offset.c.o
[ 21%] Building C object lib/CMakeFiles/zip.dir/zip_file_rename.c.o
[ 21%] Building C object lib/CMakeFiles/zip.dir/zip_file_replace.c.o
[ 22%] Building C object lib/CMakeFiles/zip.dir/zip_file_set_comment.c.o
[ 23%] Building C object lib/CMakeFiles/zip.dir/zip_file_set_encryption.c.o
[ 24%] Building C object lib/CMakeFiles/zip.dir/zip_file_set_external_attributes.c.o
[ 24%] Building C object lib/CMakeFiles/zip.dir/zip_file_set_mtime.c.o
[ 25%] Building C object lib/CMakeFiles/zip.dir/zip_file_strerror.c.o
[ 26%] Building C object lib/CMakeFiles/zip.dir/zip_fopen_encrypted.c.o
[ 27%] Building C object lib/CMakeFiles/zip.dir/zip_fopen.c.o
[ 27%] Building C object lib/CMakeFiles/zip.dir/zip_fopen_index.c.o
[ 28%] Building C object lib/CMakeFiles/zip.dir/zip_fopen_index_encrypted.c.o
[ 29%] Building C object lib/CMakeFiles/zip.dir/zip_fread.c.o
[ 29%] Building C object lib/CMakeFiles/zip.dir/zip_fseek.c.o
[ 30%] Building C object lib/CMakeFiles/zip.dir/zip_ftell.c.o
[ 31%] Building C object lib/CMakeFiles/zip.dir/zip_get_archive_comment.c.o
[ 32%] Building C object lib/CMakeFiles/zip.dir/zip_get_archive_flag.c.o
[ 32%] Building C object lib/CMakeFiles/zip.dir/zip_get_encryption_implementation.c.o
[ 33%] Building C object lib/CMakeFiles/zip.dir/zip_get_file_comment.c.o
[ 34%] Building C object lib/CMakeFiles/zip.dir/zip_get_name.c.o
[ 35%] Building C object lib/CMakeFiles/zip.dir/zip_get_num_entries.c.o
[ 35%] Building C object lib/CMakeFiles/zip.dir/zip_get_num_files.c.o
[ 36%] Building C object lib/CMakeFiles/zip.dir/zip_hash.c.o
[ 37%] Building C object lib/CMakeFiles/zip.dir/zip_io_util.c.o
[ 37%] Building C object lib/CMakeFiles/zip.dir/zip_libzip_version.c.o
[ 38%] Building C object lib/CMakeFiles/zip.dir/zip_memdup.c.o
[ 39%] Building C object lib/CMakeFiles/zip.dir/zip_name_locate.c.o
[ 40%] Building C object lib/CMakeFiles/zip.dir/zip_new.c.o
[ 40%] Building C object lib/CMakeFiles/zip.dir/zip_open.c.o
[ 41%] Building C object lib/CMakeFiles/zip.dir/zip_pkware.c.o
[ 42%] Building C object lib/CMakeFiles/zip.dir/zip_progress.c.o
[ 43%] Building C object lib/CMakeFiles/zip.dir/zip_rename.c.o
[ 43%] Building C object lib/CMakeFiles/zip.dir/zip_replace.c.o
[ 44%] Building C object lib/CMakeFiles/zip.dir/zip_set_archive_comment.c.o
[ 45%] Building C object lib/CMakeFiles/zip.dir/zip_set_archive_flag.c.o
[ 45%] Building C object lib/CMakeFiles/zip.dir/zip_set_default_password.c.o
[ 46%] Building C object lib/CMakeFiles/zip.dir/zip_set_file_comment.c.o
[ 47%] Building C object lib/CMakeFiles/zip.dir/zip_set_file_compression.c.o
[ 48%] Building C object lib/CMakeFiles/zip.dir/zip_set_name.c.o
[ 48%] Building C object lib/CMakeFiles/zip.dir/zip_source_accept_empty.c.o
[ 49%] Building C object lib/CMakeFiles/zip.dir/zip_source_begin_write.c.o
[ 50%] Building C object lib/CMakeFiles/zip.dir/zip_source_begin_write_cloning.c.o
[ 51%] Building C object lib/CMakeFiles/zip.dir/zip_source_buffer.c.o
[ 51%] Building C object lib/CMakeFiles/zip.dir/zip_source_call.c.o
[ 52%] Building C object lib/CMakeFiles/zip.dir/zip_source_close.c.o
[ 53%] Building C object lib/CMakeFiles/zip.dir/zip_source_commit_write.c.o
[ 54%] Building C object lib/CMakeFiles/zip.dir/zip_source_compress.c.o
[ 54%] Building C object lib/CMakeFiles/zip.dir/zip_source_crc.c.o
[ 55%] Building C object lib/CMakeFiles/zip.dir/zip_source_error.c.o
[ 56%] Building C object lib/CMakeFiles/zip.dir/zip_source_file_common.c.o
[ 56%] Building C object lib/CMakeFiles/zip.dir/zip_source_file_stdio.c.o
[ 57%] Building C object lib/CMakeFiles/zip.dir/zip_source_free.c.o
[ 58%] Building C object lib/CMakeFiles/zip.dir/zip_source_function.c.o
[ 59%] Building C object lib/CMakeFiles/zip.dir/zip_source_get_dostime.c.o
[ 59%] Building C object lib/CMakeFiles/zip.dir/zip_source_get_file_attributes.c.o
[ 60%] Building C object lib/CMakeFiles/zip.dir/zip_source_is_deleted.c.o
[ 61%] Building C object lib/CMakeFiles/zip.dir/zip_source_layered.c.o
[ 62%] Building C object lib/CMakeFiles/zip.dir/zip_source_open.c.o
[ 62%] Building C object lib/CMakeFiles/zip.dir/zip_source_pass_to_lower_layer.c.o
[ 63%] Building C object lib/CMakeFiles/zip.dir/zip_source_pkware_decode.c.o
[ 64%] Building C object lib/CMakeFiles/zip.dir/zip_source_pkware_encode.c.o
[ 65%] Building C object lib/CMakeFiles/zip.dir/zip_source_remove.c.o
[ 65%] Building C object lib/CMakeFiles/zip.dir/zip_source_read.c.o
[ 66%] Building C object lib/CMakeFiles/zip.dir/zip_source_rollback_write.c.o
[ 67%] Building C object lib/CMakeFiles/zip.dir/zip_source_seek.c.o
[ 67%] Building C object lib/CMakeFiles/zip.dir/zip_source_seek_write.c.o
[ 68%] Building C object lib/CMakeFiles/zip.dir/zip_source_stat.c.o
[ 69%] Building C object lib/CMakeFiles/zip.dir/zip_source_supports.c.o
[ 70%] Building C object lib/CMakeFiles/zip.dir/zip_source_tell.c.o
[ 70%] Building C object lib/CMakeFiles/zip.dir/zip_source_tell_write.c.o
[ 71%] Building C object lib/CMakeFiles/zip.dir/zip_source_window.c.o
[ 72%] Building C object lib/CMakeFiles/zip.dir/zip_source_write.c.o
[ 72%] Building C object lib/CMakeFiles/zip.dir/zip_source_zip.c.o
[ 73%] Building C object lib/CMakeFiles/zip.dir/zip_source_zip_new.c.o
[ 74%] Building C object lib/CMakeFiles/zip.dir/zip_stat.c.o
[ 75%] Building C object lib/CMakeFiles/zip.dir/zip_stat_index.c.o
[ 75%] Building C object lib/CMakeFiles/zip.dir/zip_stat_init.c.o
[ 76%] Building C object lib/CMakeFiles/zip.dir/zip_strerror.c.o
[ 77%] Building C object lib/CMakeFiles/zip.dir/zip_string.c.o
[ 78%] Building C object lib/CMakeFiles/zip.dir/zip_unchange.c.o
[ 78%] Building C object lib/CMakeFiles/zip.dir/zip_unchange_all.c.o
[ 79%] Building C object lib/CMakeFiles/zip.dir/zip_unchange_archive.c.o
[ 80%] Building C object lib/CMakeFiles/zip.dir/zip_unchange_data.c.o
[ 81%] Building C object lib/CMakeFiles/zip.dir/zip_utf-8.c.o
[ 81%] Building C object lib/CMakeFiles/zip.dir/zip_err_str.c.o
[ 82%] Building C object lib/CMakeFiles/zip.dir/zip_source_file_stdio_named.c.o
[ 83%] Building C object lib/CMakeFiles/zip.dir/zip_random_unix.c.o
[ 83%] Building C object lib/CMakeFiles/zip.dir/zip_algorithm_bzip2.c.o
[ 84%] Building C object lib/CMakeFiles/zip.dir/zip_algorithm_xz.c.o
[ 85%] Building C object lib/CMakeFiles/zip.dir/zip_algorithm_zstd.c.o
[ 86%] Linking C static library libzip.a
[ 86%] Built target zip
[ 87%] Building C object src/CMakeFiles/zipcmp.dir/zipcmp.c.o
[ 88%] Building C object src/CMakeFiles/zipcmp.dir/diff_output.c.o
[ 88%] Building C object ossfuzz/CMakeFiles/zip_read_file_fuzzer.dir/zip_read_file_fuzzer.c.o
[ 89%] Building C object ossfuzz/CMakeFiles/zip_read_file_fuzzer.dir/fuzz_main.c.o
[ 90%] Building C object src/CMakeFiles/ziptool.dir/ziptool.c.o
[ 90%] Building C object src/CMakeFiles/zipmerge.dir/zipmerge.c.o
[ 91%] Building C object ossfuzz/CMakeFiles/zip_write_encrypt_pkware_file_fuzzer.dir/fuzz_main.c.o
[ 91%] Building C object ossfuzz/CMakeFiles/zip_write_encrypt_aes256_file_fuzzer.dir/fuzz_main.c.o
[ 92%] Building C object ossfuzz/CMakeFiles/zip_write_encrypt_pkware_file_fuzzer.dir/zip_write_encrypt_pkware_file_fuzzer.c.o
[ 93%] Building C object ossfuzz/CMakeFiles/zip_write_encrypt_aes256_file_fuzzer.dir/zip_write_encrypt_aes256_file_fuzzer.c.o
[ 93%] Building C object ossfuzz/CMakeFiles/zip_read_fuzzer.dir/fuzz_main.c.o
[ 94%] Building C object ossfuzz/CMakeFiles/zip_read_fuzzer.dir/zip_read_fuzzer.c.o
[ 95%] Linking C executable zip_read_file_fuzzer
[ 95%] Linking C executable zip_write_encrypt_pkware_file_fuzzer
[ 96%] Linking C executable zip_write_encrypt_aes256_file_fuzzer
[ 97%] Linking C executable zip_read_fuzzer
[ 98%] Linking C executable ziptool
[ 99%] Linking C executable zipmerge
[100%] Linking C executable zipcmp
[100%] Built target zip_read_file_fuzzer
[100%] Built target zip_write_encrypt_pkware_file_fuzzer
[100%] Built target zip_write_encrypt_aes256_file_fuzzer
[100%] Built target zip_read_fuzzer
[100%] Built target ziptool
[100%] Built target zipmerge
[100%] Built target zipcmp

libzip/1.11.2: Package 'e801f4f6596bd8013b64260f66f189743ba0f4e0' built
libzip/1.11.2: Build folder /Users/abril/.conan2/p/b/libzie044a32dbc590/b/build/Release
libzip/1.11.2: Generating the package
libzip/1.11.2: Packaging in folder /Users/abril/.conan2/p/b/libzie044a32dbc590/p
libzip/1.11.2: Calling package()
libzip/1.11.2: Running CMake.install()
libzip/1.11.2: RUN: cmake --install "/Users/abril/.conan2/p/b/libzie044a32dbc590/b/build/Release" --prefix "/Users/abril/.conan2/p/b/libzie044a32dbc590/p"
-- Install configuration: "Release"
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/pkgconfig/libzip.pc
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/cmake/libzip/modules/FindNettle.cmake
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/cmake/libzip/modules/Findzstd.cmake
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/cmake/libzip/modules/FindMbedTLS.cmake
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/include/zipconf.h
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/cmake/libzip/libzip-config.cmake
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/cmake/libzip/libzip-config-version.cmake
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/cmake/libzip/libzip-targets.cmake
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/cmake/libzip/libzip-targets-release.cmake
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/lib/libzip.a
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/include/zip.h
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/bin/zipcmp
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/bin/zipmerge
-- Installing: /Users/abril/.conan2/p/b/libzie044a32dbc590/p/bin/ziptool

libzip/1.11.2: [HOOK - hook_ms_runtime_files.py] post_package(): Skipping libzip from checking MS files: Not msvc.
libzip/1.11.2: package(): Packaged 4 files: zipmerge, ziptool, zipcmp, LICENSE
libzip/1.11.2: package(): Packaged 2 '.h' files: zip.h, zipconf.h
libzip/1.11.2: package(): Packaged 1 '.a' file: libzip.a
libzip/1.11.2: Created package revision 6451069e9df8b1b9921ccb61af030150
libzip/1.11.2: Package 'e801f4f6596bd8013b64260f66f189743ba0f4e0' created
libzip/1.11.2: Full package reference: libzip/1.11.2#99bad9f93eca0800c372d7e723c1bcb4:e801f4f6596bd8013b64260f66f189743ba0f4e0#6451069e9df8b1b9921ccb61af030150
libzip/1.11.2: Package folder /Users/abril/.conan2/p/b/libzie044a32dbc590/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: brotli/1.1.0, bzip2/1.0.8, gmp/6.3.0, zlib/1.3.1, gnutls/3.8.2, libiconv/1.17, zstd/1.5.5, xz_utils/5.4.5
WARN: deprecated:     'cpp_info.build_modules' used in: xz_utils/5.4.5, gnutls/3.8.2, bzip2/1.0.8
WARN: deprecated:     'env_info' used in: gnutls/3.8.2, bzip2/1.0.8, libiconv/1.17, zstd/1.5.5

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    libzip/1.11.2 (test package): /Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/conanfile.py
Requirements
    brotli/1.1.0#d56d7bb9ca722942aba17369cb5c0519 - Cache
    bzip2/1.0.8#d00dac990f08d991998d624be81a9526 - Cache
    gmp/6.3.0#df20ffb6d21c34d67704305bcd1dea9e - Cache
    gnutls/3.8.2#e0f4b969ab1676ac533a91dffad28ed2 - Cache
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd - Cache
    libzip/1.11.2#99bad9f93eca0800c372d7e723c1bcb4 - Cache
    nettle/3.9.1#e764066b07b4d951c025795c5af809bf - Cache
    xz_utils/5.4.5#b885d1d79c9d30cff3803f7f551dbe66 - Cache
    zlib/1.3.1#e20364c96c45455608a72543f3a53133 - Cache
    zstd/1.5.5#b87dc3b185caa4b122979ac4ae8ef7e8 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    meson/1.5.2 - Platform
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
Replaced requires
    meson/1.2.2: meson/[>=1.0 <2]

======== Computing necessary packages ========
Requirements
    brotli/1.1.0#d56d7bb9ca722942aba17369cb5c0519:063f98cf19e03d6ad7db1db05444f80065307f33#057374b27417e0ac149a15ef8461a9da - Cache
    bzip2/1.0.8#d00dac990f08d991998d624be81a9526:1b365626531995eab090d0d1b1d474dd9a356923#b1785cad50c9b11ecda525152b088c1e - Cache
    gmp/6.3.0#df20ffb6d21c34d67704305bcd1dea9e:54d2478e2d30d65d558f49d6ed7a5abbd05f22d0#4bb7d21f0d8066b075b07ef4a2a9c36e - Cache
    gnutls/3.8.2#e0f4b969ab1676ac533a91dffad28ed2:8f2c5d3cc51a30a7cbc2dfe9cd1c2b4174e0ef82#2d0af3f72eb9848d800aaa5518ed0e96 - Cache
    libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd:405e382fa7fb6368c140a7f5c5cd71c32b009653#d792220a2db8d78cc07f324a892260ff - Cache
    libzip/1.11.2#99bad9f93eca0800c372d7e723c1bcb4:e801f4f6596bd8013b64260f66f189743ba0f4e0#6451069e9df8b1b9921ccb61af030150 - Cache
    nettle/3.9.1#e764066b07b4d951c025795c5af809bf:fe81106ecf76e7316874b180267dc98fe324c2d2#5759ef1a1b0a9ceb0fb55fc20b11346b - Cache
    xz_utils/5.4.5#b885d1d79c9d30cff3803f7f551dbe66:405e382fa7fb6368c140a7f5c5cd71c32b009653#5ea646391d65958efee88b799d9db7fa - Cache
    zlib/1.3.1#e20364c96c45455608a72543f3a53133:405e382fa7fb6368c140a7f5c5cd71c32b009653#b7bd0f651c882e73b0b3da240b280c20 - Cache
    zstd/1.5.5#b87dc3b185caa4b122979ac4ae8ef7e8:8eeafb9ab9fd57066c2629ff886059e5941ca64c#a518a96bcdd28146c57d0d6ab9d0e213 - Cache
Build requirements
Skipped binaries
    autoconf/2.71, automake/1.16.5, gnu-config/cci.20210814, libtool/2.4.7, m4/1.4.19, meson/1.5.2, pkgconf/2.1.0

======== Installing packages ========
brotli/1.1.0: Already installed! (1 of 10)
bzip2/1.0.8: Already installed! (2 of 10)
libiconv/1.17: Already installed! (3 of 10)
xz_utils/5.4.5: Already installed! (4 of 10)
zlib/1.3.1: Already installed! (5 of 10)
zstd/1.5.5: Already installed! (6 of 10)
gmp/6.3.0: Already installed! (7 of 10)
nettle/3.9.1: Already installed! (8 of 10)
gnutls/3.8.2: Already installed! (9 of 10)
libzip/1.11.2: Already installed! (10 of 10)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: brotli/1.1.0, bzip2/1.0.8, gmp/6.3.0, zlib/1.3.1, gnutls/3.8.2, libiconv/1.17, zstd/1.5.5, xz_utils/5.4.5
WARN: deprecated:     'cpp_info.build_modules' used in: xz_utils/5.4.5, gnutls/3.8.2, bzip2/1.0.8
WARN: deprecated:     'env_info' used in: gnutls/3.8.2, bzip2/1.0.8, libiconv/1.17, zstd/1.5.5

======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/build/apple-clang-16-armv8-gnu17-release
libzip/1.11.2 (test package): Test package build: build/apple-clang-16-armv8-gnu17-release
libzip/1.11.2 (test package): Test package build folder: /Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/build/apple-clang-16-armv8-gnu17-release
libzip/1.11.2 (test package): Writing generators to /Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/build/apple-clang-16-armv8-gnu17-release/generators
libzip/1.11.2 (test package): Generator 'CMakeToolchain' calling 'generate()'
libzip/1.11.2 (test package): CMakeToolchain generated: conan_toolchain.cmake
libzip/1.11.2 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/build/apple-clang-16-armv8-gnu17-release/generators/CMakePresets.json
libzip/1.11.2 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/CMakeUserPresets.json
libzip/1.11.2 (test package): Generator 'CMakeDeps' calling 'generate()'
libzip/1.11.2 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(libzip)
    target_link_libraries(... libzip::zip)
libzip/1.11.2 (test package): Generator 'VirtualRunEnv' calling 'generate()'
libzip/1.11.2 (test package): Generating aggregated env files
libzip/1.11.2 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
libzip/1.11.2 (test package): Calling build()
libzip/1.11.2 (test package): Running CMake.configure()
libzip/1.11.2 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/coding/conan-center-index/recipes/libzip/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/abril/coding/conan-center-index/recipes/libzip/all/test_package"
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Using Conan toolchain: /Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/build/apple-clang-16-armv8-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'libzip::zip'
-- Conan: Target declared 'BZip2::BZip2'
-- Conan: Including build module from '/Users/abril/.conan2/p/b/bzip2ea9ce1f033a6a/p/lib/cmake/conan-official-bzip2-variables.cmake'
-- Conan: Target declared 'LibLZMA::LibLZMA'
-- Conan: Including build module from '/Users/abril/.conan2/p/b/xz_ut8370d52c9dc3c/p/lib/cmake/conan-official-xz_utils-variables.cmake'
-- Conan: Target declared 'GnuTLS::GnuTLS'
-- Conan: Component target declared 'nettle::libnettle'
-- Conan: Component target declared 'nettle::hogweed'
-- Conan: Target declared 'nettle::nettle'
-- Conan: Component target declared 'gmp::libgmp'
-- Conan: Component target declared 'gmp::gmpxx'
-- Conan: Target declared 'gmp::gmp'
-- Conan: Target declared 'Iconv::Iconv'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Component target declared 'brotli::brotlicommon'
-- Conan: Component target declared 'brotli::brotlidec'
-- Conan: Component target declared 'brotli::brotlienc'
-- Conan: Target declared 'brotli::brotli'
-- Conan: Component target declared 'zstd::libzstd_static'
-- Conan: Including build module from '/Users/abril/.conan2/p/b/gnutlef926e095f917/p/lib/cmake/conan-official-gnutls-variables.cmake'
-- Configuring done (0.5s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/build/apple-clang-16-armv8-gnu17-release

libzip/1.11.2 (test package): Running CMake.build()
libzip/1.11.2 (test package): RUN: cmake --build "/Users/abril/coding/conan-center-index/recipes/libzip/all/test_package/build/apple-clang-16-armv8-gnu17-release" -- -j12
[ 50%] Building C object CMakeFiles/test_package.dir/test_package.c.o
[100%] Linking C executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
libzip/1.11.2 (test package): Running test()
libzip/1.11.2 (test package): RUN: ./test_package
```