### PR TITLE
openssl: fix build error 

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -143,7 +143,7 @@ class OpenSSLConan(ConanFile):
             raise ConanInvalidConfiguration("OpenSSL 3 does not support building shared libraries for iOS")
 
     def build_requirements(self):
-        if self.settings_build.os == "Windows":
+        if self.settings.os == "Windows":
             if self.conf.get("user.openssl:windows_use_jom", False):
                 self.tool_requires("jom/[*]")
             if not self.options.no_asm and self.settings.arch in ["x86", "x86_64"]:


### PR DESCRIPTION
RT, fix openssl build broken after  #26151

### Summary
Changes to recipe:  **openssl/3.x.x**

#### Motivation
openssl 3.x conan build broken

#### Details
```
ERROR: openssl/3.3.2: Error in build_requirements() method, line 146
	if self.settings_build.os == "Windows":
	AttributeError: 'OpenSSLConan' object has no attribute 'settings_build'
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
