### PR TITLE
jsoncons: add version 1.0.0

### DIFF
--- a/recipes/jsoncons/all/conandata.yml
+++ b/recipes/jsoncons/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/danielaparker/jsoncons/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "5b602e131761a3eb0fc85043a67e8006f04fa0ce2f2012aeca48371cd99ec85f"
   "0.178.0":
     url: "https://github.com/danielaparker/jsoncons/archive/refs/tags/v0.178.0.tar.gz"
     sha256: "c531b4288bb08c9c2b36fba53f568bc800e93656830bcffc18a87a3af1f46290"

--- a/recipes/jsoncons/config.yml
+++ b/recipes/jsoncons/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: "all"
   "0.178.0":
     folder: "all"
   "0.177.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **jsoncons/1.0.0**

#### Motivation
Major version up.

#### Details
https://github.com/danielaparker/jsoncons/releases/tag/v1.0.0
https://github.com/danielaparker/jsoncons/compare/v0.178.0...v1.0.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
