### PR TITLE
Added qnx support and added version 5.9.3 to conandata

### DIFF
--- a/recipes/net-snmp/all/conandata.yml
+++ b/recipes/net-snmp/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
   "5.9.4":
-    url: "https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.4/net-snmp-5.9.4.zip/download"
-    sha256: "ceea0c876f23b87731de2073e6a3a683ea610c66a5a67b5cabf4986b7813c22b"
+    url: "https://github.com/net-snmp/net-snmp/archive/refs/tags/v5.9.4.tar.gz"
+    sha256: "0699e7effc5782124c1fa2f2823d816ae740fac5bef002440edfee86b17c1aba"
+  "5.9.3":
+    url: "https://github.com/net-snmp/net-snmp/archive/refs/tags/v5.9.3.tar.gz"
+    sha256: "022c7e67c338a6829637dbb73b6a3ee602d1d3dd737249ce8d4f18ab8e640609"
 patches:
   "5.9.4":
     - patch_file: patches/0001-fix-openssl-linking-msvc.patch
@@ -11,3 +14,27 @@ patches:
       patch_description: "Avoid install extra helper libraries"
     - patch_file: patches/0003-fix-perl-scripts-msvc.patch
       patch_description: "Avoid injecting extra flags when running perl"
+    - patch_file: patches/0004-exclude_syslog.patch
+      patch_description: "Fixed proper syslog include path"
+      patch_source: "https://github.com/net-snmp/net-snmp/pull/921/commits/08076fb9f300556e97ed44f2e36939868bbfd38a"
+    - patch_file: patches/0005-include_select.patch
+      patch_description: "Added include for select.h"
+      patch_source: "https://github.com/net-snmp/net-snmp/pull/921/commits/08076fb9f300556e97ed44f2e36939868bbfd38a"
+    - patch_file: patches/0006-remove-setlocale-on-qnx.patch
+      patch_description: "Prevent qnx builds from calling unsafe setlocale"
+      patch_source: "https://github.com/net-snmp/net-snmp/pull/921/commits/08076fb9f300556e97ed44f2e36939868bbfd38a"
+  "5.9.3":
+    - patch_file: patches/0001-fix-openssl-linking-msvc.patch
+      patch_description: "Use Conan OpenSSL when linking on Windows"
+      patch_source: "https://github.com/net-snmp/net-snmp/commit/99332c80b68248cb60023d12297135dc9c6c8abf"
+    - patch_file: patches/0003-fix-perl-scripts-msvc.patch
+      patch_description: "Avoid injecting extra flags when running perl"
+    - patch_file: patches/0004-exclude_syslog.patch
+      patch_description: "Fixed proper syslog include path"
+      patch_source: "https://github.com/net-snmp/net-snmp/pull/921/commits/08076fb9f300556e97ed44f2e36939868bbfd38a"
+    - patch_file: patches/0005-include_select.patch
+      patch_description: "Added include for select.h"
+      patch_source: "https://github.com/net-snmp/net-snmp/pull/921/commits/08076fb9f300556e97ed44f2e36939868bbfd38a"
+    - patch_file: patches/0006-remove-setlocale-on-qnx.patch
+      patch_description: "Prevent qnx builds from calling unsafe setlocale"
+      patch_source: "https://github.com/net-snmp/net-snmp/pull/921/commits/08076fb9f300556e97ed44f2e36939868bbfd38a"

--- a/recipes/net-snmp/all/conanfile.py
+++ b/recipes/net-snmp/all/conanfile.py
@@ -118,6 +118,9 @@ class NetSnmpConan(ConanFile):
             if self.settings.os in ["Linux"]:
                 tc.extra_ldflags.append("-ldl")
                 tc.extra_ldflags.append("-lpthread")
+            elif self.settings.os in ["Neutrino"]:
+                tc.extra_ldflags.append("-lregex")
+
             tc.generate()
 
             deps = AutotoolsDeps(self)
@@ -217,5 +220,7 @@ class NetSnmpConan(ConanFile):
         self.cpp_info.libs = ["netsnmp"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["rt", "pthread", "m"])
+        elif self.settings.os == "Neutrino":
+            self.cpp_info.system_libs.extend(["rt", "m", "regex"])
         if is_apple_os(self):
             self.cpp_info.frameworks.extend(["CoreFoundation", "DiskArbitration", "IOKit"])

--- a/recipes/net-snmp/all/patches/0004-exclude_syslog.patch
+++ b/recipes/net-snmp/all/patches/0004-exclude_syslog.patch
@@ -1,0 +1,11 @@
+--- snmplib/snmp_debug.c	2021-05-26 00:19:35.000000000 +0200
++++ snmplib/snmp_debug.c	2022-09-05 13:51:14.733064200 +0200
+@@ -37,7 +37,7 @@
+ #endif
+ 
+ #ifdef HAVE_PRIORITYNAMES
+-#include <sys/syslog.h>
++#include <syslog.h>
+ #endif
+ 
+ #include <net-snmp/types.h>

--- a/recipes/net-snmp/all/patches/0005-include_select.patch
+++ b/recipes/net-snmp/all/patches/0005-include_select.patch
@@ -1,0 +1,12 @@
+--- include/net-snmp/library/types.h	2023-07-16 15:14:12.240768782 +0200
++++ include/net-snmp/library/types.h	2023-07-16 15:14:43.021108707 +0200
+@@ -5,6 +5,9 @@
+ #error "Please include <net-snmp/net-snmp-config.h> before this file"
+ #endif
+ 
++#if HAVE_SYS_SELECT_H
++  #include <sys/select.h>
++#endif
+ 
+ #include <net-snmp/types.h>
+ 

--- a/recipes/net-snmp/all/patches/0006-remove-setlocale-on-qnx.patch
+++ b/recipes/net-snmp/all/patches/0006-remove-setlocale-on-qnx.patch
@@ -1,0 +1,15 @@
+--- snmplib/snmp_api.c	2024-12-16 13:24:24.714579100 +0100
++++ snmplib/snmp_api.c	2024-12-16 13:29:38.407792100 +0100
+@@ -896,8 +896,11 @@
+ 
+     /*
+      * set our current locale properly to initialize isprint() type functions 
++     *
++     * Do not use setlocale on qnx, it is buggy 
++     * https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/setlocale.html
+      */
+-#ifdef HAVE_SETLOCALE
++#if defined(HAVE_SETLOCALE) && !defined(__QNX__)
+     setlocale(LC_CTYPE, "");
+ #endif
+ 


### PR DESCRIPTION
### Summary
Changes to recipe:  net-snmp/5.9.3 and net-snmp/5.9.4

#### Motivation
Adding ntp-snmp 5.9.3
Adding support for building to qnx

#### Details
Patched some includes and added system libs to recipe.
Upstream PR: https://github.com/net-snmp/net-snmp/pull/921


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
