### PR TITLE
multiple recipes: increase cmake_minimum_required

### DIFF
--- a/recipes/bzip3/all/CMakeLists.txt
+++ b/recipes/bzip3/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(bzip3 LANGUAGES C)
 
 option(BZIP3_WITH_THREAD "enable thread" OFF)

--- a/recipes/grpc-proto/all/CMakeLists.txt
+++ b/recipes/grpc-proto/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 
 project(grpc-proto)
 

--- a/recipes/gsoap/all/CMakeLists.txt
+++ b/recipes/gsoap/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 project(gSOAP)
 
 include(GNUInstallDirs)

--- a/recipes/libelf/all/CMakeLists.txt
+++ b/recipes/libelf/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(elf LANGUAGES C)
 
 if(EXISTS "${LIBELF_SRC_DIR}/lib/sys_elf.h.w32")

--- a/recipes/pthreadpool/all/CMakeLists.txt
+++ b/recipes/pthreadpool/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 find_package(fxdiv REQUIRED CONFIG)


### PR DESCRIPTION
For the following recipes:
- bzip3
- grpc-proto
- gsoap
- libelf
- pthreadpool

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects