### PR TITLE
reckless: only x86 architectures are supported

### DIFF
--- a/recipes/reckless/all/test_package/CMakeLists.txt
+++ b/recipes/reckless/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(reckless REQUIRED CONFIG)

--- a/recipes/reckless/all/test_package/conanfile.py
+++ b/recipes/reckless/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **reckless/[*]**

#### Motivation
Relies on x86 instructions.

https://github.com/mattiasflodin/reckless/blob/v3.0.3/reckless/include/reckless/detail/platform.hpp#L310-L319
https://github.com/mattiasflodin/reckless/blob/v3.0.3/reckless/include/reckless/detail/platform.hpp#L373-L384

#### Details
Fails to compile on armv8:
```
In file included from /home/user/.conan2/p/b/reckl39bf6b926638b/b/src/reckless/include/reckless/detail/mpsc_ring_buffer.hpp:22,
                 from /home/user/.conan2/p/b/reckl39bf6b926638b/b/src/reckless/src/mpsc_ring_buffer.cpp:22:
/home/user/.conan2/p/b/reckl39bf6b926638b/b/src/reckless/include/reckless/detail/platform.hpp: In function ‘uint64_t reckless::detail::rdtsc()’:
/home/user/.conan2/p/b/reckl39bf6b926638b/b/src/reckless/include/reckless/detail/platform.hpp:313:12: error: ‘__builtin_ia32_rdtsc’ was not declared in this scope; did you mean ‘__builtin_va_list’?
  313 |     return __builtin_ia32_rdtsc();
      |            ^~~~~~~~~~~~~~~~~~~~
      |            __builtin_va_list
In file included from /home/user/.conan2/p/b/reckl39bf6b926638b/b/src/reckless/include/reckless/detail/lockless_cv.hpp:25,
                 from /home/user/.conan2/p/b/reckl39bf6b926638b/b/src/reckless/src/lockless_cv.cpp:22:
/home/user/.conan2/p/b/reckl39bf6b926638b/b/src/reckless/include/reckless/detail/platform.hpp: In function ‘uint64_t reckless::detail::rdtsc()’:
/home/user/.conan2/p/b/reckl39bf6b926638b/b/src/reckless/include/reckless/detail/platform.hpp:313:12: error: ‘__builtin_ia32_rdtsc’ was not declared in this scope; did you mean ‘__builtin_va_list’?
  313 |     return __builtin_ia32_rdtsc();
      |            ^~~~~~~~~~~~~~~~~~~~
      |            __builtin_va_list
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
