### PR TITLE
add yaml-cpp 0.6.2-0f9a586-p1 for cpp-libp2p

### DIFF
--- a/recipes/yaml-cpp/all/conandata.yml
+++ b/recipes/yaml-cpp/all/conandata.yml
@@ -8,6 +8,10 @@ sources:
   "0.6.3":
     url: "https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.3.tar.gz"
     sha256: "77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed"
+  "0.6.2-0f9a586-p1":
+    url: "https://github.com/hunter-packages/yaml-cpp/archive/refs/tags/v0.6.2-0f9a586-p1.tar.gz"
+    sha256: "b416ab3f1b018e55755dafe6af0ed59150e7bcfadef59425195a8814c9a19bed"
+
 patches:
   "0.7.0":
     - patch_file: "patches/0001-install-0.7.0.patch"
@@ -18,3 +22,8 @@ patches:
       patch_description: "Adds assert to enable compilation with libcxx + gcc"
       patch_type: "portability"
       patch_source: "https://github.com/jbeder/yaml-cpp/pull/947"
+  "0.6.2-0f9a586-p1":
+    - patch_file: "patches/0003-update-0.6.2-0f9a586-p1.patch"
+      patch_description: "Adapt to CPP 11 standard"
+      patch_type: "portability"
+      patch_source: "https://github.com/simbahebinbo/yaml-cpp/commit/b633ec8ef18b6ca4f02972a6a99691f2d8210abe"

--- a/recipes/yaml-cpp/all/patches/0003-update-0.6.2-0f9a586-p1.patch
+++ b/recipes/yaml-cpp/all/patches/0003-update-0.6.2-0f9a586-p1.patch
@@ -1,0 +1,34 @@
+From b633ec8ef18b6ca4f02972a6a99691f2d8210abe Mon Sep 17 00:00:00 2001
+From: simbahebinbo <lansheng228@163.com>
+Date: Thu, 5 Sep 2024 15:27:40 +0800
+Subject: [PATCH] update
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b53bf89..c91cbc7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,6 +8,8 @@ cmake_minimum_required(VERSION 3.1)
+ include(CheckCXXCompilerFlag)
+ include(CMakePackageConfigHelpers)
+ 
++set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+ ###
+ ### Project settings
+@@ -24,7 +26,7 @@ set(YAML_CPP_VERSION "${YAML_CPP_VERSION_MAJOR}.${YAML_CPP_VERSION_MINOR}.${YAML
+ ### Project options
+ ###
+ ## Project stuff
+-option(YAML_CPP_BUILD_TESTS "Enable testing" ON)
++option(YAML_CPP_BUILD_TESTS "Enable testing" OFF)
+ option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
+ option(YAML_CPP_BUILD_CONTRIB "Enable contrib stuff in library" ON)
+ option(YAML_CPP_INSTALL "Enable generation of install target" ON)
+-- 
+2.40.0
+

--- a/recipes/yaml-cpp/config.yml
+++ b/recipes/yaml-cpp/config.yml
@@ -5,3 +5,6 @@ versions:
     folder: all
   "0.6.3":
     folder: all
+  "0.6.2-0f9a586-p1":
+    folder: all
+


### PR DESCRIPTION
Summary
Changes to recipe: yaml-cpp/0.6.2-0f9a586-p1

Motivation
This version has been modified by cpp-libp2p developers. Without this version, cpp-libp2p cannot run.

https://github.com/libp2p/cpp-libp2p/issues/264
https://github.com/xDimon/soralog/issues/11