### PR TITLE
indicators: add a missing include for GCC 13

### DIFF
--- a/recipes/indicators/all/conandata.yml
+++ b/recipes/indicators/all/conandata.yml
@@ -11,3 +11,12 @@ sources:
   "1.9":
     url: "https://github.com/p-ranav/indicators/archive/v1.9.tar.gz"
     sha256: "842e11fa542ac392a2a2ddee48620a06c3005ec38ca25cf352471e46e18f389d"
+patches:
+  "2.3":
+    - patch_file: "patches/add-missing-cstdint-include.patch"
+      patch_type: "backport"
+      patch_source: "https://github.com/p-ranav/indicators/pull/124"
+  "2.2":
+    - patch_file: "patches/add-missing-cstdint-include.patch"
+      patch_type: "backport"
+      patch_source: "https://github.com/p-ranav/indicators/pull/124"

--- a/recipes/indicators/all/conanfile.py
+++ b/recipes/indicators/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=2.0"
 
 
 class IndicatorsConan(ConanFile):
@@ -31,8 +31,7 @@ class IndicatorsConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, 11)
+        check_min_cppstd(self, 11)
 
         if Version(self.version) < "2.0":
             if is_msvc(self) or (self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "5"):

--- a/recipes/indicators/all/conanfile.py
+++ b/recipes/indicators/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import  get, copy
+from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
@@ -20,6 +20,9 @@ class IndicatorsConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -42,6 +45,7 @@ class IndicatorsConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def package(self):
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/indicators/all/patches/add-missing-cstdint-include.patch
+++ b/recipes/indicators/all/patches/add-missing-cstdint-include.patch
@@ -1,0 +1,38 @@
+From 525ce444f41e2002756241bde345d53a68986347 Mon Sep 17 00:00:00 2001
+From: tocic <tocic@protonmail.ch>
+Date: Sun, 7 May 2023 12:36:15 +0300
+Subject: [PATCH] Add missing <cstdint> header
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes the "‘uint8_t’ has not been declared" error with gcc 13.1.1.
+---
+ include/indicators/termcolor.hpp         | 1 +
+ single_include/indicators/indicators.hpp | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/include/indicators/termcolor.hpp b/include/indicators/termcolor.hpp
+index 3e82bdc..1a5a813 100644
+--- a/include/indicators/termcolor.hpp
++++ b/include/indicators/termcolor.hpp
+@@ -14,6 +14,7 @@
+ 
+ #include <iostream>
+ #include <cstdio>
++#include <cstdint>
+ 
+ // Detect target's platform and set some macros in order to wrap platform
+ // specific code this library depends on.
+diff --git a/single_include/indicators/indicators.hpp b/single_include/indicators/indicators.hpp
+index 6123158..234e158 100644
+--- a/single_include/indicators/indicators.hpp
++++ b/single_include/indicators/indicators.hpp
+@@ -46,6 +46,7 @@ enum class ProgressType { incremental, decremental };
+ 
+ #include <iostream>
+ #include <cstdio>
++#include <cstdint>
+ 
+ // Detect target's platform and set some macros in order to wrap platform
+ // specific code this library depends on.

--- a/recipes/indicators/all/test_package/CMakeLists.txt
+++ b/recipes/indicators/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(indicators REQUIRED CONFIG)

--- a/recipes/indicators/all/test_package/conanfile.py
+++ b/recipes/indicators/all/test_package/conanfile.py
@@ -5,8 +5,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)
@@ -21,5 +20,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/indicators/all/test_package/test_package.cpp
+++ b/recipes/indicators/all/test_package/test_package.cpp
@@ -1,57 +1,7 @@
 #include <indicators/cursor_control.hpp>
 #include <indicators/progress_bar.hpp>
 #include <indicators/progress_spinner.hpp>
