### PR TITLE
multiple recipes: increase cmake_minimum_required (4)

### DIFF
--- a/recipes/drmp3/all/CMakeLists.txt
+++ b/recipes/drmp3/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(dr_mp3 LANGUAGES C)
 
 include(GNUInstallDirs)
@@ -10,7 +10,7 @@ add_library(${CMAKE_PROJECT_NAME} dr_mp3.c)
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${DRMP3_SRC_DIR})
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES 
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
     PUBLIC_HEADER ${DRMP3_SRC_DIR}/dr_mp3.h
     C_STANDARD 99
 )

--- a/recipes/drwav/all/CMakeLists.txt
+++ b/recipes/drwav/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(dr_wav LANGUAGES C)
 
 include(GNUInstallDirs)
@@ -11,7 +11,7 @@ add_library(${CMAKE_PROJECT_NAME} dr_wav.c)
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${DRWAV_SRC_DIR})
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES 
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
     PUBLIC_HEADER ${DRWAV_SRC_DIR}/dr_wav.h
     C_STANDARD 99
 )

--- a/recipes/farmhash/all/CMakeLists.txt
+++ b/recipes/farmhash/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(farmhash LANGUAGES CXX)
 
 include(GNUInstallDirs)

--- a/recipes/fft/all/CMakeLists.txt
+++ b/recipes/fft/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.15)
 project(fft LANGUAGES C)
 
 option(FFT_THREADS "use threads" OFF)

--- a/recipes/flatc/all/CMakeLists.txt
+++ b/recipes/flatc/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
For the following recipes:

- drmp3
- drwav
- farmhash
- fft
- flatc


These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects