### PR TITLE
[quill] add version 8.1.0

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.1.0":
+    url: "https://github.com/odygrd/quill/releases/download/v8.1.0/quill-8.1.0.zip"
+    sha256: "11cf2cfb96e2a0ef28ce4b3ba6795cab5d8d1a04fea84805310bbb2d57f0a657"
   "7.5.0":
     url: "https://github.com/odygrd/quill/releases/download/v7.5.0/quill-7.5.0.zip"
     sha256: "cb0b7d43e54af7cb7ea912d2079eb439d185ddc5fe684f8297d28bb25015d503"

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.1.0":
+    folder: "all"
   "7.5.0":
     folder: "all"
   "7.4.0":


### PR DESCRIPTION
### Summary
Add [Quill ](https://github.com/odygrd/quill) version 8.1.0

#### Motivation
Version dump that includes improvements and fixes. For example

```
Updated bundled libfmt to 11.1.3
Suppressed clang-19 warning when building the tests with C++17
Fixed windows linkage error 
Fixed redefinition of struct fmt_detail::time_zone error
```

#### Details
config.yml and conandata.yml point to the latest version


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
