### PR TITLE
p7zip: use the correct compiler executables

### DIFF
--- a/recipes/p7zip/all/conanfile.py
+++ b/recipes/p7zip/all/conanfile.py
@@ -1,11 +1,10 @@
-from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, replace_in_file, chdir
-from conan.tools.layout import basic_layout
-from conan.tools.gnu import AutotoolsToolchain, Autotools
-from conan.tools.apple import is_apple_os, to_apple_arch
 import os
 
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, chdir
+from conan.tools.gnu import AutotoolsToolchain, Autotools
+from conan.tools.layout import basic_layout
 
 required_conan_version = ">=1.52.0"
 
@@ -36,39 +35,33 @@ class PSevenZipConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} is only supported by x86_64 and armv8")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    @property
+    def _compiler_executables(self):
+        compiler = str(self.settings.compiler)
+        cc = "clang" if "clang" in compiler else compiler
+        cxx = "clang++" if "clang" in compiler else compiler
+        if compiler == "gcc":
+            cxx = "g++"
+        tc_vars = AutotoolsToolchain(self).vars()
+        cc = tc_vars.get("CC", cc)
+        cxx = tc_vars.get("CXX", cxx)
+        return cc, cxx
 
     def generate(self):
+        cc, cxx = self._compiler_executables
         tc = AutotoolsToolchain(self)
+        tc_vars = tc.vars()
+        tc.make_args.extend([
+            f"CC={cc}",
+            f"CXX={cxx}",
+            f"OPTFLAGS={tc_vars['CFLAGS']}",
+        ])
         tc.generate()
 
-    def _patch_compiler(self):
-        optflags = ''
-        if is_apple_os(self):
-            optflags = '-arch ' + to_apple_arch(self)
-        cc = "clang" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
-        cxx = "clang++" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
-        if self.settings.compiler == "gcc":
-            cxx = "g++"
-        # Replace the hard-coded compilers instead of using the 40 different Makefile permutations
-        replace_in_file(self, os.path.join(self.source_folder, "makefile.machine"),
-                              "CC=gcc", f"CC={cc}")
-        replace_in_file(self, os.path.join(self.source_folder, "makefile.machine"),
-                              "CXX=g++", f"CXX={cxx}")
-        # Manually modify the -O flag here based on the build type
-        optflags += " -O2" if self.settings.build_type == "Release" else " -O0"
-        # Silence the warning about `-s` not being valid on clang
-        if cc != "clang":
-            optflags += ' -s'
-        replace_in_file(self, os.path.join(self.source_folder, "makefile.machine"),
-                            "OPTFLAGS=-O -s", "OPTFLAGS=" + optflags)
-
-    def _patch_sources(self):
-        apply_conandata_patches(self)
-        self._patch_compiler()
-
     def build(self):
-        self._patch_sources()
         with chdir(self, self.source_folder):
             autotools = Autotools(self)
             autotools.make()
@@ -79,9 +72,5 @@ class PSevenZipConan(ConanFile):
         copy(self, "7za", src=os.path.join(self.source_folder, "bin"), dst=os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info(f"Appending PATH environment variable: {bin_path}")
-        self.env_info.PATH.append(bin_path)
-
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []

--- a/recipes/p7zip/all/test_package/conanfile.py
+++ b/recipes/p7zip/all/test_package/conanfile.py
@@ -2,10 +2,14 @@ import os.path
 
 from conan import ConanFile
 from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        basic_layout(self)
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
### Summary
Changes to recipe:  **p7zip/[*]**

#### Motivation
The recipe currently ignores the C/C++ compiler executables set via `tools.build:compiler_executables`.
Using plain `gcc`/`clang` as the executable is hacky and the generic executable is not guaranteed to exist if just a specific version of the compiler is installed on the system.

#### Details
Would greatly benefit from better handling of compiler executables on the Conan client side: https://github.com/conan-io/conan/issues/17602

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
