### PR TITLE
cpp-httplib: add version 0.19.0

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.19.0":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.19.0.tar.gz"
+    sha256: "c9b9e0524666e1cd088f0874c57c1ce7c0eaa8552f9f4e15c755d5201fc8c608"
   "0.18.3":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.18.3.tar.gz"
     sha256: "a0567bcd6c3fe5cef1b329b96245119047f876b49e06cc129a36a7a8dffe173e"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.19.0":
+    folder: all
   "0.18.3":
     folder: all
   "0.18.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-httplib/0.19.0**

#### Motivation
Bump version of cpp-httplib. It contains one new feature and various bug fixes since the previously released conan package (0.18.3).

#### Details
https://github.com/yhirose/cpp-httplib/compare/v0.18.3...v0.19.0


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
