### PR TITLE
libmeshb: avoid building of a Fortran API

### DIFF
--- a/recipes/libmeshb/all/conanfile.py
+++ b/recipes/libmeshb/all/conanfile.py
@@ -17,12 +17,14 @@ class LibmeshbConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_gmf_asio": [True, False]
+        "with_gmf_asio": [True, False],
+        "enable_fortran": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_gmf_asio": False
+        "with_gmf_asio": False,
+        "enable_fortran": False,
     }
 
     def config_options(self):
@@ -50,6 +52,8 @@ class LibmeshbConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["WITH_GMF_AIO"] = self.options.get_safe("with_gmf_asio", False)
+        if not self.options.enable_fortran:
+            tc.variables["CMAKE_Fortran_COMPILER"] = ""
         tc.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libmeshb/[*]**

#### Motivation
The project tries to find a Fortran compiler (https://github.com/LoicMarechal/libMeshb/blob/v7.80/CMakeLists.txt#L16-L21) and links a Fortran API module into the library if found (https://github.com/LoicMarechal/libMeshb/blob/v7.80/sources/CMakeLists.txt#L7).

This can introduce an unexpected dependency against Fortran runtime libraries and also makes the build less reproducible.

The Fortran module is just an API for the library: "a partial Fortran77 API is provided".

#### Details
Disable Fortran compiler detection by default, but leave a `fortran_enabled` option as a workaround.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
