### PR TITLE
update libjxl to 0.11.1

### DIFF
--- a/recipes/libjxl/all/conandata.yml
+++ b/recipes/libjxl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.1":
+    url: "https://github.com/libjxl/libjxl/archive/v0.11.1.tar.gz"
+    sha256: "1492dfef8dd6c3036446ac3b340005d92ab92f7d48ee3271b5dac1d36945d3d9"
   "0.10.3":
     url: "https://github.com/libjxl/libjxl/archive/v0.10.3.zip"
     sha256: "a9e2103f61ab79f5561b506ad03fcba33207263284b1a796eba3ca826ab0a75f"

--- a/recipes/libjxl/config.yml
+++ b/recipes/libjxl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.1":
+    folder: all
   "0.10.3":
     folder: all
   "0.10.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjxl/0.11.1**

#### Motivation
The newest version available on conan center is [0.10.3](https://conan.io/center/recipes/libjxl?version=0.10.3).
This version also seems to [fix some security vulnerabilities](https://github.com/libjxl/libjxl/releases/tag/v0.11.1)?

I was also thinking that we should maybe update all usages to this new Version?
There are only three recipes using it:
- gdal: [`libjxl/0.6.1`](https://github.com/conan-io/conan-center-index/blob/9578f41c91ff6c4e3f3e188449b2b84dc62eb6a9/recipes/gdal/post_3.5.0/conanfile.py#L233C28-L233C40)
- libvips: [`libjxl/0.6.1`](https://github.com/conan-io/conan-center-index/blob/9578f41c91ff6c4e3f3e188449b2b84dc62eb6a9/recipes/libvips/all/conanfile.py#L157)
- sail: [`libjxl/0.8.2`](https://github.com/conan-io/conan-center-index/blob/9578f41c91ff6c4e3f3e188449b2b84dc62eb6a9/recipes/sail/all/conanfile.py#L67)

Notice that the version `0.6.1` isn't even available on the conan center!?

There is also a pull request for [0.11.0](https://github.com/conan-io/conan-center-index/pull/25254) but that seems to be abandoned?

#### Details
Just added the data to the ymls.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
