### PR TITLE
mold: add version 2.36.0

### DIFF
--- a/recipes/mold/all/conandata.yml
+++ b/recipes/mold/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.36.0":
+    url: "https://github.com/rui314/mold/archive/refs/tags/v2.36.0.tar.gz"
+    sha256: "3f57fe75535500ecce7a80fa1ba33675830b7d7deb1e5ee9a737e2bc43cdb1c7"
   "2.34.1":
     url: "https://github.com/rui314/mold/archive/refs/tags/v2.34.1.tar.gz"
     sha256: "a8cf638045b4a4b2697d0bcc77fd96eae93d54d57ad3021bf03b0333a727a59d"

--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -65,6 +65,8 @@ class MoldConan(ConanFile):
             raise ConanInvalidConfiguration("GCC version 10 or higher required")
         if self.settings.compiler in ('clang', 'apple-clang') and Version(self.settings.compiler.version) < "12":
             raise ConanInvalidConfiguration("Clang version 12 or higher required")
+        if Version(self.version) >= "2.34.0" and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "14":
+            raise ConanInvalidConfiguration("Apple-Clang version 14 or higher required due to C++20 features")
         if self.settings.compiler == "apple-clang" and "armv8" == self.settings.arch :
             raise ConanInvalidConfiguration(f'{self.name} is still not supported by Mac M1.')
         if Version(self.version) == "2.33.0" and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "14":

--- a/recipes/mold/all/test_package/conanfile.py
+++ b/recipes/mold/all/test_package/conanfile.py
@@ -4,12 +4,10 @@ from conan.tools.build import can_run
 
 class MoldTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "VirtualBuildEnv"
-    test_type = "explicit"
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def test(self):
         if can_run(self):
-            self.run("mold -v")
+            self.run("mold -v", env="conanrun")

--- a/recipes/mold/config.yml
+++ b/recipes/mold/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.36.0":
+    folder: all
   "2.34.1":
     folder: all
   "2.33.0":


### PR DESCRIPTION
follow up on https://github.com/conan-io/conan-center-index/pull/26553 

* Add version 2.36.0
* Refactor handling of min cpp std
* Move checks to validate_build()  - this is an executable/application where the compiler.cppstd should not cause issues to downstream consumers
