### PR TITLE
muparser: add version 2.3.5

### DIFF
--- a/recipes/muparser/all/conandata.yml
+++ b/recipes/muparser/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3.5":
+    url: "https://github.com/beltoforion/muparser/archive/refs/tags/v2.3.5.tar.gz"
+    sha256: "20b43cc68c655665db83711906f01b20c51909368973116dfc8d7b3c4ddb5dd4"
   "2.3.4":
     url: "https://github.com/beltoforion/muparser/archive/refs/tags/v2.3.4.tar.gz"
     sha256: "0c3fa54a3ebf36dda0ed3e7cd5451c964afbb15102bdbcba08aafb359a290121"

--- a/recipes/muparser/config.yml
+++ b/recipes/muparser/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3.5":
+    folder: all
   "2.3.4":
     folder: all
   "2.3.2":


### PR DESCRIPTION
Ref #14561
This should resolve issue #17356


### Summary
Changes to recipe:  **muparser/2.3.5**

#### Motivation
Bump muparser patch release to allow building with MSVC / C++20

#### Details
Just bump version, no change to the recipe needed. Tested locally on Win 11 machine running msvc v194 compiler


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
