### PR TITLE
Update to SQLite3 Multiple Ciphers 2.0.2

### DIFF
--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.2":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.0.2.tar.gz"
+    sha256: "dc34a1575480d1ec6d7ed3a9ce0b3227c1d463a0a3e8885c16efe47d0e395bc7"
   "1.9.0":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v1.9.0.tar.gz"
     sha256: "b30dcf695ad3a53b32b8907a3920ab2b38670c7d37232839d0fb3148c41166da"

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.2":
+    folder: all
   "1.9.0":
     folder: all
   "1.8.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3mc**

#### Motivation
**sqlite3mc version 2.0.2** supports the latest _SQLite_ version **3.48.0**, adds the new cipher scheme _AEGIS_, and includes several bug fixes.

#### Details
An entry for version 2.0.2 was added to the recipe.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
