### PR TITLE
libcap/2.73: Bump version

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.73":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.73.tar.xz"
+    sha256: "6405f6089cf4cdd8c271540cd990654d78dd0b1989b2d9bda20f933a75a795a5"
   "2.70":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.70.tar.xz"
     sha256: "23a6ef8aadaf1e3e875f633bb2d116cfef8952dba7bc7c569b13458e1952b30f"
@@ -36,6 +39,13 @@ sources:
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.45.tar.xz"
     sha256: "d66639f765c0e10557666b00f519caf0bd07a95f867dddaee131cd284fac3286"
 patches:
+  "2.73":
+    - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
+      patch_description: "allow to configure fPIC option from conan recipe"
+      patch_type: "conan"
+    - patch_file: "patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch"
+      patch_description: "allow to override compiler via environment variables"
+      patch_type: "conan"
   "2.70":
     - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
       patch_description: "allow to configure fPIC option from conan recipe"

--- a/recipes/libcap/all/patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch
+++ b/recipes/libcap/all/patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch
@@ -1,0 +1,26 @@
+From 8b86ac7b057ce529900969ead958a9ca7ae85b3c Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Sun, 22 Dec 2024 20:30:31 +0700
+Subject: [PATCH 1/2] libcap: Remove hardcoded -fPIC
+
+Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+---
+ libcap/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcap/Makefile b/libcap/Makefile
+index 5f5c601..02be223 100644
+--- a/libcap/Makefile
++++ b/libcap/Makefile
+@@ -19,7 +19,7 @@ PSXFILES=../psx/psx ../psx/wrap/psx_wrap
+ PSXMAGICOBJ=psx_magic.o
+ 
+ # Always build libcap sources this way:
+-CFLAGS += -fPIC -D_LIBPSX_PTHREAD_LINKAGE
++CFLAGS += -D_LIBPSX_PTHREAD_LINKAGE
+ 
+ # https://bugzilla.kernel.org/show_bug.cgi?id=219168
+ OVERRIDE_BSYMBOLIC_FUNCTIONS := -Wl,-Bsymbolic-functions
+-- 
+2.47.1
+

--- a/recipes/libcap/all/patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch
+++ b/recipes/libcap/all/patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch
@@ -1,0 +1,33 @@
+From 903c526352f0cea70200c3f3231dffce8d1c9621 Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Sun, 22 Dec 2024 20:52:43 +0700
+Subject: [PATCH 2/2] Make.Rules: Make compile tools configurable
+
+Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+---
+ Make.Rules | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Make.Rules b/Make.Rules
+index d349697..7bec1af 100644
+--- a/Make.Rules
++++ b/Make.Rules
+@@ -66,11 +66,11 @@ DEFINES := -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ SYSTEM_HEADERS = /usr/include
+ 
+ SUDO := sudo
+-CC := $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD := $(CC) -Wl,-x -shared -Wl,-shared
+-AR := $(CROSS_COMPILE)ar
+-RANLIB := $(CROSS_COMPILE)ranlib
+-OBJCOPY := $(CROSS_COMPILE)objcopy
++AR ?= $(CROSS_COMPILE)ar
++RANLIB ?= $(CROSS_COMPILE)ranlib
++OBJCOPY ?= $(CROSS_COMPILE)objcopy
+ 
+ # Reference:
+ #   CPPFLAGS used for building .o files from .c & .h files
+-- 
+2.47.1
+

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.73":
+    folder: all
   "2.70":
     folder: all
   "2.69":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcap/2.73**

#### Motivation
A new version of libcap is available. Full diff between 2.70 and 2.73: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/diff/?id=libcap-2.73&id2=libcap-2.70

#### Details
Conan-specific patches are the same as for the previous versions. They are only rebased on version 2.73.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
