### PR TITLE
libpq: pg_config should be built first

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -188,13 +188,14 @@ class LibpqConan(ConanFile):
                 autotools.make()
             with chdir(self, os.path.join(self.build_folder, "src", "include")):
                 autotools.make()
+            with chdir(self, os.path.join(self.build_folder, "src", "bin", "pg_config")):
+                autotools.make()
             with chdir(self, os.path.join(self.build_folder, "src", "interfaces", "libpq")):
                 autotools.make()
             if Version(self.version) >= 12:
                 with chdir(self, os.path.join(self.build_folder, "src", "port")):
                     autotools.make()
-            with chdir(self, os.path.join(self.build_folder, "src", "bin", "pg_config")):
-                autotools.make()
+
 
     def _remove_unused_libraries_from_package(self):
         bin_folder = os.path.join(self.package_folder, "bin")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpq/all versions**

#### Motivation

The pg_config should be built ahead of `interfaces/libpq`, otherwise we could get the following undefined errors, it does NOT always happen(I don't know why it does not fail though)

```
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c: In function ‘get_includeserver_path’:
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c:863:38: error: ‘INCLUDEDIRSERVER’ undeclared (first use in this function); did you mean ‘INCLUDEDIR’?
  863 |         make_relative_path(ret_path, INCLUDEDIRSERVER, PGBINDIR, my_exec_path);
      |                                      ^~~~~~~~~~~~~~~~
      |                                      INCLUDEDIR
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -fPIC -I../../src/port -DFRONTEND -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/fls.c -o fls_shlib.o
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c:863:38: note: each undeclared identifier is reported only once for each function it appears in
echo "#define LIBDIR \"//lib\"" >>pg_config_paths.h
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c: In function ‘get_lib_path’:
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c:872:38: error: ‘LIBDIR’ undeclared (first use in this function); did you mean ‘EISDIR’?
  872 |         make_relative_path(ret_path, LIBDIR, PGBINDIR, my_exec_path);
      |                                      ^~~~~~
      |                                      EISDIR
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -fPIC -I../../src/port -DFRONTEND -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/strlcpy.c -o strlcpy_shlib.o
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c: In function ‘get_pkglib_path’:
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c:881:38: error: ‘PKGLIBDIR’ undeclared (first use in this function); did you mean ‘PGBINDIR’?
  881 |         make_relative_path(ret_path, PKGLIBDIR, PGBINDIR, my_exec_path);
      |                                      ^~~~~~~~~
      |                                      PGBINDIR
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -fPIC -I../../src/port -DFRONTEND -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/pg_crc32c_sse42_choose.c -o pg_crc32c_sse42_choose_shlib.o
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c: In function ‘get_locale_path’:
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c:890:38: error: ‘LOCALEDIR’ undeclared (first use in this function)
  890 |         make_relative_path(ret_path, LOCALEDIR, PGBINDIR, my_exec_path);
      |                                      ^~~~~~~~~
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c: In function ‘get_doc_path’:
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c:899:38: error: ‘DOCDIR’ undeclared (first use in this function)
  899 |         make_relative_path(ret_path, DOCDIR, PGBINDIR, my_exec_path);
      |                                      ^~~~~~
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c: In function ‘get_html_path’:
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c:908:38: error: ‘HTMLDIR’ undeclared (first use in this function)
  908 |         make_relative_path(ret_path, HTMLDIR, PGBINDIR, my_exec_path);
      |                                      ^~~~~~~
echo 'Description: PostgreSQL libpq library' >>libpq.pc
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c: In function ‘get_man_path’:
/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/path.c:917:38: error: ‘MANDIR’ undeclared (first use in this function)
  917 |         make_relative_path(ret_path, MANDIR, PGBINDIR, my_exec_path);
      |                                      ^~~~~~
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -fPIC -I../../src/port -DFRONTEND -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/bsearch_arg.c -o bsearch_arg_shlib.o
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -fPIC -I../../src/port -DFRONTEND -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/noblock.c -o noblock_shlib.o
echo "#define PKGLIBDIR \"//lib/postgresql\"" >>pg_config_paths.h
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -fPIC -I../../src/port -DFRONTEND -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/pgsleep.c -o pgsleep_shlib.o
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -fPIC -I../../src/port -DFRONTEND -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/pgstrsignal.c -o pgstrsignal_shlib.o
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3  -I../../src/port  -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/fls.c -o fls_srv.o
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3  -I../../src/port  -I../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -c /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port/getpeereid.c -o getpeereid_srv.o
make[1]: *** [<builtin>: path.o] Error 1
make[1]: *** Waiting for unfinished jobs....
echo 'Url: https://www.postgresql.org/' >>libpq.pc
echo "#define LOCALEDIR \"//share/locale\"" >>pg_config_paths.h
echo 'Version: 15.4' >>libpq.pc
echo "#define DOCDIR \"//share/doc//postgresql\"" >>pg_config_paths.h
echo 'Requires: ' >>libpq.pc
echo "#define HTMLDIR \"//share/doc//postgresql\"" >>pg_config_paths.h
echo 'Requires.private: ' >>libpq.pc
echo "#define MANDIR \"//share/man\"" >>pg_config_paths.h
echo 'Cflags: -I${includedir}' >>libpq.pc
make[1]: Leaving directory '/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/build-release/src/port'
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -pthread -D_REENTRANT -D_THREAD_SAFE -fPIC -DFRONTEND -DUNSAFE_STAT_OK -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/interfaces/libpq -I../../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -I../../../src/port -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port -DSO_MAJOR_VERSION=5  -c -o fe-connect.o /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/interfaces/libpq/fe-connect.c
/usr/bin/gcc-13 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation  -m64 -fPIC -O3 -pthread -D_REENTRANT -D_THREAD_SAFE -fPIC -DFRONTEND -DUNSAFE_STAT_OK -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/interfaces/libpq -I../../../src/include -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/include  -DNDEBUG -D_GNU_SOURCE  -I../../../src/port -I/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/port -DSO_MAJOR_VERSION=5  -c -o fe-misc.o /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/src/src/interfaces/libpq/fe-misc.c
echo 'Libs: -L${libdir} -lpq' >>libpq.pc
echo 'Libs.private:  -lpgcommon -lpgport -lm' >>libpq.pc
make[1]: Leaving directory '/home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/build-release/src/port'
make: *** [../../../src/Makefile.global:620: submake-libpgport] Error 2
make: *** Waiting for unfinished jobs....
libpq/15.4: 
libpq/15.4: ERROR: Package 'c11224e931af7eb47df7c689b7ad7afc6b151bd9' build failed
libpq/15.4: WARN: Build folder /home/hsuan/.conan/data/libpq/15.4/_/_/build/c11224e931af7eb47df7c689b7ad7afc6b151bd9/build-release
ERROR: libpq/15.4: Error in build() method, line 192
        autotools.make()
        ConanException: Error 2 while executing make 'DESTDIR=/home/hsuan/.conan/data/libpq/15.4/_/_/package/c11224e931af7eb47df7c689b7ad7afc6b151bd9' -j36
```

#### Details

pg_config should be built first so those vars will be defined, which then will be used in the following `interfaces/libpq`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
