### PR TITLE
hdf5/1.14.5: fix zlib-ng, add lib infix, disable utils

### DIFF
--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -177,6 +177,7 @@ class Hdf5Conan(ConanFile):
         tc.variables["HDF5_INSTALL_INCLUDE_DIR"] = "include/hdf5"
 
         tc.variables["HDF5_BUILD_TOOLS"] = False
+        tc.variables["HDF5_BUILD_UTILS"] = False
         tc.variables["HDF5_BUILD_EXAMPLES"] = False
         tc.variables["HDF5_BUILD_HL_LIB"] = self.options.hl
         tc.variables["HDF5_BUILD_FORTRAN"] = False


### PR DESCRIPTION
### Summary
Changes to recipe:  **hdf5/1.14.5**

#### Motivation
This PR:
- fixes zlib-ng usage that hasn't been working at all. Closes #26233
- allows adding custom lib infixes which might help with name clashes. Closes #23741
- disable utils to make build faster and resulting packages slightly smaller

#### Details
It seems that using zlib-ng without compatibility isn't supported in 1.14.5 - even after adding workarounds for header name, target name, etc. there were errors during compilation because hdf5 code uses types that aren't present without compatibility (z_stream, for example). This might be changed with next release.

<details><summary>Log with lib infix and zlib-ng</summary>

