### PR TITLE
mpg123: drop unused pkgconf tool_requires

### DIFF
--- a/recipes/mpg123/all/conanfile.py
+++ b/recipes/mpg123/all/conanfile.py
@@ -91,8 +91,6 @@ class Mpg123Conan(ConanFile):
 
 
     def build_requirements(self):
-        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
         if self.settings.arch in ["x86", "x86_64"]:
             self.tool_requires("yasm/1.3.0")
         if self.settings_build.os == "Windows" and not is_msvc(self):
@@ -102,6 +100,7 @@ class Mpg123Conan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         env = VirtualBuildEnv(self)
@@ -157,7 +156,6 @@ class Mpg123Conan(ConanFile):
             tc.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         if is_msvc(self):
             cmake = CMake(self)
             cmake.configure(build_script_folder=os.path.join(self.source_folder, "ports", "cmake"))
@@ -185,7 +183,7 @@ class Mpg123Conan(ConanFile):
             rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-        
+
         fix_apple_shared_install_name(self)
 
     def package_info(self):

--- a/recipes/mpg123/all/test_package/CMakeLists.txt
+++ b/recipes/mpg123/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(mpg123 REQUIRED CONFIG)

--- a/recipes/mpg123/all/test_package/conanfile.py
+++ b/recipes/mpg123/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **mpg123/[*]**

#### Motivation
The recipe does not use PkgConfigDeps and it builds fine without pkg-config/pkgconf being available.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
