### PR TITLE
[joltphysics] Export missing compiler definitions

### DIFF
--- a/recipes/joltphysics/5.x/conanfile.py
+++ b/recipes/joltphysics/5.x/conanfile.py
@@ -90,6 +90,11 @@ class JoltPhysicsConan(ConanFile):
             self.cpp_info.defines.extend(["JPH_USE_AVX2", "JPH_USE_AVX", "JPH_USE_SSE4_1",
                                           "JPH_USE_SSE4_2", "JPH_USE_LZCNT", "JPH_USE_TZCNT",
                                           "JPH_USE_F16C", "JPH_USE_FMADD"])
+        if is_msvc(self):
+            # INFO: Floating point exceptions are enabled by default
+            # https://github.com/jrouwe/JoltPhysics/blob/v5.2.0/Build/CMakeLists.txt#L37
+            # https://github.com/jrouwe/JoltPhysics/blob/v5.2.0/Jolt/Jolt.cmake#L529
+            self.cpp_info.defines.append("JPH_FLOATING_POINT_EXCEPTIONS_ENABLED")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("pthread")

--- a/recipes/joltphysics/5.x/conanfile.py
+++ b/recipes/joltphysics/5.x/conanfile.py
@@ -96,5 +96,13 @@ class JoltPhysicsConan(ConanFile):
             # https://github.com/jrouwe/JoltPhysics/blob/v5.2.0/Jolt/Jolt.cmake#L529
             self.cpp_info.defines.append("JPH_FLOATING_POINT_EXCEPTIONS_ENABLED")
 
+        if self.options.shared:
+            # https://github.com/jrouwe/JoltPhysics/blob/v5.2.0/Jolt/Jolt.cmake#L495
+            self.cpp_info.defines.append("JPH_SHARED_LIBRARY")
+
+        # https://github.com/jrouwe/JoltPhysics/blob/v5.2.0/Build/CMakeLists.txt#L48
+        # https://github.com/jrouwe/JoltPhysics/blob/v5.2.0/Jolt/Jolt.cmake#L554
+        self.cpp_info.defines.append("JPH_OBJECT_LAYER_BITS=16")
+
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("pthread")

--- a/recipes/joltphysics/5.x/test_package/test_package.cpp
+++ b/recipes/joltphysics/5.x/test_package/test_package.cpp
@@ -1,8 +1,12 @@
 #include <cstdlib>
 #include <Jolt/Jolt.h>
+#include <Jolt/Core/Factory.h>
+#include <Jolt/RegisterTypes.h>
 
 
 int main() {
     JPH::RegisterDefaultAllocator();
+    auto factory = JPH::Factory();
+    JPH::UnregisterTypes();
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Changes to recipe:  **joltphysics/5.2.0**

#### Motivation

I'm able to reproduce the bug reported by #26561. The Joltphysics has several compiler definition exposed as public, but some of them are missing in the recipe: https://github.com/jrouwe/JoltPhysics/blob/v5.2.0/Jolt/Jolt.cmake

fixes #26561

#### Details

Build logs on Windows, using the example listed in issue #26561

- [jost-static-fix-windows.log](https://github.com/user-attachments/files/18795297/jost-static-fix-windows.log)
- [jost-shared-fix-windows.log](https://github.com/user-attachments/files/18795298/jost-shared-fix-windows.log)

/cc @AbrilRBS 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
