### PR TITLE
Add support for the arrow 19.0.1 package

### DIFF
--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "19.0.1":
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-19.0.1/apache-arrow-19.0.1.tar.gz?action=download"
     sha256: "acb76266e8b0c2fbb7eb15d542fbb462a73b3fd1e32b80fad6c2fafd95a51160"
+  "18.1.0":
+    url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-18.1.0/apache-arrow-18.1.0.tar.gz?action=download"
+    sha256: "2dc8da5f8796afe213ecc5e5aba85bb82d91520eff3cf315784a52d0fa61d7fc"
   "18.0.0":
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-18.0.0/apache-arrow-18.0.0.tar.gz?action=download"
     sha256: "abcf1934cd0cdddd33664e9f2d9a251d6c55239d1122ad0ed223b13a583c82a9"

--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -18,6 +18,10 @@ sources:
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-14.0.2/apache-arrow-14.0.2.tar.gz?action=download"
     sha256: "1304dedb41896008b89fe0738c71a95d9b81752efc77fa70f264cb1da15d9bc2"
 patches:
+  "19.0.1":
+    - patch_file: "patches/19.0.1-0001-fix-cmake.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "18.1.0":
     - patch_file: "patches/18.0.0-0001-fix-cmake.patch"
       patch_description: "use cci package"

--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -25,6 +25,9 @@ patches:
     - patch_file: "patches/19.0.1-0001-fix-cmake.patch"
       patch_description: "use cci package"
       patch_type: "conan"
+    - patch_file: "patches/19.0.1-0002-fix-downloaded-mimalloc.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "18.1.0":
     - patch_file: "patches/18.0.0-0001-fix-cmake.patch"
       patch_description: "use cci package"

--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "18.1.0":
-    url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-18.1.0/apache-arrow-18.1.0.tar.gz?action=download"
-    sha256: "2dc8da5f8796afe213ecc5e5aba85bb82d91520eff3cf315784a52d0fa61d7fc"
+  "19.0.1":
+    url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-19.0.1/apache-arrow-19.0.1.tar.gz?action=download"
+    sha256: "acb76266e8b0c2fbb7eb15d542fbb462a73b3fd1e32b80fad6c2fafd95a51160"
   "18.0.0":
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-18.0.0/apache-arrow-18.0.0.tar.gz?action=download"
     sha256: "abcf1934cd0cdddd33664e9f2d9a251d6c55239d1122ad0ed223b13a583c82a9"

--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -385,6 +385,7 @@ class ArrowConan(ConanFile):
         tc.generate()
 
         deps = CMakeDeps(self)
+        deps.set_property("mimalloc", "cmake_target_name", "mimalloc::mimalloc")
         deps.generate()
 
     def _patch_sources(self):

--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -133,6 +133,8 @@ class ArrowConan(ConanFile):
             del self.options.substrait
         if is_msvc(self):
             self.options.with_boost = True
+        if Version(self.version) >= "19.0.0":
+            self.options.with_mimalloc = True
 
     def configure(self):
         if self.options.shared:
@@ -514,6 +516,8 @@ class ArrowConan(ConanFile):
             self.cpp_info.components["dataset"].libs = ["arrow_dataset"]
             if self.options.parquet:
                 self.cpp_info.components["dataset"].requires = ["libparquet"]
+            if self.options.acero and Version(self.version) >= "19.0.0":
+                self.cpp_info.components["dataset"].requires = ["libacero"]
 
         if self.options.cli and (self.options.with_cuda or self.options.with_flight_rpc or self.options.parquet):
             binpath = os.path.join(self.package_folder, "bin")

--- a/recipes/arrow/all/patches/19.0.1-0001-fix-cmake.patch
+++ b/recipes/arrow/all/patches/19.0.1-0001-fix-cmake.patch
@@ -1,0 +1,59 @@
+diff --git a/cpp/cmake_modules/FindThriftAlt.cmake b/cpp/cmake_modules/FindThriftAlt.cmake
+index 98a706d..edf195e 100644
+--- a/cpp/cmake_modules/FindThriftAlt.cmake
++++ b/cpp/cmake_modules/FindThriftAlt.cmake
+@@ -45,22 +45,20 @@ endif()
+ #   * https://github.com/apache/thrift/pull/2725
+ #   * https://github.com/apache/thrift/pull/2726
+ #   * https://github.com/conda-forge/thrift-cpp-feedstock/issues/68
+-if(NOT WIN32)
+-  set(find_package_args "")
+-  if(ThriftAlt_FIND_VERSION)
+-    list(APPEND find_package_args ${ThriftAlt_FIND_VERSION})
+-  endif()
+-  if(ThriftAlt_FIND_QUIETLY)
+-    list(APPEND find_package_args QUIET)
+-  endif()
+-  find_package(Thrift ${find_package_args})
+-  if(Thrift_FOUND)
+-    set(ThriftAlt_FOUND TRUE)
+-    add_executable(thrift::compiler IMPORTED)
+-    set_target_properties(thrift::compiler PROPERTIES IMPORTED_LOCATION
+-                                                      "${THRIFT_COMPILER}")
+-    return()
+-  endif()
++set(find_package_args "")
++if(ThriftAlt_FIND_VERSION)
++  list(APPEND find_package_args ${ThriftAlt_FIND_VERSION})
++endif()
++if(ThriftAlt_FIND_QUIETLY)
++  list(APPEND find_package_args QUIET)
++endif()
++find_package(Thrift ${find_package_args})
++if(Thrift_FOUND)
++  set(ThriftAlt_FOUND TRUE)
++  add_executable(thrift::compiler IMPORTED)
++  set_target_properties(thrift::compiler PROPERTIES IMPORTED_LOCATION
++                                                    "${THRIFT_COMPILER}")
++  return()
+ endif()
+ 
+ function(extract_thrift_version)
+diff --git a/cpp/src/parquet/CMakeLists.txt b/cpp/src/parquet/CMakeLists.txt
+index 83eb52248..d165fd4d2 100644
+--- a/cpp/src/parquet/CMakeLists.txt
++++ b/cpp/src/parquet/CMakeLists.txt
+@@ -261,11 +261,11 @@ if(NOT PARQUET_MINIMAL_DEPENDENCY)
+
+   # These are libraries that we will link privately with parquet_shared (as they
+   # do not need to be linked transitively by other linkers)
+-  list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS thrift::thrift)
++  list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS Boost::headers thrift::thrift)
+
+   # Link publicly with parquet_static (because internal users need to
+   # transitively link all dependencies)
+-  list(APPEND PARQUET_STATIC_LINK_LIBS thrift::thrift)
++  list(APPEND PARQUET_STATIC_LINK_LIBS Boost::headers thrift::thrift)
+   if(NOT THRIFT_VENDORED)
+     list(APPEND PARQUET_STATIC_INSTALL_INTERFACE_LIBS thrift::thrift)
+   endif()

