### PR TITLE
luau: add version 0.655

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.655":
+    url: "https://github.com/Roblox/luau/archive/0.655.tar.gz"
+    sha256: "1c0ff05ce18493d6c83062a17cf6822a71ce254bfa0db41dd086d313b674ca33"
   "0.650":
     url: "https://github.com/Roblox/luau/archive/0.650.tar.gz"
     sha256: "a605ae7a188455844ab131ff0d2df6f38c088142d6bd5eebb87795e619c3d7aa"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.655":
+    folder: all
   "0.650":
     folder: all
   "0.645":


### PR DESCRIPTION
### Summary
Changes to recipe:  **luau/0.655**

#### Motivation
There are several improvements since 0.650.

#### Details
https://github.com/luau-lang/luau/releases/tag/0.655
https://github.com/luau-lang/luau/compare/0.650...0.655

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
