### PR TITLE
libsersi: Deprecate opendis6 in favour of libsersi

### DIFF
--- a/recipes/libsersi/all/conandata.yml
+++ b/recipes/libsersi/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.1.0":
-    url: "https://github.com/crhowell3/libseri/archive/refs/tags/0.1.0.tar.gz"
+    url: "https://github.com/crhowell3/libsersi/archive/refs/tags/0.1.0.tar.gz"
     sha256: "b3ce8c73a5b69b963e3c5090e2e237fe142f9aff69a1b6b477b52e2a6a55abb4"

--- a/recipes/libsersi/all/conanfile.py
+++ b/recipes/libsersi/all/conanfile.py
@@ -2,18 +2,16 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get, rmdir, replace_in_file
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
-from conan.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
-class OpenDis6Conan(ConanFile):
-    name = "opendis6"
-    homepage = "https://github.com/crhowell3/opendis6"
+class LibsersiConan(ConanFile):
+    name = "libsersi"
+    homepage = "https://github.com/crhowell3/libsersi"
     description = "Modern C++ implementation of IEEE 1278.1a-1998"
-    topics = ("library", "protocol", "dis")
+    topics = ("dis", "ieee", "1278.1a-1998")
     url = "https://github.com/conan-io/conan-center-index"
     license = "BSD-2-Clause"
     package_type = "library"
@@ -27,26 +25,7 @@ class OpenDis6Conan(ConanFile):
         "fPIC": True
     }
 
-    provides = "libsersi"
-    deprecated = "libsersi"
-
-    @property
-    def _min_cppstd(self):
-        return "14"
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "Visual Studio": "15",
-            "msvc": "191",
-            "gcc": "7",
-            "clang": "7",
-            "apple-clang": "10",
-        }
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
+    implements = ["auto_shared_fpic"]
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -57,22 +36,16 @@ class OpenDis6Conan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        replace_in_file(self, os.path.join(self.source_folder, "cmake", "libsersi-api.cmake"),
+                        "set(CMAKE_CXX_STANDARD 17)", "")
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.22 <4]")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+        check_min_cppstd(self, 14)
 
     def build(self):
         cmake = CMake(self)
@@ -89,10 +62,8 @@ class OpenDis6Conan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.libs = ["OpenDIS6"]
-        self.cpp_info.set_property("cmake_file_name", "OpenDIS")
-        self.cpp_info.set_property("cmake_target_name", "OpenDIS::OpenDIS6")
-        self.cpp_info.set_property("cmake_target_aliases", ["OpenDIS::DIS6","OpenDIS6"])
+        self.cpp_info.libs = ["sersi"]
+        self.cpp_info.set_property("cmake_target_name", "libsersi::sersi")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/libsersi/all/conanfile.py
+++ b/recipes/libsersi/all/conanfile.py
@@ -47,6 +47,10 @@ class LibsersiConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+
+        # build scripts assume CMAKE_BUILD_TYPE is a cache variable,
+        # but CMakeToolchain sets it as a regular variable otherwise
+        tc.cache_variables["CMAKE_BUILD_TYPE"] = str(self.settings.build_type)
         tc.cache_variables["BUILD_EXAMPLES"] = False
         tc.cache_variables["BUILD_TESTS"] = False
         tc.generate()

--- a/recipes/libsersi/all/test_package/CMakeLists.txt
+++ b/recipes/libsersi/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(libsersi CONFIG REQUIRED)
+
+add_executable(test_package_dis test_package.cpp)
+target_link_libraries(test_package_dis PRIVATE libsersi::sersi)
+set_target_properties(test_package_dis PROPERTIES CXX_STANDARD 14)

--- a/recipes/libsersi/all/test_package/conanfile.py
+++ b/recipes/libsersi/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0],
+                     "test_package_dis"), env="conanrun")

--- a/recipes/libsersi/all/test_package/test_package.cpp
+++ b/recipes/libsersi/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include "libsersi/entity_information/EntityStatePdu.h"
+
+int main() {
+  dis::EntityStatePdu pdu1, pdu2;
+
+  dis::DataStream ds(dis::kBig);
+  pdu1.Marshal(ds);
+  pdu2.Unmarshal(ds);
+
+  std::cout << "Success\n";
+  return EXIT_SUCCESS;
+}

--- a/recipes/libsersi/config.yml
+++ b/recipes/libsersi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all

--- a/recipes/opendis6/all/conandata.yml
+++ b/recipes/opendis6/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.1.0":
-    url: "https://github.com/crhowell3/libseri/archive/refs/tags/0.1.0.tar.gz"
+    url: "https://github.com/crhowell3/libsersi/archive/refs/tags/v0.1.0.tar.gz"
     sha256: "b3ce8c73a5b69b963e3c5090e2e237fe142f9aff69a1b6b477b52e2a6a55abb4"

--- a/recipes/opendis6/all/conandata.yml
+++ b/recipes/opendis6/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.1.0":
-    url: "https://github.com/crhowell3/libsersi/archive/refs/tags/v0.1.0.tar.gz"
-    sha256: "b3ce8c73a5b69b963e3c5090e2e237fe142f9aff69a1b6b477b52e2a6a55abb4"
+    url: "https://github.com/crhowell3/opendis6/archive/refs/tags/0.1.0.tar.gz"
+    sha256: "7acfd6ecdcea03c75f93834c4e8ad532aee03eb0fdd2736c9095e2d548214125"


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsersi/[*]**/**opendis/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Upstream renamed, with the new CI system this is now actually not an issue

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
See https://github.com/conan-io/conan-center-index/pull/24487 for details

(Also https://github.com/conan-io/conan-center-index/pull/24601 for the old CI system workaround, this PR combines both)

The idea is that after the current opendis6 revision is published, we can stop publishing new revisions for it by removing from the Git repository (But note that we won't remove the already-published binaries for Opendis6 at any point)
