### PR TITLE
Add activemq-cpp-3.9.5

### DIFF
--- a/recipes/activemq-cpp/all/conandata.yml
+++ b/recipes/activemq-cpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.9.5":
+    url: "https://github.com/apache/activemq-cpp/archive/refs/tags/activemq-cpp-3.9.5.tar.gz"
+    sha256: "3a56b526360155fd920f136b187ffb84942890b9b7e206976c81ef9f2ab2b11b"

--- a/recipes/activemq-cpp/all/conanfile.py
+++ b/recipes/activemq-cpp/all/conanfile.py
@@ -1,0 +1,117 @@
+from conan import ConanFile, conan_version
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import check_min_cppstd, cross_building
+from conan.tools.env import Environment, VirtualRunEnv
+from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, mkdir, rm, rmdir
+from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, unix_path
+from conans.tools import Version
+import os
+
+class PackageConan(ConanFile):
+    name = "activemq-cpp"
+    description = "JMS-like API for C++ for interfacing with Message Brokers such as Apache ActiveMQ"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/apache/activemq-cpp"
+    topics = ("ruby", "python", "c", "java", "php", "csharp", "cplusplus", "perl", "activemq", "network-server", "network-client")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    # In case having config_options() or configure() method, the logic should be moved to the specific methods.
+    implements = ["auto_shared_fpic"]
+
+    # no exports_sources attribute, but export_sources(self) method instead
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("apr/1.7.4")
+        self.requires("openssl/[>=1.0.0]")
+
+    def validate(self):
+        # validate the minimum cpp standard supported. Only for C++ projects
+        check_min_cppstd(self, 14)
+
+        # Always comment the reason including the upstream issue.
+        # INFO: Upstream only support Unix systems. See <URL>
+        if self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
+            raise ConanInvalidConfiguration(f"{self.ref} is not supported on {self.settings.os}.")
+
+    # if a tool other than the compiler or autotools is required to build the project (pkgconf, bison, flex etc)
+    def build_requirements(self):
+        self.tool_requires("libtool/[>=1.5.22]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    def generate(self):
+        # inject required env vars into the build scope
+        # it's required in case of native build when there is AutotoolsDeps & at least one dependency which might be shared, because configure tries to run a test executable
+        if not cross_building(self):
+            VirtualRunEnv(self).generate(scope="build")
+        tc = AutotoolsToolchain(self)
+        # autotools usually uses 'yes' and 'no' to enable/disable options
+        def yes_no(v): return "yes" if v else "no"
+        tc.autoreconf_args.extend(["-I", "config", "-I", "m4"])
+        if self.options.shared:
+            tc.configure_args.extend(["--enable-shared"])
+        tc.generate()
+        # generate pkg-config files of dependencies (useless if upstream configure.ac doesn't rely on PKG_CHECK_MODULES macro)
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        deps = AutotoolsDeps(self)
+        deps.generate()
+
+    def build(self):
+        autotools = Autotools(self)
+
+        script_folder = "activemq-cpp"
+
+        if conan_version >= Version("2.0.2"):
+            autotools.autoreconf(build_script_folder=script_folder)
+        else:
+            with chdir(self, os.path.join(self.source_folder, script_folder)):
+                mkdir(self, "config")
+                command = "autoreconf --force --install -I config -I m4"
+                self.run(command)
+            
+        autotools.configure(build_script_folder=script_folder)
+        autotools.make()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+
+        # Some files extensions and folders are not allowed. Please, read the FAQs to get informed.
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+        # In shared lib/executable files, autotools set install_name (macOS) to lib dir absolute path instead of @rpath, it's not relocatable, so fix it
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.includedirs = ["include/activemq-cpp-3.9.5"]
+        self.cpp_info.libs = ["activemq-cpp"]
+
+        # if the package provides a pkgconfig file (package.pc, usually installed in <prefix>/lib/pkgconfig/)
+        self.cpp_info.set_property("pkg_config_name", "activemq-cpp")
+
+        # If they are needed on Linux, m, pthread and dl are usually needed on FreeBSD too
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["dl", "m", "pthread"])

--- a/recipes/activemq-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/activemq-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(activemq-cpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE activemq-cpp::activemq-cpp)

--- a/recipes/activemq-cpp/all/test_package/conanfile.py
+++ b/recipes/activemq-cpp/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/activemq-cpp/all/test_package/test_package.cpp
+++ b/recipes/activemq-cpp/all/test_package/test_package.cpp
@@ -1,0 +1,21 @@
+#include <cstdlib>
+#include <memory>
+#include <activemq/core/ActiveMQConnectionFactory.h>
+#include <activemq/library/ActiveMQCPP.h>
+#include <cms/Connection.h>
+#include <cms/ConnectionFactory.h>
+
+
+int main(void) {
+
+   activemq::library::ActiveMQCPP::initializeLibrary();
+
+   {
+      // Create a ConnectionFactory
+      std::unique_ptr<cms::ConnectionFactory> connectionFactory (cms::ConnectionFactory::createCMSConnectionFactory("failover:(tcp://localhost:61616)"));
+   }
+
+    activemq::library::ActiveMQCPP::shutdownLibrary();
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/activemq-cpp/config.yml
+++ b/recipes/activemq-cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.9.5":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **activemq-cpp/3.9.5**

#### Motivation
ActiveMQ-CPP bindings are commonly used when interfacing with ActiveMQ

#### Details
Added new recipe for ActiveMQ-CPP. This is my first PR for a new recipe, so guidance is appreciated.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
