### PR TITLE
android-ndk: fix LD path

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -301,7 +301,11 @@ class AndroidNDKConan(ConanFile):
         self.buildenv_info.define_path("CC", compiler_executables["c"])
         self.buildenv_info.define_path("CXX", compiler_executables["cpp"])
         self.buildenv_info.define_path("AS", compiler_executables["c"])
-        self.buildenv_info.define_path("LD", compiler_executables["cpp"])
+
+        if self._ndk_version_major >= 22:
+            self.buildenv_info.define_path("LD", self._define_tool_var_naked("LD", "ld"))
+        else:
+            self.buildenv_info.define_path("LD", self._define_tool_var("LD", "ld"))
 
         # Versions greater than 23 had the naming convention
         # changed to no longer include the triplet.


### PR DESCRIPTION
### Summary
Changes to recipe:  **android-ndk/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fixes shared libiconv build. Now also uses the same logic as Conan v1 (where I never saw such issue).

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Shared libiconv build fails with a rather cryptic error:
```
...
cd lib && /Applications/Xcode-15.4.0.app/Contents/Developer/usr/bin/make install-lib libdir='/Users/andrey.filipenkov/.conan2/p/b/libica26957a837e7d/b/build-release/lib' includedir='/Users/andrey.filipenkov/.conan2/p/b/libica26957a837e7d/b/build-release/lib'
/bin/sh /Users/andrey.filipenkov/.conan2/p/b/libica26957a837e7d/b/src/libcharset/build-aux/mkinstalldirs /Users/andrey.filipenkov/.conan2/p/b/libica26957a837e7d/b/build-release/lib
/bin/sh ../libtool --mode=install /usr/bin/install -c libcharset.la /Users/andrey.filipenkov/.conan2/p/b/libica26957a837e7d/b/build-release/lib/libcharset.la
libtool: install: /usr/bin/install -c .libs/libcharset.so /Users/andrey.filipenkov/.conan2/p/b/libica26957a837e7d/b/build-release/lib/libcharset.so
install: .libs/libcharset.so: No such file or directory
make[2]: *** [install-lib] Error 71
make[1]: *** [install-lib] Error 2
make: *** [lib/localcharset.h] Error 2
```

The reason of that seems to be "naked" linker usage (see references in the end), this can be seen during configure step:
```
checking for ld... /Users/andrey.filipenkov/.conan2/p/androc439eef6aa9d6/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi21-clang++
checking if the linker (/Users/andrey.filipenkov/.conan2/p/androc439eef6aa9d6/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi21-clang++) is GNU ld... no
```

But clang's linker is definitely GNU ld. With this change linker becomes identified correctly and build succeeds.
```
checking for ld... /Users/andrey.filipenkov/.conan2/p/androc439eef6aa9d6/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/ld
checking if the linker (/Users/andrey.filipenkov/.conan2/p/androc439eef6aa9d6/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/ld) is GNU ld... yes
```

References:
- https://mail.gnu.org/archive/html/bug-gnu-libiconv/2020-07/msg00002.html

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
