### PR TITLE
md4c: fix building for Apple non-macOS

### DIFF
--- a/recipes/md4c/all/conanfile.py
+++ b/recipes/md4c/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rmdir
 
@@ -36,6 +37,8 @@ class Md4cConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if is_apple_os(self) and self.settings.os != "Macos":
+            del self.options.md2html
 
     def configure(self):
         if self.options.shared:
@@ -55,7 +58,7 @@ class Md4cConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["BUILD_MD2HTML_EXECUTABLE"] = self.options.md2html
+        tc.variables["BUILD_MD2HTML_EXECUTABLE"] = self.options.get_safe("md2html", False)
         if self.options.encoding == "utf-8":
             tc.preprocessor_definitions["MD4C_USE_UTF8"] = "1"
         elif self.options.encoding == "utf-16":

--- a/recipes/md4c/all/conanfile.py
+++ b/recipes/md4c/all/conanfile.py
@@ -63,7 +63,7 @@ class Md4cConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         if self._hasMd2html():
-            tc.variables["BUILD_MD2HTML_EXECUTABLE"] = self.options.get_safe("md2html", False)
+            tc.cache_variables["BUILD_MD2HTML_EXECUTABLE"] = self.options.get_safe("md2html", False)
         if self.options.encoding == "utf-8":
             tc.preprocessor_definitions["MD4C_USE_UTF8"] = "1"
         elif self.options.encoding == "utf-16":

--- a/recipes/md4c/all/conanfile.py
+++ b/recipes/md4c/all/conanfile.py
@@ -42,7 +42,7 @@ class Md4cConan(ConanFile):
             # Set it to false for iOS, tvOS, watchOS, visionOS
             # to prevent cmake from creating a bundle for the md2html executable
             is_ios_variant = is_apple_os(self) and not self.settings.os == "Macos"
-            self.options.md2html = False if is_ios_variant else True
+            self.options.md2html = not is_ios_variant
         else:
             # md2html was introduced in 0.5.0
             del self.options.md2html
@@ -116,10 +116,3 @@ class Md4cConan(ConanFile):
         # to create unofficial target or pkgconfig file
         self.cpp_info.set_property("cmake_target_name", "md4c::md4c-html")
         self.cpp_info.set_property("pkg_config_name", "md4c-html")
-
-        # TODO: to remove in conan v2
-        self.cpp_info.components["_md4c"].names["cmake_find_package"] = "md4c"
-        self.cpp_info.components["_md4c"].names["cmake_find_package_multi"] = "md4c"
-        self.cpp_info.components["md4c_html"].names["cmake_find_package"] = "md4c-html"
-        self.cpp_info.components["md4c_html"].names["cmake_find_package_multi"] = "md4c-html"
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
### Summary
Changes to recipe:  **md4c/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fixes building for Apple non-macOS

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Building the package with default options for iOS produces the following CMake configuration error:
```
CMake Error at md2html/CMakeLists.txt:14 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "md2html".
```

As executable for Apple non-macOS doesn't really make any sense, it's disabled and the corresponding option is deleted. Basically same fix as #25964

Also, the option `BUILD_MD2HTML_EXECUTABLE` appeared only in v0.5.0 (see https://github.com/mity/md4c/commit/ecce1715b771b8784e2b7174223570f149693a48), this is now checked.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
