### PR TITLE
arrow: add version 19.0.0

### DIFF
--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -21,6 +21,10 @@ sources:
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-14.0.2/apache-arrow-14.0.2.tar.gz?action=download"
     sha256: "1304dedb41896008b89fe0738c71a95d9b81752efc77fa70f264cb1da15d9bc2"
 patches:
+  "19.0.0":
+    - patch_file: "patches/19.0.0-0001-fix-cmake.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "18.1.0":
     - patch_file: "patches/18.0.0-0001-fix-cmake.patch"
       patch_description: "use cci package"

--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "19.0.0":
+    url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-19.0.0/apache-arrow-19.0.0.tar.gz?action=download"
+    sha256: "f89b93f39954740f7184735ff1e1d3b5be2640396febc872c4955274a011f56b"
   "18.1.0":
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-18.1.0/apache-arrow-18.1.0.tar.gz?action=download"
     sha256: "2dc8da5f8796afe213ecc5e5aba85bb82d91520eff3cf315784a52d0fa61d7fc"

--- a/recipes/arrow/all/patches/19.0.0-0001-fix-cmake.patch
+++ b/recipes/arrow/all/patches/19.0.0-0001-fix-cmake.patch
@@ -1,0 +1,59 @@
+diff --git a/cpp/cmake_modules/FindThriftAlt.cmake b/cpp/cmake_modules/FindThriftAlt.cmake
+index 98a706d..edf195e 100644
+--- a/cpp/cmake_modules/FindThriftAlt.cmake
++++ b/cpp/cmake_modules/FindThriftAlt.cmake
+@@ -45,22 +45,20 @@ endif()
+ #   * https://github.com/apache/thrift/pull/2725
+ #   * https://github.com/apache/thrift/pull/2726
+ #   * https://github.com/conda-forge/thrift-cpp-feedstock/issues/68
+-if(NOT WIN32)
+-  set(find_package_args "")
+-  if(ThriftAlt_FIND_VERSION)
+-    list(APPEND find_package_args ${ThriftAlt_FIND_VERSION})
+-  endif()
+-  if(ThriftAlt_FIND_QUIETLY)
+-    list(APPEND find_package_args QUIET)
+-  endif()
+-  find_package(Thrift ${find_package_args})
+-  if(Thrift_FOUND)
+-    set(ThriftAlt_FOUND TRUE)
+-    add_executable(thrift::compiler IMPORTED)
+-    set_target_properties(thrift::compiler PROPERTIES IMPORTED_LOCATION
+-                                                      "${THRIFT_COMPILER}")
+-    return()
+-  endif()
++set(find_package_args "")
++if(ThriftAlt_FIND_VERSION)
++  list(APPEND find_package_args ${ThriftAlt_FIND_VERSION})
++endif()
++if(ThriftAlt_FIND_QUIETLY)
++  list(APPEND find_package_args QUIET)
++endif()
++find_package(Thrift ${find_package_args})
++if(Thrift_FOUND)
++  set(ThriftAlt_FOUND TRUE)
++  add_executable(thrift::compiler IMPORTED)
++  set_target_properties(thrift::compiler PROPERTIES IMPORTED_LOCATION
++                                                    "${THRIFT_COMPILER}")
++  return()
+ endif()
+ 
+ function(extract_thrift_version)
+diff --git a/cpp/src/parquet/CMakeLists.txt b/cpp/src/parquet/CMakeLists.txt
+index b984ef7..429fc6d 100644
+--- a/cpp/src/parquet/CMakeLists.txt
++++ b/cpp/src/parquet/CMakeLists.txt
+@@ -263,11 +263,11 @@ if(NOT PARQUET_MINIMAL_DEPENDENCY)
+ 
+   # These are libraries that we will link privately with parquet_shared (as they
+   # do not need to be linked transitively by other linkers)
+-  list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS thrift::thrift)
++  list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS Boost::headers thrift::thrift)
+ 
+   # Link publicly with parquet_static (because internal users need to
+   # transitively link all dependencies)
+-  list(APPEND PARQUET_STATIC_LINK_LIBS thrift::thrift)
++  list(APPEND PARQUET_STATIC_LINK_LIBS Boost::headers thrift::thrift)
+   if(NOT THRIFT_VENDORED)
+     list(APPEND PARQUET_STATIC_INSTALL_INTERFACE_LIBS thrift::thrift)
+   endif()

--- a/recipes/arrow/config.yml
+++ b/recipes/arrow/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "19.0.0":
+    folder: all
   "18.1.0":
     folder: all
   "18.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/19.0.0**

#### Motivation

Arrow 19.0.0 was released 2025/01/16. This PR updates conan's index with the new release.

#### Details

We fully script these changes and they're minimal so this should be easy to review. Previous versions have needed the cmake patch and I'm not yet sure if this one does.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
