### PR TITLE
approvaltests.cpp: Make conanfile compatible with mirror urls

### DIFF
--- a/recipes/approvaltests.cpp/all/conanfile.py
+++ b/recipes/approvaltests.cpp/all/conanfile.py
@@ -76,7 +76,8 @@ class ApprovalTestsCppConan(ConanFile):
 
     def source(self):
         for source in self.conan_data["sources"][self.version]:
-            url = source["url"]
+            urls = source["url"]
+            url = urls[0] if isinstance(urls, (list, tuple)) else urls
             filename = url[url.rfind("/") + 1:]
             download(self, url, filename, sha256=source["sha256"])
         rename(self, src=os.path.join(self.source_folder, f"ApprovalTests.v.{self.version}.hpp"),

--- a/recipes/approvaltests.cpp/all/conanfile.py
+++ b/recipes/approvaltests.cpp/all/conanfile.py
@@ -79,7 +79,7 @@ class ApprovalTestsCppConan(ConanFile):
             urls = source["url"]
             url = urls[0] if isinstance(urls, (list, tuple)) else urls
             filename = url[url.rfind("/") + 1:]
-            download(self, url, filename, sha256=source["sha256"])
+            download(self, urls, filename, sha256=source["sha256"])
         rename(self, src=os.path.join(self.source_folder, f"ApprovalTests.v.{self.version}.hpp"),
                      dst=os.path.join(self.source_folder, self._header_file))
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **approvaltests.cpp**

#### Motivation
Fixes #26683
Passing multiple URLs per file in conandata.yml  results in `self.conan_data["sources"][version]["url"]` being a list instead of a string.
This recipe had hardcoded behavior that assumed the url would always be a string, which breaks when more urls are specified (as is the case in our downstream automation).

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Fix the `source` method to accept either a string, list or tuple as URL. I took inspiration by the implementation of `conan.tools.files.get`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
