### PR TITLE
simdjson: Add version 3.11.5

### DIFF
--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.11.5":
+    url: "https://github.com/simdjson/simdjson/archive/v3.11.5.tar.gz"
+    sha256: "509bf4880978666f5a6db1eb3d747681e0cc6e0b5bddd94ab0f14a4199d93e18"
   "3.11.2":
     url: "https://github.com/simdjson/simdjson/archive/v3.11.2.tar.gz"
     sha256: "47a6d78a70c25764386a01b55819af386b98fc421da79ae8de3ae0242cf66d93"

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.11.5":
+    folder: all
   "3.11.2":
     folder: all
   "3.10.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **simdjson/3.11.5**

#### Motivation
Version bump
https://github.com/simdjson/simdjson/compare/v3.11.2...v3.11.5

#### Details
config.yml and conandata.yml point to the newly created simdjson/3.11.5


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
