### PR TITLE
intel-ipsec-mb: add settings.arch check to validate()

### DIFF
--- a/recipes/intel-ipsec-mb/all/conanfile.py
+++ b/recipes/intel-ipsec-mb/all/conanfile.py
@@ -54,6 +54,9 @@ class PackageConan(ConanFile):
     def validate(self):
         if self.settings.os not in ("FreeBSD", "Linux", "Windows"):
             raise ConanInvalidConfiguration(f"{self.ref} does not support the O.S. {self.settings.os}.")
+        if self.settings.arch not in ["x86", "x86_64"]:
+            # Relies on x86 SIMD intrinsics.
+            raise ConanInvalidConfiguration(f"{self.ref} does not support the architecture {self.settings.arch}.")
 
     def build_requirements(self):
         self.tool_requires("nasm/2.15.05")

--- a/recipes/intel-ipsec-mb/all/test_package/conanfile.py
+++ b/recipes/intel-ipsec-mb/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
### Summary
Changes to recipe:  **intel-ipsec-mb/[*]**

#### Motivation
The library relies on x86 intrinsics.

#### Details
```
aarch64-linux-gnu-gcc-13: error: unrecognized command-line option ‘-maes’
aarch64-linux-gnu-gcc-13: error: unrecognized command-line option ‘-maes’
aarch64-linux-gnu-gcc-13: error: unrecognized command-line option ‘-mpclmul’
aarch64-linux-gnu-gcc-13: error: unrecognized command-line option ‘-mpclmul’
gmake[3]: *** [lib/CMakeFiles/IPSec_MB.dir/build.make:1935: lib/CMakeFiles/IPSec_MB.dir/avx2_t1/mb_mgr_avx2_t1.c.o] Error 1
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
