### PR TITLE
thrift: use a version range for Qt5, explicitly set WITH_QT5

### DIFF
--- a/recipes/thrift/all/test_package/CMakeLists.txt
+++ b/recipes/thrift/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(Thrift CONFIG REQUIRED)

--- a/recipes/thrift/all/test_package/conanfile.py
+++ b/recipes/thrift/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -22,6 +21,6 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")
             self.run("thrift --version", env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **thrift/[*]**

#### Motivation
The build can end up using Qt5 from system due to `WITH_QT5` not being explicitly passed to CMake.
Also allow any newer Qt 5.15.x to be used.

#### Details
Dropped a lot of legacy Conan v1 logic as well.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
