### PR TITLE
foxglove-schemas-protobuf: Update url + hash sum

### DIFF
--- a/recipes/foxglove-schemas-protobuf/all/conandata.yml
+++ b/recipes/foxglove-schemas-protobuf/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   0.1.0:
-    url: https://github.com/foxglove/schemas/archive/refs/tags/releases/python/foxglove-schemas-protobuf/v0.1.0.tar.gz
-    sha256: 42153b62000c0c614301ecd2b9173c69f467dd543db3328a1b0491bce8ee5594
+    url: https://github.com/foxglove/foxglove-sdk/archive/refs/tags/releases/python/foxglove-schemas-protobuf/v0.1.0.tar.gz
+    sha256: 6479c73250f0f7268a77cb2b1d379e17c2e78a7553e467daf0d2f353a28868b3

--- a/recipes/foxglove-schemas-protobuf/all/conanfile.py
+++ b/recipes/foxglove-schemas-protobuf/all/conanfile.py
@@ -14,7 +14,7 @@ required_conan_version = ">=1.60.0"
 class FoxgloveSchemasProtobufConan(ConanFile):
     name = "foxglove-schemas-protobuf"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/foxglove/schemas"
+    homepage = "https://github.com/foxglove/foxglove-sdk"
     description = "Protobuf schemas for Foxglove"
     license = "MIT"
     topics = ("foxglove", "protobuf", "schemas")


### PR DESCRIPTION
### Summary
Changes to recipe:  **foxglove-schemas-protobuf/0.1.0**

#### Motivation
Update URL + hash sum that changed because github repository has been renamed

#### Details
The repository github.com/foxglove/schemas got recently renamed to github.com/foxglove/foxglove-sdk which unfortunately changed the hash sum of all source code archives downloaded from github. This is because the archives include a top level folder which is made up of the repository name. Since that name changed, also the top level folder name changed and effectively also the hash sum of the entire archive.

Name of top-level folder before and after the repository got renamed:

Before: `schemas-releases-python-foxglove-schemas-protobuf-v0.1.0`
After: `foxglove-sdk-releases-python-foxglove-schemas-protobuf-v0.1.0`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
