### PR TITLE
libtool: automake is a tool requirement

### DIFF
--- a/recipes/libtool/all/conanfile.py
+++ b/recipes/libtool/all/conanfile.py
@@ -1,17 +1,17 @@
 from conan import ConanFile
 from conan.errors import ConanException
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
-from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
+from conan.tools.env import Environment
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, rename, replace_in_file, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import check_min_vs, is_msvc, unix_path_package_info_legacy
+from conan.tools.microsoft import is_msvc
 
 import os
 import re
 import shutil
 
-required_conan_version = ">=1.60.0 <2 || >=2.0.5"
+required_conan_version = ">=2.4"
 
 
 class LibtoolConan(ConanFile):
@@ -25,6 +25,8 @@ class LibtoolConan(ConanFile):
     topics = ("configure", "library", "shared", "static")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     settings = "os", "arch", "compiler", "build_type"
+    languages = ["C"]
+    implements = ["auto_shared_fpic"]
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -34,44 +36,17 @@ class LibtoolConan(ConanFile):
         "fPIC": True,
     }
 
-    @property
-    def _has_dual_profiles(self):
-        return hasattr(self, "settings_build")
-
     def export_sources(self):
         export_conandata_patches(self)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.libcxx")
-        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
-    def requirements(self):
-        self.requires("automake/1.16.5")
-
-        #TODO: consider adding m4 as direct dependency, perhaps when we start using version ranges.
-        # https://github.com/conan-io/conan-center-index/pull/16248#discussion_r1116332095
-        #self.requires("m4/1.4.19")
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
     def build_requirements(self):
-        if self._has_dual_profiles:
-            self.tool_requires("automake/<host_version>")
-            self.tool_requires("m4/1.4.19")               # Needed by configure
-
+        self.tool_requires("automake/1.16.5")
+        self.tool_requires("m4/1.4.19")               # Needed by configure
         self.tool_requires("gnu-config/cci.20210814")
-        if self._settings_build.os == "Windows":
+        if self.settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
@@ -84,10 +59,6 @@ class LibtoolConan(ConanFile):
         return os.path.join(self.package_folder, "res")
 
     def generate(self):
-        VirtualBuildEnv(self).generate()
-        if not self._has_dual_profiles:
-            VirtualRunEnv(self).generate(scope="build")
-
         if is_msvc(self):
             # __VSCMD_ARG_NO_LOGO: this test_package has too many invocations,
             #                      this avoids printing the logo everywhere
@@ -99,10 +70,6 @@ class LibtoolConan(ConanFile):
             env.vars(self, scope="build").save_script("conanbuild_vcvars_options.bat")
 
         tc = AutotoolsToolchain(self)
