### PR TITLE
libiconv: use ftpmirror.gnu.org for sources

### DIFF
--- a/recipes/libiconv/all/conandata.yml
+++ b/recipes/libiconv/all/conandata.yml
@@ -1,12 +1,18 @@
 sources:
   "1.17":
-    url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
+      - "https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
     sha256: "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"
   "1.16":
-    url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz"
+      - "https://ftp.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz"
     sha256: "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04"
   "1.15":
-    url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.15.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.15.tar.gz"
+      - "https://ftp.gnu.org/gnu/libiconv/libiconv-1.15.tar.gz"
     sha256: "ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178"
 patches:
   "1.16":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libiconv/[*]**

#### Motivation
`libiconv` is a common transitive dependency and the default `ftp.gnu.org` tends to be slow and unreliable.

Add `ftpmirror.gnu.org` as the default source URL and keep `ftp.gnu.org` as a fall-back.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
