### PR TITLE
Update cyclonedds to include 0.10.5 release

### DIFF
--- a/recipes/cyclonedds/all/conandata.yml
+++ b/recipes/cyclonedds/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.5":
+    url: "https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.10.5.tar.gz"
+    sha256: "ec3ec898c52b02f939a969cd1a276e219420e5e8419b21cea276db35b4821848"
   "0.10.4":
     url: "https://github.com/eclipse-cyclonedds/cyclonedds/archive/0.10.4.tar.gz"
     sha256: "fe7bb5a4348e31656a935f72dec909a7d2b0fcf10840614fb552f08eb2da8484"

--- a/recipes/cyclonedds/all/conanfile.py
+++ b/recipes/cyclonedds/all/conanfile.py
@@ -25,6 +25,7 @@ class CycloneDDSConan(ConanFile):
         "fPIC": [True, False],
         "with_ssl": [True, False],
         "with_shm" : [True, False],
+        "with_lto": [True, False],
         "enable_security" : [True, False],
         "enable_discovery" : [True, False],
     }
@@ -35,6 +36,7 @@ class CycloneDDSConan(ConanFile):
         "with_shm": False,
         "enable_security": False,
         "enable_discovery": True,
+        "with_lto": True,
     }
 
     short_paths = True
@@ -77,7 +79,7 @@ class CycloneDDSConan(ConanFile):
 
     def requirements(self):
         if self.options.with_shm:
-            self.requires("iceoryx/2.0.5")
+            self.requires("iceoryx/2.0.6")
         if self.options.with_ssl:
             self.requires("openssl/[>=1.1 <4]")
 
@@ -111,6 +113,7 @@ class CycloneDDSConan(ConanFile):
         # variables which effects build
         tc.variables["ENABLE_SSL"] = self.options.with_ssl
         tc.variables["ENABLE_SHM"] = self.options.with_shm
+        tc.variables["ENABLE_LTO"] = self.options.with_lto
         tc.variables["ENABLE_SECURITY"] = self.options.enable_security
         tc.variables["ENABLE_TYPE_DISCOVERY"] = self.options.enable_discovery
         tc.variables["ENABLE_TOPIC_DISCOVERY"] = self.options.enable_discovery

--- a/recipes/cyclonedds/config.yml
+++ b/recipes/cyclonedds/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.10.5":
+    folder: all
   "0.10.4":
     folder: all
   "0.10.3":


### PR DESCRIPTION
Additionally include the option to enable/disable LTO.


### Summary
Changes to recipe: cyclondds/0.10.5

#### Motivation
Adding the 0.10.5 release, and add the build option to disable LTO. 

#### Details
We require the LTO control because we often work in mixed language environments (C++ and Rust) and very often we're unable to link with Cyclone because of this error. 

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
