### PR TITLE
nng: remove `nsl` from system_libs

### DIFF
--- a/recipes/nng/all/conanfile.py
+++ b/recipes/nng/all/conanfile.py
@@ -100,6 +100,7 @@ class NngConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -122,7 +123,6 @@ class NngConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -141,13 +141,9 @@ class NngConan(ConanFile):
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.system_libs.extend(["mswsock", "ws2_32"])
         elif self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.extend(["pthread", "rt", "nsl"])
+            self.cpp_info.system_libs.extend(["pthread", "rt"])
 
         if self.options.shared:
             self.cpp_info.defines.append("NNG_SHARED_LIB")
         else:
             self.cpp_info.defines.append("NNG_STATIC_LIB")
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.names["cmake_find_package"] = "nng"
-        self.cpp_info.names["cmake_find_package_multi"] = "nng"


### PR DESCRIPTION
### Summary
Changes to recipe:  **nng/[*]**

#### Motivation
`nsl` is not guaranteed to be available on all systems and does not appear to be necessary either. It was most likely added just to fix a linter warning from Conan CI.

```
[ 50%] Building C object CMakeFiles/test_package.dir/test_package.c.o
[100%] Linking C executable test_package
/usr/lib/gcc-cross/aarch64-linux-gnu/13/../../../../aarch64-linux-gnu/bin/ld: cannot find -lnsl: No such file or directory
collect2: error: ld returned 1 exit status
```

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
