### PR TITLE
llama-cpp: Add new b4570 version

### DIFF
--- a/recipes/llama-cpp/all/cmake/llama-cpp-cuda-static.cmake
+++ b/recipes/llama-cpp/all/cmake/llama-cpp-cuda-static.cmake
@@ -1,7 +1,0 @@
-find_dependency(CUDAToolkit REQUIRED)
-if (WIN32)
-    # As of 12.3.1 CUDA Toolkit for Windows does not offer a static cublas library
-    target_link_libraries(llama-cpp::common INTERFACE CUDA::cudart_static CUDA::cublas CUDA::cublasLt CUDA::cuda_driver)
-else ()
-    target_link_libraries(llama-cpp::common INTERFACE CUDA::cudart_static CUDA::cublas_static CUDA::cublasLt_static CUDA::cuda_driver)
-endif()

--- a/recipes/llama-cpp/all/conandata.yml
+++ b/recipes/llama-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "b4570":
+    url: "https://github.com/ggerganov/llama.cpp/archive/refs/tags/b4570.tar.gz"
+    sha256: "35bfe07807fd0cf30710023765b9a7ab6c1003f27ef907ce9cea2c5464411430"
   "b4079":
     url: "https://github.com/ggerganov/llama.cpp/archive/refs/tags/b4079.tar.gz"
     sha256: "79093413dcdbd30f83b800aeb958c87369fdfdaf4e5603b094185898ff404a32"

--- a/recipes/llama-cpp/all/conandata.yml
+++ b/recipes/llama-cpp/all/conandata.yml
@@ -8,9 +8,6 @@ sources:
   "b3542":
     url: "https://github.com/ggerganov/llama.cpp/archive/refs/tags/b3542.tar.gz"
     sha256: "6f8b23d930400fce5708d2c85022ef33f1083af8f6ac395abefadacee0942e78"
-  "b3040":
-    url: "https://github.com/ggerganov/llama.cpp/archive/refs/tags/b3040.tar.gz"
-    sha256: "020e040139660eb40113503bb1057d5387677d249b990e008e04821532f7cd62"
 patches:
   "b4570":
     - patch_file: "patches/b4570-001-curl-patch-targets.patch"
@@ -18,5 +15,3 @@ patches:
     - patch_file: "patches/b4079-001-curl-patch-targets.patch"
   "b3542":
     - patch_file: "patches/b3542-001-curl-patch-targets.patch"
-  "b3040":
-    - patch_file: "patches/b3040-001-curl-patch-targets.patch"

--- a/recipes/llama-cpp/all/conandata.yml
+++ b/recipes/llama-cpp/all/conandata.yml
@@ -12,6 +12,8 @@ sources:
     url: "https://github.com/ggerganov/llama.cpp/archive/refs/tags/b3040.tar.gz"
     sha256: "020e040139660eb40113503bb1057d5387677d249b990e008e04821532f7cd62"
 patches:
+  "b4570":
+    - patch_file: "patches/b4570-001-curl-patch-targets.patch"
   "b4079":
     - patch_file: "patches/b4079-001-curl-patch-targets.patch"
   "b3542":

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -51,7 +51,7 @@ class LlamaCppConan(ConanFile):
         check_min_cppstd(self, 17 if self._is_new_llama else 11)
 
     def validate_build(self):
-        if Version(self.version) >= "b4570" and self.settings.compiler == "msvc" and "arm" in self.settings.arch:
+        if self._is_new_llama and self.settings.compiler == "msvc" and "arm" in self.settings.arch:
             raise ConanInvalidConfiguration("llama-cpp does not support ARM architecture on msvc, it recommends to use clang instead")
 
     def layout(self):

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -68,6 +68,7 @@ class LlamaCppConan(ConanFile):
         tc.variables["LLAMA_CURL"] = self.options.get_safe("with_curl")
         if cross_building(self):
             tc.variables["LLAMA_NATIVE"] = False
+            tc.variables["GGML_NATIVE_DEFAULT"] = False
 
         tc.variables["GGML_BUILD_TESTS"] = False
         #tc.variables["GGML_BUILD_EXAMPLES"] = self.options.get_safe("with_examples")
@@ -108,6 +109,7 @@ class LlamaCppConan(ConanFile):
         self.cpp_info.components["common"].requires = ["llama"]
         if self.options.with_curl:
             self.cpp_info.components["common"].requires.append("libcurl::libcurl")
+            self.cpp_info.components["common"].defines.append("LLAMA_USE_CURL")
         if is_apple_os(self):
             self.cpp_info.components["common"].frameworks.extend(["Foundation", "Accelerate", "Metal"])
         elif self.settings.os in ("Linux", "FreeBSD"):

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -192,6 +192,3 @@ class LlamaCppConan(ConanFile):
                     self.cpp_info.components["ggml-blas"].frameworks.append("Accelerate")
                 if "metal" in backends:
                     self.cpp_info.components["ggml-metal"].frameworks.extend(["Metal", "MetalKit", "Foundation", "CoreFoundation"])
