### PR TITLE
drogon: add version 1.9.9

### DIFF
--- a/recipes/drogon/all/conandata.yml
+++ b/recipes/drogon/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.9":
+    url: "https://github.com/drogonframework/drogon/archive/v1.9.9.tar.gz"
+    sha256: "4155f78196902ef2f9d06b708897c9e8acaa1536cc4a8c8da9726ceb8ada2aaf"
   "1.9.8":
     url: "https://github.com/drogonframework/drogon/archive/v1.9.8.tar.gz"
     sha256: "62332a4882cc7db1c7cf04391b65c91ddf6fcbb49af129fc37eb0130809e0449"
@@ -30,6 +33,13 @@ sources:
     url: "https://github.com/drogonframework/drogon/archive/v1.8.7.tar.gz"
     sha256: "d2d80d35becd69bf80d74bf09b69425193f1b7be3926bd44f3ac7b951e54465d"
 patches:
+  "1.9.9":
+    - patch_file: "patches/1.8.5-0001-remove-shared-libs.patch"
+      patch_description: "remove shared libs option"
+      patch_type: "conan"
+    - patch_file: "patches/1.9.7-0002-find-cci-packages.patch"
+      patch_description: "Fix jsoncpp cmake target name"
+      patch_type: "conan"
   "1.9.8":
     - patch_file: "patches/1.8.5-0001-remove-shared-libs.patch"
       patch_description: "remove shared libs option"

--- a/recipes/drogon/config.yml
+++ b/recipes/drogon/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.9":
+    folder: "all"
   "1.9.8":
     folder: "all"
   "1.9.7":


### PR DESCRIPTION
### Summary
Changes to recipe:  **drogon/1.9.9**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

The Drogon Framework was updated three weeks ago. So, the current version is 1.9.9
[the framework on GitHub](https://github.com/drogonframework/drogon)

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

- [x] recipes/drogon/all/conandata.yml: added a link to the archive
- [ ] recipes/drogon/all/conanfile.py: updated requirements
- [x] recipes/drogon/config.yml: added the new version

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

PR exists, but it was not created correctly.
That's my first PR to Conan.

I followed these tutorials:
https://docs.conan.io/2/tutorial/developing_packages/local_package_development_flow.html
https://docs.conan.io/2/tutorial/creating_packages/test_conan_packages.html
This package requires an exact version with each command such as --version 1.9.9 (and the other versions)