### PR TITLE
stacktrace: add version 1.0.0

### DIFF
--- a/recipes/stacktrace/all/conanfile.py
+++ b/recipes/stacktrace/all/conanfile.py
@@ -1,0 +1,45 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=2.0"
+
+
+class PackageConan(ConanFile):
+    name = "stacktrace"
+    version = "1.0"
+    description = "Print stack backtrace programmatically with demangled function names"
+    license = "WTFPL"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://panthema.net/2008/0901-stacktrace-demangled/"
+    topics = ("stacktrace", "backtrace", "backtrace_symbols", "demangle", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def export_sources(self):
+        copy(self, "stacktrace.h", self.recipe_folder, self.export_sources_folder)
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        check_min_cppstd(self, 98)
+        if str(self.settings.compiler) not in ["gcc", "clang"]:
+            raise ConanInvalidConfiguration(f"{self.ref} does only demangle gcc and clang properly.")
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration(f"{self.ref} might not compile on Windows.")
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "stacktrace.h", self.source_folder, os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/stacktrace/all/stacktrace.h
+++ b/recipes/stacktrace/all/stacktrace.h
@@ -1,0 +1,93 @@
+// stacktrace.h (c) 2008, Timo Bingmann from http://idlebox.net/
+// published under the WTFPL v2.0
+
+#ifndef _STACKTRACE_H_
+#define _STACKTRACE_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <execinfo.h>
+#include <cxxabi.h>
+
+/** Print a demangled stack backtrace of the caller function to FILE* out. */
+static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63)
+{
+    fprintf(out, "stack trace:\n");
+
+    // storage array for stack trace address data
+    void* addrlist[max_frames+1];
+
+    // retrieve current stack addresses
+    int addrlen = backtrace(addrlist, sizeof(addrlist) / sizeof(void*));
+
+    if (addrlen == 0) {
+	fprintf(out, "  <empty, possibly corrupt>\n");
+	return;
+    }
+
+    // resolve addresses into strings containing "filename(function+address)",
+    // this array must be free()-ed
+    char** symbollist = backtrace_symbols(addrlist, addrlen);
+
+    // allocate string which will be filled with the demangled function name
+    size_t funcnamesize = 256;
+    char* funcname = (char*)malloc(funcnamesize);
+
+    // iterate over the returned symbol lines. skip the first, it is the
+    // address of this function.
+    for (int i = 1; i < addrlen; i++)
+    {
+	char *begin_name = 0, *begin_offset = 0, *end_offset = 0;
+
+	// find parentheses and +address offset surrounding the mangled name:
+	// ./module(function+0x15c) [0x8048a6d]
+	for (char *p = symbollist[i]; *p; ++p)
+	{
+	    if (*p == '(')
+		begin_name = p;
+	    else if (*p == '+')
+		begin_offset = p;
+	    else if (*p == ')' && begin_offset) {
+		end_offset = p;
+		break;
+	    }
+	}
+
+	if (begin_name && begin_offset && end_offset
+	    && begin_name < begin_offset)
+	{
+	    *begin_name++ = '\0';
+	    *begin_offset++ = '\0';
+	    *end_offset = '\0';
+
+	    // mangled name is now in [begin_name, begin_offset) and caller
+	    // offset in [begin_offset, end_offset). now apply
+	    // __cxa_demangle():
+
+	    int status;
+	    char* ret = abi::__cxa_demangle(begin_name,
+					    funcname, &funcnamesize, &status);
+	    if (status == 0) {
+		funcname = ret; // use possibly realloc()-ed string
+		fprintf(out, "  %s : %s+%s\n",
+			symbollist[i], funcname, begin_offset);
+	    }
+	    else {
+		// demangling failed. Output function name as a C function with
+		// no arguments.
+		fprintf(out, "  %s : %s()+%s\n",
+			symbollist[i], begin_name, begin_offset);
+	    }
+	}
+	else
+	{
+	    // couldn't parse the line? print the whole line.
+	    fprintf(out, "  %s\n", symbollist[i]);
+	}
+    }
+
+    free(funcname);
+    free(symbollist);
+}
+
+#endif // _STACKTRACE_H_

--- a/recipes/stacktrace/all/test_package/CMakeLists.txt
+++ b/recipes/stacktrace/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(stacktrace REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE stacktrace::stacktrace)

--- a/recipes/stacktrace/all/test_package/conanfile.py
+++ b/recipes/stacktrace/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/stacktrace/all/test_package/test_package.cpp
+++ b/recipes/stacktrace/all/test_package/test_package.cpp
@@ -1,0 +1,38 @@
+#include "stacktrace.h"
+#include <map>
+
+namespace Nu {
+
+template<typename Type>
+struct Alpha {
+    struct Beta {
+	void func() {
+	    print_stacktrace();
+	}
+	void func(Type) {
+	    print_stacktrace();
+	}
+    };
+};
+
+struct Gamma {
+    template <int N>
+    void unroll(double d) {
+	unroll<N-1>(d);
+    }
+};
+
+template<>
+void Gamma::unroll<0>(double) {
+    print_stacktrace();
+}
+
+} // namespace Nu
+
+int main(void) {
+    Nu::Alpha<int>::Beta().func(42);
+    Nu::Alpha<char*>::Beta().func("42");
+    Nu::Alpha< Nu::Alpha< std::map<int, double> > >::Beta().func();
+    Nu::Gamma().unroll<5>(42.0);
+    return EXIT_SUCCESS;
+}

--- a/recipes/stacktrace/config.yml
+++ b/recipes/stacktrace/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **stacktrace/[1.0.0]**

#### Motivation
I'd like to get rid of a submodule in our project.
For most of my dependencies there existed conan2 packages, this one is lacking.

The header is small, not expected to change anymore and not present in git or zip-form.

#### Details

In 2008 Timo Bingmann wrote a useful helper to demangle gcc/clang compilations and did a writeup: https://panthema.net/2008/0901-stacktrace-demangled/

I really appreciate the size/usefulness ratio and would like to see it in the CCI.

There is currently no CCI issue this PR fixes, as I did read the guide after implementing the recipe. I can open an issue if desired, just feel like we can discuss the contribution here as well.

_I'm a first time contributor, and though I read the guidelines and the packaging tutorial increased attention to detail while reviewing might be in order :)_

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan **2.12.2**
