### PR TITLE
OpenColorIO: Add version 2.4.1

### DIFF
--- a/recipes/opencolorio/all/conandata.yml
+++ b/recipes/opencolorio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.1":
+    url: "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v2.4.1.tar.gz"
+    sha256: "d4eb15408b33dffd6ba0bba9a53328085b40bdd9319fa3d0d7348d06a8cbe842"
   "2.4.0":
     url: "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v2.4.0.tar.gz"
     sha256: "0ff3966b9214da0941b2b1cbdab3975a00a51fc6f3417fa860f98f5358f2c282"
@@ -15,6 +18,10 @@ sources:
     url: "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v1.1.1.tar.gz"
     sha256: "c9b5b9def907e1dafb29e37336b702fff22cc6306d445a13b1621b8a754c14c8"
 patches:
+  "2.4.1":
+    - patch_file: "patches/2.4.0-0001-fix-cmake-source-dir-and-targets.patch"
+      patch_description: "use cci package, use PROJECT_BINARY_DIR/PROJECT_SOURCE_DIR"
+      patch_type: "conan"
   "2.4.0":
     - patch_file: "patches/2.4.0-0001-fix-cmake-source-dir-and-targets.patch"
       patch_description: "use cci package, use PROJECT_BINARY_DIR/PROJECT_SOURCE_DIR"

--- a/recipes/opencolorio/config.yml
+++ b/recipes/opencolorio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.1":
+    folder: "all"
   "2.4.0":
     folder: "all"
   "2.3.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencolorio/2.4.1**

#### Motivation
Patch level so a number of fixes and internal optimization that have been introduced since 2.4.0.

#### Details
https://github.com/AcademySoftwareFoundation/OpenColorIO/releases/tag/v2.4.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