--- a/recipes/arrow/all/patches/19.0.1-0001-fix-cmake.patch
+++ b/recipes/arrow/all/patches/19.0.1-0001-fix-cmake.patch
@@ -39,24 +39,6 @@ index 98a706d..edf195e 100644
  endif()
  
  function(extract_thrift_version)
-diff --git a/cpp/src/parquet/CMakeLists.txt b/cpp/src/parquet/CMakeLists.txt
-index 83eb52248..d165fd4d2 100644
---- a/cpp/src/parquet/CMakeLists.txt
-+++ b/cpp/src/parquet/CMakeLists.txt
-@@ -261,11 +261,11 @@ if(NOT PARQUET_MINIMAL_DEPENDENCY)
-
-   # These are libraries that we will link privately with parquet_shared (as they
-   # do not need to be linked transitively by other linkers)
--  list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS thrift::thrift)
-+  list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS Boost::headers thrift::thrift)
-
-   # Link publicly with parquet_static (because internal users need to
-   # transitively link all dependencies)
--  list(APPEND PARQUET_STATIC_LINK_LIBS thrift::thrift)
-+  list(APPEND PARQUET_STATIC_LINK_LIBS Boost::headers thrift::thrift)
-   if(NOT THRIFT_VENDORED)
-     list(APPEND PARQUET_STATIC_INSTALL_INTERFACE_LIBS thrift::thrift)
-   endif()
 diff --git a/cpp/src/parquet/size_statistics.cc b/cpp/src/parquet/size_statistics.cc
 index 1ce6c937a..e45eef3f0 100644
 --- a/cpp/src/parquet/size_statistics.cc

--- a/recipes/arrow/all/patches/19.0.1-0001-fix-cmake.patch
+++ b/recipes/arrow/all/patches/19.0.1-0001-fix-cmake.patch
@@ -57,3 +57,19 @@ index 83eb52248..d165fd4d2 100644
    if(NOT THRIFT_VENDORED)
      list(APPEND PARQUET_STATIC_INSTALL_INTERFACE_LIBS thrift::thrift)
    endif()
+diff --git a/cpp/src/parquet/size_statistics.cc b/cpp/src/parquet/size_statistics.cc
+index 1ce6c937a..e45eef3f0 100644
+--- a/cpp/src/parquet/size_statistics.cc
++++ b/cpp/src/parquet/size_statistics.cc
+@@ -18,9 +18,11 @@
+ #include "parquet/size_statistics.h"
+
+ #include <algorithm>
++#include <array>
+ #include <numeric>
+ #include <ostream>
+ #include <string_view>
++#include <vector>
+
+ #include "arrow/util/logging.h"
+ #include "parquet/exception.h"

--- a/recipes/arrow/all/patches/19.0.1-0002-fix-downloaded-mimalloc.patch
+++ b/recipes/arrow/all/patches/19.0.1-0002-fix-downloaded-mimalloc.patch
@@ -1,0 +1,15 @@
+diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+index abfe6d2..cc0f3c5 100644
+--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -2259,6 +2259,10 @@ endif()
+ # mimalloc - Cross-platform high-performance allocator, from Microsoft
+ 
+ if(ARROW_MIMALLOC)
++  find_package(mimalloc REQUIRED CONFIG)
++endif()
++
++if(0)
+   if(NOT ARROW_ENABLE_THREADING)
+     message(FATAL_ERROR "Can't use mimalloc with ARROW_ENABLE_THREADING=OFF")
+   endif()

--- a/recipes/arrow/config.yml
+++ b/recipes/arrow/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "19.0.1":
+    folder: all
   "18.1.0":
     folder: all
   "18.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/19.0.1**

#### Motivation
This provides access to the 19.0.1 release of Arrow.

#### Details
The change provides access to a new version and updates the required patch currently needed for this package to build correctly.

Tested locally with:
```[settings]
arch=armv8
build_type=Debug
compiler=gcc
compiler.cppstd=20
compiler.libcxx=libstdc++11
compiler.version=13
os=Macos
mold*:build_type=Release
[conf]
tools.build:compiler_executables={'c': 'gcc-13', 'cpp': 'g++-13'}

```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
