### PR TITLE
bshoshany-thread-pool: add version 5.0.0

### DIFF
--- a/recipes/bshoshany-thread-pool/all/conandata.yml
+++ b/recipes/bshoshany-thread-pool/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.0.0":
+    sha256: "617a8fbc2c360577f498998f336777c73d581810831d4ce9c920f11ec680b07b"
+    url: "https://github.com/bshoshany/thread-pool/archive/refs/tags/v5.0.0.tar.gz"
   "4.1.0":
     sha256: "be7abecbc420bb87919eeef729b13ff7c29d5ce547bdae284923296c695415bd"
     url: "https://github.com/bshoshany/thread-pool/archive/refs/tags/v4.1.0.tar.gz"

--- a/recipes/bshoshany-thread-pool/all/conanfile.py
+++ b/recipes/bshoshany-thread-pool/all/conanfile.py
@@ -12,10 +12,10 @@ required_conan_version = ">=1.43.0"
 
 class BShoshanyThreadPoolConan(ConanFile):
     name = "bshoshany-thread-pool"
-    description = "BS::thread_pool: a fast, lightweight, and easy-to-use C++17 thread pool library"
+    description = "BS::thread_pool: a fast, lightweight, modern, and easy-to-use C++17 / C++20 / C++23 thread pool library"
     homepage = "https://github.com/bshoshany/thread-pool"
     license = "MIT"
-    topics = ("concurrency", "cpp17", "header-only", "library", "multi-threading", "parallel-computing", "thread-pool", "threads")
+    topics = ("concurrency", "cpp17", "cpp20", "cpp23", "header-only", "library", "multi-threading", "parallel-computing", "thread-pool", "threads", "module", "modules")
     url = "https://github.com/conan-io/conan-center-index"
     package_type = "header-library"
     settings = "arch", "build_type", "compiler", "os"
@@ -58,8 +58,11 @@ class BShoshanyThreadPoolConan(ConanFile):
         copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
         if Version(self.version) < "3.5.0":
             copy(self, "*.hpp", self.source_folder, os.path.join(self.package_folder, "include"))
-        else:
+        elif Version(self.version) < "5.0.0":
             copy(self, "*.hpp", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+        else:
+            copy(self, "BS_thread_pool.hpp", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+            copy(self, "BS.thread_pool.cppm", os.path.join(self.source_folder, "modules"), os.path.join(self.package_folder, "modules"))
 
     def package_info(self):
         self.cpp_info.bindirs = []

--- a/recipes/bshoshany-thread-pool/config.yml
+++ b/recipes/bshoshany-thread-pool/config.yml
@@ -1,17 +1,19 @@
 versions:
-    "4.1.0":
-        folder: all
-    "4.0.1":
-        folder: all
-    "3.5.0":
-        folder: all
-    "3.4.0":
-        folder: all
-    "3.3.0":
-        folder: all
-    "3.2.0":
-        folder: all
-    "3.1.0":
-        folder: all
-    "3.0.0":
-        folder: all
+  "5.0.0":
+    folder: all
+  "4.1.0":
+    folder: all
+  "4.0.1":
+    folder: all
+  "3.5.0":
+    folder: all
+  "3.4.0":
+    folder: all
+  "3.3.0":
+    folder: all
+  "3.2.0":
+    folder: all
+  "3.1.0":
+    folder: all
+  "3.0.0":
+    folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:  **bshoshany-thread-pool/5.0.0**

#### Motivation

Updated to v5.0.0.

#### Details

Starting with this version, the library is also available as a C++20 module. I tried to find if Conan supports modules, but could not find anything other than a blog post saying you're working on it. Currently, in addition to copying the header file `include/BS_thread_pool.hpp` (which can still be included as a normal header file if C++20 modules are not available) to `os.path.join(self.package_folder, "include")`, the recipe also copies the module file, `modules/BS.thread_pool.cppm`, to `os.path.join(self.package_folder, "modules")`. Does that make sense, or would the user not have access to that folder? Any help would be appreciated.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
