### PR TITLE
mimalloc: Added recipe option for MI_WIN_REDIRECT

### DIFF
--- a/recipes/mimalloc/all/conanfile.py
+++ b/recipes/mimalloc/all/conanfile.py
@@ -45,6 +45,8 @@ class MimallocConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        else:
+            del self.options.win_redirect
 
         # single_object and inject are options
         # only when overriding on Unix-like platforms:
@@ -70,6 +72,7 @@ class MimallocConan(ConanFile):
             self.options.rm_safe("single_object")
             self.options.rm_safe("inject")
 
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -90,6 +93,14 @@ class MimallocConan(ConanFile):
            is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration(
                 "Dynamic runtime (MD/MDd) is required when using mimalloc as a shared library for override")
+        
+        if self.options.get_safe("win_redirect") and not (
+            self.options.override and \
+            self.options.shared and \
+            is_msvc(self) and \
+            not is_msvc_static_runtime(self)):
+            raise ConanInvalidConfiguration(
+                "Windows redirect requires 'override', 'shared' and building against a dynamic runtime (MD/MDd)")
 
         if self.options.override and \
            self.options.get_safe("single_object") and \
@@ -110,7 +121,7 @@ class MimallocConan(ConanFile):
         tc.variables["MI_BUILD_OBJECT"] = self.options.get_safe("single_object", False)
         tc.variables["MI_OVERRIDE"] = "ON" if self.options.override else "OFF"
         tc.variables["MI_SECURE"] = "ON" if self.options.secure else "OFF"
-        tc.variables["MI_WIN_REDIRECT"] = "ON" if self.options.win_redirect else "OFF"
+        tc.variables["MI_WIN_REDIRECT"] = "ON" if self.options.get_safe("win_redirect") else "OFF"
         tc.variables["MI_INSTALL_TOPLEVEL"] = "ON"
         tc.generate()
         venv = VirtualBuildEnv(self)

--- a/recipes/mimalloc/all/conanfile.py
+++ b/recipes/mimalloc/all/conanfile.py
@@ -27,6 +27,7 @@ class MimallocConan(ConanFile):
         "override": [True, False],
         "inject": [True, False],
         "single_object": [True, False],
+        "win_redirect": [True, False],
     }
     default_options = {
         "shared": False,
@@ -35,6 +36,7 @@ class MimallocConan(ConanFile):
         "override": False,
         "inject": False,
         "single_object": False,
+        "win_redirect": False,
     }
 
     def export_sources(self):
@@ -108,7 +110,7 @@ class MimallocConan(ConanFile):
         tc.variables["MI_BUILD_OBJECT"] = self.options.get_safe("single_object", False)
         tc.variables["MI_OVERRIDE"] = "ON" if self.options.override else "OFF"
         tc.variables["MI_SECURE"] = "ON" if self.options.secure else "OFF"
-        tc.variables["MI_WIN_REDIRECT"] = "OFF"
+        tc.variables["MI_WIN_REDIRECT"] = "ON" if self.options.win_redirect else "OFF"
         tc.variables["MI_INSTALL_TOPLEVEL"] = "ON"
         tc.generate()
         venv = VirtualBuildEnv(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **mimalloc/***

proposes fix for #26646
#### Motivation
Adding an option for MI_WIN_REDIRECT adds transparency and avoids hard to find build errors. See  #26646

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
