### PR TITLE
unordered_dense: add new version 4.5.0

### DIFF
--- a/recipes/unordered_dense/all/conandata.yml
+++ b/recipes/unordered_dense/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.5.0":
+    url: "https://github.com/martinus/unordered_dense/archive/v4.5.0.tar.gz"
+    sha256: "2364ce4bc4c23bd02549bbb3a7572d881684cd46057f3737fd53be53669743aa"
   "4.4.0":
     url: "https://github.com/martinus/unordered_dense/archive/v4.4.0.tar.gz"
     sha256: "3976399793e8cb4db1409ce15610fbd9e5e406ced4745f262d393a9311efbd88"

--- a/recipes/unordered_dense/config.yml
+++ b/recipes/unordered_dense/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.5.0":
+    folder: all
   "4.4.0":
     folder: all
   "4.3.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **unordered_dense/4.5.0**

#### Motivation
There are several improvements in 4.5.0.

#### Details
https://github.com/martinus/unordered_dense/releases/tag/v4.5.0
https://github.com/martinus/unordered_dense/compare/v4.4.0...v4.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
