### PR TITLE
qarchive: fix test_package build with qt6

### DIFF
--- a/recipes/qarchive/all/test_package/CMakeLists.txt
+++ b/recipes/qarchive/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.16)
 project(test_package CXX)
 
 find_package(QArchive REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} QArchive)
-# Must compile with "-fPIC" since Qt was built with -reduce-relocations.
-target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE QArchive)

--- a/recipes/qarchive/all/test_package/conanfile.py
+++ b/recipes/qarchive/all/test_package/conanfile.py
@@ -12,6 +12,9 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
     def layout(self):
         cmake_layout(self)
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **qarchive/\***

#### Motivation and Details

When building test_package and using qt6 this error occurs:
```
CMake Warning (dev) at D:/conan2/qtd87b8da2e6f46/p/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:2827 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  D:/conan2/qtd87b8da2e6f46/p/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:2884 (_qt_internal_add_deploy_support)
  D:/conan2/qtd87b8da2e6f46/p/lib/cmake/Qt6Core/Qt6CoreConfigExtras.cmake:30 (_qt_internal_setup_deploy_support)
  build/msvc-192-x86_64-17-release/generators/Qt6Config.cmake:38 (include)
  C:/Program Files/CMake/share/cmake-3.29/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  build/msvc-192-x86_64-17-release/generators/QArchiveConfig.cmake:24 (find_dependency)
  CMakeLists.txt:4 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at D:/conan2/qtd87b8da2e6f46/p/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:2827 (if):
  if given arguments:

    "NOT" "D:/cci/recipes/qarchive/all/test_package/build/msvc-192-x86_64-17-release/.qt/QtDeployTargets-\$<CONFIG>.cmake" "IN_LIST" "scripts"

  Unknown arguments specified
```

[CMP0057](https://cmake.org/cmake/help/latest/policy/CMP0057.html) is required for the code in Qt6CoreMacros.cmake to work. This can be fixed by adjusting version in `cmake_minimum_required` (which is [3.16 for Qt](https://doc.qt.io/qt-6/cmake-supported-cmake-versions.html))

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
