### PR TITLE
fmt: add version 11.1.1, fix unicode and cmake version handling

### DIFF
--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "11.1.1":
+    url: "https://github.com/fmtlib/fmt/releases/download/11.1.1/fmt-11.1.1.zip"
+    sha256: "a25124e41c15c290b214c4dec588385153c91b47198dbacda6babce27edc4b45"
   "11.0.2":
     url: "https://github.com/fmtlib/fmt/releases/download/11.0.2/fmt-11.0.2.zip"
     sha256: "40fc58bebcf38c759e11a7bd8fdc163507d2423ef5058bba7f26280c5b9c5465"

--- a/recipes/fmt/config.yml
+++ b/recipes/fmt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "11.1.1":
+    folder: all
   "11.0.2":
     folder: all
   "11.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fmt/11.1.1**

#### Motivation
There are several improvements since 11.0.2.

#### Details
https://github.com/fmtlib/fmt/compare/11.0.2...11.1.1

### Changes by maintainers:
* Define `cmake_config_version_compat` to `AnyNewerVersion` to mirror what upstream does (proper fix for https://github.com/conan-io/conan-center-index/pull/17545)
* Propagate `FMT_UNICODE=0` macro when unicode is disabled (mirror what upstream does) - https://github.com/conan-io/conan-center-index/issues/26267
* Remove "dead" code in Conan 2 (legacy cpp_info properties)

Close https://github.com/conan-io/conan-center-index/issues/26267


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
