### PR TITLE
cutlass: add version 3.1.0

### DIFF
--- a/recipes/cutlass/all/conandata.yml
+++ b/recipes/cutlass/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "3.5.0":
     url: "https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.5.0.tar.gz"
     sha256: "ef6af8526e3ad04f9827f35ee57eec555d09447f70a0ad0cf684a2e426ccbcb6"
+  "3.1.0":
+    url: "https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.1.0.tar.gz"
+    sha256: "821aa2e5b709a2e5d3922dcf2c5d445b4898a6ef8bac683cfb00125eafbca029"

--- a/recipes/cutlass/config.yml
+++ b/recipes/cutlass/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "3.5.0":
     folder: all
+  "3.1.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cutlass/3.1.0**

#### Motivation and Details

PR adds older version of cutlass - 3.1.0. This specific version is required to build onnxruntime 1.18.x with `with_cuda=True`: https://github.com/microsoft/onnxruntime/blob/v1.18.2/cmake/deps.txt#L56. I've had no success building onnxruntime with newer cutlass.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
