### PR TITLE
cyclonedds-cxx: properly handle shm support

### DIFF
--- a/recipes/cyclonedds-cxx/all/conanfile.py
+++ b/recipes/cyclonedds-cxx/all/conanfile.py
@@ -21,10 +21,12 @@ class CycloneDDSCXXConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_shm": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_shm": False,
     }
 
     @property
@@ -69,6 +71,9 @@ class CycloneDDSCXXConan(ConanFile):
         #      <dds/topic/detail/Topic.hpp>:34
         self.requires("cyclonedds/{}".format(self.version), transitive_headers=True)
 
+        if self.options.with_shm:
+            self.requires("iceoryx/2.0.5")
+
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
@@ -77,6 +82,10 @@ class CycloneDDSCXXConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
+
+        if self.options.with_shm != self.dependencies['cyclonedds'].options.with_shm:
+            raise ConanInvalidConfiguration(
+                "cyclonedds-cxx and cyclonedds must be built with the same 'with_shm' option")
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.16 <4]")
@@ -93,13 +102,14 @@ class CycloneDDSCXXConan(ConanFile):
         tc.variables["BUILD_EXAMPLES"] = False
         # variables which effects build
         tc.variables["ENABLE_LEGACY"] = False
-        tc.variables["ENABLE_SHM"] = self.dependencies["cyclonedds"].options.with_shm
+        tc.variables["ENABLE_SHM"] = self.options.with_shm
         tc.variables["ENABLE_TYPE_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
         tc.variables["ENABLE_TOPIC_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
         tc.variables["ENABLE_COVERAGE"] = False
         tc.generate()
-        cd = CMakeDeps(self)
-        cd.generate()
+        deps = CMakeDeps(self)
+        deps.set_property("iceoryx", "cmake_file_name", "iceoryx_binding_c")
+        deps.generate()
 
     def _patch_sources(self):
         cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
@@ -154,6 +164,8 @@ class CycloneDDSCXXConan(ConanFile):
         self.cpp_info.components["ddscxx"].set_property("cmake_target_name", "CycloneDDS-CXX::ddscxx")
         self.cpp_info.components["ddscxx"].set_property("pkg_config_name", "CycloneDDS-CXX")
         self.cpp_info.components["ddscxx"].requires = ["cyclonedds::CycloneDDS"]
+        if self.options.with_shm:
+            self.cpp_info.components["ddscxx"].requires.append("iceoryx::iceoryx")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["ddscxx"].system_libs = ["m"]
         self.cpp_info.components["idlcxx"].libs = ["cycloneddsidlcxx"]

--- a/recipes/cyclonedds/all/conanfile.py
+++ b/recipes/cyclonedds/all/conanfile.py
@@ -107,6 +107,7 @@ class CycloneDDSConan(ConanFile):
         tc.variables["BUILD_IDLC_TESTING"] = False
         tc.variables["BUILD_DDSPERF"] = False
         tc.variables["BUILD_IDLC_TESTING"] = False
+        tc.cache_variables["ENABLE_LTO"] = False
         # variables which effects build
         tc.variables["ENABLE_SSL"] = self.options.with_ssl
         tc.variables["ENABLE_SHM"] = self.options.with_shm


### PR DESCRIPTION
Fix #26288

cyclonedds:
* Disable LTO which makes the binaries extra sensitive to the exact compiler version

cyclonedds-cxx:
* Properly expose with_shm: this controls the conditional dependency
* Ensure in `validate()` that when it is enabled, it is also enabled in `cyclonedds`
* Via cmakedeps, use the name expected by the cmake build scripts
