### PR TITLE
gobject-introspection: set package_type to shared-library, misc

### DIFF
--- a/recipes/gobject-introspection/all/conandata.yml
+++ b/recipes/gobject-introspection/all/conandata.yml
@@ -5,3 +5,14 @@ sources:
   "1.72.0":
     url: "https://download.gnome.org/sources/gobject-introspection/1.72/gobject-introspection-1.72.0.tar.xz"
     sha256: "02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc"
+patches:
+  "1.78.1":
+    - patch_file: "patches/1.78.1-fix-distutils.msvccompiler.patch"
+      patch_description: "Handle removed distutils.msvccompiler"
+      patch_type: "backport"
+      patch_source: "https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490"
+  "1.72.0":
+    - patch_file: "patches/1.72.0-fix-distutils.msvccompiler.patch"
+      patch_description: "Handle removed distutils.msvccompiler"
+      patch_type: "backport"
+      patch_source: "https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/490"

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -58,6 +58,13 @@ class GobjectIntrospectionConan(ConanFile):
         # ffi.h is exposed by public header gobject-introspection-1.0/girffi.h
         self.requires("libffi/3.4.4", transitive_headers=True)
 
+    def validate_build(self):
+        if cross_building(self):
+            # Requires QEMU or similar as an exe_wrapper for Meson to run the built executables during cross-compilation.
+            # Disabling even if 'can_run' is True, since the introspection data generation when using the package still tries to
+            # link against libgirepository-1.0.so of the executable and fails when cross-compiling.
+            raise ConanInvalidConfiguration("Cross-compilation is not supported.")
+
     def validate(self):
         if self.settings.os == "Windows" and self.settings.build_type == "Debug":
             # fatal error LNK1104: cannot open file 'python37_d.lib'

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -2,14 +2,13 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import cross_building
-from conan.tools.env import VirtualRunEnv
+from conan.tools.env import VirtualRunEnv, Environment
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import MesonToolchain, Meson
-from conan.tools.env import Environment
-from conan.tools.apple import fix_apple_shared_install_name
 
 required_conan_version = ">=2.4"
 
@@ -21,9 +20,9 @@ class GobjectIntrospectionConan(ConanFile):
     license = "LGPL-2.1-or-later"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.gnome.org/GNOME/gobject-introspection"
-    topics = ("gobject-instrospection",)
+    topics = ("gobject", "introspection",)
 
-    package_type = "application"
+    package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "build_introspection_data": [True, False],
@@ -47,7 +46,7 @@ class GobjectIntrospectionConan(ConanFile):
             self.options.build_introspection_data = False
 
     def configure(self):
-        if self.options.get_safe("build_introspection_data"):
+        if self.options.build_introspection_data:
             # INFO: g-ir-scanner looks for dynamic glib and gobject libraries when running
             self.options["glib"].shared = True
 

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -10,10 +10,8 @@ from conan.tools.layout import basic_layout
 from conan.tools.meson import MesonToolchain, Meson
 from conan.tools.env import Environment
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.scm import Version
-from conan import conan_version
 
-required_conan_version = ">=1.60.0 <2.0 || >=2.0.5"
+required_conan_version = ">=2.0.5"
 
 
 class GobjectIntrospectionConan(ConanFile):
@@ -121,25 +119,11 @@ class GobjectIntrospectionConan(ConanFile):
         replace_in_file(self, os.path.join(self.source_folder, "tools", "g-ir-tool-template.in"),
                         "os.path.join(filedir, '..', 'share')",
                         "os.path.join(filedir, '..', 'res')")