-#include <vector>
-
-// Copied from indicators' demo
 
 int main() {
-  using namespace indicators;
-
-  // Hide cursor
-  show_console_cursor(false);
-
-  {
-    //
-    // PROGRESS BAR 1
-    //
-    indicators::ProgressBar p{
-        option::BarWidth{50},
-        option::Start{"["},
-        option::Fill{"■"},
-        option::Lead{"■"},
-        option::Remainder{" "},
-        option::End{" ]"},
-        option::ForegroundColor{indicators::Color::yellow},
-        option::FontStyles{std::vector<indicators::FontStyle>{indicators::FontStyle::bold}}};
-
-    std::atomic<size_t> index{0};
-    std::vector<std::string> status_text = {"Rocket.exe is not responding",
-                                            "Buying more snacks",
-                                            "Finding a replacement engineer",
-                                            "Assimilating the modding community",
-                                            "Crossing fingers",
-                                            "Porting KSP to a Nokia 3310",
-                                            "Flexing struts",
-                                            "Releasing space whales",
-                                            "Watching paint dry"};
-
-    auto job = [&p, &index, &status_text]() {
-      while (true) {
-        if (p.is_completed())
-          break;
-        p.set_option(option::PostfixText{status_text[index % status_text.size()]});
-        p.set_progress(index * 10);
-        index += 1;
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      }
-    };
-    std::thread thread(job);
-    thread.join();
-  }
-
-  // Show cursor
-  show_console_cursor(true);
-
-  return 0;
+  indicators::show_console_cursor(true);
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **indicators/[*]**

#### Motivation
Add a missing include for GCC 13 compatibility.

#### Details
- Add a missing include for GCC 13 based on an official commit. Only applied it to versions that are compatible with the patch.
- Simplified test_package to a minimum.
- Cleaned up all Conan v1 compatibility cruft.

#### Logs
<details>
  <summary>Build failure before the changes</summary>
  
  ```
  indicators/2.3 (test package): Running CMake.build()
  indicators/2.3 (test package): RUN: cmake --build "/tmp/package/test_package/build/gcc-13-armv8-20-release" -- -j16
  gmake[1]: Entering directory '/tmp/package/test_package/build/gcc-13-armv8-20-release'
  gmake[2]: Entering directory '/tmp/package/test_package/build/gcc-13-armv8-20-release'
  Scanning dependencies of target test_package
  gmake[2]: Leaving directory '/tmp/package/test_package/build/gcc-13-armv8-20-release'
  gmake[2]: Entering directory '/tmp/package/test_package/build/gcc-13-armv8-20-release'
  [ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
  In file included from /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/details/stream_helper.hpp:7,
                  from /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/progress_bar.hpp:5,
                  from /tmp/package/test_package/test_package.cpp:2:
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:202:15: error: ‘uint8_t’ has not been declared
    202 |     template <uint8_t code> inline
        |               ^~~~~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp: In function ‘std::ostream& termcolor::color(std::ostream&)’:
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:209:70: error: ‘code’ was not declared in this scope
    209 |             std::snprintf(command, sizeof(command), "\033[38;5;%dm", code);
        |                                                                      ^~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp: At global scope:
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:217:15: error: ‘uint8_t’ has not been declared
    217 |     template <uint8_t code> inline
        |               ^~~~~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp: In function ‘std::ostream& termcolor::on_color(std::ostream&)’:
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:224:70: error: ‘code’ was not declared in this scope
    224 |             std::snprintf(command, sizeof(command), "\033[48;5;%dm", code);
        |                                                                      ^~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp: At global scope:
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:232:15: error: ‘uint8_t’ has not been declared
    232 |     template <uint8_t r, uint8_t g, uint8_t b> inline
        |               ^~~~~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:232:26: error: ‘uint8_t’ has not been declared
    232 |     template <uint8_t r, uint8_t g, uint8_t b> inline
        |                          ^~~~~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:232:37: error: ‘uint8_t’ has not been declared
    232 |     template <uint8_t r, uint8_t g, uint8_t b> inline
        |                                     ^~~~~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp: In function ‘std::ostream& termcolor::color(std::ostream&)’:
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:239:76: error: ‘r’ was not declared in this scope
    239 |             std::snprintf(command, sizeof(command), "\033[38;2;%d;%d;%dm", r, g, b);
        |                                                                            ^
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:239:79: error: ‘g’ was not declared in this scope
    239 |             std::snprintf(command, sizeof(command), "\033[38;2;%d;%d;%dm", r, g, b);
        |                                                                               ^
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:239:82: error: ‘b’ was not declared in this scope
    239 |             std::snprintf(command, sizeof(command), "\033[38;2;%d;%d;%dm", r, g, b);
        |                                                                                  ^
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp: At global scope:
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:247:15: error: ‘uint8_t’ has not been declared
    247 |     template <uint8_t r, uint8_t g, uint8_t b> inline
        |               ^~~~~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:247:26: error: ‘uint8_t’ has not been declared
    247 |     template <uint8_t r, uint8_t g, uint8_t b> inline
        |                          ^~~~~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:247:37: error: ‘uint8_t’ has not been declared
    247 |     template <uint8_t r, uint8_t g, uint8_t b> inline
        |                                     ^~~~~~~
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp: In function ‘std::ostream& termcolor::on_color(std::ostream&)’:
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:254:76: error: ‘r’ was not declared in this scope
    254 |             std::snprintf(command, sizeof(command), "\033[48;2;%d;%d;%dm", r, g, b);
        |                                                                            ^
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:254:79: error: ‘g’ was not declared in this scope
    254 |             std::snprintf(command, sizeof(command), "\033[48;2;%d;%d;%dm", r, g, b);
        |                                                                               ^
  /home/user/.conan2/p/b/indic47d359faa7c9b/p/include/indicators/termcolor.hpp:254:82: error: ‘b’ was not declared in this scope
    254 |             std::snprintf(command, sizeof(command), "\033[48;2;%d;%d;%dm", r, g, b);
        |                                                                                  ^
  gmake[2]: *** [CMakeFiles/test_package.dir/build.make:63: CMakeFiles/test_package.dir/test_package.cpp.o] Error 1
  gmake[2]: Leaving directory '/tmp/package/test_package/build/gcc-13-armv8-20-release'
  gmake[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/test_package.dir/all] Error 2
  gmake[1]: Leaving directory '/tmp/package/test_package/build/gcc-13-armv8-20-release'
  gmake: *** [Makefile:84: all] Error 2

  ERROR: indicators/2.3 (test package): Error in build() method, line 20
    cmake.build()
    ConanException: Error 2 while executing
  ```
</details>

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
