### PR TITLE
openh264: drop pkgconf tool_requires

### DIFF
--- a/recipes/openh264/all/conanfile.py
+++ b/recipes/openh264/all/conanfile.py
@@ -1,6 +1,5 @@
 from conan import ConanFile
 from conan.tools.build import stdcpp_library
-from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rmdir, rm, rename, replace_in_file
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
@@ -46,9 +45,7 @@ class OpenH264Conan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.4.1")
-        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/[>=2.2 <3]")
+        self.tool_requires("meson/[>=1.2.3 <2]")
         if self.settings.arch in ["x86", "x86_64"]:
             self.tool_requires("nasm/2.16.01")
 
@@ -59,12 +56,9 @@ class OpenH264Conan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} does not support {self.settings.os}. Try a newer version.")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        env = VirtualBuildEnv(self)
-        env.generate()
         tc = MesonToolchain(self)
         tc.project_options["tests"] = "disabled"
         tc.generate()

--- a/recipes/openh264/all/test_package/CMakeLists.txt
+++ b/recipes/openh264/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package C)
 
 find_package(openh264 REQUIRED CONFIG)

--- a/recipes/openh264/all/test_package/conanfile.py
+++ b/recipes/openh264/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **openh264/[*]**

#### Motivation
No `PkgConfigDeps` generator used in the recipe and builds fine even if `pkg-config`/`pkgconf` is not installed on the system.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
