### PR TITLE
glaze: add version 4.4.3

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.4.2":
-    url: "https://github.com/stephenberry/glaze/archive/v4.4.2.tar.gz"
-    sha256: "5f9c8efe35491f90755ef7a9d392ddd2ac395fd2e005e3ca61b5daf54ebfc9de"
+  "4.4.3":
+    url: "https://github.com/stephenberry/glaze/archive/v4.4.3.tar.gz"
+    sha256: "d0dd03f156f95860bf9c2957da0704ee0f7651e21089ff34e3d26fa0190e8684"
   "4.3.1":
     url: "https://github.com/stephenberry/glaze/archive/v4.3.1.tar.gz"
     sha256: "934b16d0a00dfc2b06bc2920a6444b8a6a34edb4f0fe872f8ad7a044518a37e3"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.4.1":
+    url: "https://github.com/stephenberry/glaze/archive/v4.4.1.tar.gz"
+    sha256: "0a5490905483e0e8fbc4c14a8edfe0cff2b298dfb0299c2a658d6e1ab4fc2e0a"
   "4.3.1":
     url: "https://github.com/stephenberry/glaze/archive/v4.3.1.tar.gz"
     sha256: "934b16d0a00dfc2b06bc2920a6444b8a6a34edb4f0fe872f8ad7a044518a37e3"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.4.1":
-    url: "https://github.com/stephenberry/glaze/archive/v4.4.1.tar.gz"
-    sha256: "0a5490905483e0e8fbc4c14a8edfe0cff2b298dfb0299c2a658d6e1ab4fc2e0a"
+  "4.4.2":
+    url: "https://github.com/stephenberry/glaze/archive/v4.4.2.tar.gz"
+    sha256: "5f9c8efe35491f90755ef7a9d392ddd2ac395fd2e005e3ca61b5daf54ebfc9de"
   "4.3.1":
     url: "https://github.com/stephenberry/glaze/archive/v4.3.1.tar.gz"
     sha256: "934b16d0a00dfc2b06bc2920a6444b8a6a34edb4f0fe872f8ad7a044518a37e3"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.4.1":
+    folder: all
   "4.3.1":
     folder: all
   "4.0.1":

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.4.1":
+  "4.4.2":
     folder: all
   "4.3.1":
     folder: all

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.4.2":
+  "4.4.3":
     folder: all
   "4.3.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **glaze/4.4.2**

#### Motivation
- Add TRACE Option
- AVX2 is used by default, also disable AVX2 flag is added.

#### Details
https://github.com/stephenberry/glaze/compare/v4.3.1...v4.4.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
