### PR TITLE
Fix simd build

### DIFF
--- a/recipes/simd/all/conanfile.py
+++ b/recipes/simd/all/conanfile.py
@@ -67,6 +67,8 @@ class SimdConan(ConanFile):
             tc = CMakeToolchain(self)
             tc.variables["SIMD_TEST"] = False
             tc.variables["SIMD_SHARED"] = self.options.shared
+            tc.variables["SIMD_TOOLCHAIN"] = ""
+            tc.variables["SIMD_TARGET"] = ""
             tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
             tc.generate()
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **simd/6.1.143**

#### Motivation
The simd build expects cmake variables `SIMD_TOOLCHAIN` and `SIMD_TARGET` to be set (source https://github.com/ermig1979/Simd/blob/dcfe97350f98b5d9c93aa2179990efe1d3dcb755/README.md?plain=1#L68).
By not setting these variables the build will fail (`CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` will get replaced by empty strings).

#### Details
By setting `SIMD_TOOLCHAIN=""` the cmake variables `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` wont be changed (source https://github.com/ermig1979/Simd/blob/dcfe97350f98b5d9c93aa2179990efe1d3dcb755/prj/cmake/CMakeLists.txt#L46)
By setting `SIMD_TARGET=""` the current arch is being used as target (source https://github.com/ermig1979/Simd/blob/dcfe97350f98b5d9c93aa2179990efe1d3dcb755/prj/cmake/CMakeLists.txt#L31)


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
