### PR TITLE
Fix QODBCDriverPlugin component name

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -1197,9 +1197,9 @@ class QtConan(ConanFile):
         if self.options.with_odbc:
             _create_plugin("QODBCDriverPlugin", "qsqlodbc", "sqldrivers", [])
             if self.settings.os != "Windows":
-                self.cpp_info.components["QODBCDriverPlugin"].requires.append("odbc::odbc")
+                self.cpp_info.components["qtQODBCDriverPlugin"].requires.append("odbc::odbc")
             else:
-                self.cpp_info.components["QODBCDriverPlugin"].system_libs.append("odbc32")
+                self.cpp_info.components["qtQODBCDriverPlugin"].system_libs.append("odbc32")
         networkReqs = []
         if self.options.openssl:
             networkReqs.append("openssl::openssl")


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6**

#### Motivation
Fix #26737. 


QODBCDriverPlugin has two component: 
```
-- Conan: Component target declared 'qt::QODBCDriverPlugin'
-- Conan: Component target declared 'Qt6::QODBCDriverPlugin'
```
which mean that in your code you'll have to do something like:

```
target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::QODBCDriverPlugin qt::QODBCDriverPlugin)
```


#### Details
QODBCDriverPlugin was missing the 'qt' prefix when adding requirements outside of _create_plugin(), which lead to a different component name.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
