### PR TITLE
Add patch to fix C++20 support when building doxygen

### DIFF
--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -6,6 +6,11 @@ sources:
     url: "https://sourceforge.net/projects/doxygen/files/doxygen-1.9.4.src.tar.gz"
     sha256: "a15e9cd8c0d02b7888bc8356eac200222ecff1defd32f3fe05257d81227b1f37"
 patches:
+  "1.12.0":
+    - patch_file: "patches/1.9.4-0001-enable-modern-compilers.patch"
+      patch_description: "Fix compiler error when compiling doxygen in C++20 mode"
+      patch_type: "portability"
+      patch_source: "https://github.com/doxygen/doxygen/commit/54259f7ad46f91316468248d92b2a65e58d4586d"
   "1.9.4":
     - patch_file: "patches/1.9.4-0001-enable-modern-compilers.patch"
       patch_description: "Enable modern compilers"

--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -7,7 +7,7 @@ sources:
     sha256: "a15e9cd8c0d02b7888bc8356eac200222ecff1defd32f3fe05257d81227b1f37"
 patches:
   "1.12.0":
-    - patch_file: "patches/1.9.4-0001-enable-modern-compilers.patch"
+    - patch_file: "patches/1.12.0-0001-fix-compiler-error-when-compiling-doxygen-in-C++20-mode.patch"
       patch_description: "Fix compiler error when compiling doxygen in C++20 mode"
       patch_type: "portability"
       patch_source: "https://github.com/doxygen/doxygen/commit/54259f7ad46f91316468248d92b2a65e58d4586d"

--- a/recipes/doxygen/all/patches/1.12.0-0001-fix-compiler-error-when-compiling-doxygen-in-C++20-mode.patch
+++ b/recipes/doxygen/all/patches/1.12.0-0001-fix-compiler-error-when-compiling-doxygen-in-C++20-mode.patch
@@ -1,0 +1,40 @@
+From 54259f7ad46f91316468248d92b2a65e58d4586d Mon Sep 17 00:00:00 2001
+From: Dimitri van Heesch <doxygen@gmail.com>
+Date: Sun, 29 Dec 2024 22:48:47 +0100
+Subject: [PATCH] Fix compiler error when compiling doxygen in C++20 mode
+
+---
+ src/trace.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/trace.h b/src/trace.h
+index 2d70079328..858b1df23d 100644
+--- a/src/trace.h
++++ b/src/trace.h
+@@ -100,7 +100,7 @@ class AutoTrace
+         }
+         else
+         {
+-          g_tracer->log(m_loc,spdlog::level::trace,"> "+fmt,std::forward<Args>(args)...);
++          g_tracer->log(m_loc,spdlog::level::trace,fmt::runtime("> "+fmt),std::forward<Args>(args)...);
+         }
+       }
+     }
+@@ -126,7 +126,7 @@ class AutoTrace
+     {
+       if (g_tracer)
+       {
+-        g_tracer->log(loc,spdlog::level::trace,": "+fmt,std::forward<Args>(args)...);
++        g_tracer->log(loc,spdlog::level::trace,fmt::runtime(": "+fmt),std::forward<Args>(args)...);
+       }
+     }
+     template<typename... Args>
+@@ -134,7 +134,7 @@ class AutoTrace
+                  const std::string &msg,Args&&...args)
+     {
+       m_loc = loc;
+-      m_exitMessage = fmt::format(msg,std::forward<Args>(args)...);
++      m_exitMessage = fmt::format(fmt::runtime(msg),std::forward<Args>(args)...);
+     }
+   private:
+    spdlog::source_loc m_loc;

--- a/recipes/doxygen/all/patches/1.12.0-0001-fix-compiler-error-when-compiling-doxygen-in-C++20-mode.patch
+++ b/recipes/doxygen/all/patches/1.12.0-0001-fix-compiler-error-when-compiling-doxygen-in-C++20-mode.patch
@@ -1,14 +1,5 @@
-From 54259f7ad46f91316468248d92b2a65e58d4586d Mon Sep 17 00:00:00 2001
-From: Dimitri van Heesch <doxygen@gmail.com>
-Date: Sun, 29 Dec 2024 22:48:47 +0100
-Subject: [PATCH] Fix compiler error when compiling doxygen in C++20 mode
-
----
- src/trace.h | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
 diff --git a/src/trace.h b/src/trace.h
-index 2d70079328..858b1df23d 100644
+index 13a816650..858b1df23 100644
 --- a/src/trace.h
 +++ b/src/trace.h
 @@ -100,7 +100,7 @@ class AutoTrace
@@ -20,7 +11,7 @@ index 2d70079328..858b1df23d 100644
          }
        }
      }
-@@ -126,7 +126,7 @@ class AutoTrace
+@@ -126,13 +126,15 @@ class AutoTrace
      {
        if (g_tracer)
        {
@@ -29,12 +20,121 @@ index 2d70079328..858b1df23d 100644
        }
      }
      template<typename... Args>
