### PR TITLE
zstd: add version 1.5.7

### DIFF
--- a/recipes/zstd/all/conandata.yml
+++ b/recipes/zstd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.7":
+    url: "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz"
+    sha256: "eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3"
   "1.5.6":
     url: "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz"
     sha256: "8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1"

--- a/recipes/zstd/config.yml
+++ b/recipes/zstd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.7":
+    folder: all
   "1.5.6":
     folder: all
   "1.5.5":


### PR DESCRIPTION
### Summary
Changes to recipe:  **zstd/1.5.7**

#### Motivation
zstd/1.5.7 brings better compression speed.
https://www.phoronix.com/news/Zstd-Zstandard-1.5.7

#### Details
https://github.com/facebook/zstd/compare/v1.5.6...v1.5.7

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
