### PR TITLE
opencppcoverage: add recipe

### DIFF
--- a/recipes/opencppcoverage/all/conandata.yml
+++ b/recipes/opencppcoverage/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "0.9.9.0":
+    url:
+    - "https://github.com/OpenCppCoverage/OpenCppCoverage/archive/refs/tags/release-0.9.9.0.tar.gz"
+    sha256: "33f4413d9e83c5fe586efa743922eddbb1ad5f4ccc193e91c24efc7112954dfe"

--- a/recipes/opencppcoverage/all/conanfile.py
+++ b/recipes/opencppcoverage/all/conanfile.py
@@ -28,8 +28,7 @@ class PackageConan(ConanFile):
         if not is_msvc(self):
             raise ConanInvalidConfiguration(f"{self.ref} can be built only by Visual Studio and msvc.")
 
-        if not check_min_vs(self, "192"):
-            raise ConanInvalidConfiguration("Visual Studio 2019 (version 192) or higher is required.")
+        check_min_vs(self, "192")
 
         if not self.settings.arch in ["x86", "x86_64"]:
             raise ConanInvalidConfiguration(f"{self.ref} can be built only for x86 or x64.")

--- a/recipes/opencppcoverage/all/conanfile.py
+++ b/recipes/opencppcoverage/all/conanfile.py
@@ -1,0 +1,81 @@
+import os
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import MSBuild, MSBuildToolchain, is_msvc, check_min_vs
+
+required_conan_version = ">=2.0"
+
+class PackageConan(ConanFile):
+    name = "opencppcoverage"
+    description = "OpenCppCoverage is an open source code coverage tool for C++ under Windows."
+    license = "GPL-3.0-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/OpenCppCoverage/OpenCppCoverage"
+    topics = ("coverage", "test", "debug")
+    package_type = "application"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if not is_msvc(self):
+            raise ConanInvalidConfiguration(f"{self.ref} can be built only by Visual Studio and msvc.")
+
+        if not check_min_vs(self, "192"):
+            raise ConanInvalidConfiguration("Visual Studio 2019 (version 192) or higher is required.")
+
+        if not self.settings.arch in ["x86", "x86_64"]:
+            raise ConanInvalidConfiguration(f"{self.ref} can be built only for x86 or x64.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    @property
+    def _msbuild_configuration(self):
+        return "Debug" if self.settings.build_type == "Debug" else "Release"
+
+    @property
+    def _msbuild_platform(self):
+        return "x64" if self.settings.arch == "x86_64" else "Win32"
+
+    def generate(self):
+        tc = MSBuildToolchain(self)
+        tc.configuration = self._msbuild_configuration
+        tc.generate()
+
+    def build(self):
+        self.run("powershell -ExecutionPolicy Bypass -File InstallThirdPartyLibraries.ps1",
+                 cwd=self.source_folder)
+
+        msbuild = MSBuild(self)
+        msbuild.build_type = self._msbuild_configuration
+        msbuild.platform = self._msbuild_platform
+        msbuild_command = msbuild.command(sln="CppCoverage.sln")
+
+        self.run(msbuild_command, cwd=self.source_folder)
+
+    def package(self):
+        build_output = os.path.join(
+            self.source_folder,
+            "x64" if self.settings.arch == "x86_64" else "",
+            self._msbuild_configuration)
+
+        install_bin = os.path.join(
+            self.package_folder,
+            "bin")
+
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.dll", build_output, install_bin)
+        copy(self, "*.exe", build_output, install_bin)
+        copy(self, "Template/*", build_output, install_bin)
+
+    def package_info(self):
+        bindir = os.path.join(self.package_folder, "bin")
+        self.env_info.PATH.append(bindir)

--- a/recipes/opencppcoverage/all/test_package/conanfile.py
+++ b/recipes/opencppcoverage/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout
+from conan.tools.build import can_run
+from conans.errors import ConanException
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            # INFO: The --help option does not cause a 0 exit code as usual
+            # INFO: The exit code is different between 32 and 64 bits due to overflow
+            retcode_expected = 2676788828 if self.settings.arch == "x86_64" else -1618178468
+            retcode_received = self.run("OpenCppCoverage.exe --help", env="conanrun", ignore_errors=True)
+
+            if retcode_received != retcode_expected:
+                raise ConanException(f"Error {retcode_received} while executing")

--- a/recipes/opencppcoverage/config.yml
+++ b/recipes/opencppcoverage/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.9.9.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencppcoverage/0.9.9.0**

#### Motivation
- **opencppcoverage** is a code coverage analysis tool for Windows.
- Over 900 stars on GitHub.
- Seems to not have received updates for a while, but we lack other options for Windows. Linux has other tools available.

#### Details
Few unusual points about the recipe:
- The project is a Visual Studio solution that imports dependencies via _Nuget_. The _Nuget_ commands are called from a _Powershell_ script.
- I'm keeping this behavior in the recipe as per the build instructions in the repo's docs.
- The dependencies DO exist on _conan center_, but changing that would required heavy patching of the original repo.
- The application does not provide a "--version" option, and the "--help" option returns a hardcoded constant, which overflows in 32-bit, so it gives a different number from the 64-bits version, causing the _test\_package_ to be somewhat convoluted.
- This is an application meant to be used as a *tool_requires*

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
