### PR TITLE
openexr: Suggest libdeflate version range

### DIFF
--- a/recipes/openexr/3.x/conanfile.py
+++ b/recipes/openexr/3.x/conanfile.py
@@ -65,7 +65,7 @@ class OpenEXRConan(ConanFile):
         # Note: OpenEXR and Imath are versioned independently.
         self.requires("imath/3.1.9", transitive_headers=True)
         if self._with_libdeflate:
-            self.requires("libdeflate/1.19")
+            self.requires("libdeflate/[>=1.19 <=1.22]")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
### Summary
Changes to recipe:  **openexr/3.x**

#### Motivation
Recently, libtiff was changed to use version range: https://github.com/conan-io/conan-center-index/commit/04911c61af10b04a3f85b4ba7c3ee740d32c3aab

This now results into version conflicts downstream, namely for OpenImageIO: https://github.com/conan-io/conan-center-index/pull/25672

#### Details
The changeset of libdeflate between 1.19 and 1.22 looks innocent enough with only internal changes and bugfixes & optimizations based on the changelog and openexr still builds well with 1.22.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
