### PR TITLE
simdjson: add version 3.12.2, add MIT license

### DIFF
--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.12.2":
+    url: "https://github.com/simdjson/simdjson/archive/v3.12.2.tar.gz"
+    sha256: "8ac7c97073d5079f54ad66d04381ec75e1169c2e20bfe9b6500bc81304da3faf"
   "3.11.5":
     url: "https://github.com/simdjson/simdjson/archive/v3.11.5.tar.gz"
     sha256: "509bf4880978666f5a6db1eb3d747681e0cc6e0b5bddd94ab0f14a4199d93e18"

--- a/recipes/simdjson/all/conanfile.py
+++ b/recipes/simdjson/all/conanfile.py
@@ -3,6 +3,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -11,7 +12,7 @@ required_conan_version = ">=1.53.0"
 class SimdjsonConan(ConanFile):
     name = "simdjson"
     description = "Parsing gigabytes of JSON per second"
-    license = "Apache-2.0"
+    license = ("Apache-2.0", "MIT")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/lemire/simdjson"
     topics = ("json", "parser", "simd", "format")
@@ -36,6 +37,8 @@ class SimdjsonConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        if Version(self.version) < "3.12.0":
+            self.license = "Apache-2.0"
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.12.2":
+    folder: all
   "3.11.5":
     folder: all
   "3.10.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
simdjson is dual licensed(Apache-2.0 and MIT) since 3.12.0.
performance improvements on Zen4 CPU in 3.12.2.

#### Details
https://github.com/simdjson/simdjson/compare/v3.11.5...v3.12.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
