### PR TITLE
libqasm: add version 1.0.0

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.0.0/libqasm-1.0.0.tar.gz"
+    sha256: "22968e2892194e69ca3cea9f4655c2f51470aae60d9e7dbd662136eb4088c984"
   "0.6.9":
     url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.9.tar.gz"
     sha256: "23c5d0e4e506e1974668408f8018034d1b1303e65c6d2d28639eae9499759c4d"

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.6.9":
     folder: all
   "0.6.8":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libqasm/1.0.0**

#### Motivation
Just a version bump.

#### Details
`config.yml` and `conandata.yml` point to the newly created libqasm/1.0.0.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
