### PR TITLE
qt6: add ability to crossbuild

### DIFF
--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -2,14 +2,14 @@ import os
 
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualRunEnv
 from conan.tools.files import copy, save
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv"
+    generators = "CMakeDeps", "VirtualBuildEnv"
     test_type = "explicit"
 
     def layout(self):
@@ -21,11 +21,19 @@ class TestPackageConan(ConanFile):
     def build_requirements(self):
         if not can_run(self):
             self.tool_requires(self.tested_reference_str)
+            self.tool_requires("cmake/[>=3.27 <4]")
 
     def generate(self):
         path = self.dependencies["qt"].package_folder.replace("\\", "/")
         save(self, "qt.conf", f"""[Paths]
 Prefix = {path}""")
+
+        tc = CMakeToolchain(self)
+        if 'qt' in self.dependencies.build:
+            qt_tools_rootdir = self.conf.get("user.qt:tools_directory", None)
+            for tool in ["moc", "rcc", "uic"]:
+                tc.cache_variables[f"CMAKE_AUTO{tool.upper()}_EXECUTABLE"] = os.path.join(qt_tools_rootdir, f"{tool}.exe" if self.settings_build.os == "Windows" else tool)
+        tc.generate()
 
         VirtualRunEnv(self).generate()
         if can_run(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  qt/6.x.x

#### Motivation
Provide ability to cross-build recipe

#### Details
* Preserve `Qt6HostInfoConfig.cmake` in the package folder - this is needed by Qt itself when crossbuilding (it does not define targets, just some meta-information about the build)
* Define `QT_HOST_PATH` to point to the self-dependency in the build context 
* In lieu of `Qt6CoreTools` - simply pre-include the target executable information that is already in the dependency in the build context - that will define things like `Qt6::moc` and will use those instead
* Include executables part of Qtbase tools that were not defined in the targets file - these are needed when crossbuilding qt
* Delete logic around `android_sdk` (is not an option)
* Minimally adapt the test_package to get it to work when cross-building (it's subject to further changes in the future)

### Tested on
* macOS arm64 -> x86_64 (should be on CI too)
* Linux aarch64 -> x86_64

Android may require additional work, as it requires an SDK setup (and not just the NDK). Not invalidating this, as it may be possible to inject the necessary variables via `tools.cmake.cmaketoolchain:extra_variables` to get a successful build


Close https://github.com/conan-io/conan-center-index/issues/20257
Close https://github.com/conan-io/conan-center-index/issues/8120

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
