### PR TITLE
libiconv: don't hardcode name of windres executable

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -87,19 +87,6 @@ class LibiconvConan(ConanFile):
         env.generate()
 
         tc = AutotoolsToolchain(self)
-        if self.settings.os == "Windows" and self.settings.compiler == "gcc":
-            if self.settings.arch == "x86":
-                tc.update_configure_args({
-                    "--host": "i686-w64-mingw32",
-                    "RC": "windres --target=pe-i386",
-                    "WINDRES": "windres --target=pe-i386",
-                })
-            elif self.settings.arch == "x86_64":
-                tc.update_configure_args({
-                    "--host": "x86_64-w64-mingw32",
-                    "RC": "windres --target=pe-x86-64",
-                    "WINDRES": "windres --target=pe-x86-64",
-                })
         msvc_version = {"Visual Studio": "12", "msvc": "180"}
         if is_msvc(self) and Version(self.settings.compiler.version) >= msvc_version[str(self.settings.compiler)]:
             # https://github.com/conan-io/conan/issues/6514

--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -18,7 +18,7 @@ from conan.tools.microsoft import is_msvc, unix_path
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class LibiconvConan(ConanFile):
@@ -49,10 +49,6 @@ class LibiconvConan(ConanFile):
     def _msvc_tools(self):
         return ("clang-cl", "llvm-lib", "lld-link") if self._is_clang_cl else ("cl", "lib", "link")
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -74,7 +70,7 @@ class LibiconvConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows":
+        if self.settings_build.os == "Windows":
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
             self.win_bash = True
@@ -87,15 +83,11 @@ class LibiconvConan(ConanFile):
         env.generate()
 
         tc = AutotoolsToolchain(self)
-        msvc_version = {"Visual Studio": "12", "msvc": "180"}
-        if is_msvc(self) and Version(self.settings.compiler.version) >= msvc_version[str(self.settings.compiler)]:
-            # https://github.com/conan-io/conan/issues/6514
-            tc.extra_cflags.append("-FS")
         if cross_building(self) and is_msvc(self):
             triplet_arch_windows = {"x86_64": "x86_64", "x86": "i686", "armv8": "aarch64"}
             # ICU doesn't like GNU triplet of conan for msvc (see https://github.com/conan-io/conan/issues/12546)
             host_arch = triplet_arch_windows.get(str(self.settings.arch))
-            build_arch = triplet_arch_windows.get(str(self._settings_build.arch))
+            build_arch = triplet_arch_windows.get(str(self.settings_build.arch))
 
             if host_arch and build_arch:
                 host = f"{host_arch}-w64-mingw32"
@@ -150,8 +142,3 @@ class LibiconvConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "Iconv")
         self.cpp_info.set_property("cmake_target_name", "Iconv::Iconv")
         self.cpp_info.libs = ["iconv", "charset"]
-
-        # TODO: to remove in conan v2
-        self.cpp_info.names["cmake_find_package"] = "Iconv"
-        self.cpp_info.names["cmake_find_package_multi"] = "Iconv"
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
### Summary
Changes to recipe:  libiconv/all

#### Motivation
Fix autodetection of `windres` by autotools - let autotools pick up the correct executable, OR let the executable be defined by either RC (env var) or `rc` conan configuration - rather than hardcode a name.

Close https://github.com/conan-io/conan-center-index/issues/26445

#### Details
Fix the following issue when working with a mingw toolchain *on Linux*, where the executable has a different name

```
libtool: compile:  windres --target=pe-x86-64 -DPACKAGE_VERSION_STRING=\\\"1.17\\\" -DPACKAGE_VERSION_MAJOR=1 -DPACKAGE_VERSION_MINOR=17 -DPACKAGE_VERSION_SUBMINOR=0 -i /home/crash/.conan2/p/b/libic2b01ca099ce3a/b/src/lib/../windows/libiconv.rc --output-format=coff -o libiconv.res.o
../libtool: line 1932: windres: command not found
```

By reverting https://github.com/conan-io/conan-center-index/pull/22665, which hardcoded the name of the executable.
Note that https://github.com/conan-io/conan-center-index/pull/22665 should not be necessary - and https://github.com/conan-io/conan-center-index/pull/20693 already works around the issue of the wrong windres.exe being picked up on Windows when targetting i686 with mingw
(see details here https://github.com/conan-io/conan-center-index/issues/26445#issuecomment-2609762616)

Tested the following configurations - all working:
* `mingw` from Linux (package provided by Ubuntu)
* `mingw` on Windows, with the toolchain provided by `mingw-builds` and msys2 provided by the msys2 package (tested 64-bit only)
* `mingw` on Windows, with a standalone installation of the msys2 mingw64 toolchain targetting x86_64
* `mingw` on Windows, with a standalone installation of the msys2 mingw32 toolchain targetting x86

Note that in any case, the patch in https://github.com/conan-io/conan-center-index/pull/20693 (which remains in place) had the same goal and thus the one being reverted is at best, redundant.


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
