### PR TITLE
qt: fix Platform component

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -977,6 +977,10 @@ class QtConan(ConanFile):
                 )""")
             save(self, os.path.join(self.package_folder, self._cmake_entry_point_file), contents)
 
+        # https://github.com/qt/qtbase/blob/6.7.3/cmake/QtPlatformTargetHelpers.cmake#L68
+        # https://github.com/qt/qtbase/blob/6.7.3/cmake/QtPlatformTargetHelpers.cmake#L71
+        # https://github.com/qt/qtbase/blob/6.7.3/cmake/QtFlagHandlingHelpers.cmake#L384
+        # https://github.com/qt/qtbase/blob/6.7.3/cmake/QtFlagHandlingHelpers.cmake#L402
         if self.settings.os == "Windows" or is_msvc(self):
             contents = textwrap.dedent("""\
                 set(utf8_flags "")


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.x**

#### Motivation and Details

Qt6::Platform component and its relationship with Qt6::Core differ from the upstream ones. This prevents me from compiling one of the closed-source libraries (QtitanRibbon) using Qt6 taken from CCI.

Actually Qt6::Core depends on Qt6::Platform, see `<package>\lib\cmake\Qt6Core\Qt6CoreTargets.cmake`:
```cmake
set_target_properties(Qt6::Core PROPERTIES
  COMPATIBLE_INTERFACE_STRING "QT_MAJOR_VERSION;QT_COORD_TYPE"
  INTERFACE_COMPILE_DEFINITIONS "QT_CORE_LIB"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/QtCore;${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "Qt6::Platform;mpr;userenv;WrapAtomic::WrapAtomic;\$<\$<AND:\$<NOT:\$<BOOL:\$<TARGET_PROPERTY:qt_no_entrypoint>>>,\$<STREQUAL:\$<TARGET_PROPERTY:TYPE>,EXECUTABLE>,\$<BOOL:\$<TARGET_PROPERTY:WIN32_EXECUTABLE>>>:Qt6::EntryPointPrivate>"
  ...
)
```

And `-permissive-` and `-Zc:__cplusplus` flags come from Qt6::Platform, not from Qt6::Core, see `<package>\lib\cmake\Qt6\Qt6Targets.cmake`:

```cmake

# Create imported target Qt6::Platform
add_library(Qt6::Platform INTERFACE IMPORTED)

set_target_properties(Qt6::Platform PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;_WIN64;\$<\$<NOT:\$<BOOL:\$<TARGET_PROPERTY:QT_NO_UNICODE_DEFINES>>>:UNICODE\$<SEMICOLON>_UNICODE>"
  INTERFACE_COMPILE_FEATURES "cxx_std_17"
  INTERFACE_COMPILE_OPTIONS "\$<\$<AND:\$<CXX_COMPILER_ID:MSVC>,\$<COMPILE_LANGUAGE:CXX>>:-Zc:__cplusplus;-permissive->;\$<\$<AND:\$<NOT:\$<BOOL:\$<TARGET_PROPERTY:QT_NO_UTF8_SOURCE>>>,\$<COMPILE_LANGUAGE:C,CXX>>:\$<\$<CXX_COMPILER_ID:MSVC>:-utf-8>>"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/mkspecs/win32-msvc;${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "Threads::Threads"
  _qt_package_version "6.7.3"
)
```
there we can also see that it "links" to Threads::Threads. There are also conditional compile definitions and compile options which are missing (`_UNICODE` and `-utf-8`). You can look at this file https://github.com/qt/qtbase/blob/92b685784960eea6eb353688cf0edeb94d69c6cd/cmake/QtPlatformTargetHelpers.cmake#L61 to get a better idea where they come from (see calls to `qt_set_msvc_cplusplus_options`, `qt_enable_utf8_sources`, `qt_internal_enable_unicode_defines`). And you can also notice that Qt6::Platform requires `log` library on Android.

These changes are also required for these documented functions to work: https://doc.qt.io/qt-6/qt-disable-unicode-defines.html, https://doc.qt.io/qt-6/qt-allow-non-utf8-sources.html.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
