### PR TITLE
[openssl] Add new version of OpenSSL 3.4.0

### DIFF
--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  3.4.0:
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz"
+    sha256: e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf
   3.3.2:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz"
     sha256: 2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -97,6 +97,10 @@ class OpenSSLConan(ConanFile):
     default_options["tls_security_level"] = None
 
     @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    @property
     def _is_clang_cl(self):
         return self.settings.os == "Windows" and self.settings.compiler == "clang" and \
                self.settings.compiler.get_safe("runtime")
@@ -143,7 +147,7 @@ class OpenSSLConan(ConanFile):
             raise ConanInvalidConfiguration("OpenSSL 3 does not support building shared libraries for iOS")
 
     def build_requirements(self):
-        if self.settings_build.os == "Windows":
+        if self._settings_build.os == "Windows":
             if self.conf.get("user.openssl:windows_use_jom", False):
                 self.tool_requires("jom/[*]")
             if not self.options.no_asm and self.settings.arch in ["x86", "x86_64"]:

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4.0":
+    folder: "3.x.x"
   "3.3.2":
     folder: "3.x.x"
   "3.2.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **openssl/3.4.0**

#### Motivation
Bugfixes in 3.4.0 are needed that prevent using 3.3.2 on CentOS - bump version


#### Details
 - Add version 3.4.0 of OpenSSL
 - eliminate use of `settings_build` from the recipe


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
