### PR TITLE
box2d/3.0.0: fix build issue with clang-19 on MacOS

### DIFF
--- a/recipes/box2d/all/conandata.yml
+++ b/recipes/box2d/all/conandata.yml
@@ -19,6 +19,9 @@ patches:
     - patch_file: "patches/3.0.0-0002-use-cci.patch"
       patch_description: "use cci package"
       patch_type: "conan"
+    - patch_file: "patches/3.0.0-0003-disable-warning-as-errors.patch"
+      patch_description: "disable warnign as errors"
+      patch_type: "conan"
   "2.4.0":
     - patch_file: "patches/0001-install-and-allow-shared.patch"
       patch_description: "add install, allow shared build"

--- a/recipes/box2d/all/conandata.yml
+++ b/recipes/box2d/all/conandata.yml
@@ -19,8 +19,8 @@ patches:
     - patch_file: "patches/3.0.0-0002-use-cci.patch"
       patch_description: "use cci package"
       patch_type: "conan"
-    - patch_file: "patches/3.0.0-0003-disable-warning-as-errors.patch"
-      patch_description: "disable warnign as errors"
+    - patch_file: "patches/3.0.0-0003-remove-compile-warnings-as-error.patch"
+      patch_description: "remove warnings as errors"
       patch_type: "conan"
   "2.4.0":
     - patch_file: "patches/0001-install-and-allow-shared.patch"

--- a/recipes/box2d/all/patches/3.0.0-0003-disable-warning-as-errors.patch
+++ b/recipes/box2d/all/patches/3.0.0-0003-disable-warning-as-errors.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d6590d7..365f95e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,7 +46,7 @@ endif()
+ 
+ # C++17 needed for imgui
+ set(CMAKE_CXX_STANDARD 17)
+-set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
++set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
+ 
+ # set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/recipes/box2d/all/patches/3.0.0-0003-remove-compile-warnings-as-error.patch
+++ b/recipes/box2d/all/patches/3.0.0-0003-remove-compile-warnings-as-error.patch
@@ -1,13 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d6590d7..365f95e 100644
+index d6590d7..2323e7c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -46,7 +46,7 @@ endif()
+@@ -46,7 +46,6 @@ endif()
  
  # C++17 needed for imgui
  set(CMAKE_CXX_STANDARD 17)
 -set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
-+set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
  
  # set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
  set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
### Summary
Changes to recipe:  **box2d/3.0.0**

#### Motivation

box2d fails to build on MacOS with clang-19, because box2d builds traits compiler warning as error and clang-19 has stricter rules than the installed apple-clang 16.

I've created an [issue](https://github.com/erincatto/box2d/issues/882) on the upstream project. 

#### Details

clang-19 fails the build with the following error, for more details, see the issue above.

```
contact_solver.c:824:28: error: AVX vector return of type 'simde__m256' (vector of 8 'simde_float32' values) without 'avx' enabled changes the ABI [-Werror,-Wpsabi]
  824 |                 b2FloatW tangentY = sub( simde_mm256_setzero_ps(), c->normal.X );
      |                                          ^
```

The fix is to disable the warnign as errors.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
