### PR TITLE
openslide: fix cross-compilation, use version ranges for sqlite and libtiff

### DIFF
--- a/recipes/openslide/all/conanfile.py
+++ b/recipes/openslide/all/conanfile.py
@@ -10,7 +10,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import is_msvc
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.4"
 
 
 class OpenSlideConan(ConanFile):
@@ -35,19 +35,11 @@ class OpenSlideConan(ConanFile):
         "fPIC": True,
         "jpeg": "libjpeg",
     }
+    languages = ["C"]
+    implements = ["auto_shared_fpic"]
 
     def export_sources(self):
         export_conandata_patches(self)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.cppstd")
-        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -58,10 +50,10 @@ class OpenSlideConan(ConanFile):
         self.requires("glib/2.78.3")
         self.requires("libdicom/1.0.5")
         self.requires("libpng/[>=1.6 <2]")
-        self.requires("libtiff/4.6.0")
+        self.requires("libtiff/[>=4.5 <5]")
         self.requires("libxml2/[>=2.12.5 <3]")
         self.requires("openjpeg/2.5.2")
-        self.requires("sqlite3/3.45.3")
+        self.requires("sqlite3/[>=3.45.0 <4]")
         self.requires("zlib/[>=1.2.11 <2]")
         if self.options.jpeg == "libjpeg":
             self.requires("libjpeg/9e")
@@ -82,6 +74,7 @@ class OpenSlideConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = MesonToolchain(self)
@@ -95,7 +88,6 @@ class OpenSlideConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         meson = Meson(self)
         meson.configure()
         meson.build()

--- a/recipes/openslide/all/conanfile.py
+++ b/recipes/openslide/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.env import VirtualBuildEnv
+from conan.tools.build import cross_building
 from conan.tools.files import copy, get, rm, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
@@ -84,12 +84,13 @@ class OpenSlideConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        venv = VirtualBuildEnv(self)
-        venv.generate()
         tc = MesonToolchain(self)
         tc.project_options["test"] = "disabled"
         tc.project_options["doc"] = "disabled"
         tc.generate()
+        if cross_building(self):
+            # A native C compiler needs to be defined
+            MesonToolchain(self, native=True).generate()
         deps = PkgConfigDeps(self)
         deps.generate()
 

--- a/recipes/openslide/all/test_package/conanfile.py
+++ b/recipes/openslide/all/test_package/conanfile.py
@@ -7,8 +7,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
-    test_type = "explicit"
+    generators = "PkgConfigDeps", "MesonToolchain"
 
     def layout(self):
         basic_layout(self)
@@ -17,9 +16,9 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.3")
+        self.tool_requires("meson/[>=1.2.3 <2]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def build(self):
         meson = Meson(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **openslide/[*]**

#### Motivation
Enable cross-compilation.

#### Details
- A host compiler needs to be defined when cross-compiling for helper executables created during build. Requires Conan v2.3+.
- Use version ranges for sqlite, libtiff, meson and pkgconf.
- Cleaned up all Conan v1 compatibility cruft.

#### Logs
<details>
  <summary>Build failure before the changes</summary>
  
  ```
  openslide/4.0.0: Calling build()
  openslide/4.0.0: Apply patch (backport): Fix 'error__use__openslide_fclose_instead' compilation error
  openslide/4.0.0: Meson configure cmd: meson setup --cross-file "/home/user/.conan2/p/b/opens75b173803f5c2/b/build-release/conan/conan_meson_cross.ini" "/home/user/.conan2/p/b/opens75b173803f5c2/b/build-release" "/home/user/.conan2/p/b/opens75b173803f5c2/b/src" --prefix=/
  openslide/4.0.0: RUN: meson setup --cross-file "/home/user/.conan2/p/b/opens75b173803f5c2/b/build-release/conan/conan_meson_cross.ini" "/home/user/.conan2/p/b/opens75b173803f5c2/b/build-release" "/home/user/.conan2/p/b/opens75b173803f5c2/b/src" --prefix=/
  The Meson build system
  Version: 1.6.1
  Source dir: /home/user/.conan2/p/b/opens75b173803f5c2/b/src
  Build dir: /home/user/.conan2/p/b/opens75b173803f5c2/b/build-release
  Build type: cross build
  Project name: openslide
  Project version: 4.0.0
  C compiler for the host machine: aarch64-linux-gnu-gcc-13 (gcc 13.3.0 "aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2) 13.3.0")
  C linker for the host machine: aarch64-linux-gnu-gcc-13 ld.bfd 2.43.1
  Compiler for language c for the build machine not found.
  Build machine cpu family: x86_64
  Build machine cpu: x86_64
  Host machine cpu family: aarch64
  Host machine cpu: armv8
  Target machine cpu family: aarch64
  Target machine cpu: armv8

  ../src/meson.build:48:18: ERROR: Tried to access compiler for language "c", not specified for build machine.

  A full log can be found at /home/user/.conan2/p/b/opens75b173803f5c2/b/build-release/meson-logs/meson-log.txt
  ```
</details>

Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [openslide-static.log](https://github.com/user-attachments/files/18815135/openslide-static.log)
- [openslide-shared.log](https://github.com/user-attachments/files/18815134/openslide-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
