### PR TITLE
libffi: fix conditionals when building on Windows

### DIFF
--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -62,7 +62,7 @@ class LibffiConan(ConanFile):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
                 self.tool_requires("msys2/cci.latest")
-        if is_msvc(self):
+        if is_msvc(self) or self.settings.compiler == "clang":
             self.tool_requires("automake/1.16.5")
 
     def source(self):

--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -62,8 +62,7 @@ class LibffiConan(ConanFile):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
                 self.tool_requires("msys2/cci.latest")
-        if is_msvc(self) or self.settings.compiler == "clang":
-            self.tool_requires("automake/1.16.5")
+        self.tool_requires("automake/1.16.5")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -11,7 +11,7 @@ import glob
 import os
 import shutil
 
-required_conan_version = ">=1.57.0"
+required_conan_version = ">=2.0"
 
 
 class LibffiConan(ConanFile):
@@ -31,11 +31,6 @@ class LibffiConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-
-    @property
-    def _settings_build(self):
-        # TODO: Remove for Conan v2
-        return getattr(self, "settings_build", self.settings)
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -58,11 +53,12 @@ class LibffiConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows":
+        if self.settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
                 self.tool_requires("msys2/cci.latest")
-        self.tool_requires("automake/1.16.5")
+        if self.settings_build == "Windows" and self.settings.get_safe("compiler.runtime"):
+            self.tool_requires("automake/1.16.5")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -79,7 +75,7 @@ class LibffiConan(ConanFile):
             "--enable-docs=no",
         ])
 
-        if self._settings_build.compiler == "apple-clang":
+        if self.settings_build.compiler == "apple-clang":
             tc.configure_args.append("--disable-multi-os-directory")
 
         if self.options.shared:
@@ -90,10 +86,10 @@ class LibffiConan(ConanFile):
             tc.extra_defines.append("FFI_STATIC_BUILD")
 
         env = tc.environment()
-        if self._settings_build.os == "Windows" and (is_msvc(self) or self.settings.compiler == "clang"):
+        if self.settings_build.os == "Windows" and self.settings.get_safe("compiler.runtime"):
             build = "{}-{}-{}".format(
-                "x86_64" if self._settings_build.arch == "x86_64" else "i686",
-                "pc" if self._settings_build.arch == "x86" else "win64",
+                "x86_64" if self.settings_build.arch == "x86_64" else "i686",
+                "pc" if self.settings_build.arch == "x86" else "win64",
                 "mingw64")
             host = "{}-{}-{}".format(
                 "x86_64" if self.settings.arch == "x86_64" else "i686",

--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -57,7 +57,7 @@ class LibffiConan(ConanFile):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
                 self.tool_requires("msys2/cci.latest")
-        if self.settings_build == "Windows" and self.settings.get_safe("compiler.runtime"):
+        if self.settings_build.os == "Windows" and self.settings.get_safe("compiler.runtime"):
             self.tool_requires("automake/1.16.5")
 
     def source(self):


### PR DESCRIPTION
bug

conan profile
```
[settings]
os=Windows
arch=x86_64
compiler=clang
compiler.version=18
compiler.libcxx=libc++
build_type=Debug
compiler.cppstd=20

[conf]
tools.cmake.cmaketoolchain:generator=Ninja
```

conanfile.txt
```
[requires]
qt/6.7.3

[generators]
CMakeDeps
CMakeToolchain

[layout]
cmake_layout
```

error
```
ERROR: libffi/3.4.4: Error in generate() method, line 130
        ar_wrapper = unix_path(self, self.dependencies.build["automake"].conf_info.get("user.automake:lib-wrapper"))
        KeyError: "'automake' not found in the dependency set"
```