### PR TITLE
[libe57format] Fix compilation with gcc-13

### DIFF
--- a/recipes/libe57format/all/conandata.yml
+++ b/recipes/libe57format/all/conandata.yml
@@ -1,3 +1,6 @@
+patches:
+  "2.3.0":
+  - patch_file: patches/0001-Fix-gcc13-compilation.patch
 sources:
   "3.2.0":
     url: "https://github.com/asmaloney/libE57Format/archive/refs/tags/v3.2.0.tar.gz"

--- a/recipes/libe57format/all/conanfile.py
+++ b/recipes/libe57format/all/conanfile.py
@@ -5,7 +5,7 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy, get, rmdir, save, replace_in_file
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save, replace_in_file
 from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
@@ -29,6 +29,9 @@ class LibE57FormatConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -77,6 +80,7 @@ class LibE57FormatConan(ConanFile):
 
     def build(self):
         self._patch_sources()
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/libe57format/all/patches/0001-Fix-gcc13-compilation.patch
+++ b/recipes/libe57format/all/patches/0001-Fix-gcc13-compilation.patch
@@ -1,0 +1,10 @@
+--- a/include/E57Format.h
++++ b/include/E57Format.h
+@@ -32,6 +32,7 @@
+ //! @file  E57Format.h Header file for the E57 API.
+ 
+ #include <cfloat>
++#include <cstdint>
+ #include <memory>
+ #include <vector>
+ 


### PR DESCRIPTION
See: https://gcc.gnu.org/gcc-13/porting_to.html


### Summary
Changes to recipe:  **libe57format/[2.3.0]**

#### Motivation
Does not compile with gcc-13

#### Details
See: https://gcc.gnu.org/gcc-13/porting_to.html
`<cstdint>` now needs to be included directly.