### PR TITLE
abseil: add version 20240722.1

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20240722.1":
+    url: "https://github.com/abseil/abseil-cpp/archive/20240722.1.tar.gz"
+    sha256: "40cee67604060a7c8794d931538cb55f4d444073e556980c88b6c49bb9b19bb7"
   "20240722.0":
     url: "https://github.com/abseil/abseil-cpp/archive/20240722.0.tar.gz"
     sha256: "f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3"
@@ -21,6 +24,11 @@ sources:
     url: "https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz"
     sha256: "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4"
 patches:
+  "20240722.1":
+    - patch_file: "patches/0003-absl-string-libm-20240116.patch"
+      patch_description: "link libm to absl string"
+      patch_type: "portability"
+      patch_source: "https://github.com/abseil/abseil-cpp/issues/1100"
   "20240722.0":
     - patch_file: "patches/0003-absl-string-libm-20240116.patch"
       patch_description: "link libm to absl string"

--- a/recipes/abseil/config.yml
+++ b/recipes/abseil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20240722.1":
+    folder: all
   "20240722.0":
     folder: all
   "20240116.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil/20240722.1**

#### Motivation
New upstream version to fix CVE-2025-0838

#### Details
https://github.com/abseil/abseil-cpp/compare/20240722.0...20240722.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
