### PR TITLE
liboping: add cross-compilation support

### DIFF
--- a/recipes/liboping/all/conanfile.py
+++ b/recipes/liboping/all/conanfile.py
@@ -31,10 +31,6 @@ class LibopingConan(ConanFile):
         "fPIC": True,
     }
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -63,13 +59,14 @@ class LibopingConan(ConanFile):
             raise ConanInvalidConfiguration("Liboping cannot be built on a Mac/M1 at this time")
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows":
+        if self.settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = AutotoolsToolchain(self)
@@ -84,7 +81,6 @@ class LibopingConan(ConanFile):
         tc.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         autotools = Autotools(self)
         autotools.configure()
         autotools.make()
@@ -104,8 +100,3 @@ class LibopingConan(ConanFile):
             self.cpp_info.system_libs.append("m")
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs.append("ws2_32")
-
-        # TODO: Legacy, to be removed on Conan 2.0
-        bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bindir))
-        self.env_info.PATH.append(bindir)

--- a/recipes/liboping/all/conanfile.py
+++ b/recipes/liboping/all/conanfile.py
@@ -3,6 +3,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
+from conan.tools.build import can_run
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
@@ -76,6 +77,10 @@ class LibopingConan(ConanFile):
             "--without-ncurses",
             "--without-perl-bindings",
         ]
+        if not can_run(self):
+            # Add a guess for a try_run check.
+            # All modern compilers return non-NULL for malloc(0).
+            tc.configure_args.append("ac_cv_func_malloc_0_nonnull=yes")
         tc.generate()
 
     def build(self):

--- a/recipes/liboping/all/test_package/conanfile.py
+++ b/recipes/liboping/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
### Summary
Changes to recipe:  **liboping/[*]**

#### Motivation
Add cross-compilation support.

#### Logs
Without the correct try_compile guess:
```
libtool: link: aarch64-linux-gnu-gcc-13 -Wall -Werror -fPIC -O3 -o oping oping.o  ./.libs/liboping.a -lm
/usr/lib/gcc-cross/aarch64-linux-gnu/13/../../../../aarch64-linux-gnu/bin/ld: ./.libs/liboping.a(liboping_la-liboping.o): in function `ping_construct':
liboping.c:(.text+0x11c0): undefined reference to `rpl_malloc'
/usr/lib/gcc-cross/aarch64-linux-gnu/13/../../../../aarch64-linux-gnu/bin/ld: ./.libs/liboping.a(liboping_la-liboping.o): in function `ping_setopt':
liboping.c:(.text+0x1538): undefined reference to `rpl_malloc'
/usr/lib/gcc-cross/aarch64-linux-gnu/13/../../../../aarch64-linux-gnu/bin/ld: ./.libs/liboping.a(liboping_la-liboping.o): in function `ping_host_add':
liboping.c:(.text+0x1dc0): undefined reference to `rpl_malloc'
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:564: oping] Error 1
```

Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [liboping-static.log](https://github.com/user-attachments/files/18829652/liboping-static.log)
- [liboping-shared.log](https://github.com/user-attachments/files/18829651/liboping-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
