### PR TITLE
qt6: Add option for libb2

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -50,6 +50,7 @@ class QtConan(ConanFile):
         "with_fontconfig": [True, False],
         "with_icu": [True, False],
         "with_harfbuzz": [True, False],
+        "with_libb2": [True, False],
         "with_libjpeg": ["libjpeg", "libjpeg-turbo", False],
         "with_libpng": [True, False],
         "with_sqlite3": [True, False],
@@ -95,6 +96,7 @@ class QtConan(ConanFile):
         "with_fontconfig": True,
         "with_icu": True,
         "with_harfbuzz": True,
+        "with_libb2": False,
         "with_libjpeg": False,
         "with_libpng": True,
         "with_sqlite3": True,
@@ -329,6 +331,9 @@ class QtConan(ConanFile):
 
         if self.options.get_safe("qtspeech") and not self.options.qtdeclarative:
             raise ConanInvalidConfiguration("qtspeech requires qtdeclarative, cf QTBUG-108381")
+
+        if self.options.get_safe("with_libb2") and self.options.multiconfiguration:
+            raise ConanInvalidConfiguration("non system variant of libb2 is not supported by qt. Contributions welcomed")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -583,6 +588,7 @@ class QtConan(ConanFile):
                               ("with_doubleconversion", "doubleconversion"),
                               ("with_freetype", "freetype"),
                               ("with_harfbuzz", "harfbuzz"),
+                              ("with_libb2", "libb2"),
                               ("with_libjpeg", "libjpeg"),
                               ("with_libpng", "libpng"),
                               ("with_md4c", "libmd4c"),


### PR DESCRIPTION

### Summary
Changes to recipe:  **qt/6.7.3**

#### Motivation
If libb2 is present on host and lib is build as static, link will fail. See issue #26551

#### Details
Pass libb2=no to Qt make rather than relying on auto detection.

Would require more patch to be able to use libb2 from conan. 
- In qtbase/src/corelib/CMakeLists.txt, Qt uses Libb2::Libb2 rather than libb2::libb2 in conan
- Need to remove qtbase/cmake/FindLibb2.cmake since conan provide it own find

But I wasn't able to make it work. Qt will fail at install because libb2 is not declared as dependency (from the Qt build, not conan).

Anyhow, with this patch, at least system libb2 is not used.
---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
