### PR TITLE
p7zip: fix test package

### DIFF
--- a/recipes/p7zip/all/conanfile.py
+++ b/recipes/p7zip/all/conanfile.py
@@ -18,6 +18,7 @@ class PSevenZipConan(ConanFile):
     homepage = "https://sourceforge.net/projects/p7zip/"
     topics = ("7zip", "zip", "compression", "decompression")
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "application"
 
     def export_sources(self):
         export_conandata_patches(self)

--- a/recipes/p7zip/all/test_package/conanfile.py
+++ b/recipes/p7zip/all/test_package/conanfile.py
@@ -1,15 +1,16 @@
+import os.path
+
 from conan import ConanFile
 from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualRunEnv"
+    generators = "VirtualRunEnv", "VirtualBuildEnv"
     test_type = "explicit"
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def test(self):
-        if can_run(self):
-            self.run("7za", env="conanrun")
+        assert os.path.exists(os.path.join(self.dependencies[self.tested_reference_str].cpp_info.bindir, "7za"))

--- a/recipes/p7zip/all/test_package/conanfile.py
+++ b/recipes/p7zip/all/test_package/conanfile.py
@@ -6,11 +6,11 @@ from conan.tools.build import can_run
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualRunEnv", "VirtualBuildEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
 
     def test(self):
         assert os.path.exists(os.path.join(self.dependencies[self.tested_reference_str].cpp_info.bindir, "7za"))
+        if can_run(self):
+            self.run("7za", env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **p7zip/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
This PR ensures we can generate binaries for the library in Conan 2. This is a minimal diff that almost exclusively targets the test_package (except for a change in the recipe's package_type to force an export)

Closes https://github.com/conan-io/conan-center-index/issues/25059 which complained about Conan 2 not having packages for the recipe

#### Details
* Use a regular requires in the test_package and test as such
* Add missing package_type


Incidentally, this fixes the issue of missing binaries as it will generate a new revision and publish the necessary binaries.
