### PR TITLE
multiple recipes: increase cmake_minimum_required (2)

### DIFF
--- a/recipes/bigint/all/CMakeLists.txt
+++ b/recipes/bigint/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(bigint LANGUAGES CXX)
 
 include(GNUInstallDirs)

--- a/recipes/cgltf/all/CMakeLists.txt
+++ b/recipes/cgltf/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(cgltf C)
 
 set(SOURCES_DIR ${CMAKE_CURRENT_LIST_DIR}/src)

--- a/recipes/cmp/all/CMakeLists.txt
+++ b/recipes/cmp/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(cmp LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/recipes/co/all/CMakeLists.txt
+++ b/recipes/co/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/cpp-optparse/all/CMakeLists.txt
+++ b/recipes/cpp-optparse/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(cpp-optparse LANGUAGES CXX)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
For the following recipes:
- bigint
- cgltf
- cmp
- co
- cpp-optparse

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects