### PR TITLE
qt: output requested modules as debug

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -235,7 +235,7 @@ class QtConan(ConanFile):
                     self.output.warning(f"qt6: {module} requested because {status}_modules=True"
                                         f" but it has been explicitly disabled with {module}=False")
 
-        self.output.info(f"qt6: requested modules {list(requested_modules)}")
+        self._debug_output(f"qt6: requested modules {list(requested_modules)}")
 
         required_modules =  {}
         for module in requested_modules:


### PR DESCRIPTION
### Summary
Only emit `qt6: requested modules` line as debug message, not info

#### Motivation
The message gets spuriously printed at other times when just loading the file, more than just building/interacting.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