-@@ -134,7 +134,7 @@ class AutoTrace
-                  const std::string &msg,Args&&...args)
+-    void setExit(const std::string &msg,Args&&...args)
++    void setExit(spdlog::source_loc loc,
++                 const std::string &msg,Args&&...args)
      {
-       m_loc = loc;
 -      m_exitMessage = fmt::format(msg,std::forward<Args>(args)...);
++      m_loc = loc;
 +      m_exitMessage = fmt::format(fmt::runtime(msg),std::forward<Args>(args)...);
      }
    private:
     spdlog::source_loc m_loc;
+@@ -142,7 +144,7 @@ class AutoTrace
+ #if ENABLE_TRACING
+ #define AUTO_TRACE(...)      AutoTrace trace_{spdlog::source_loc{__FILE__,__LINE__,SPDLOG_FUNCTION},__VA_ARGS__}
+ #define AUTO_TRACE_ADD(...)  trace_.add(spdlog::source_loc{__FILE__,__LINE__,SPDLOG_FUNCTION},__VA_ARGS__)
+-#define AUTO_TRACE_EXIT(...) trace_.setExit(__VA_ARGS__)
++#define AUTO_TRACE_EXIT(...) trace_.setExit(spdlog::source_loc{__FILE__,__LINE__,SPDLOG_FUNCTION},__VA_ARGS__)
+ #else
+ #define AUTO_TRACE(...)      (void)0
+ #define AUTO_TRACE_ADD(...)  (void)0
+@@ -156,7 +158,7 @@ namespace fmt { template<typename T> struct formatter {}; }
+ //! adds support for formatting QCString
+ template<> struct fmt::formatter<QCString> : formatter<std::string>
+ {
+-  auto format(const QCString &c, format_context& ctx) {
++  auto format(const QCString &c, format_context& ctx) const {
+     return formatter<std::string>::format(c.str(), ctx);
+   }
+ };
+@@ -164,7 +166,7 @@ template<> struct fmt::formatter<QCString> : formatter<std::string>
+ //! adds support for formatting Protected
+ template<> struct fmt::formatter<Protection> : formatter<std::string>
+ {
+-  auto format(Protection prot, format_context& ctx) {
++  auto format(Protection prot, format_context& ctx) const {
+     std::string result="Unknown";
+     switch (prot)
+     {
+@@ -180,7 +182,7 @@ template<> struct fmt::formatter<Protection> : formatter<std::string>
+ //! adds support for formatting Specifier
+ template<> struct fmt::formatter<Specifier> : formatter<std::string>
+ {
+-  auto format(Specifier spec, format_context& ctx) {
++  auto format(Specifier spec, format_context& ctx) const {
+     std::string result="Unknown";
+     switch (spec)
+     {
+@@ -195,7 +197,7 @@ template<> struct fmt::formatter<Specifier> : formatter<std::string>
+ //! adds support for formatting MethodTypes
+ template<> struct fmt::formatter<MethodTypes> : formatter<std::string>
+ {
+-  auto format(MethodTypes mtype, format_context& ctx) {
++  auto format(MethodTypes mtype, format_context& ctx) const {
+     std::string result="Unknown";
+     switch (mtype)
+     {
+@@ -213,7 +215,7 @@ template<> struct fmt::formatter<MethodTypes> : formatter<std::string>
+ //! adds support for formatting RelatesType
+ template<> struct fmt::formatter<RelatesType> : formatter<std::string>
+ {
+-  auto format(RelatesType type, format_context& ctx) {
++  auto format(RelatesType type, format_context& ctx) const {
+     std::string result="Unknown";
+     switch (type)
+     {
+@@ -228,7 +230,7 @@ template<> struct fmt::formatter<RelatesType> : formatter<std::string>
+ //! adds support for formatting RelationShip
+ template<> struct fmt::formatter<Relationship> : formatter<std::string>
+ {
+-  auto format(Relationship relation, format_context& ctx) {
++  auto format(Relationship relation, format_context& ctx) const {
+     std::string result="Unknown";
+     switch (relation)
+     {
+@@ -243,7 +245,7 @@ template<> struct fmt::formatter<Relationship> : formatter<std::string>
+ //! adds support for formatting SrcLangExt
+ template<> struct fmt::formatter<SrcLangExt> : formatter<std::string>
+ {
+-  auto format(SrcLangExt lang, format_context& ctx) {
++  auto format(SrcLangExt lang, format_context& ctx) const {
+     std::string result="Unknown";
+     switch (lang)
+     {
+@@ -273,7 +275,7 @@ template<> struct fmt::formatter<SrcLangExt> : formatter<std::string>
+ //! adds support for formatting MemberType
+ template<> struct fmt::formatter<MemberType> : formatter<std::string>
+ {
+-  auto format(MemberType mtype, format_context& ctx) {
++  auto format(MemberType mtype, format_context& ctx) const {
+     std::string result="Unknown";
+     switch (mtype)
+     {
+@@ -301,7 +303,7 @@ template<> struct fmt::formatter<MemberType> : formatter<std::string>
+ //! adds support for formatting TypeSpecifier
+ template<> struct fmt::formatter<TypeSpecifier> : formatter<std::string>
+ {
+-  auto format(TypeSpecifier type, format_context& ctx) {
++  auto format(TypeSpecifier type, format_context& ctx) const {
+     return formatter<std::string>::format(type.to_string(),ctx);
+   }
+ };
+@@ -309,7 +311,7 @@ template<> struct fmt::formatter<TypeSpecifier> : formatter<std::string>
+ //! adds support for formatting EntryType
+ template<> struct fmt::formatter<EntryType> : formatter<std::string>
+ {
+-  auto format(EntryType type, format_context& ctx) {
++  auto format(EntryType type, format_context& ctx) const {
+     return formatter<std::string>::format(type.to_string(),ctx);
+   }
+ };
+@@ -317,7 +319,7 @@ template<> struct fmt::formatter<EntryType> : formatter<std::string>
+ //! adds support for formatting MemberListType
+ template<> struct fmt::formatter<MemberListType> : formatter<std::string>
+ {
+-  auto format(MemberListType type, format_context& ctx) {
++  auto format(MemberListType type, format_context& ctx) const {
+     return formatter<std::string>::format(type.to_string(),ctx);
+   }
+ };


### PR DESCRIPTION
### Summary
Changes to recipe:  **doxygen/1.12.0**

#### Motivation
The **doxygen/1.120** package does not compile under C++20.  This was fixed in the Doxygen repository in this change: https://github.com/doxygen/doxygen/commit/54259f7ad46f91316468248d92b2a65e58d4586d

Currently this fails with the following error:
```
FAILED: src/CMakeFiles/doxymain.dir/Debug/__/generated_src/commentscan.cpp.o 
/usr/local/bin/c++ -DSPDLOG_COMPILED_LIB -DYY_BUF_SIZE=262144 -DYY_READ_BUF_SIZE=262144 -DCMAKE_INTDIR=\"Debug\" -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/libic04cfbfc6d8130/p/include -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/deps/TinyDeflate -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/deps/filesystem -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/deps/libmd5 -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/deps/liblodepng -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/deps/libmscgen -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/libversion -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/libxml -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/vhdlparser -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/src -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/build/generated_src -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/deps/spdlog/include -I/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/deps/sqlite3 -m64       -DJAVACC_CHAR_TYPE="unsigned char" -g -D_GLIBCXX_ASSERTIONS -DJAVACC_CHAR_TYPE="unsigned char" -std=gnu++20 -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wdouble-promotion -Wformat=2 -Wno-unused-parameter -Wno-sign-conversion -Wno-format-nonliteral -Wno-implicit-fallthrough -MD -MT src/CMakeFiles/doxymain.dir/Debug/__/generated_src/commentscan.cpp.o -MF src/CMakeFiles/doxymain.dir/Debug/__/generated_src/commentscan.cpp.o.d -o src/CMakeFiles/doxymain.dir/Debug/__/generated_src/commentscan.cpp.o -c /home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/build/generated_src/commentscan.cpp
In file included from /home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/src/commentscan.l:66:
/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/src/trace.h: In instantiation of ‘AutoTrace::AutoTrace(spdlog::source_loc, const std::string&, Args&& ...) [with Args = {QCString, const QCString&, int&, bool&, bool&, bool&, Protection&, bool&}; std::string = std::__cxx11::basic_string<char>]’:
/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/src/commentscan.l:4682:3:   required from here
/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/src/trace.h:103:24: error: ‘fmt’ is not a constant expression
  103 |           g_tracer->log(m_loc,spdlog::level::trace,"> "+fmt,std::forward<Args>(args)...);
      |           ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/src/trace.h: In instantiation of ‘void AutoTrace::setExit(const std::string&, Args&& ...) [with Args = {int&, bool&, bool&}; std::string = std::__cxx11::basic_string<char>]’:
/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/src/commentscan.l:4790:3:   required from here
/home/runner/work/Morpheus/Morpheus/.conan2/p/b/doxyg89f11ab705f4d/b/src/src/trace.h:135:34: error: ‘msg’ is not a constant expression
  135 |       m_exitMessage = fmt::format(msg,std::forward<Args>(args)...);
      |                       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[156/273] Building CXX object src/CMakeFiles/doxymain.dir/Debug/__/generated_src/declinfo.cpp.o
[157/273] Building CXX object src/CMakeFiles/doxymain.dir/Debug/__/generated_src/defargs.cpp.o
[158/273] Building CXX object src/CMakeFiles/doxymain.dir/Debug/__/generated_src/code.cpp.o
ninja: build stopped: subcommand failed.
```

#### Details
This change introduces a patch that is required to ensure Doxygen builds under C++20


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
