### PR TITLE
Add onetbb 2021.13.0 and add recipe flags to build into apple frameworks

### DIFF
--- a/recipes/onetbb/all/conandata.yml
+++ b/recipes/onetbb/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "2022.0.0":
     url: "https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2022.0.0.tar.gz"
     sha256: "e8e89c9c345415b17b30a2db3095ba9d47647611662073f7fbf54ad48b7f3c2a"
+  "2021.13.0":
+    url: "https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.13.0.tar.gz"
+    sha256: "3ad5dd08954b39d113dc5b3f8a8dc6dc1fd5250032b7c491eb07aed5c94133e1"
   "2021.12.0":
     url: "https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.12.0.tar.gz"
     sha256: "c7bb7aa69c254d91b8f0041a71c5bcc3936acb64408a1719aec0b2b7639dd84f"

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -61,7 +61,8 @@ class OneTBBConan(ConanFile):
 
     @property
     def _tbb_apple_frameworks_supported(self):
-        return self.settings.os == "Macos" and Version(self.version) >= "2021.12.0"
+        # if the version is 2021.13.0 or later, the build_apple_frameworks option is supported on macOS
+        return self.settings.os == "Macos" and Version(self.version) >= "2021.13.0"
 
     @property
     def _tbbbind_build(self):

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -61,8 +61,10 @@ class OneTBBConan(ConanFile):
 
     @property
     def _tbb_apple_frameworks_supported(self):
-        # if the version is 2021.13.0 or later, the build_apple_frameworks option is supported on macOS
-        return self.settings.os == "Macos" and Version(self.version) >= "2021.13.0"
+        if is_apple_os(self):
+            # if the version is 2021.13.0 or later, the build_apple_frameworks option is supported on macOS
+            return Version(self.version) >= "2021.13.0"
+        return False
 
     @property
     def _tbbbind_build(self):

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -30,12 +30,14 @@ class OneTBBConan(ConanFile):
         "tbbproxy": [True, False],
         "tbbbind": [True, False],
         "interprocedural_optimization": [True, False],
+        "build_apple_frameworks": [True, False],
     }
     default_options = {
         "tbbmalloc": True,
         "tbbproxy": True,
         "tbbbind": True,
         "interprocedural_optimization": True,
+        "build_apple_frameworks": False,
     }
 
     @property
@@ -56,6 +58,10 @@ class OneTBBConan(ConanFile):
         if is_apple_os(self):
             return self.settings.os == "Macos" and Version(self.version) >= "2021.11.0"
         return True
+
+    @property
+    def _tbb_apple_frameworks_supported(self):
+        return self.settings.os == "Macos" and Version(self.version) >= "2021.12.0"
 
     @property
     def _tbbbind_build(self):
@@ -79,6 +85,8 @@ class OneTBBConan(ConanFile):
             del self.options.tbbbind
         if Version(self.version) < "2021.6.0" or self.settings.os == "Android":
             del self.options.interprocedural_optimization
+        if not self._tbb_apple_frameworks_supported:
+            del self.options.build_apple_frameworks
 
     def configure(self):
         if Version(self.version) >= "2021.6.0" and not self.options.tbbmalloc:
@@ -133,6 +141,8 @@ class OneTBBConan(ConanFile):
             if self.settings.os == "Windows":
                 toolchain.variables[f"CMAKE_HWLOC_{self._tbbbind_hwloc_version}_DLL_PATH"] = \
                     os.path.join(hwloc_package_folder, "bin", "hwloc.dll").replace("\\", "/")
+        if self.options.get_safe("build_apple_frameworks"):
+            toolchain.variables["TBB_BUILD_APPLE_FRAMEWORKS"] = True
         toolchain.generate()
 
         if self._tbbbind_build and not self._tbbbind_explicit_hwloc:
@@ -168,7 +178,11 @@ class OneTBBConan(ConanFile):
         tbb = self.cpp_info.components["libtbb"]
 
         tbb.set_property("cmake_target_name", "TBB::tbb")
-        tbb.libs = [lib_name("tbb")]
+        if self.options.get_safe("build_apple_frameworks"):
+            tbb.frameworkdirs.append(os.path.join(self.package_folder, "lib"))
+            tbb.frameworks.append("tbb")
+        else:
+            tbb.libs = [lib_name("tbb")]
         if self.settings.os == "Windows":
             version_info = load(self,
                 os.path.join(self.package_folder, "include", "oneapi", "tbb",
@@ -189,7 +203,13 @@ class OneTBBConan(ConanFile):
             tbbmalloc = self.cpp_info.components["tbbmalloc"]
 
             tbbmalloc.set_property("cmake_target_name", "TBB::tbbmalloc")
-            tbbmalloc.libs = [lib_name("tbbmalloc")]
+
+            if self.options.get_safe("build_apple_frameworks"):
+                tbbmalloc.frameworkdirs.append(os.path.join(self.package_folder, "lib"))
+                tbbmalloc.frameworks.append("tbbmalloc")
+            else:
+                tbbmalloc.libs = [lib_name("tbbmalloc")]
+
             if self.settings.os in ["Linux", "FreeBSD"]:
                 tbbmalloc.system_libs = ["dl", "pthread"]
 
@@ -198,7 +218,13 @@ class OneTBBConan(ConanFile):
                 tbbproxy = self.cpp_info.components["tbbmalloc_proxy"]
 
                 tbbproxy.set_property("cmake_target_name", "TBB::tbbmalloc_proxy")
-                tbbproxy.libs = [lib_name("tbbmalloc_proxy")]
+                
+                if self.options.get_safe("build_apple_frameworks"):
+                    tbbproxy.frameworkdirs.append(os.path.join(self.package_folder, "lib"))
+                    tbbproxy.frameworks.append("tbbmalloc_proxy")
+                else:
+                    tbbproxy.libs = [lib_name("tbbmalloc_proxy")]
+
                 tbbproxy.requires = ["tbbmalloc"]
                 if self.settings.os in ["Linux", "FreeBSD"]:
                     tbbproxy.system_libs = ["m", "dl", "pthread"]

--- a/recipes/onetbb/config.yml
+++ b/recipes/onetbb/config.yml
@@ -1,6 +1,8 @@
 versions:
   "2022.0.0":
     folder: all
+  "2021.13.0":
+    folder: all
   "2021.12.0":
     folder: all
   "2021.10.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  onetbb

#### Motivation
in OneTBB 2021.13.0 a new flag has been added to allow tbb to be build into Apple .frameworks instead of dylibs. iOS doesn't allow for bare dylibs to be loaded unless they are system libaries.

#### Details
- add source url for version 2021.13.0
- add an 'Apple OS only' recipe option to enable oneTBB to build into frameworks

I'm aware there is also a PR for 2022.0.0, but that one doesn't add the build option 'build_apple_frameworks' and makes some changes to the test_package, so scope isn't the same.
Since that PR doesn't make changes to the recipe itself, merging should be easy.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
