### PR TITLE
foxglove-websocket: add version 1.4.0

### DIFF
--- a/recipes/foxglove-websocket/all/conandata.yml
+++ b/recipes/foxglove-websocket/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  1.4.0:
+    url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v1.4.0.tar.gz
+    sha256: 2257383f1ae39c775fb624c78efa2faa4b3aa22c24f84c0b9940aa7848270cfc
   1.3.1:
     url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v1.3.1.tar.gz
     sha256: 48bae8599603da893e559b952e7fec1392aeb55cc6d59288feac6e6428e61bef

--- a/recipes/foxglove-websocket/config.yml
+++ b/recipes/foxglove-websocket/config.yml
@@ -1,4 +1,6 @@
 versions:
+  1.4.0:
+    folder: all
   1.3.1:
     folder: all
   1.3.0:


### PR DESCRIPTION
### Summary
Changes to recipe:  **foxglove-websocket/1.4.0**

#### Motivation
Version bump

#### Details
See https://github.com/foxglove/ws-protocol/releases/tag/releases%2Fcpp%2Fv1.4.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
