### PR TITLE
openssl: add versions `3.0.16`, `3.1.8`, `3.2.4`, `3.3.3`, `3.4.1`, stop publishing new revisions for version `3.0.15`

### DIFF
--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -1,16 +1,28 @@
 sources:
+  3.4.1:
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz"
+    sha256: 002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3
   3.4.0:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz"
     sha256: e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf
+  3.3.3:
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.3.3/openssl-3.3.3.tar.gz"
+    sha256: 712590fd20aaa60ec75d778fe5b810d6b829ca7fb1e530577917a131f9105539
   3.3.2:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz"
     sha256: 2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281
+  3.2.4:
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.2.4/openssl-3.2.4.tar.gz"
+    sha256: b23ad7fd9f73e43ad1767e636040e88ba7c9e5775bfa5618436a0dd2c17c3716
   3.2.3:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.2.3/openssl-3.2.3.tar.gz"
     sha256: 52b5f1c6b8022bc5868c308c54fb77705e702d6c6f4594f99a0df216acf46239
+  3.1.8:
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.1.8/openssl-3.1.8.tar.gz"
+    sha256: d319da6aecde3aa6f426b44bbf997406d95275c5c59ab6f6ef53caaa079f456f
   3.1.7:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.1.7/openssl-3.1.7.tar.gz"
     sha256: 053a31fa80cf4aebe1068c987d2ef1e44ce418881427c4464751ae800c31d06c
-  3.0.15: # LTS: keep the most recent 3.0.x until a new LTS is designated
-    url: "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz"
-    sha256: 23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533
+  3.0.16: # LTS: keep the most recent 3.0.x until a new LTS is designated
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz"
+    sha256: 57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,13 +1,21 @@
 versions:
+  "3.4.1":
+    folder: "3.x.x"
   "3.4.0":
+    folder: "3.x.x"
+  "3.3.3":
     folder: "3.x.x"
   "3.3.2":
     folder: "3.x.x"
+  "3.2.4":
+    folder: "3.x.x"
   "3.2.3":
+    folder: "3.x.x"
+  "3.1.8":
     folder: "3.x.x"
   "3.1.7":
     folder: "3.x.x"
-  "3.0.15":
+  "3.0.16":
     folder: "3.x.x"
   "1.1.1w":
     folder: "1.x.x"


### PR DESCRIPTION

### Summary

OpenSSL 3.4.1 is a security patch release. The most severe CVE fixed in this release is High ([CVE-2024-12797](https://openssl-library.org/news/secadv/20250211.txt)).

Changes to recipe:  **openssl/***

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
