### PR TITLE
gtest: add version 1.16.0

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.16.0":
+    url: "https://github.com/google/googletest/archive/v1.16.0.tar.gz"
+    sha256: "78c676fc63881529bf97bf9d45948d905a66833fbfa5318ea2cd7478cb98f399"
   "1.15.0":
     url: "https://github.com/google/googletest/releases/download/v1.15.0/googletest-1.15.0.tar.gz"
     sha256: "7315acb6bf10e99f332c8a43f00d5fbb1ee6ca48c52f6b936991b216c586aaad"

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.16.0":
+    folder: all
   "1.15.0":
     folder: all
   "1.14.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)  
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)


### Summary
Changes to recipe:  **gtest/1.16.0**

#### Motivation
New major release of GoogleTest.   
Upstream Changes: https://github.com/google/googletest/compare/v1.15.0...v1.16.0

#### Details
Added URL & SHA256 to new version

Fixes #26718 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
