### PR TITLE
nspr: fix macos build on arm64

### DIFF
--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -105,10 +105,6 @@ class NsprConan(ConanFile):
             ]
         elif self.settings.os == "Windows":
             tc.configure_args.append("--enable-win32-target={}".format(self.options.win32_target))
-        if is_apple_os(self) and self.settings.arch == "armv8":
-            # conan adds `-arch`, which conflicts with nspr's apple silicon support
-            tc.cflags.remove("-arch arm64")
-            tc.cxxflags.remove("-arch arm64")
         tc.generate()
 
         if is_msvc(self):

--- a/recipes/nspr/all/test_package/conanfile.py
+++ b/recipes/nspr/all/test_package/conanfile.py
@@ -13,15 +13,6 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
 
-    def build_requirements(self):
-        if is_apple_os(self) and self.settings.arch == "armv8":
-            # Workaround for CMake bug with error message:
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
-            self.tool_requires("cmake/3.22.0")
-
     def layout(self):
         cmake_layout(self)
 


### PR DESCRIPTION


Fix this error when building natively on macOS arm64:

```
ERROR: nspr/4.35: Error in generate() method, line 110
        tc.cflags.remove("-arch arm64")
        ValueError: list.remove(x): x not in list
```

Re: 

> conan adds `-arch`, which conflicts with nspr's apple silicon support

Conan only adds `-arch` when crossbuilding, which is explicitly disabled as unsupported in this recipe - there should no issue building this natively