### PR TITLE
[boost] Boost process requires boost context as transitive dependency of asio

### DIFF
--- a/recipes/boost/all/dependencies/dependencies-1.87.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.87.0.yml
@@ -120,6 +120,7 @@ dependencies:
   process:
   - filesystem
   - system
+  - context
   program_options: []
   python: []
   random:


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.87.0**

#### Motivation

fixes #26741

#### Details

The boost 1.87.0 will always produce the library boost context, because is required by boost asio. When disabling it, but keeping boost process enabled, it will result in a mismatch.

This fix is palliative, as the boost 1.87.0 introduced the modular build support (https://github.com/boostorg/asio/commit/a31cca5ec175b0d3b2e5b7f5e211f3ca75616e30), we should investigate the script `rebuild-dependencies.py` to avoid similar problems. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
