### PR TITLE
[openscenegraph] Fix '_FPOSOFF' has been deprecated

### DIFF
--- a/recipes/openscenegraph/all/conandata.yml
+++ b/recipes/openscenegraph/all/conandata.yml
@@ -36,3 +36,9 @@ patches:
       patch_source:
         - https://github.com/openscenegraph/OpenSceneGraph/pull/1296
         - https://github.com/openscenegraph/OpenSceneGraph/pull/951
+    - patch_file: patches/0012-_FPOSOFF-deprecated.patch
+      patch_description: _FPOSOFF identifier not found
+      patch_type: bugfix
+      patch_source:
+        - https://github.com/openscenegraph/OpenSceneGraph/issues/1323
+        - https://github.com/microsoft/vcpkg/pull/38666/files

--- a/recipes/openscenegraph/all/patches/0012-_FPOSOFF-deprecated.patch
+++ b/recipes/openscenegraph/all/patches/0012-_FPOSOFF-deprecated.patch
@@ -1,0 +1,13 @@
+diff --git a/src/osgPlugins/osga/OSGA_Archive.cpp b/src/osgPlugins/osga/OSGA_Archive.cpp
+index b9f518a..19186a7 100644
+--- a/src/osgPlugins/osga/OSGA_Archive.cpp
++++ b/src/osgPlugins/osga/OSGA_Archive.cpp
+@@ -77,7 +77,7 @@ inline OSGA_Archive::pos_type ARCHIVE_POS( const std::streampos & pos )
+ #else // older Dinkumware (eg: one included in Win Server 2003 Platform SDK )
+ 	fpos_t position = pos.get_fpos_t();
+ #endif
+-    std::streamoff offset = pos.operator std::streamoff( ) - _FPOSOFF( position );
++    std::streamoff offset = 0;
+
+     return OSGA_Archive::pos_type( position + offset );
+ }


### PR DESCRIPTION
### Summary
Changes to recipe:  openscenegraph/3.6.5

#### Motivation
Fix build error with latest Visual Studio.
_FPOSOFF has been removed.

#### Details
https://github.com/openscenegraph/OpenSceneGraph/issues/1323
https://github.com/microsoft/vcpkg/pull/38666/files

---
- [x ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x] Tested locally with at least one configuration using a recent version of Conan
