### PR TITLE
Bring all requirements to freetype/2.13 to .2 patch

### DIFF
--- a/recipes/librasterlite2/all/conanfile.py
+++ b/recipes/librasterlite2/all/conanfile.py
@@ -69,7 +69,7 @@ class Librasterlite2Conan(ConanFile):
 
     def requirements(self):
         self.requires("cairo/1.17.6")
-        self.requires("freetype/2.13.0")
+        self.requires("freetype/2.13.2")
         self.requires("giflib/5.2.1")
         self.requires("libcurl/8.1.2")
         self.requires("libgeotiff/1.7.1")

--- a/recipes/librasterlite2/all/conanfile.py
+++ b/recipes/librasterlite2/all/conanfile.py
@@ -69,7 +69,7 @@ class Librasterlite2Conan(ConanFile):
 
     def requirements(self):
         self.requires("cairo/1.17.6")
-        self.requires("freetype/2.13.2")
+        self.requires("freetype/2.13.0")
         self.requires("giflib/5.2.1")
         self.requires("libcurl/8.1.2")
         self.requires("libgeotiff/1.7.1")

--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -102,7 +102,7 @@ class OpenCascadeConan(ConanFile):
         self.requires("tcl/8.6.10")
         if self._link_tk:
             self.requires("tk/8.6.10")
-        self.requires("freetype/2.13.0")
+        self.requires("freetype/2.13.2")
         if self._link_opengl:
             self.requires("opengl/system")
         if self._is_linux:

--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -100,7 +100,7 @@ class OpenCVConan(ConanFile):
         if self.options.with_webp:
             self.requires("libwebp/1.3.2")
         if self.options.contrib:
-            self.requires("freetype/2.13.0")
+            self.requires("freetype/2.13.2")
             self.requires("harfbuzz/8.2.2")
             self.requires("gflags/2.2.2")
             self.requires("glog/0.6.0")

--- a/recipes/pdf-writer/all/conanfile.py
+++ b/recipes/pdf-writer/all/conanfile.py
@@ -50,7 +50,7 @@ class PDFWriterConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("freetype/2.13.0")
+        self.requires("freetype/2.13.2")
         self.requires("libaesgm/2013.1.1")
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_png:


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Closes https://github.com/conan-io/conan-center-index/issues/26515

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Brings all freetype/2.13 to .2 patch to avoid conflicts.
Note that there are other recipes that require a different minor version, but those are:
- Not yet ported to Conan 2
- Very old, and we haven't received any request to upgrade those
