### PR TITLE
tree-sitter: add version 0.25.1

### DIFF
--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.25.1":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.25.1.tar.gz"
+    sha256: "99a2446075c2edf60e82755c48415d5f6e40f2d9aacb3423c6ca56809b70fe59"
   "0.24.4":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.24.4.tar.gz"
     sha256: "d704832a6bfaac8b3cbca3b5d773cad613183ba8c04166638af2c6e5dfb9e2d2"

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.25.1":
+    folder: all
   "0.24.4":
     folder: all
   "0.24.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-sitter/0.25.1**

#### Motivation
0.25.0 is a large release. There are lots of improvements.
https://github.com/tree-sitter/tree-sitter/releases/tag/v0.25.0

#### Details
https://github.com/tree-sitter/tree-sitter/compare/v0.24.4...v0.25.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
