### PR TITLE
Update bear to latest version and add missing build tool

### DIFF
--- a/recipes/bear/all/conandata.yml
+++ b/recipes/bear/all/conandata.yml
@@ -1,7 +1,12 @@
 sources:
+  "3.1.5":
+    url: "https://github.com/rizsotto/Bear/archive/refs/tags/3.1.5.tar.gz"
+    sha256: "4ac7b041222dcfc7231c6570d5bd76c39eaeda7a075ee2385b84256e7d659733"
   "3.0.21":
     url: "https://github.com/rizsotto/Bear/archive/refs/tags/3.0.21.tar.gz"
     sha256: "0c949a6a907bc61a1284661f8d9dab1788a62770c265f6142602669b6e5c389d"
 patches:
+  "3.1.5":
+    - patch_file: "patches/3.1.5-0001-fix-cmake.diff"
   "3.0.21":
     - patch_file: "patches/7de12540948cd5e0ee5f966b5cc383bc0c0e5fe9.diff"

--- a/recipes/bear/all/conanfile.py
+++ b/recipes/bear/all/conanfile.py
@@ -41,12 +41,14 @@ class BearConan(ConanFile):
 
     def requirements(self):
         self.requires("grpc/1.50.1")
-        self.requires("fmt/9.1.0")
-        self.requires("spdlog/1.11.0")
-        self.requires("nlohmann_json/3.11.2")
+        self.requires("fmt/11.0.2")
+        self.requires("spdlog/1.15.0")
+        self.requires("nlohmann_json/3.11.3")
 
     def build_requirements(self):
         self.tool_requires("grpc/1.50.1")
