### PR TITLE
mbedtls: propagate snprintf macro in package_info, only for current versions

### DIFF
--- a/recipes/mbedtls/all/conanfile.py
+++ b/recipes/mbedtls/all/conanfile.py
@@ -87,11 +87,8 @@ class MBedTLSConan(ConanFile):
         if Version(self.version) < "3.0.0":
             # relocatable shared libs on macOS
             tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
-        if is_msvc(self):
-            if check_min_vs(self, 190, raise_invalid=False):
-                tc.preprocessor_definitions["MBEDTLS_PLATFORM_SNPRINTF_MACRO"] = "snprintf"
-            else:
-                tc.preprocessor_definitions["MBEDTLS_PLATFORM_SNPRINTF_MACRO"] = "MBEDTLS_PLATFORM_STD_SNPRINTF"
+        if is_msvc(self) and "2.16.12" <= Version(self.version) <= "3.6.0":
+            tc.preprocessor_definitions["MBEDTLS_PLATFORM_SNPRINTF_MACRO"] = "snprintf"
         if self.options.enable_threading:
             tc.preprocessor_definitions["MBEDTLS_THREADING_C"] = True
             tc.preprocessor_definitions["MBEDTLS_THREADING_PTHREAD"] = True
@@ -139,6 +136,11 @@ class MBedTLSConan(ConanFile):
         self.cpp_info.components["libembedtls"].set_property("cmake_target_name", "MbedTLS::mbedtls")
         self.cpp_info.components["libembedtls"].libs = ["mbedtls"]
         self.cpp_info.components["libembedtls"].requires = ["mbedx509"]
+
+        if is_msvc(self) and "2.16.12" <= Version(self.version) <= "3.6.0":
+            for component in ["mbedcrypto", "libembedtls", "mbedx509"]:
+                self.cpp_info.components[component].defines.append("MBEDTLS_PLATFORM_SNPRINTF_MACRO=snprintf")
+
         if Version(self.version) >= "3.6.0":
             self.cpp_info.components["libembedtls"].set_property("pkg_config_name", "embedtls")
 


### PR DESCRIPTION
When the recipe started defining the `MBEDTLS_PLATFORM_SNPRINTF_MACRO` as a build-time macro, it causes a mismatch for some versions of the recipe - where consumers who don't define this macro with the same value, end up falling back with its default value (as set by upstream) - resulting in undefined references because different symbols are expected - this was experienced here:

* https://github.com/conan-io/conan-center-index/pull/25623/checks?check_run_id=32491832397 ([logs](https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-25623/3/package_build_logs/test_log_lief_0_15_1_947d4157b396ee3cc726a8c556d10689_547d30ce0e93556d841360172fd5bdac4ffd1893.txt))
* https://github.com/conan-io/conan-center-index/pull/25623#discussion_r1841907794

Version 3.6.0 and newer should handle this correctly: https://github.com/Mbed-TLS/mbedtls/commit/1463e49a3c2f2bdd7cac52964c0c0c599ef63d94

This PR: 

* Ensure that consumers also expect the same symbols, by propagating that macro in the `package_info` method 
* Limit defining that macro for current versions - this is not something that should've gone in the recipe if the defaults already worked. Also - newer versions seem to handle this different, so in the future just let it fallback to its defaults
