### PR TITLE
grpc: add version 1.69.0

### DIFF
--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.69.0":
+    url: "https://github.com/grpc/grpc/archive/v1.69.0.tar.gz"
+    sha256: "cd256d91781911d46a57506978b3979bfee45d5086a1b6668a3ae19c5e77f8dc"
   "1.67.1":
     url: "https://github.com/grpc/grpc/archive/v1.67.1.tar.gz"
     sha256: "d74f8e99a433982a12d7899f6773e285c9824e1d9a173ea1d1fb26c9bd089299"

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -152,6 +152,8 @@ class GrpcConan(ConanFile):
         if cross_building(self):
             # when cross compiling we need pre compiled grpc plugins for protoc
             self.tool_requires(f"grpc/{self.version}")
+        if Version(self.version) >= "1.69":
+            self.tool_requires("cmake/[>3.16 <4]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/grpc/all/target_info/grpc_1.69.0.yml
+++ b/recipes/grpc/all/target_info/grpc_1.69.0.yml
@@ -1,0 +1,188 @@
+grpc_version: 1.69.0
+grpc_targets:
+    - name: "address_sorting"
+      lib: "address_sorting"
+    - name: "gpr"
+      lib: "gpr"
+      requires:
+        - abseil::absl_base
+        - abseil::absl_core_headers
+        - abseil::absl_log_severity
+        - abseil::absl_flags
+        - abseil::absl_flags_marshalling
+        - abseil::absl_any_invocable
+        - abseil::absl_check
+        - abseil::absl_log_globals
+        - abseil::absl_log
+        - abseil::absl_memory
+        - abseil::absl_bits
+        - abseil::absl_random_random
+        - abseil::absl_status
+        - abseil::absl_cord
+        - abseil::absl_str_format
+        - abseil::absl_strings
+        - abseil::absl_synchronization
+        - abseil::absl_time
+        - abseil::absl_optional
+        - abseil::absl_variant
+    - name: "_grpc"
+      lib: "grpc"
+      requires:
+        - upb_json_lib
+        - upb_textformat_lib
+        - re2::re2
+        - zlib::zlib
+        - abseil::absl_algorithm_container
+        - abseil::absl_config
+        - abseil::absl_no_destructor
+        - abseil::absl_cleanup
+        - abseil::absl_flat_hash_map
+        - abseil::absl_flat_hash_set
+        - abseil::absl_inlined_vector
+        - abseil::absl_bind_front
+        - abseil::absl_function_ref
+        - abseil::absl_hash
+        - abseil::absl_type_traits
+        - abseil::absl_random_bit_gen_ref
+        - abseil::absl_random_distributions
+        - abseil::absl_statusor
+        - abseil::absl_span
+        - abseil::absl_utility
+        - c-ares::cares
+        - gpr
+        - openssl::ssl
+        - openssl::crypto
+        - address_sorting
+      frameworks: ['CoreFoundation']
+    - name: "grpc_unsecure"
+      lib: "grpc_unsecure"
+      requires:
+        - upb_mini_descriptor_lib
+        - upb_wire_lib
+        - zlib::zlib
+        - abseil::absl_algorithm_container
+        - abseil::absl_config
+        - abseil::absl_no_destructor
+        - abseil::absl_cleanup
+        - abseil::absl_flat_hash_map
+        - abseil::absl_flat_hash_set
+        - abseil::absl_inlined_vector
+        - abseil::absl_bind_front
+        - abseil::absl_function_ref
+        - abseil::absl_hash
+        - abseil::absl_type_traits
+        - abseil::absl_random_bit_gen_ref
+        - abseil::absl_random_distributions
+        - abseil::absl_statusor
+        - abseil::absl_span
+        - abseil::absl_utility
+        - c-ares::cares
+        - gpr
+        - address_sorting
+      frameworks: ['CoreFoundation']
+    - name: "upb_base_lib"
+      lib: "upb_base_lib"
+    - name: "upb_mini_descriptor_lib"
+      lib: "upb_mini_descriptor_lib"
+      requires:
+        - upb_base_lib
+        - upb_mem_lib
+    - name: "upb_wire_lib"
+      lib: "upb_wire_lib"
+      requires:
+        - utf8_range_lib
+        - upb_message_lib
+    - name: "upb_json_lib"
+      lib: "upb_json_lib"
+      requires:
+        - upb_mini_descriptor_lib
+        - upb_wire_lib
+    - name: "upb_mem_lib"
+      lib: "upb_mem_lib"
+    - name: "upb_message_lib"
+      lib: "upb_message_lib"
+      requires:
+        - upb_base_lib
+        - upb_mem_lib
+    - name: "upb_textformat_lib"
+      lib: "upb_textformat_lib"
+      requires:
+        - upb_mini_descriptor_lib
+        - upb_wire_lib
+    - name: "utf8_range_lib"
+      lib: "utf8_range_lib"
+    - name: "grpc++"
+      lib: "grpc++"
+      requires:
+        - abseil::absl_absl_check
+        - abseil::absl_absl_log
+        - _grpc
+        - protobuf::libprotobuf
+    - name: "grpc++_alts"
+      lib: "grpc++_alts"
+      requires:
+        - grpc++
+    - name: "grpc++_error_details"
+      lib: "grpc++_error_details"
+      requires:
+        - grpc++
+    - name: "grpc++_reflection"
+      lib: "grpc++_reflection"
+      requires:
+        - grpc++
+    - name: "grpc++_unsecure"
+      lib: "grpc++_unsecure"
+      requires:
+        - abseil::absl_absl_check
+        - abseil::absl_absl_log
+        - grpc_unsecure
+        - protobuf::libprotobuf
+    - name: "grpc_authorization_provider"
+      lib: "grpc_authorization_provider"
+      requires:
+        - upb_mini_descriptor_lib
+        - upb_wire_lib
+        - re2::re2
+        - zlib::zlib
+        - abseil::absl_config
+        - abseil::absl_no_destructor
+        - abseil::absl_cleanup
+        - abseil::absl_flat_hash_map
+        - abseil::absl_flat_hash_set
+        - abseil::absl_inlined_vector
+        - abseil::absl_function_ref
+        - abseil::absl_hash
+        - abseil::absl_type_traits
+        - abseil::absl_statusor
+        - abseil::absl_span
+        - abseil::absl_utility
+        - c-ares::cares
+        - gpr
+        - address_sorting
+    - name: "grpc_plugin_support"
+      lib: "grpc_plugin_support"
+      requires:
+        - abseil::absl_status
+        - protobuf::libprotobuf
+        - protobuf::libprotoc
+    - name: "grpcpp_channelz"
+      lib: "grpcpp_channelz"
+      requires:
+        - grpc++
+grpc_plugins:
+    - target: "gRPC::grpc_cpp_plugin"
+      executable: "grpc_cpp_plugin"
+    - target: "gRPC::grpc_csharp_plugin"
+      executable: "grpc_csharp_plugin"
+    - target: "gRPC::grpc_node_plugin"
+      executable: "grpc_node_plugin"
+    - target: "gRPC::grpc_objective_c_plugin"
+      executable: "grpc_objective_c_plugin"
+    - target: "gRPC::grpc_php_plugin"
+      executable: "grpc_php_plugin"
+    - target: "gRPC::grpc_python_plugin"
+      executable: "grpc_python_plugin"
+    - target: "gRPC::grpc_ruby_plugin"
+      executable: "grpc_ruby_plugin"
+    - target: "gRPC::grpc_otel_plugin"
+      executable: "grpc_otel_plugin"

--- a/recipes/grpc/config.yml
+++ b/recipes/grpc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.69.0":
+    folder: "all"
   "1.67.1":
     folder: "all"
   "1.65.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **grpc/1.69.0**

Close https://github.com/conan-io/conan-center-index/issues/26590

#### Motivation
* Newer version of gRPC contains an important fix of compilation errors caused by new version of Windows 
SDK 10.0.26100. [Issue](https://github.com/grpc/grpc/issues/37210#issuecomment-2226809722)
* Includes a fix for https://nvd.nist.gov/vuln/detail/CVE-2024-11407

#### Details
Updated target_info file by checking diff for gRPC CMakeLists.txt.

Tested new version package in Windows x64 environment.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
