### PR TITLE
spirv-cross: Add version 1.4.304.0

### DIFF
--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.4.304.0":
-    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.4.304.0.tar.gz"
-    sha256: "635b9b9ed2318df5ac65a0e1db1f92deb1e9c29e9dac30cd4b14eb3d72be5cf3"
+  "1.4.309.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.4.309.0.tar.gz"
+    sha256: "cf4f12a767d63f63024e61750e372ffdc95567513b99ed9be6f21f474b328ddd"
   "1.3.296.0":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
     sha256: "4f7f9a8a643e6694f155712016b9b572c13a9444e65b3f43b27bb464c0ab76e0"

--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "1.4.304.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.4.304.0.tar.gz"
+    sha256: "635b9b9ed2318df5ac65a0e1db1f92deb1e9c29e9dac30cd4b14eb3d72be5cf3"
   "1.3.296.0":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz"
-    sha256: "4f7f9a8a643e6694f155712016b9b572c13a9444e65b3f43b27bb464c0ab76e0"  
+    sha256: "4f7f9a8a643e6694f155712016b9b572c13a9444e65b3f43b27bb464c0ab76e0"
   "1.3.268.0":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.3.268.0.tar.gz"
     sha256: "dd656a51ba4c229c1a0bb220b7470723e8fd4b68abb7f2cf2ca4027df824f4a0"

--- a/recipes/spirv-cross/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-cross/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 # FIXME: this is not the official way to find spirv-cross components

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.4.304.0":
+  "1.4.309.0":
     folder: all
   "1.3.296.0":
     folder: all  

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.304.0":
+    folder: all
   "1.3.296.0":
     folder: all  
   "1.3.268.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **spirv-cross/1.4.304.0**

#### Motivation
Version bump
https://github.com/KhronosGroup/SPIRV-Cross/compare/vulkan-sdk-1.3.296.0...vulkan-sdk-1.4.304.0

#### Details
config.yml and conandata.yml point to the newly created spirv-cross/1.4.304.0.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
