### PR TITLE
[abseil] Handle msvc static runtime

### DIFF
--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -95,7 +95,7 @@ class AbseilConan(ConanFile):
         if is_msvc(self):
             # see https://github.com/abseil/abseil-cpp/issues/649
             tc.preprocessor_definitions["_HAS_DEPRECATED_RESULT_OF"] = 1
-            tc.cache_variables["ABSL_MSVC_STATIC_RUNTIME"] = "ON" if is_msvc_static_runtime(self) else "OFF"
+            tc.cache_variables["ABSL_MSVC_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
         tc.generate()
 
     def _patch_sources(self):

--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd, cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import export_conandata_patches, apply_conandata_patches, copy, get, load, replace_in_file, rmdir, save
-from conan.tools.microsoft import is_msvc
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import json
 import os
@@ -95,6 +95,7 @@ class AbseilConan(ConanFile):
         if is_msvc(self):
             # see https://github.com/abseil/abseil-cpp/issues/649
             tc.preprocessor_definitions["_HAS_DEPRECATED_RESULT_OF"] = 1
+            tc.cache_variables["ABSL_MSVC_STATIC_RUNTIME"] = "ON" if is_msvc_static_runtime(self) else "OFF"
         tc.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil/all**

#### Motivation
With newer versions of abseil the variable ABSL_MSVC_STATIC_RUNTIME needs to be defined.
Added with https://github.com/abseil/abseil-cpp/pull/1699

#### Details
With msvc, set ABSL_MSVC_STATIC_RUNTIME based on is_msvc_static_runtime.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
