### PR TITLE
ogdf: remove -march=native

### DIFF
--- a/recipes/ogdf/all/conanfile.py
+++ b/recipes/ogdf/all/conanfile.py
@@ -68,6 +68,8 @@ class OGDFConan(ConanFile):
                                     ("src", "GraphIO_graphml.cpp"),
                                     ("src", "GraphIO_gexf.cpp")]:
             replace_in_file(self, join(self.source_folder, dir_name, "ogdf", "fileformats", file_name), "ogdf/lib/pugixml/pugixml.h", "pugixml.hpp")
+        # -march=native is not portable
+        replace_in_file(self, join(self.source_folder, "cmake", "compiler-specifics.cmake"), "-march=native", "")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
### Summary
Changes to recipe:  **ogdf/[*]**

#### Motivation
`-march=native` breaks ARM builds and leads to non-portable binaries.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