-        if Version(conan_version) < "2":
-            # INFO: Conan 1.x generates PkgConfigDeps with libdir1 and includedir1 variables only for glib due its modules
-            replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
-                            "glib_dep.get_variable(pkgconfig: 'libdir')",
-                            "glib_dep.get_variable(pkgconfig: 'libdir1')")
-            replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
-                            "join_paths(glib_dep.get_variable(pkgconfig: 'includedir'), 'glib-2.0')",
-                            "join_paths(glib_dep.get_variable(pkgconfig: 'includedir1'), 'glib-2.0')")
-            # gir/meson.build expects the gio-unix-2.0 includedir to be passed as a build flag.
-            # Patch this for glib from Conan.
-            replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
-                            "join_paths(giounix_dep.get_variable(pkgconfig: 'includedir'), 'gio-unix-2.0')",
-                            "giounix_dep.get_variable(pkgconfig: 'includedir1')")
-        else:
-            # gir/meson.build expects the gio-unix-2.0 includedir to be passed as a build flag.
-            # Patch this for glib from Conan.
-            replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
-                            "join_paths(giounix_dep.get_variable(pkgconfig: 'includedir'), 'gio-unix-2.0')",
-                            "giounix_dep.get_variable(pkgconfig: 'includedir')")
+        # gir/meson.build expects the gio-unix-2.0 includedir to be passed as a build flag.
+        # Patch this for glib from Conan.
+        replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
+                        "join_paths(giounix_dep.get_variable(pkgconfig: 'includedir'), 'gio-unix-2.0')",
+                        "giounix_dep.get_variable(pkgconfig: 'includedir')")
 
     def build(self):
         self._patch_sources()
@@ -180,9 +164,3 @@ class GobjectIntrospectionConan(ConanFile):
         )
         self.buildenv_info.define_path("GI_GIR_PATH", os.path.join(self.package_folder, "res", "gir-1.0"))
         self.buildenv_info.define_path("GI_TYPELIB_PATH", os.path.join(self.package_folder, "lib", "girepository-1.0"))
-
-        # TODO: remove in conan v2
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.env_info.PATH.append(bin_path)
-        self.env_info.GI_GIR_PATH = os.path.join(self.package_folder, "res", "gir-1.0")
-        self.env_info.GI_TYPELIB_PATH = os.path.join(self.package_folder, "lib", "girepository-1.0")

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -42,9 +42,6 @@ class GobjectIntrospectionConan(ConanFile):
             # Building gobject-introspection as a tool_requires.
             # Build only the tools by default.
             self.options.build_introspection_data = False
-        if cross_building(self):
-            # Cross-compilation of introspection data requires an exe_wrapper like QEMU.
-            self.options.build_introspection_data = False
         if self.settings.os in ["Windows", "Macos"]:
             # FIXME: tools/g-ir-scanner fails to load glib
             self.options.build_introspection_data = False
@@ -76,7 +73,9 @@ class GobjectIntrospectionConan(ConanFile):
             # giscanner/_giscanner.cpython-37m-darwin.so, 0x0002): Library not loaded: /lib/libgnuintl.8.dylib
             raise ConanInvalidConfiguration(f"{self.ref} fails to run g-ir-scanner due glib loaded as shared. Use -o 'glib/*:shared=False'. Contributions to fix this are welcome.")
         if self.options.build_introspection_data and cross_building(self):
-            raise ConanInvalidConfiguration(f"{self.ref} build_introspection_data is not supported when cross-building. Use '&:build_introspection_data=False'.")
+            # Cross-compilation of introspection data requires an exe_wrapper like QEMU.
+            raise ConanInvalidConfiguration("build_introspection_data is not supported when cross-building."
+                                            f" Use '-o gobject-introspection/*:build_introspection_data=False' if it's not needed.")
 
     def build_requirements(self):
         self.tool_requires("meson/[>=1.2.3 <2]")

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
-from conan.tools.files import copy, get, replace_in_file, rm, rmdir
+from conan.tools.files import copy, get, replace_in_file, rm, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import MesonToolchain, Meson
@@ -34,6 +34,9 @@ class GobjectIntrospectionConan(ConanFile):
         "build_introspection_data": True,
     }
     short_paths = True
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -96,6 +99,7 @@ class GobjectIntrospectionConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         env = VirtualBuildEnv(self)

