### PR TITLE
[tesseract] Update the version of libarchive used by tesseract

### DIFF
--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -61,7 +61,7 @@ class TesseractConan(ConanFile):
             self.requires("libtiff/4.6.0")
         # libarchive is required for 4.x so default value is true
         if self.options.get_safe("with_libarchive", default=True):
-            self.requires("libarchive/3.7.6")
+            self.requires("libarchive/[>=3.7 <3.8]")
         # libcurl is not required for 4.x
         if self.options.get_safe("with_libcurl", default=False):
             self.requires("libcurl/[>=7.78.0 <9]")

--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -61,7 +61,7 @@ class TesseractConan(ConanFile):
             self.requires("libtiff/4.6.0")
         # libarchive is required for 4.x so default value is true
         if self.options.get_safe("with_libarchive", default=True):
-            self.requires("libarchive/3.7.2")
+            self.requires("libarchive/3.7.6")
         # libcurl is not required for 4.x
         if self.options.get_safe("with_libcurl", default=False):
             self.requires("libcurl/[>=7.78.0 <9]")


### PR DESCRIPTION
Update the version of libarchive used by tesseract because 3.7.2 is vulnerable.

[NVD libarchive](https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe%3A2.3%3Aa%3Alibarchive%3Alibarchive%3A3.7.2%3A*%3A*%3A*%3A*%3A*%3A*%3A*)

### Summary
Changes to recipe:  **tesseract/[all]**

#### Motivation

[NVD libarchive](https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe%3A2.3%3Aa%3Alibarchive%3Alibarchive%3A3.7.2%3A*%3A*%3A*%3A*%3A*%3A*%3A*)


#### Details
bump version from 3.7.2 to 3.7.6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
