### PR TITLE
[fmt] Do not support Clang 20 + cppstd=20 due string literal evaluation

### DIFF
--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -82,11 +82,12 @@ class FmtConan(ConanFile):
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, 11)
-        if self.settings.os == "Emscripten" and "20" in str(self.settings.compiler.cppstd):
-            # INFO: https://github.com/conan-io/conan-center-index/issues/26169
-            # Confirmed by upstream: https://github.com/fmtlib/fmt/issues/4177
-            # TODO: Revisit after be fixed in the upstream. There is no milestone for this hotfix.
-            raise ConanInvalidConfiguration(f"Emscripten with C++20 is not supported by fmt, please use C++17 instead. See https://github.com/fmtlib/fmt/issues/4177")
+        if Version(self.version) <= "11.0.2" and self.settings.compiler == "clang" and Version(self.settings.compiler.version) >= "20":
+            # INFO: https://github.com/fmtlib/fmt/issues/4177
+            # Partially fixed by: https://github.com/fmtlib/fmt/commit/cacc3108c5b74020dba7bf3c6d3a7e58cdc085b2
+            # Completely fixed by: https://github.com/fmtlib/fmt/pull/4187
+            # TODO: Revisit after be released a new version of fmt
+            raise ConanInvalidConfiguration(f"FMT does not support Clang 20 for now, please use Clang 19 or earlier. See https://github.com/fmtlib/fmt/issues/4177")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -82,12 +82,13 @@ class FmtConan(ConanFile):
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, 11)
-        if Version(self.version) <= "11.0.2" and self.settings.compiler == "clang" and Version(self.settings.compiler.version) >= "20":
+        if Version(self.version).major in (8, 10, 11) and \
+             self.settings.compiler == "clang" and Version(self.settings.compiler.version) >= "20":
             # INFO: https://github.com/fmtlib/fmt/issues/4177
             # Partially fixed by: https://github.com/fmtlib/fmt/commit/cacc3108c5b74020dba7bf3c6d3a7e58cdc085b2
             # Completely fixed by: https://github.com/fmtlib/fmt/pull/4187
             # TODO: Revisit after be released a new version of fmt
-            raise ConanInvalidConfiguration(f"FMT does not support Clang 20 for now, please use Clang 19 or earlier. See https://github.com/fmtlib/fmt/issues/4177")
+            raise ConanInvalidConfiguration(f"This version of FMT does not currently support Clang 20; please use Clang 19 or an earlier version. See https://github.com/fmtlib/fmt/issues/4177")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -83,12 +83,13 @@ class FmtConan(ConanFile):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, 11)
         if Version(self.version).major in (8, 10, 11) and \
-             self.settings.compiler == "clang" and Version(self.settings.compiler.version) >= "20":
+             self.settings.compiler == "clang" and Version(self.settings.compiler.version) >= "20" and \
+             Version(str(self.settings.compiler.cppstd).replace("gnu", "")) >= "20":
             # INFO: https://github.com/fmtlib/fmt/issues/4177
             # Partially fixed by: https://github.com/fmtlib/fmt/commit/cacc3108c5b74020dba7bf3c6d3a7e58cdc085b2
             # Completely fixed by: https://github.com/fmtlib/fmt/pull/4187
             # TODO: Revisit after be released a new version of fmt
-            raise ConanInvalidConfiguration(f"This version of FMT does not currently support Clang 20; please use Clang 19 or an earlier version. See https://github.com/fmtlib/fmt/issues/4177")
+            raise ConanInvalidConfiguration(f"This version of FMT does not currently support Clang 20 with C++20; please use -s compiler.cppstd=17. See https://github.com/fmtlib/fmt/issues/4177")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.layout import basic_layout
-from conan.tools.build import check_min_cppstd
+from conan.tools.build import check_min_cppstd, valid_max_cppstd
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
 from conan.errors import ConanInvalidConfiguration
@@ -84,7 +84,7 @@ class FmtConan(ConanFile):
             check_min_cppstd(self, 11)
         if Version(self.version).major in (8, 10, 11) and \
              self.settings.compiler == "clang" and Version(self.settings.compiler.version) >= "20" and \
-             Version(str(self.settings.compiler.cppstd).replace("gnu", "")) >= "20":
+             not valid_max_cppstd(self, 20):
             # INFO: https://github.com/fmtlib/fmt/issues/4177
             # Partially fixed by: https://github.com/fmtlib/fmt/commit/cacc3108c5b74020dba7bf3c6d3a7e58cdc085b2
             # Completely fixed by: https://github.com/fmtlib/fmt/pull/4187

--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -7,6 +7,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
+from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.53.0"
 
@@ -81,6 +82,11 @@ class FmtConan(ConanFile):
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, 11)
+        if self.settings.os == "Emscripten" and "20" in str(self.settings.compiler.cppstd):
+            # INFO: https://github.com/conan-io/conan-center-index/issues/26169
+            # Confirmed by upstream: https://github.com/fmtlib/fmt/issues/4177
+            # TODO: Revisit after be fixed in the upstream. There is no milestone for this hotfix.
+            raise ConanInvalidConfiguration(f"Emscripten with C++20 is not supported by fmt, please use C++17 instead. See https://github.com/fmtlib/fmt/issues/4177")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary

Changes to recipe:  **fmt/[*]**

#### Motivation

closes #26169

/cc @AbrilRBS 

#### Details

It was reported by @skhaz on issue #26169, the same bug was reported to fmt directly: https://github.com/fmtlib/fmt/issues/4264

Probably fixed by https://github.com/fmtlib/fmt/issues/4177, but there is no milestone indicated for that hotfix.

The error ONLY occurs when building for C++20 (or newer) and using Clang 20. Here are some scenarios used for the validation:

- [fmt-10.2.0-linux-cppstd20.log](https://github.com/user-attachments/files/18113627/fmt-10.2.0-linux-cppstd20.log)
- [fmt-10.2.1-emscripten-cppstd20.log](https://github.com/user-attachments/files/18113629/fmt-10.2.1-emscripten-cppstd20.log)
- [fmt-11.0.2-emscripten-cppstd14.log](https://github.com/user-attachments/files/18113630/fmt-11.0.2-emscripten-cppstd14.log)
- [fmt-11.0.2-emscripten-cppstd17.log](https://github.com/user-attachments/files/18113631/fmt-11.0.2-emscripten-cppstd17.log)
- [fmt-11.0.2-emscripten-cppstd20.log](https://github.com/user-attachments/files/18113632/fmt-11.0.2-emscripten-cppstd20.log)
- [fmt-11.0.2-linux-cppstd20.log](https://github.com/user-attachments/files/18113633/fmt-11.0.2-linux-cppstd20.log)
- [fmt-11.0.2-emscripten-cppstd23.log](https://github.com/user-attachments/files/18114032/fmt-11.0.2-emscripten-cppstd23.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