-            if "cuda" in backends:
-                # TODO: Add CUDA information
-                pass

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -70,7 +70,7 @@ class LlamaCppConan(ConanFile):
             tc.variables["LLAMA_NATIVE"] = False
 
         tc.variables["GGML_BUILD_TESTS"] = False
-        tc.variables["GGML_BUILD_EXAMPLES"] = self.options.get_safe("with_examples")
+        #tc.variables["GGML_BUILD_EXAMPLES"] = self.options.get_safe("with_examples")
         tc.variables["GGML_CUDA"] = self.options.get_safe("with_cuda")
         tc.generate()
 

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -6,7 +6,6 @@ from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd, cross_building
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, apply_conandata_patches, export_conandata_patches
-from conan.tools.scm import Version
 
 
 required_conan_version = ">=2.0.9"
@@ -45,6 +44,10 @@ class LlamaCppConan(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 11)
+
+    def validate_build(self):
+        if self.settings.compiler == "msvc" and "arm" in self.settings.arch:
+            raise ConanInvalidConfiguration("llama-cpp does not support ARM architecture on msvc, it recommends to use clang instead")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -151,4 +154,3 @@ class LlamaCppConan(ConanFile):
             self.cpp_info.builddirs.append(os.path.join("lib", "cmake"))
             module_path = os.path.join("lib", "cmake", "llama-cpp-cuda-static.cmake")
             self.cpp_info.set_property("cmake_build_modules", [module_path])
