### PR TITLE
media libraries: fix missing system libs for Android, fix libx264 android build

### DIFF
--- a/recipes/libsvtav1/all/conanfile.py
+++ b/recipes/libsvtav1/all/conanfile.py
@@ -137,10 +137,14 @@ class SVTAV1Conan(ConanFile):
             self.cpp_info.components["encoder"].requires = ["cpuinfo::cpuinfo"]
             if self.settings.os in ("FreeBSD", "Linux"):
                 self.cpp_info.components["encoder"].system_libs = ["pthread", "dl", "m"]
+            if self.settings.os == "Android":
+                self.cpp_info.components["encoder"].system_libs = ["m"]
         if self.options.get_safe("build_decoder"):
             self.cpp_info.components["decoder"].libs = ["SvtAv1Dec"]
             self.cpp_info.components["decoder"].includedirs = ["include/svt-av1"]
             self.cpp_info.components["decoder"].set_property("pkg_config_name", "SvtAv1Dec")
             self.cpp_info.components["decoder"].requires = ["cpuinfo::cpuinfo"]
             if self.settings.os in ("FreeBSD", "Linux"):
-                self.cpp_info.components["encoder"].system_libs = ["pthread", "dl", "m"]
+                self.cpp_info.components["decoder"].system_libs = ["pthread", "dl", "m"]
+            if self.settings.os == "Android":
+                self.cpp_info.components["decoder"].system_libs = ["m"]