```


======== Exporting recipe to the cache ========
hdf5/1.14.5: Exporting package recipe: C:\dev\conan\conan-center-index\recipes\hdf5\all\conanfile.py
hdf5/1.14.5: exports: File 'conandata.yml' found. Exporting it...
hdf5/1.14.5: Calling export_sources()
hdf5/1.14.5: Copied 1 '.yml' file: conandata.yml
hdf5/1.14.5: Copied 1 '.py' file: conanfile.py
hdf5/1.14.5: Exported to cache folder: C:\Users\Nekto\.conan2\p\hdf5ac6bc12373cdf\e
hdf5/1.14.5: Exported: hdf5/1.14.5#9350f66b2f28daa124d726a367f744d7 (2024-12-20 14:02:53 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=msvc
compiler.cppstd=17
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows
[options]
hdf5/*:enable_cxx=False
hdf5/*:hl=False
hdf5/*:lib_infix=_1.14.5
hdf5/*:shared=False
hdf5/*:threadsafe=True
hdf5/*:with_zlib=False
hdf5/*:with_zlibng=True
zlib-ng/*:zlib_compat=True

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=msvc
compiler.cppstd=17
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows


======== Computing dependency graph ========
Graph root
    cli
Requirements
    hdf5/1.14.5#9350f66b2f28daa124d726a367f744d7 - Cache
    zlib-ng/2.2.2#894a58b509be21a864c41b3bd154e92f - Cache
Build requirements
    cmake/3.31.0#ba7dbf3b2fc9e70653b4c0fb5bbd2483 - Cache
Resolved version ranges
    cmake/[>=3.18 <4]: cmake/3.31.0

======== Computing necessary packages ========
hdf5/1.14.5: Main binary package '040e6098b3810087ef9cec9594b2cbcc7a59bcb1' missing
hdf5/1.14.5: Checking 1 compatible configurations
hdf5/1.14.5: Compatible configurations not found in cache, checking servers
hdf5/1.14.5: '7c6eef5f23dca9de4a9455d199a933935c20e279': compiler.version=193
Requirements
    hdf5/1.14.5#9350f66b2f28daa124d726a367f744d7:040e6098b3810087ef9cec9594b2cbcc7a59bcb1 - Build
    zlib-ng/2.2.2#894a58b509be21a864c41b3bd154e92f:832599b4571f8d042f2034987cf86cf4512ce10f#ed0e05b99106f8f5ccaf99ad967b550e - Cache
Build requirements
    cmake/3.31.0#ba7dbf3b2fc9e70653b4c0fb5bbd2483:522dcea5982a3f8a5b624c16477e47195da2f84f#0d3590c43637cae952cc4bad766ca336 - Cache

======== Installing packages ========
cmake/3.31.0: Already installed! (1 of 3)
cmake/3.31.0: Appending PATH environment variable: C:\Users\Nekto\.conan2\p\cmake3b664862bb1ed\p\bin
zlib-ng/2.2.2: Already installed! (2 of 3)
hdf5/1.14.5: Calling source() in C:\Users\Nekto\.conan2\p\hdf5ac6bc12373cdf\s\src
hdf5/1.14.5: Downloading 37.8MB hdf5_1.14.5.tar.gz
hdf5/1.14.5: Unzipping hdf5_1.14.5.tar.gz to .

-------- Installing package hdf5/1.14.5 (3 of 3) --------
hdf5/1.14.5: Building from source
hdf5/1.14.5: Package hdf5/1.14.5:040e6098b3810087ef9cec9594b2cbcc7a59bcb1
hdf5/1.14.5: Copying sources to build folder
hdf5/1.14.5: Building your package in C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b
hdf5/1.14.5: Calling generate()
hdf5/1.14.5: Generators folder: C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\generators
hdf5/1.14.5: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(ZLIB)
    target_link_libraries(... ZLIB::ZLIB)
hdf5/1.14.5: CMakeToolchain generated: conan_toolchain.cmake
hdf5/1.14.5: CMakeToolchain generated: C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\generators\CMakePresets.json
hdf5/1.14.5: CMakeToolchain generated: C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\CMakeUserPresets.json
hdf5/1.14.5: Generating aggregated env files
hdf5/1.14.5: Generated aggregated env files: ['conanbuild.bat', 'conanrun.bat']
hdf5/1.14.5: Calling build()
hdf5/1.14.5: Running CMake.configure()
hdf5/1.14.5: RUN: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/b/src"
-- Using Conan toolchain: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/b/build/generators/conan_toolchain.cmake
-- Conan toolchain: CMAKE_GENERATOR_TOOLSET=v143
-- Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Release>:MultiThreadedDLL>
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- Selecting Windows SDK version 10.0.22000.0 to target Windows 10.0.22631.
-- The C compiler identification is MSVC 19.40.33812.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Final: .
-- Looking for include file sys/file.h
-- Looking for include file sys/file.h - not found
-- Looking for include file sys/ioctl.h
-- Looking for include file sys/ioctl.h - not found
-- Looking for include file sys/resource.h
-- Looking for include file sys/resource.h - not found
-- Looking for include file sys/socket.h
-- Looking for include file sys/socket.h - not found
-- Looking for include file sys/stat.h
-- Looking for include file sys/stat.h - found
-- Looking for include files sys/stat.h, sys/time.h
-- Looking for include files sys/stat.h, sys/time.h - not found
-- Looking for include files sys/stat.h, sys/types.h
-- Looking for include files sys/stat.h, sys/types.h - found
-- Looking for 3 include files sys/stat.h, ..., features.h
-- Looking for 3 include files sys/stat.h, ..., features.h - not found
-- Looking for 3 include files sys/stat.h, ..., dirent.h
-- Looking for 3 include files sys/stat.h, ..., dirent.h - not found
-- Looking for 3 include files sys/stat.h, ..., unistd.h
-- Looking for 3 include files sys/stat.h, ..., unistd.h - not found
-- Looking for 3 include files sys/stat.h, ..., pwd.h
-- Looking for 3 include files sys/stat.h, ..., pwd.h - not found
-- Looking for 3 include files sys/stat.h, ..., pthread.h
-- Looking for 3 include files sys/stat.h, ..., pthread.h - not found
-- Looking for 3 include files sys/stat.h, ..., dlfcn.h
-- Looking for 3 include files sys/stat.h, ..., dlfcn.h - not found
-- Looking for 3 include files sys/stat.h, ..., netinet/in.h
-- Looking for 3 include files sys/stat.h, ..., netinet/in.h - not found
-- Looking for 3 include files sys/stat.h, ..., netdb.h
-- Looking for 3 include files sys/stat.h, ..., netdb.h - not found
-- Looking for 3 include files sys/stat.h, ..., arpa/inet.h
-- Looking for 3 include files sys/stat.h, ..., arpa/inet.h - not found
-- Looking for 3 include files sys/stat.h, ..., shlwapi.h
-- Looking for 3 include files sys/stat.h, ..., shlwapi.h - found
-- Looking for include file quadmath.h
-- Looking for include file quadmath.h - not found
-- Looking for gethostname in ucb;
-- Looking for gethostname in ucb; - not found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of char
-- Check size of char - done
-- Check size of short
-- Check size of short - done
-- Check size of int
-- Check size of int - done
-- Check size of unsigned
-- Check size of unsigned - done
-- Check size of long
-- Check size of long - done
-- Check size of long long
-- Check size of long long - done
-- Check size of float
-- Check size of float - done
-- Check size of double
-- Check size of double - done
-- Check size of long double
-- Check size of long double - done
-- Check size of int8_t
-- Check size of int8_t - done
-- Check size of uint8_t
-- Check size of uint8_t - done
-- Check size of int_least8_t
-- Check size of int_least8_t - done
-- Check size of uint_least8_t
-- Check size of uint_least8_t - done
-- Check size of int_fast8_t
-- Check size of int_fast8_t - done
-- Check size of uint_fast8_t
-- Check size of uint_fast8_t - done
-- Check size of int16_t
-- Check size of int16_t - done
-- Check size of uint16_t
-- Check size of uint16_t - done
-- Check size of int_least16_t
-- Check size of int_least16_t - done
-- Check size of uint_least16_t
-- Check size of uint_least16_t - done
-- Check size of int_fast16_t
-- Check size of int_fast16_t - done
-- Check size of uint_fast16_t
-- Check size of uint_fast16_t - done
-- Check size of int32_t
-- Check size of int32_t - done
-- Check size of uint32_t
-- Check size of uint32_t - done
-- Check size of int_least32_t
-- Check size of int_least32_t - done
-- Check size of uint_least32_t
-- Check size of uint_least32_t - done
-- Check size of int_fast32_t
-- Check size of int_fast32_t - done
-- Check size of uint_fast32_t
-- Check size of uint_fast32_t - done
-- Check size of int64_t
-- Check size of int64_t - done
-- Check size of uint64_t
-- Check size of uint64_t - done
-- Check size of int_least64_t
-- Check size of int_least64_t - done
-- Check size of uint_least64_t
-- Check size of uint_least64_t - done
-- Check size of int_fast64_t
-- Check size of int_fast64_t - done
-- Check size of uint_fast64_t
-- Check size of uint_fast64_t - done
-- Check size of size_t
-- Check size of size_t - done
-- Check size of ssize_t
-- Check size of ssize_t - failed
-- Check size of off_t
-- Check size of off_t - done
-- Check size of time_t
-- Check size of time_t - done
-- Check size of _Bool
-- Check size of _Bool - done
-- Looking for alarm
-- Looking for alarm - not found
-- Looking for fcntl
-- Looking for fcntl - not found
-- Looking for flock
-- Looking for flock - not found
-- Looking for fork
-- Looking for fork - not found
-- Looking for getrusage
-- Looking for getrusage - not found
-- Looking for pread
-- Looking for pread - not found
-- Looking for pwrite
-- Looking for pwrite - not found
-- Looking for rand_r
-- Looking for rand_r - not found
-- Looking for random
-- Looking for random - not found
-- Looking for strcasestr
-- Looking for strcasestr - not found
-- Looking for symlink
-- Looking for symlink - not found
-- Looking for tmpfile
-- Looking for tmpfile - found
-- Looking for asprintf
-- Looking for asprintf - not found
-- Looking for vasprintf
-- Looking for vasprintf - not found
-- Looking for waitpid
-- Looking for waitpid - not found
-- Looking for sigsetjmp
-- Looking for sigsetjmp - not found
-- Check size of CLOCK_MONOTONIC_COARSE
-- Check size of CLOCK_MONOTONIC_COARSE - failed
-- Checking if _Float16 support is available
-- Check size of _Float16
-- Check size of _Float16 - failed
-- _Float16 support has been disabled since the _Float16 type was not found
-- Could NOT find Perl (missing: PERL_EXECUTABLE) 
-- ....All Warnings are enabled
-- Conan: Target declared 'ZLIB::ZLIB'
-- Filter PLUGIN file is /
-- Configuring done (51.9s)
-- Generating done (0.1s)
-- Build files have been written to: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/b/build

hdf5/1.14.5: Running CMake.build()
hdf5/1.14.5: RUN: cmake --build "C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build" --config Release
MSBuild version 17.10.4+10fbfbf2e for .NET Framework

  1>Checking Build System
  Building Custom Rule C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/b/src/src/CMakeLists.txt
  H5.c
  H5build_settings.c
  H5checksum.c
  H5dbg.c
  H5mpi.c
  H5system.c
  H5timer.c
  H5trace.c
  H5A.c
  H5Abtree2.c
  H5Adense.c
  H5Adeprec.c
  H5Aint.c
  H5Atest.c
  H5AC.c
  H5ACdbg.c
  H5ACmpio.c
  H5ACproxy_entry.c
  H5B.c
  H5Bcache.c
  H5Bdbg.c
  H5B2.c
  H5B2cache.c
  H5B2dbg.c
  H5B2hdr.c
  H5B2int.c
  H5B2internal.c
  H5B2leaf.c
  H5B2stat.c
  H5B2test.c
  H5C.c
  H5Cdbg.c
  H5Centry.c
  H5Cepoch.c
  H5Cimage.c
  H5Cint.c
C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\src\H5B2internal.c(622,107): warning C4018: '>=': signed/unsigned mismatch [C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\hdf5-static.vcxproj]
  H5Clog.c
  H5Clog_json.c
  H5Clog_trace.c
  H5Cmpio.c
  H5Cprefetched.c
C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\src\H5B2internal.c(628,107): warning C4018: '>=': signed/unsigned mismatch [C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\hdf5-static.vcxproj]
  H5Cquery.c
C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\src\H5B2internal.c(634,107): warning C4018: '>=': signed/unsigned mismatch [C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\hdf5-static.vcxproj]
C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\src\H5B2internal.c(639,75): warning C4018: '>=': signed/unsigned mismatch [C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\hdf5-static.vcxproj]
  H5Ctag.c
  H5Ctest.c
  H5CX.c
  H5D.c
  H5Dbtree.c
  H5Dbtree2.c
  H5Dchunk.c
  H5Dcompact.c
  H5Dcontig.c
  H5Ddbg.c
  H5Ddeprec.c
  H5Dearray.c
  H5Defl.c
  H5Dfarray.c
  H5Dfill.c
  H5Dint.c
  H5Dio.c
  H5Dlayout.c
  H5Dmpio.c
  H5Dnone.c
  H5Doh.c
  H5Dscatgath.c
  H5Dselect.c
  H5Dsingle.c
  H5Dtest.c
  H5Dvirtual.c
  H5E.c
  H5Edeprec.c
  H5Eint.c
  H5EA.c
  H5EAcache.c
  H5EAdbg.c
  H5EAdblkpage.c
  H5EAdblock.c
  H5EAhdr.c
  H5EAiblock.c
  H5EAint.c
  H5EAsblock.c
  H5EAstat.c
  H5EAtest.c
  H5ES.c
  H5ESevent.c
  H5ESint.c
  H5ESlist.c
  H5F.c
  H5Faccum.c
  H5Fcwfs.c
  H5Fdbg.c
  H5Fdeprec.c
  H5Fefc.c
  H5Ffake.c
  H5Fint.c
  H5Fio.c
  H5Fmount.c
  H5Fmpi.c
  H5Fquery.c
  H5Fsfile.c
  H5Fspace.c
  H5Fsuper.c
  H5Fsuper_cache.c
  H5Ftest.c
  H5FA.c
  H5FAcache.c
  H5FAdbg.c
  H5FAdblkpage.c
  H5FAdblock.c
  H5FAhdr.c
  H5FAint.c
  H5FAstat.c
  H5FAtest.c
  H5FD.c
  H5FDcore.c
  H5FDdirect.c
  H5FDfamily.c
  H5FDhdfs.c
  H5FDint.c
  H5FDlog.c
  H5FDmirror.c
  H5FDmpi.c
  H5FDmpio.c
  H5FDmulti.c
  H5FDonion.c
  H5FDonion_header.c
  H5FDonion_history.c
  H5FDonion_index.c
  H5FDperform.c
  H5FDros3.c
  H5FDs3comms.c
  H5FDsec2.c
  H5FDspace.c
  H5FDsplitter.c
  H5FDstdio.c
  H5FDtest.c
  H5FDwindows.c
  H5FL.c
  H5FO.c
  H5FS.c
  H5FScache.c
  H5FSdbg.c
  H5FSint.c
  H5FSsection.c
  H5FSstat.c
  H5FStest.c
  H5G.c
  H5Gbtree2.c
  H5Gcache.c
  H5Gcompact.c
  H5Gdense.c
  H5Gdeprec.c
  H5Gent.c
  H5Gint.c
  H5Glink.c
  H5Gloc.c
  H5Gname.c
  H5Gnode.c
  H5Gobj.c
  H5Goh.c
  H5Groot.c
  H5Gstab.c
  H5Gtest.c
  H5Gtraverse.c
  H5HF.c
  H5HFbtree2.c
  H5HFcache.c
  H5HFdbg.c
  H5HFdblock.c
  H5HFdtable.c
  H5HFhdr.c
  H5HFhuge.c
  H5HFiblock.c
  H5HFiter.c
  H5HFman.c
  H5HFsection.c
  H5HFspace.c
  H5HFstat.c
  H5HFtest.c
  H5HFtiny.c
C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\src\H5HFcache.c(713,12): warning C4090: '=': different 'const' qualifiers [C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\hdf5-static.vcxproj]
C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\src\H5HFcache.c(1277,12): warning C4090: '=': different 'const' qualifiers [C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\hdf5-static.vcxproj]
  H5HG.c
  H5HGcache.c
  H5HGdbg.c
  H5HGquery.c
  H5HL.c
  H5HLcache.c
C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\src\H5HFhuge.c(195,51): warning C4018: '<=': signed/unsigned mismatch [C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\hdf5-static.vcxproj]
  H5HLdbg.c
  H5HLdblk.c
  H5HLint.c
  H5HLprfx.c
  H5I.c
  H5Idbg.c
  H5Iint.c
  H5Itest.c
  H5L.c
  H5Ldeprec.c
  H5Lexternal.c
  H5Lint.c
  H5M.c
  H5MF.c
  H5MFaggr.c
  H5MFdbg.c
  H5MFsection.c
  H5MM.c
  H5O.c
  H5Oainfo.c
  H5Oalloc.c
  H5Oattr.c
  H5Oattribute.c
  H5Obogus.c
  H5Obtreek.c
  H5Ocache.c
  H5Ocache_image.c
  H5Ochunk.c
  H5Ocont.c
  H5Ocopy.c
  H5Ocopy_ref.c
  H5Odbg.c
  H5Odeprec.c
  H5Odrvinfo.c
  H5Odtype.c
  H5Oefl.c
  H5Ofill.c
  H5Oflush.c
  H5Ofsinfo.c
  H5Oginfo.c
  H5Oint.c
  H5Olayout.c
  H5Olinfo.c
  H5Olink.c
  H5Omessage.c
  H5Omtime.c
  H5Oname.c
  H5Onull.c
  H5Opline.c
  H5Orefcount.c
  H5Osdspace.c
  H5Oshared.c
  H5Oshmesg.c
  H5Ostab.c
  H5Otest.c
  H5Ounknown.c
  H5P.c
  H5Pacpl.c
  H5Pdapl.c
  H5Pdcpl.c
  H5Pdeprec.c
  H5Pdxpl.c
  H5Pencdec.c
  H5Pfapl.c
  H5Pfcpl.c
  H5Pfmpl.c
  H5Pgcpl.c
  H5Pint.c
  H5Plapl.c
  H5Plcpl.c
  H5Pmapl.c
  H5Pmcpl.c
  H5Pocpl.c
  H5Pocpypl.c
  H5Pstrcpl.c
  H5Ptest.c
  H5PB.c
  H5PL.c
  H5PLint.c
  H5PLpath.c
  H5PLplugin_cache.c
  H5R.c
  H5Rdeprec.c
  H5Rint.c
  H5UC.c
  H5RS.c
  H5S.c
  H5Sall.c
  H5Sdbg.c
  H5Sdeprec.c
  H5Shyper.c
  H5Smpio.c
  H5Snone.c
  H5Spoint.c
  H5Sselect.c
  H5Stest.c
  H5SL.c
  H5SM.c
  H5SMbtree2.c
  H5SMcache.c
  H5SMmessage.c
  H5SMtest.c
  H5T.c
  H5Tarray.c
  H5Tbit.c
  H5Tcommit.c
  H5Tcompound.c
  H5Tconv.c
  H5Tconv_integer.c
  H5Tconv_float.c
  H5Tconv_string.c
  H5Tconv_bitfield.c
  H5Tconv_compound.c
  H5Tconv_reference.c
  H5Tconv_enum.c
  H5Tconv_vlen.c
  H5Tconv_array.c
  H5Tcset.c
  H5Tdbg.c
  H5Tdeprec.c
  H5Tenum.c
  H5Tfields.c
  H5Tfixed.c
  H5Tfloat.c
  H5Tinit_float.c
  H5Tnative.c
  H5Toffset.c
  H5Toh.c
  H5Topaque.c
  H5Torder.c
  H5Tpad.c
  H5Tprecis.c
  H5Tref.c
  H5Tstrpad.c
  H5Tvisit.c
  H5Tvlen.c
  H5TS.c
  H5VL.c
  H5VLcallback.c
  H5VLdyn_ops.c
  H5VLint.c
  H5VLnative.c
  H5VLnative_attr.c
  H5VLnative_blob.c
  H5VLnative_dataset.c
  H5VLnative_datatype.c
  H5VLnative_file.c
  H5VLnative_group.c
  H5VLnative_link.c
  H5VLnative_introspect.c
  H5VLnative_object.c
  H5VLnative_token.c
  H5VLpassthru.c
  H5VLtest.c
  H5VM.c
  H5WB.c
  H5Z.c
  H5Zfletcher32.c
  H5Znbit.c
  H5Zscaleoffset.c
  H5Zshuffle.c
  H5Zszip.c
  H5Ztrans.c
  H5Zdeflate.c
C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\src\src\H5Zdeflate.c(150,59): warning C4267: 'function': conversion from 'size_t' to 'unsigned long', possible loss of data [C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\hdf5-static.vcxproj]
  hdf5-static.vcxproj -> C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build\src\Release\libhdf5_1.14.5.lib
  Building Custom Rule C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/b/src/CMakeLists.txt

hdf5/1.14.5: Package '040e6098b3810087ef9cec9594b2cbcc7a59bcb1' built
hdf5/1.14.5: Build folder C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build
hdf5/1.14.5: Generating the package
hdf5/1.14.5: Packaging in folder C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\p
hdf5/1.14.5: Calling package()
hdf5/1.14.5: Running CMake.install()
hdf5/1.14.5: RUN: cmake --install "C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\b\build" --config Release --prefix "C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p"
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/hdf5.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5api_adpt.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5encode.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5public.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Apublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5ACpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Cpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Dpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Epubgen.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Epublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5ESdevelop.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5ESpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Fpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDcore.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDdevelop.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDdirect.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDfamily.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDhdfs.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDlog.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDmirror.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDmpi.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDmpio.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDmulti.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDonion.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDros3.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDs3comms.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDsec2.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDsplitter.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDstdio.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDwindows.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDsubfiling.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5FDioc.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Gpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Idevelop.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Ipublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Ldevelop.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Lpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Mpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5MMpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Opublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Ppublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5PLextern.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5PLpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Rpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Spublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Tdevelop.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Tpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5TSdevelop.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5VLconnector.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5VLconnector_passthru.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5VLnative.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5VLpassthru.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5VLpublic.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Zdevelop.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Zpublic.h
-- Up-to-date: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5Epubgen.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5version.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5overflow.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/include/hdf5/H5pubconf.h
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/lib/libhdf5_1.14.5.lib
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/lib/pkgconfig/hdf5.pc
-- Installing: C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/lib/libhdf5.settings

hdf5/1.14.5: package(): Packaged 59 '.h' files
hdf5/1.14.5: package(): Packaged 1 '.lib' file: libhdf5_1.14.5.lib
hdf5/1.14.5: package(): Packaged 2 '.cmake' files: conan-official-hdf5-targets.cmake, conan-official-hdf5-variables.cmake
hdf5/1.14.5: package(): Packaged 1 file: COPYING
hdf5/1.14.5: Created package revision 193317be3b0f79f1d2bdbd0b740d989d
hdf5/1.14.5: Package '040e6098b3810087ef9cec9594b2cbcc7a59bcb1' created
hdf5/1.14.5: Full package reference: hdf5/1.14.5#9350f66b2f28daa124d726a367f744d7:040e6098b3810087ef9cec9594b2cbcc7a59bcb1#193317be3b0f79f1d2bdbd0b740d989d
hdf5/1.14.5: Package folder C:\Users\Nekto\.conan2\p\b\hdf53e9e496765834\p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'env_info' used in: cmake/3.31.0
WARN: deprecated:     'cpp_info.names' used in: hdf5/1.14.5, zlib-ng/2.2.2
WARN: deprecated:     'cpp_info.build_modules' used in: hdf5/1.14.5

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    hdf5/1.14.5 (test package): C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\conanfile.py
Requirements
    hdf5/1.14.5#9350f66b2f28daa124d726a367f744d7 - Cache
    zlib-ng/2.2.2#894a58b509be21a864c41b3bd154e92f - Cache
Build requirements
    cmake/3.31.0#ba7dbf3b2fc9e70653b4c0fb5bbd2483 - Cache

======== Computing necessary packages ========
Requirements
    hdf5/1.14.5#9350f66b2f28daa124d726a367f744d7:040e6098b3810087ef9cec9594b2cbcc7a59bcb1#193317be3b0f79f1d2bdbd0b740d989d - Cache
    zlib-ng/2.2.2#894a58b509be21a864c41b3bd154e92f:832599b4571f8d042f2034987cf86cf4512ce10f#ed0e05b99106f8f5ccaf99ad967b550e - Cache
Build requirements
Skipped binaries
    cmake/3.31.0

======== Installing packages ========
zlib-ng/2.2.2: Already installed! (1 of 2)
hdf5/1.14.5: Already installed! (2 of 2)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: hdf5/1.14.5, zlib-ng/2.2.2
WARN: deprecated:     'cpp_info.build_modules' used in: hdf5/1.14.5

======== Testing the package ========
Removing previously existing 'test_package' build folder: C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\build\msvc-194-x86_64-17-release
hdf5/1.14.5 (test package): Test package build: build\msvc-194-x86_64-17-release
hdf5/1.14.5 (test package): Test package build folder: C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\build\msvc-194-x86_64-17-release
hdf5/1.14.5 (test package): Writing generators to C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\build\msvc-194-x86_64-17-release\generators
hdf5/1.14.5 (test package): Generator 'CMakeDeps' calling 'generate()'
hdf5/1.14.5 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(HDF5)
    target_link_libraries(... HDF5::HDF5)
hdf5/1.14.5 (test package): Generator 'VirtualRunEnv' calling 'generate()'
hdf5/1.14.5 (test package): Calling generate()
hdf5/1.14.5 (test package): Generators folder: C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\build\msvc-194-x86_64-17-release\generators
hdf5/1.14.5 (test package): CMakeToolchain generated: conan_toolchain.cmake
hdf5/1.14.5 (test package): CMakeToolchain generated: C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\build\msvc-194-x86_64-17-release\generators\CMakePresets.json
hdf5/1.14.5 (test package): CMakeToolchain generated: C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\CMakeUserPresets.json
hdf5/1.14.5 (test package): Generating aggregated env files
hdf5/1.14.5 (test package): Generated aggregated env files: ['conanrun.bat', 'conanbuild.bat']

======== Testing the package: Building ========
hdf5/1.14.5 (test package): Calling build()
hdf5/1.14.5 (test package): Running CMake.configure()
hdf5/1.14.5 (test package): RUN: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/dev/conan/conan-center-index/recipes/hdf5/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "C:/dev/conan/conan-center-index/recipes/hdf5/all/test_package"
-- Using Conan toolchain: C:/dev/conan/conan-center-index/recipes/hdf5/all/test_package/build/msvc-194-x86_64-17-release/generators/conan_toolchain.cmake
-- Conan toolchain: CMAKE_GENERATOR_TOOLSET=v143
-- Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Release>:MultiThreadedDLL>
-- Conan toolchain: C++ Standard 17 with extensions OFF
-- Selecting Windows SDK version 10.0.22000.0 to target Windows 10.0.22631.
-- The C compiler identification is MSVC 19.40.33812.0
-- The CXX compiler identification is MSVC 19.40.33812.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'hdf5::hdf5'
-- Conan: Target declared 'HDF5::HDF5'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from 'C:/Users/Nekto/.conan2/p/b/hdf53e9e496765834/p/lib/cmake/conan-official-hdf5-variables.cmake'
-- Configuring done (2.7s)
-- Generating done (0.0s)
-- Build files have been written to: C:/dev/conan/conan-center-index/recipes/hdf5/all/test_package/build/msvc-194-x86_64-17-release

hdf5/1.14.5 (test package): Running CMake.build()
hdf5/1.14.5 (test package): RUN: cmake --build "C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\build\msvc-194-x86_64-17-release" --config Release
MSBuild version 17.10.4+10fbfbf2e for .NET Framework

  1>Checking Build System
  Building Custom Rule C:/dev/conan/conan-center-index/recipes/hdf5/all/test_package/CMakeLists.txt
  test_package.c
  test_package.vcxproj -> C:\dev\conan\conan-center-index\recipes\hdf5\all\test_package\build\msvc-194-x86_64-17-release\Release\test_package.exe
  Building Custom Rule C:/dev/conan/conan-center-index/recipes/hdf5/all/test_package/CMakeLists.txt


======== Testing the package: Executing test ========
hdf5/1.14.5 (test package): Running test()
hdf5/1.14.5 (test package): RUN: Release\test_package
Testing C API

```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
