### PR TITLE
pistache: add version 0.4.25

### DIFF
--- a/recipes/pistache/all/conandata.yml
+++ b/recipes/pistache/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.25":
+    url: "https://github.com/pistacheio/pistache/archive/refs/tags/v0.4.25.tar.gz"
+    sha256: "30569c5d7290f38d2874e9a7c1a2e9a1a8f16b7567f581eba9590d7e1016756e"
   "0.0.5":
     url: "https://github.com/pistacheio/pistache/archive/refs/tags/0.0.5.tar.gz"
     sha256: "e2da87ebc01367e33bd8d7800cb2bf5c23e9fb4e6f49dce2cab5f8756df8dca0"

--- a/recipes/pistache/config.yml
+++ b/recipes/pistache/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.25":
+    folder: all
   "0.0.5":
     folder: all
   "cci.20240107":


### PR DESCRIPTION
### Summary
Changes to recipe:  **pistache/0.4.25**

#### Motivation
0.4.25 supports Windows and macOS!

#### Details
https://github.com/pistacheio/pistache/releases/tag/v0.4.25
https://github.com/pistacheio/pistache/compare/0.0.5...v0.4.25

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
