### PR TITLE
[breakpad] Fix compilation with gcc-13

### DIFF
--- a/recipes/breakpad/all/conandata.yml
+++ b/recipes/breakpad/all/conandata.yml
@@ -7,3 +7,4 @@ patches:
     - patch_file: "patches/0001-Use_conans_lss.patch"
     - patch_file: "patches/0002-Remove-hardcoded-fpic.patch"
     - patch_file: "patches/0003-Fix-gcc11-compilation.patch"
+    - patch_file: "patches/0004-Fix-gcc13-compilation.patch"

--- a/recipes/breakpad/all/conandata.yml
+++ b/recipes/breakpad/all/conandata.yml
@@ -8,3 +8,4 @@ patches:
     - patch_file: "patches/0002-Remove-hardcoded-fpic.patch"
     - patch_file: "patches/0003-Fix-gcc11-compilation.patch"
     - patch_file: "patches/0004-Fix-gcc13-compilation.patch"
+    - patch_file: "patches/0005-Apply-upstream-fixes.patch"

--- a/recipes/breakpad/all/patches/0004-Fix-gcc13-compilation.patch
+++ b/recipes/breakpad/all/patches/0004-Fix-gcc13-compilation.patch
@@ -8,13 +8,3 @@
  #include <assert.h>
  #include <sys/types.h>
  
---- a/configure
-+++ b/configure
-@@ -7476,7 +7476,6 @@
- 
- done
- 
--as_fn_append WARN_CXXFLAGS " -Werror"
- ac_ext=c
- ac_cpp='$CPP $CPPFLAGS'
- ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/recipes/breakpad/all/patches/0004-Fix-gcc13-compilation.patch
+++ b/recipes/breakpad/all/patches/0004-Fix-gcc13-compilation.patch
@@ -1,0 +1,20 @@
+--- a/src/client/linux/handler/minidump_descriptor.h
++++ b/src/client/linux/handler/minidump_descriptor.h
+@@ -30,6 +30,7 @@
+ #ifndef CLIENT_LINUX_HANDLER_MINIDUMP_DESCRIPTOR_H_
+ #define CLIENT_LINUX_HANDLER_MINIDUMP_DESCRIPTOR_H_
+ 
++#include <cstdint>
+ #include <assert.h>
+ #include <sys/types.h>
+ 
+--- a/configure
++++ b/configure
+@@ -7476,7 +7476,6 @@
+ 
+ done
+ 
+-as_fn_append WARN_CXXFLAGS " -Werror"
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/recipes/breakpad/all/patches/0005-Apply-upstream-fixes.patch
+++ b/recipes/breakpad/all/patches/0005-Apply-upstream-fixes.patch
@@ -1,0 +1,24 @@
+--- a/src/processor/exploitability_linux.cc
++++ b/src/processor/exploitability_linux.cc
+@@ -516,18 +516,17 @@
+            raw_bytes_tmpfile);
+   FILE* objdump_fp = popen(cmd, "r");
+   if (!objdump_fp) {
+-    fclose(objdump_fp);
+     unlink(raw_bytes_tmpfile);
+     BPLOG(ERROR) << "Failed to call objdump.";
+     return false;
+   }
+-  if (fread(objdump_output_buffer, 1, buffer_len, objdump_fp) <= 0) {
+-    fclose(objdump_fp);
++  if (fread(objdump_output_buffer, 1, buffer_len, objdump_fp) != buffer_len) {
++    pclose(objdump_fp);
+     unlink(raw_bytes_tmpfile);
+     BPLOG(ERROR) << "Failed to read objdump output.";
+     return false;
+   }
+-  fclose(objdump_fp);
++  pclose(objdump_fp);
+   unlink(raw_bytes_tmpfile);
+   return true;
+ }


### PR DESCRIPTION
### Summary
Changes to recipe:  **breakpad/cci.20210521**

#### Motivation
Breakpad would not compile with gcc-13 on Ubuntu 24.02 Noble Numbat

#### Details

#### 1. Fix missing include
See for reference: https://gcc.gnu.org/gcc-13/porting_to.html

> Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile.
> 
> The following headers are used less widely in libstdc++ and may need to be included explicitly when compiling with GCC 13:
> - <string> (for std::string, std::to_string, std::stoi etc.)
> - <system_error> (for std::error_code, std::error_category, std::system_error).
> - <cstdint> (for std::int8_t, std::int32_t etc.)
> - <cstdio> (for std::printf, std::fopen etc.)
> - <cstdlib> (for std::strtol, std::malloc etc.)

In particular header `<cstdint>` now needs to be included directly to compile with gcc-13

#### 2. Fix `-Wnonnull` error
`fclose` is called on a null file (see the if-check above it). The patch removes the call to `fclose`
