### PR TITLE
added extra-cmake-modules 6.8.0

### DIFF
--- a/recipes/extra-cmake-modules/all/conandata.yml
+++ b/recipes/extra-cmake-modules/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.8.0":
+    url: "https://download.kde.org/stable/frameworks/6.8/extra-cmake-modules-6.8.0.tar.xz"
+    sha256: "ff8a0bf72285bec1768e3acd8f7c665a26d55a1527e96d73e35789dc9f0e3472" 
   "6.2.0":
     url: "https://download.kde.org/stable/frameworks/6.2/extra-cmake-modules-6.2.0.tar.xz"
     sha256: "6374bfa0dded8be265c702acd5de11eecd2851c625b93e1c87d8d0f5f1a8ebe1"
@@ -23,3 +26,8 @@ sources:
   "5.75.0":
     url: "https://download.kde.org/stable/frameworks/5.75/extra-cmake-modules-5.75.0.zip"
     sha256: "dc937fd2018eb8285c1b07d4b5de104c60959404c4979883f6bdb0a4d40cf98e"
+patches:
+  "6.8.0":
+    - patch_file: "patches/0001-fix-find_package-qt.patch"
+      patch_description: "fix find_package qt"
+      patch_type: "portability"

--- a/recipes/extra-cmake-modules/all/conandata.yml
+++ b/recipes/extra-cmake-modules/all/conandata.yml
@@ -1,31 +1,7 @@
 sources:
   "6.8.0":
     url: "https://download.kde.org/stable/frameworks/6.8/extra-cmake-modules-6.8.0.tar.xz"
-    sha256: "ff8a0bf72285bec1768e3acd8f7c665a26d55a1527e96d73e35789dc9f0e3472" 
-  "6.2.0":
-    url: "https://download.kde.org/stable/frameworks/6.2/extra-cmake-modules-6.2.0.tar.xz"
-    sha256: "6374bfa0dded8be265c702acd5de11eecd2851c625b93e1c87d8d0f5f1a8ebe1"
-  "5.113.0":
-    url: "https://download.kde.org/stable/frameworks/5.113/extra-cmake-modules-5.113.0.tar.xz"
-    sha256: "265e5440eebeca07351a469e617a4bf35748927bd907b00ace9c018392bb3bc4"
-  "5.111.0":
-    url: "https://download.kde.org/stable/frameworks/5.111/extra-cmake-modules-5.111.0.tar.xz"
-    sha256: "555d3c1dfa6727b4e64a35d3f01724c9fcd6209c2a41f2b2297c39ed7aabea9a"
-  "5.108.0":
-    url: "https://download.kde.org/stable/frameworks/5.108/extra-cmake-modules-5.108.0.tar.xz"
-    sha256: "ff14abd21abd34c2d8c00ee7a1ccd173b9a57ed1824e5c01090897ffffed447a"
-  "5.93.0":
-    url: "https://download.kde.org/stable/frameworks/5.93/extra-cmake-modules-5.93.0.tar.xz"
-    sha256: "093dea7b11647bc5f74e6971d47ef15b5c410cba2b4620acae00f008d5480b21"
-  "5.84.0":
-    url: "https://download.kde.org/stable/frameworks/5.84/extra-cmake-modules-5.84.0.tar.xz"
-    sha256: "bb085ef2e177c182ff46988516b6b31849d1497beb2ff5301165ad2ba12a1c41"
-  "5.80.0":
-    url: "https://download.kde.org/stable/frameworks/5.80/extra-cmake-modules-5.80.0.tar.xz"
-    sha256: "2370fd80f685533d0b96efa6fa443ceea68e0ceba4e8a9d7c151d297b1c96f64"
-  "5.75.0":
-    url: "https://download.kde.org/stable/frameworks/5.75/extra-cmake-modules-5.75.0.zip"
-    sha256: "dc937fd2018eb8285c1b07d4b5de104c60959404c4979883f6bdb0a4d40cf98e"
+    sha256: "ff8a0bf72285bec1768e3acd8f7c665a26d55a1527e96d73e35789dc9f0e3472"
 patches:
   "6.8.0":
     - patch_file: "patches/0001-fix-find_package-qt.patch"

--- a/recipes/extra-cmake-modules/all/conanfile.py
+++ b/recipes/extra-cmake-modules/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches
 from conan.tools.scm import Version
 
 required_conan_version = ">=1.50.0"
