### PR TITLE
pdf-writer: add a missing pkgconf tool_requires

### DIFF
--- a/recipes/pdf-writer/all/conanfile.py
+++ b/recipes/pdf-writer/all/conanfile.py
@@ -61,11 +61,15 @@ class PDFWriterConan(ConanFile):
             self.requires("libtiff/4.6.0")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, self._min_cppstd)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -77,7 +81,6 @@ class PDFWriterConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()


### PR DESCRIPTION
### Summary
Changes to recipe:  **pdf-writer/[*]**

#### Motivation
To match the `PkgConfigDeps(self)`.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
