### PR TITLE
glib: package_info() fixes

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -6,6 +6,7 @@ from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 
 
@@ -164,6 +165,9 @@ class GLibConan(ConanFile):
             os.path.join("lib", "glib-2.0", "include")
         ]
         self.cpp_info.components["glib-2.0"].resdirs = ["res"]
+        if Version(self.version) >= "2.81.0":
+            if not self.options.shared and self.settings.compiler in ["gcc", "clang"]:
+                self.cpp_info.components["glib-2.0"].system_libs.append("atomic")
 
         self.cpp_info.components["gmodule-no-export-2.0"].set_property("pkg_config_name", "gmodule-no-export-2.0")
         self.cpp_info.components["gmodule-no-export-2.0"].libs = ["gmodule-2.0"]

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -1,3 +1,6 @@
+import os
+import textwrap
+
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.env import VirtualBuildEnv
@@ -7,8 +10,6 @@ from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
-import os
-
 
 required_conan_version = ">=2.0"
 
@@ -201,6 +202,19 @@ class GLibConan(ConanFile):
 
         self.cpp_info.components["gresource"].set_property("pkg_config_name", "gresource")
         self.cpp_info.components["gresource"].libs = []  # this is actually an executable
+
+        if Version(self.version) >= "2.79.0":
+            self.cpp_info.components["girepository-2.0"].set_property("pkg_config_name", "girepository-2.0")
+            self.cpp_info.components["girepository-2.0"].set_property("pkg_config_custom_content", textwrap.dedent("""\
+                gidatadir=${datadir}/gobject-introspection-1.0
+                girdir=${datadir}/gir-1.0
+                typelibdir=${libdir}/girepository-1.0
+            """))
+            self.cpp_info.components["girepository-2.0"].libs = ["girepository-2.0"]
+            self.cpp_info.components["girepository-2.0"].resdirs = ["res"]
+            self.cpp_info.components["girepository-2.0"].requires += ["glib-2.0", "gobject-2.0", "gmodule-no-export-2.0", "gio-2.0", "libffi::libffi"]
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.components["girepository-2.0"].system_libs.append("m")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["glib-2.0"].system_libs.append("pthread")

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -1,13 +1,12 @@
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, rename
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import is_msvc
 import os
-import shutil
 
 
 required_conan_version = ">=2.0"
@@ -87,6 +86,7 @@ class GLibConan(ConanFile):
         self.tool_requires("meson/[>=1.2.3 <2]")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/[>=2.2 <3]")
+        self.tool_requires("gettext/0.22.5")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -151,10 +151,7 @@ class GLibConan(ConanFile):
         meson.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "libexec"))
-        shutil.move(
-            os.path.join(self.package_folder, "share"),
-            os.path.join(self.package_folder, "res"),
-        )
+        rename(self, os.path.join(self.package_folder, "share"), os.path.join(self.package_folder, "res"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
         fix_apple_shared_install_name(self)
         fix_msvc_libname(self)

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -176,9 +176,13 @@ class GLibConan(ConanFile):
 
         self.cpp_info.components["gmodule-export-2.0"].set_property("pkg_config_name", "gmodule-export-2.0")
         self.cpp_info.components["gmodule-export-2.0"].requires += ["gmodule-no-export-2.0", "glib-2.0"]
+        if self.settings.os in ["Linux", "FreeBSD"] or self.settings.get_safe("os.subsystem") == "cygwin":
+            # https://gitlab.gnome.org/GNOME/glib/-/blob/2.82.4/meson.build?ref_type=tags#L2488-2501
+            self.cpp_info.components["gmodule-export-2.0"].sharedlinkflags.append("-Wl,--export-dynamic")
+            self.cpp_info.components["gmodule-export-2.0"].exelinkflags.append("-Wl,--export-dynamic")
 
         self.cpp_info.components["gmodule-2.0"].set_property("pkg_config_name", "gmodule-2.0")
-        self.cpp_info.components["gmodule-2.0"].requires += ["gmodule-no-export-2.0", "glib-2.0"]
+        self.cpp_info.components["gmodule-2.0"].requires = ["gmodule-export-2.0"]
 
         self.cpp_info.components["gobject-2.0"].set_property("pkg_config_name", "gobject-2.0")
         self.cpp_info.components["gobject-2.0"].libs = ["gobject-2.0"]
@@ -193,7 +197,7 @@ class GLibConan(ConanFile):
         self.cpp_info.components["gio-2.0"].set_property("pkg_config_name", "gio-2.0")
         self.cpp_info.components["gio-2.0"].libs = ["gio-2.0"]
         self.cpp_info.components["gio-2.0"].resdirs = ["res"]
-        self.cpp_info.components["gio-2.0"].requires += ["glib-2.0", "gobject-2.0", "gmodule-2.0", "zlib::zlib"]
+        self.cpp_info.components["gio-2.0"].requires += ["glib-2.0", "gobject-2.0", "gmodule-no-export-2.0", "zlib::zlib"]
 
         self.cpp_info.components["gresource"].set_property("pkg_config_name", "gresource")
         self.cpp_info.components["gresource"].libs = []  # this is actually an executable

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)
@@ -22,7 +21,7 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")
             if self.settings.os != "Windows":
                 self.run("gdbus-codegen -h", env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **glib/[*]**

#### Motivation
- Add missing girepository-2.0 component.
- Add missing -Wl,--export-dynamic to gmodule-export-2.0. Affects #26330, where it's used by several components.
- Add missing -latomic.
- Add gettext for i18n support and more reproducible builds.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
