### PR TITLE
avahi: fix shadowed headers (#26265)

### DIFF
--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -113,7 +113,8 @@ class AvahiConan(ConanFile):
             self.cpp_info.components[lib].names["cmake_find_package"] = lib
             self.cpp_info.components[lib].names["cmake_find_package_multi"] = lib
             self.cpp_info.components[lib].libs = [avahi_lib]
-            self.cpp_info.components[lib].includedirs = ["include", os.path.join("include", avahi_lib)]
+            if lib != "common":
+                self.cpp_info.components[lib].includedirs = ["include", os.path.join("include", avahi_lib)]
         self.cpp_info.components["compat-libdns_sd"].libs = ["dns_sd"]
 
         self.cpp_info.components["client"].requires = ["common", "dbus::dbus"]

--- a/recipes/avahi/all/test_package/test_package.c
+++ b/recipes/avahi/all/test_package/test_package.c
@@ -1,8 +1,10 @@
+#include <malloc.h>
 #include <stdlib.h>
 
 #include "dns_sd.h"
-#include "avahi-core/log.h"
-
+#include <avahi-core/log.h>
+#include <avahi-common/malloc.h>
+#include <avahi-common/error.h>
 
 int main(void) {
     DNSServiceRef sdRef;
@@ -16,5 +18,6 @@ int main(void) {
     {
         avahi_log_info("DNSServiceBrowse failed: %d\n", err);
     }
+    malloc_trim(0);  // from <malloc.h>
     return EXIT_SUCCESS;
 }

--- a/recipes/avahi/all/test_package/test_package.c
+++ b/recipes/avahi/all/test_package/test_package.c
@@ -1,10 +1,8 @@
-#include <malloc.h>
 #include <stdlib.h>
 
 #include "dns_sd.h"
-#include <avahi-core/log.h>
-#include <avahi-common/malloc.h>
-#include <avahi-common/error.h>
+#include "avahi-core/log.h"
+
 
 int main(void) {
     DNSServiceRef sdRef;
@@ -18,6 +16,5 @@ int main(void) {
     {
         avahi_log_info("DNSServiceBrowse failed: %d\n", err);
     }
-    malloc_trim(0);  // from <malloc.h>
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **avahi/0.8**

#### Motivation
This PR fixes the shadowing of standard headers as described in #26265.

#### Details
This PR reverts the change introduced in #20741 for headers in `<avahi-common/*.h>`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
