### PR TITLE
openscenegraph: fix building with other jpeg implementations

### DIFF
--- a/recipes/openscenegraph/all/conanfile.py
+++ b/recipes/openscenegraph/all/conanfile.py
@@ -246,6 +246,10 @@ class OpenSceneGraphConanFile(ConanFile):
         deps = CMakeDeps(self)
         deps.set_property("freetype", "cmake_module_file_name", "Freetype")
         deps.set_property("giflib", "cmake_file_name", "GIFLIB")
+        deps.set_property("libjpeg-turbo", "cmake_file_name", "JPEG")
+        deps.set_property("libjpeg-turbo::jpeg", "cmake_target_name", "JPEG::JPEG")
+        deps.set_property("mozjpeg", "cmake_file_name", "JPEG")
+        deps.set_property("mozjpeg::libjpeg", "cmake_target_name", "JPEG::JPEG")
         deps.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **openscenegraph/\***

#### Motivation and Details

This allows openscenegraph to build when `with_jpeg=libjpeg-turbo` or when `with_jpeg=mozjpeg`


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
