### PR TITLE
opentrackio-cpp: add version 1.0.1

### DIFF
--- a/recipes/opentrackio-cpp/all/conandata.yml
+++ b/recipes/opentrackio-cpp/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  "1.0.0":
+  "1.0.1":
     url:
-    - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/1.0.0.tar.gz"
-    sha256: "c3dd23723a3b5bdc5a210434cbcd0542c8cd993b9b89cabfc6d3c9592caeae14"
+    - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/1.0.1.tar.gz"
+    sha256: "079b3998e9e1e12e5b7a3c72f2f177bbc48f7da5220cd0f6dfd556056ba5663f"

--- a/recipes/opentrackio-cpp/all/conandata.yml
+++ b/recipes/opentrackio-cpp/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
   "1.0.0":
     url:
-    - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/v1.0.0.tar.gz"
-    sha256: "89bd489774a8efac9b18ddcff9a2219d57d46a73d53ea0a5fd71a94c27fc1257"
+    - "https://github.com/mosys/opentrackio-cpp/archive/refs/tags/1.0.0.tar.gz"
+    sha256: "c3dd23723a3b5bdc5a210434cbcd0542c8cd993b9b89cabfc6d3c9592caeae14"

--- a/recipes/opentrackio-cpp/all/test_package/test_package.cpp
+++ b/recipes/opentrackio-cpp/all/test_package/test_package.cpp
@@ -8,7 +8,7 @@ int main(void) {
     std::string example = R"({
       "protocol": {
         "name": "OpenTrackIO",
-        "version": "0.9.0"
+        "version": "1.0.0"
       },
       "tracker": {
         "notes": "Example generated sample.",

--- a/recipes/opentrackio-cpp/config.yml
+++ b/recipes/opentrackio-cpp/config.yml
@@ -1,4 +1,4 @@
 versions:
   # Newer versions at the top
-  "1.0.0":
+  "1.0.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentrackio-cpp/1.0.0**

#### Motivation
Replacing with the correct version 1.0.0 to match the outputs of [CamDKit](https://github.com/SMPTE/ris-osvp-metadata-camdkit)

#### Details
Fix link and SHA to v1.0.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
