### PR TITLE
luajit: fix building for iOS and Android

### DIFF
--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -15,3 +15,7 @@ patches:
       patch_description: "Fix POSIX install with missing or incompatible ldconfig"
       patch_source: "https://github.com/LuaJIT/LuaJIT/commit/18c9cf7d3788a8f7408df45df92fc4ae3bcc0d80"
       patch_type: "bugfix"
+    - patch_file: "patches/2.1.0-beta3-ios-dylib-extension.diff"
+      patch_description: "Use dylib extension for iOS installs"
+      patch_source: "https://github.com/LuaJIT/LuaJIT/commit/b1179ea5f708c62aacc60235d28230112f419a69"
+      patch_type: "bugfix"

--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -11,3 +11,7 @@ patches:
     - patch_file: "patches/2.1.0-beta3-0001-remove-mac-deploy.patch"
       patch_type: "conan"
       patch_description: "Do not enforce default value for MACOSX_DEPLOYMENT_TARGET"
+    - patch_file: "patches/2.1.0-beta3-fix-so-symlinks-with-missing-ldconfig.diff"
+      patch_description: "Fix POSIX install with missing or incompatible ldconfig"
+      patch_source: "https://github.com/LuaJIT/LuaJIT/commit/18c9cf7d3788a8f7408df45df92fc4ae3bcc0d80"
+      patch_type: "bugfix"

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -107,6 +107,10 @@ class LuajitConan(ConanFile):
         if "clang" in str(self.settings.compiler):
             args.append("DEFAULT_CC=clang")
 
+        # upstream doesn't read CPPFLAGS, inject them manually
+        cppflags = AutotoolsToolchain(self).environment().vars(self).get("CPPFLAGS")
+        args.append(f"TARGET_CFLAGS='{cppflags}'")
+
         if self.settings.os == "Macos" and self._apple_deployment_target():
             args.append(f"MACOSX_DEPLOYMENT_TARGET={self._apple_deployment_target()}")
         elif self.settings.os == "iOS":

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -129,6 +129,8 @@ class LuajitConan(ConanFile):
                 f"TARGET_LD={compiler_path}",
                 f"TARGET_STRIP={buildenv_vars.get('STRIP')}",
             ])
+            if self._is_host_32bit:
+                args.append("HOST_CC='gcc -m32'")
             if self.settings_build.os != "Linux":
                 args.append("TARGET_SYS=Linux")
             if self.settings_build.os == "Macos":

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -41,6 +41,15 @@ class LuajitConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
+    @property
+    def _is_host_32bit(self):
+        return self.settings.arch in ["armv7", "x86"]
+
+    def validate_build(self):
+        if self._is_host_32bit and self.settings_build.os == "Macos":
+            # well, technically it should work on macOS <= 10.14
+            raise ConanInvalidConfiguration(f"{self.ref} cannot be cross-built to a 32-bit platform on macOS, see https://github.com/LuaJIT/LuaJIT/issues/664")
+
     def validate(self):
         if self.settings.os == "Macos" and self.settings.arch == "armv8" and cross_building(self):
             raise ConanInvalidConfiguration(f"{self.ref} can not be cross-built to Mac M1. Please, try any version >=2.1")

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -83,8 +83,6 @@ class LuajitConan(ConanFile):
                 replace_in_file(self, makefile,
                                       'TARGET_O= $(LUAJIT_A)',
                                       'TARGET_O= $(LUAJIT_SO)')
-            if "clang" in str(self.settings.compiler):
-                replace_in_file(self, makefile, 'CC= $(DEFAULT_CC)', 'CC= clang')
 
     @property
     def _macosx_deployment_target(self):
@@ -93,6 +91,9 @@ class LuajitConan(ConanFile):
     @property
     def _make_arguments(self):
         args = [f"PREFIX={unix_path(self, self.package_folder)}"]
+        if "clang" in str(self.settings.compiler):
+            args.append("DEFAULT_CC=clang")
+
         if is_apple_os(self) and self._macosx_deployment_target:
             args.append(f"MACOSX_DEPLOYMENT_TARGET={self._macosx_deployment_target}")
         return args

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -6,6 +6,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.apple import XCRun, to_apple_arch
 from conan.tools.build import cross_building
+from conan.tools.env import VirtualBuildEnv
 from conan.errors import ConanInvalidConfiguration
 import os
 
@@ -69,7 +70,7 @@ class LuajitConan(ConanFile):
         else:
             tc = AutotoolsToolchain(self)
             env = tc.environment()
-            if self.settings.os == "iOS":
+            if self.settings.os == "iOS" or self.settings.os == "Android":
                 env.define("CFLAGS", "")
                 env.define("LDFLAGS", "")
             tc.generate(env)
@@ -116,6 +117,29 @@ class LuajitConan(ConanFile):
                 f"""TARGET_FLAGS='-isysroot "{xcrun.sdk_path}" -target {target_flag}'""",
                 "TARGET_SYS=iOS",
             ])
