### PR TITLE
ffmpeg: obey pkg_config configuration

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -373,7 +373,8 @@ class FFMpegConan(ConanFile):
                 self.tool_requires("nasm/2.16.01")
             else:
                 self.tool_requires("yasm/1.3.0")
-        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+        if self.settings.os != "Linux" and not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            # See https://github.com/conan-io/conan-center-index/pull/26447#discussion_r1926682155
             self.tool_requires("pkgconf/[>=2.1 <3]")
         if self._settings_build.os == "Windows":
             self.win_bash = True


### PR DESCRIPTION
### Summary
Changes to recipe:  ffmpeg/all

#### Motivation
If the user specifies which pkg-config to use, propagate that to the ffmpeg scripts.

#### Details

Unlike other tools (autotools, cmake), the `./configure` script in ffmpeg is *not* strictly derived from autotools, so it makes choices of its own.
`pkg-config` is taken from https://github.com/FFmpeg/FFmpeg/blob/master/configure#L404, which resolves to either
- `pkg-config` (https://github.com/FFmpeg/FFmpeg/blob/master/configure#L4125)
- `[cross-prefix]-pkg-config` (https://github.com/FFmpeg/FFmpeg/blob/6ecc96f4d08d74b0590ab03f39f93f386910c4c0/configure#L4700C1-L4700C58)- but only when a `--cross-prefix` is provided

In either case, if the user specifies the Conan configuration `tools.gnu:pkg_config` or `PKG_CONFIG` - it will be completely ignored. This is particularly problematic when crossbuilding and we need a pkg-config tailored to handle system dependencies, e.g
- we are expecting to use a prefixed executable, e.g. `aarch64-linux-gnu-pkgconf`, but we either did not pass `cross-prefix`, *OR* we are using `pkgconfg` (newer debians use pkgconf)
- we are using a wrapper as documented in https://autotools.info/pkgconfig/cross-compiling.html?mtm_campaign=homepage&amp;mtm_content=redirects  



In both cases, when cross building and dealing with system dependencies, it is important that *both* of the following are true:

- pkg-config only locates libraries for the host platform (the "target", what we are building _for_), see for [example](https://github.com/jcar87/conan-crossbuild-with-sysroot/blob/main/support_files/pkg-config#L7-L9)
- pkg-config **must** prune "system" paths (locations where the compiler and linker already look), so that they don't end up having higher precedence than Conan ones. When doing a native build, `pkg-config` already does this by default, but if we want to reuse the native executable, we need to tailor this to the sysroot in question, see [example](https://github.com/jcar87/conan-crossbuild-with-sysroot/blob/main/support_files/pkg-config#L14-L16) 

The ffmpeg configure behaviour might explain why there was already logic in the recipe, chances are this was failing on systems where `pkg-config` as an executable is not found on the path

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
