### PR TITLE
c4core: add version 0.2.5

### DIFF
--- a/recipes/c4core/all/conandata.yml
+++ b/recipes/c4core/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.5":
+    url: "https://github.com/biojppm/c4core/releases/download/v0.2.5/c4core-0.2.5-src.tgz"
+    sha256: "758f23718cbdc9465f104249561c4028858caf3355a90616b54d1dd937a981b1"
   "0.2.2":
     url: "https://github.com/biojppm/c4core/releases/download/v0.2.2/c4core-0.2.2-src.tgz"
     sha256: "beea43a5bdc64616d897cc0af728f408e35e2d75a8bb6014e6e25e90e0484578"
@@ -21,6 +24,10 @@ sources:
     url: "https://github.com/biojppm/c4core/releases/download/v0.1.8/c4core-0.1.8-src.tgz"
     sha256: "95c0663192c6bff7a098b50afcb05d22a34dd0fd8e6be2e1b61edad2b9675fde"
 patches:
+  "0.2.5":
+    - patch_file: "patches/0.2.5-0001-make-fast_float-external.patch"
+      patch_description: "use cci's fast_float recipe"
+      patch_type: "conan"
   "0.2.2":
     - patch_file: "patches/0.2.2-0001-make-fast_float-external.patch"
       patch_description: "use cci's fast_float recipe"

--- a/recipes/c4core/all/patches/0.2.5-0001-make-fast_float-external.patch
+++ b/recipes/c4core/all/patches/0.2.5-0001-make-fast_float-external.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba9983c..124e87b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -78,7 +78,7 @@ set(C4CORE_SRC_FILES
+ if(C4CORE_WITH_FASTFLOAT)
+     list(APPEND C4CORE_SRC_FILES
+         c4/ext/fast_float.hpp
+-        c4/ext/fast_float_all.h
++#        c4/ext/fast_float_all.h
+         )
+ endif()
+ set(C4CORE_AMALGAMATED ${C4CORE_SRC_DIR}/../src_singleheader/c4/c4core_all.hpp)
+@@ -97,7 +97,10 @@ c4_add_library(c4core
+     SOURCE_ROOT ${C4CORE_SRC_DIR}
+     SOURCES ${C4CORE_SRC_FILES}
+ )
+-if(NOT C4CORE_WITH_FASTFLOAT)
++if(C4CORE_WITH_FASTFLOAT)
++    find_package(FastFloat REQUIRED CONFIG)
++    target_link_libraries(c4core PUBLIC "FastFloat::fast_float")
++else()
+     target_compile_definitions(c4core PUBLIC -DC4CORE_NO_FAST_FLOAT)
+ endif()
+ if(C4CORE_NO_DEBUG_BREAK)
+diff --git a/src/c4/ext/fast_float.hpp b/src/c4/ext/fast_float.hpp
+index f54e073..a2d5c44 100644
+--- a/src/c4/ext/fast_float.hpp
++++ b/src/c4/ext/fast_float.hpp
+@@ -25,7 +25,7 @@
+ #   endif
+ #endif
+ 
+-#include "c4/ext/fast_float_all.h"
++#include "fast_float/fast_float.h"
+ 
+ #ifdef _MSC_VER
+ #   pragma warning(pop)

--- a/recipes/c4core/config.yml
+++ b/recipes/c4core/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.5":
+    folder: all
   "0.2.2":
     folder: all
   "0.2.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **c4core/0.2.5**

#### Motivation
Several CPU architectures are supported since 0.2.2.

There are lots of new features and improvements.
Those will be required by future rapidyaml releases.

#### Details
https://github.com/biojppm/c4core/releases/tag/v0.2.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
