### PR TITLE
faker-cxx: add version 4.0.1

### DIFF
--- a/recipes/faker-cxx/all/conandata.yml
+++ b/recipes/faker-cxx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.1":
+    url: "https://github.com/cieslarmichal/faker-cxx/archive/refs/tags/v4.0.1.tar.gz"
+    sha256: "ebeac25780878905d0e73cd6a5211bd0b5ce065d06961570f0de7f1a25ec7d9d"
   "3.0.0":
     url: "https://github.com/cieslarmichal/faker-cxx/archive/refs/tags/v3.0.0.tar.gz"
     sha256: "63d6846376593e05da690136cabe8e7bf42ddcdd4edad3ae9b48696f86d80468"

--- a/recipes/faker-cxx/all/conanfile.py
+++ b/recipes/faker-cxx/all/conanfile.py
@@ -77,7 +77,8 @@ class FakerCXXConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["USE_SYSTEM_DEPENDENCIES"] = True
+        if Version(self.version) < "4.0.0":
+            tc.variables["USE_SYSTEM_DEPENDENCIES"] = True
         tc.variables["BUILD_TESTING"] = False
         tc.variables["WARNINGS_AS_ERRORS"] = False
         tc.variables["WITH_STD_FORMAT"] = self.options.with_std_format

--- a/recipes/faker-cxx/all/test_package/test_package.cpp
+++ b/recipes/faker-cxx/all/test_package/test_package.cpp
@@ -11,13 +11,12 @@
 
 int main()
 {
-    const auto id = faker::string::uuid();
     const auto email = faker::internet::email();
     const auto password = faker::internet::password();
     const auto createdAt = faker::date::pastDate(5, faker::date::DateFormat::ISO);
     const auto updatedAt = faker::date::recentDate(2, faker::date::DateFormat::ISO);
 
-    std::cout << "id: " << id << ", email: " << email << ", password: " <<  password << ", createdAt: " << createdAt << ", updatedAt: " << updatedAt << "\n";
+    std::cout << "email: " << email << ", password: " <<  password << ", createdAt: " << createdAt << ", updatedAt: " << updatedAt << "\n";
 
     return 0;
 }

--- a/recipes/faker-cxx/config.yml
+++ b/recipes/faker-cxx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.1":
+    folder: all
   "3.0.0":
     folder: all
   "2.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **faker-cxx/4.0.1**

#### Motivation
Major version up.

#### Details
- Because `uuid` is renamed to `uuidV4`, test_package doesn't use `uuid` now.
- `USE_SYSTEM_DEPENDENCIES` is ommited.

https://github.com/cieslarmichal/faker-cxx/releases/tag/v4.0.1
https://github.com/cieslarmichal/faker-cxx/releases/tag/v4.0.0
https://github.com/cieslarmichal/faker-cxx/compare/v3.0.0...v4.0.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
