### PR TITLE
md4qt: bump version

### DIFF
--- a/recipes/md4qt/all/conandata.yml
+++ b/recipes/md4qt/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.0.0":
-    url: "https://github.com/igormironchik/md4qt/archive/refs/tags/4.0.0.tar.gz"
-    sha256: "fc40e93d24aab504329efeabd42f098915bf3a089f0802640b99ec671c7ce452"
+  "4.1.0":
+    url: "https://github.com/igormironchik/md4qt/archive/refs/tags/4.1.0.tar.gz"
+    sha256: "b6fe728fb2a60a53ee75fa1895b908aea1ba9d430ba5503a95a79749a5e2285b"
   "3.0.0":
     url: "https://github.com/igormironchik/md4qt/archive/refs/tags/3.0.0.tar.gz"
     sha256: "757f94ce1818123abe899729bba00aa1d99150d4cbe934ab57a95b308fd536dd"

--- a/recipes/md4qt/all/conandata.yml
+++ b/recipes/md4qt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.0":
+    url: "https://github.com/igormironchik/md4qt/archive/refs/tags/4.0.0.tar.gz"
+    sha256: "fc40e93d24aab504329efeabd42f098915bf3a089f0802640b99ec671c7ce452"
   "3.0.0":
     url: "https://github.com/igormironchik/md4qt/archive/refs/tags/3.0.0.tar.gz"
     sha256: "757f94ce1818123abe899729bba00aa1d99150d4cbe934ab57a95b308fd536dd"

--- a/recipes/md4qt/all/conanfile.py
+++ b/recipes/md4qt/all/conanfile.py
@@ -40,8 +40,6 @@ class Md4QtConan(ConanFile):
     def requirements(self):
         self.requires("icu/74.1")
         self.requires("uriparser/0.9.7")
-        if Version(self.version) >= "4.0.0":
-            self.requires("extra-cmake-modules/6.2.0")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/md4qt/all/conanfile.py
+++ b/recipes/md4qt/all/conanfile.py
@@ -40,6 +40,8 @@ class Md4QtConan(ConanFile):
     def requirements(self):
         self.requires("icu/74.1")
         self.requires("uriparser/0.9.7")
+        if Version(self.version) >= "4.0.0":
+            self.requires("extra-cmake-modules/6.2.0")
 
     def package_id(self):
         self.info.clear()
@@ -64,7 +66,10 @@ class Md4QtConan(ConanFile):
             copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         else:
             copy(self, "MIT.txt", src=os.path.join(self.source_folder, "LICENSES"), dst=os.path.join(self.package_folder, "licenses"))
-        copy(self, "*.hpp", src=os.path.join(self.source_folder, "md4qt"), dst=os.path.join(self.package_folder, "include", "md4qt"))
+        if Version(self.version) < "4.0.0":
+            copy(self, "*.hpp", src=os.path.join(self.source_folder, "md4qt"), dst=os.path.join(self.package_folder, "include", "md4qt"))
+        else:
+            copy(self, "*.h", src=os.path.join(self.source_folder, "md4qt"), dst=os.path.join(self.package_folder, "include", "md4qt"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "md4qt")

--- a/recipes/md4qt/all/test_package/CMakeLists.txt
+++ b/recipes/md4qt/all/test_package/CMakeLists.txt
@@ -6,3 +6,7 @@ find_package(md4qt REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE md4qt::md4qt)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+if(md4qt_VERSION_STRING VERSION_GREATER_EQUAL "4.0.0")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE MD4QT_GREATER_EQUAL_4)
+endif()

--- a/recipes/md4qt/all/test_package/CMakeLists.txt
+++ b/recipes/md4qt/all/test_package/CMakeLists.txt
@@ -8,5 +8,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE md4qt::md4qt)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 if(md4qt_VERSION_STRING VERSION_GREATER_EQUAL "4.0.0")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE MD4QT_GREATER_EQUAL_4)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE MD4QT_VERSION_GREATER_EQUAL_4)
 endif()

--- a/recipes/md4qt/all/test_package/test_package.cpp
+++ b/recipes/md4qt/all/test_package/test_package.cpp
@@ -1,5 +1,9 @@
 #define MD4QT_ICU_STL_SUPPORT
+#ifdef MD4QT_GREATER_EQUAL_4
+#include <md4qt/parser.h>
+#else
 #include <md4qt/parser.hpp>
+#endif
 
 #include <memory>
 #include <iostream>

--- a/recipes/md4qt/all/test_package/test_package.cpp
+++ b/recipes/md4qt/all/test_package/test_package.cpp
@@ -1,5 +1,5 @@
 #define MD4QT_ICU_STL_SUPPORT
-#ifdef MD4QT_GREATER_EQUAL_4
+#ifdef MD4QT_VERSION_GREATER_EQUAL_4
 #include <md4qt/parser.h>
 #else
 #include <md4qt/parser.hpp>

--- a/recipes/md4qt/config.yml
+++ b/recipes/md4qt/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.0.0":
+  "4.1.0":
     folder: all
   "3.0.0":
     folder: all

--- a/recipes/md4qt/config.yml
+++ b/recipes/md4qt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.0":
+    folder: all
   "3.0.0":
     folder: all
   "2.8.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **md4qt/4.1.0**

#### Motivation
This is a major update of the library.

#### Details
https://invent.kde.org/libraries/md4qt/-/commits/master?ref_type=HEADS

##### Main improvements

* The code is formatted with KDE Coding Style.
* Fixed performance regression introduced in `3.0.0`.
* Fixed RTL support in generated HTML.
* Made text entities in Markdown AST with spaces as in source Markdown file. 
* Fixed parsing of HTML in some cases in lists.
* HTML visitor and function made more generic.
* Fixed performance slowdown in parsing emphasises.
* Fixed parsing of breaked lists.
* Fixed parsing of HTML in combinations with fenced code blocks.
* Minor improvements and fixes.

Development is going in KDE repository, but I have a hitch there with release process, so I imported all done things to GitHub and made there releases of versions `4.0.0` and `4.1.0`.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
