### PR TITLE
flecs: add 4.0.4

### DIFF
--- a/recipes/flecs/all/conandata.yml
+++ b/recipes/flecs/all/conandata.yml
@@ -2,15 +2,6 @@ sources:
   "4.0.4":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.4.tar.gz"
     sha256: "a3b6238a913f65d90db18759ab5442393901da914e4a9bfe30aa8823687dce86"
-  "4.0.3":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.3.tar.gz"
-    sha256: "feb5185bca93eeadeb641329bfa88adedf4bd7aea5a4d89ade055b65c3af0517"
-  "4.0.2":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.2.tar.gz"
-    sha256: "131b703c30f53e08e30f2bac8da657276350b3f324a3321f753c3a9eccaa3f63"
-  "4.0.1":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.1.tar.gz"
-    sha256: "d88928226b3a6e7ebc7c818db50b2fb5828021ed3bcd206c4e2a3b0406472d2b"
   "4.0.0":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.0.tar.gz"
     sha256: "6c9826c8602f797acd775269d143763adfb3d3a93031cc81bced2b6d267469d2"

--- a/recipes/flecs/all/conandata.yml
+++ b/recipes/flecs/all/conandata.yml
@@ -1,4 +1,16 @@
 sources:
+  "4.0.4":
+    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.4.tar.gz"
+    sha256: "a3b6238a913f65d90db18759ab5442393901da914e4a9bfe30aa8823687dce86"
+  "4.0.3":
+    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.3.tar.gz"
+    sha256: "feb5185bca93eeadeb641329bfa88adedf4bd7aea5a4d89ade055b65c3af0517"
+  "4.0.2":
+    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.2.tar.gz"
+    sha256: "131b703c30f53e08e30f2bac8da657276350b3f324a3321f753c3a9eccaa3f63"
+  "4.0.1":
+    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.1.tar.gz"
+    sha256: "d88928226b3a6e7ebc7c818db50b2fb5828021ed3bcd206c4e2a3b0406472d2b"
   "4.0.0":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.0.tar.gz"
     sha256: "6c9826c8602f797acd775269d143763adfb3d3a93031cc81bced2b6d267469d2"

--- a/recipes/flecs/config.yml
+++ b/recipes/flecs/config.yml
@@ -1,4 +1,12 @@
 versions:
+  "4.0.4":
+    folder: all
+  "4.0.3":
+    folder: all
+  "4.0.2":
+    folder: all
+  "4.0.1":
+    folder: all
   "4.0.0":
     folder: all
   "3.2.11":

--- a/recipes/flecs/config.yml
+++ b/recipes/flecs/config.yml
@@ -1,12 +1,6 @@
 versions:
   "4.0.4":
     folder: all
-  "4.0.3":
-    folder: all
-  "4.0.2":
-    folder: all
-  "4.0.1":
-    folder: all
   "4.0.0":
     folder: all
   "3.2.11":


### PR DESCRIPTION
### Summary
Changes to recipes:  **flecs/4.0.4**

#### Motivation
Last modification to flecs recipe is 4.0.0.
This PR add the version 4.0.4, which is the latest stable version for flecs, as of today.

Previous PR:
https://github.com/conan-io/conan-center-index/pull/24621

#### Details
Add URL for flecs 4.0.4.
Based on the latest update by @NukeBird.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
