### PR TITLE
package_templates: remove a misplaced config.yml

### DIFF
--- a/docs/package_templates/cmake_package/all/test_package/config.yml
+++ b/docs/package_templates/cmake_package/all/test_package/config.yml
@@ -1,5 +1,0 @@
-versions:
-  "1.2.0":
-    folder: all
-  "1.1.0":
-    folder: all


### PR DESCRIPTION
Remove a `cmake_package/all/test_package/config.yml` accidentally added in #25849.

@uilianries