### PR TITLE
Bump libsodium to 1.0.20

### DIFF
--- a/recipes/cnats/all/conanfile.py
+++ b/recipes/cnats/all/conanfile.py
@@ -49,7 +49,7 @@ class PackageConan(ConanFile):
         if self.options.with_tls:
             self.requires("openssl/[>=1.1 <4]")
         if self.options.with_sodium:
-            self.requires("libsodium/cci.20220430")
+            self.requires("libsodium/1.0.20")
         # FIXME: C3I Jenkins does not have protobuf-c static x shared deps for now
         if self.options.enable_streaming:
             self.requires("protobuf-c/1.4.1")

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -79,7 +79,7 @@ class FollyConan(ConanFile):
         self.requires("zstd/1.5.5", transitive_libs=True)
         if not is_msvc(self):
             self.requires("libdwarf/0.9.1")
-        self.requires("libsodium/1.0.19")
+        self.requires("libsodium/1.0.20")
         self.requires("xz_utils/[>=5.4.5 <6]")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("libiberty/9.1.0")

--- a/recipes/gamenetworkingsockets/all/conanfile.py
+++ b/recipes/gamenetworkingsockets/all/conanfile.py
@@ -48,7 +48,7 @@ class GameNetworkingSocketsConan(ConanFile):
         if self.options.encryption == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         elif self.options.encryption == "libsodium":
-            self.requires("libsodium/cci.20220430")
+            self.requires("libsodium/1.0.20")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/yojimbo/all/conanfile.py
+++ b/recipes/yojimbo/all/conanfile.py
@@ -29,7 +29,7 @@ class YojimboConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("libsodium/1.0.20")
+        self.requires("libsodium/1.0.18")
         self.requires("mbedtls/2.25.0")
  
     def source(self):

--- a/recipes/yojimbo/all/conanfile.py
+++ b/recipes/yojimbo/all/conanfile.py
@@ -29,7 +29,7 @@ class YojimboConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("libsodium/1.0.18")
+        self.requires("libsodium/1.0.20")
         self.requires("mbedtls/2.25.0")
  
     def source(self):

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -60,7 +60,7 @@ class ZeroMQConan(ConanFile):
 
     def requirements(self):
         if self.options.encryption == "libsodium":
-            self.requires("libsodium/1.0.19")
+            self.requires("libsodium/1.0.20")
         if self.options.with_norm:
             self.requires("norm/1.5.9")
 


### PR DESCRIPTION
Fix https://github.com/conan-io/conan-center-index/issues/26682

### Changed recipes

The following recipes have been updated to avoid any `libsodium` conflict. 

* cnats
* folly
* gamenetworkingsockets
* zeromq

### Logs

Attaching logs of recipes which have `libsodium` disabled by default, all compiling:
```sh
$ conan create recipes/cnats/all --version 3.9.2 -o '&:with_sodium=True' --build missing
```

[cnats_with_sodium.txt](https://github.com/user-attachments/files/18961512/cnats_with_sodium.txt)

```sh
$  conan create recipes/gamenetworkingsockets/all --version 1.4.1 -o '&:encryption=libsodium' -s arch=x86_64 --build=missing 
```
[gamenetworkingsockets_encryption_libsodium.txt](https://github.com/user-attachments/files/18961513/gamenetworkingsockets_encryption_libsodium.txt)


#### Motivation

libsodium/1.0.19 is broken and has been fixed on upstream in the following commit, and released on 1.0.20
https://github.com/jedisct1/libsodium/commit/bf972efda0c1647f31546ca4a3a4e3a38f902362
The patch is too complex to support it in CCI.
