### PR TITLE
sfml: add version 3.0.0

### DIFF
--- a/recipes/sfml/all/conandata.yml
+++ b/recipes/sfml/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.0":
+    url: "https://www.sfml-dev.org/files/SFML-3.0.0-sources.zip"
+    sha256: 8cc41db46b59f07c44ecf21c74a0f956d37735dec9d90ff4522856cb162ba642
   "2.6.2":
     url: "https://www.sfml-dev.org/files/SFML-2.6.2-sources.zip"
     sha256: "19d6dbd9c901c74441d9888c13cb1399f614fe8993d59062a72cfbceb00fed04"

--- a/recipes/sfml/all/conanfile.py
+++ b/recipes/sfml/all/conanfile.py
@@ -91,9 +91,11 @@ class SfmlConan(ConanFile):
         tc.variables["SFML_BUILD_AUDIO"] = self.options.audio
         tc.variables["SFML_INSTALL_PKGCONFIG_FILES"] = False
         tc.variables["SFML_GENERATE_PDB"] = False
-        tc.variables["SFML_USE_SYSTEM_DEPS"] = True
+        tc.variables["SFML_USE_SYSTEM_DEPS"] = Version(self.version) < "3.0.0"
         tc.variables["WARNINGS_AS_ERRORS"] = False
-        if Version(self.version) >= "2.6.0":
+        if Version(self.version) >= "3.0.0":
+            tc.variables["CMAKE_CXX_STANDARD"] = 17
+        elif Version(self.version) >= "2.6.0":
             tc.variables["CMAKE_CXX_STANDARD"] = 11
         if is_msvc(self):
             tc.variables["SFML_USE_STATIC_STD_LIBS"] = is_msvc_static_runtime(self)

--- a/recipes/sfml/all/test_package/CMakeLists.txt
+++ b/recipes/sfml/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.24)
 project(test_package LANGUAGES CXX)
 
 add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/sfml/all/test_package/test_package.cpp
+++ b/recipes/sfml/all/test_package/test_package.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <SFML/System.hpp>
 
 #ifdef SFML_WITH_WINDOW
@@ -16,10 +18,16 @@
 int main()
 {
     sf::Clock clock;
-    clock.getElapsedTime().asSeconds();
+    std::cout << "Seconds elapsed: "
+              << clock.getElapsedTime().asSeconds()
+              << std::endl;
 
 #ifdef SFML_WITH_WINDOW
+ #if SFML_VERSION_MAJOR >= 3
+    sf::VideoMode videoMode({720, 480});
+ #else
     sf::VideoMode videoMode(720, 480);
+ #endif
 #endif
 
 #ifdef SFML_WITH_GRAPHICS
@@ -29,13 +37,14 @@ int main()
 
 #ifdef SFML_WITH_NETWORK
     sf::TcpListener listener;
-    listener.isBlocking();
+    std::cout << "TCP blocking: "
+              << listener.isBlocking()
+              << std::endl;
 #endif
 
 #ifdef SFML_WITH_AUDIO
     sf::SoundBuffer buffer;
-    sf::Sound sound;
-    sound.setBuffer(buffer);
+    sf::Sound sound(buffer);
 #endif
 
     return 0;

--- a/recipes/sfml/config.yml
+++ b/recipes/sfml/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.0":
+    folder: all
   "2.6.2":
     folder: all
   "2.6.1":


### PR DESCRIPTION
changes:
- cmake required version 3.1 -> 3.24
- added SFML 3.0.0 source zip + sha256
- updated test_package.cpp to work with both SFML 3.0.0

The cmake minimum version was changed to 3.24 because:
- Linux SFML 3.0.0 requires 3.22
- Windows SFML 3.0.0 requires 3.24

It was deemed simpler to just have a single version required for the sake of the test package.

More info: https://github.com/SFML/SFML/blob/7f1162dfea4969bc17417563ac55d93b72e84c1e/CMakeLists.txt#L1-L9


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
