### PR TITLE
Add version 1.11.2 of libcpr

### DIFF
--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.2":
+    url: "https://github.com/libcpr/cpr/archive/refs/tags/1.11.2.tar.gz"
+    sha256: "3795a3581109a9ba5e48fbb50f9efe3399a3ede22f2ab606b71059a615cd6084"
   "1.11.1":
     url: "https://github.com/libcpr/cpr/archive/refs/tags/1.11.1.tar.gz"
     sha256: "e84b8ef348f41072609f53aab05bdaab24bf5916c62d99651dfbeaf282a8e0a2"
@@ -21,6 +24,10 @@ sources:
     url: "https://github.com/libcpr/cpr/archive/refs/tags/1.7.2.tar.gz"
     sha256: "aa38a414fe2ffc49af13a08b6ab34df825fdd2e7a1213d032d835a779e14176f"
 patches:
+  "1.11.2":
+    - patch_file: "patches/008-1.11.2-remove-warning-flags.patch"
+      patch_description: "disable warning flags and warning as error"
+      patch_type: "portability"
   "1.11.1":
     - patch_file: "patches/008-1.11.0-remove-warning-flags.patch"
       patch_description: "disable warning flags and warning as error"

--- a/recipes/cpr/all/patches/008-1.11.2-remove-warning-flags.patch
+++ b/recipes/cpr/all/patches/008-1.11.2-remove-warning-flags.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3f6e1d0..6e1e8ff 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -390,14 +390,14 @@ if(CPR_BUILD_TESTS)
+     restore_variable(DESTINATION CMAKE_CXX_CLANG_TIDY BACKUP CMAKE_CXX_CLANG_TIDY_BKP)
+ endif()
+ 
+-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+-else()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
+-    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+-        # Disable C++98 compatibility support in clang: https://github.com/libcpr/cpr/issues/927
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-nonportable-system-include-path -Wno-exit-time-destructors -Wno-undef -Wno-global-constructors -Wno-switch-enum -Wno-old-style-cast -Wno-covered-switch-default -Wno-undefined-func-template")
+-    endif()
+-endif()
++#if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
++#else()
++#    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
++#    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
++#        # Disable C++98 compatibility support in clang: https://github.com/libcpr/cpr/issues/927
++#        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-nonportable-system-include-path -Wno-exit-time-destructors -Wno-undef -Wno-global-constructors -Wno-switch-enum -Wno-old-style-cast -Wno-covered-switch-default -Wno-undefined-func-template")
++#    endif()
++#endif()
+ 
+ add_subdirectory(cpr)
+ add_subdirectory(include)

--- a/recipes/cpr/config.yml
+++ b/recipes/cpr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.11.2":
+    folder: all
   "1.11.1":
     folder: all
   "1.11.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcpr/1.11.2**

#### Motivation
There was a new bugfix release for libcpr, which I want to consume via conancenter https://github.com/libcpr/cpr/releases/tag/1.11.2

#### Details
Version bump of libcpr to 1.11.2


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
