### PR TITLE
spirv-headers: Add version 1.4.309.0

### DIFF
--- a/recipes/spirv-headers/all/conandata.yml
+++ b/recipes/spirv-headers/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.4.304.0":
-    url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.304.0.tar.gz"
-    sha256: "162b864ebaf339d66953fc2c4ad974bc4f453e0f04155cd3755a85e33f408eee"
+  "1.4.309.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.309.0.tar.gz"
+    sha256: "a96f8b4f2dfb18f7432e5c523e220ab0075372a9509e0c25fbff21c76af0de7c"
   "1.3.296.0":
     url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
     sha256: "1423d58a1171611d5aba2bf6f8c69c72ef9c38a0aca12c3493e4fda64c9b2dc6"

--- a/recipes/spirv-headers/all/conandata.yml
+++ b/recipes/spirv-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.304.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.304.0.tar.gz"
+    sha256: "162b864ebaf339d66953fc2c4ad974bc4f453e0f04155cd3755a85e33f408eee"
   "1.3.296.0":
     url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
     sha256: "1423d58a1171611d5aba2bf6f8c69c72ef9c38a0aca12c3493e4fda64c9b2dc6"

--- a/recipes/spirv-headers/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-headers/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(SPIRV-Headers REQUIRED CONFIG)

--- a/recipes/spirv-headers/config.yml
+++ b/recipes/spirv-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.304.0":
+    folder: all
   "1.3.296.0":
     folder: all
   "1.3.268.0":

--- a/recipes/spirv-headers/config.yml
+++ b/recipes/spirv-headers/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.4.304.0":
+  "1.4.309.0":
     folder: all
   "1.3.296.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **spirv-headers/1.4.304.0**

#### Motivation
Version bump
https://github.com/KhronosGroup/SPIRV-Headers/compare/vulkan-sdk-1.3.296.0...vulkan-sdk-1.4.304.0

#### Details
config.yml and conandata.yml point to the newly created spirv-headers/1.4.304.0.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
