### PR TITLE
openldap: improve cross-compilation support

### DIFF
--- a/recipes/openldap/all/conanfile.py
+++ b/recipes/openldap/all/conanfile.py
@@ -1,12 +1,11 @@
 import os
-import shutil
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualRunEnv
 from conan.tools.files import chdir, copy, get, rm, rmdir, replace_in_file, save
-from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, GnuToolchain
+from conan.tools.gnu import Autotools, AutotoolsDeps, GnuToolchain
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.layout import basic_layout
 
@@ -117,7 +116,3 @@ class OpenldapConan(ConanFile):
         self.cpp_info.components["lber"].libs = ["lber"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["lber"].system_libs = ["pthread"]
-
-        # TODO: to remove in conan v2
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.env_info.PATH.append(bin_path)

--- a/recipes/openldap/all/test_package/conanfile.py
+++ b/recipes/openldap/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
### Summary
Changes to recipe:  **openldap/[*]**

#### Motivation
Improve cross-compilation support.

#### Details
- The correct `strip` executable needs to be provided via `STRIP` env var for cross-compilation. GnuToolchain handles that automatically.
- The `soelim` executable is not guaranteed to be available on the system. Either way, it is only used to build docs, which are not included in the package. It's better to disable building of docs altogether.

#### Logs
Build logs for gcc-13-aarch64-linux-gnu ([profile and environment](https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861)):

- [openldap-static.log](https://github.com/user-attachments/files/18831327/openldap-static.log)
- [openldap-shared.log](https://github.com/user-attachments/files/18831326/openldap-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
