### PR TITLE
scons: fix `SCONS` env var export, use the correct compiler in test_package

### DIFF
--- a/recipes/scons/all/conanfile.py
+++ b/recipes/scons/all/conanfile.py
@@ -89,14 +89,8 @@ class SConsConan(ConanFile):
         self._chmod_x(self._scons_sh)
         bindir = os.path.join(self.package_folder, "bin")
 
-        # For Conan 1.x downstream consumers, can be removed once recipe is Conan 2.x only:
-        self.output.info("Appending PATH environment var: {}".format(bindir))
-        self.env_info.PATH.append(bindir)
-
         if self.settings.os == "Windows":
             scons_bin = os.path.join(bindir, "scons.cmd")
         else:
             scons_bin = os.path.join(bindir, "scons")
-        self.user_info.scons = scons_bin
-        self.output.info("Setting SCONS environment variable: {}".format(scons_bin))
-        self.env_info.SCONS = scons_bin
+        self.buildenv_info.define_path("SCONS", scons_bin)

--- a/recipes/scons/all/test_package/SConscript
+++ b/recipes/scons/all/test_package/SConscript
@@ -3,6 +3,7 @@ import os
 
 env = Environment()
 
+env['CC'] = os.environ.get('CC', 'cc')
 print("CC is: {}".format(env.subst('$CC')))
 
 test_package = env.Program(["test_package.c"])

--- a/recipes/scons/all/test_package/conanfile.py
+++ b/recipes/scons/all/test_package/conanfile.py
@@ -7,8 +7,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualBuildEnv"
-    test_type = "explicit"
+    generators = "AutotoolsToolchain"
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
@@ -32,6 +31,6 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not cross_building(self):
-            # Scons build put executable righe here
+            # Scons build put executable right here
             bin_path = os.path.join(self.recipe_folder, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **scons/[*]**

#### Motivation
`SCONS` env var is currently set via the legacy `self.env_info` and not `self.buildenv_info`.

test_package can fail if `gcc` is not found on PATH.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
