### PR TITLE
benchmark: add version 1.9.1

### DIFF
--- a/recipes/benchmark/all/conandata.yml
+++ b/recipes/benchmark/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
+  "1.9.1":
+    url: "https://github.com/google/benchmark/archive/refs/tags/v1.9.1.tar.gz"
+    sha256: "32131c08ee31eeff2c8968d7e874f3cb648034377dfc32a4c377fa8796d84981"
+  # keep 1.9.0, the last release for c++14
   "1.9.0":
     url: "https://github.com/google/benchmark/archive/refs/tags/v1.9.0.tar.gz"
     sha256: "35a77f46cc782b16fac8d3b107fbfbb37dcd645f7c28eee19f3b8e0758b48994"

--- a/recipes/benchmark/config.yml
+++ b/recipes/benchmark/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.1":
+    folder: all
   "1.9.0":
     folder: all
   "1.8.5":


### PR DESCRIPTION
### Summary
Changes to recipe:  **benchmark/1.9.1**

#### Motivation
There are several improvements in 1.9.1.
1.9.1 requires C++17.

#### Details
https://github.com/google/benchmark/releases/tag/v1.9.1
https://github.com/google/benchmark/compare/v1.9.0...v1.9.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
