### PR TITLE
protobuf: add version 5.29.3, depends on toge:protobuf-5.28.2

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "5.28.3":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.tar.gz"
     sha256: "7fce939b9b7181bd0bd157360e0cc88a8cabf01ac4efe4662494f56dd955d4c1"
+  "5.28.2":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.2.tar.gz"
+    sha256: "31c6cc07431af43dcc056a2fbfe1aaa09e53d95f77685db79f054d490145ed97"
   "5.27.0":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.27.0.tar.gz"
     sha256: "1611a03e550c27c526bde1da544c94f7aa65c10687bbc8e570537dfa94069e1a"
@@ -28,6 +31,45 @@ patches:
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
   "5.28.3":
+      - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_if_constexpr
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_optional
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_type_traits
+    - absl_utility
+    - absl_variant
+  "5.28.2":
     - absl_absl_check
     - absl_absl_log
     - absl_algorithm

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -73,7 +73,7 @@ absl_deps:
     - absl_utility
     - absl_variant
   "5.28.3":
-      - absl_absl_check
+    - absl_absl_check
     - absl_absl_log
     - absl_algorithm
     - absl_base

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -5,9 +5,6 @@ sources:
   "5.28.3":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.tar.gz"
     sha256: "7fce939b9b7181bd0bd157360e0cc88a8cabf01ac4efe4662494f56dd955d4c1"
-  "5.28.2":
-    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.2.tar.gz"
-    sha256: "31c6cc07431af43dcc056a2fbfe1aaa09e53d95f77685db79f054d490145ed97"
   "5.27.0":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.27.0.tar.gz"
     sha256: "1611a03e550c27c526bde1da544c94f7aa65c10687bbc8e570537dfa94069e1a"
@@ -73,45 +70,6 @@ absl_deps:
     - absl_utility
     - absl_variant
   "5.28.3":
-    - absl_absl_check
-    - absl_absl_log
-    - absl_algorithm
-    - absl_base
-    - absl_bind_front
-    - absl_bits
-    - absl_btree
-    - absl_cleanup
-    - absl_cord
-    - absl_core_headers
-    - absl_debugging
-    - absl_die_if_null
-    - absl_dynamic_annotations
-    - absl_flags
-    - absl_flat_hash_map
-    - absl_flat_hash_set
-    - absl_function_ref
-    - absl_hash
-    - absl_if_constexpr
-    - absl_layout
-    - absl_log_initialize
-    - absl_log_globals
-    - absl_log_severity
-    - absl_memory
-    - absl_node_hash_map
-    - absl_node_hash_set
-    - absl_optional
-    - absl_random_distributions
-    - absl_random_random
-    - absl_span
-    - absl_status
-    - absl_statusor
-    - absl_strings
-    - absl_synchronization
-    - absl_time
-    - absl_type_traits
-    - absl_utility
-    - absl_variant
-  "5.28.2":
     - absl_absl_check
     - absl_absl_log
     - absl_algorithm

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.29.3":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.29.3.tar.gz"
+    sha256: "7fce939b9b7181bd0bd157360e0cc88a8cabf01ac4efe4662494f56dd955d4c1"
   "5.28.3":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.tar.gz"
     sha256: "7fce939b9b7181bd0bd157360e0cc88a8cabf01ac4efe4662494f56dd955d4c1"
@@ -30,6 +33,45 @@ patches:
       patch_source: "https://github.com/protocolbuffers/protobuf/pull/10103"
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
+  "5.29.3":
+    - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_if_constexpr
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_optional
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_type_traits
+    - absl_utility
+    - absl_variant
   "5.28.3":
       - absl_absl_check
     - absl_absl_log

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "5.29.3":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.29.3.tar.gz"
-    sha256: "7fce939b9b7181bd0bd157360e0cc88a8cabf01ac4efe4662494f56dd955d4c1"
+    sha256: "fe35f190d7a63533b06558915d6ee469cbee143de70891e1dd54d197b05f362a"
   "5.28.3":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.tar.gz"
     sha256: "7fce939b9b7181bd0bd157360e0cc88a8cabf01ac4efe4662494f56dd955d4c1"

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.28.3":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.tar.gz"
+    sha256: "7fce939b9b7181bd0bd157360e0cc88a8cabf01ac4efe4662494f56dd955d4c1"
   "5.27.0":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.27.0.tar.gz"
     sha256: "1611a03e550c27c526bde1da544c94f7aa65c10687bbc8e570537dfa94069e1a"
@@ -23,6 +26,46 @@ patches:
       patch_type: "bugfix"
       patch_source: "https://github.com/protocolbuffers/protobuf/pull/10103"
 absl_deps:
+  # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
+  "5.28.3":
+    - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_if_constexpr
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_optional
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_type_traits
+    - absl_utility
+    - absl_variant
   "5.27.0":
     - absl_absl_check
     - absl_absl_log

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -259,7 +259,7 @@ class ProtobufConan(ConanFile):
         self.cpp_info.components["libprotobuf"].libs = [lib_prefix + "protobuf" + lib_suffix]
         if self.options.with_zlib:
             self.cpp_info.components["libprotobuf"].requires = ["zlib::zlib"]
-        if self._protobuf_release >= "22.0":    
+        if self._protobuf_release >= "22.0":     
             self.cpp_info.components["libprotobuf"].requires.extend(absl_deps)
             if not self.options.shared:
                 self.cpp_info.components["libprotobuf"].requires.extend(["utf8_validity"])

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -15,10 +15,10 @@ required_conan_version = ">=1.53"
 class ProtobufConan(ConanFile):
     name = "protobuf"
     description = "Protocol Buffers - Google's data interchange format"