--- a/recipes/libwebp/all/conanfile.py
+++ b/recipes/libwebp/all/conanfile.py
@@ -101,6 +101,8 @@ class LibwebpConan(ConanFile):
         self.cpp_info.components["webpdecoder"].libs = ["webpdecoder"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["webpdecoder"].system_libs = ["m", "pthread"]
+        if self.settings.os == "Android":
+            self.cpp_info.components["webpdecoder"].system_libs = ["m"]
 
         # webp
         self.cpp_info.components["webp"].set_property("cmake_target_name", "WebP::webp")
@@ -108,6 +110,8 @@ class LibwebpConan(ConanFile):
         self.cpp_info.components["webp"].libs = ["webp"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["webp"].system_libs = ["m", "pthread"]
+        if self.settings.os == "Android":
+            self.cpp_info.components["webp"].system_libs = ["m"]
 
         if Version(self.version) >= "1.3.0":
             # sharpyuv
@@ -116,6 +120,8 @@ class LibwebpConan(ConanFile):
             self.cpp_info.components["sharpyuv"].libs = ["sharpyuv"]
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["sharpyuv"].system_libs = ["m", "pthread"]
+            if self.settings.os == "Android":
+                self.cpp_info.components["sharpyuv"].system_libs = ["m"]
             # note: webp now depends on sharpyuv
             self.cpp_info.components["webp"].requires = ["sharpyuv"]
 
@@ -130,7 +136,7 @@ class LibwebpConan(ConanFile):
         self.cpp_info.components["webpmux"].set_property("pkg_config_name", "libwebpmux")
         self.cpp_info.components["webpmux"].libs = ["webpmux"]
         self.cpp_info.components["webpmux"].requires = ["webp"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
+        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
             self.cpp_info.components["webpmux"].system_libs = ["m"]
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed

--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -111,31 +111,6 @@ class LibX264Conan(ConanFile):
             env.define("AS", unix_path(self, os.path.join(self.dependencies.build["nasm"].package_folder, "bin", "nasm{}".format(".exe" if self.settings.os == "Windows" else ""))))
             env.vars(self).save_script("conanbuild_nasm")
 
-        if cross_building(self):
-            if self.settings.os == "Android":
-                buildenv_vars = VirtualBuildEnv(self).vars()
-                ndk_root = self.conf.get("tools.android:ndk_path", buildenv_vars.get("NDK_ROOT"))
-
-                # INFO: Conan package android-ndk does not expose toolchain path. Looks fragile but follows always same for Android NDK
-                build_os = {"Linux": "linux", "Macos": "darwin", "Windows": "windows"}.get(str(self.settings_build.os))
-                toolchain = os.path.join(ndk_root, "toolchains", "llvm", "prebuilt", f"{build_os}-{self.settings_build.arch}")
-
-                sysroot = self.conf.get("tools.build:sysroot", buildenv_vars.get("SYSROOT", f"{toolchain}/sysroot"))
-                # INFO: x264 will look for strings appended to the cross prefix
-                cross_prefix = os.path.join(toolchain, "bin", "llvm-")
-
-                compilers_from_conf = self.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
-
-                args["--build"] = None # --build is not recognized
-                args["--cross-prefix"] = cross_prefix
-                args["--sysroot"] = sysroot
-
-                # the as of ndk does not work well for building libx264
-                env = Environment()
-                cc_as = compilers_from_conf.get("c", buildenv_vars.get("AS", "clang"))
-                env.define("AS", cc_as)
-                env_vars = env.vars(self, scope="build")
-                env_vars.save_script("conanbuild_android")
 
         if is_msvc(self):
             env = Environment()

--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -76,8 +76,10 @@ class VorbisConan(ConanFile):
         self.cpp_info.components["vorbismain"].set_property("cmake_target_name", "Vorbis::vorbis")
         self.cpp_info.components["vorbismain"].set_property("pkg_config_name", "vorbis")
         self.cpp_info.components["vorbismain"].libs = ["vorbis"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
+        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
             self.cpp_info.components["vorbismain"].system_libs.append("m")
+        if self.settings.os == "Android":
+            self.cpp_info.components["vorbismain"].system_libs.append("log")
         self.cpp_info.components["vorbismain"].requires = ["ogg::ogg"]
 
         # TODO: Upstream VorbisConfig.cmake defines components 'Enc' and 'File',


### PR DESCRIPTION
libsvtav1, libwebp, vorbis:
* Add missing system libraries on Android (this only affects consumers of the static variant) - in all cases, consumers get missing symbols from either the m library or log library (see logs) 

libx264:
* remove broken Android handling logic, fix https://github.com/conan-io/conan-center-index/issues/24640 - tested with the current android-ndk recipe, there seems to be no need for any custom logic in the recipe, for details [see](https://github.com/conan-io/conan-center-index/pull/26583#discussion_r1952710345) 

This fixes issues experienced when building ffmpeg for Android using static dependencies:
Note: despite the "not found using pkg-config" errors - the libraries _are_ found by pkg-config, it's the subsequent test that fails. 

```
ERROR: SvtAv1Enc >= 0.9.0 not found using pkg-config



/Users/conan/.conan2/p/pkgco429aafb5f4b15/p/bin/pkgconf --exists --print-errors SvtAv1Enc >= 0.9.0
check_func_headers EbSvtAv1Enc.h svt_av1_enc_init_handle -I/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/include/svt-av1 -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -L/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/lib -lSvtAv1Enc -L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib -lcpuinfo -llog
test_ld cc -I/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/include/svt-av1 -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -L/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/lib -lSvtAv1Enc -L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib -lcpuinfo -llog
test_cc -I/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/include/svt-av1 -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -L/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/lib -L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib
BEGIN /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.CnNDaicp/test.c
    1	#include <EbSvtAv1Enc.h>
    2	#include <stdint.h>
    3	long check_svt_av1_enc_init_handle(void) { return (long) svt_av1_enc_init_handle; }
    4	int main(void) { int ret = 0;
    5	 ret |= ((intptr_t)check_svt_av1_enc_init_handle) & 0xFFFF;
    6	return ret; }
END /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.CnNDaicp/test.c
/Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang -DNDEBUG -I/Users/conan/.conan2/p/b/freetddb34e758c50c/p/include -I/Users/conan/.conan2/p/b/freetddb34e758c50c/p/include/freetype2 -I/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/include/svt-av1 -I/Users/conan/.conan2/p/b/opens4d14881c0eff9/p/include -I/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/include -I/Users/conan/.conan2/p/b/libpn3bcb69dc2c862/p/include -I/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/include -I/Users/conan/.conan2/p/b/libao612e7042df044/p/include -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -I/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/include -I/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/include -I/Users/conan/.conan2/p/b/libmp76afa2e0ebffd/p/include -I/Users/conan/.conan2/p/b/libvpc003ec7703987/p/include -I/Users/conan/.conan2/p/b/libx2e87db79390858/p/include -I/Users/conan/.conan2/p/b/libx25d1604a34db7c/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -I/Users/conan/.conan2/p/b/openhe01551d159f83/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include/openjpeg-2.5 -I/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/include -I/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/include/brotli -I/Users/conan/.conan2/p/b/bzip23a90a39c11490/p/include -I/Users/conan/.conan2/p/b/libic755e55e19bbe3/p/include -I/Users/conan/.conan2/p/b/xz_ut8a5ab8ed81b55/p/include -DLZMA_API_STATIC -D_ISOC11_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Dstrtod=avpriv_strtod -DPIC -fPIC --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -O3 -fPIC --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -O3 -std=c17 -fPIE -fomit-frame-pointer -fPIC -pthread -I/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/include -I/Users/conan/.conan2/p/b/libao612e7042df044/p/include -I/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/include -I/Users/conan/.conan2/p/b/openhe01551d159f83/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include/openjpeg-2.5 -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/include/svt-av1 -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -L/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/lib -L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib -c -o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.CnNDaicp/test.o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.CnNDaicp/test.c
clang: warning: argument unused during compilation: '-L/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/lib' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib' [-Wunused-command-line-argument]
/Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -L/Users/conan/.conan2/p/b/freetddb34e758c50c/p/lib -L/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/lib -L/Users/conan/.conan2/p/b/opens4d14881c0eff9/p/lib -L/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib -L/Users/conan/.conan2/p/b/libpn3bcb69dc2c862/p/lib -L/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/lib -L/Users/conan/.conan2/p/b/libao612e7042df044/p/lib -L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib -L/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/lib -L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib -L/Users/conan/.conan2/p/b/libmp76afa2e0ebffd/p/lib -L/Users/conan/.conan2/p/b/libvpc003ec7703987/p/lib -L/Users/conan/.conan2/p/b/libx2e87db79390858/p/lib -L/Users/conan/.conan2/p/b/libx25d1604a34db7c/p/lib -L/Users/conan/.conan2/p/b/opus52624b5050cd2/p/lib -L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib -L/Users/conan/.conan2/p/b/openhe01551d159f83/p/lib -L/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/lib -L/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/lib -L/Users/conan/.conan2/p/b/bzip23a90a39c11490/p/lib -L/Users/conan/.conan2/p/b/libic755e55e19bbe3/p/lib -L/Users/conan/.conan2/p/b/xz_ut8a5ab8ed81b55/p/lib --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Wl,--as-needed -Wl,-z,noexecstack -fPIE -pie -I/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/include/svt-av1 -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -L/Users/conan/.conan2/p/b/libsv486de3e07d9e0/p/lib -L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib -o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.CnNDaicp/test /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.CnNDaicp/test.o -lSvtAv1Enc -lcpuinfo -llog
ld.lld: error: undefined symbol: pow

```


```
/Users/conan/.conan2/p/pkgco429aafb5f4b15/p/bin/pkgconf --exists --print-errors vorbis
check_func_headers vorbis/codec.h vorbis_info_init -I/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/include -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -L/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib -lvorbis -L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib -logg
test_ld cc -I/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/include -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -L/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib -lvorbis -L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib -logg
test_cc -I/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/include -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -L/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib -L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib
BEGIN /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.qB627zwO/test.c
    1	#include <vorbis/codec.h>
    2	#include <stdint.h>
    3	long check_vorbis_info_init(void) { return (long) vorbis_info_init; }
    4	int main(void) { int ret = 0;
    5	 ret |= ((intptr_t)check_vorbis_info_init) & 0xFFFF;
    6	return ret; }
END /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.qB627zwO/test.c
/Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang -DNDEBUG -I/Users/conan/.conan2/p/b/freetddb34e758c50c/p/include -I/Users/conan/.conan2/p/b/freetddb34e758c50c/p/include/freetype2 -I/Users/conan/.conan2/p/b/libsvc9ea951b59468/p/include/svt-av1 -I/Users/conan/.conan2/p/b/opens4d14881c0eff9/p/include -I/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/include -I/Users/conan/.conan2/p/b/libpn3bcb69dc2c862/p/include -I/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/include -I/Users/conan/.conan2/p/b/libao612e7042df044/p/include -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -I/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/include -I/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/include -I/Users/conan/.conan2/p/b/libmp76afa2e0ebffd/p/include -I/Users/conan/.conan2/p/b/libvpc003ec7703987/p/include -I/Users/conan/.conan2/p/b/libx2e87db79390858/p/include -I/Users/conan/.conan2/p/b/libx25d1604a34db7c/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -I/Users/conan/.conan2/p/b/openhe01551d159f83/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include/openjpeg-2.5 -I/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/include -I/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/include/brotli -I/Users/conan/.conan2/p/b/bzip23a90a39c11490/p/include -I/Users/conan/.conan2/p/b/libic755e55e19bbe3/p/include -I/Users/conan/.conan2/p/b/xz_ut8a5ab8ed81b55/p/include -DLZMA_API_STATIC -D_ISOC11_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Dstrtod=avpriv_strtod -DPIC -fPIC --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -O3 -fPIC --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -O3 -std=c17 -fPIE -fomit-frame-pointer -fPIC -pthread -I/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/include -I/Users/conan/.conan2/p/b/libao612e7042df044/p/include -I/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/include -I/Users/conan/.conan2/p/b/openhe01551d159f83/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include/openjpeg-2.5 -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/libsvc9ea951b59468/p/include/svt-av1 -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -I/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/include -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -L/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib -L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib -c -o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.qB627zwO/test.o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.qB627zwO/test.c
clang: warning: argument unused during compilation: '-L/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib' [-Wunused-command-line-argument]
/Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -L/Users/conan/.conan2/p/b/freetddb34e758c50c/p/lib -L/Users/conan/.conan2/p/b/libsvc9ea951b59468/p/lib -L/Users/conan/.conan2/p/b/opens4d14881c0eff9/p/lib -L/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib -L/Users/conan/.conan2/p/b/libpn3bcb69dc2c862/p/lib -L/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/lib -L/Users/conan/.conan2/p/b/libao612e7042df044/p/lib -L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib -L/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/lib -L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib -L/Users/conan/.conan2/p/b/libmp76afa2e0ebffd/p/lib -L/Users/conan/.conan2/p/b/libvpc003ec7703987/p/lib -L/Users/conan/.conan2/p/b/libx2e87db79390858/p/lib -L/Users/conan/.conan2/p/b/libx25d1604a34db7c/p/lib -L/Users/conan/.conan2/p/b/opus52624b5050cd2/p/lib -L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib -L/Users/conan/.conan2/p/b/openhe01551d159f83/p/lib -L/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/lib -L/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/lib -L/Users/conan/.conan2/p/b/bzip23a90a39c11490/p/lib -L/Users/conan/.conan2/p/b/libic755e55e19bbe3/p/lib -L/Users/conan/.conan2/p/b/xz_ut8a5ab8ed81b55/p/lib --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Wl,--as-needed -Wl,-z,noexecstack -fPIE -pie -I/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/include -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -L/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib -L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib -o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.qB627zwO/test /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.qB627zwO/test.o -lvorbis -logg
ld.lld: error: undefined symbol: log
>>> referenced by psy.c:273 (/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/b/src/lib/psy.c:273)
>>>               psy.c.o:(_vp_psy_init) in archive /Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib/libvorbis.a
>>> referenced by psy.c:275 (/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/b/src/lib/psy.c:275)
>>>               psy.c.o:(_vp_psy_init) in archive /Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib/libvorbis.a
>>> referenced by psy.c:276 (/Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/b/src/lib/psy.c:276)
>>>               psy.c.o:(_vp_psy_init) in archive /Users/conan/.conan2/p/b/vorbi10ad1729d7c2f/p/lib/libvorbis.a
>>> referenced 8 more times
```


```
/Users/conan/.conan2/p/pkgco429aafb5f4b15/p/bin/pkgconf --exists --print-errors libwebp >= 0.2.0
check_func_headers webp/encode.h WebPGetEncoderVersion -I/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/include -L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib -lwebp -lsharpyuv
test_ld cc -I/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/include -L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib -lwebp -lsharpyuv
test_cc -I/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/include -L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib
BEGIN /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.IGZmI0CE/test.c
    1	#include <webp/encode.h>
    2	#include <stdint.h>
    3	long check_WebPGetEncoderVersion(void) { return (long) WebPGetEncoderVersion; }
    4	int main(void) { int ret = 0;
    5	 ret |= ((intptr_t)check_WebPGetEncoderVersion) & 0xFFFF;
    6	return ret; }
END /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.IGZmI0CE/test.c
/Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang -DNDEBUG -I/Users/conan/.conan2/p/b/freetddb34e758c50c/p/include -I/Users/conan/.conan2/p/b/freetddb34e758c50c/p/include/freetype2 -I/Users/conan/.conan2/p/b/libsvc9ea951b59468/p/include/svt-av1 -I/Users/conan/.conan2/p/b/opens4d14881c0eff9/p/include -I/Users/conan/.conan2/p/b/vorbi030ec5ffe5192/p/include -I/Users/conan/.conan2/p/b/libpn3bcb69dc2c862/p/include -I/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/include -I/Users/conan/.conan2/p/b/libao612e7042df044/p/include -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -I/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/include -I/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/include -I/Users/conan/.conan2/p/b/libmp76afa2e0ebffd/p/include -I/Users/conan/.conan2/p/b/libvpc003ec7703987/p/include -I/Users/conan/.conan2/p/b/libx2e87db79390858/p/include -I/Users/conan/.conan2/p/b/libx25d1604a34db7c/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -I/Users/conan/.conan2/p/b/openhe01551d159f83/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include/openjpeg-2.5 -I/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/include -I/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/include/brotli -I/Users/conan/.conan2/p/b/bzip23a90a39c11490/p/include -I/Users/conan/.conan2/p/b/libic755e55e19bbe3/p/include -I/Users/conan/.conan2/p/b/xz_ut8a5ab8ed81b55/p/include -DLZMA_API_STATIC -D_ISOC11_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Dstrtod=avpriv_strtod -DPIC -fPIC --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -O3 -fPIC --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -O3 -std=c17 -fPIE -fomit-frame-pointer -fPIC -pthread -I/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/include -I/Users/conan/.conan2/p/b/libao612e7042df044/p/include -I/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/include -I/Users/conan/.conan2/p/b/openhe01551d159f83/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include -I/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/include/openjpeg-2.5 -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include -I/Users/conan/.conan2/p/b/opus52624b5050cd2/p/include/opus -I/Users/conan/.conan2/p/b/libsvc9ea951b59468/p/include/svt-av1 -I/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/include -I/Users/conan/.conan2/p/b/vorbi030ec5ffe5192/p/include -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -I/Users/conan/.conan2/p/b/vorbi030ec5ffe5192/p/include -I/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/include -I/Users/conan/.conan2/p/b/libvpc003ec7703987/p/include -I/Users/conan/.conan2/p/b/libvpc003ec7703987/p/include -I/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/include -L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib -c -o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.IGZmI0CE/test.o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.IGZmI0CE/test.c
clang: warning: argument unused during compilation: '-L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib' [-Wunused-command-line-argument]
/Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android26-clang --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -L/Users/conan/.conan2/p/b/freetddb34e758c50c/p/lib -L/Users/conan/.conan2/p/b/libsvc9ea951b59468/p/lib -L/Users/conan/.conan2/p/b/opens4d14881c0eff9/p/lib -L/Users/conan/.conan2/p/b/vorbi030ec5ffe5192/p/lib -L/Users/conan/.conan2/p/b/libpn3bcb69dc2c862/p/lib -L/Users/conan/.conan2/p/b/dav1db64f8b3c9b27c/p/lib -L/Users/conan/.conan2/p/b/libao612e7042df044/p/lib -L/Users/conan/.conan2/p/b/cpuinb98624a7263e6/p/lib -L/Users/conan/.conan2/p/b/zlibf10015565d7e1/p/lib -L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib -L/Users/conan/.conan2/p/b/libmp76afa2e0ebffd/p/lib -L/Users/conan/.conan2/p/b/libvpc003ec7703987/p/lib -L/Users/conan/.conan2/p/b/libx2e87db79390858/p/lib -L/Users/conan/.conan2/p/b/libx25d1604a34db7c/p/lib -L/Users/conan/.conan2/p/b/opus52624b5050cd2/p/lib -L/Users/conan/.conan2/p/b/ogg84f7879795dcd/p/lib -L/Users/conan/.conan2/p/b/openhe01551d159f83/p/lib -L/Users/conan/.conan2/p/b/openjd206ee22cbf11/p/lib -L/Users/conan/.conan2/p/b/brotld93ee24d81f0d/p/lib -L/Users/conan/.conan2/p/b/bzip23a90a39c11490/p/lib -L/Users/conan/.conan2/p/b/libic755e55e19bbe3/p/lib -L/Users/conan/.conan2/p/b/xz_ut8a5ab8ed81b55/p/lib --sysroot /Users/conan/.conan2/p/b/andro84569d51af9c2/p/bin/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -Wl,--as-needed -Wl,-z,noexecstack -fPIE -pie -I/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/include -L/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib -o /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.IGZmI0CE/test /var/folders/j3/bswhj5j50db0cqjgkbc2cdy00000gn/T//ffconf.IGZmI0CE/test.o -lwebp -lsharpyuv
ld.lld: error: undefined symbol: log10
>>> referenced by webp_enc.c:268 (/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/b/src/src/enc/webp_enc.c:268)
>>>               webp_enc.c.o:(StoreStats) in archive /Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib/libwebp.a
>>> referenced by webp_enc.c:268 (/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/b/src/src/enc/webp_enc.c:268)
>>>               webp_enc.c.o:(StoreStats) in archive /Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib/libwebp.a
>>> referenced by webp_enc.c:268 (/Users/conan/.conan2/p/b/libweaa39c20ec5dd1/b/src/src/enc/webp_enc.c:268)
>>>               webp_enc.c.o:(StoreStats) in archive /Users/conan/.conan2/p/b/libweaa39c20ec5dd1/p/lib/libwebp.a
>>> referenced 4 more times
```


Close https://github.com/conan-io/conan-center-index/issues/24640