### PR TITLE
qxmpp: improve cross-compilation support

### DIFF
--- a/recipes/qxmpp/all/conanfile.py
+++ b/recipes/qxmpp/all/conanfile.py
@@ -1,15 +1,12 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, rename, mkdir
 from conan.tools.microsoft import is_msvc
-from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
-from conan.tools.scm import Version
 
-required_conan_version = ">=1.60.0 <2 || >=2.0.5"
+required_conan_version = ">=2.0.9"
 
 
 class QxmppConan(ConanFile):
@@ -33,31 +30,10 @@ class QxmppConan(ConanFile):
         "fPIC": True,
         "with_gstreamer": False,
     }
-
-    @property
-    def _min_cppstd(self):
-        return 17
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "10",
-            "Visual Studio": "17",
-            "msvc": "192",
-            "clang": "8",
-            "apple-clang": "13",
-        }
+    implements = ["auto_shared_fpic"]
 
     def export_sources(self):
         export_conandata_patches(self)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.get_safe("shared"):
-            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -69,23 +45,17 @@ class QxmppConan(ConanFile):
             self.requires("glib/2.78.3")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+        check_min_cppstd(self, 17)
 
     def build_requirements(self):
+        self.tool_requires("cmake/[>=3.27 <4]")
         self.tool_requires("qt/<host_version>")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
-        venv = VirtualBuildEnv(self)
-        venv.generate()
-        venv = VirtualRunEnv(self)
-        venv.generate(scope="build")
         tc = CMakeToolchain(self)
         tc.variables["BUILD_DOCUMENTATION"] = False
         tc.variables["BUILD_TESTS"] = False
@@ -98,7 +68,6 @@ class QxmppConan(ConanFile):
         tc.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/qxmpp/all/test_package/conanfile.py
+++ b/recipes/qxmpp/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
### Summary
Changes to recipe:  **qxmpp/[*]**

#### Motivation
Ensure the Qt tool_requires works correctly, especially for cross-compilation, after the changes from #26565.

#### Details
The only functional change is the addition of `self.tool_requires("cmake/[>=3.27 <4]")`, necessary for `CMAKE_AUTOMOC_EXECUTABLE` etc support.

#### Logs

Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [qxmpp-static.log](https://github.com/user-attachments/files/18830531/qxmpp-static.log)
- [qxmpp-shared.log](https://github.com/user-attachments/files/18830530/qxmpp-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