-    topics = ("protocol-buffers", "protocol-compiler", "serialization", "rpc", "protocol-compiler")
+    license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/protocolbuffers/protobuf"
-    license = "BSD-3-Clause"
+    topics = ("protocol-buffers", "protocol-compiler", "serialization", "rpc", "protocol-compiler")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -49,7 +49,7 @@ class ProtobufConan(ConanFile):
     @property
     def _is_clang_x86(self):
         return self.settings.compiler == "clang" and self.settings.arch == "x86"
-    
+
     @property
     def _protobuf_release(self):
         current_ver = Version(self.version)
@@ -78,7 +78,7 @@ class ProtobufConan(ConanFile):
             self.requires("zlib/[>=1.2.11 <2]")
 
         if self._protobuf_release >= "22.0":
-            self.requires("abseil/20240116.2", transitive_headers=True)
+            self.requires("abseil/[>=20230802.1 <=20240722.0]", transitive_headers=True)
 
     @property
     def _compilers_minimum_version(self):
@@ -93,7 +93,7 @@ class ProtobufConan(ConanFile):
     def validate(self):
         if self.options.shared and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration("Protobuf can't be built with shared + MT(d) runtimes")
-        
+
         if is_msvc(self) and self._protobuf_release >= "22" and self.options.shared and \
             not self.dependencies["abseil"].options.shared:
             raise ConanInvalidConfiguration("When building protobuf as a shared library on Windows, "
@@ -109,7 +109,7 @@ class ProtobufConan(ConanFile):
                     raise ConanInvalidConfiguration(
                         f"{self.ref} requires C++14, which your compiler does not support.",
                     )
-        
+
         check_min_vs(self, "190")
 
         if self.settings.compiler == "clang":
@@ -259,7 +259,7 @@ class ProtobufConan(ConanFile):
         self.cpp_info.components["libprotobuf"].libs = [lib_prefix + "protobuf" + lib_suffix]
         if self.options.with_zlib:
             self.cpp_info.components["libprotobuf"].requires = ["zlib::zlib"]
-        if self._protobuf_release >= "22.0":     
+        if self._protobuf_release >= "22.0":
             self.cpp_info.components["libprotobuf"].requires.extend(absl_deps)
             if not self.options.shared:
                 self.cpp_info.components["libprotobuf"].requires.extend(["utf8_validity"])

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -15,10 +15,10 @@ required_conan_version = ">=1.53"
 class ProtobufConan(ConanFile):
     name = "protobuf"
     description = "Protocol Buffers - Google's data interchange format"
-    license = "BSD-3-Clause"
+    topics = ("protocol-buffers", "protocol-compiler", "serialization", "rpc", "protocol-compiler")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/protocolbuffers/protobuf"
-    topics = ("protocol-buffers", "protocol-compiler", "serialization", "rpc", "protocol-compiler")
+    license = "BSD-3-Clause"
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -49,7 +49,7 @@ class ProtobufConan(ConanFile):
     @property
     def _is_clang_x86(self):
         return self.settings.compiler == "clang" and self.settings.arch == "x86"
-
+    
     @property
     def _protobuf_release(self):
         current_ver = Version(self.version)
@@ -93,7 +93,7 @@ class ProtobufConan(ConanFile):
     def validate(self):
         if self.options.shared and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration("Protobuf can't be built with shared + MT(d) runtimes")
-
+        
         if is_msvc(self) and self._protobuf_release >= "22" and self.options.shared and \
             not self.dependencies["abseil"].options.shared:
             raise ConanInvalidConfiguration("When building protobuf as a shared library on Windows, "
@@ -109,7 +109,7 @@ class ProtobufConan(ConanFile):
                     raise ConanInvalidConfiguration(
                         f"{self.ref} requires C++14, which your compiler does not support.",
                     )
-
+        
         check_min_vs(self, "190")
 
         if self.settings.compiler == "clang":
@@ -259,7 +259,7 @@ class ProtobufConan(ConanFile):
         self.cpp_info.components["libprotobuf"].libs = [lib_prefix + "protobuf" + lib_suffix]
         if self.options.with_zlib:
             self.cpp_info.components["libprotobuf"].requires = ["zlib::zlib"]
-        if self._protobuf_release >= "22.0":
+        if self._protobuf_release >= "22.0":    
             self.cpp_info.components["libprotobuf"].requires.extend(absl_deps)
             if not self.options.shared:
                 self.cpp_info.components["libprotobuf"].requires.extend(["utf8_validity"])

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -3,8 +3,6 @@ versions:
     folder: all
   "5.28.3":
     folder: all
-  "5.28.2":
-    folder: all
   "5.27.0":
     folder: all
   "4.25.3":

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,5 +1,7 @@
 versions:
   "5.28.3":
+    folder: all  
+  "5.28.2":
     folder: all
   "5.27.0":
     folder: all

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.28.3":
+    folder: all
   "5.27.0":
     folder: all
   "4.25.3":

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,6 +1,8 @@
 versions:
+  "5.29.3":
+    folder: all
   "5.28.3":
-    folder: all  
+    folder: all
   "5.28.2":
     folder: all
   "5.27.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuf/* **
Fixes https://github.com/conan-io/conan-center-index/issues/26604

#### Motivation
Remaining current with protobuf repo releases

Started from https://github.com/conan-io/conan-center-index/pull/25693, who deserves most of the credit

#### Details

https://github.com/protocolbuffers/protobuf/compare/v27.0...v29.3

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
