### PR TITLE
onnxruntime: fix abseil linking errors when with_cuda=True

### DIFF
--- a/recipes/onnxruntime/all/cmake/onnxruntime_external_deps.cmake
+++ b/recipes/onnxruntime/all/cmake/onnxruntime_external_deps.cmake
@@ -4,6 +4,7 @@ if(NOT onnxruntime_DISABLE_ABSEIL)
   find_package(absl REQUIRED CONFIG)
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES abseil::abseil)
   include_directories(${absl_INCLUDE_DIRS})
+  set(ABSEIL_LIBS abseil::abseil)
 endif()
 
 find_package(re2 REQUIRED CONFIG)


### PR DESCRIPTION
### Summary
Changes to recipe:  **onnxruntime/\***

#### Motivation

onnxruntime expects `ABSEIL_LIBS` in cmake to be set to all the targets of abseil library: 
https://github.com/microsoft/onnxruntime/blob/3e4c5e64877c6d9814e4ebce5dcbb1fe71588ec5/cmake/external/abseil-cpp.cmake#L52

In the recipe we replace `onnxruntime_external_deps.cmake` with our own:
https://github.com/conan-io/conan-center-index/blob/c305e9cf19080bdec9db1e803ed6757606f77fb1/recipes/onnxruntime/all/conanfile.py#L189-L191 which doesn't define `ABSEIL_LIBS` at all.

But this is especially important when cuda prodivers are built (i.e. with_cuda=True):
https://github.com/microsoft/onnxruntime/blob/3e4c5e64877c6d9814e4ebce5dcbb1fe71588ec5/cmake/onnxruntime_providers_cuda.cmake#L196-L210 

and when `ABSEIL_LIBS` is empty you'll get linking errors like this one:
```
cuda_allocator.obj : error LNK2019: unresolved external symbol "unsigned __int64 __cdecl absl::lts_20240116::hash_internal:: ...
```


#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