--- a/recipes/gobject-introspection/all/patches/1.72.0-fix-distutils.msvccompiler.patch
+++ b/recipes/gobject-introspection/all/patches/1.72.0-fix-distutils.msvccompiler.patch
@@ -1,0 +1,98 @@
+From a2139dba59eac283a7f543ed737f038deebddc19 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Wed, 28 Aug 2024 21:26:02 +0200
+Subject: [PATCH] giscanner: remove dependency on distutils.msvccompiler
+
+It was removed with setuptools 74.0.0. Since we still depend on the
+MSVCCompiler class use new_compiler() to get it some other way.
+
+Remove any reference to MSVC9Compiler, which was for Visual Studio 2008
+which we no longer support anyway.
+
+Fixes #515
+---
+ giscanner/ccompiler.py    |  7 +++----
+ giscanner/msvccompiler.py | 14 +++++++-------
+ 2 files changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index a6be9ee6..b6064874 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -26,7 +26,6 @@ import tempfile
+ import sys
+ import distutils
+ 
+-from distutils.msvccompiler import MSVCCompiler
+ from distutils.unixccompiler import UnixCCompiler
+ from distutils.cygwinccompiler import Mingw32CCompiler
+ from distutils.sysconfig import get_config_vars
+@@ -132,7 +131,7 @@ class CCompiler(object):
+         # Now, create the distutils ccompiler instance based on the info we have.
+         if compiler_name == 'msvc':
+             # For MSVC, we need to create a instance of a subclass of distutil's
+-            # MSVC9Compiler class, as it does not provide a preprocess()
++            # MSVCCompiler class, as it does not provide a preprocess()
+             # implementation
+             from . import msvccompiler
+             self.compiler = msvccompiler.get_msvc_compiler()
+@@ -425,7 +424,7 @@ class CCompiler(object):
+             return self.compiler.linker_exe
+ 
+     def check_is_msvc(self):
+-        return isinstance(self.compiler, MSVCCompiler)
++        return self.compiler.compiler_type == "msvc"
+ 
+     # Private APIs
+     def _set_cpp_options(self, options):
+@@ -451,7 +450,7 @@ class CCompiler(object):
+                     # macros for compiling using distutils
+                     # get dropped for MSVC builds, so
+                     # escape the escape character.
+-                    if isinstance(self.compiler, MSVCCompiler):
++                    if self.check_is_msvc():
+                         macro_value = macro_value.replace('\"', '\\\"')
+                 macros.append((macro_name, macro_value))
+             elif option.startswith('-U'):
+diff --git a/giscanner/msvccompiler.py b/giscanner/msvccompiler.py
+index 0a543982..e333a80f 100644
+--- a/giscanner/msvccompiler.py
++++ b/giscanner/msvccompiler.py
+@@ -19,30 +19,30 @@
+ #
+ 
+ import os
+-import distutils
++from typing import Type
+ 
+ from distutils.errors import DistutilsExecError, CompileError
+-from distutils.ccompiler import CCompiler, gen_preprocess_options
++from distutils.ccompiler import CCompiler, gen_preprocess_options, new_compiler
+ from distutils.dep_util import newer
+ 
+ # Distutil's MSVCCompiler does not provide a preprocess()
+ # Implementation, so do our own here.
+ 
+ 
++DistutilsMSVCCompiler: Type = type(new_compiler(compiler="msvc"))
++
++
+ def get_msvc_compiler():
+     return MSVCCompiler()
+ 
+ 
+-class MSVCCompiler(distutils.msvccompiler.MSVCCompiler):
++class MSVCCompiler(DistutilsMSVCCompiler):
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+-        super(distutils.msvccompiler.MSVCCompiler, self).__init__()
++        super(DistutilsMSVCCompiler, self).__init__()
+         CCompiler.__init__(self, verbose, dry_run, force)
+         self.__paths = []
+         self.__arch = None  # deprecated name
+-        if os.name == 'nt':
+-            if isinstance(self, distutils.msvc9compiler.MSVCCompiler):
+-                self.__version = distutils.msvc9compiler.VERSION
+         self.initialized = False
+         self.preprocess_options = None
+         if self.check_is_clang_cl():

