### PR TITLE
android-ndk: dont set LD and AS variables

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -300,8 +300,6 @@ class AndroidNDKConan(ConanFile):
         self.conf_info.update("tools.build:compiler_executables", compiler_executables)
         self.buildenv_info.define_path("CC", compiler_executables["c"])
         self.buildenv_info.define_path("CXX", compiler_executables["cpp"])
-        self.buildenv_info.define_path("AS", compiler_executables["c"])
-        self.buildenv_info.define_path("LD", compiler_executables["cpp"])
 
         # Versions greater than 23 had the naming convention
         # changed to no longer include the triplet.


### PR DESCRIPTION
Revert https://github.com/conan-io/conan-center-index/pull/23346

While the documentation is correct (the compiler should be used as the assembler and as the linker) - that's a determination for build systems (and they usually get it right) - they usually _do_ invoke the compiler to perform the link stage, and not the linker directly

This PR fixes an issue in some autotools recipes when targetting android and the linker needs to be invoked (e.g. when building shared libraries)


#### bad: if autotools determines that the linker is not GNU ld, it may not build the shared libraries at all
```
configure:7608: checking for ld used by /Users/conan/.conan2/p/androc439eef6aa9d6/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang
configure:7676: result: /Users/conan/.conan2/p/androc439eef6aa9d6/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang++
configure:7683: checking if the linker (/Users/conan/.conan2/p/androc439eef6aa9d6/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang++) is GNU ld... no
```

#### good: this test should be yes
```
checking for ld used by /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang... /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/ld
checking if the linker (/Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/ld) is GNU ld... yes
....


libtool: link: /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -O3 iconv.o -o iconv  ../srclib/libicrt.a /Users/conan/.conan2/p/b/libicec9f75520d508/p//lib/libiconv.so -L/Users/conan/.conan2/p/b/libicec9f75520d508/p//lib -L/Users/conan/.conan2/p/b/libicec9f75520d508/p//lib
```

Note:
* in both cases it queries the compiler to determine the linker
* when actually linking, it is done correctly by invoking the compiler

Close https://github.com/conan-io/conan-center-index/pull/26258
