### PR TITLE
fribidi: add native MesonToolchain generator when cross-compiling

### DIFF
--- a/recipes/fribidi/all/test_package/CMakeLists.txt
+++ b/recipes/fribidi/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(fribidi REQUIRED CONFIG)

--- a/recipes/fribidi/all/test_package/conanfile.py
+++ b/recipes/fribidi/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **fribidi/[*]**

#### Motivation
Pass the correct host C compiler to the Meson project when cross-compiling.

#### Logs
<details>
  <summary>Build failure before the changes</summary>
  
  ```
  fribidi/1.0.13: RUN: meson setup --cross-file "/home/user/.conan2/p/b/fribi93693f9e09e79/b/build-release/conan/conan_meson_cross.ini" "/home/user/.conan2/p/b/fribi93693f9e09e79/b/build-release" "/home/user/.conan2/p/b/fribi93693f9e09e79/b/src" --prefix=/
  The Meson build system
  Version: 1.2.1
  Source dir: /home/user/.conan2/p/b/fribi93693f9e09e79/b/src
  Build dir: /home/user/.conan2/p/b/fribi93693f9e09e79/b/build-release
  Build type: cross build
  Project name: fribidi
  Project version: 1.0.13
  C compiler for the host machine: aarch64-linux-gnu-gcc-13 (gcc 13.3.0 "aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2) 13.3.0")
  C linker for the host machine: aarch64-linux-gnu-gcc-13 ld.bfd 2.43.1
  Compiler for language c for the build machine not found.
  Build machine cpu family: x86_64
  Build machine cpu: x86_64
  Host machine cpu family: aarch64
  Host machine cpu: armv8
  Target machine cpu family: aarch64
  Target machine cpu: armv8
  Compiler for C supports arguments -ansi: YES 
  Checking for function "memmove" : YES 
  Checking for function "memset" : YES 
  Checking for function "strdup" : YES 
  Has header "stdlib.h" : YES 
  Has header "string.h" : YES 
  Has header "memory.h" : YES 
  Has header "strings.h" : YES 
  Has header "sys/times.h" : YES 
  Has header "strings.h" : YES (cached)
  Configuring config.h using configuration
  Has header "stdlib.h" : YES (cached)
  Has header "string.h" : YES (cached)
  Has header "strings.h" : YES (cached)

  ../src/gen.tab/meson.build:32:22: ERROR: No build machine compiler for 'gen.tab/gen-unicode-version.c'

  A full log can be found at /home/user/.conan2/p/b/fribi93693f9e09e79/b/build-release/meson-logs/meson-log.txt

  fribidi/1.0.13: ERROR: 
  Package 'add8654bbbf39e9aedf870c676fbada983655cff' build failed
  fribidi/1.0.13: WARN: Build folder /home/user/.conan2/p/b/fribi93693f9e09e79/b/build-release
  ERROR: fribidi/1.0.13: Error in build() method, line 70
    meson.configure()
    ConanException: Error 1 while executing
  ```
</details>

Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [fribidi-static.log](https://github.com/user-attachments/files/18828602/fribidi-static.log)
- [fribidi-shared.log](https://github.com/user-attachments/files/18828601/fribidi-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan