### PR TITLE
openimageio: Fixed test_package bug

### DIFF
--- a/recipes/openimageio/all/test_package/conanfile.py
+++ b/recipes/openimageio/all/test_package/conanfile.py
@@ -20,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not can_run(self):
+        if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio**

#### Motivation

Testing the following issue https://github.com/conan-io/conan-center-index/issues/10327
I found the `conanfile.py` test_package has an incorrect logic introduced in during the recipe migration to conan v2, see https://github.com/conan-io/conan-center-index/pull/19950/files#diff-af6917236b5b08ff903a94d288a0226a9d6b7159b086a3694de1da36c6b42749R23


#### Details

Changed logic in `test_package` for `not can_run` to `can_run`.
Minor improvements have been made. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