@@ -21,6 +21,9 @@ class ExtracmakemodulesConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def package_id(self):
         self.info.clear()
@@ -48,6 +51,7 @@ class ExtracmakemodulesConan(ConanFile):
         tc.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/extra-cmake-modules/all/conanfile.py
+++ b/recipes/extra-cmake-modules/all/conanfile.py
@@ -32,6 +32,7 @@ class ExtracmakemodulesConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -49,7 +50,6 @@ class ExtracmakemodulesConan(ConanFile):
         tc.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/extra-cmake-modules/all/conanfile.py
+++ b/recipes/extra-cmake-modules/all/conanfile.py
@@ -3,7 +3,6 @@ import os
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches
-from conan.tools.scm import Version
 
 required_conan_version = ">=1.50.0"
 
@@ -29,8 +28,7 @@ class ExtracmakemodulesConan(ConanFile):
         self.info.clear()
 
     def build_requirements(self):
-        if Version(self.version) >= "5.84.0":
-            self.tool_requires("cmake/[>=3.16 <4]")
+        self.tool_requires("cmake/[>=3.16 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/extra-cmake-modules/all/patches/0001-fix-find_package-qt.patch
+++ b/recipes/extra-cmake-modules/all/patches/0001-fix-find_package-qt.patch
@@ -1,0 +1,245 @@
+From 1de6be1b19c8a349f81910d50e18a5c3d010daec Mon Sep 17 00:00:00 2001
+From: Walid Boussafa <walid.boussafa@dotmatics.com>
+Date: Sat, 14 Dec 2024 11:14:37 +0100
+Subject: [PATCH] CNI-2015 fix qt find_package
+
+---
+ find-modules/FindGradle.cmake                        | 2 +-
+ find-modules/FindQHelpGenerator.cmake                | 2 +-
+ kde-modules/KDEFrameworkCompilerSettings.cmake       | 2 +-
+ modules/ECMAddAndroidApk.cmake                       | 4 ++--
+ modules/ECMAddQch.cmake                              | 2 +-
+ modules/ECMAddQtDesignerPlugin.cmake                 | 8 ++++----
+ modules/ECMCreateQmFromPoFiles.cmake                 | 2 +-
+ modules/ECMPoQmTools.cmake                           | 2 +-
+ modules/ECMQueryQmake.cmake                          | 4 ++--
+ modules/ECMQueryQt.cmake                             | 4 ++--
+ tests/ECMAddTests/multi_tests/CMakeLists.txt         | 2 +-
+ tests/ECMAddTests/single_tests/CMakeLists.txt        | 2 +-
+ tests/ECMPoQmToolsTest/CMakeLists.txt                | 2 +-
+ tests/ECMQtDeclareLoggingCategoryTest/CMakeLists.txt | 2 +-
+ toolchain/ECMAndroidDeployQt5.cmake                  | 2 +-
+ 15 files changed, 21 insertions(+), 21 deletions(-)
+
+diff --git a/find-modules/FindGradle.cmake b/find-modules/FindGradle.cmake
+index f08ccc2..88ddcdc 100644
+--- a/find-modules/FindGradle.cmake
++++ b/find-modules/FindGradle.cmake
+@@ -30,7 +30,7 @@ Since 5.76.0.
+ include(${CMAKE_CURRENT_LIST_DIR}/../modules/QtVersionOption.cmake)
+ include(FindPackageHandleStandardArgs)
+ 
+-find_package(Qt${QT_MAJOR_VERSION}Core REQUIRED)
++find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core REQUIRED)
+ 
+ set (Gradle_PRECOMMAND "")
+ if (NOT WIN32)
+diff --git a/find-modules/FindQHelpGenerator.cmake b/find-modules/FindQHelpGenerator.cmake
+index b259010..65830d9 100644
+--- a/find-modules/FindQHelpGenerator.cmake
++++ b/find-modules/FindQHelpGenerator.cmake
+@@ -13,7 +13,7 @@ Finds the Qt5 QHelpGenerator
+ #]=======================================================================]
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/../modules/QtVersionOption.cmake)
+-find_package(Qt${QT_MAJOR_VERSION}Help QUIET)
++find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Help QUIET)
+ if (TARGET Qt5::qhelpgenerator)
+     get_target_property(QHelpGenerator_EXECUTABLE Qt5::qhelpgenerator LOCATION)
+ else()
+diff --git a/kde-modules/KDEFrameworkCompilerSettings.cmake b/kde-modules/KDEFrameworkCompilerSettings.cmake
+index 67bc7f3..4413f6b 100644
+--- a/kde-modules/KDEFrameworkCompilerSettings.cmake
++++ b/kde-modules/KDEFrameworkCompilerSettings.cmake
+@@ -48,7 +48,7 @@ endif()
+ # otherwise we'll break function pointer based connects and method lookups
+ include(${CMAKE_CURRENT_LIST_DIR}/../modules/QtVersionOption.cmake)
+ if (QT_MAJOR_VERSION EQUAL "6")
+-    find_package(Qt6Core)
++    find_package(Qt6 COMPONENTS Core)
+     set(ENABLE_BSYMBOLICFUNCTIONS ${QT_FEATURE_reduce_relocations})
+     set(CMAKE_CXX_STANDARD 20)
+     set(CMAKE_CXX_EXTENSIONS OFF)
+diff --git a/modules/ECMAddAndroidApk.cmake b/modules/ECMAddAndroidApk.cmake
+index 897db4c..90c146b 100644
+--- a/modules/ECMAddAndroidApk.cmake
++++ b/modules/ECMAddAndroidApk.cmake
+@@ -52,8 +52,8 @@ if (QT_MAJOR_VERSION EQUAL 5)
+     return()
+ endif()
+ 
+-find_package(Qt6Core REQUIRED) # required for the following to work stand-alone
+-find_package(Qt6CoreTools REQUIRED)
++find_package(Qt6 COMPONENTS Core REQUIRED) # required for the following to work stand-alone
++find_package(Qt6 COMPONENTS CoreTools REQUIRED)
+ find_package(Python3 COMPONENTS Interpreter REQUIRED)
+ 
+ set(_ECM_TOOLCHAIN_DIR "${CMAKE_CURRENT_LIST_DIR}/../toolchain")
+diff --git a/modules/ECMAddQch.cmake b/modules/ECMAddQch.cmake
+index 4f5261a..891f8d8 100644
+--- a/modules/ECMAddQch.cmake
++++ b/modules/ECMAddQch.cmake
+@@ -279,7 +279,7 @@ function(_ecm_ensure_qt_qch_targets)
+     # Ideally one day Qt CMake Config files provide these
+     if(NOT TARGET Qt${QT_MAJOR_VERSION}Core_QCH)
+         # get Qt version, if any
+-        find_package(Qt${QT_MAJOR_VERSION}Core CONFIG QUIET)
++        find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core CONFIG QUIET)
+         # lookup tag files
+         ecm_query_qt(qt_docs_dir QT_INSTALL_DOCS TRY)
+         find_path(_qtcoreTagsPath qtcore/qtcore.tags
+diff --git a/modules/ECMAddQtDesignerPlugin.cmake b/modules/ECMAddQtDesignerPlugin.cmake
+index d847e66..83cee5a 100644
+--- a/modules/ECMAddQtDesignerPlugin.cmake
++++ b/modules/ECMAddQtDesignerPlugin.cmake
+@@ -441,16 +441,16 @@ macro(ecm_add_qtdesignerplugin target)
+     endif()
+ 
+     # Check deps
+-    if(NOT Qt${QT_MAJOR_VERSION}UiPlugin_FOUND)
+-        find_package(Qt${QT_MAJOR_VERSION}UiPlugin QUIET CONFIG)
+-        set_package_properties(Qt${QT_MAJOR_VERSION}UiPlugin PROPERTIES
++    if(NOT TARGET Qt${QT_MAJOR_VERSION}::UiPlugin)
++        find_package(Qt${QT_MAJOR_VERSION} COMPONENTS UiPlugin QUIET CONFIG)
++        set_package_properties(Qt${QT_MAJOR_VERSION}::UiPlugin PROPERTIES
+             PURPOSE "Required to build Qt Designer plugins"
+             TYPE REQUIRED
+         )
+     endif()
+ 
+     # setup plugin only if uiplugin lib was found, as we do not abort hard the cmake run otherwise
+-    if (Qt${QT_MAJOR_VERSION}UiPlugin_FOUND)
++    if (TARGET Qt${QT_MAJOR_VERSION}::UiPlugin)
+         set(_generation_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}_ECMQtDesignerPlugin")
+         file(MAKE_DIRECTORY "${_generation_dir}")
+         set(_rc_icon_dir "/${ARGS_NAME}/designer")
+diff --git a/modules/ECMCreateQmFromPoFiles.cmake b/modules/ECMCreateQmFromPoFiles.cmake
+index 98e656d..60f0c00 100644
+--- a/modules/ECMCreateQmFromPoFiles.cmake
++++ b/modules/ECMCreateQmFromPoFiles.cmake
+@@ -165,7 +165,7 @@ endfunction()
+ function(ECM_CREATE_QM_FROM_PO_FILES)
+     # This gives us Qt5::lrelease and Qt5::lupdate but unfortunately no Qt5::lconvert
+     # See https://bugreports.qt-project.org/browse/QTBUG-37937
+-    find_package(Qt5LinguistTools CONFIG REQUIRED)
++    find_package(Qt5 COMPONENTS LinguistTools CONFIG REQUIRED)
+ 
+     foreach (arg ${ARGN})
+         if (arg STREQUAL "PO_DIR")
+diff --git a/modules/ECMPoQmTools.cmake b/modules/ECMPoQmTools.cmake
+index b05a57b..5120cc1 100644
+--- a/modules/ECMPoQmTools.cmake
++++ b/modules/ECMPoQmTools.cmake
+@@ -148,7 +148,7 @@ function(ecm_process_po_files_as_qm lang)
+ 
+     # Find lrelease and lconvert
+     if (QT_MAJOR_VERSION EQUAL "5")
+-        find_package(Qt5LinguistTools CONFIG REQUIRED)
++        find_package(Qt5 COMPONENTS LinguistTools CONFIG REQUIRED)
+     else()
+         find_package(Qt6 COMPONENTS LinguistTools CONFIG REQUIRED)
+     endif()
+diff --git a/modules/ECMQueryQmake.cmake b/modules/ECMQueryQmake.cmake
+index 4277eee..91f3c17 100644
+--- a/modules/ECMQueryQmake.cmake
++++ b/modules/ECMQueryQmake.cmake
+@@ -3,9 +3,9 @@ if (${ECM_GLOBAL_FIND_VERSION} VERSION_GREATER_EQUAL 5.93)
+ endif()
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/QtVersionOption.cmake)
+-find_package(Qt${QT_MAJOR_VERSION}Core QUIET)
++find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core QUIET)
+ 
+-if (Qt5Core_FOUND)
++if (TARGET Qt5::Core)
+     set(_qmake_executable_default "qmake-qt5")
+ endif ()
+ if (TARGET Qt5::qmake)
+diff --git a/modules/ECMQueryQt.cmake b/modules/ECMQueryQt.cmake
+index 639b2b5..fcc4412 100644
+--- a/modules/ECMQueryQt.cmake
++++ b/modules/ECMQueryQt.cmake
+@@ -46,7 +46,7 @@ endif()
+ 
+ if (QT_MAJOR_VERSION STREQUAL "5")
+     # QUIET to accommodate the TRY option
+-    find_package(Qt${QT_MAJOR_VERSION}Core QUIET)
++    find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core QUIET)
+     set(_exec_name_text "Qt5 qmake")
+     if(TARGET Qt5::qmake)
+         get_target_property(_qmake_executable_default Qt5::qmake LOCATION)
+@@ -56,7 +56,7 @@ if (QT_MAJOR_VERSION STREQUAL "5")
+     endif()
+ elseif(QT_MAJOR_VERSION STREQUAL "6")
+     # QUIET to accommodate the TRY option
+-    find_package(Qt6 COMPONENTS CoreTools QUIET CONFIG)
++    find_package(Qt6 COMPONENTS Core QUIET CONFIG)
+     set(_exec_name_text "Qt6 qtpaths")
+     if (TARGET Qt6::qtpaths)
+         get_target_property(_qtpaths_executable Qt6::qtpaths LOCATION)
+diff --git a/tests/ECMAddTests/multi_tests/CMakeLists.txt b/tests/ECMAddTests/multi_tests/CMakeLists.txt
+index ff15c99..e7b44fd 100644
+--- a/tests/ECMAddTests/multi_tests/CMakeLists.txt
++++ b/tests/ECMAddTests/multi_tests/CMakeLists.txt
+@@ -9,7 +9,7 @@ target_include_directories(testhelper PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
+ 
+ # Link to QtCore for WinMain on Windows
+ include(QtVersionOption)
+-find_package(Qt${QT_MAJOR_VERSION}Core REQUIRED)
++find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core REQUIRED)
+ target_link_libraries(testhelper PUBLIC Qt${QT_MAJOR_VERSION}::Core)
+ 
+ enable_testing()
+diff --git a/tests/ECMAddTests/single_tests/CMakeLists.txt b/tests/ECMAddTests/single_tests/CMakeLists.txt
+index 3a619f7..67924b2 100644
+--- a/tests/ECMAddTests/single_tests/CMakeLists.txt
++++ b/tests/ECMAddTests/single_tests/CMakeLists.txt
+@@ -9,7 +9,7 @@ target_include_directories(testhelper PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
+ 
+ # Link to QtCore for WinMain on Windows
+ include(QtVersionOption)
+-find_package(Qt${QT_MAJOR_VERSION}Core REQUIRED)
++find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core REQUIRED)
+ target_link_libraries(testhelper PUBLIC Qt${QT_MAJOR_VERSION}::Core)
+ 
+ enable_testing()
+diff --git a/tests/ECMPoQmToolsTest/CMakeLists.txt b/tests/ECMPoQmToolsTest/CMakeLists.txt
+index 1aee4f8..683cc09 100644
+--- a/tests/ECMPoQmToolsTest/CMakeLists.txt
++++ b/tests/ECMPoQmToolsTest/CMakeLists.txt
+@@ -66,7 +66,7 @@ unset(LOCALE_INSTALL_DIR)
+ #                      #
+ ########################
+ 
+-find_package(Qt${QT_MAJOR_VERSION}Core CONFIG REQUIRED)
++find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core CONFIG REQUIRED)
+ ecm_install_po_files_as_qm(tr_test-po)
+ 
+ 
+diff --git a/tests/ECMQtDeclareLoggingCategoryTest/CMakeLists.txt b/tests/ECMQtDeclareLoggingCategoryTest/CMakeLists.txt
+index c196ef2..e2b0ec7 100644
+--- a/tests/ECMQtDeclareLoggingCategoryTest/CMakeLists.txt
++++ b/tests/ECMQtDeclareLoggingCategoryTest/CMakeLists.txt
+@@ -44,7 +44,7 @@ ecm_qt_export_logging_category(
+     DESCRIPTION "log 4"
+ )
+ 
+-find_package(Qt${QT_MAJOR_VERSION}Core REQUIRED)
++find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Core REQUIRED)
+ 
+ add_executable(testmain testmain.cpp ${sources})
+ target_include_directories(testmain
+diff --git a/toolchain/ECMAndroidDeployQt5.cmake b/toolchain/ECMAndroidDeployQt5.cmake
+index 30af69e..cc66980 100644
+--- a/toolchain/ECMAndroidDeployQt5.cmake
++++ b/toolchain/ECMAndroidDeployQt5.cmake
+@@ -1,5 +1,5 @@
+ cmake_minimum_required (VERSION 3.19 FATAL_ERROR)
+-find_package(Qt5Core REQUIRED)
++find_package(Qt5 COMPONENTS Core REQUIRED)
+ find_package(Python3 COMPONENTS Interpreter REQUIRED)
+ 
+ # Taken from https://stackoverflow.com/a/62311397
+-- 
+2.39.2
+

--- a/recipes/extra-cmake-modules/config.yml
+++ b/recipes/extra-cmake-modules/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.8.0":
+    folder: "all"
   "6.2.0":
     folder: "all"
   "5.113.0":

--- a/recipes/extra-cmake-modules/config.yml
+++ b/recipes/extra-cmake-modules/config.yml
@@ -1,19 +1,3 @@
 versions:
   "6.8.0":
     folder: "all"
-  "6.2.0":
-    folder: "all"
-  "5.113.0":
-    folder: "all"
-  "5.111.0":
-    folder: "all"
-  "5.108.0":
-    folder: "all"
-  "5.93.0":
-    folder: "all"
-  "5.84.0":
-    folder: "all"
-  "5.80.0":
-    folder: "all"
-  "5.75.0":
-    folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **extra-cmake-modules/6.8.0**

#### Motivation

* Added new version: 6.8.0
  * Fixed `find_package` line for Qt. Added patch.
* Stopped publishing new revisions for older versions.

#### Details

Conan's qt package does not define config file for each qt component, also <component>_FOUND are not defined.

For example: 
* `find_package(Qt6Core)` does not work with conan, and therefore I had to change it to `find_package(Qt6 COMPONENTS Core)`
* `Qt5Core_FOUND` is not defined by conan, and I had to change it to `if (TARGET Qt5::Core)`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
