### PR TITLE
OpenColorIO: Bump version of OpenEXR to a supported one

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -51,7 +51,7 @@ class OpenColorIOConan(ConanFile):
         if Version(self.version) < "2.2.0":
             self.requires("openexr/2.5.7")
         else:
-            self.requires("openexr/3.2.3")
+            self.requires("openexr/3.3.2")
             self.requires("imath/3.1.9")
 
         if Version(self.version) < "2.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencolorio/?**

#### Motivation
Bumping the dependency to OpenEXR 3.3.2 (latest one) as the current one is no longer supported and thus doesn't support libdeflate ranges. However, to be compatible with libtiff when both are required by OpenImageIO, they require a version of OpenEXR with libdeflate support.

#### Details
I have problems to solve the dependency tree of #25672 due to libdeflate so this change should solve the problem. Also I guess it is beneficial to have a supported version of a dependency in the requires.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
