### PR TITLE
tz: use the compiler configured in profile

### DIFF
--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -16,10 +16,6 @@ class TzConan(ConanFile):
     topics = ("tz", "tzdb", "time", "zone", "date")
     settings = "os", "build_type", "arch", "compiler"
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
     def configure(self):
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
@@ -32,7 +28,7 @@ class TzConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("mawk/1.3.4-20230404")
-        if self._settings_build.os == "Windows":
+        if self.settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")

--- a/recipes/tz/all/test_package/conanfile.py
+++ b/recipes/tz/all/test_package/conanfile.py
@@ -1,10 +1,15 @@
+import os
+
 from conan import ConanFile
 from conan.tools.build import can_run
-import os
+from conan.tools.layout import basic_layout
 
 
 class TzTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
+
+    def layout(self):
+        basic_layout(self)
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)

--- a/recipes/tz/all/test_package/conanfile.py
+++ b/recipes/tz/all/test_package/conanfile.py
@@ -1,35 +1,17 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.errors import ConanException
 import os
 
 
 class TzTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "VirtualBuildEnv", "VirtualRunEnv"
-    test_type = "explicit"
-    tzdata = None
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
             self.tool_requires("msys2/cci.latest")
-
-    def generate(self):
-        # INFO: zdump does not consume TZDATA, need to pass absolute path of the zoneinfo directory
-        self.tzdata = self.dependencies.build['tz'].buildenv_info.vars(self).get('TZDATA')
-        with open("tzdata.info", "w") as fd:
-            fd.write(self.tzdata)
-
-    def build(self):
-        pass
 
     def test(self):
         if can_run(self):
-            with open("tzdata.info", "r") as fd:
-                self.tzdata = fd.read()
-            self.run(f"zdump {os.path.join(self.tzdata, 'America', 'Los_Angeles')}")
+            tzdata = self.dependencies.build['tz'].buildenv_info.vars(self).get('TZDATA')
+            self.run(f"zdump {os.path.join(tzdata, 'America', 'Los_Angeles')}")


### PR DESCRIPTION
### Summary
Changes to recipe:  **tz/[*]**

#### Motivation
Ensure that the C compiler from Conan profile is used, if configured. Fall back to `cc`, if not set.
Remove unnecessary Conan v1 workarounds from test_package.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
