### PR TITLE
tiledb: add version 2.28.0

### DIFF
--- a/recipes/tiledb/all/conandata.yml
+++ b/recipes/tiledb/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "2.27.0":
     url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.27.0.tar.gz"
     sha256: "a1d42e675a983291c1a0edd1a13f70e26649700160bb2bee5d6011a2af55837a"
-  "2.26.3":
-    url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.26.3.tar.gz"
-    sha256: "860097e8060cec16eb86cfd94794ea38d42b2d757fba9a690ac9778c0def77e2"
   "2.26.1":
     url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.26.1.tar.gz"
     sha256: "f90461850c6f87f63fe77788d7932fd53a4d1de7e2ba7263f5e8f2fd1df23e38"

--- a/recipes/tiledb/all/conandata.yml
+++ b/recipes/tiledb/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "2.27.0":
+    url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.27.0.tar.gz"
+    sha256: "a1d42e675a983291c1a0edd1a13f70e26649700160bb2bee5d6011a2af55837a"
+  "2.26.3":
+    url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.26.3.tar.gz"
+    sha256: "860097e8060cec16eb86cfd94794ea38d42b2d757fba9a690ac9778c0def77e2"
   "2.26.1":
     url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.26.1.tar.gz"
     sha256: "f90461850c6f87f63fe77788d7932fd53a4d1de7e2ba7263f5e8f2fd1df23e38"

--- a/recipes/tiledb/all/conandata.yml
+++ b/recipes/tiledb/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.27.0":
-    url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.27.0.tar.gz"
-    sha256: "a1d42e675a983291c1a0edd1a13f70e26649700160bb2bee5d6011a2af55837a"
+  "2.27.1":
+    url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.27.1.tar.gz"
+    sha256: "9433475cabd1af6384d3c6b8ec0310169997a2e323ebe236a83ac3e709e72cc5"
   "2.26.1":
     url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.26.1.tar.gz"
     sha256: "f90461850c6f87f63fe77788d7932fd53a4d1de7e2ba7263f5e8f2fd1df23e38"

--- a/recipes/tiledb/all/conandata.yml
+++ b/recipes/tiledb/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.27.1":
-    url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.27.1.tar.gz"
-    sha256: "9433475cabd1af6384d3c6b8ec0310169997a2e323ebe236a83ac3e709e72cc5"
+  "2.28.0":
+    url: "https://github.com/TileDB-Inc/TileDB/releases/download/2.28.0/tiledb-source-2.28.0-4764907.tar.gz"
+    sha256: "87460e81f8e0b6ddc252fcf788466e8ec5579d6a2125dbbd60905b52a101ce18"
   "2.26.1":
     url: "https://github.com/TileDB-Inc/TileDB/archive/refs/tags/2.26.1.tar.gz"
     sha256: "f90461850c6f87f63fe77788d7932fd53a4d1de7e2ba7263f5e8f2fd1df23e38"

--- a/recipes/tiledb/all/conanfile.py
+++ b/recipes/tiledb/all/conanfile.py
@@ -157,7 +157,8 @@ class TileDBConan(ConanFile):
             self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        strip_root = Version(self.version) < "2.28.0"
+        get(self, **self.conan_data["sources"][self.version], strip_root=strip_root)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -216,7 +217,7 @@ class TileDBConan(ConanFile):
             "libwebp::webpmux": "WebP::libwebpmux",
             "lz4": "LZ4::LZ4",
             "zlib": "ZLIB::ZLIB",
-            "zstd": "Zstd::Zstd",
+            "zstd": "Zstd::Zstd" if Version(self.version) < "2.28.0" else "zstd::libzstd",
         }
         for component, new_target_name in renamed_targets.items():
             deps.set_property(component, "cmake_target_name", new_target_name)

--- a/recipes/tiledb/config.yml
+++ b/recipes/tiledb/config.yml
@@ -1,3 +1,7 @@
 versions:
+  "2.27.0":
+    folder: all
+  "2.26.3":
+    folder: all
   "2.26.1":
     folder: all

--- a/recipes/tiledb/config.yml
+++ b/recipes/tiledb/config.yml
@@ -1,7 +1,5 @@
 versions:
   "2.27.0":
     folder: all
-  "2.26.3":
-    folder: all
   "2.26.1":
     folder: all

--- a/recipes/tiledb/config.yml
+++ b/recipes/tiledb/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.27.0":
+  "2.27.1":
     folder: all
   "2.26.1":
     folder: all

--- a/recipes/tiledb/config.yml
+++ b/recipes/tiledb/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.27.1":
+  "2.28.0":
     folder: all
   "2.26.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **tiledb/***

#### Motivation
There are several new features in 2.27.0.

#### Details
https://github.com/TileDB-Inc/TileDB/releases/tag/2.27.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
