### PR TITLE
add mongo 1.29.1

### DIFF
--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.29.1":
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.29.1/mongo-c-driver-1.29.1.tar.gz"
-    sha256: "e3dbe86e1f40e100344c48a4c0e39d2da360d2b12a54f16031fa8f90ff16fe5e"
+    sha256: "64382a775353e67c510450c83d72b72e6747ba18256dd1d313deeef7db073b4f"
   "1.29.0":
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.29.0/mongo-c-driver-1.29.0.tar.gz"
     sha256: "e3dbe86e1f40e100344c48a4c0e39d2da360d2b12a54f16031fa8f90ff16fe5e"

--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.29.1":
+    url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.29.1/mongo-c-driver-1.29.1.tar.gz"
+    sha256: "e3dbe86e1f40e100344c48a4c0e39d2da360d2b12a54f16031fa8f90ff16fe5e"
   "1.29.0":
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.29.0/mongo-c-driver-1.29.0.tar.gz"
     sha256: "e3dbe86e1f40e100344c48a4c0e39d2da360d2b12a54f16031fa8f90ff16fe5e"

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.29.1":
+    folder: all
   "1.29.0":
     folder: all
   "1.28.1":


### PR DESCRIPTION
### Summary
add mongo-c-driver/1.29.1

#### Motivation
close: https://github.com/conan-io/conan-center-index/issues/26166

#### Details
New tag: https://github.com/mongodb/mongo-c-driver/releases/tag/1.29.1
Compared to the previous version: https://github.com/mongodb/mongo-c-driver/compare/1.29.0...1.29.1

