### PR TITLE
Fix http2 detection in CMake builds

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -381,6 +381,7 @@ class LibcurlConan(ConanFile):
             replace_in_file(self, cmakelists, "find_package(NGHTTP2 REQUIRED)", "find_package(libnghttp2 REQUIRED CONFIG)")
         else:
             replace_in_file(self, cmakelists, "find_package(NGHTTP2)", "find_package(libnghttp2 REQUIRED CONFIG)")
+            replace_in_file(self, cmakelists, "NGHTTP2_FOUND", "libnghttp2_FOUND")
         replace_in_file(self, cmakelists, "${NGHTTP2_INCLUDE_DIRS}", "${libnghttp2_INCLUDE_DIRS}")
         replace_in_file(self, cmakelists, "${NGHTTP2_LIBRARIES}", "libnghttp2::nghttp2")
 

--- a/recipes/libcurl/all/test_package/test_package.c
+++ b/recipes/libcurl/all/test_package/test_package.c
@@ -6,6 +6,7 @@ int main(void)
   CURL *curl;
   int retval = 0;
   const char *const *proto;
+  const char *const *feat;
   curl_version_info_data* id = curl_version_info(CURLVERSION_NOW);
   if (!id)
     return 1;
@@ -14,7 +15,12 @@ int main(void)
   for(proto = id->protocols; *proto; proto++) {
     printf("%s ", *proto);
   }
-  printf("\nversion: %s\nssl version: %s\nfeatures: %d\n", id->version, id->ssl_version, id->features);
+  printf("\nversion: %s\nssl version: %s\n", id->version, id->ssl_version);
+
+  printf("features: ");
+  for(feat = id->feature_names; *feat; feat++) {
+    printf("%s ", *feat);
+  }
 
   curl = curl_easy_init();
   if(curl) {


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcurl/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Simpler fix for missing libnghttp2 detection

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Closes https://github.com/conan-io/conan-center-index/issues/26054 and is a subset of the changes from https://github.com/conan-io/conan-center-index/pull/26063


Without the fix, the test_package for `conan create . --version=8.11.1 -b=missing -o="&:with_nghttp2=True"` on Windows shows:
```
======== Testing the package: Executing test ========
libcurl/8.11.1 (test package): Running test()
libcurl/8.11.1 (test package): RUN: Release\test_package
protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp ws wss
version: 8.11.1
ssl version: OpenSSL/3.3.2
features: alt-svc AsynchDNS HSTS HTTPS-proxy IPv6 Largefile libz NTLM SSL threadsafe TLS-SRP Unicode UnixSockets Succeed
```
note the lack of `HTTP2` in the listed features


And with the fix:
```
======== Testing the package: Executing test ========
libcurl/8.11.1 (test package): Running test()
libcurl/8.11.1 (test package): RUN: Release\test_package
protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp ws wss
version: 8.11.1
ssl version: OpenSSL/3.3.2
features: alt-svc AsynchDNS HSTS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM SSL threadsafe TLS-SRP Unicode UnixSockets Succeed
```

where `HTTP2` properly shows up
