### PR TITLE
godot-cpp: add v4.x, switch from SCons to CMake

### DIFF
--- a/recipes/godot-cpp/4.x/conandata.yml
+++ b/recipes/godot-cpp/4.x/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "4.4":
+    url: "https://github.com/godotengine/godot-cpp/archive/godot-4.4-stable.tar.gz"
+    sha256: "472c6e7f3f7a9d576f21e2c57d16390b46d238f98e69a47d84730e943f5c5506"

--- a/recipes/godot-cpp/4.x/conanfile.py
+++ b/recipes/godot-cpp/4.x/conanfile.py
@@ -1,0 +1,107 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.android import android_abi
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.microsoft import is_msvc
+
+required_conan_version = ">=2.0"
+
+
+class GodotCppConan(ConanFile):
+    name = "godot-cpp"
+    description = "C++ bindings for the Godot script API"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/godotengine/godot-cpp"
+    topics = ("game-engine", "game-development", "c++")
+
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self._system is None:
+            raise ConanInvalidConfiguration(f"Unsupported system: {self.settings.os}")
+        if self._arch is None:
+            raise ConanInvalidConfiguration(f"Unsupported architecture: {self.settings.arch}")
+        check_min_cppstd(self, 17)
+
+    def build_requirements(self):
+        self.tool_requires("cpython/[~3.12]")
+
+    @property
+    def _system(self):
+        # https://github.com/godotengine/godot-cpp/blob/godot-4.4-stable/cmake/godotcpp.cmake#L260-L268
+        if self.settings.os == "Android":
+            return f"android.{android_abi(self)}"
+        return {
+            "Windows": "windows",
+            "Linux": "linux",
+            "Macos": "osx",
+            "iOS": "ios",
+            "Emscripten": "web",
+        }.get(str(self.settings.os))
+
+    @property
+    def _target(self):
+        return "template_debug" if self.settings.build_type == "Debug" else "template_release"
+
+    @property
+    def _arch(self):
+        # https://github.com/godotengine/godot-cpp/blob/godot-4.4-stable/cmake/godotcpp.cmake#L47-L99
+        return {
+            "x86": "x86",
+            "x86_64": "x86_64",
+            "armv7": "arm32",
+            "armv8": "arm64",
+            "riscv64": "rv64",
+            "ppc": "ppc32",
+            "ppc64le": "ppc64",
+        }.get(str(self.settings.arch))
+
+    @property
+    def _libname(self):
+        return f"godot-cpp.{self._system}.{self._target}.{self._arch}"
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["GODOTCPP_ENABLE_TESTING"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build(target=f"godot-cpp.{self._target}")
+
+    def package(self):
+        copy(self, "LICENSE*", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "gdextension_interface.h",
+             os.path.join(self.source_folder, "gdextension"),
+             os.path.join(self.package_folder, "include"))
+        copy(self, "*.hpp",
+             os.path.join(self.source_folder, "include"),
+             os.path.join(self.package_folder, "include"))
+        copy(self, "*.hpp",
+             os.path.join(self.build_folder, "gen", "include"),
+             os.path.join(self.package_folder, "include"))
+        bin_dir = os.path.join(self.build_folder, "bin")
+        copy(self, "*.a", bin_dir, os.path.join(self.package_folder, "lib"))
+        copy(self, "*.lib", bin_dir, os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        # https://github.com/godotengine/godot-cpp/blob/godot-4.4-stable/cmake/godotcpp.cmake#L311
+        self.cpp_info.set_property("cmake_target_aliases", [f"godot-cpp::{self._target}"])
+
+        if is_msvc(self):
+            self.cpp_info.libs = [f"lib{self._libname}"]
+        else:
+            self.cpp_info.libs = [self._libname]

--- a/recipes/godot-cpp/4.x/test_package/CMakeLists.txt
+++ b/recipes/godot-cpp/4.x/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(godot-cpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} godot-cpp::godot-cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/godot-cpp/4.x/test_package/conanfile.py
+++ b/recipes/godot-cpp/4.x/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/godot-cpp/4.x/test_package/test_package.cpp
+++ b/recipes/godot-cpp/4.x/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <godot_cpp/variant/vector2.hpp>
+
+int main()
+{
+    godot::Vector2{1.0, -1.0};
+}

--- a/recipes/godot-cpp/all/conandata.yml
+++ b/recipes/godot-cpp/all/conandata.yml
@@ -5,6 +5,3 @@ sources:
   "3.3.4":
     url: "https://github.com/godotengine/godot-cpp/archive/godot-3.3.4-stable.tar.gz"
     sha256: "fa12b8dd8652109eceae7aecf134f64529edfb34ec33d24b1a9c220b40599575"
-  "cci.3.2-20200130":
-    url: "https://github.com/godotengine/godot-cpp/archive/aba8766618c6aa40c6f7b40b513e8e47cfa807f4.zip"
-    sha256: "a6dba9cda3c36c669ffca2bb9dd4e372bcd1fbf23c74076505467247c15f0e77"

--- a/recipes/godot-cpp/all/conanfile.py
+++ b/recipes/godot-cpp/all/conanfile.py
@@ -46,6 +46,7 @@ class GodotCppConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("scons/4.3.0")
+        self.tool_requires("cpython/[~3.12]")
 
     @property
     def _bits(self):

--- a/recipes/godot-cpp/all/conanfile.py
+++ b/recipes/godot-cpp/all/conanfile.py
@@ -90,7 +90,12 @@ class GodotCppConan(ConanFile):
 
     def package(self):
         copy(self, "LICENSE*", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        copy(self, "*.hpp", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include/godot-cpp"))
+        copy(self, "*.hpp",
+             os.path.join(self.source_folder, "include"),
+             os.path.join(self.package_folder, "include", "godot-cpp"))
+        copy(self, "*.hpp",
+             os.path.join(self.build_folder, "include"),
+             os.path.join(self.package_folder, "include", "godot-cpp"))
         bin_dir = os.path.join(self.source_folder, "bin")
         copy(self, "*.a", bin_dir, os.path.join(self.package_folder, "lib"))
         copy(self, "*.so", bin_dir, os.path.join(self.package_folder, "lib"))

--- a/recipes/godot-cpp/all/conanfile.py
+++ b/recipes/godot-cpp/all/conanfile.py
@@ -1,14 +1,11 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
-from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -45,37 +42,7 @@ class GodotCppConan(ConanFile):
             self.info.settings.build_type = "Release"
 
     def validate(self):
-        minimal_cpp_standard = 14
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, minimal_cpp_standard)
-
-        minimal_version = {
-            "gcc": "5",
-            "clang": "4",
-            "apple-clang": "10",
-            "msvc": "191",
-            "Visual Studio": "15",
-        }
-
-        compiler = str(self.settings.compiler)
-        if compiler not in minimal_version:
-            self.output.warning(
-                f"{self.name} recipe lacks information about the {compiler} compiler standard version support"
-            )
-            self.output.warning(
-                f"{self.name} requires a compiler that supports at least C++{minimal_cpp_standard}"
-            )
-            return
-
-        version = Version(self.settings.compiler.version)
-        if version < minimal_version[compiler]:
-            if compiler in ["apple-clang", "clang"]:
-                raise ConanInvalidConfiguration(
-                    f"{self.name} requires a clang version that supports the '-Og' flag"
-                )
-            raise ConanInvalidConfiguration(
-                f"{self.name} requires a compiler that supports at least C++{minimal_cpp_standard}"
-            )
+        check_min_cppstd(self, 14)
 
     def build_requirements(self):
         self.tool_requires("scons/4.3.0")
@@ -128,9 +95,6 @@ class GodotCppConan(ConanFile):
         VirtualBuildEnv(self).generate()
 
     def build(self):
-        self.run("python  --version")
-        if is_apple_os(self):
-            self.run("which python")
         self.run("scons  --version")
         self.run(" ".join([
             "scons",

--- a/recipes/godot-cpp/all/test_package/conanfile.py
+++ b/recipes/godot-cpp/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/godot-cpp/config.yml
+++ b/recipes/godot-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.4":
+    folder: 4.x
   "3.5.1":
     folder: all
   "3.3.4":

--- a/recipes/godot-cpp/config.yml
+++ b/recipes/godot-cpp/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: all
   "3.3.4":
     folder: all
-  "cci.3.2-20200130":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **godot-cpp/[*]**

#### Motivation
Adds godot-cpp 4.x, which has been out for two years already.

The existing SCons-based build is limited in several ways:
- SCons is much less well supported by Conan.
- SCons is intentionally very rigid and basically predefines a set of build profiles / toolchains in the project files. This means that the compiler executables in the Conan profiles are currently effectively ignored, for example.
- Limited to a static build only on v3.
- Cross-compilation is not supported by the current recipe.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
