### PR TITLE
uwebsockets: add version 20.71.0 (retry)

### DIFF
--- a/recipes/uwebsockets/all/conandata.yml
+++ b/recipes/uwebsockets/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.71.0":
+    url: "https://github.com/uNetworking/uWebSockets/archive/v20.71.0.tar.gz"
+    sha256: "1e4e7bfa379dd8096182d0b47ae648c7bcf93be4a4130ad6e7625ed1d46aec1d"
   "20.70.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v20.70.0.tar.gz"
     sha256: "39a7e32182df2da02955ab1c1681af9710c82115075f4caabb8689a2c04460b9"

--- a/recipes/uwebsockets/config.yml
+++ b/recipes/uwebsockets/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.71.0":
+    folder: all
   "20.70.0":
     folder: all
   "20.68.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **uwebsockets/20.71.0**

#### Motivation
There are several improvements in 20.71.0.

#### Details
Retry https://github.com/conan-io/conan-center-index/pull/26345.

https://github.com/uNetworking/uWebSockets/releases/tag/v20.71.0
https://github.com/uNetworking/uWebSockets/compare/v20.70.0...v20.71.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan