### PR TITLE
scnlib: 3.0.2 onwards works for gcc 11

### DIFF
--- a/recipes/scnlib/all/conanfile.py
+++ b/recipes/scnlib/all/conanfile.py
@@ -82,7 +82,7 @@ class ScnlibConan(ConanFile):
         # TODO: This should probably be a del self.options.header_only in config_options once the CI supports it
         if self.options.header_only:
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support header only mode.")
-        if self.settings.compiler == "gcc" and Version(self.settings.compiler.version).major == "11":
+        if Version(self.version) < "3.0.2" and self.settings.compiler == "gcc" and Version(self.settings.compiler.version).major == "11":
             raise ConanInvalidConfiguration(f"{self.ref} doesn't support gcc 11.x due to std::regex_constants::multiline is not defined.")
 
     def build_requirements(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **scnlib/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
As reported in https://github.com/conan-io/conan-center-index/issues/26224, scnlib compiles just fine for gcc 11 for newer versions, the recipe was never updated to reflect this

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Linux logs for gcc 11:

<details>

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| Running in container: "conan create /root/conanrunner/all --version=3.0.2 -b=missing -pr:h=docker_example_host -pr:b=docker_example_build -f json > create.json" |
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘


======== Exporting recipe to the cache ========
scnlib/3.0.2: Exporting package recipe: /root/conanrunner/all/conanfile.py
scnlib/3.0.2: exports: File 'conandata.yml' found. Exporting it...
scnlib/3.0.2: Copied 1 '.py' file: conanfile.py
scnlib/3.0.2: Copied 1 '.yml' file: conandata.yml
scnlib/3.0.2: Exported to cache folder: /root/.conan2/p/scnlie36abdbb458c7/e
scnlib/3.0.2: Exported: scnlib/3.0.2#be40c573e6227ffb7719e7a2b02f05e5 (2024-12-20 10:00:35 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux


======== Computing dependency graph ========
fast_float/6.1.0: Not found in local cache, looking in remotes...
fast_float/6.1.0: Checking remote: conancenter
fast_float/6.1.0: Downloaded recipe revision f6088e57bf83ac9f9b3abf37fe766cea
cmake/3.31.0: Not found in local cache, looking in remotes...
cmake/3.31.0: Checking remote: conancenter
cmake/3.31.0: Downloaded recipe revision ba7dbf3b2fc9e70653b4c0fb5bbd2483
Graph root
    cli
Requirements
    fast_float/6.1.0#f6088e57bf83ac9f9b3abf37fe766cea - Downloaded (conancenter)
    scnlib/3.0.2#be40c573e6227ffb7719e7a2b02f05e5 - Cache
Build requirements
    cmake/3.31.0#ba7dbf3b2fc9e70653b4c0fb5bbd2483 - Downloaded (conancenter)
Resolved version ranges
    cmake/[>=3.16 <4]: cmake/3.31.0

======== Computing necessary packages ========
scnlib/3.0.2: Main binary package 'd584eb36b6d64c5fdcc195be2a00938c418de927' missing
scnlib/3.0.2: Checking 5 compatible configurations
scnlib/3.0.2: Compatible configurations not found in cache, checking servers
scnlib/3.0.2: '81ed3e2cd9af3c095840e1c83451a244c6ee37dd': compiler.cppstd=17
scnlib/3.0.2: '0d64ca3a74189a73fbc58cd56ad01a9fc590fdad': compiler.cppstd=20
scnlib/3.0.2: '076921116b01d99146c56bbd935ec61fb7d19262': compiler.cppstd=gnu20
scnlib/3.0.2: '2340289d59d065f716c9736f6d5c2bc51b701fe8': compiler.cppstd=23
scnlib/3.0.2: '6f5c76cfb0ed4a69a04a6b888c97e6baaa51c8c7': compiler.cppstd=gnu23
Requirements
    fast_float/6.1.0#f6088e57bf83ac9f9b3abf37fe766cea:da39a3ee5e6b4b0d3255bfef95601890afd80709#38ce0a19014c0ff016772731a38dc33b - Download (conancenter)
    scnlib/3.0.2#be40c573e6227ffb7719e7a2b02f05e5:d584eb36b6d64c5fdcc195be2a00938c418de927 - Build
Build requirements
    cmake/3.31.0#ba7dbf3b2fc9e70653b4c0fb5bbd2483:c93719558cf197f1df5a7f1d071093e26f0e44a0 - Build

======== Installing packages ========

-------- Downloading 1 package --------
fast_float/6.1.0: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter' 
fast_float/6.1.0: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
fast_float/6.1.0: Downloaded package revision 38ce0a19014c0ff016772731a38dc33b

-------- Installing package cmake/3.31.0 (1 of 3) --------
cmake/3.31.0: Building from source
cmake/3.31.0: Package cmake/3.31.0:c93719558cf197f1df5a7f1d071093e26f0e44a0
cmake/3.31.0: Copying sources to build folder
cmake/3.31.0: Building your package in /root/.conan2/p/b/cmake7a1436be1bd0b/b
cmake/3.31.0: Generating aggregated env files
cmake/3.31.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
cmake/3.31.0: Calling build()
cmake/3.31.0: Downloading 56.3MB cmake-3.31.0-linux-aarch64.tar.gz
cmake/3.31.0: Downloaded 9.9MB 17% cmake-3.31.0-linux-aarch64.tar.gz
cmake/3.31.0: Downloaded 18.8MB 33% cmake-3.31.0-linux-aarch64.tar.gz
cmake/3.31.0: Downloaded 28.5MB 50% cmake-3.31.0-linux-aarch64.tar.gz
cmake/3.31.0: Downloaded 37.9MB 67% cmake-3.31.0-linux-aarch64.tar.gz
cmake/3.31.0: Downloaded 48.0MB 85% cmake-3.31.0-linux-aarch64.tar.gz
cmake/3.31.0: Unzipping cmake-3.31.0-linux-aarch64.tar.gz to /root/.conan2/p/b/cmake7a1436be1bd0b/b
cmake/3.31.0: Package 'c93719558cf197f1df5a7f1d071093e26f0e44a0' built
cmake/3.31.0: Build folder /root/.conan2/p/b/cmake7a1436be1bd0b/b
cmake/3.31.0: Generating the package
cmake/3.31.0: Packaging in folder /root/.conan2/p/b/cmake7a1436be1bd0b/p
cmake/3.31.0: Calling package()
cmake/3.31.0: package(): Packaged 8 '.sh' files
cmake/3.31.0: package(): Packaged 10 files
cmake/3.31.0: package(): Packaged 74 '.txt' files
cmake/3.31.0: package(): Packaged 1 '.m4' file: cmake.m4
cmake/3.31.0: package(): Packaged 8 '.png' files
cmake/3.31.0: package(): Packaged 1 '.el' file: cmake-mode.el
cmake/3.31.0: package(): Packaged 2 '.xml' files: cmakecache.xml, nasm.xml
cmake/3.31.0: package(): Packaged 2 '.vim' files: cmake.vim, cmake.vim
cmake/3.31.0: package(): Packaged 1 '.desktop' file: cmake-gui.desktop
cmake/3.31.0: package(): Packaged 2071 '.rst' files
cmake/3.31.0: package(): Packaged 1 '.make' file: CTEST_EXAMPLE_MAKEFILE_JOB_SERVER.make
cmake/3.31.0: package(): Packaged 39 '.json' files
cmake/3.31.0: package(): Packaged 4 '.h' files: cmCPluginAPI.h, CXX-DetectStdlib.h, CMakeCompilerCUDAArch.h, CMakeCompilerABI.h
cmake/3.31.0: package(): Packaged 104 '.in' files
cmake/3.31.0: package(): Packaged 1 '.plist' file: AppleInfo.plist
cmake/3.31.0: package(): Packaged 2 '.vsmacros' files: CMakeVSMacros1.vsmacros, CMakeVSMacros2.vsmacros
cmake/3.31.0: package(): Packaged 2 '.targets' files: nasm.targets, CustomBuildDepFile.targets
cmake/3.31.0: package(): Packaged 1 '.pfx' file: Windows_TemporaryKey.pfx
cmake/3.31.0: package(): Packaged 1349 '.cmake' files
cmake/3.31.0: package(): Packaged 2 '.bat' files: Squish4RunTestCase.bat, SquishRunTestCase.bat
cmake/3.31.0: package(): Packaged 6 '.cxx' files
cmake/3.31.0: package(): Packaged 15 '.c' files
cmake/3.31.0: package(): Packaged 1 '.ispc' file: CMakeISPCCompilerABI.ispc
cmake/3.31.0: package(): Packaged 1 '.F90' file: CMakeFortranCompilerABI.F90
cmake/3.31.0: package(): Packaged 1 '.cu' file: CMakeCUDACompilerABI.cu
cmake/3.31.0: package(): Packaged 3 '.cpp' files: CMakeCXXCompilerABI.cpp, main.cpp, foo.cpp
cmake/3.31.0: package(): Packaged 2 '.F' files: CMakeFortranCompilerABI.F, main.F
cmake/3.31.0: package(): Packaged 1 '.hip' file: CMakeHIPCompilerABI.hip
cmake/3.31.0: package(): Packaged 1 '.mm' file: CMakeOBJCXXCompilerABI.mm
cmake/3.31.0: package(): Packaged 1 '.m' file: CMakeOBJCCompilerABI.m
cmake/3.31.0: package(): Packaged 7 '.f' files
cmake/3.31.0: package(): Packaged 3 '.f90' files: my_module.f90, mymodule.f90, call_mod.f90
cmake/3.31.0: package(): Packaged 1 '.pas' file: ISComponents.pas
cmake/3.31.0: Created package revision 06be6a543c1488c5e08844493b0894c1
cmake/3.31.0: Package 'c93719558cf197f1df5a7f1d071093e26f0e44a0' created
cmake/3.31.0: Full package reference: cmake/3.31.0#ba7dbf3b2fc9e70653b4c0fb5bbd2483:c93719558cf197f1df5a7f1d071093e26f0e44a0#06be6a543c1488c5e08844493b0894c1
cmake/3.31.0: Package folder /root/.conan2/p/b/cmake7a1436be1bd0b/p
cmake/3.31.0: Appending PATH environment variable: /root/.conan2/p/b/cmake7a1436be1bd0b/p/bin
scnlib/3.0.2: Calling source() in /root/.conan2/p/scnlie36abdbb458c7/s/src
scnlib/3.0.2: Unzipping v3.0.2.tar.gz to .

-------- Installing package scnlib/3.0.2 (3 of 3) --------
scnlib/3.0.2: Building from source
scnlib/3.0.2: Package scnlib/3.0.2:d584eb36b6d64c5fdcc195be2a00938c418de927
scnlib/3.0.2: Copying sources to build folder
scnlib/3.0.2: Building your package in /root/.conan2/p/b/scnli5cac88a8e80ea/b
scnlib/3.0.2: Calling generate()
scnlib/3.0.2: Generators folder: /root/.conan2/p/b/scnli5cac88a8e80ea/b/build/Release/generators
scnlib/3.0.2: CMakeToolchain generated: conan_toolchain.cmake
scnlib/3.0.2: CMakeToolchain generated: /root/.conan2/p/b/scnli5cac88a8e80ea/b/build/Release/generators/CMakePresets.json
scnlib/3.0.2: CMakeToolchain generated: /root/.conan2/p/b/scnli5cac88a8e80ea/b/src/CMakeUserPresets.json
scnlib/3.0.2: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(FastFloat)
    target_link_libraries(... FastFloat::fast_float)
scnlib/3.0.2: Generating aggregated env files
scnlib/3.0.2: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
scnlib/3.0.2: Calling build()
scnlib/3.0.2: Running CMake.configure()
scnlib/3.0.2: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/root/.conan2/p/b/scnli5cac88a8e80ea/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/root/.conan2/p/b/scnli5cac88a8e80ea/b/src"
-- Using Conan toolchain: /root/.conan2/p/b/scnli5cac88a8e80ea/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: C++ Standard 17 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'FastFloat::fast_float'
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /root/.conan2/p/b/scnli5cac88a8e80ea/b/build/Release
scnlib/3.0.2: Running CMake.build()
scnlib/3.0.2: RUN: cmake --build "/root/.conan2/p/b/scnli5cac88a8e80ea/b/build/Release" -- -j2
[ 50%] Building CXX object CMakeFiles/scn.dir/src/scn/impl.cpp.o
[100%] Linking CXX static library libscn.a
[100%] Built target scn
scnlib/3.0.2: Package 'd584eb36b6d64c5fdcc195be2a00938c418de927' built
scnlib/3.0.2: Build folder /root/.conan2/p/b/scnli5cac88a8e80ea/b/build/Release
scnlib/3.0.2: Generating the package
scnlib/3.0.2: Packaging in folder /root/.conan2/p/b/scnli5cac88a8e80ea/p
scnlib/3.0.2: Calling package()
scnlib/3.0.2: Running CMake.install()
scnlib/3.0.2: RUN: cmake --install "/root/.conan2/p/b/scnli5cac88a8e80ea/b/build/Release" --prefix "/root/.conan2/p/b/scnli5cac88a8e80ea/p"
-- Install configuration: "Release"
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/lib/libscn.a
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/include
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/include/scn
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/include/scn/ranges.h
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/include/scn/fwd.h
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/include/scn/istream.h
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/include/scn/xchar.h
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/include/scn/scan.h
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/include/scn/regex.h
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/lib/cmake/scn/scn-targets.cmake
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/lib/cmake/scn/scn-targets-release.cmake
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/lib/cmake/scn/scn-config.cmake
-- Installing: /root/.conan2/p/b/scnli5cac88a8e80ea/p/lib/cmake/scn/scn-config-version.cmake

scnlib/3.0.2: package(): Packaged 1 file: LICENSE
scnlib/3.0.2: package(): Packaged 1 '.a' file: libscn.a
scnlib/3.0.2: package(): Packaged 6 '.h' files
scnlib/3.0.2: Created package revision 1a88639657a3aabb5c149d52a32ae5de
scnlib/3.0.2: Package 'd584eb36b6d64c5fdcc195be2a00938c418de927' created
scnlib/3.0.2: Full package reference: scnlib/3.0.2#be40c573e6227ffb7719e7a2b02f05e5:d584eb36b6d64c5fdcc195be2a00938c418de927#1a88639657a3aabb5c149d52a32ae5de
scnlib/3.0.2: Package folder /root/.conan2/p/b/scnli5cac88a8e80ea/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'env_info' used in: cmake/3.31.0
WARN: deprecated:     'cpp_info.names' used in: scnlib/3.0.2, fast_float/6.1.0

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    scnlib/3.0.2 (test package): /root/conanrunner/all/test_package/conanfile.py
Requirements
    fast_float/6.1.0#f6088e57bf83ac9f9b3abf37fe766cea - Cache
    scnlib/3.0.2#be40c573e6227ffb7719e7a2b02f05e5 - Cache
Build requirements
    cmake/3.31.0#ba7dbf3b2fc9e70653b4c0fb5bbd2483 - Cache

======== Computing necessary packages ========
Requirements
    scnlib/3.0.2#be40c573e6227ffb7719e7a2b02f05e5:d584eb36b6d64c5fdcc195be2a00938c418de927#1a88639657a3aabb5c149d52a32ae5de - Cache
Build requirements
Skipped binaries
    fast_float/6.1.0, cmake/3.31.0

======== Installing packages ========
scnlib/3.0.2: Already installed! (1 of 1)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: scnlib/3.0.2

======== Testing the package ========
Removing previously existing 'test_package' build folder: /root/conanrunner/all/test_package/build/gcc-11-armv8-gnu17-release
scnlib/3.0.2 (test package): Test package build: build/gcc-11-armv8-gnu17-release
scnlib/3.0.2 (test package): Test package build folder: /root/conanrunner/all/test_package/build/gcc-11-armv8-gnu17-release
scnlib/3.0.2 (test package): Writing generators to /root/conanrunner/all/test_package/build/gcc-11-armv8-gnu17-release/generators
scnlib/3.0.2 (test package): Generator 'CMakeDeps' calling 'generate()'
scnlib/3.0.2 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(scn)
    target_link_libraries(... scn::scn)
scnlib/3.0.2 (test package): Generator 'CMakeToolchain' calling 'generate()'
scnlib/3.0.2 (test package): CMakeToolchain generated: conan_toolchain.cmake
scnlib/3.0.2 (test package): CMakeToolchain generated: /root/conanrunner/all/test_package/build/gcc-11-armv8-gnu17-release/generators/CMakePresets.json
scnlib/3.0.2 (test package): CMakeToolchain generated: /root/conanrunner/all/test_package/CMakeUserPresets.json
scnlib/3.0.2 (test package): Generator 'VirtualRunEnv' calling 'generate()'
scnlib/3.0.2 (test package): Generating aggregated env files
scnlib/3.0.2 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
scnlib/3.0.2 (test package): Calling build()
scnlib/3.0.2 (test package): Running CMake.configure()
scnlib/3.0.2 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/root/conanrunner/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/root/conanrunner/all/test_package"
-- Using Conan toolchain: /root/conanrunner/all/test_package/build/gcc-11-armv8-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'scn::scn'
-- Configuring done
-- Generating done
-- Build files have been written to: /root/conanrunner/all/test_package/build/gcc-11-armv8-gnu17-release
scnlib/3.0.2 (test package): Running CMake.build()
scnlib/3.0.2 (test package): RUN: cmake --build "/root/conanrunner/all/test_package/build/gcc-11-armv8-gnu17-release" -- -j2
gmake: Warning: File 'Makefile' has modification time 0.18 s in the future
gmake[1]: Warning: File 'CMakeFiles/Makefile2' has modification time 0.18 s in the future
gmake[2]: Warning: File 'CMakeFiles/test_package.dir/flags.make' has modification time 0.17 s in the future
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
gmake[2]: Warning: File 'CMakeFiles/test_package.dir/flags.make' has modification time 0.17 s in the future
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
gmake[2]: warning:  Clock skew detected.  Your build may be incomplete.
[100%] Built target test_package
gmake[1]: warning:  Clock skew detected.  Your build may be incomplete.
gmake: warning:  Clock skew detected.  Your build may be incomplete.


======== Testing the package: Executing test ========
scnlib/3.0.2 (test package): Running test()
scnlib/3.0.2 (test package): RUN: ./test_package
Hello


┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
| Running in container: "conan cache save --list=pkglist.json --file "/root/conanrunner/all"/.conanrunner/docker_cache_save.tgz" |
```

</details>