### PR TITLE
xnnpack: bump cpuinfo dep fixing version conflict with onnxruntime

### DIFF
--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.microsoft import check_min_vs
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.51.1"
+required_conan_version = ">=2.4"
 
 
 class XnnpackConan(ConanFile):
@@ -35,19 +35,11 @@ class XnnpackConan(ConanFile):
         "memopt": True,
         "sparse": True,
     }
+    implements = ["auto_shared_fpic"]
+    languages = ["C"]
 
     def export_sources(self):
         copy(self, "xnnpack_project_include.cmake", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.libcxx")
-        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -66,7 +58,7 @@ class XnnpackConan(ConanFile):
         check_min_vs(self, 192)
         compiler = self.settings.compiler
         compiler_version = Version(compiler.version)
-        if self.version < "cci.20230715":
+        if Version(self.version) < "cci.20230715":
             if (compiler == "gcc" and compiler_version < "6") or \
                 (compiler == "clang" and compiler_version < "5"):
                 raise ConanInvalidConfiguration(f"{self.ref} doesn't support {compiler} {compiler.version}")

--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -54,7 +54,7 @@ class XnnpackConan(ConanFile):
 
     def requirements(self):
         if self.version in ["cci.20220801", "cci.20220621", "cci.20211210"]:
-            self.requires("cpuinfo/cci.20220228")
+            self.requires("cpuinfo/cci.20220618")
         else:
             self.requires("cpuinfo/cci.20231129")
         self.requires("fp16/cci.20210320")


### PR DESCRIPTION
Co-authored-by: @czoido

### Summary
Changes to recipe:  **xnnpack <= cci.20220801**

#### Motivation

Fixes https://github.com/conan-io/conan-center-index/issues/10327

#### Details

Current conflict: 
![image](https://github.com/user-attachments/assets/e5fbc7f5-04b3-4790-a884-68cdd2240555)

By securely bumping `cpuinfo` in `xnnpack` on versions <= `cci.20220801`, the conflict will be fixed.

**Note**: apart from `onnxruntime`, only `tensorflow-lite` depends on `xnnpack`, but it would not be affected as it depends on a new version, see https://github.com/conan-io/conan-center-index/blob/97ba1699a4e855e32573f93fb0572e284f36b624/recipes/tensorflow-lite/all/conanfile.py?plain=1#L93 

Little refactors have been made.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
