### PR TITLE
Updated cuda-api-wrappers with versions 0.7.1 and 0.8.0

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,10 +1,13 @@
 sources:
-  "0.7.0-b2":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.0-b2.tar.gz"
-    sha256: "9439cb2250dd3045a05d43c4ca66b5d49535eeba123b05a2e49169354fdb3123"
-  "0.7-b1":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/0.7b1.tar.gz"
-    sha256: "1ed5912d8f602ccd176865b824de17f462cb57142eb2a685d7cc034831e54a71"
+  "0.8.0":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.0.tar.gz"
+    sha256: "16c68e450e553d2839f00503a44e85b32c4f4e08f154e9f7c85f706bc5c79bf3"
+  "0.7.1":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.1.tar.gz"
+    sha256: "fa30c9fe43a62f5a3fd82a5deb477838fbf0bf455c73a2d2bb5ab6284184900b"
+  "0.7.0":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.0.tar.gz"
+    sha256: "a47d11607ffa0c41cfffe689840a14125520da3f4bb504267e9d232ebb846457"
   "0.6.8":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.8.tar.gz"
     sha256: "a0d1b062dbe41c99d06df4ae7885a053c2ae3815d6fe12df0458bc5277d08ed7"

--- a/recipes/cuda-api-wrappers/all/conanfile.py
+++ b/recipes/cuda-api-wrappers/all/conanfile.py
@@ -44,6 +44,6 @@ class CudaApiWrappersConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-
+        self.cpp_info.set_property("cmake_target_name", "cuda-api-wrappers::runtime-and-driver")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/recipes/cuda-api-wrappers/all/conanfile.py
+++ b/recipes/cuda-api-wrappers/all/conanfile.py
@@ -3,6 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.files import get, copy
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.52.0"
 
@@ -45,5 +46,8 @@ class CudaApiWrappersConan(ConanFile):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.set_property("cmake_target_name", "cuda-api-wrappers::runtime-and-driver")
+        if Version(self.version) < "0.7.0":
+            # For previously published versions the target name was different, maintain compatibility
+            self.cpp_info.set_property("cmake_target_aliases", ["cuda-api-wrappers::cuda-api-wrappers"])
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/recipes/cuda-api-wrappers/all/test_package/CMakeLists.txt
+++ b/recipes/cuda-api-wrappers/all/test_package/CMakeLists.txt
@@ -4,7 +4,7 @@ project(test_package LANGUAGES CXX)
 find_package(cuda-api-wrappers REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE cuda-api-wrappers::cuda-api-wrappers)
+target_link_libraries(${PROJECT_NAME} PRIVATE cuda-api-wrappers::runtime-and-driver)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     CUDA_API_WRAPPERS_VERSION=\"${cuda-api-wrappers_VERSION_STRING}\")

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,7 +1,9 @@
 versions:
-  "0.7.0-b2":
+  "0.8.0":
     folder: all
-  "0.7-b1":
+  "0.7.1":
+    folder: all
+  "0.7.0":
     folder: all
   "0.6.8":
     folder: all


### PR DESCRIPTION

### Summary
Changes to recipe:  **cuda-api-wrappers**

#### Motivation
* [previous PR](https://github.com/conan-io/conan-center-index/pull/25029) for one the last version was ignored for months
* New version of the library have been released
* Mistype in the CMakeLists.txt for the test package

#### Details
* Updated the recipe with versions [0.7.1](https://github.com/eyalroz/cuda-api-wrappers/releases/v0.7.1) and [0.8.0](https://github.com/eyalroz/cuda-api-wrappers/releases/v0.7.1) 
* fixed a mistype in the test package CMakeLists.txt.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
