### PR TITLE
mocknetworkaccessmanager: support cross-compilation, avoid overlinking

### DIFF
--- a/recipes/mocknetworkaccessmanager/all/test_package/conanfile.py
+++ b/recipes/mocknetworkaccessmanager/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **mocknetworkaccessmanager/[*]**

#### Motivation
Add cross-compilation support.

#### Details
- Also deprecate `with_qt` option, since the version can be simply overridden instead. The change is backwards-compatible, though.

- Requires
  - https://github.com/conan-io/conan-center-index/pull/26565

- The set of specific `cpp_info.requires` is based on https://gitlab.com/julrich/MockNetworkAccessManager/-/blob/main/MockNetworkAccessManager.hpp?ref_type=heads#L38

- Building without specifying the target failed for some reason with:
```
mocknetworkaccessmanager/0.12.0: Calling package()
mocknetworkaccessmanager/0.12.0: Running CMake.install()
mocknetworkaccessmanager/0.12.0: RUN: cmake --install "/home/user/.conan2/p/b/mockn406171b2d2d2b/b/build/Release" --prefix "/home/user/.conan2/p/b/mockn406171b2d2d2b/p"
-- Install configuration: "Release"
CMake Error at cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "/home/user/.conan2/p/b/mockn406171b2d2d2b/b/build/Release/libMockNetworkAccessManager.a":
  No such file or directory.
```

#### Logs

Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [mocknetworkaccessmanager-static.log](https://github.com/user-attachments/files/18815617/mocknetworkaccessmanager-static.log)
- [mocknetworkaccessmanager-shared.log](https://github.com/user-attachments/files/18815616/mocknetworkaccessmanager-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
