### PR TITLE
jsoncons: add version 1.3.0

### DIFF
--- a/recipes/jsoncons/all/conandata.yml
+++ b/recipes/jsoncons/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.0":
+    url: "https://github.com/danielaparker/jsoncons/archive/refs/tags/v1.3.0.tar.gz"
+    sha256: "7a485c2af0ff214b62bb00f5a1487e5a0c4997eadc6ee9155ce3e8c9d05b9d7a"
   "1.2.0":
     url: "https://github.com/danielaparker/jsoncons/archive/refs/tags/v1.2.0.tar.gz"
     sha256: "3bdc0c8ceba1943b5deb889559911ebe97377971453a11227ed0a51a05e5d5d8"

--- a/recipes/jsoncons/config.yml
+++ b/recipes/jsoncons/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.0":
+    folder: "all"
   "1.2.0":
     folder: "all"
   "1.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **jsoncons/1.3.0**

#### Motivation
Improve JMESPath features.
Add support comment and tailing commma.

#### Details
https://github.com/danielaparker/jsoncons/releases/tag/v1.3.0
https://github.com/danielaparker/jsoncons/compare/v1.2.0...v1.3.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
