### PR TITLE
vtu11: add a patch for a missing include

### DIFF
--- a/recipes/vtu11/all/conandata.yml
+++ b/recipes/vtu11/all/conandata.yml
@@ -1,5 +1,9 @@
 sources:
   "1.2":
-    url:
-      - "https://github.com/phmkopp/vtu11/archive/refs/tags/v1.2.tar.gz"
+    url: "https://github.com/phmkopp/vtu11/archive/refs/tags/v1.2.tar.gz"
     sha256: "c2b560d397c1a86c10e13f029b4ef08621f70ca4c897c44c19e7d025f11baec3"
+patches:
+  "1.2":
+    - patch_file: "patches/add-missing-include.patch"
+      patch_description: "Add a missing #include <cstdint>"
+      patch_source: "https://github.com/phmkopp/vtu11/pull/62"

--- a/recipes/vtu11/all/conanfile.py
+++ b/recipes/vtu11/all/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches
 from conan.tools.layout import basic_layout
 import os
 
 from conan.tools.microsoft import is_msvc
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class PackageConan(ConanFile):
@@ -27,9 +27,8 @@ class PackageConan(ConanFile):
         "with_zlib": True,
     }
 
-    @property
-    def _min_cppstd(self):
-        return 11
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -42,11 +41,11 @@ class PackageConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, 11)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
@@ -67,9 +66,3 @@ class PackageConan(ConanFile):
         # The library uses __cplusplus for feature detection, ensure vs returns the proper one
         if is_msvc(self):
             self.cpp_info.cxxflags.append("/Zc:__cplusplus")
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "vtu11"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "vtu11"
-        self.cpp_info.names["cmake_find_package"] = "vtu11"
-        self.cpp_info.names["cmake_find_package_multi"] = "vtu11"

--- a/recipes/vtu11/all/patches/add-missing-include.patch
+++ b/recipes/vtu11/all/patches/add-missing-include.patch
@@ -1,0 +1,21 @@
+From a6a98721bf12c3fcbe78fb4ecd059fe8ad22d13d Mon Sep 17 00:00:00 2001
+From: Martin Valgur <martin.valgur@gmail.com>
+Date: Tue, 10 Dec 2024 18:56:17 +0200
+Subject: [PATCH] alias.hpp: add missing #include <cstdint>
+
+---
+ vtu11/inc/alias.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vtu11/inc/alias.hpp b/vtu11/inc/alias.hpp
+index 8eaeb4c..33c0c48 100644
+--- a/vtu11/inc/alias.hpp
++++ b/vtu11/inc/alias.hpp
+@@ -10,6 +10,7 @@
+ #ifndef VTU11_ALIAS_HPP
+ #define VTU11_ALIAS_HPP
+ 
++#include <cstdint>
+ #include <string>
+ #include <map>
+ #include <utility>

--- a/recipes/vtu11/all/test_package/CMakeLists.txt
+++ b/recipes/vtu11/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 
 project(test_package CXX)
 

--- a/recipes/vtu11/all/test_package/conanfile.py
+++ b/recipes/vtu11/all/test_package/conanfile.py
@@ -10,8 +10,7 @@ from pathlib import Path
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -26,7 +25,7 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")
             test_vtu = Path(self.build_folder, "test.vtu")
             if not test_vtu.exists() or "VTKFile" not in test_vtu.read_text(encoding="utf-8"):

--- a/recipes/vtu11/all/test_package/test_package.cpp
+++ b/recipes/vtu11/all/test_package/test_package.cpp
@@ -1,6 +1,7 @@
+#include <vtu11/vtu11.hpp>
+
 #include <cstdlib>
 #include <iostream>
-#include "vtu11/vtu11.hpp"
 
 
 int main(void) {


### PR DESCRIPTION
### Summary
Changes to recipe:  **vtu11/1.2**

#### Motivation
Backports a fix for a compilation error on GCC 13 due to a missing `#include <cstdint>`.

#### Details
Applies
- https://github.com/phmkopp/vtu11/pull/62

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
