### PR TITLE
enchant: fix changed source URL

### DIFF
--- a/recipes/enchant/all/conandata.yml
+++ b/recipes/enchant/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.3.2":
+    url: "https://github.com/rrthomas/enchant/releases/download/v2.3.2/enchant-2.3.2.tar.gz"
     sha256: "ce9ba47fd4d34031bd69445598a698a6611602b2b0e91d705e91a6f5099ead6e"
-    url: https://github.com/AbiWord/enchant/releases/download/v2.3.2/enchant-2.3.2.tar.gz
 patches:
   "2.3.2":
     - patch_file: patches/0001-add-visibility-annotations.patch

--- a/recipes/enchant/all/conanfile.py
+++ b/recipes/enchant/all/conanfile.py
@@ -15,7 +15,7 @@ class EnchantConan(ConanFile):
     )
     license = "LGPL-2.1-or-later"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://abiword.github.io/enchant/"
+    homepage = "https://rrthomas.github.io/enchant/"
     topics = ("enchant", "spell", "spell-check")
 
     package_type = "shared-library"


### PR DESCRIPTION
### Summary
Changes to recipe:  **enchant/2.3.2**

#### Motivation
The current source URL (https://github.com/AbiWord/enchant/releases/download/v2.3.2/enchant-2.3.2.tar.gz) no longer works. The source distribution archives appear to have been moved to https://github.com/rrthomas/enchant/releases, which the home page points to as well.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
