### PR TITLE
thorvg: add version 0.15.6

### DIFF
--- a/recipes/thorvg/all/conandata.yml
+++ b/recipes/thorvg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.15.6":
+    url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.15.6.tar.gz"
+    sha256: "0ed4897aee82275afd838513e03073fd4e65c0321c9adfdaa36df7cd553fa436"
   "0.15.4":
     url: "https://github.com/thorvg/thorvg/archive/refs/tags/v0.15.4.tar.gz"
     sha256: "3031a3e070322194fc5368419e996420f05f26ec2ec8137beca17eba5e5e8a58"

--- a/recipes/thorvg/all/conanfile.py
+++ b/recipes/thorvg/all/conanfile.py
@@ -36,6 +36,7 @@ class ThorvgConan(ConanFile):
         "with_simd": [True, False],
         "with_examples": [True, False],
         "with_extra": [False, 'lottie_expressions'],
+        "with_file": [True, False],
     }
     default_options = {
         "shared": False,
@@ -49,6 +50,7 @@ class ThorvgConan(ConanFile):
         "with_simd": False,
         "with_examples": False,
         "with_extra": 'lottie_expressions',
+        "with_file": True,
     }
     # See more here: https://github.com/thorvg/thorvg/blob/main/meson_options.txt
     options_description = {
@@ -81,6 +83,8 @@ class ThorvgConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "0.15.6":
+            del self.options.with_file
 
     def configure(self):
         if self.options.shared:
@@ -148,6 +152,8 @@ class ThorvgConan(ConanFile):
         tc.project_options["simd"] = bool(self.options.with_simd)
         if self.options.with_extra:
             tc.project_options["extra"] = str(self.options.with_extra)
+        if "with_file" in self.options:
+            tc.project_options["file"] = self.options.with_file
         tc.generate()
         tc = PkgConfigDeps(self)
         tc.generate()

--- a/recipes/thorvg/config.yml
+++ b/recipes/thorvg/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.15.6":
+    folder: all
   "0.15.4":
     folder: all
   "0.15.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
There are several improvements since 0.15.6.
`file` option has been introduced in meson.build.

#### Details
https://github.com/thorvg/thorvg/releases/tag/v0.15.6
https://github.com/thorvg/thorvg/compare/v0.15.4...v0.15.6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
