### PR TITLE
msys2:change the error message to let user know how to work on windows arm64.

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -67,6 +67,8 @@ class MSYS2Conan(ConanFile):
     def validate(self):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only Windows supported")
+        if self.settings.arch == "armv8":
+            raise ConanInvalidConfiguration("msys2 does not support arm64 natively now, you may use the setting of build: \"msys2/*:arch=x86_64\" to let msys2 run on x86 emulation.")
         if self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Only Windows x64 supported")
 


### PR DESCRIPTION
fixes https://github.com/conan-io/conan-center-index/issues/26379

### Summary
Changes to recipe:  **msys2/cci.latest**

#### Motivation
msys2 now doesn't fully support native arm64, but its default installed x86_64 executable files can work on x86 emulation on windows 11 arm, please refer to:
https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation

And can use the mingw-w64-cross-gcc package fro arm64 cross build from x64, please refer to:
https://github.com/Windows-on-ARM-Experiments/msys2-woarm64-build

so, we can set the arch of build profile to x64 and the arch of host profile to arm64 for msys2:
```
======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=msvc
compiler.cppstd=14
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows
[conf]

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=msvc
compiler.cppstd=14
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows
msys2/*:arch=x86_64
[conf]
```
or add the --settings:build command line argument: 
`conan install --require=libxxx/xxx --build=missing --settings:build="msys2/*:arch=x86_64"`

That will try to run msys2 in x86 emulation mode, work together with other arm64 native tool; and if any recipe needs arm cross build, it can install mingw-w64-cross-gcc package and utilize it manually.

#### Details
The error message can be refined to tip user how to correctly run x64 files of msys2, if user doesn't have this background knowledge, they will consume many time to research, and may not find the simple way to make the build successfully.
I think msys2 will support native arm64 in future, and this rare issue only happened between windows with x86 emulation and no arm64 tool, it may be not important enough to write in the document.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
