### PR TITLE
Export binutils libraries

### DIFF
--- a/recipes/binutils/all/conanfile.py
+++ b/recipes/binutils/all/conanfile.py
@@ -22,7 +22,7 @@ class BinutilsConan(ConanFile):
     description = "The GNU Binutils are a collection of binary tools."
     package_type = "library"
     license = "GPL-2.0-or-later"
-    url = "https://github.com/conan-io/conan-center-index/"
+    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.gnu.org/software/binutils"
     topics = ("gnu", "ld", "linker", "as", "assembler", "objcopy", "objdump")
     settings = "os", "arch", "compiler", "build_type"
@@ -67,6 +67,8 @@ class BinutilsConan(ConanFile):
     def configure(self):
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
         if not self.options.target_triplet:
             if not self.options.target_arch:

--- a/recipes/binutils/all/conanfile.py
+++ b/recipes/binutils/all/conanfile.py
@@ -172,7 +172,7 @@ class BinutilsConan(ConanFile):
         autotools.install()
 
         rmdir(self, os.path.join(self.package_folder, "share"))
-        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"), recursive=True)
         copy(
             self,
             pattern="COPYING*",

--- a/recipes/binutils/all/conanfile.py
+++ b/recipes/binutils/all/conanfile.py
@@ -189,7 +189,21 @@ class BinutilsConan(ConanFile):
 
         absolute_target_bindir = os.path.join(self.package_folder, target_bindir)
 
-        self.cpp_info.libs = ["bfd", "ctf", "ctf-nobfd", "gprofng", "opcodes", "sframe"]
+        self.cpp_info.components["sframe"].libs = ["sframe"]
+
+        self.cpp_info.components["ctf-nobfd"].libs = ["ctf-nobfd"]
+
+        self.cpp_info.components["bfd"].libs = ["bfd"]
+        self.cpp_info.components["bfd"].requires = ["sframe"]
+
+        self.cpp_info.components["gprofng"].libs = ["gprofng"]
+        self.cpp_info.components["gprofng"].requires = ["opcodes", "bfd"]
+
+        self.cpp_info.components["opcodes"].libs = ["opcodes"]
+        self.cpp_info.components["opcodes"].requires = ["bfd"]
+
+        self.cpp_info.components["ctf"].libs = ["ctf"]
+        self.cpp_info.components["ctf"].requires = ["bfd"]
 
         # v1 exports
         bindir = os.path.join(self.package_folder, "bin")

--- a/recipes/binutils/all/test_package/CMakeLists.txt
+++ b/recipes/binutils/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
-find_package(binutils REQUIRED CONFIG)
+find_package(binutils COMPONENTS bfd sframe ctf-nobfd gprofng opcodes ctf REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} binutils::binutils)
+target_link_libraries(${PROJECT_NAME} binutils::sframe)

--- a/recipes/binutils/all/test_package/CMakeLists.txt
+++ b/recipes/binutils/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(binutils REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} binutils::binutils)

--- a/recipes/binutils/all/test_package/conanfile.py
+++ b/recipes/binutils/all/test_package/conanfile.py
@@ -14,9 +14,6 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
-
     def build(self):
         cmake = CMake(self)
         cmake.configure()
@@ -39,7 +36,7 @@ class TestPackageConan(ConanFile):
                 binaries.append("ld")
 
             for binary in binaries:
-                self.run(f"{binary} --version", env="conanbuild")
+                self.run(f"{binary} --version", env="conanrun")
 
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/binutils/all/test_package/conanfile.py
+++ b/recipes/binutils/all/test_package/conanfile.py
@@ -1,36 +1,45 @@
 from conan import ConanFile
-from conan.tools.layout import basic_layout
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualBuildEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     @property
     def _has_as(self):
-        return self._settings_build.os not in ("Macos",)
+        return self.settings_build.os not in ("Macos",)
 
     @property
     def _has_ld(self):
-        return self._settings_build.os not in ("Macos",)
-
-    def layout(self):
-        basic_layout(self)
+        return self.settings_build.os not in ("Macos",)
 
     def test(self):
-        binaries = ["ar", "nm", "objcopy", "objdump", "ranlib", "readelf", "strip"]
-        if self._has_as:
-            binaries.append("as")
-        if self._has_ld:
-            binaries.append("ld")
+        if can_run(self):
+            binaries = ["ar", "nm", "objcopy", "objdump", "ranlib", "readelf", "strip"]
+            if self._has_as:
+                binaries.append("as")
+            if self._has_ld:
+                binaries.append("ld")
 
-        for binary in binaries:
-            self.run(f"{binary} --version", env="conanbuild")
+            for binary in binaries:
+                self.run(f"{binary} --version", env="conanbuild")
+
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/binutils/all/test_package/test_package.c
+++ b/recipes/binutils/all/test_package/test_package.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <sframe-api.h>
+
+
+int main(void) {
+    const char* error_msg = sframe_errmsg(SFRAME_ERR_VERSION_INVAL);
+    printf("Conan test package - binutils error message as validation: %s\n", error_msg);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
### Summary

Changes to recipe:  **binutils/2.42**

#### Motivation

closes #26568

#### Details

Other package managers, like Arch Linux are packaging the libraries as well: https://archlinux.org/packages/core/x86_64/binutils/files/

Plus, binutils is a requirement for backward-cpp too: https://github.com/bombela/backward-cpp/tree/master?tab=readme-ov-file#libunwind-from-the-libunwind-project

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
Signed-off-by: Uilian Ries <uilianries@gmail.com>