+        elif self.settings.os == "Android":
+            buildenv_vars = VirtualBuildEnv(self).vars()
+            compiler_path = buildenv_vars.get("CC")
+            triplet_prefix = f"{buildenv_vars.get('CHOST')}-"
+            args.extend([
+                f"CROSS={os.path.join(buildenv_vars.get('NDK_ROOT'), 'bin', triplet_prefix)}",
+                f"DYNAMIC_CC='{compiler_path} -fPIC'",
+                f"STATIC_CC={compiler_path}",
+                f"TARGET_AR='{buildenv_vars.get('AR')} rcus'",
+                f"TARGET_LD={compiler_path}",
+                f"TARGET_STRIP={buildenv_vars.get('STRIP')}",
+            ])
+            if self.settings_build.os != "Linux":
+                args.append("TARGET_SYS=Linux")
+            if self.settings_build.os == "Macos":
+                # must look for headers in macOS SDK, having NDK clang in PATH breaks this default behavior
+                xcrun_build = XCRun(self, sdk='macosx')
+                isysroot_flag = f"""'-isysroot "{xcrun_build.sdk_path}"'"""
+                args.extend([
+                    f"HOST_CC='{xcrun_build.cc}'",
+                    f"HOST_CFLAGS={isysroot_flag}",
+                    f"HOST_LDFLAGS={isysroot_flag}",
+                ])
         return args
 
     @property

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -23,8 +23,16 @@ class LuajitConan(ConanFile):
     topics = ("lua", "jit")
     provides = "lua"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_gc64": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_gc64": False, # note: on by default in later versions
+    }
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -32,6 +40,8 @@ class LuajitConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self._is_host_32bit:
+            del self.options.with_gc64
 
     def configure(self):
         if self.options.shared:
@@ -106,6 +116,8 @@ class LuajitConan(ConanFile):
         args = [f"PREFIX={unix_path(self, self.package_folder)}"]
         if "clang" in str(self.settings.compiler):
             args.append("DEFAULT_CC=clang")
+        if self.options.get_safe("with_gc64", False):
+            args.append("XCFLAGS=-DLUAJIT_ENABLE_GC64")
 
         # upstream doesn't read CPPFLAGS, inject them manually
         cppflags = AutotoolsToolchain(self).environment().vars(self).get("CPPFLAGS")
@@ -160,8 +172,10 @@ class LuajitConan(ConanFile):
         self._patch_sources()
         if is_msvc(self):
             with chdir(self, os.path.join(self.source_folder, "src")):
-                variant = '' if self.options.shared else 'static'
-                self.run(f"msvcbuild.bat {variant}", env="conanbuild")
+                build_opts = "gc64" if self.options.get_safe("with_gc64", False) else ""
+                if not self.options.shared:
+                    build_opts += " static"
+                self.run(f"msvcbuild.bat {build_opts}", env="conanbuild")
         else:
             with chdir(self, self.source_folder):
                 autotools = Autotools(self)

--- a/recipes/luajit/all/patches/2.1.0-beta3-fix-so-symlinks-with-missing-ldconfig.diff
+++ b/recipes/luajit/all/patches/2.1.0-beta3-fix-so-symlinks-with-missing-ldconfig.diff
@@ -1,0 +1,22 @@
+diff --git a/Makefile b/Makefile
+index 07bc70faf4..bff53f2867 100644
+--- a/Makefile
++++ b/Makefile
+@@ -75,7 +75,7 @@ SYMLINK= ln -sf
+ INSTALL_X= install -m 0755
+ INSTALL_F= install -m 0644
+ UNINSTALL= $(RM)
+-LDCONFIG= ldconfig -n
++LDCONFIG= ldconfig -n 2>/dev/null
+ SED_PC= sed -e "s|^prefix=.*|prefix=$(PREFIX)|" \
+             -e "s|^multilib=.*|multilib=$(MULTILIB)|"
+ 
+@@ -121,7 +121,7 @@ install: $(INSTALL_DEP)
+ 	$(RM) $(INSTALL_DYN) $(INSTALL_SHORT1) $(INSTALL_SHORT2)
+ 	cd src && test -f $(FILE_SO) && \
+ 	  $(INSTALL_X) $(FILE_SO) $(INSTALL_DYN) && \
+-	  $(LDCONFIG) $(INSTALL_LIB) && \
++	  ( $(LDCONFIG) $(INSTALL_LIB) || : ) && \
+ 	  $(SYMLINK) $(INSTALL_SONAME) $(INSTALL_SHORT1) && \
+ 	  $(SYMLINK) $(INSTALL_SONAME) $(INSTALL_SHORT2) || :
+ 	cd etc && $(INSTALL_F) $(FILE_MAN) $(INSTALL_MAN)

--- a/recipes/luajit/all/patches/2.1.0-beta3-ios-dylib-extension.diff
+++ b/recipes/luajit/all/patches/2.1.0-beta3-ios-dylib-extension.diff
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index d789e9f374..c41b3345dd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -97,7 +97,7 @@ else
+ endif
+ TARGET_SYS?= $(HOST_SYS)
+ 
+-ifeq (Darwin,$(TARGET_SYS))
++ifneq (,$(filter $(TARGET_SYS),Darwin iOS))
+   INSTALL_SONAME= $(INSTALL_DYLIBNAME)
+   INSTALL_SOSHORT1= $(INSTALL_DYLIBSHORT1)
+   INSTALL_SOSHORT2= $(INSTALL_DYLIBSHORT2)

