### PR TITLE
xmlsec: fix header conflicts between OpenSSL and Windows

### DIFF
--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -105,6 +105,9 @@ class XmlSecConan(ConanFile):
             tc = AutotoolsToolchain(self)
             if not self.options.shared:
                 tc.extra_defines.append("XMLSEC_STATIC")
+            if self.settings.os == "Windows":
+                tc.extra_defines.append("WIN32_LEAN_AND_MEAN")
+
             yes_no = lambda v: "yes" if v else "no"
             tc.configure_args.extend([
                 "--enable-crypto-dl=no",


### PR DESCRIPTION
### Summary
Changes to recipe:  **xmlsec/1.3.6**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
fixes #26621 

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Set the define `WIN32_LEAN_AND_MEAN` when the compiler is mingw . The `WIN32_LEAN_AND_MEAN` define is used in Windows to exclude some of the less frequently used APIs from the Windows headers. This can help prevents the inclusion of some headers like cryptography, among others that can help to fix header conflicts with openssl.
This is based on the defines used on msvc makefile in the project:
https://github.com/lsh123/xmlsec/blob/f48168188a9d0ecda4a19b3f5586860b00d81b69/win32/Makefile.msvc#L365-L375


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
