### PR TITLE
pcapplusplus: Fix iphlpap linkage and WholeProgramOptimization

### DIFF
--- a/recipes/pcapplusplus/all/conanfile.py
+++ b/recipes/pcapplusplus/all/conanfile.py
@@ -86,6 +86,7 @@ class PcapplusplusConan(ConanFile):
                 # so that we have precedence over PlatformToolset version
                 replace_in_file(self, template_file, '<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />', 
                                 f'<Import Project="{props_file}" />\n<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />')
+                replace_in_file(self, template_file, "<WholeProgramOptimization>true</WholeProgramOptimization>", "<WholeProgramOptimization>false</WholeProgramOptimization>")
 
     def generate(self):
         if self.settings.os == "Windows":
@@ -143,4 +144,4 @@ class PcapplusplusConan(ConanFile):
         if self.settings.os == "Macos":
             self.cpp_info.frameworks.extend(["CoreFoundation", "Security", "SystemConfiguration"])
         if self.settings.os == "Windows":
-            self.cpp_info.system_libs = ["ws2_32"]
+            self.cpp_info.system_libs = ["ws2_32", "iphlpapi"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **pcapplusplus/[>=21.05 <=22.11]**

#### Motivation

Fix https://github.com/conan-io/conan-center-index/issues/26269 by disabling `<WholeProgramOptimization>`  to prevent error when the consumer is using a different compiler version (but still compatible)

Add `iphlpapi` to system libraries on Windows: - fixes issue:

```
Pcap++.lib(PcapLiveDeviceList.obj) : error LNK2019: unresolved external symbol __imp_GetNetworkParams referenced in function "private: void __cdecl pcpp::PcapLiv 
eDeviceList::setDnsServers(void)" (?setDnsServers@PcapLiveDeviceList@pcpp@@AEAAXXZ) [Z:\sources\conan-center-index\recipes\pcapplusplus\all\test_package\build\ms 
vc-194-x86_64-14-release\test_package.vcxproj]
```



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