--- a/recipes/gobject-introspection/all/patches/1.78.1-fix-distutils.msvccompiler.patch
+++ b/recipes/gobject-introspection/all/patches/1.78.1-fix-distutils.msvccompiler.patch
@@ -1,0 +1,98 @@
+From a2139dba59eac283a7f543ed737f038deebddc19 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Wed, 28 Aug 2024 21:26:02 +0200
+Subject: [PATCH] giscanner: remove dependency on distutils.msvccompiler
+
+It was removed with setuptools 74.0.0. Since we still depend on the
+MSVCCompiler class use new_compiler() to get it some other way.
+
+Remove any reference to MSVC9Compiler, which was for Visual Studio 2008
+which we no longer support anyway.
+
+Fixes #515
+---
+ giscanner/ccompiler.py    |  7 +++----
+ giscanner/msvccompiler.py | 14 +++++++-------
+ 2 files changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index 2912fe0e..766c9a36 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -26,7 +26,6 @@ import tempfile
+ import sys
+ import distutils
+ 
+-from distutils.msvccompiler import MSVCCompiler
+ from distutils.unixccompiler import UnixCCompiler
+ from distutils.cygwinccompiler import Mingw32CCompiler
+ from distutils.sysconfig import get_config_vars
+@@ -167,7 +166,7 @@ class CCompiler(object):
+         # Now, create the distutils ccompiler instance based on the info we have.
+         if compiler_name == 'msvc':
+             # For MSVC, we need to create a instance of a subclass of distutil's
+-            # MSVC9Compiler class, as it does not provide a preprocess()
++            # MSVCCompiler class, as it does not provide a preprocess()
+             # implementation
+             from . import msvccompiler
+             self.compiler = msvccompiler.get_msvc_compiler()
+@@ -453,7 +452,7 @@ class CCompiler(object):
+             return self.compiler.linker_exe
+ 
+     def check_is_msvc(self):
+-        return isinstance(self.compiler, MSVCCompiler)
++        return self.compiler.compiler_type == "msvc"
+ 
+     # Private APIs
+     def _set_cpp_options(self, options):
+@@ -479,7 +478,7 @@ class CCompiler(object):
+                     # macros for compiling using distutils
+                     # get dropped for MSVC builds, so
+                     # escape the escape character.
+-                    if isinstance(self.compiler, MSVCCompiler):
++                    if self.check_is_msvc():
+                         macro_value = macro_value.replace('\"', '\\\"')
+                 macros.append((macro_name, macro_value))
+             elif option.startswith('-U'):
+diff --git a/giscanner/msvccompiler.py b/giscanner/msvccompiler.py
+index 0a543982..e333a80f 100644
+--- a/giscanner/msvccompiler.py
++++ b/giscanner/msvccompiler.py
+@@ -19,30 +19,30 @@
+ #
+ 
+ import os
+-import distutils
++from typing import Type
+ 
+ from distutils.errors import DistutilsExecError, CompileError
+-from distutils.ccompiler import CCompiler, gen_preprocess_options
++from distutils.ccompiler import CCompiler, gen_preprocess_options, new_compiler
+ from distutils.dep_util import newer
+ 
+ # Distutil's MSVCCompiler does not provide a preprocess()
+ # Implementation, so do our own here.
+ 
+ 
++DistutilsMSVCCompiler: Type = type(new_compiler(compiler="msvc"))
++
++
+ def get_msvc_compiler():
+     return MSVCCompiler()
+ 
+ 
+-class MSVCCompiler(distutils.msvccompiler.MSVCCompiler):
++class MSVCCompiler(DistutilsMSVCCompiler):
+ 
+     def __init__(self, verbose=0, dry_run=0, force=0):
+-        super(distutils.msvccompiler.MSVCCompiler, self).__init__()
++        super(DistutilsMSVCCompiler, self).__init__()
+         CCompiler.__init__(self, verbose, dry_run, force)
+         self.__paths = []
+         self.__arch = None  # deprecated name
+-        if os.name == 'nt':
+-            if isinstance(self, distutils.msvc9compiler.MSVCCompiler):
+-                self.__version = distutils.msvc9compiler.VERSION
+         self.initialized = False
+         self.preprocess_options = None
+         if self.check_is_clang_cl():

