### PR TITLE
libvdpau: requires C++ compiler, fix X11 linking

### DIFF
--- a/recipes/libvdpau/all/conandata.yml
+++ b/recipes/libvdpau/all/conandata.yml
@@ -7,3 +7,4 @@ patches:
     - patch_file: "patches/add-missing-x11-dep.patch"
       patch_description: "Add a missing X11 dependency to vdpau_trace"
       patch_type: "bugfix"
+      patch_source: "https://gitlab.freedesktop.org/vdpau/libvdpau/-/issues/6"

--- a/recipes/libvdpau/all/conandata.yml
+++ b/recipes/libvdpau/all/conandata.yml
@@ -2,3 +2,8 @@ sources:
   "1.5":
     url: "https://gitlab.freedesktop.org/vdpau/libvdpau/-/archive/1.5/libvdpau-1.5.tar.bz2"
     sha256: "a5d50a42b8c288febc07151ab643ac8de06a18446965c7241f89b4e810821913"
+patches:
+  "1.5":
+    - patch_file: "patches/add-missing-x11-dep.patch"
+      patch_description: "Add a missing X11 dependency to vdpau_trace"
+      patch_type: "bugfix"

--- a/recipes/libvdpau/all/conanfile.py
+++ b/recipes/libvdpau/all/conanfile.py
@@ -79,3 +79,9 @@ class PackageConan(ConanFile):
         self.cpp_info.libs = ["vdpau"]
         self.cpp_info.set_property("pkg_config_name", "vdpau")
         self.cpp_info.system_libs.extend(["pthread", "dl"])
+        self.cpp_info.requires = ["xorg::x11"]
+        if self.options.with_dri2:
+            self.cpp_info.requires.extend([
+                "xorg-proto::xorg-proto",
+                "xorg::xext",
+            ])

--- a/recipes/libvdpau/all/conanfile.py
+++ b/recipes/libvdpau/all/conanfile.py
@@ -35,10 +35,6 @@ class PackageConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
-    def configure(self):
-        self.settings.rm_safe("compiler.cppstd")
-        self.settings.rm_safe("compiler.libcxx")
-
     def layout(self):
         basic_layout(self, src_folder="src")
 

--- a/recipes/libvdpau/all/patches/add-missing-x11-dep.patch
+++ b/recipes/libvdpau/all/patches/add-missing-x11-dep.patch
@@ -1,0 +1,11 @@
+--- a/trace/meson.build
++++ b/trace/meson.build
+@@ -1,7 +1,7 @@
+ trace = shared_library('vdpau_trace',
+     sources : 'vdpau_trace.cpp',
+     include_directories : inc,
+-    dependencies : libdl,
++    dependencies : [x11, libdl],
+     version : '1.0.0',
+     install : true,
+     install_dir : moduledir,

--- a/recipes/libvdpau/all/test_package/CMakeLists.txt
+++ b/recipes/libvdpau/all/test_package/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(libvdpau REQUIRED CONFIG)
+find_package(X11 REQUIRED)
 
 add_executable(test_package test_package.c)
-target_link_libraries(test_package PRIVATE libvdpau::libvdpau)
+target_link_libraries(test_package PRIVATE libvdpau::libvdpau X11::X11)

--- a/recipes/libvdpau/all/test_package/conanfile.py
+++ b/recipes/libvdpau/all/test_package/conanfile.py
@@ -7,10 +7,11 @@ from conan.tools.cmake import CMake, cmake_layout
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+        self.requires("xorg/system", libs=False)
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +23,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not cross_building(self):
-            cmd = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(cmd, env="conanrun")

--- a/recipes/libvdpau/all/test_package/test_package.c
+++ b/recipes/libvdpau/all/test_package/test_package.c
@@ -1,46 +1,12 @@
 #include <vdpau/vdpau.h>
 #include <vdpau/vdpau_x11.h>
 
-#include <X11/Xlib.h>
+#include <stddef.h>
 
-#include <stdio.h>
+void dummy() {
+    vdp_device_create_x11(NULL, 0, NULL, NULL);
+}
 
 int main()
 {
-    VdpDevice device;
-    VdpGetProcAddress * get_proc_address;
-    VdpGetInformationString * get_information_string;
-    VdpGetApiVersion * get_api_version;
-    VdpStatus status;
-    Display * display = XOpenDisplay(NULL);
-    if (!display)
-    {
-        printf("XOpenDisplay failed!\n");
-        return 0;
-    }
-    status = vdp_device_create_x11(display, 0, &device, &get_proc_address);
-    if (status != VDP_STATUS_OK)
-    {
-        XCloseDisplay(display);
-        printf("vdp_device_create_x11 failed\n");
-        return 0;
-    }
-    status = get_proc_address(device, VDP_FUNC_ID_GET_INFORMATION_STRING, (void**) &get_information_string);
-    if (status == VDP_STATUS_OK)
-    {
-        char const * information_string;
-        status = get_information_string(&information_string);
-        if (status == VDP_STATUS_OK)
-            printf("VDPAU information string: %s\n", information_string);
-    }
-    status = get_proc_address(device, VDP_FUNC_ID_GET_API_VERSION, (void**) &get_api_version);
-    if (status == VDP_STATUS_OK)
-    {
-        uint32_t api_version;
-        status = get_api_version(&api_version);
-        if (status == VDP_STATUS_OK)
-            printf("VDPAU API version: %d\n", api_version);
-    }
-    XCloseDisplay(display);
-    return 0;
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **libvdpau/[*]**

#### Motivation
Fails to compile if some system C++ compiler is not found, since removing `compiler.cppstd` and `compiler.libcxx` makes Conan not pass the compiler executable.

#### Details
- Not C-only: https://gitlab.freedesktop.org/vdpau/libvdpau/-/blob/master/trace/vdpau_trace.cpp
- Fix X11 not being linked against correctly in the project.
- Add missing X11 dependency to test_package. I suppose `transitive_headers=True` could also be used, but its use is limited to `vdpau/vdpau_x11.h`, so I would keep it optional.
- List X11 requires to avoid overlinking.
- Simplify test_package.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
