### PR TITLE
libsndio: add cross-compilation support

### DIFF
--- a/recipes/libsndio/all/conanfile.py
+++ b/recipes/libsndio/all/conanfile.py
@@ -79,7 +79,7 @@ class LibsndioConan(ConanFile):
         tc.configure_args.append("--datadir=${prefix}/res")
 
         # Bundled `configure` script does not support these options, so remove
-        exclusions = ["--enable-shared", "--disable-shared", "--disable-static", "--enable-static", "--sbindir", "--oldincludedir"]
+        exclusions = ["--enable-shared", "--disable-shared", "--disable-static", "--enable-static", "--sbindir", "--oldincludedir", "--host", "--build"]
         tc.configure_args = [arg for arg in tc.configure_args if not any(exclusion in arg for exclusion in exclusions)]
 
         # Add alsa support

--- a/recipes/libsndio/all/conanfile.py
+++ b/recipes/libsndio/all/conanfile.py
@@ -140,8 +140,3 @@ class LibsndioConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "sndio")
         self.cpp_info.libs = ["sndio"]
         self.cpp_info.system_libs = ["dl", "m", "rt"]
-
-        # TODO: to remove in conan v2?
-        self.cpp_info.names["cmake_find_package"] = "sndio"
-        self.cpp_info.names["cmake_find_package_multi"] = "sndio"
-        self.cpp_info.names["pkg_config"] = "sndio"

--- a/recipes/libsndio/all/test_package/CMakeLists.txt
+++ b/recipes/libsndio/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(sndio REQUIRED CONFIG)

--- a/recipes/libsndio/all/test_package/conanfile.py
+++ b/recipes/libsndio/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsndio/[*]**

#### Motivation
Enables the recipe to be cross-compiled on Linux, and most likely on other platforms as well.

#### Details
Only needed to make sure `--host` and `--build` triplet flags are not being dropped from the ./configure command.

Also cleaned up all Conan v1 compatibility cruft.

#### Logs
<details>
  <summary>Build failure before the changes</summary>
  
  ```
  libsndio/1.9.0: Calling build()
  libsndio/1.9.0: RUN: "/home/user/.conan2/p/b/libsnfd5927499fad0/b/configure" --prefix=/ '--bindir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' --host=aarch64-linux-gnu --build=x86_64-linux-gnu '--datadir=${prefix}/res' --disable-alsa CFLAGS= LDFLAGS= 
  Usage: configure [options]
  --prefix=DIR			set arch independent install prefix to DIR [/]
  --exec-prefix=DIR		set arch dependent install prefix to DIR [$prefix]
  --bindir=DIR			install executables in DIR [$exec_prefix/bin]
  --datadir=DIR			install read-only data in DIR [$prefix/share]
  --includedir=DIR		install header files in DIR [$prefix/include]
  --libdir=DIR			install libraries in DIR [$exec_prefix/lib]
  --pkgconfdir=DIR		install pkg-config file in DIR [$libdir/pkgconfig]
  --mandir=DIR			install man pages in DIR [$prefix/man]
  --precision=NUMBER		default sndiod device bit-depth [16]
  --privsep-user=USER		non-privileged user for sndio daemon [sndiod]
  --enable-alsa			enable alsa audio & midi backends [yes]
  --disable-alsa			disable alsa audio & midi backends
  --enable-sun			enable sun audio backend [no]
  --disable-sun			disable sun audio backend
  --enable-rmidi			enable character device midi backend [no]
  --disable-rmidi			disable character device midi backend
  --enable-umidi			enable usb-midi backend [no]
  --disable-umidi			disable usb-midi backend
  --with-libbsd			use the libbsd rather than bsd-compat/*
  --without-libbsd		don't use libbsd
  --default-dev=DEV		set default device []
  
  libsndio/1.9.0: ERROR: 
  Package '5e9ecd7d0e08866aeb0a18cc6646fb25e7f87761' build failed
  libsndio/1.9.0: WARN: Build folder /home/user/.conan2/p/b/libsnfd5927499fad0/b
  ERROR: libsndio/1.9.0: Error in build() method, line 125
	  autotools.configure()
	  ConanException: Error 1 while executing
  ```
</details>

Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [libsndio-static.log](https://github.com/user-attachments/files/18815045/libsndio-static.log)
- [libsndio-shared.log](https://github.com/user-attachments/files/18815048/libsndio-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
