### PR TITLE
Add llama-cpp 4079

### DIFF
--- a/recipes/llama-cpp/all/conandata.yml
+++ b/recipes/llama-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "b4079":
+    url: "https://github.com/ggerganov/llama.cpp/archive/refs/tags/b4079.tar.gz"
+    sha256: "79093413dcdbd30f83b800aeb958c87369fdfdaf4e5603b094185898ff404a32"
   "b3542":
     url: "https://github.com/ggerganov/llama.cpp/archive/refs/tags/b3542.tar.gz"
     sha256: "6f8b23d930400fce5708d2c85022ef33f1083af8f6ac395abefadacee0942e78"
@@ -6,6 +9,8 @@ sources:
     url: "https://github.com/ggerganov/llama.cpp/archive/refs/tags/b3040.tar.gz"
     sha256: "020e040139660eb40113503bb1057d5387677d249b990e008e04821532f7cd62"
 patches:
+  "b4079":
+    - patch_file: "patches/b4079-001-curl-patch-targets.patch"
   "b3542":
     - patch_file: "patches/b3542-001-curl-patch-targets.patch"
   "b3040":

--- a/recipes/llama-cpp/all/patches/b4079-001-curl-patch-targets.patch
+++ b/recipes/llama-cpp/all/patches/b4079-001-curl-patch-targets.patch
@@ -1,0 +1,15 @@
+diff --git a/common/CMakeLists.txt b/common/CMakeLists.txt
+index 5ab1ffa1..4cd462ee 100644
+--- a/common/CMakeLists.txt
++++ b/common/CMakeLists.txt
+@@ -78,9 +78,7 @@ set(LLAMA_COMMON_EXTRA_LIBS build_info)
+ if (LLAMA_CURL)
+     find_package(CURL REQUIRED)
+     add_definitions(-DLLAMA_USE_CURL)
+-    include_directories(${CURL_INCLUDE_DIRS})
+-    find_library(CURL_LIBRARY curl REQUIRED)
+-    set(LLAMA_COMMON_EXTRA_LIBS ${LLAMA_COMMON_EXTRA_LIBS} ${CURL_LIBRARY})
++    list(APPEND LLAMA_COMMON_EXTRA_LIBS CURL::libcurl)
+ endif ()
+ 
+ target_include_directories(${TARGET} PUBLIC .)

--- a/recipes/llama-cpp/config.yml
+++ b/recipes/llama-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "b4079":
+    folder: "all"
   "b3542":
     folder: "all"
   "b3040":


### PR DESCRIPTION
This is a bit newer version of llama-cpp (14-Nov-2025)

Starting in this one we will need to update the recipe because all backends will be separated in different libraries from 4080 version.