### PR TITLE
tinycolormap: use a version range for Qt dependencies, allow Qt6

### DIFF
--- a/recipes/tinycolormap/all/conanfile.py
+++ b/recipes/tinycolormap/all/conanfile.py
@@ -38,12 +38,11 @@ class TinycolormapConan(ConanFile):
         if self.options.with_eigen:
             self.requires("eigen/3.4.0")
         if self.options.with_qt:
-            # Only Qt5 is supported
-            self.requires("qt/5.15.13")
+            # Fails with qInitResources_gui_shaders() if transitive_libs=False
+            self.requires("qt/[>=5.15 <7]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, 11)
+        check_min_cppstd(self, 11)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/tinycolormap/all/test_package/conanfile.py
+++ b/recipes/tinycolormap/all/test_package/conanfile.py
@@ -4,11 +4,9 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/tinycolormap/all/test_package/test_package.cpp
+++ b/recipes/tinycolormap/all/test_package/test_package.cpp
@@ -7,4 +7,9 @@ int main() {
     auto color = tinycolormap::GetColor(value, tinycolormap::ColormapType::Viridis);
     std::cout << "Viridis RGB values at " << value << ": "
               << (int)color.ri() << " " << (int)color.gi() << " " << (int)color.bi() << std::endl;
+#ifdef TINYCOLORMAP_WITH_QT5
+    auto qt_color = color.ConvertToQColor();
+    std::cout << "Viridis QColor values at " << value << ": "
+              << qt_color.red() << " " << qt_color.green() << " " << qt_color.blue() << std::endl;
+#endif
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **tinycolormap/[*]**

#### Motivation
Allow any Qt version to be used.

#### Logs

Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [tinycolormap-static.log](https://github.com/user-attachments/files/18815476/tinycolormap-static.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
