### PR TITLE
libcurl: add version 8.12.1; #26560

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "8.12.1":
+    url:
+      - "https://curl.se/download/curl-8.12.1.tar.xz"
+      - "https://github.com/curl/curl/releases/download/curl-8_12_1/curl-8.12.1.tar.xz"
+    sha256: "0341f1ed97a26c811abaebd37d62b833956792b7607ea3f15d001613c76de202"
   "8.11.1":
     url:
       - "https://curl.se/download/curl-8.11.1.tar.xz"

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.12.1":
+    folder: all
   "8.11.1":
     folder: all
   "8.10.1":


### PR DESCRIPTION
### Summary
Changes to recipe:   libcurl/8.12.1

#### Motivation
libcurl 8.12 introduces important bugfixes, for instance https://curl.se/docs/CVE-2025-0665.html

#### Details
Nothing special...simple upgrade.


---
- [ x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x] Tested locally with at least one configuration using a recent version of Conan
