### PR TITLE
Drogon : update for 1.9.9 release

### DIFF
--- a/recipes/drogon/config.yml
+++ b/recipes/drogon/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.9":
+    folder: "all"
   "1.9.8":
     folder: "all"
   "1.9.7":


### PR DESCRIPTION
API changes list

    Added Partitioned flag for cookies.

Changed

    Update FindFilesystem.cmake to check for GNU instead of GCC for CMAKE_CXX_COMPILER_ID.

    Update README.

    Chore(workflow/cmake.yml): upgrade macos runner.

    Add emptiness check to the LogStream &operator<< with std::string_view.

Fixed

    Fix a bug in plugin Redirector.

    Fix CMAKE issues mentioned in https://github.com/drogonframework/drogon/issues/2144 and a linking problem which manifest with gcc12.3 when building with shared libs.

    Fix: Remove dependency on locales being installed on the system.