### PR TITLE
sdl_image: Fix static builds for mingw 

### DIFF
--- a/recipes/sdl_image/all/conandata.yml
+++ b/recipes/sdl_image/all/conandata.yml
@@ -5,9 +5,6 @@ sources:
   "2.6.3":
     url: "https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.3/SDL2_image-2.6.3.tar.gz"
     sha256: "931c9be5bf1d7c8fae9b7dc157828b7eee874e23c7f24b44ba7eff6b4836312c"
-  "2.0.5":
-    url: "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz"
-    sha256: "bdd5f6e026682f7d7e1be0b6051b209da2f402a2dd8bd1c4bd9c25ad263108d0"
 patches:
   "2.8.2":
     - patch_description: "Fix webpdemux cmake target name"

--- a/recipes/sdl_image/all/conanfile.py
+++ b/recipes/sdl_image/all/conanfile.py
@@ -204,11 +204,10 @@ class SDLImageConan(ConanFile):
 
     def package_info(self):
         lib_postfix = ""
-        if Version(self.version) >= "2.6":
-            if self.settings.os == "Windows" and not self.options.shared:
-                lib_postfix += "-static"
-            if self.settings.build_type == "Debug":
-                lib_postfix += "d"
+        if self.settings.compiler == "msvc" and not self.options.shared:
+            lib_postfix += "-static"
+        if self.settings.build_type == "Debug":
+            lib_postfix += "d"
 
         self.cpp_info.set_property("cmake_file_name", "SDL2_image")
         self.cpp_info.set_property("cmake_target_name", "SDL2_image::SDL2_image")

--- a/recipes/sdl_image/config.yml
+++ b/recipes/sdl_image/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: "all"
   "2.6.3":
     folder: "all"
-  "2.0.5":
-    folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl_image/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fix for https://github.com/conan-io/conan-center-index/issues/26522

The library has tons of improvements, but that can be tackled in a follow-up PR to keep this diff clear

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Only in msvc is the name changed

From sdl_image's CMakeLists, for the static case:

```cmake
 if(MSVC OR (WATCOM AND (WIN32 OR OS2)))
    set_target_properties(SDL2_image PROPERTIES
        OUTPUT_NAME "SDL2_image-static"
    )
 endif()
```


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
