### PR TITLE
quill: add version 8.2.0

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.2.0":
+    url: "https://github.com/odygrd/quill/releases/download/v8.2.0/quill-8.2.0.zip"
+    sha256: "846a2ace10e4d5482215e4c2461eb9b157a1b4d7f485700233b06d393cab97c4"
   "8.1.0":
     url: "https://github.com/odygrd/quill/releases/download/v8.1.0/quill-8.1.0.zip"
     sha256: "11cf2cfb96e2a0ef28ce4b3ba6795cab5d8d1a04fea84805310bbb2d57f0a657"

--- a/recipes/quill/all/test_package/CMakeLists.txt
+++ b/recipes/quill/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.12)
 project(test_package LANGUAGES CXX)
 
 find_package(quill REQUIRED CONFIG)
@@ -7,4 +7,3 @@ add_executable(${PROJECT_NAME} test_package.cpp)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE quill::quill)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-target_compile_definitions(${PROJECT_NAME} PRIVATE QUILL_FILE_HANDLERS_API_V3_3)

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.2.0":
+    folder: "all"
   "8.1.0":
     folder: "all"
   "7.5.0":


### PR DESCRIPTION
### Summary  
Changes to recipe: **quill/8.2.0**  

#### Motivation  
This is an upstream update that introduces a long-requested feature, making it easier to log user-defined types. Additionally, it includes several minor improvements.  

#### Details  
- Changelog: [v8.2.0](https://github.com/odygrd/quill/releases/tag/v8.2.0)  
- Compare: [v8.1.0...v8.2.0](https://github.com/odygrd/quill/compare/v8.1.0...v8.2.0)  

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
