### PR TITLE
sail: Fix compilation with shared=True

### DIFF
--- a/recipes/sail/all/conandata.yml
+++ b/recipes/sail/all/conandata.yml
@@ -14,3 +14,24 @@ sources:
   "0.9.0":
     url: "https://github.com/HappySeaFox/sail/archive/v0.9.0.tar.gz"
     sha256: "892738e0f56fed8c6387e1045bba2bfbf1b095024a495845d4879edb310cd1a7"
+patches:
+  "0.9.6":
+    - patch_file: "patches/0.9.1-fix-libjxl-find.patch"
+      patch_description: "Fix find_package on libjxl dependency"
+      patch_type: "conan"
+  "0.9.5":
+    - patch_file: "patches/0.9.1-fix-libjxl-find.patch"
+      patch_description: "Fix find_package on libjxl dependency"
+      patch_type: "conan"
+  "0.9.4":
+    - patch_file: "patches/0.9.1-fix-libjxl-find.patch"
+      patch_description: "Fix find_package on libjxl dependency"
+      patch_type: "conan"
+  "0.9.1":
+    - patch_file: "patches/0.9.1-fix-libjxl-find.patch"
+      patch_description: "Fix find_package on libjxl dependency"
+      patch_type: "conan"
+  "0.9.0":
+    - patch_file: "patches/0.9.0-fix-libjxl-find.patch"
+      patch_description: "Fix find_package on libjxl dependency"
+      patch_type: "conan"

--- a/recipes/sail/all/patches/0.9.0-fix-libjxl-find.patch
+++ b/recipes/sail/all/patches/0.9.0-fix-libjxl-find.patch
@@ -1,0 +1,28 @@
+diff --git a/src/sail-codecs/jpegxl/CMakeLists.txt b/src/sail-codecs/jpegxl/CMakeLists.txt
+index 54441fa6..7c290456 100644
+--- a/src/sail-codecs/jpegxl/CMakeLists.txt
++++ b/src/sail-codecs/jpegxl/CMakeLists.txt
+@@ -1,3 +1,4 @@
++if(0)
+ find_library(JPEGXL_LIBRARY jxl                 NAMES jxl jxl-static                 ${SAIL_CODEC_JPEGXL_REQUIRED_OPTION})
+ find_library(JPEGXL_THREADS_LIBRARY jxl_threads NAMES jxl_threads jxl_threads-static ${SAIL_CODEC_JPEGXL_REQUIRED_OPTION})
+ find_path(JPEGXL_INCLUDE_DIRS jxl/decode.h                                           ${SAIL_CODEC_JPEGXL_REQUIRED_OPTION})
+@@ -50,3 +51,18 @@ sail_codec(NAME jpegxl
+             DEPENDENCY_INCLUDE_DIRS ${JPEGXL_INCLUDE_DIRS}
+             DEPENDENCY_LIBS ${BROTLI_COMMON_LIBRARY} ${BROTLI_DEC_LIBRARY} ${HWY_LIBRARY}
+                             ${JPEGXL_LIBRARY} ${JPEGXL_THREADS_LIBRARY})
++endif()
++# Find libjxl package
++find_package(libjxl REQUIRED CONFIG)
++
++# Common codec configuration
++sail_codec(NAME jpegxl
++           SOURCES helpers.h helpers.c jpegxl.c memory.h memory.c
++           ICON jpegxl.png)
++
++# For static builds, define JXL_STATIC_DEFINE
++if(NOT BUILD_SHARED_LIBS)
++    target_compile_definitions(sail-codec-jpegxl PRIVATE JXL_STATIC_DEFINE)
++endif()
++
++target_link_libraries(${SAIL_CODEC_TARGET} PRIVATE libjxl::libjxl)

