### PR TITLE
reflect-cpp: Added new version 0.17.0

### DIFF
--- a/recipes/reflect-cpp/all/conandata.yml
+++ b/recipes/reflect-cpp/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "0.16.0":
     url: "https://github.com/getml/reflect-cpp/archive/refs/tags/v0.16.0.tar.gz"
     sha256: "a84d94dbd353d788926d6e54507b44c046863f7bc4ecb35afe0338374a68a77d"
+  "0.17.0":
+    url: "https://github.com/getml/reflect-cpp/archive/refs/tags/v0.17.0.tar.gz"
+    sha256: "08b6406cbe4c6c14ff1a619fe93a94f92f6d9eb22213d93529ad975993945e45"

--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -70,12 +70,16 @@ class ReflectCppConan(ConanFile):
     }
     implements = ["auto_shared_fpic"]
 
+    def config_options(self):
+        if Version(self.version) < "0.17.0":
+            del self.options.with_capnproto
+
     def requirements(self):
         self.requires("ctre/3.9.0", transitive_headers=True)
         # INFO: include/rfl/json/Writer.hpp includes yyjson.h
         # INFO: Transitive lib needed to avoid undefined reference to symbol 'yyjson_mut_doc_new'
         self.requires("yyjson/0.10.0", transitive_headers=True, transitive_libs=True)
-        if self.options.with_capnproto:
+        if self.options.get_safe("with_capnproto"):
             self.requires("capnproto/1.1.0", transitive_headers=True)
         if self.options.with_cbor:
             if Version(self.version) >= Version("0.17.0"):
@@ -123,7 +127,8 @@ class ReflectCppConan(ConanFile):
         tc.cache_variables["REFLECTCPP_BUILD_SHARED"] = self.options.shared
         tc.cache_variables["REFLECTCPP_USE_BUNDLED_DEPENDENCIES"] = False
         tc.cache_variables["REFLECTCPP_USE_VCPKG"] = False
-        tc.cache_variables["REFLECTCPP_CAPNPROTO"] = self.options.with_capnproto
+        if self.options.get_safe("with_capnproto") is not None:
+            tc.cache_variables["REFLECTCPP_CAPNPROTO"] = self.options.get_safe("with_capnproto")
         tc.cache_variables["REFLECTCPP_CBOR"] = self.options.with_cbor
         tc.cache_variables["REFLECTCPP_FLEXBUFFERS"] = self.options.with_flatbuffers
         tc.cache_variables["REFLECTCPP_MSGPACK"] = self.options.with_msgpack

--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -21,6 +21,7 @@ class ReflectCppConan(ConanFile):
         "reflection",
         "serialization",
         "memory",
+        "Cap'n Proto",
         "cbor",
         "flatbuffers",
         "json",
@@ -46,6 +47,7 @@ class ReflectCppConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_capnproto": [True, False],
         "with_cbor": [True, False],
         "with_flatbuffers": [True, False],
         "with_msgpack": [True, False],
@@ -57,6 +59,7 @@ class ReflectCppConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_capnproto": False,
         "with_cbor": False,
         "with_flatbuffers": False,
         "with_msgpack": False,
@@ -72,8 +75,13 @@ class ReflectCppConan(ConanFile):
         # INFO: include/rfl/json/Writer.hpp includes yyjson.h
         # INFO: Transitive lib needed to avoid undefined reference to symbol 'yyjson_mut_doc_new'
         self.requires("yyjson/0.10.0", transitive_headers=True, transitive_libs=True)
+        if self.options.with_capnproto:
+            self.requires("capnproto/1.1.0", transitive_headers=True)
         if self.options.with_cbor:
-            self.requires("tinycbor/0.6.0", transitive_headers=True)
+            if self.version >= "0.17.0":
+                self.requires("jsoncons/0.176.0", transitive_headers=True)
+            else:
+                self.requires("tinycbor/0.6.0", transitive_headers=True)
         if self.options.with_flatbuffers:
             self.requires("flatbuffers/24.3.25", transitive_headers=True)
         if self.options.with_msgpack:
@@ -115,10 +123,12 @@ class ReflectCppConan(ConanFile):
         tc.cache_variables["REFLECTCPP_BUILD_SHARED"] = self.options.shared
         tc.cache_variables["REFLECTCPP_USE_BUNDLED_DEPENDENCIES"] = False
         tc.cache_variables["REFLECTCPP_USE_VCPKG"] = False
+        tc.cache_variables["REFLECTCPP_CAPNPROTO"] = self.options.with_capnproto
         tc.cache_variables["REFLECTCPP_CBOR"] = self.options.with_cbor
         tc.cache_variables["REFLECTCPP_FLEXBUFFERS"] = self.options.with_flatbuffers
         tc.cache_variables["REFLECTCPP_MSGPACK"] = self.options.with_msgpack
         tc.cache_variables["REFLECTCPP_TOML"] = self.options.with_toml
+        tc.cache_variables["REFLECTCPP_UBJSON"] = self.options.with_ubjson
         tc.cache_variables["REFLECTCPP_XML"] = self.options.with_xml
         tc.cache_variables["REFLECTCPP_YAML"] = self.options.with_yaml
         tc.generate()

--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -71,6 +71,8 @@ class ReflectCppConan(ConanFile):
     implements = ["auto_shared_fpic"]
 
     def config_options(self):
+        if self.settings.get_safe("os") == "Windows":
+            self.options.rm_safe("fPIC")
         if Version(self.version) < "0.17.0":
             del self.options.with_capnproto
 

--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -78,7 +78,7 @@ class ReflectCppConan(ConanFile):
         if self.options.with_capnproto:
             self.requires("capnproto/1.1.0", transitive_headers=True)
         if self.options.with_cbor:
-            if self.version >= "0.17.0":
+            if Version(self.version) >= Version("0.17.0"):
                 self.requires("jsoncons/0.176.0", transitive_headers=True)
             else:
                 self.requires("tinycbor/0.6.0", transitive_headers=True)

--- a/recipes/reflect-cpp/config.yml
+++ b/recipes/reflect-cpp/config.yml
@@ -1,3 +1,5 @@
 versions:
   "0.16.0":
     folder: all
+  "0.17.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **reflect-cpp/0.17.0**

#### Motivation
reflect-cpp 0.17.0 was recently released. This updates the Conan package.

#### Details
- reflect-cpp 0.17.0 added support for Cap'n Proto, so I added this as an option. 
- reflect-cpp 0.17.0 switched to jsoncons as the package for CBOR, so I updated the dependencies accordingly, while maintaining backward compatibility.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
