### PR TITLE
rebound: no need to disable cross-compilation

### DIFF
--- a/recipes/rebound/all/conanfile.py
+++ b/recipes/rebound/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.build import cross_building
 from conan.tools.files import chdir, copy, get, rm, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
@@ -25,7 +24,7 @@ class ReboundConan(ConanFile):
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
-    
+
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -39,10 +38,6 @@ class ReboundConan(ConanFile):
     def validate(self):
         if self.settings.os in ["Windows", "Macos"]:
             raise ConanInvalidConfiguration(f"{self.ref} recipe does not support {self.settings.os}, contributions welcomed!")
-
-    def validate_build(self):
-        if cross_building(self):
-            raise ConanInvalidConfiguration(f"{self.ref} cross-building is not supported yet, contributions welcomed!")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/rebound/all/conanfile.py
+++ b/recipes/rebound/all/conanfile.py
@@ -29,7 +29,8 @@ class ReboundConan(ConanFile):
 
     def package_id(self):
         # Always compiled with optimizations enabled
-        del self.info.settings.build_type
+        if self.info.settings.build_type == "Debug":
+            self.info.settings.build_type = "RelWithDebInfo"
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/rebound/all/test_package/conanfile.py
+++ b/recipes/rebound/all/test_package/conanfile.py
@@ -4,11 +4,9 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **rebound/[*]**

#### Motivation
Enable cross-compilation on Linux. Windows and macOS are disabled anyway.

#### Details
- Drop validate() check for cross-compilation. It might still apply to macOS M1 builds, though.
- Mark Debug builds as RelWithDebInfo in package_id() since -O3 is always set for Debug:
  ```
  aarch64-linux-gnu-gcc-13 -c -std=c99 -Wpointer-arith -D_GNU_SOURCE -O3 -fPIC -Wall -g  -Wno-unknown-pragmas -DSERVER -DGITHASH=0000000000gitnotfound0000000000000000000 -o transformations.o transformations.c
  ```
- Cleaned up all Conan v1 compatibility cruft.

#### Logs
Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [rebound-static.log](https://github.com/user-attachments/files/18815175/rebound-static.log)
- [rebound-shared.log](https://github.com/user-attachments/files/18815174/rebound-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
