### PR TITLE
libsigcpp/2.x: use a more reliable source URL

### DIFF
--- a/recipes/libsigcpp/2.x.x/conandata.yml
+++ b/recipes/libsigcpp/2.x.x/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.10.8":
-    url: "https://ftp2.nluug.nl/windowing/gnome/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz"
+    url: "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz"
     sha256: "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a"


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
The existing https://ftp2.nluug.nl/windowing/gnome/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz has certificate errors.

#### Details


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