-
-        if is_msvc(self) and check_min_vs(self, "180", raise_invalid=False):
-            tc.extra_cflags.append("-FS")
-
         tc.configure_args.extend([
             "--datarootdir=${prefix}/res",
             "--enable-shared",
@@ -238,8 +205,3 @@ class LibtoolConan(ConanFile):
         self.buildenv_info.append_path("AUTOMAKE_CONAN_INCLUDES", libtool_aclocal_dir)
         self.runenv_info.append_path("ACLOCAL_PATH", libtool_aclocal_dir)
         self.runenv_info.append_path("AUTOMAKE_CONAN_INCLUDES", libtool_aclocal_dir)
-
-        # For Conan 1.x downstream consumers, can be removed once recipe is Conan 1.x only:
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
-        self.env_info.ACLOCAL_PATH.append(unix_path_package_info_legacy(self, libtool_aclocal_dir))
-        self.env_info.AUTOMAKE_CONAN_INCLUDES.append(unix_path_package_info_legacy(self, libtool_aclocal_dir))

--- a/recipes/libtool/all/test_package/conanfile.py
+++ b/recipes/libtool/all/test_package/conanfile.py
@@ -103,6 +103,10 @@ class TestPackageConan(ConanFile):
             env.append_path(var, os.path.join(self.autotools_package_folder, "lib"))
         env.vars(self, scope="run").save_script("conanrun_libtool_testpackage")
 
+        env = Environment()
+        env.prepend_path("PATH", os.path.join(self.dependencies["libtool"].package_folder, "bin"))
+        env.vars(self, scope="build").save_script("conanbuild_libtoolize")
+
         runenv = VirtualRunEnv(self)
         runenv.generate()
 

--- a/recipes/libtool/all/test_package/conanfile.py
+++ b/recipes/libtool/all/test_package/conanfile.py
@@ -17,11 +17,6 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     test_type = "explicit"
     short_paths = True
-    win_bash = True # This assignment must be *here* to avoid "Cannot wrap command with different envs." in Conan 1.x
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
 
     def layout(self):
         basic_layout(self)
@@ -30,9 +25,6 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str) # Since we are testing libltdl as well
 
     def build_requirements(self):
-        if hasattr(self, "settings_build") and not cross_building(self):
-            self.tool_requires(self.tested_reference_str) # We are testing libtool/libtoolize
-    
         self.tool_requires("autoconf/2.71")
         self.tool_requires("automake/1.16.5")
         if self._settings_build.os == "Windows":

--- a/recipes/libtool/all/test_package/conanfile.py
+++ b/recipes/libtool/all/test_package/conanfile.py
@@ -27,7 +27,7 @@ class TestPackageConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("autoconf/2.71")
         self.tool_requires("automake/1.16.5")
-        if self._settings_build.os == "Windows":
+        if self.settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")

--- a/recipes/libtool/all/test_package/ltdl/CMakeLists.txt
+++ b/recipes/libtool/all/test_package/ltdl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.15)
 project(test_package)
 
 find_package(libtool REQUIRED CONFIG)


### PR DESCRIPTION
### Summary
Changes to recipe:  libtool/all

#### Motivation
`automake` contains build-time-only executable scripts - so this should not be propagated as a dependency of libtool

#### Details
`m4` appears in the _host_ context when crossbuilding, due to libtools dependency on automake (which depends on m4) - this causea Android build failures (as m4 does not build on android as it currently is, the reasons are irrelevanat).

`m4` is also a build-time executable and should not appear in the host profile

### Other changes
- use the languages property and `auto_shared_fpic` rather than implementing `config_options` and `configure` (equivalent functionality)
- use `settings_build`
- assume `-FS` is already passed by Conan where needed
- remove `env_info` (no-ops in Conan 2)


<details>
<summary> Before and after logs </summary>

### Before
```
conan install --require="libtool/[*]" -pr android-v8  --build=missing
```

```
======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=clang
compiler.cppstd=14
compiler.libcxx=c++_static
compiler.version=14
os=Android
os.api_level=21
[conf]
tools.android:ndk_path=/opt/android_ndk_r25b
[buildenv]
AR=/opt/android_ndk_r25b/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
CC=/opt/android_ndk_r25b/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
AS=/opt/android_ndk_r25b/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
CXX=/opt/android_ndk_r25b/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang++
LD=/opt/android_ndk_r25b/toolchains/llvm/prebuilt/darwin-x86_64/bin/ld
RANLIB=/opt/android_ndk_r25b/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ranlib
STRIP=/opt/android_ndk_r25b/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-strip

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=15
os=Macos


======== Computing dependency graph ========
Graph root
    cli
Requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    libtool/2.4.7#08316dad5c72c541ed21e039e4cf217b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
Resolved version ranges
    libtool/[*]: libtool/2.4.7

... (when building m4)

         ~~  ^
/Users/luisc/.conan2/p/b/m4856a9cecf3189/b/src/lib/fpending.c:44:23: error: no member named '_bf' in 'struct __sFILE'
  return fp->_p - fp->_bf._base;
                  ~~  ^
  CC       frexpl.o
2 errors generated.
make[3]: *** [fpending.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

### After
(m4 no longer a requirement in the host)

```
conan install --require="libtool/[*]" -pr android-v8  --build=missing
```

```
======== Computing dependency graph ========
Graph root
    cli
Requirements
    libtool/2.4.7#6f6227e6c1e93a270bb139ce53afc849 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
Resolved version ranges
    libtool/[*]: libtool/2.4.7

```


</details>


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
