### PR TITLE
libpng: add version 1.6.47

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.47":
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.47/libpng-1.6.47.tar.xz"
+    sha256: "b213cb381fbb1175327bd708a77aab708a05adde7b471bc267bd15ac99893631"
   "1.6.46":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.46/libpng-1.6.46.tar.xz"
     sha256: "f3aa8b7003998ab92a4e9906c18d19853e999f9d3bca9bd1668f54fa81707cb1"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.47":
+    folder: all
   "1.6.46":
     folder: all
   "1.6.45":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpng/1.6.47**

#### Motivation
New upstream version

#### Details
https://github.com/pnggroup/libpng/compare/v1.6.46...v1.6.47

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
