### PR TITLE
msgpack23: add version 2.1

### DIFF
--- a/recipes/msgpack23/all/conandata.yml
+++ b/recipes/msgpack23/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.0":
+    url:
+    - "https://github.com/rwindegger/msgpack23/archive/refs/tags/v1.0.tar.gz"
+    sha256: "0E3296B3162DE73CA866E973B7E447BB8C3233A854A5F94F1AE0CAA8B0E60D4C"
+requirements:
+  - "gtest/1.15.0"

--- a/recipes/msgpack23/all/conandata.yml
+++ b/recipes/msgpack23/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.0":
+  "2.0":
     url:
-    - "https://github.com/rwindegger/msgpack23/archive/refs/tags/v1.0.tar.gz"
-    sha256: "0E3296B3162DE73CA866E973B7E447BB8C3233A854A5F94F1AE0CAA8B0E60D4C"
+    - "https://github.com/rwindegger/msgpack23/archive/refs/tags/v2.0.tar.gz"
+    sha256: "AB10DD6DD5AB022C34135A777381CDC1BAD62DDBCDB87797B1E0FB9479E87168"
 requirements:
   - "gtest/1.15.0"

--- a/recipes/msgpack23/all/conandata.yml
+++ b/recipes/msgpack23/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
   "2.0":
-    url:
-    - "https://github.com/rwindegger/msgpack23/archive/refs/tags/v2.0.tar.gz"
+    url: "https://github.com/rwindegger/msgpack23/archive/refs/tags/v2.0.tar.gz"
     sha256: "AB10DD6DD5AB022C34135A777381CDC1BAD62DDBCDB87797B1E0FB9479E87168"
-requirements:
-  - "gtest/1.15.0"

--- a/recipes/msgpack23/all/conanfile.py
+++ b/recipes/msgpack23/all/conanfile.py
@@ -1,0 +1,67 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+import os
+
+
+required_conan_version = ">=2.0.9"
+
+
+
+class PackageConan(ConanFile):
+    name = "msgpack23"
+    description = "A modern, header-only C++ library for MessagePack serialization and deserialization."
+    license = "MIT"
+    url = "https://github.com/rwindegger/msgpack23"
+    homepage = "https://github.com/rwindegger/msgpack23"
+    topics = ("msgpack", "serialization", "MessagePack")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    exports_sources = ( "CMakeLists.txt", "include/*", "tests/*", "cmake/*" )
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        requirements = self.conan_data.get('requirements', [])
+        for requirement in requirements:
+            self.requires(requirement)
+
+    def validate(self):
+        #check_min_cppstd(self, 23)
+        pass
+        
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.28 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.libs = ["msgpack23"]
+        self.cpp_info.set_property("cmake_file_name", "msgpack23")
+        self.cpp_info.set_property("cmake_target_name", "msgpack23::msgpack23")

--- a/recipes/msgpack23/all/conanfile.py
+++ b/recipes/msgpack23/all/conanfile.py
@@ -9,8 +9,6 @@ import os
 
 required_conan_version = ">=2.0.9"
 
-
-
 class PackageConan(ConanFile):
     name = "msgpack23"
     description = "A modern, header-only C++ library for MessagePack serialization and deserialization."
@@ -26,15 +24,9 @@ class PackageConan(ConanFile):
     def layout(self):
         cmake_layout(self)
 
-    def requirements(self):
-        requirements = self.conan_data.get('requirements', [])
-        for requirement in requirements:
-            self.requires(requirement)
-
     def validate(self):
-        #check_min_cppstd(self, 23)
-        pass
-        
+        check_min_cppstd(self, 23)
+
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.28 <4]")
 

--- a/recipes/msgpack23/all/conanfile.py
+++ b/recipes/msgpack23/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.files import copy, get, rmdir
 import os
 
 
@@ -19,10 +19,8 @@ class PackageConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
 
-    exports_sources = ( "CMakeLists.txt", "include/*", "tests/*", "cmake/*" )
-
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder="src")
 
     def validate(self):
         check_min_cppstd(self, 23)
@@ -32,6 +30,9 @@ class PackageConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package_id(self):
+        self.info.clear()
 
     def generate(self):
         deps = CMakeDeps(self)
@@ -54,6 +55,7 @@ class PackageConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.libs = ["msgpack23"]
+        self.cpp_info.libdirs = []
+        self.cpp_info.bindirs = []
         self.cpp_info.set_property("cmake_file_name", "msgpack23")
         self.cpp_info.set_property("cmake_target_name", "msgpack23::msgpack23")

--- a/recipes/msgpack23/all/test_package/CMakeLists.txt
+++ b/recipes/msgpack23/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.28)
+project(test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(msgpack23 REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE msgpack23::msgpack23)

--- a/recipes/msgpack23/all/test_package/conanfile.py
+++ b/recipes/msgpack23/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/msgpack23/all/test_package/test_package.cpp
+++ b/recipes/msgpack23/all/test_package/test_package.cpp
@@ -5,7 +5,7 @@ int main(void) {
     msgpack23::Packer packer {};
 	std::uint8_t const expected = 42;
 	auto data = packer(expected);
-	msgpack23::Unpacker unpacker {data.data(), data.size()};
+	msgpack23::Unpacker unpacker {data};
 	std::int8_t actual {};
 	unpacker(actual);
 	

--- a/recipes/msgpack23/all/test_package/test_package.cpp
+++ b/recipes/msgpack23/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include <msgpack23/msgpack23.h>
+
+int main(void) {
+	
+    msgpack23::Packer packer {};
+	std::uint8_t const expected = 42;
+	auto data = packer(expected);
+	msgpack23::Unpacker unpacker {data.data(), data.size()};
+	std::int8_t actual {};
+	unpacker(actual);
+	
+    return EXIT_SUCCESS;
+}

--- a/recipes/msgpack23/config.yml
+++ b/recipes/msgpack23/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0":
+    folder: all

--- a/recipes/msgpack23/config.yml
+++ b/recipes/msgpack23/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.0":
+  "2.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **msgpack23/2.0**

#### Motivation
Add a new library for MessagePack based on the C++23 standard.

#### Details
Add a new library that supports serialization and deserialization of the MessagePack standard.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
