### PR TITLE
llvm-core: add cross-compilation support

### DIFF
--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -26,7 +26,7 @@ import re
 import textwrap
 from pathlib import Path
 
-required_conan_version = ">=1.62.0"
+required_conan_version = ">=2.4"
 
 # LLVM's default config is to enable all targets, but end users can significantly reduce
 # build times for the package by specifying only the targets they need as a


### PR DESCRIPTION
### Summary
Changes to recipe:  **llvm-core/[*]**

#### Motivation
Enable cross-compilation of the recipe.

#### Details
Uses GnuToolchain to set the required triplet value.

Tested with gcc-13-aarch64-linux-gnu: https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861
- static: [llvm-core.log](https://github.com/user-attachments/files/18707190/llvm-core.log)
- shared: [llvm-core.log](https://github.com/user-attachments/files/18707198/llvm-core.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
