### PR TITLE
Add a new version of harfbuzz 10.4.0

### DIFF
--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "10.4.0":
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/10.4.0/harfbuzz-10.4.0.tar.xz"
+    sha256: "480b6d25014169300669aa1fc39fb356c142d5028324ea52b3a27648b9beaad8"
   "8.3.0":
     url: "https://github.com/harfbuzz/harfbuzz/releases/download/8.3.0/harfbuzz-8.3.0.tar.xz"
     sha256: "109501eaeb8bde3eadb25fab4164e993fbace29c3d775bcaa1c1e58e2f15f847"

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "10.4.0":
+    folder: all
   "8.3.0":
     folder: all
   "8.2.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  add version **harfbuzz/10.4.0**

#### Motivation
many versions have been skipped over, but CVEs are reported in 8.5.0 through 10.0.1, so we wouldn't want to add those.

#### Details
add a version that has no known vulnerabilities

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
