### PR TITLE
vulkan-memory-allocator: relax vulkan-headers version requirement

### DIFF
--- a/recipes/vulkan-memory-allocator/all/conanfile.py
+++ b/recipes/vulkan-memory-allocator/all/conanfile.py
@@ -29,7 +29,7 @@ class VulkanMemoryAllocatorConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("vulkan-headers/1.3.243.0")
+        self.requires("vulkan-headers/[>=1.0]")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-memory-allocator/***

#### Motivation
`vulkan-headers` version is too restrictive as VMA states to support Vulkan 1.0...1.4

#### Details
Modified `vulkan-headers` requirement to be at least 1.0

Tested on Windows/MSVC with vulkan-headers already in cache (uses an existing version) and using `conanio/gcc11-ubuntu16.04` image (takes the latest `vulkan-headers`)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
