### PR TITLE
[package]poco/1.13.3 Extend system_libs with mswsock for poco_net component, when building with MinGW

### DIFF
--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -116,6 +116,10 @@ class PocoConan(ConanFile):
             },
         }.get(self._min_cppstd, {})
 
+    @property
+    def _is_mingw(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "gcc"
+
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -368,6 +372,9 @@ class PocoConan(ConanFile):
             self.cpp_info.components["poco_foundation"].defines.append("POCO_STATIC=ON")
             if self.settings.os == "Windows":
                 self.cpp_info.components["poco_foundation"].system_libs.extend(["ws2_32", "iphlpapi", "crypt32"])
+        if self.options.enable_net:
+            if not self.options.shared and self._is_mingw and Version(self.version) >= "1.13.0":
+                self.cpp_info.components["poco_net"].system_libs.extend(["mswsock"])
         if self.options.enable_data_odbc:
             if self.settings.os == "Windows":
                 self.cpp_info.components["poco_dataodbc"].system_libs.extend(["odbc32", "odbccp32"])


### PR DESCRIPTION
### Summary
Changes to recipe:  **poco/1.13.3**

#### Motivation
Fixes #26404

#### Details
Added `_is_mingw` property.
Modified `package_info` to extend `system_libs` with `mswsock` for the `poco_net` component when building with MinGW.
This happens when building poco as a static library, when `enable_net` is set to True and when the version of poco is >= 1.13.0.

[output_before_patch.txt](https://github.com/user-attachments/files/18474075/output_before_patch.txt): Build output before applying change.
[output_after_patch.txt](https://github.com/user-attachments/files/18474077/output_after_patch.txt): Build output after applying change.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
