### PR TITLE
mariadb-connector-c: force-disable krb5 dependency detection

### DIFF
--- a/recipes/mariadb-connector-c/all/conanfile.py
+++ b/recipes/mariadb-connector-c/all/conanfile.py
@@ -84,6 +84,8 @@ class MariadbConnectorcConan(ConanFile):
         else:
             tc.variables["WITH_MYSQLCOMPAT"] = False
             tc.variables["WITH_ICONV"] = self.options.with_iconv
+            if not self.options.get_safe("with_krb5"):
+                tc.variables["KRB5_CONFIG"] = ""
         tc.variables["WITH_UNIT_TESTS"] = False
         tc.variables["WITH_DYNCOL"] = self.options.dyncol
         tc.variables["WITH_EXTERNAL_ZLIB"] = True

--- a/recipes/mariadb-connector-c/all/conanfile.py
+++ b/recipes/mariadb-connector-c/all/conanfile.py
@@ -74,6 +74,7 @@ class MariadbConnectorcConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -104,10 +105,7 @@ class MariadbConnectorcConan(ConanFile):
         deps.generate()
 
     def _patch_sources(self):
-        apply_conandata_patches(self)
-
         root_cmake = os.path.join(self.source_folder, "CMakeLists.txt")
-        libmariadb_cmake = os.path.join(self.source_folder, "libmariadb", "CMakeLists.txt")
         replace_in_file(self,
             root_cmake,
             "SET(SSL_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})",
@@ -153,6 +151,3 @@ class MariadbConnectorcConan(ConanFile):
 
         plugin_dir = os.path.join(self.package_folder, "lib", "plugin").replace("\\", "/")
         self.runenv_info.prepend_path("MARIADB_PLUGIN_DIR", plugin_dir)
-
-        # TODO: to remove in conan v2
-        self.env_info.MARIADB_PLUGIN_DIR.append(plugin_dir)

--- a/recipes/mariadb-connector-c/all/conanfile.py
+++ b/recipes/mariadb-connector-c/all/conanfile.py
@@ -85,8 +85,6 @@ class MariadbConnectorcConan(ConanFile):
         else:
             tc.variables["WITH_MYSQLCOMPAT"] = False
             tc.variables["WITH_ICONV"] = self.options.with_iconv
-            if not self.options.get_safe("with_krb5"):
-                tc.variables["KRB5_CONFIG"] = ""
         tc.variables["WITH_UNIT_TESTS"] = False
         tc.variables["WITH_DYNCOL"] = self.options.dyncol
         tc.variables["WITH_EXTERNAL_ZLIB"] = True
@@ -98,6 +96,7 @@ class MariadbConnectorcConan(ConanFile):
         tc.variables["ZLIB_LIBRARY"] = "ZLIB::ZLIB"
         # To install relocatable shared libs on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_GSSAPI"] = True  # TODO: add as an option
         tc.generate()
         deps = CMakeDeps(self)
         if Version(self.version) >= "3.3":

--- a/recipes/mariadb-connector-c/all/test_package/CMakeLists.txt
+++ b/recipes/mariadb-connector-c/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(mariadb-connector-c REQUIRED CONFIG)

--- a/recipes/mariadb-connector-c/all/test_package/conanfile.py
+++ b/recipes/mariadb-connector-c/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **mariadb-connector-c/[*]**

#### Motivation
Otherwise uses any random krb5-config executable found on PATH for the krb5 dependency (https://github.com/mariadb-corporation/mariadb-connector-c/blob/v3.4.4/cmake/FindGSSAPI.cmake#L49).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
