### PR TITLE
libdeflate: Add version 1.23

### DIFF
--- a/recipes/libdeflate/all/conandata.yml
+++ b/recipes/libdeflate/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.23":
+    url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.23.tar.gz"
+    sha256: "1ab18349b9fb0ce8a0ca4116bded725be7dcbfa709e19f6f983d99df1fb8b25f"
   "1.22":
     url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.22.tar.gz"
     sha256: "7f343c7bf2ba46e774d8a632bf073235e1fd27723ef0a12a90f8947b7fe851d6"

--- a/recipes/libdeflate/config.yml
+++ b/recipes/libdeflate/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.23":
+    folder: "all"
   "1.22":
     folder: "all"
   "1.21":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdeflate/1.23**

#### Motivation
When looking into #26364 I just saw that a new version of libdeflate with some bugfixes was released in December.

#### Details
* https://github.com/ebiggers/libdeflate/blob/master/NEWS.md
* https://github.com/ebiggers/libdeflate/compare/v1.22...v1.23

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
