### PR TITLE
[opentrackio-cpp] add version 0.9.1 and replace incorrect v1.0.0 with…

### DIFF
--- a/recipes/opentrackio-cpp/all/conandata.yml
+++ b/recipes/opentrackio-cpp/all/conandata.yml
@@ -2,7 +2,7 @@ sources:
   "0.9.1":
     url:
     - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/0.9.1.tar.gz"
-    sha256: "2be56986205f93ab3bae418746d7eb979188cabd1efa4e324ab724cb7a419c34"
+    sha256: "fa9dfe31e8ea3802ef0fe00c97f1c5fe3006ad56a7835b0e9790772260d8af3e"
   "0.9.0":
     url:
     - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/0.9.0.tar.gz"

--- a/recipes/opentrackio-cpp/all/conandata.yml
+++ b/recipes/opentrackio-cpp/all/conandata.yml
@@ -1,5 +1,9 @@
 sources:
-  "1.0.0":
+  "0.9.1":
     url:
-    - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/v1.0.0.tar.gz"
-    sha256: "89bd489774a8efac9b18ddcff9a2219d57d46a73d53ea0a5fd71a94c27fc1257"
+    - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/0.9.1.tar.gz"
+    sha256: "2be56986205f93ab3bae418746d7eb979188cabd1efa4e324ab724cb7a419c34"
+  "0.9.0":
+    url:
+    - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/0.9.0.tar.gz"
+    sha256: "1a4d4475d904e4c3f391deae0208f3dc577695f10231fd085a75585494dee0d7"

--- a/recipes/opentrackio-cpp/all/test_package/test_package.cpp
+++ b/recipes/opentrackio-cpp/all/test_package/test_package.cpp
@@ -8,7 +8,7 @@ int main(void) {
     std::string example = R"({
       "protocol": {
         "name": "OpenTrackIO",
-        "version": "0.9.0"
+        "version": [0,9,1]
       },
       "tracker": {
         "notes": "Example generated sample.",

--- a/recipes/opentrackio-cpp/config.yml
+++ b/recipes/opentrackio-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
   # Newer versions at the top
-  "1.0.0":
+  "0.9.1":
+    folder: all
+  "0.9.0":
     folder: all


### PR DESCRIPTION
… 0.9.0


### Summary
Changes to recipe:  **opentrackio-cpp/0.9.1**

#### Motivation
Fixing the previous version tag
Adding the 0.9.1 release

#### Details
Replacing the incorrect initial version v1.0.0 with 0.9.0 to match the OpenTrackIO version to which this relates.


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