--- a/recipes/sail/all/patches/0.9.1-fix-libjxl-find.patch
+++ b/recipes/sail/all/patches/0.9.1-fix-libjxl-find.patch
@@ -1,0 +1,28 @@
+diff --git a/src/sail-codecs/jpegxl/CMakeLists.txt b/src/sail-codecs/jpegxl/CMakeLists.txt
+index 16971a48..2bfc3930 100644
+--- a/src/sail-codecs/jpegxl/CMakeLists.txt
++++ b/src/sail-codecs/jpegxl/CMakeLists.txt
+@@ -1,3 +1,4 @@
++if(0)
+ # Don't use SAIL_CODEC_JPEGXL_REQUIRED_OPTION as it requires CMake 3.18
+ #
+ find_library(JPEGXL_LIBRARY jxl                 NAMES jxl jxl-static)
+@@ -56,3 +57,18 @@ sail_codec(NAME jpegxl
+             DEPENDENCY_INCLUDE_DIRS ${JPEGXL_INCLUDE_DIRS}
+             DEPENDENCY_LIBS ${BROTLI_COMMON_LIBRARY} ${BROTLI_DEC_LIBRARY} ${HWY_LIBRARY}
+                             ${JPEGXL_LIBRARY} ${JPEGXL_THREADS_LIBRARY})
++endif()
++# Find libjxl package
++find_package(libjxl REQUIRED CONFIG)
++
++# Common codec configuration
++sail_codec(NAME jpegxl
++           SOURCES helpers.h helpers.c jpegxl.c memory.h memory.c
++           ICON jpegxl.png)
++
++# For static builds, define JXL_STATIC_DEFINE
++if(NOT BUILD_SHARED_LIBS)
++    target_compile_definitions(sail-codec-jpegxl PRIVATE JXL_STATIC_DEFINE)
++endif()
++
++target_link_libraries(${SAIL_CODEC_TARGET} PRIVATE libjxl::libjxl)

--- a/recipes/sail/all/test_package/CMakeLists.txt
+++ b/recipes/sail/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package C CXX)
 
 # Enable strict C++11


### PR DESCRIPTION

### Summary
Changes to recipe:  **sail**
- Bump libavif to fix linkage issues against yuv and libwebp
- conan v2 refactor

#### Motivation

When building `sail` as shared and their dependencies as static, following error appears:

```sh
$ conan create recipes/sail/all --version 0.9.6  --build=missing -o '&:shared=True'
...
 "std::__1::basic_stringbuf<char, std::__1::char_traits<char>, std::__1::allocator<char>>::str() const", referenced from:
      jxl::ModularStreamId::DebugString() const in libjxl.a[82](dec_modular.cc.o)
      jxl::BlendingInfo::DebugString() const in libjxl.a[92](frame_header.cc.o)
      jxl::Passes::DebugString() const in libjxl.a[92](frame_header.cc.o)
      jxl::FrameHeader::DebugString() const in libjxl.a[92](frame_header.cc.o)
      jxl::BitDepth::DebugString() const in libjxl.a[100](image_metadata.cc.o)
      jxl::ExtraChannelInfo::DebugString() const in libjxl.a[100](image_metadata.cc.o)
      jxl::ImageMetadata::DebugString() const in libjxl.a[100](image_metadata.cc.o)
      ...
  "std::__1::locale::use_facet(std::__1::locale::id&) const", referenced from:
      std::__1::basic_ostream<char, std::__1::char_traits<char>>& std::__1::__put_character_sequence[abi:un170006]<char, std::__1::char_traits<char>>(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, char const*, unsigned long) in libjxl.a[82](dec_modular.cc.o)
...
```

New patches aim to modify `sail-codecs/jpegxl/CMakeLists.txt` to use a standard `find_package` instead of custom find library logic.
This way conan `libjxl` can be found by project.

Also, other errors have been found when the previous error were solved:

```sh
Undefined symbols for architecture arm64:
  "_SharpYuvConvertWithOptions", referenced from:
      _avifImageRGBToYUVLibSharpYUV in libavif.a[13](reformat_libsharpyuv.c.o)
  "_SharpYuvOptionsInitInternal", referenced from:
      _avifImageRGBToYUVLibSharpYUV in libavif.a[13](reformat_libsharpyuv.c.o)
```
This error exists in every `sail` version compiling statically or shared.
Can be fixed bumping `libavif` dependency to a newer one, as upstream does in their CI downloading the latest version from homebrew. See [upstream](https://github.com/HappySeaFox/sail/blob/7246e41edcb371243f449c1e429c5a3860406a2d/.travis.yml#L14) code.

Minor changes made, removed conan v1 old logic.

Fix https://github.com/conan-io/conan-center-index/issues/25807

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
