### PR TITLE
pybind11: add cross-compilation support, drop old versions

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -26,18 +26,3 @@ sources:
   "2.10.1":
     url: "https://github.com/pybind/pybind11/archive/v2.10.1.tar.gz"
     sha256: "111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad"
-  "2.10.0":
-    url: "https://github.com/pybind/pybind11/archive/v2.10.0.tar.gz"
-    sha256: "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec"
-  "2.9.2":
-    url: "https://github.com/pybind/pybind11/archive/v2.9.2.tar.gz"
-    sha256: "6bd528c4dbe2276635dc787b6b1f2e5316cf6b49ee3e150264e455a0d68d19c1"
-  "2.9.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz"
-    sha256: "c6160321dc98e6e1184cc791fbeadd2907bb4a0ce0e447f2ea4ff8ab56550913"
-  "2.8.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.8.1.tar.gz"
-    sha256: "f1bcc07caa568eb312411dde5308b1e250bd0e1bc020fae855bf9f43209940cc"
-  "2.7.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz"
-    sha256: "616d1c42e4cf14fa27b2a4ff759d7d7b33006fdc5ad8fd603bb2c22622f27020"

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -64,13 +64,10 @@ class PyBind11Conan(ConanFile):
         self.cpp_info.components["headers"].includedirs = ["include"]
         self.cpp_info.components["pybind11_"].set_property("cmake_target_name", "pybind11::pybind11")
         self.cpp_info.components["pybind11_"].set_property("cmake_module_file_name", "pybind11")
-        self.cpp_info.components["pybind11_"].names["cmake_find_package"] = "pybind11"
         self.cpp_info.components["pybind11_"].builddirs = [cmake_base_path]
         self.cpp_info.components["pybind11_"].requires = ["headers"]
         cmake_file = os.path.join(cmake_base_path, "pybind11Common.cmake")
         self.cpp_info.set_property("cmake_build_modules", [cmake_file])
-        for generator in ["cmake_find_package", "cmake_find_package_multi"]:
-            self.cpp_info.components["pybind11_"].build_modules[generator].append(cmake_file)
         self.cpp_info.components["embed"].requires = ["pybind11_"]
         self.cpp_info.components["module"].requires = ["pybind11_"]
         self.cpp_info.components["python_link_helper"].requires = ["pybind11_"]

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -69,8 +69,7 @@ class PyBind11Conan(ConanFile):
                         "if(NOT Python_FOUND AND NOT Python3_FOUND)",
                         "if(TRUE)")
         replace_in_file(self, os.path.join(self.package_folder, "lib", "cmake", "pybind11", "pybind11NewTools.cmake"),
-                        "Python 3.7 REQUIRED",
-                        "Python3 REQUIRED")
+                        "Python 3.", "Python3 3.")
 
     def package_info(self):
         cmake_base_path = os.path.join("lib", "cmake", "pybind11")

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -29,9 +29,6 @@ class PyBind11Conan(ConanFile):
     def requirements(self):
         self.requires("cpython/[~3.12]", transitive_headers=True, transitive_libs=True)
 
-    def build_requirements(self):
-        self.tool_requires("cpython/<host_version>")
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/pybind11/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11/all/test_package/CMakeLists.txt
@@ -4,4 +4,3 @@ project(test_package LANGUAGES CXX)
 find_package(pybind11 REQUIRED CONFIG)
 
 pybind11_add_module(test_package MODULE test_package.cpp)
-set_property(TARGET test_package PROPERTY CXX_STANDARD 11)

--- a/recipes/pybind11/all/test_package/conanfile.py
+++ b/recipes/pybind11/all/test_package/conanfile.py
@@ -10,7 +10,6 @@ import sys
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/pybind11/all/test_package/conanfile.py
+++ b/recipes/pybind11/all/test_package/conanfile.py
@@ -13,7 +13,8 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.tool_requires("cpython/<host_version>")
+        if not can_run(self):
+            self.tool_requires("cpython/<host_version>")
 
     def generate(self):
         deps = CMakeDeps(self)

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -17,13 +17,3 @@ versions:
     folder: all
   "2.10.1":
     folder: all
-  "2.10.0":
-    folder: all
-  "2.9.2":
-    folder: all
-  "2.9.1":
-    folder: all
-  "2.8.1":
-    folder: all
-  "2.7.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **pybind11/[*]**

#### Motivation
Ensure that cpython development library is available, found and used. Explicitly set `Python_EXECUTABLE` for native Python interpreter to be found when cross-compiling.

#### Details
Cross-compilation build logs for gcc-13-aarch64-linux-gnu (https://gist.github.com/valgur/5a550530a55b0df98016b89dbb25d861):
- [pybind11-static.log](https://github.com/user-attachments/files/19093817/pybind11-static.log)
- [pybind11-shared.log](https://github.com/user-attachments/files/19093814/pybind11-shared.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
