### PR TITLE
vulkan-headers: Add version 1.4.309.0

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.304.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.4.304.0.tar.gz"
+    sha256: "46f8f5b6384a36c688e0c40d28d534df41d22de406493dfb5c9b7bcc29672613"
   "1.3.296.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
     sha256: "1e872a0be3890784bbe68dcd89b7e017fed77ba95820841848718c98bda6dc33"

--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.4.304.0":
-    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.4.304.0.tar.gz"
-    sha256: "46f8f5b6384a36c688e0c40d28d534df41d22de406493dfb5c9b7bcc29672613"
+  "1.4.309.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.4.309.0.tar.gz"
+    sha256: "2bc1b4127950badc80212abf1edfa5c3b5032f3425edf37255863ba7592c1969"
   "1.3.296.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
     sha256: "1e872a0be3890784bbe68dcd89b7e017fed77ba95820841848718c98bda6dc33"

--- a/recipes/vulkan-headers/all/test_package/CMakeLists.txt
+++ b/recipes/vulkan-headers/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(VulkanHeaders REQUIRED CONFIG)

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.304.0":
+    folder: all
   "1.3.296.0":
     folder: all
   "1.3.290.0":

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.4.304.0":
+  "1.4.309.0":
     folder: all
   "1.3.296.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-headers/1.4.304.0**

#### Motivation
Version bump
https://github.com/KhronosGroup/Vulkan-Headers/compare/vulkan-sdk-1.3.296.0...vulkan-sdk-1.4.304.0

#### Details
config.yml and conandata.yml point to the newly created vulkan-headers/1.4.304.0.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
