### PR TITLE
ninja: remove build_type option in package_id() property

### DIFF
--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -21,6 +21,7 @@ class NinjaConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def package_id(self):
+        del self.info.settings.build_type
         del self.info.settings.compiler
 
     def source(self):


### PR DESCRIPTION
Ninja being an application package which is intended to be required only when added to `tool_requires`, there is no need to follow the profile's build_type.

### Summary
Changes to recipe:  **ninja/\***

#### Motivation
conan-installing ninja as tool-requires with a debug profile builds ninja in debug mode. It should not happen and the release version of ninja should be downloaded (or built) instead

#### Details
This PR excludes the `build_type` setting from the `package_id()` method (as discussed in conan-io/conan#17667)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
