### PR TITLE
runtimeqml: improve cross-compilation, avoid overlinking

### DIFF
--- a/recipes/runtimeqml/all/CMakeLists.txt
+++ b/recipes/runtimeqml/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 project(runtimeqml LANGUAGES CXX)
 
@@ -13,18 +13,19 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 find_package(Qt5 CONFIG)
 find_package(Qt6 CONFIG)
 if (Qt6_FOUND)
+    set(Qt Qt6)
     set(HEADERS runtimeqml.hpp)
     add_library(${PROJECT_NAME} runtimeqml.hpp runtimeqml.cpp)
 elseif(Qt5_FOUND)
+    set(Qt Qt5)
     set(HEADERS runtimeqml.h)
     add_library(${PROJECT_NAME} runtimeqml.h runtimeqml.cpp)
 else()
     message(FATAL_ERROR "Qt was not found")
 endif()
 
-target_link_libraries(${PROJECT_NAME} PUBLIC qt::qt)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${Qt}::Core ${Qt}::Quick ${Qt}::Widgets)
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADERS}" C_VISIBILITY_PRESET hidden)
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}

--- a/recipes/runtimeqml/all/conanfile.py
+++ b/recipes/runtimeqml/all/conanfile.py
@@ -1,13 +1,13 @@
-from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.microsoft import is_msvc, check_min_vs
-from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
-from conan.tools.files import get, copy
-from conan.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.50.0"
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import get, copy
+from conan.tools.scm import Version
+
+required_conan_version = ">=2.0.9"
 
 
 class RuntimeQml(ConanFile):
@@ -27,54 +27,34 @@ class RuntimeQml(ConanFile):
         "shared": False,
         "fPIC": True
     }
-
-    @property
-    def _minimum_cpp_standard(self):
-        return 17
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "7",
-            "clang": "7",
-            "apple-clang": "10",
-        }
+    implements = ["auto_shared_fpic"]
 
     def export_sources(self):
         copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=os.path.join(self.export_sources_folder, "src"))
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
-
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    @property
+    def _qt_options(self):
+        return {
+            "qtdeclarative": True,
+            "qtshadertools": True,
+        }
+
     def requirements(self):
-        if Version(self.version) <= "cci.20211220":
-            self.requires("qt/5.15.13")
-        else:
-            self.requires("qt/6.6.2")
+        qt_version = "[>=6.6 <7]" if Version(self.version) >= "cci.20220923" else "[~5.15]"
+        self.requires(f"qt/{qt_version}", transitive_headers=True, transitive_libs=True, options=self._qt_options)
 
     def validate(self):
-        if self.info.settings.compiler.cppstd:
-            check_min_cppstd(self, self._minimum_cpp_standard)
-        check_min_vs(self, 191)
-        if not is_msvc(self):
-            minimum_version = self._compilers_minimum_version.get(
-                str(self.info.settings.compiler), False)
-            if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
-                raise ConanInvalidConfiguration(
-                    f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support."
-                )
-        qt = self.dependencies["qt"]
-        if not qt.options.qtdeclarative:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires option qt:qtdeclarative=True")
+        check_min_cppstd(self, 17)
+        qt_opt = self.dependencies["qt"].options
+        if not (qt_opt.qtdeclarative and qt_opt.qtshadertools):
+            raise ConanInvalidConfiguration(f"{self.ref} requires options qt:qtdeclarative=True and qt:qtshadertools=True")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.27 <4]")
+        self.tool_requires("qt/<host_version>", options=self._qt_options)
 
     def source(self):
         get(self, **self.conan_data["sources"][str(self.version)], strip_root=True)
@@ -82,8 +62,8 @@ class RuntimeQml(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.generate()
-        tc = CMakeDeps(self)
-        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         cmake = CMake(self)
@@ -91,10 +71,10 @@ class RuntimeQml(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, pattern="LICENSE", src=self.source_folder,
-             dst=os.path.join(self.package_folder, "licenses"), keep_path=False)
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
 
     def package_info(self):
         self.cpp_info.libs = ["runtimeqml"]
+        self.cpp_info.requires = ["qt::qtCore", "qt::qtQuick", "qt::qtWidgets"]

--- a/recipes/runtimeqml/all/test_package/CMakeLists.txt
+++ b/recipes/runtimeqml/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
 
 find_package(runtimeqml REQUIRED CONFIG)

--- a/recipes/runtimeqml/all/test_package/conanfile.py
+++ b/recipes/runtimeqml/all/test_package/conanfile.py
@@ -5,8 +5,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -21,5 +20,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **runtimeqml/[*]**

#### Motivation
Enable cross-compilation.

#### Details
- Always use tool_requires for Qt. Requires #26565.
- Depend on Qt6 by default. Use a version range allowing both 5 and 6 to be used.
- Link only against a specific set of Qt libraries, to avoid accidental linking against irrelevant parts of Qt.
- Cleaned up all Conan v1 compatibility cruft.

#### Logs
Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [runtimeqml-static.log](https://github.com/user-attachments/files/18815081/runtimeqml-static.log)
- [runtimeqml-shared.log](https://github.com/user-attachments/files/18815080/runtimeqml-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
