### PR TITLE
Fix sqlite3 dependencies

### DIFF
--- a/recipes/apr-util/all/conanfile.py
+++ b/recipes/apr-util/all/conanfile.py
@@ -88,7 +88,7 @@ class AprUtilConan(ConanFile):
         if self.options.with_mysql:
             self.requires("libmysqlclient/8.1.0")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/3.45.3")
         if self.options.with_expat:
             self.requires("expat/[>=2.6.2 <3]")
         if self.options.with_postgresql:

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -96,7 +96,7 @@ class DlibConan(ConanFile):
         if self.options.get_safe("with_webp"):
             self.requires("libwebp/1.3.2")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/3.45.3")
         if self.options.with_openblas:
             self.requires("openblas/0.3.26")
 

--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -130,7 +130,7 @@ class DrogonConan(ConanFile):
         if self.options.get_safe("with_mysql"):
             self.requires("libmysqlclient/8.1.0")
         if self.options.get_safe("with_sqlite"):
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/3.45.3")
         if self.options.get_safe("with_redis"):
             self.requires("hiredis/1.2.0")
         if self.options.get_safe("with_yaml_cpp", False):

--- a/recipes/oatpp-sqlite/all/conanfile.py
+++ b/recipes/oatpp-sqlite/all/conanfile.py
@@ -41,7 +41,7 @@ class OatppsqliteConan(ConanFile):
 
     def requirements(self):
         self.requires(f"oatpp/{self.version}", transitive_headers=True)
-        self.requires("sqlite3/3.45.0")
+        self.requires("sqlite3/3.45.3")
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -159,7 +159,7 @@ class PocoConan(ConanFile):
         if self.options.enable_xml:
             self.requires("expat/[>=2.6.2 <3]", transitive_headers=True)
         if self.options.enable_data_sqlite:
-            self.requires("sqlite3/3.45.0")
+            self.requires("sqlite3/3.45.3")
         if self.options.enable_apacheconnector:
             self.requires("apr/1.7.4")
             self.requires("apr-util/1.6.1")

--- a/recipes/sqlite_orm/all/conanfile.py
+++ b/recipes/sqlite_orm/all/conanfile.py
@@ -40,7 +40,7 @@ class SqliteOrmConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("sqlite3/3.45.0", transitive_headers=True, transitive_libs=True)
+        self.requires("sqlite3/3.45.3", transitive_headers=True, transitive_libs=True)
 
     def package_id(self):
         self.info.clear()

--- a/recipes/sqlitecpp/all/conanfile.py
+++ b/recipes/sqlitecpp/all/conanfile.py
@@ -43,7 +43,7 @@ class SQLiteCppConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("sqlite3/3.45.0")
+        self.requires("sqlite3/3.45.3")
 
     def validate(self):
         if Version(self.version) >= "3.0.0" and self.info.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
3.45.0 -> 3.45.3: 26480


### Summary
Changes to recipes:  
**apr-util/all**
**dlib/all**
**drogon/all**
**oatpp-sqlite/all**
**poco/all**
**sqlite_orm/all**
**sqlitecpp/all**

#### Motivation
[Link to the bug: ](https://github.com/conan-io/conan-center-index/issues/26480)

#### Details
Just replacing all instances of where the no-longer-existing `sqlite3/3.45.0` was a requirement by the existing one `sqlite3/3.45.3`


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