-

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -117,8 +117,8 @@ class LlamaCppConan(ConanFile):
         copy(self, "*common*.so", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
         copy(self, "*common*.dylib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
         copy(self, "*common*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
-        copy(self, "*.cmake", src=os.path.join(self.export_sources_folder, "cmake"), dst=os.path.join(self.package_folder, "lib", "cmake"))
-        save(self, os.path.join(self.package_folder, "lib", "cmake", "llama-cpp-cuda-static.cmake"), self._cuda_build_module)
+        if self.options.with_cuda and not self.options.shared:
+            save(self, os.path.join(self.package_folder, "lib", "cmake", "llama-cpp-cuda-static.cmake"), self._cuda_build_module)
 
     def _get_backends(self):
         results = ["cpu"]

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -46,6 +46,8 @@ class LlamaCppConan(ConanFile):
 
     @property
     def _cuda_build_module(self):
+        # Adding this to the package info is necessary if we want consumers of llama to link correctly when
+        # they activate the CUDA option. In the future, when we have a CUDA recipe this could be removed.
         cuda_target = "ggml-cuda" if self._is_new_llama else "ggml"
         return textwrap.dedent(f"""\
             find_dependency(CUDAToolkit REQUIRED)

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -115,7 +115,6 @@ class LlamaCppConan(ConanFile):
         return results
 
     def package_info(self):
-        self.cpp_info.components["llama"].set_property("cmake_target_aliases", ["common"])
         self.cpp_info.components["common"].includedirs = [os.path.join("include", "common")]
         self.cpp_info.components["common"].libs = ["common"]
         self.cpp_info.components["common"].requires = ["llama"]

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -139,14 +139,10 @@ class LlamaCppConan(ConanFile):
         self.cpp_info.components["llama"].libs = ["llama"]
         self.cpp_info.components["llama"].resdirs = ["res"]
         self.cpp_info.components["llama"].requires.append("ggml")
-        self.cpp_info.components["llama"].set_property("cmake_target_name", "llama")
-        self.cpp_info.components["llama"].set_property("cmake_target_aliases", ["llama-cpp::llama"])
 
         self.cpp_info.components["common"].includedirs = [os.path.join("include", "common")]
         self.cpp_info.components["common"].libs = ["common"]
         self.cpp_info.components["common"].requires = ["llama"]
-        self.cpp_info.components["common"].set_property("cmake_target_name", "common")
-        self.cpp_info.components["common"].set_property("cmake_target_aliases", ["llama-cpp::common"])
 
         if self.options.with_curl:
             self.cpp_info.components["common"].requires.append("libcurl::libcurl")
@@ -166,7 +162,7 @@ class LlamaCppConan(ConanFile):
             self.cpp_info.components["ggml-base"].libs = ["ggml-base"]
             self.cpp_info.components["ggml-base"].resdirs = ["res"]
             self.cpp_info.components["ggml-base"].set_property("cmake_target_name", "ggml-base")
-    
+
             self.cpp_info.components["ggml"].requires = ["ggml-base"]
             if self.settings.os in ("Linux", "FreeBSD"):
                 self.cpp_info.components["ggml-base"].system_libs.extend(["dl", "m", "pthread"])
@@ -186,7 +182,7 @@ class LlamaCppConan(ConanFile):
                     self.cpp_info.components[f"ggml-{backend}"].defines.append("GGML_BACKEND_SHARED")
                 self.cpp_info.components["ggml"].defines.append(f"GGML_USE_{backend.upper()}")
                 self.cpp_info.components["ggml"].requires.append(f"ggml-{backend}")
-                
+
             if is_apple_os(self):
                 if "blas" in backends:
                     self.cpp_info.components["ggml-blas"].frameworks.append("Accelerate")

--- a/recipes/llama-cpp/all/conanfile.py
+++ b/recipes/llama-cpp/all/conanfile.py
@@ -72,7 +72,6 @@ class LlamaCppConan(ConanFile):
         tc.variables["GGML_BUILD_TESTS"] = False
         tc.variables["GGML_BUILD_EXAMPLES"] = self.options.get_safe("with_examples")
         tc.variables["GGML_CUDA"] = self.options.get_safe("with_cuda")
-        tc.variables["GGML_BLAS"] = False
         tc.generate()
 
     def build(self):
@@ -99,7 +98,7 @@ class LlamaCppConan(ConanFile):
     def _get_default_backends(self):
         results = ["cpu"]
         if is_apple_os(self):
-            # results.append("blas")
+            results.append("blas")
             results.append("metal")
         return results
 
@@ -141,7 +140,7 @@ class LlamaCppConan(ConanFile):
             if self.options.shared:
                 self.cpp_info.components[f"ggml-{backend}"].defines.append("GGML_BACKEND_SHARED")
             self.cpp_info.components["ggml"].defines.append(f"GGML_USE_{backend.upper()}")
-            self.cpp_info.components["ggml"].requires = [f"ggml-{backend}"]
+            self.cpp_info.components["ggml"].requires.append(f"ggml-{backend}")
 
         if is_apple_os(self):
             self.cpp_info.components["ggml-blas"].frameworks.append("Accelerate")

--- a/recipes/llama-cpp/all/patches/b4570-001-curl-patch-targets.patch
+++ b/recipes/llama-cpp/all/patches/b4570-001-curl-patch-targets.patch
@@ -1,0 +1,15 @@
+diff --git a/common/CMakeLists.txt b/common/CMakeLists.txt
+index 24b7f87..e332bec 100644
+--- a/common/CMakeLists.txt
++++ b/common/CMakeLists.txt
+@@ -84,9 +84,7 @@ set(LLAMA_COMMON_EXTRA_LIBS build_info)
+ if (LLAMA_CURL)
+     find_package(CURL REQUIRED)
+     target_compile_definitions(${TARGET} PUBLIC LLAMA_USE_CURL)
+-    include_directories(${CURL_INCLUDE_DIRS})
+-    find_library(CURL_LIBRARY curl REQUIRED)
+-    set(LLAMA_COMMON_EXTRA_LIBS ${LLAMA_COMMON_EXTRA_LIBS} ${CURL_LIBRARY})
++    list(APPEND LLAMA_COMMON_EXTRA_LIBS CURL::libcurl)
+ endif ()
+ 
+ target_include_directories(${TARGET} PUBLIC .)

--- a/recipes/llama-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/llama-cpp/all/test_package/CMakeLists.txt
@@ -5,5 +5,5 @@ project(test_package CXX)
 find_package(llama-cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE llama-cpp::llama llama-cpp::common)
+target_link_libraries(${PROJECT_NAME} PRIVATE llama common)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/llama-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/llama-cpp/all/test_package/CMakeLists.txt
@@ -5,5 +5,5 @@ project(test_package CXX)
 find_package(llama-cpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE llama common)
+target_link_libraries(${PROJECT_NAME} PRIVATE llama-cpp::llama llama-cpp::common)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/llama-cpp/config.yml
+++ b/recipes/llama-cpp/config.yml
@@ -5,5 +5,3 @@ versions:
     folder: "all"
   "b3542":
     folder: "all"
-  "b3040":
-    folder: "all"

--- a/recipes/llama-cpp/config.yml
+++ b/recipes/llama-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "b4570":
+    folder: "all"
   "b4079":
     folder: "all"
   "b3542":


### PR DESCRIPTION
### Summary
Changes to recipe:  **llama-cpp/b4570**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
We wanted to use it in a future blogpost

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Lots of changes for this new version, so the package_info is split in two: the old one, and the new one. Maybe it would be better to remove the old versions from the conandata and just keep this new version, but thought that the current approach is a bit better until we can decide

The ARM msvc validation check is due to this:


`ggml/src/ggml-cpu/CMakeLists.txt` has this when adding ggml-cpu:

```
if (MSVC AND NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
            message(FATAL_ERROR "MSVC is not supported for ARM, use clang")
        else()
```

As the cpu backend is always enabled in the recipe, I just validate this case out
