### PR TITLE
opusfile: fix building for Android with http=True

### DIFF
--- a/recipes/opusfile/all/conanfile.py
+++ b/recipes/opusfile/all/conanfile.py
@@ -135,6 +135,9 @@ class OpusFileConan(ConanFile):
             msbuild.platform = "Win32" if self.settings.arch == "x86" else msbuild.platform
             msbuild.build(os.path.join(sln_folder, "opusfile.sln"), targets=["opusfile"])
         else:
+            if self.settings.os == "Android":
+                replace_in_file(self, os.path.join(self.source_folder, "configure.ac"), "c89", "c99")
+
             autotools = Autotools(self)
             autotools.autoreconf()
             autotools.configure()

--- a/recipes/opusfile/all/conanfile.py
+++ b/recipes/opusfile/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, MSBuild, MSBuildDeps, MSBuildToolchain
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.4.0"
 
 
 class OpusFileConan(ConanFile):
@@ -136,7 +136,8 @@ class OpusFileConan(ConanFile):
             msbuild.build(os.path.join(sln_folder, "opusfile.sln"), targets=["opusfile"])
         else:
             if self.settings.os == "Android":
-                replace_in_file(self, os.path.join(self.source_folder, "configure.ac"), "c89", "c99")
+                cstd = self.settings.get_safe("compiler.cstd", default="99")
+                replace_in_file(self, os.path.join(self.source_folder, "configure.ac"), "c89", f"c{cstd}")
 
             autotools = Autotools(self)
             autotools.autoreconf()

--- a/recipes/opusfile/all/conanfile.py
+++ b/recipes/opusfile/all/conanfile.py
@@ -136,6 +136,7 @@ class OpusFileConan(ConanFile):
             msbuild.build(os.path.join(sln_folder, "opusfile.sln"), targets=["opusfile"])
         else:
             if self.settings.os == "Android":
+                # See https://github.com/conan-io/conan-center-index/pull/26245#pullrequestreview-2825164395
                 cstd = self.settings.get_safe("compiler.cstd", default="99")
                 replace_in_file(self, os.path.join(self.source_folder, "configure.ac"), "c89", f"c{cstd}")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **opusfile/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fixes building opusfile with `http=True` for Android

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Build fails due to using C99 features but compiling in C89 mode. I've opened issue in upstream https://github.com/xiph/opusfile/issues/52 as I'm not sure what's the right way to proceed here (if I can blindly replace 89 with 99). In the recipe I replace 89 with 99 only for Android (because again I'm not sure if there will be any side effects on other platforms).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
