### PR TITLE
Fix libjxl usage in libvips

### DIFF
--- a/recipes/libjxl/all/conanfile.py
+++ b/recipes/libjxl/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.gnu import PkgConfigDeps
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
 
 class LibjxlConan(ConanFile):
@@ -199,6 +199,7 @@ class LibjxlConan(ConanFile):
                 self.cpp_info.components["jxl"].defines.append("JXL_CMS_STATIC_DEFINE")
             if libcxx:
                 self.cpp_info.components["jxl_cms"].system_libs.append(libcxx)
+            self.cpp_info.components["jxl"].requires.append("jxl_cms")
 
         # jxl_dec
         if Version(self.version) < "0.9.0":

--- a/recipes/libvips/all/conanfile.py
+++ b/recipes/libvips/all/conanfile.py
@@ -154,7 +154,7 @@ class LibvipsConan(ConanFile):
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/4.1.5")
         if self.options.with_jpeg_xl:
-            self.requires("libjxl/0.6.1")
+            self.requires("libjxl/0.11.1")
         if self.options.with_lcms:
             self.requires("lcms/2.16")
         if self.options.with_magick:
@@ -218,9 +218,9 @@ class LibvipsConan(ConanFile):
             raise ConanInvalidConfiguration("librsvg recipe not available in conancenter yet")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.4.0")
+        self.tool_requires("meson/[>=1.2.3 <2]")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
         if self.options.introspection:
             self.tool_requires("gobject-introspection/1.72.0")
         self.tool_requires("glib/<host_version>")
@@ -303,7 +303,7 @@ class LibvipsConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        
+
         # Disable tests
         meson_build = os.path.join(self.source_folder, "meson.build")
         replace_in_file(self, meson_build, "subdir('test')", "")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libvips/[*]** & **libjxl[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fixes #26465

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
The generated pc file in libjxl contains `Requires: libhwy libbrotlienc libbrotlidec libjxl_cms`, but the recipe did not reflect this

The recipes, specially libjxl's, need some improvements (It currently fetches dependencies from the system instead of Conan, for example), but that's left as a follow-up PR to minimize the diff here