### PR TITLE
[pango] Fix cairo not in dependency graph error when with_cairo=False option

### DIFF
--- a/recipes/pango/all/conanfile.py
+++ b/recipes/pango/all/conanfile.py
@@ -106,7 +106,7 @@ class PangoConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} requires -o=&:with_fontconfig=True for {self.settings.os}")
 
         if (self.options.with_fontconfig and self.options.with_freetype
-                and not self.dependencies["cairo"].options.with_fontconfig):
+                and self.options.with_cairo and not self.dependencies["cairo"].options.with_fontconfig):
             raise ConanInvalidConfiguration(f"{self.ref} with -o=&:with_fontconfig=True and -o=&:with_freetype=True requires -o=cairo/*:with_fontconfig=True")
 
         if self.options.shared:


### PR DESCRIPTION
### Summary
Changes to recipe:  **pango/***

#### Motivation
closes https://github.com/conan-io/conan-center-index/issues/26410

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
