### PR TITLE
Update to SQLite3 Multiple Ciphers 2.1.0

### DIFF
--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.0":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.1.0.tar.gz"
+    sha256: "e7778297643f613bc2dabbcec8070d38a19e24b50d2faaed71b3d70ef0f0fe84"
   "2.0.2":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.0.2.tar.gz"
     sha256: "dc34a1575480d1ec6d7ed3a9ce0b3227c1d463a0a3e8885c16efe47d0e395bc7"

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.0":
+    folder: all
   "2.0.2":
     folder: all
   "1.9.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3mc**

#### Motivation
**sqlite3mc version 2.1.0** supports the latest SQLite version **3.49.1**, and includes an important bug fix affecting multi-threaded applications.

#### Details
An entry for version 2.1.0 was added to the recipe.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