--- a/recipes/gobject-introspection/all/test_package/conanfile.py
+++ b/recipes/gobject-introspection/all/test_package/conanfile.py
@@ -19,9 +19,13 @@ class TestPackageConan(ConanFile):
         if not can_run(self):
             self.tool_requires("gobject-introspection/<host_version>")
 
+    @property
+    def _have_introspection_data(self):
+        return self.dependencies["gobject-introspection"].options.build_introspection_data
+
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["GLIB_INTROSPECTION_DATA_AVAILABLE"] = self.dependencies["gobject-introspection"].options.build_introspection_data
+        tc.variables["GLIB_INTROSPECTION_DATA_AVAILABLE"] = self._have_introspection_data
         tc.generate()
 
     def build(self):
@@ -33,9 +37,8 @@ class TestPackageConan(ConanFile):
         if can_run(self):
             if self.settings.os != "Windows":
                 gobject_introspection_bin = self.dependencies["gobject-introspection"].cpp_info.bindir
-                gobject_introspection_data = self.dependencies["gobject-introspection"].options.build_introspection_data
                 for tool in ["g-ir-compiler", "g-ir-generate", "g-ir-scanner", "g-ir-annotation-tool"]:
-                    if not gobject_introspection_data and tool in ["g-ir-scanner", "g-ir-annotation-tool"]:
+                    if not self._have_introspection_data and tool in ["g-ir-scanner", "g-ir-annotation-tool"]:
                         continue
                     tool_path = os.path.join(gobject_introspection_bin, tool)
                     if os.path.exists(tool_path):

--- a/recipes/gobject-introspection/all/test_package/conanfile.py
+++ b/recipes/gobject-introspection/all/test_package/conanfile.py
@@ -10,7 +10,7 @@ class TestPackageConan(ConanFile):
     generators = "CMakeDeps"
 
     def requirements(self):
-        self.requires(self.tested_reference_str, headers=True, libs=True, run=can_run(self))
+        self.requires(self.tested_reference_str, run=can_run(self))
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/gobject-introspection/all/test_package/conanfile.py
+++ b/recipes/gobject-introspection/all/test_package/conanfile.py
@@ -9,8 +9,7 @@ from conan.tools.apple import is_apple_os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps"
 
     def requirements(self):
         self.requires(self.tested_reference_str, run=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **gobject-introspection/[*]**

#### Motivation
The correct pattern for gobject-introspection usage with Conan should really be:
```python
def requirements(self):
    self.requires("gobject-introspection/1.78.1")

def build_requirements(self):
    self.tool_requires("gobject-introspection/<host_version>") # for g-ir-scanner
```

The .gir introspection data is architecture-specific and needs to have the `arch` of the host context.

For `self.requires(...)` to work without `libs=True`, `headers=True`, it makes more sense to use `shared-library` instead of `application` as the package type.

#### Details
The tool_requires for g-ir-scanner also needs a Python interpreter. `self.requires("cpython/[~3.12]", build=True, visible=True, run=True)` ensures that it's present in consuming recipes.

Also backports a patch for newer setuptools versions that have dropped `distutils.msvccompiler`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
