### PR TITLE
libssh2/1.10.0: Fix CVE-2020-22218

### DIFF
--- a/recipes/libssh2/all/conandata.yml
+++ b/recipes/libssh2/all/conandata.yml
@@ -18,11 +18,6 @@ sources:
     sha256: 39f34e2f6835f4b992cafe8625073a88e5a28ba78f83e8099610a7b3af4676d4
     url: https://github.com/libssh2/libssh2/releases/download/libssh2-1.8.0/libssh2-1.8.0.tar.gz
 patches:
-  "1.10.0":
-    - patch_file: "patches/libssh2-1.9.0-CVE2020-22218.patch"
-      patch_description: "Fix CVE2020-22218"
-      patch_type: "vulnerability"
-      patch_source: "https://github.com/libssh2/libssh2/pull/476"
   "1.9.0":
     - patch_file: "patches/libssh2-1.9.0-CVE2020-22218.patch"
       patch_description: "Fix CVE2020-22218"

--- a/recipes/libssh2/all/conandata.yml
+++ b/recipes/libssh2/all/conandata.yml
@@ -17,3 +17,25 @@ sources:
   "1.8.0":
     sha256: 39f34e2f6835f4b992cafe8625073a88e5a28ba78f83e8099610a7b3af4676d4
     url: https://github.com/libssh2/libssh2/releases/download/libssh2-1.8.0/libssh2-1.8.0.tar.gz
+patches:
+  "1.10.0":
+    - patch_file: "patches/libssh2-1.9.0-CVE2020-22218.patch"
+      patch_description: "Fix CVE2020-22218"
+      patch_type: "vulnerability"
+      patch_source: "https://github.com/libssh2/libssh2/pull/476"
+  "1.9.0":
+    - patch_file: "patches/libssh2-1.9.0-CVE2020-22218.patch"
+      patch_description: "Fix CVE2020-22218"
+      patch_type: "vulnerability"
+      patch_source: "https://github.com/libssh2/libssh2/pull/476"
+  "1.8.2":
+    - patch_file: "patches/libssh2-1.8.2-CVE2020-22218.patch"
+      patch_description: "Fix CVE2020-22218"
+      patch_type: "vulnerability"
+      patch_source: "https://github.com/libssh2/libssh2/pull/476"
+  "1.8.0":
+    - patch_file: "patches/libssh2-1.8.0-CVE2020-22218.patch"
+      patch_description: "Fix CVE2020-22218"
+      patch_type: "vulnerability"
+      patch_source: "https://github.com/libssh2/libssh2/pull/476"
+

--- a/recipes/libssh2/all/patches/libssh2-1.8.0-CVE2020-22218.patch
+++ b/recipes/libssh2/all/patches/libssh2-1.8.0-CVE2020-22218.patch
@@ -1,0 +1,13 @@
+diff --git a/src/transport.c b/src/transport.c
+index 96fca6b8cc..adf96c2437 100644
+--- a/src/transport.c
++++ b/src/transport.c
+@@ -460,7 +460,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
+             /* Get a packet handle put data into. We get one to
+                hold all data, including padding and MAC. */
+             p->payload = LIBSSH2_ALLOC(session, total_num);
+-            if (!p->payload) {
++            if(total_num == 0 || !p->payload) {
+                 return LIBSSH2_ERROR_ALLOC;
+             }
+             p->total_num = total_num;

--- a/recipes/libssh2/all/patches/libssh2-1.8.2-CVE2020-22218.patch
+++ b/recipes/libssh2/all/patches/libssh2-1.8.2-CVE2020-22218.patch
@@ -1,0 +1,13 @@
+diff --git a/src/transport.c b/src/transport.c
+index 96fca6b8cc..adf96c2437 100644
+--- a/src/transport.c
++++ b/src/transport.c
+@@ -470,7 +470,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
+             /* Get a packet handle put data into. We get one to
+                hold all data, including padding and MAC. */
+             p->payload = LIBSSH2_ALLOC(session, total_num);
+-            if (!p->payload) {
++            if(total_num == 0 || !p->payload) {
+                 return LIBSSH2_ERROR_ALLOC;
+             }
+             p->total_num = total_num;

--- a/recipes/libssh2/all/patches/libssh2-1.9.0-CVE2020-22218.patch
+++ b/recipes/libssh2/all/patches/libssh2-1.9.0-CVE2020-22218.patch
@@ -1,0 +1,13 @@
+diff --git a/src/transport.c b/src/transport.c
+index 96fca6b8cc..adf96c2437 100644
+--- a/src/transport.c
++++ b/src/transport.c
+@@ -472,7 +472,7 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
+             /* Get a packet handle put data into. We get one to
+                hold all data, including padding and MAC. */
+             p->payload = LIBSSH2_ALLOC(session, total_num);
+-            if(!p->payload) {
++            if(total_num == 0 || !p->payload) {
+                 return LIBSSH2_ERROR_ALLOC;
+             }
+             p->total_num = total_num;


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-22218

patch source: https://github.com/libssh2/libssh2/pull/476


### Summary
Changes to recipe:  **lib/1.10.0**
Changes to recipe:  **lib/1.9.0**
Changes to recipe:  **lib/1.8.2**
Changes to recipe:  **lib/1.8.0**

#### Motivation
I noticed CVE-2020-22218 with a severity of 7.5HIGH was not patched in Conan center, and it was fairly easy to fix.

#### Details
all .patch files differ only by the line address the code itself is from https://github.com/libssh2/libssh2/pull/476 which is cited by nist as the fix.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
