### PR TITLE
numcpp: add version 2.14.0

### DIFF
--- a/recipes/numcpp/all/conandata.yml
+++ b/recipes/numcpp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.14.0":
     url: "https://github.com/dpilger26/NumCpp/archive/Version_2.14.0.tar.gz"
-    sha256: "f462ecd27126e6057b31fa38f1f72cef2c4223c9d848515412970714a5bb6d16"
+    sha256: "f7d3a11d12f3209c95c098d0566e6aee072cfc493f1e9376796c91520958686f"
   "2.12.1":
     url: "https://github.com/dpilger26/NumCpp/archive/Version_2.12.1.tar.gz"
     sha256: "f462ecd27126e6057b31fa38f1f72cef2c4223c9d848515412970714a5bb6d16"

--- a/recipes/numcpp/all/conandata.yml
+++ b/recipes/numcpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.14.0":
+    url: "https://github.com/dpilger26/NumCpp/archive/Version_2.14.0.tar.gz"
+    sha256: "f462ecd27126e6057b31fa38f1f72cef2c4223c9d848515412970714a5bb6d16"
   "2.12.1":
     url: "https://github.com/dpilger26/NumCpp/archive/Version_2.12.1.tar.gz"
     sha256: "f462ecd27126e6057b31fa38f1f72cef2c4223c9d848515412970714a5bb6d16"

--- a/recipes/numcpp/config.yml
+++ b/recipes/numcpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.14.0":
+    folder: "all"
   "2.12.1":
     folder: "all"
   "2.12.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **numcpp/2.14.0**

#### Motivation
First release in 1.5 years.
Several new features since 2.12.1.

#### Details
https://github.com/dpilger26/NumCpp/releases/tag/Version_2.14.0
https://github.com/dpilger26/NumCpp/compare/Version_2.12.1...Version_2.14.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
