### PR TITLE
spectra: add v1.1.0, use cmake.install(), simplify test_package

### DIFF
--- a/recipes/spectra/all/conandata.yml
+++ b/recipes/spectra/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/yixuan/spectra/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "d29671e3d1b8036728933cadfddb05668a3cd6133331e91fc4535a9b85bedc79"
   "1.0.1":
     url: "https://github.com/yixuan/spectra/archive/refs/tags/v1.0.1.tar.gz"
     sha256: "919e3fbc8c539a321fd5a0766966922b7637cc52eb50a969241a997c733789f3"

--- a/recipes/spectra/all/test_package/CMakeLists.txt
+++ b/recipes/spectra/all/test_package/CMakeLists.txt
@@ -1,12 +1,7 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(spectra REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE Spectra::Spectra)
-if(spectra_VERSION VERSION_LESS "1.0.0")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE "SPECTRA_LESS_1_0_0")
-else()
-    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
-endif()

--- a/recipes/spectra/all/test_package/conanfile.py
+++ b/recipes/spectra/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/spectra/all/test_package/test_package.cpp
+++ b/recipes/spectra/all/test_package/test_package.cpp
@@ -1,42 +1,7 @@
 #include <Eigen/Core>
 #include <Spectra/SymEigsSolver.h>
 
-#include <iostream>
-
 int main() {
-    // We are going to calculate the eigenvalues of M
     Eigen::MatrixXd A = Eigen::MatrixXd::Random(10, 10);
-    Eigen::MatrixXd M = A + A.transpose();
-
-    // Construct matrix operation object using the wrapper class DenseSymMatProd
-    Spectra::DenseSymMatProd<double> op(M);
-
-    // Construct eigen solver object, requesting the largest three eigenvalues
-#ifdef SPECTRA_LESS_1_0_0
-    Spectra::SymEigsSolver< double, Spectra::LARGEST_ALGE, Spectra::DenseSymMatProd<double> > eigs(&op, 3, 6);
-#else
-    Spectra::SymEigsSolver<Spectra::DenseSymMatProd<double>> eigs(op, 3, 6);
-#endif
-
-    // Initialize and compute
-    eigs.init();
-#ifdef SPECTRA_LESS_1_0_0
-    int nconv = eigs.compute();
-#else
-    int nconv = eigs.compute(Spectra::SortRule::LargestAlge);
-#endif
-
-    // Retrieve results
-    Eigen::VectorXd evalues;
-#ifdef SPECTRA_LESS_1_0_0
-    if (eigs.info() == Spectra::SUCCESSFUL) {
-#else
-    if (eigs.info() == Spectra::CompInfo::Successful) {
-#endif
-        evalues = eigs.eigenvalues();
-    }
-
-    std::cout << "Eigenvalues found:\n" << evalues << std::endl;
-
-    return 0;
+    Spectra::DenseSymMatProd<double> op(A);
 }

--- a/recipes/spectra/config.yml
+++ b/recipes/spectra/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.0":
+    folder: "all"
   "1.0.1":
     folder: "all"
   "1.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **spectra/1.1.0**

#### Motivation
New release in 2.5 years. Would like to use it to backport C++20 fixes in #25597.

Switched from a simple copy to `cmake.install()` as this is the preferred method on CCI. Helps safeguard against `version.h` or some other generated header being accidentally missed in a future release.

#### Details
https://github.com/yixuan/spectra/releases/tag/v1.1.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
