### PR TITLE
commata: add version 1.0.2

### DIFF
--- a/recipes/commata/all/conandata.yml
+++ b/recipes/commata/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.2":
+    url: "https://github.com/furfurylic/commata/archive/refs/tags/v1.0.2.tar.gz"
+    sha256: "55999ba71e167fa05055069a1e02e79b4ce6b9c1c98f5c0b64db93b5fcec8f1a"
   "1.0.1":
     url: "https://github.com/furfurylic/commata/archive/refs/tags/v1.0.1.tar.gz"
     sha256: "b6e91ede0ec8b7c69ced1e243eba204717e05fcd9ae26163a54425ca800124ef"

--- a/recipes/commata/config.yml
+++ b/recipes/commata/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.2":
+    folder: all
   "1.0.1":
     folder: all
   "1.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **commata/1.0.2**

#### Motivation
There are several bug fixes in 1.0.2.

#### Details
https://github.com/furfurylic/commata/releases/tag/v1.0.2
https://github.com/furfurylic/commata/compare/v1.0.1...v1.0.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
