### PR TITLE
minizip: fix building for Android API level < 24

### DIFF
--- a/recipes/minizip/all/conandata.yml
+++ b/recipes/minizip/all/conandata.yml
@@ -14,11 +14,23 @@ sources:
 patches:
   "1.3.1":
     - patch_file: "patches/minizip.patch"
+    - patch_file: "patches/android-pre-24.diff"
+      patch_description: "Fix building for Android against API level < 24"
+      patch_type: "portability"
   "1.2.13":
     - patch_file: "patches/minizip.patch"
+    - patch_file: "patches/android-pre-24.diff"
+      patch_description: "Fix building for Android against API level < 24"
+      patch_type: "portability"
   "1.2.12":
     - patch_file: "patches/minizip.patch"
     - patch_file: "patches/ioapi.patch"
+    - patch_file: "patches/android-pre-24.diff"
+      patch_description: "Fix building for Android against API level < 24"
+      patch_type: "portability"
   "1.2.11":
     - patch_file: "patches/minizip.patch"
     - patch_file: "patches/miniunz.patch"
+    - patch_file: "patches/android-pre-24.diff"
+      patch_description: "Fix building for Android against API level < 24"
+      patch_type: "portability"

--- a/recipes/minizip/all/conanfile.py
+++ b/recipes/minizip/all/conanfile.py
@@ -52,6 +52,7 @@ class MinizipConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -66,7 +67,6 @@ class MinizipConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()

--- a/recipes/minizip/all/conanfile.py
+++ b/recipes/minizip/all/conanfile.py
@@ -59,7 +59,7 @@ class MinizipConan(ConanFile):
         tc.variables["MINIZIP_SRC_DIR"] = os.path.join(self.source_folder, "contrib", "minizip").replace("\\", "/")
         tc.variables["MINIZIP_ENABLE_BZIP2"] = self.options.bzip2
         tc.variables["MINIZIP_BUILD_TOOLS"] = self.options.tools
-        # fopen64 and similar are unavailable before API level 24: https://github.com/madler/zlib/pull/436
+        # fopen64 and similar are unavailable before API level 24: https://github.com/madler/zlib/pull/1025
         if self.settings.os == "Android" and int(str(self.settings.os.api_level)) < 24:
             tc.preprocessor_definitions["IOAPI_NO_64"] = "1"
         tc.generate()

--- a/recipes/minizip/all/patches/android-pre-24.diff
+++ b/recipes/minizip/all/patches/android-pre-24.diff
@@ -1,0 +1,11 @@
+--- a/contrib/minizip/ioapi.h
++++ b/contrib/minizip/ioapi.h
+@@ -21,7 +21,7 @@
+ #ifndef _ZLIBIOAPI64_H
+ #define _ZLIBIOAPI64_H
+ 
+-#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
++#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__)) && !(defined(__ANDROID_API__) && __ANDROID_API__ < 24)
+ 
+   // Linux needs this to support file operation on files larger then 4+GB
+   // But might need better if/def to select just the platforms that needs them.


### PR DESCRIPTION
### Summary
Changes to recipe:  **minizip/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fixes building for Android API level < 24 again.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
An improvement over #15532. Not sure how/why it worked with Conan v1 previously, but now another adjustment is needed (maybe something changed in NDK, was testing with r27c now).

I've also opened PR in upstream: https://github.com/madler/zlib/pull/1025, but Conan patch includes only one change from it as otherwise it'd require more patches (that line has changed between versions), the other one is already handled by the injected `IOAPI_NO_64` macro.

Also moved applying patches to `source()`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
