### PR TITLE
Update Wt version to 4.11.2

### DIFF
--- a/recipes/wt/all/conandata.yml
+++ b/recipes/wt/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.11.1":
-    url: "https://github.com/emweb/wt/archive/4.11.1.tar.gz"
-    sha256: "c255b7d6b0569a9c67282ef7a89af9624e3ab79477924e5a110814a570d1d017"
+  "4.11.2":
+    url: "https://github.com/emweb/wt/archive/4.11.2.tar.gz"
+    sha256: "d28ce0b18121a5ded5ad9737ee664cac17ff1e287d339cc422ecef57fa68c2b6"
   "4.10.1":
     url: "https://github.com/emweb/wt/archive/4.10.1.tar.gz"
     sha256: "f6d6114416a628604793197cd077066a9d4d98799bbb288b97de42f66705bde5"
@@ -24,7 +24,7 @@ sources:
     url: "https://github.com/emweb/wt/archive/4.6.0.tar.gz"
     sha256: "7f709e132d32c4925e6db0a590c7ccc5613344e8b9052676ef891a25ccb550e6"
 patches:
-  "4.11.1":
+  "4.11.2":
     - patch_file: "patches/4.8.0-0001-use-cci-package.patch"
       patch_description: "use cci package"
       patch_type: "conan"

--- a/recipes/wt/all/conandata.yml
+++ b/recipes/wt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.11.1":
+    url: "https://github.com/emweb/wt/archive/4.11.1.tar.gz"
+    sha256: "c255b7d6b0569a9c67282ef7a89af9624e3ab79477924e5a110814a570d1d017"
   "4.10.1":
     url: "https://github.com/emweb/wt/archive/4.10.1.tar.gz"
     sha256: "f6d6114416a628604793197cd077066a9d4d98799bbb288b97de42f66705bde5"
@@ -21,6 +24,10 @@ sources:
     url: "https://github.com/emweb/wt/archive/4.6.0.tar.gz"
     sha256: "7f709e132d32c4925e6db0a590c7ccc5613344e8b9052676ef891a25ccb550e6"
 patches:
+  "4.11.1":
+    - patch_file: "patches/4.8.0-0001-use-cci-package.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "4.10.1":
     - patch_file: "patches/4.8.0-0001-use-cci-package.patch"
       patch_description: "use cci package"

--- a/recipes/wt/config.yml
+++ b/recipes/wt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.11.2":
+    folder: all
   "4.10.1":
     folder: all
   "4.10.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **wt/4.11.2**

#### Motivation
New release of Wt library.

#### Details
Only a new version 4.11.2 added, no other changes.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
