### PR TITLE
[libmnl] Fix OS validation position

### DIFF
--- a/recipes/libmnl/all/conanfile.py
+++ b/recipes/libmnl/all/conanfile.py
@@ -27,16 +27,18 @@ class LibmnlConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def configure(self):
-        if self.settings.os != "Linux":
-            raise ConanInvalidConfiguration("libmnl is only supported on Linux")
         if self.options.shared:
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
-    
+
     def generate(self):
         tc = AutotoolsToolchain(self)
         tc.generate()
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("libmnl is only supported on Linux")
 
     def build(self):
         autotools = Autotools(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **libmnl/1.0.5**

#### Motivation

The actual recipe revision raises `ConanInvalidConfiguration` under `configure()`, breaking not only the natural build order but also affecting directly the CI.

#### Details

The PR https://github.com/conan-io/conan-center-index/pull/26200 requires libmnl and when computing this requirement, the CI can not continue due to this recipe bug. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
