### PR TITLE
mpg123: dont require msys2 when using msvc, fix macos crossbuild

### DIFF
--- a/recipes/mpg123/all/conanfile.py
+++ b/recipes/mpg123/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.cmake import cmake_layout, CMake, CMakeDeps, CMakeToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
-from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches, rmdir, rm
+from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches, replace_in_file, rmdir, rm
 from conan.tools.microsoft import is_msvc
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.build import cross_building
@@ -53,10 +53,6 @@ class Mpg123Conan(ConanFile):
     }
 
     @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
-    @property
     def _audio_module(self):
         return {
             "libalsa": "alsa",
@@ -99,14 +95,13 @@ class Mpg123Conan(ConanFile):
             self.tool_requires("pkgconf/2.0.3")
         if self.settings.arch in ["x86", "x86_64"]:
             self.tool_requires("yasm/1.3.0")
-        if self._settings_build.os == "Windows" and not is_msvc(self):
+        if self.settings_build.os == "Windows" and not is_msvc(self):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
                 self.tool_requires("msys2/cci.latest")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-
 
     def generate(self):
         env = VirtualBuildEnv(self)
@@ -168,6 +163,12 @@ class Mpg123Conan(ConanFile):
             cmake.configure(build_script_folder=os.path.join(self.source_folder, "ports", "cmake"))
             cmake.build()
         else:
+            if self.settings.compiler == "apple-clang" and cross_building(self):
+                # when testing if the assembler supports avx - propagate cflags (CFLAGS) to the assembler
+                # (which should contain "-arch x86_64" when crossbuilding with appleclang)
+                replace_in_file(self, os.path.join(self.source_folder, "configure"),
+                                    "$CCAS -c -o conftest.o",
+                                    "$CCAS $CFLAGS -c -o conftest.o")
             autotools = Autotools(self)
             autotools.configure()
             autotools.make()
@@ -193,23 +194,17 @@ class Mpg123Conan(ConanFile):
         self.cpp_info.components["libmpg123"].libs = ["mpg123"]
         self.cpp_info.components["libmpg123"].set_property("pkg_config_name", "libmpg123")
         self.cpp_info.components["libmpg123"].set_property("cmake_target_name", "MPG123::libmpg123")
-        self.cpp_info.components["libmpg123"].names["cmake_find_package"] = "libmpg123"
-        self.cpp_info.components["libmpg123"].names["cmake_find_package_multi"] = "libmpg123"
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.components["libmpg123"].defines.append("LINK_MPG123_DLL")
 
         self.cpp_info.components["libout123"].libs = ["out123"]
         self.cpp_info.components["libout123"].set_property("pkg_config_name", "libout123")
         self.cpp_info.components["libout123"].set_property("cmake_target_name", "MPG123::libout123")
-        self.cpp_info.components["libout123"].names["cmake_find_package"] = "libout123"
-        self.cpp_info.components["libout123"].names["cmake_find_package_multi"] = "libout123"
         self.cpp_info.components["libout123"].requires = ["libmpg123"]
 
         self.cpp_info.components["libsyn123"].libs = ["syn123"]
         self.cpp_info.components["libsyn123"].set_property("pkg_config_name", "libsyn123")
         self.cpp_info.components["libsyn123"].set_property("cmake_target_name", "MPG123::libsyn123")
-        self.cpp_info.components["libsyn123"].names["cmake_find_package"] = "libsyn123"
-        self.cpp_info.components["libsyn123"].names["cmake_find_package_multi"] = "libsyn123"
         self.cpp_info.components["libsyn123"].requires = ["libmpg123"]
 
         if self.settings.os == "Linux":
@@ -225,14 +220,3 @@ class Mpg123Conan(ConanFile):
             self.cpp_info.components["libout123"].requires.append("tinyalsa::tinyalsa")
         if self.options.module == "win32":
             self.cpp_info.components["libout123"].system_libs.append("winmm")
-
-
-        # TODO: Remove after Conan 2.x becomes the standard
-        self.cpp_info.filenames["cmake_find_package"] = "mpg123"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "mpg123"
-        self.cpp_info.names["cmake_find_package"] = "MPG123"
-        self.cpp_info.names["cmake_find_package_multi"] = "MPG123"
-
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bin_path))
-        self.env_info.PATH.append(bin_path)

--- a/recipes/mpg123/all/conanfile.py
+++ b/recipes/mpg123/all/conanfile.py
@@ -100,9 +100,10 @@ class Mpg123Conan(ConanFile):
         if self.settings.arch in ["x86", "x86_64"]:
             self.tool_requires("yasm/1.3.0")
         if self._settings_build.os == "Windows":
-            self.win_bash = True
-            if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
-                self.tool_requires("msys2/cci.latest")
+            if is_msvc(self) == False:
+                self.win_bash = True
+                if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
+                    self.tool_requires("msys2/cci.latest")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/mpg123/all/conanfile.py
+++ b/recipes/mpg123/all/conanfile.py
@@ -99,11 +99,10 @@ class Mpg123Conan(ConanFile):
             self.tool_requires("pkgconf/2.0.3")
         if self.settings.arch in ["x86", "x86_64"]:
             self.tool_requires("yasm/1.3.0")
-        if self._settings_build.os == "Windows":
-            if is_msvc(self) == False:
-                self.win_bash = True
-                if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
-                    self.tool_requires("msys2/cci.latest")
+        if self._settings_build.os == "Windows" and not is_msvc(self):
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
+                self.tool_requires("msys2/cci.latest")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
fixes #26380 I found if building process is in msvc environment, mpg123 never use msys2, but these lines aways add the msys2 requirement if os is windows, could we only add the requirement if that's not msvc environment?

please refer to:
https://github.com/conan-io/conan-center-index/blob/master/recipes/mpg123/all/conanfile.py#L103-L105


### Summary
Changes to recipe:  **mpg123/1.31.2**

#### Motivation
if building process is in msvc environment, mpg123 never use msys2, but these lines aways add the msys2 requirement if os is windows.

#### Details
I found if building process is in msvc environment, mpg123 never use msys2, but these lines aways add the msys2 requirement if os is windows, could we only add the requirement if that's not msvc environment?
please refer to:
https://github.com/conan-io/conan-center-index/blob/master/recipes/mpg123/all/conanfile.py#L103-L105

#### Maintainer changes
(by @jcar87)
- Fix crossbuilding issue on macOS - ensure that when testing for assembler support, `CFLAGS` are propagated
- Remove conan 1.x only logic that is a no-op in Conan 2
- Use `self.settings_build` 

---
- [*] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [*] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [*] Tested locally with at least one configuration using a recent version of Conan