### PR TITLE
mongo-c-driver: add version 1.29.2

### DIFF
--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.29.2":
+    url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.29.2/mongo-c-driver-1.29.2.tar.gz"
+    sha256: "b5c33912c365e108d1fb1a03586364bbadc90e568e5719b290e15031c6e5ad90"
   "1.29.1":
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.29.1/mongo-c-driver-1.29.1.tar.gz"
     sha256: "64382a775353e67c510450c83d72b72e6747ba18256dd1d313deeef7db073b4f"

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.29.2":
+    folder: all
   "1.29.1":
     folder: all
   "1.29.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mongo-c-driver/1.29.2**

#### Motivation

Requested in https://github.com/conan-io/conan-center-index/issues/26321

#### Details

Changelog: https://github.com/mongodb/mongo-c-driver/compare/1.29.1...1.29.2
This new version aims to solve compilation issues on Windows arm64

Fix https://github.com/conan-io/conan-center-index/issues/26321

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