--- a/recipes/luajit/all/test_package/CMakeLists.txt
+++ b/recipes/luajit/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.14)
 project(test_package C)
 
 find_package(luajit REQUIRED CONFIG)


### PR DESCRIPTION
### Summary
Changes to recipe:  **luajit/all**

#### Motivation

- Fixes building for iOS and Android
- forbids building for 32-bit platform on macOS: https://github.com/LuaJIT/LuaJIT/issues/664
- adds passing `CPPFLAGS` as `TARGET_CFLAGS` since upstream doesn't read this standard variable
- fixes producing .so symlinks when `ldconfig` is unavailable (e.g. building for Android on macOS) via upstream patch, but I had to adjust it a bit that it applies on 2.1.0-beta3
- fixes extension of shared lib when building for iOS via upstream patch, but I had to adjust it a bit that it applies on 2.1.0-beta3
- simplifies using Clang compiler
- adds option to enable GC64 mode. Keeping it off by default to match behavior of the source, but in later LuaJIT versions it's on by default.

#### Details

TODO: drop the last commits after #30447 is merged, there will also be conflicts

Followed the documentation at https://luajit.org/install.html#cross, tested building 2.1.0-beta3 for iOS on macOS and for Android on macOS and Linux.

I will explain why env modification is done. Without it target flags (i.e. `host` in Conan terms) "taint" the host ones (`build` in Conan terms) which results in non-working executable that's meant to run on the `build` platform, it can be seen in the build log:

```
HOSTCC    host/minilua.o
clang  -O2 -fomit-frame-pointer -Wall   -O3 -isysroot /Applications/Xcode-15.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk -arch arm64 -mios-version-min=12.0 -I. -DLUAJIT_OS=LUAJIT_OS_OSX -DLUAJIT_TARGET=LUAJIT_ARCH_arm64 -DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0 -DLUAJIT_NO_UNWIND  -c -o host/minilua.o host/minilua.c

HOSTLINK  host/minilua
clang   -isysroot /Applications/Xcode-15.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk -arch arm64 -mios-version-min=12.0   -o host/minilua host/minilua.o -lm 
```

Checking how the host executable is produced:

```
$(HOST_O): %.o: %.c
	$(E) "HOSTCC    $@"
	$(Q)$(HOST_CC) $(HOST_ACFLAGS) -c -o $@ $<


ASOPTIONS= $(CCOPT) $(CCWARN) $(XCFLAGS) $(CFLAGS)
CCOPTIONS= $(CCDEBUG) $(ASOPTIONS)
HOST_ACFLAGS= $(CCOPTIONS) $(HOST_XCFLAGS) $(TARGET_ARCH) $(HOST_CFLAGS)
```

first I came up with the following solution that overwrites those target flags with proper ones:

```python
xcrun_host = XCRun(self, sdk='macosx')
arch_host = {
    'x86_64': 'x86_64',
    'armv8': 'arm64',
}.get(str(self.settings_build.get_safe("arch")))
target_flag_host = f"{arch_host}-apple-macos{self.settings_build.get_safe("os.version", default='')}"
flags_host = f"'-isysroot \"{xcrun_host.sdk_path}\" -target {target_flag_host}'"

# and pass additional variables as make args:
[
    f"HOST_CFLAGS={flags_host}",
    f"HOST_LDFLAGS={flags_host}",
]
```

which results in proper executable:

```
HOSTCC    host/minilua.o
clang  -O2 -fomit-frame-pointer -Wall   -O3 -isysroot /Applications/Xcode-15.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk -arch arm64 -mios-version-min=12.0 -I. -DLUAJIT_OS=LUAJIT_OS_OSX -DLUAJIT_TARGET=LUAJIT_ARCH_arm64 -DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0 -DLUAJIT_NO_UNWIND -isysroot "/Applications/Xcode-15.4.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk" -target arm64-apple-macos -c -o host/minilua.o host/minilua.c
clang: warning: overriding '-mios-version-min=12.0' option with '-target arm64-apple-macos' [-Woverriding-t-option]


HOSTLINK  host/minilua
clang   -isysroot /Applications/Xcode-15.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk -arch arm64 -mios-version-min=12.0  -isysroot "/Applications/Xcode-15.4.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk" -target arm64-apple-macos -o host/minilua host/minilua.o -lm   
clang: warning: overriding '-mios-version-min=12.0' option with '-target arm64-apple-macos' [-Woverriding-t-option]
```

But later I figured out that it's much easier to simply drop CFLAGS / LDFLAGS from the environment, as LuaJIT uses its own variables for host/target flags. And Android has quite a similar issue.

Also when building a _build_ binary in Android build on macOS, a workaround is required - passing `-isysroot` in HOST_CFLAGS and HOST_LDFLAGS. This looks like a common issue related to the NDK recipe, I've opened #26585 about that.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
