### PR TITLE
Eigen: backport DisableStupidWarnings.h, clearer license expression

### DIFF
--- a/recipes/eigen/all/conandata.yml
+++ b/recipes/eigen/all/conandata.yml
@@ -11,6 +11,12 @@ sources:
   "3.3.7":
     url: "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2"
     sha256: "685adf14bd8e9c015b78097c1dc22f2f01343756f196acdc76a678e1ae352e11"
+# Backport latest DisableStupidWarnings.h to disable warnings from newer compiler versions
+disable_stupid_warnings_h:
+  # 2024-10-29 version of
+  # https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Core/util/DisableStupidWarnings.h
+  url: "https://gitlab.com/libeigen/eigen/-/raw/1d8b82b0740839c0de7f1242a3585e3390ff5f33/Eigen/src/Core/util/DisableStupidWarnings.h"
+  sha256: "12ac7e06cfbcc65bf3217de6131f154e742082596bee210962a217af8bbea0c4"
 patches:
   "3.4.0":
     - patch_file: "patches/3.4.0-0001-vec-reduce-half.patch"

--- a/recipes/eigen/all/conanfile.py
+++ b/recipes/eigen/all/conanfile.py
@@ -15,7 +15,7 @@ class EigenConan(ConanFile):
                   " numerical solvers, and related algorithms."
     topics = ("algebra", "linear-algebra", "matrix", "vector", "numerical", "header-only")
     package_type = "header-library"
-    license = ("MPL-2.0", "LGPL-3.0-or-later")  # Taking into account the default value of MPL2_only option
+    license = "MPL-2.0 AND LGPL-3.0-or-later"  # Taking into account the default value of MPL2_only option
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -29,7 +29,7 @@ class EigenConan(ConanFile):
         export_conandata_patches(self)
 
     def configure(self):
-        self.license = "MPL-2.0" if self.options.MPL2_only else ("MPL-2.0", "LGPL-3.0-or-later")
+        self.license = "MPL-2.0" if self.options.MPL2_only else "MPL-2.0 AND LGPL-3.0-or-later"
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/eigen/all/conanfile.py
+++ b/recipes/eigen/all/conanfile.py
@@ -68,19 +68,12 @@ class EigenConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "Eigen3")
         self.cpp_info.set_property("cmake_target_name", "Eigen3::Eigen")
         self.cpp_info.set_property("pkg_config_name", "eigen3")
-        # TODO: back to global scope once cmake_find_package* generators removed
+
         self.cpp_info.components["eigen3"].bindirs = []
         self.cpp_info.components["eigen3"].libdirs = []
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["eigen3"].system_libs = ["m"]
         if self.options.MPL2_only:
             self.cpp_info.components["eigen3"].defines = ["EIGEN_MPL2_ONLY"]
-
-        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
-        self.cpp_info.names["cmake_find_package"] = "Eigen3"
-        self.cpp_info.names["cmake_find_package_multi"] = "Eigen3"
-        self.cpp_info.names["pkg_config"] = "eigen3"
-        self.cpp_info.components["eigen3"].names["cmake_find_package"] = "Eigen"
-        self.cpp_info.components["eigen3"].names["cmake_find_package_multi"] = "Eigen"
         self.cpp_info.components["eigen3"].set_property("cmake_target_name", "Eigen3::Eigen")
         self.cpp_info.components["eigen3"].includedirs = [os.path.join("include", "eigen3")]

--- a/recipes/eigen/all/test_package/CMakeLists.txt
+++ b/recipes/eigen/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(Eigen3 REQUIRED CONFIG)

--- a/recipes/eigen/all/test_package/conanfile.py
+++ b/recipes/eigen/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ from conan.tools.cmake import CMake, cmake_layout
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -22,4 +21,4 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")
+            self.run(os.path.join(self.cpp.build.bindir, "test_package"), env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **eigen/[*]**

#### Motivation
Eigen is in no rush to release a new version and the existing versions produce an insane amount of irrelevant warnings on nvcc.

#### Details
- Copy the current latest version of DisableStupidWarnings.h. This matches the behavior of Vcpkg, for example: https://github.com/microsoft/vcpkg/blob/master/ports/eigen3/update-warning-suppression-to-latest.patch
- Also made the license expression clearer. See https://repology.org/project/eigen/information for the expressions used by other package managers.
- Cleaned up some Conan v1 cruft.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