+        self.tool_requires("pkgconf/2.2.0")
+        self.tool_requires("protobuf/3.21.12")
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/bear/all/patches/3.1.5-0001-fix-cmake.diff
+++ b/recipes/bear/all/patches/3.1.5-0001-fix-cmake.diff
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f1ecfe0..5b9706a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -111,12 +111,6 @@ endif ()
+ 
+ # Install the project artifacts from the staged directory
+ include(GNUInstallDirs)
+-install(DIRECTORY
+-            ${STAGED_INSTALL_PREFIX}/
+-        DESTINATION
+-            .
+-        USE_SOURCE_PERMISSIONS
+-)
+ install(FILES
+             COPYING README.md INSTALL.md CONTRIBUTING.md CODE_OF_CONDUCT.md
+         DESTINATION


### PR DESCRIPTION
### Summary
Changes to recipe:  **bear/3.1.5**

#### Motivation
The current Bear package is causing problems in the dependency graph due to conflicts in fmt versions due to indirect dependencies from its dependent packages resulting in:
```
ERROR: Version conflict: Conflict between fmt/10.0.0 and fmt/9.1.0 in the graph.
```
This provides an update to the latest version and fixes multiple build missing tool dependencies.

#### Details
This bumps the version to 3.1.5 and then adds build tool requirements that result in compile errors when building the package.  It is possible these tools are found on the local host, so this error can be hidden, but inspecting the CMake configure step for the project will show where the tools are located and now confirm them to be found from the dependent Conan packages (see details below which demonstrate PkcConf and Protobuf now being sources from Conan packages, where previously it had used system versions).  

<details>
```
bear/3.1.5: Running CMake.build()
bear/3.1.5: RUN: cmake --build "/Users/antony/.conan2/p/b/beard7854e8b1a4d9/b/build/Debug" -- -j12
[  0%] Built target spdlog_dependency
[  0%] Built target fmt_dependency
[  0%] Built target nlohmann_json_dependency
[  0%] Built target googletest_dependency
[  0%] Built target grpc_dependency
[ 11%] Creating directories for 'BearSource'
[ 22%] No download step for 'BearSource'
[ 33%] No update step for 'BearSource'
[ 44%] No patch step for 'BearSource'
[ 55%] Performing configure step for 'BearSource'
loading initial cache file /Users/antony/.conan2/p/b/beard7854e8b1a4d9/b/build/Debug/subprojects/tmp/BearSource/BearSource-cache-Debug.cmake
-- Using Conan toolchain: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/b/build/Debug/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- The C compiler identification is AppleClang 16.0.0.16000026
-- The CXX compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Conan: Target declared 'nlohmann_json::nlohmann_json'
-- Conan: Component target declared 'fmt::fmt'
-- Conan: Component target declared 'spdlog::spdlog'
-- Found PkgConfig: /Users/antony/.conan2/p/b/pkgcode6bb9e9f4374/p/bin/pkgconf (found version "2.2.0")
-- Checking for modules 'protobuf;grpc++'
--   Found protobuf, version 3.21.12
--   Found grpc++, version 1.50.1
-- Looking for spawn.h
-- Looking for spawn.h - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for dlfcn.h
-- Looking for dlfcn.h - found
-- Looking for errno.h
-- Looking for errno.h - found
-- Looking for sys/utsname.h
-- Looking for sys/utsname.h - found
-- Looking for sys/wait.h
-- Looking for sys/wait.h - found
-- Looking for sys/time.h
-- Looking for sys/time.h - found
-- Looking for sys/stat.h
-- Looking for sys/stat.h - found
-- Looking for gnu/lib-names.h
-- Looking for gnu/lib-names.h - not found
-- Looking for _NSGetEnviron
-- Looking for _NSGetEnviron - found
-- Looking for dlopen
-- Looking for dlopen - found
-- Looking for dlsym
-- Looking for dlsym - found
-- Looking for dlerror
-- Looking for dlerror - found
-- Looking for dlclose
-- Looking for dlclose - found
-- Looking for RTLD_NEXT
-- Looking for RTLD_NEXT - found
-- Looking for EACCES
-- Looking for EACCES - found
-- Looking for ENOENT
-- Looking for ENOENT - found
-- Looking for strerror_r
-- Looking for strerror_r - found
-- Looking for environ
-- Looking for environ - not found
-- Looking for uname
-- Looking for uname - found
-- Looking for confstr
-- Looking for confstr - found
-- Looking for _CS_PATH
-- Looking for _CS_PATH - found
-- Looking for _CS_GNU_LIBC_VERSION
-- Looking for _CS_GNU_LIBC_VERSION - not found
-- Looking for _CS_GNU_LIBPTHREAD_VERSION
-- Looking for _CS_GNU_LIBPTHREAD_VERSION - not found
-- Looking for protoc ... /Users/antony/.conan2/p/b/proto49888aecdd29e/p/bin/protoc
-- Looking for grpc_cpp_plugin ... /Users/antony/.conan2/p/b/grpc05c1df1b98b7c/p/bin/grpc_cpp_plugin
-- Configuring done (2.7s)
-- Generating done (0.1s)
-- Build files have been written to: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/b/build/Debug/subprojects/Build/BearSource
[ 66%] Performing build step for 'BearSource'
[  3%] Generating supervise.pb.h, supervise.grpc.pb.h, supervise.pb.cc, supervise.grpc.pb.cc
[  3%] Generating intercept.pb.h, intercept.grpc.pb.h, intercept.pb.cc, intercept.grpc.pb.cc
[  5%] Building CXX object libflags/CMakeFiles/flags_a.dir/source/Flags.cc.o
[  8%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Path.cc.o
[  8%] Building CXX object libshell/CMakeFiles/shell_a.dir/source/Command.cc.o
[ 10%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Environment.cc.o
[ 12%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Guard.cc.o
[ 13%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Linker.cc.o
[ 15%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Executor.cc.o
[ 17%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Errors.cc.o
[ 18%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Buffer.cc.o
[ 20%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Os.cc.o
[ 22%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Process.cc.o
[ 24%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Logger.cc.o
[ 25%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Paths.cc.o
[ 27%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Resolver.cc.o
[ 29%] Building CXX object intercept/proto/CMakeFiles/rpc_a.dir/supervise.pb.cc.o
[ 31%] Building CXX object intercept/CMakeFiles/exec_a.dir/source/report/libexec/Session.cc.o
[ 32%] Building CXX object libsys/CMakeFiles/sys_a.dir/source/Signal.cc.o
[ 34%] Building CXX object intercept/proto/CMakeFiles/rpc_a.dir/supervise.grpc.pb.cc.o
[ 36%] Building CXX object intercept/proto/CMakeFiles/rpc_a.dir/intercept.pb.cc.o
[ 37%] Building CXX object intercept/proto/CMakeFiles/rpc_a.dir/intercept.grpc.pb.cc.o
[ 37%] Built target exec_a
[ 41%] Building CXX object intercept/CMakeFiles/exec.dir/source/report/libexec/std.cc.o
[ 41%] Building CXX object intercept/CMakeFiles/exec.dir/source/report/libexec/lib.cc.o
[ 41%] Built target shell_a
[ 41%] Built target flags_a
[ 43%] Building CXX object libmain/CMakeFiles/main_a.dir/source/SubcommandFromArgs.cc.o
[ 44%] Building CXX object libmain/CMakeFiles/main_a.dir/source/ApplicationLogConfig.cc.o
[ 46%] Building CXX object libmain/CMakeFiles/main_a.dir/source/ApplicationFromArgs.cc.o
[ 48%] Linking CXX shared library libexec.dylib
[ 48%] Built target exec
[ 48%] Built target sys_a
[ 51%] Building CXX object citnames/CMakeFiles/citnames_json_a.dir/source/Configuration.cc.o
[ 51%] Building CXX object citnames/CMakeFiles/citnames_json_a.dir/source/Output.cc.o
[ 51%] Built target main_a
[ 51%] Built target rpc_a
[ 58%] Building CXX object intercept/CMakeFiles/events_db_a.dir/source/collect/db/EventsDatabaseReader.cc.o
[ 58%] Building CXX object intercept/CMakeFiles/domain_a.dir/source/Domain.cc.o
[ 58%] Building CXX object intercept/CMakeFiles/events_db_a.dir/source/collect/db/EventsDatabaseWriter.cc.o
[ 58%] Building CXX object intercept/CMakeFiles/domain_a.dir/source/Convert.cc.o
[ 58%] Built target domain_a
[ 62%] Building CXX object intercept/CMakeFiles/wrapper_a.dir/source/report/wrapper/RpcClients.cc.o
[ 63%] Building CXX object intercept/CMakeFiles/wrapper_a.dir/source/report/wrapper/Application.cc.o
[ 63%] Building CXX object intercept/CMakeFiles/wrapper_a.dir/source/report/wrapper/EventReporter.cc.o
[ 65%] Building CXX object intercept/CMakeFiles/wrapper_a.dir/source/report/wrapper/EventFactory.cc.o
[ 65%] Built target events_db_a
[ 67%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/Reporter.cc.o
[ 68%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/RpcServices.cc.o
[ 70%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/Intercept.cc.o
[ 74%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/SessionWrapper.cc.o
[ 74%] Building CXX object intercept/CMakeFiles/intercept_a.dir/source/collect/Session.cc.o
[ 74%] Built target citnames_json_a
[ 75%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/Citnames.cc.o
[ 77%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/Parsers.cc.o
[ 79%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/Build.cc.o
[ 81%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/Semantic.cc.o
[ 82%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/ToolAny.cc.o
[ 84%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/ToolClang.cc.o
[ 86%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/ToolCuda.cc.o
[ 87%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/ToolGcc.cc.o
[ 89%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/ToolWrapper.cc.o
[ 91%] Building CXX object citnames/CMakeFiles/citnames_a.dir/source/semantic/ToolExtendingWrapper.cc.o
[ 91%] Built target intercept_a
[ 91%] Built target wrapper_a
[ 93%] Building CXX object intercept/CMakeFiles/wrapper.dir/source/report/wrapper/main.cc.o
[ 93%] Built target citnames_a
[ 94%] Building CXX object bear/CMakeFiles/bear_a.dir/source/Application.cc.o
[ 96%] Linking CXX executable wrapper
[ 96%] Built target wrapper
[ 96%] Built target bear_a
[ 98%] Building CXX object bear/CMakeFiles/bear.dir/main.cc.o
[100%] Linking CXX executable bear
[100%] Built target bear
[ 77%] Performing test step for 'BearSource'
*********************************
No test configuration file found!
*********************************
Usage

  ctest [options]

[ 88%] Performing install step for 'BearSource'
[  3%] Built target shell_a
[  3%] Built target flags_a
[ 17%] Built target exec_a
[ 27%] Built target rpc_a
[ 37%] Built target sys_a
[ 43%] Built target main_a
[ 48%] Built target exec
[ 51%] Built target domain_a
[ 58%] Built target citnames_json_a
[ 58%] Built target events_db_a
[ 65%] Built target wrapper_a
[ 74%] Built target intercept_a
[ 77%] Built target wrapper
[ 94%] Built target citnames_a
[ 96%] Built target bear_a
[100%] Built target bear
Install the project...
-- Install configuration: "Debug"
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/share/man/man1/bear-intercept.1
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/lib/bear/wrapper
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/lib/bear/wrapper.d
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/lib/bear/libexec.dylib
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/share/man/man1/bear-citnames.1
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/bin/bear
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/share/man/man1/bear.1
[100%] Completed 'BearSource'
[100%] Built target BearSource

bear/3.1.5: Package 'c2d3ef04084bba684818fa460f44ab1f25c57971' built
bear/3.1.5: Build folder /Users/antony/.conan2/p/b/beard7854e8b1a4d9/b/build/Debug
bear/3.1.5: Generating the package
bear/3.1.5: Packaging in folder /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p
bear/3.1.5: Calling package()
bear/3.1.5: Running CMake.install()
bear/3.1.5: RUN: cmake --install "/Users/antony/.conan2/p/b/beard7854e8b1a4d9/b/build/Debug" --prefix "/Users/antony/.conan2/p/b/beard7854e8b1a4d9/p"
-- Install configuration: "Debug"
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/share/doc/Bear/COPYING
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/share/doc/Bear/README.md
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/share/doc/Bear/INSTALL.md
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/share/doc/Bear/CONTRIBUTING.md
-- Installing: /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p/share/doc/Bear/CODE_OF_CONDUCT.md

bear/3.1.5: package(): Packaged 35 files
bear/3.1.5: package(): Packaged 1 '.dylib' file: libexec.dylib
bear/3.1.5: Created package revision 0f6028cf90752f4e70047d0217195df6
bear/3.1.5: Package 'c2d3ef04084bba684818fa460f44ab1f25c57971' created
bear/3.1.5: Full package reference: bear/3.1.5#0a52de08ea0a5a477af363429d348a19:c2d3ef04084bba684818fa460f44ab1f25c57971#0f6028cf90752f4e70047d0217195df6
bear/3.1.5: Package folder /Users/antony/.conan2/p/b/beard7854e8b1a4d9/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: c-ares/1.34.3, openssl/3.3.2, protobuf/3.21.12, abseil/20230802.1, zlib/1.3.1
WARN: deprecated:     'cpp_info.build_modules' used in: abseil/20230802.1, openssl/3.3.2, protobuf/3.21.12
WARN: deprecated:     'env_info' used in: c-ares/1.34.3, openssl/3.3.2, protobuf/3.21.12, pkgconf/2.2.0, bear/3.1.5
WARN: deprecated:     'cpp_info.filenames' used in: protobuf/3.21.12
```
</details>


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
