### PR TITLE
Security / Vulnerability Scanner tool addition / SBOM : trivy and syft

### DIFF
--- a/recipes/syft/all/conandata.yml
+++ b/recipes/syft/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "1.18.0":
+    Linux:
+      x86_64:
+        url: "https://github.com/anchore/syft/releases/download/v1.18.0/syft_1.18.0_linux_amd64.tar.gz"
+        sha256: "0b6fd1e0dd5b00b19585e5cde8e1c1f4ef60dc8fba8b41fab55f00852a2fbb8d"
+    Windows:
+      x86_64:
+        sha256: "e7c5face12a70cd1a480da5ba3092e5ab4ac49cc9467fd3f056167c58b929a1d"
+        url: "https://github.com/anchore/syft/releases/download/v1.18.0/syft_1.18.0_windows_amd64.zip"

--- a/recipes/syft/all/conanfile.py
+++ b/recipes/syft/all/conanfile.py
@@ -1,0 +1,44 @@
+import os
+
+from conan import ConanFile
+from conan.tools.files import get, copy, rmdir
+from conan.tools.scm import Version
+from conan import conan_version
+from conan.errors import ConanInvalidConfiguration
+
+
+required_conan_version = ">=1.51.0"
+
+class SyftConan(ConanFile):
+    name = "syft"
+    package_type = "application"
+    description = "Syft Security Scanner."
+    topics = ("build", "scanner")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/anchore/syft"
+    license = "Apache-2.0"
+    settings = "os", "arch"
+
+    def build(self):
+        arch = str(self.settings.arch) if self.settings.os != "Macos" else "universal"
+        get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][arch],
+            destination=self.source_folder)
+        
+    def package(self):
+        copy(self, "*", src=self.build_folder, dst=self.package_folder)
+
+    def package_id(self):
+        self.info.clear()
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+
+        bindir = os.path.join(self.package_folder)
+        self.cpp_info.bindirs = [bindir]
+        
+        if conan_version.major < 2:
+            # Needed for compatibility with v1.x - Remove when 2.0 becomes the default
+            self.output.info(f"Appending PATH environment variable: {bindir}")
+            self.env_info.PATH.append(bindir)
+

--- a/recipes/syft/all/test_package/conanfile.py
+++ b/recipes/syft/all/test_package/conanfile.py
@@ -1,0 +1,23 @@
+from six import StringIO
+from conan import ConanFile
+import re
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        output = StringIO()
+        self.run("syft --version", output)
+        output_str = str(output.getvalue())
+        self.output.info("Installed version: {}".format(output_str))
+        tokens = re.split('[@#]', self.tested_reference_str)
+        require_version = tokens[0].split("/", 1)[1]
+        self.output.info("Expected version: {}".format(require_version))
+        assert_version = "syft %s" % require_version
+        assert(assert_version in output_str)

--- a/recipes/syft/config.yml
+++ b/recipes/syft/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.58.0":
+    folder: "all"

--- a/recipes/trivy/all/conandata.yml
+++ b/recipes/trivy/all/conandata.yml
@@ -1,0 +1,13 @@
+sources:
+  "0.58.0":
+    Linux:
+      armv8:
+        url: "https://github.com/aquasecurity/trivy/releases/download/v0.58.0/trivy_0.58.0_Linux-ARM.tar.gz"
+        sha256: "979e51af330de80bee61bcd1b3be9af7fdf2c59af56d3bc4c34ee13b09956cd3"
+      x86_64:
+        url: "https://github.com/aquasecurity/trivy/releases/download/v0.58.0/trivy_0.58.0_Linux-64bit.tar.gz"
+        sha256: "eb79a4da633be9c22ce8e9c73a78c0f57ffb077fb92cb1968aaf9c686a20c549"
+    Windows:
+      x86_64:
+        url: "https://github.com/aquasecurity/trivy/releases/download/v0.58.0/trivy_0.58.0_windows-64bit.zip"
+        sha256: "42555d9f9fca7315ee622e8ad737a9c3bcbfcab398e5ec7e03e9a0c3191475ba"

--- a/recipes/trivy/all/conanfile.py
+++ b/recipes/trivy/all/conanfile.py
@@ -15,8 +15,8 @@ class TrivyConan(ConanFile):
     description = "Trivy Security Scanner."
     topics = ("build", "scanner")
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = ""
-    license = ""
+    homepage = "https://github.com/aquasecurity/trivy/"
+    license = "Apache-2.0"
     settings = "os", "arch"
 
     def build(self):

--- a/recipes/trivy/all/conanfile.py
+++ b/recipes/trivy/all/conanfile.py
@@ -1,0 +1,44 @@
+import os
+
+from conan import ConanFile
+from conan.tools.files import get, copy, rmdir
+from conan.tools.scm import Version
+from conan import conan_version
+from conan.errors import ConanInvalidConfiguration
+
+
+required_conan_version = ">=1.51.0"
+
+class TrivyConan(ConanFile):
+    name = "trivy"
+    package_type = "application"
+    description = "Trivy Security Scanner."
+    topics = ("build", "scanner")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = ""
+    license = ""
+    settings = "os", "arch"
+
+    def build(self):
+        arch = str(self.settings.arch) if self.settings.os != "Macos" else "universal"
+        get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][arch],
+            destination=self.source_folder)
+        
+    def package(self):
+        copy(self, "*", src=self.build_folder, dst=self.package_folder)
+
+    def package_id(self):
+        self.info.clear()
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+
+        bindir = os.path.join(self.package_folder)
+        self.cpp_info.bindirs = [bindir]
+        
+        if conan_version.major < 2:
+            # Needed for compatibility with v1.x - Remove when 2.0 becomes the default
+            self.output.info(f"Appending PATH environment variable: {bindir}")
+            self.env_info.PATH.append(bindir)
+

--- a/recipes/trivy/all/test_package/conanfile.py
+++ b/recipes/trivy/all/test_package/conanfile.py
@@ -1,0 +1,23 @@
+from six import StringIO
+from conan import ConanFile
+import re
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        output = StringIO()
+        self.run("trivy --version", output)
+        output_str = str(output.getvalue())
+        self.output.info("Installed version: {}".format(output_str))
+        tokens = re.split('[@#]', self.tested_reference_str)
+        require_version = tokens[0].split("/", 1)[1]
+        self.output.info("Expected version: {}".format(require_version))
+        assert_version = "Version: %s" % require_version
+        assert(assert_version in output_str)

--- a/recipes/trivy/config.yml
+++ b/recipes/trivy/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.58.0":
+    folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **trivy/0.58.0** and **syft/1.18.0**

#### Motivation
SBOM and Vulnerability scanner are two tools that can improove the security of your projects. As those tools are often used during the integration process, it becomes handy when a tool could be included by tool_requires directly (as cmake can be).

#### Details
Those two recipes will ass syft and trivy to the bin path, downloading the binary GO package. No recompiliing

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
