### PR TITLE
librealsense: require libudev/system

### DIFF
--- a/recipes/librealsense/all/conandata.yml
+++ b/recipes/librealsense/all/conandata.yml
@@ -36,6 +36,9 @@ patches:
     - patch_file: "patches/2.53.1-0003-fix-GUID_DEVINTERFACE_USB_DEVICE.patch"
       patch_description: "Fix undefined ref to GUID_DEVINTERFACE_USB_DEVICE on Windows"
       patch_type: "conan"
+    - patch_file: "patches/2.53.1-0005-fix-udev-handling.patch"
+      patch_description: "Fix linking against relocated libudev"
+      patch_type: "conan"
   "2.49.0":
     - patch_file: "patches/2.49.0-0001-fix-cmake.patch"
     - patch_file: "patches/2.49.0-0002-fix-avx-check.patch"

--- a/recipes/librealsense/all/patches/2.53.1-0005-fix-udev-handling.patch
+++ b/recipes/librealsense/all/patches/2.53.1-0005-fix-udev-handling.patch
@@ -1,0 +1,23 @@
+--- a/src/linux/find_udev.cmake
++++ b/src/linux/find_udev.cmake
+@@ -6,18 +6,9 @@
+ #  UDEV_LIBRARIES - the UDEV library
+ find_package(PkgConfig)
+ 
+-pkg_check_modules(UDEV_PKGCONF libudev)
++pkg_check_modules(UDEV_PKGCONF libudev IMPORTED_TARGET)
+ 
+-find_path(UDEV_INCLUDE_DIRS
+-  NAMES libudev.h
+-  PATHS ${UDEV_PKGCONF_INCLUDE_DIRS}
+-)
+-
+-
+-find_library(UDEV_LIBRARIES
+-  NAMES udev
+-  PATHS ${UDEV_PKGCONF_LIBRARY_DIRS}
+-)
++add_library(udev ALIAS PkgConfig::UDEV_PKGCONF)
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(Udev DEFAULT_MSG UDEV_INCLUDE_DIRS UDEV_LIBRARIES)

--- a/recipes/librealsense/all/test_package/CMakeLists.txt
+++ b/recipes/librealsense/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(realsense2 REQUIRED CONFIG)

--- a/recipes/librealsense/all/test_package/conanfile.py
+++ b/recipes/librealsense/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **librealsense/[*]**

#### Motivation
Ensure that the required `libudev` is actually available on the system.

Allows a non-system libudev (#26162) to be used with `[replace_requires]` for easier cross-compilation in some cases.

#### Details
Newer CMake is required for `add_library(udev ALIAS PkgConfig::UDEV_PKGCONF)`.

#### Logs

Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [librealsense-static.log](https://github.com/user-attachments/files/18815695/librealsense-static.log)
- [librealsense-shared.log](https://github.com/user-attachments/files/18815694/librealsense-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
