### PR TITLE
glibmm: add v2.82.0.

### DIFF
--- a/recipes/glibmm/all/conandata.yml
+++ b/recipes/glibmm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.82.0":
+    url: "https://download.gnome.org/sources/glibmm/2.82/glibmm-2.82.0.tar.xz"
+    sha256: "38684cff317273615c67b8fa9806f16299d51e5506d9b909bae15b589fa99cb6"
   "2.78.1":
     url: "https://download.gnome.org/sources/glibmm/2.78/glibmm-2.78.1.tar.xz"
     sha256: "f473f2975d26c3409e112ed11ed36406fb3843fa975df575c22d4cb843085f61"

--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -47,7 +47,7 @@ class GlibmmConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.78.3", transitive_headers=True)
+        self.requires("glib/2.81.0", transitive_headers=True)
         if self._abi_version == "2.68":
             self.requires("libsigcpp/3.0.7", transitive_headers=True)
         else:

--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -47,7 +47,10 @@ class GlibmmConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.81.0", transitive_headers=True)
+        if Version(self.version) >= "2.82.0":
+            self.requires("glib/2.81.0", transitive_headers=True)
+        else:
+            self.requires("glib/2.78.3", transitive_headers=True)
         if self._abi_version == "2.68":
             self.requires("libsigcpp/3.0.7", transitive_headers=True)
         else:

--- a/recipes/glibmm/config.yml
+++ b/recipes/glibmm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.82.0":
+    folder: "all"
   "2.78.1":
     folder: "all"
   "2.75.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **glibmm/[version]**

#### Motivation
Added newer glibmm v2.82.0.

#### Details
The newer glibmm requires glib >= 2.81.0. The dependency has been updated.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
