### PR TITLE
multiple recipes: increase cmake_minimum_required (3)

### DIFF
--- a/recipes/cqrlib/all/CMakeLists.txt
+++ b/recipes/cqrlib/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(CQRlib LANGUAGES C)
 
 add_library(CQRlib ${CQRLIB_SRC_DIR}/cqrlib.c)

--- a/recipes/csm/all/CMakeLists.txt
+++ b/recipes/csm/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(csm LANGUAGES CXX)
 
 find_package(Threads REQUIRED)

--- a/recipes/diligent-fx/all/CMakeLists.txt
+++ b/recipes/diligent-fx/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/diligent-tools/all/CMakeLists.txt
+++ b/recipes/diligent-tools/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(BuildUtils.cmake)

--- a/recipes/drflac/all/CMakeLists.txt
+++ b/recipes/drflac/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(dr_flac LANGUAGES C)
 
 include(GNUInstallDirs)
@@ -14,7 +14,7 @@ add_library(${CMAKE_PROJECT_NAME} dr_flac.c)
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${DRFLAC_SRC_DIR})
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES 
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
     PUBLIC_HEADER ${DRFLAC_SRC_DIR}/dr_flac.h
     C_STANDARD 99
 )


### PR DESCRIPTION
For the following recipes:
- cqrlib
- csm
- diligent-fx
- diligent-tools
- drflac

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects