### PR TITLE
flatbuffers: add version 24.12.23

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "24.12.23":
-    url: "https://github.com/google/flatbuffers/archive/v24.3.25.tar.gz"
+    url: "https://github.com/google/flatbuffers/archive/v24.12.23.tar.gz"
     sha256: "7e2ef35f1af9e2aa0c6a7d0a09298c2cb86caf3d4f58c0658b306256e5bcab10"
   "24.3.25":
     url: "https://github.com/google/flatbuffers/archive/v24.3.25.tar.gz"

--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "24.12.23":
+    url: "https://github.com/google/flatbuffers/archive/v24.3.25.tar.gz"
+    sha256: "7e2ef35f1af9e2aa0c6a7d0a09298c2cb86caf3d4f58c0658b306256e5bcab10"
   "24.3.25":
     url: "https://github.com/google/flatbuffers/archive/v24.3.25.tar.gz"
     sha256: "4157c5cacdb59737c5d627e47ac26b140e9ee28b1102f812b36068aab728c1ed"

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "24.12.23":
+    folder: all
   "24.3.25":
     folder: all
   "24.3.7":


### PR DESCRIPTION
### Summary
Changes to recipe:  **flatbuffers/***

#### Motivation
There are several new features and compatibilities in 24.12.23

#### Details
https://github.com/google/flatbuffers/releases/tag/v24.12.23

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
