### PR TITLE
[libssh] Add version 0.11.1

### DIFF
--- a/recipes/libssh/all/conandata.yml
+++ b/recipes/libssh/all/conandata.yml
@@ -1,8 +1,15 @@
 sources:
+  "0.11.1":
+    url: "https://www.libssh.org/files/0.11/libssh-0.11.1.tar.xz"
+    sha256: "14b7dcc72e91e08151c58b981a7b570ab2663f630e7d2837645d5a9c612c1b79"
   "0.10.6":
     url: "https://www.libssh.org/files/0.10/libssh-0.10.6.tar.xz"
     sha256: "1861d498f5b6f1741b6abc73e608478491edcf9c9d4b6630eef6e74596de9dc1"
 patches:
+  "0.11.1":
+    - patch_file: patches/0.11.1-0001-fix-cmake.patch
+      patch_description: "cmake: fix MbedTLS and GCrypt compatibility"
+      patch_type: "conan"
   "0.10.6":
     - patch_file: patches/0.10.6-0001-fix-cmake.patch
       patch_description: "cmake: fix OpenSSL compatibility checks, fix ZLIB targets"

--- a/recipes/libssh/all/patches/0.11.1-0001-fix-cmake.patch
+++ b/recipes/libssh/all/patches/0.11.1-0001-fix-cmake.patch
@@ -1,0 +1,95 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 13330ea3..9b86072d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,7 +47,7 @@ if (WITH_ZLIB)
+ endif (WITH_ZLIB)
+ 
+ if (WITH_GCRYPT)
+-  find_package(GCrypt 1.5.0 REQUIRED)
++  find_package(libgcrypt 1.5.0 REQUIRED)
+   message(WARNING "libgcrypt cryptographic backend is deprecated and will be removed in future releases.")
+ elseif(WITH_MBEDTLS)
+     find_package(MbedTLS REQUIRED)
+diff --git a/ConfigureChecks.cmake b/ConfigureChecks.cmake
+index 8765dc6e..f454d325 100644
+--- a/ConfigureChecks.cmake
++++ b/ConfigureChecks.cmake
+@@ -218,22 +218,22 @@ if (OPENSSL_FOUND)
+   set(HAVE_LIBCRYPTO 1)
+ endif (OPENSSL_FOUND)
+ 
+-if (GCRYPT_FOUND)
++if (libgcrypt_FOUND)
+     set(HAVE_LIBGCRYPT 1)
+-    if (GCRYPT_VERSION VERSION_GREATER "1.4.6")
++    if (libgcrypt_VERSION VERSION_GREATER "1.4.6")
+         set(HAVE_GCRYPT_ECC 1)
+         set(HAVE_ECC 1)
+-    endif (GCRYPT_VERSION VERSION_GREATER "1.4.6")
+-    if (NOT GCRYPT_VERSION VERSION_LESS "1.7.0")
++    endif (libgcrypt_VERSION VERSION_GREATER "1.4.6")
++    if (NOT libgcrypt_VERSION VERSION_LESS "1.7.0")
+         set(HAVE_GCRYPT_CHACHA_POLY 1)
+-    endif (NOT GCRYPT_VERSION VERSION_LESS "1.7.0")
+-endif (GCRYPT_FOUND)
++    endif (NOT libgcrypt_VERSION VERSION_LESS "1.7.0")
++endif (libgcrypt_FOUND)
+ 
+-if (MBEDTLS_FOUND)
++if (MbedTLS_FOUND)
+     set(HAVE_LIBMBEDCRYPTO 1)
+     set(HAVE_ECC 1)
+ 
+-    set(CMAKE_REQUIRED_INCLUDES "${MBEDTLS_INCLUDE_DIR}/mbedtls")
++    set(CMAKE_REQUIRED_INCLUDES "${MbedTLS_INCLUDE_DIR}/mbedtls")
+     check_include_file(chacha20.h HAVE_MBEDTLS_CHACHA20_H)
+     check_include_file(poly1305.h HAVE_MBEDTLS_POLY1305_H)
+     if (WITH_BLOWFISH_CIPHER)
+@@ -242,7 +242,7 @@ if (MBEDTLS_FOUND)
+ 
+     unset(CMAKE_REQUIRED_INCLUDES)
+ 
+-endif (MBEDTLS_FOUND)
++endif (MbedTLS_FOUND)
+ 
+ if (CMAKE_USE_PTHREADS_INIT)
+     set(HAVE_PTHREAD 1)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 199acbd9..3e715a96 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -12,27 +12,13 @@ if (TARGET OpenSSL::Crypto)
+   list(APPEND LIBSSH_LINK_LIBRARIES OpenSSL::Crypto)
+ endif ()
+ 
+-if (MBEDTLS_CRYPTO_LIBRARY)
+-    set(LIBSSH_PRIVATE_INCLUDE_DIRS
+-      ${LIBSSH_PRIVATE_INCLUDE_DIRS}
+-      ${MBEDTLS_INCLUDE_DIR}
+-    )
+-  set(LIBSSH_LINK_LIBRARIES
+-    ${LIBSSH_LINK_LIBRARIES}
+-    ${MBEDTLS_CRYPTO_LIBRARY}
+-  )
+-endif (MBEDTLS_CRYPTO_LIBRARY)
+-
+-if (GCRYPT_LIBRARIES)
+-  set(LIBSSH_PRIVATE_INCLUDE_DIRS
+-    ${LIBSSH_PRIVATE_INCLUDE_DIRS}
+-    ${GCRYPT_INCLUDE_DIR}
+-  )
++if (TARGET MbedTLS::mbedcrypto)
++  list(APPEND LIBSSH_LINK_LIBRARIES MbedTLS::mbedcrypto)
++endif ()
+ 
+-  set(LIBSSH_LINK_LIBRARIES
+-    ${LIBSSH_LINK_LIBRARIES}
+-    ${GCRYPT_LIBRARIES})
+-endif()
++if (TARGET libgcrypt::libgcrypt)
++  list(APPEND LIBSSH_LINK_LIBRARIES libgcrypt::libgcrypt)
++endif ()
+ 
+ if (WITH_ZLIB)
+   list(APPEND LIBSSH_LINK_LIBRARIES ZLIB::ZLIB)

--- a/recipes/libssh/config.yml
+++ b/recipes/libssh/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.11.1":
+    folder: all
   "0.10.6":
     folder: all


### PR DESCRIPTION
### Summary
Add version 0.11.1 of libssh

#### Motivation
We are using this version of libssh and as the change is pretty minor, I thought it could be useful to add it here.

#### Details
I simply added the new version of the library and checked which patches very still required.
I tested it with two different crypto options (gcrypt and mbedtls) and conan 2.11 on Linux.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
