### PR TITLE
libpng: add version 1.6.45

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.45":
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.45/libpng-1.6.45.tar.xz"
+    sha256: "926485350139ffb51ef69760db35f78846c805fef3d59bfdcb2fba704663f370"
   "1.6.44":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.44/libpng-1.6.44.tar.xz"
     sha256: "60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.45":
+    folder: all
   "1.6.44":
     folder: all
   "1.6.43":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpng/1.6.45**

#### Motivation
New upstream version

#### Details
https://github.com/pnggroup/libpng/compare/v1.6.44...v1.6.45

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
