### PR TITLE
soci if generated with boost:header_only = false forces other targets to link against the whole boost library

### DIFF
--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -159,7 +159,7 @@ class SociConan(ConanFile):
         self.cpp_info.components["soci_core"].set_property("cmake_target_name", "SOCI::soci_core{}".format(target_suffix))
         self.cpp_info.components["soci_core"].libs = ["{}soci_core{}".format(lib_prefix, lib_suffix)]
         if self.options.with_boost:
-            self.cpp_info.components["soci_core"].requires.append("boost::boost")
+            self.cpp_info.components["soci_core"].requires.append("boost::headers")
 
         # soci_empty
         if self.options.empty:


### PR DESCRIPTION
### Summary
Changes to recipe:  **soci/[4.0.3]**

#### Motivation
since I started using soci I could not

1.  create a target which links to soci and boost (boost:header_only = false)
2.  link to that target and define a main function. 
error is:
```
&& /usr/bin/g++ -m64 -g -m64    -Wl,--dependency-file=test/CMakeFiles/_test.dir/link.d test/CMakeFiles/_test.dir/hello.cxx.o -o test/_test -L/home/walde/.conan2/p/b/socidf772d09f72e8/p/lib   -L/home/walde/.conan2/p/b/boost49d6965c089ad/p/lib   -L/home/walde/.conan2/p/b/bzip2a8b50321cfe83/p/lib   -L/home/walde/.conan2/p/b/zlib0d10831363b0b/p/lib   -L/home/walde/.conan2/p/b/libba5d08bb53c715f/p/lib   -L/home/walde/.conan2/p/b/sqlit2301a97376bfb/p/lib   -L/home/walde/.conan2/p/b/catch9f598355956bc/p/lib -Wl,-rpath,/home/walde/.conan2/p/b/socidf772d09f72e8/p/lib:/home/walde/.conan2/p/b/boost49d6965c089ad/p/lib:/home/walde/.conan2/p/b/bzip2a8b50321cfe83/p/lib:/home/walde/.conan2/p/b/zlib0d10831363b0b/p/lib:/home/walde/.conan2/p/b/libba5d08bb53c715f/p/lib:/home/walde/.conan2/p/b/sqlit2301a97376bfb/p/lib:/home/walde/.conan2/p/b/catch9f598355956bc/p/lib  src/libcxx_template.a  /home/walde/.conan2/p/b/socidf772d09f72e8/p/lib/libsoci_sqlite3.a  /home/walde/.conan2/p/b/socidf772d09f72e8/p/lib/libsoci_core.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_log_setup.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_unit_test_framework.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_type_erasure.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_log.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_locale.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_fiber_numa.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_contract.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_wave.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_thread.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_test_exec_monitor.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_prg_exec_monitor.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_nowide.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_iostreams.a  /home/walde/.conan2/p/b/bzip2a8b50321cfe83/p/lib/libbz2.a  /home/walde/.conan2/p/b/zlib0d10831363b0b/p/lib/libz.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_graph.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_fiber.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_wserialization.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_url.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_stacktrace_noop.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_stacktrace_from_exception.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_stacktrace_basic.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_stacktrace_backtrace.a  /home/walde/.conan2/p/b/libba5d08bb53c715f/p/lib/libbacktrace.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_stacktrace_addr2line.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_random.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_math_tr1l.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_math_tr1f.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_math_tr1.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_math_c99l.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_math_c99f.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_math_c99.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_json.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_filesystem.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_coroutine.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_cobalt.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_chrono.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_timer.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_serialization.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_regex.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_program_options.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_exception.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_date_time.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_context.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_container.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_charconv.a  /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_atomic.a  -lrt  /home/walde/.conan2/p/b/sqlit2301a97376bfb/p/lib/libsqlite3.a  -lpthread  -ldl  -lm  /home/walde/.conan2/p/b/catch9f598355956bc/p/lib/libCatch2WithMain.a && :
[build] /usr/bin/ld: /home/walde/.conan2/p/b/catch9f598355956bc/p/lib/libCatch2WithMain.a(catch_with_main.cpp.o): in function `main':
[build] /home/walde/.conan2/p/b/catch9f598355956bc/b/build/Debug/./single_include/catch2/catch.hpp:17523: multiple definition of `main'; /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_unit_test_framework.a(unit_test_main.o):/home/walde/.conan2/p/boost06c6495d1787e/s/src/./boost/test/impl/unit_test_main.ipp:294: first defined here
[build] /usr/bin/ld: /home/walde/.conan2/p/b/boost49d6965c089ad/p/lib/libboost_test_exec_monitor.a(test_main.o): in function `test_main_caller::operator()()':
[build] /home/walde/.conan2/p/boost06c6495d1787e/s/src/./boost/test/impl/test_main.ipp:34:(.text._ZN16test_main_callerclEv[_ZN16test_main_callerclEv]+0x3c): undefined reference to `test_main(int, char**)'
```
So I had to use boost header only.
Recently one of my dependencies got changed and I could not use "boost:header_only=True" anymore.


#### Details
I changed one line of code so a target linked to a target linked to soci should not pull in the whole boost library. Especially not boost unit tests which crated the multiple main problem for me.


---
- [ x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x] Tested locally with at least one configuration using a recent version of Conan
