### PR TITLE
Add missing linkage to boost random

### DIFF
--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -71,4 +71,4 @@ class WebsocketPPConan(ConanFile):
             self.cpp_info.defines.extend(["ASIO_STANDALONE", "_WEBSOCKETPP_CPP11_STL_"])
             self.cpp_info.requires.append("asio::asio")
         elif self.options.asio == "boost":
-            self.cpp_info.requires.append("boost::headers")
+            self.cpp_info.requires.extend(["boost::headers","boost::random"] )

--- a/recipes/websocketpp/all/test_package/test_package.cpp
+++ b/recipes/websocketpp/all/test_package/test_package.cpp
@@ -1,7 +1,12 @@
 #include <websocketpp/server.hpp>
 #include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/config/asio_client.hpp>
+#include <websocketpp/client.hpp>
+
 
 int main()
 {
     websocketpp::server<websocketpp::config::asio> server;
+
+    websocketpp::client<websocketpp::config::asio_tls_client> client;
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **websocketpp/0.8.2**

#### Motivation
Bug fix: https://github.com/conan-io/conan-center-index/issues/26452

#### Details
Websocketpp requires boost random when creating websocket client.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
