### PR TITLE
nlopt: add version 2.9.1

### DIFF
--- a/recipes/nlopt/all/conandata.yml
+++ b/recipes/nlopt/all/conandata.yml
@@ -2,12 +2,6 @@ sources:
   "2.9.1":
     url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.9.1.tar.gz"
     sha256: "1e6c33f8cbdc4138d525f3326c231f14ed50d99345561e85285638c49b64ee93"
-  "2.9.0":
-    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.9.0.tar.gz"
-    sha256: "6e899e297485e457ec1bf84844de29921aeef674f9d5caf60277df45dca6ff76"
-  "2.8.0":
-    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.8.0.tar.gz"
-    sha256: "e02a4956a69d323775d79fdaec7ba7a23ed912c7d45e439bc933d991ea3193fd"
   "2.7.1":
     url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.7.1.tar.gz"
     sha256: "db88232fa5cef0ff6e39943fc63ab6074208831dc0031cf1545f6ecd31ae2a1a"

--- a/recipes/nlopt/all/conandata.yml
+++ b/recipes/nlopt/all/conandata.yml
@@ -1,4 +1,13 @@
 sources:
+  "2.9.1":
+    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.9.1.tar.gz"
+    sha256: "1e6c33f8cbdc4138d525f3326c231f14ed50d99345561e85285638c49b64ee93"
+  "2.9.0":
+    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.9.0.tar.gz"
+    sha256: "6e899e297485e457ec1bf84844de29921aeef674f9d5caf60277df45dca6ff76"
+  "2.8.0":
+    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.8.0.tar.gz"
+    sha256: "e02a4956a69d323775d79fdaec7ba7a23ed912c7d45e439bc933d991ea3193fd"
   "2.7.1":
     url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.7.1.tar.gz"
     sha256: "db88232fa5cef0ff6e39943fc63ab6074208831dc0031cf1545f6ecd31ae2a1a"

--- a/recipes/nlopt/all/conanfile.py
+++ b/recipes/nlopt/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.build import stdcpp_library
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir
+from packaging.version import Version
 import os
 
 required_conan_version = ">=1.54.0"
@@ -62,9 +63,10 @@ class NloptConan(ConanFile):
 
     def _patch_sources(self):
         # don't force PIC
-        cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
-        replace_in_file(self, cmakelists, "set (CMAKE_C_FLAGS \"-fPIC ${CMAKE_C_FLAGS}\")", "")
-        replace_in_file(self, cmakelists, "set (CMAKE_CXX_FLAGS \"-fPIC ${CMAKE_CXX_FLAGS}\")", "")
+        if Version(self.version) < Version("2.8.0"):
+            cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
+            replace_in_file(self, cmakelists, "set (CMAKE_C_FLAGS \"-fPIC ${CMAKE_C_FLAGS}\")", "")
+            replace_in_file(self, cmakelists, "set (CMAKE_CXX_FLAGS \"-fPIC ${CMAKE_CXX_FLAGS}\")", "")
 
     def build(self):
         self._patch_sources()

--- a/recipes/nlopt/all/conanfile.py
+++ b/recipes/nlopt/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.tools.build import stdcpp_library
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir
-from packaging.version import Version
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.54.0"

--- a/recipes/nlopt/config.yml
+++ b/recipes/nlopt/config.yml
@@ -1,4 +1,10 @@
 versions:
+  "2.9.1":
+    folder: all
+  "2.9.0":
+    folder: all
+  "2.8.0":
+    folder: all
   "2.7.1":
     folder: all
   "2.7.0":

--- a/recipes/nlopt/config.yml
+++ b/recipes/nlopt/config.yml
@@ -1,10 +1,6 @@
 versions:
   "2.9.1":
     folder: all
-  "2.9.0":
-    folder: all
-  "2.8.0":
-    folder: all
   "2.7.1":
     folder: all
   "2.7.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **nlopt/[2.8.0 2.9.0 2.9.1]**

#### Motivation
Follow library versions

#### Details
Starting from 2.8.0, the patch used in the recipe is not valid anymore.
The related lines were removed in commit 3106ca560ac6 of nlopt repository.

I think that the "fPIC" option in `recipes/nlopt/all/conanfile.py: 25` should be removed, but as I'm not sure I leave it untouched.



---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
