### PR TITLE
multiple recipes: increase cmake_minimum_required (5)

### DIFF
--- a/recipes/glslang/all/CMakeLists.txt
+++ b/recipes/glslang/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 # TODO:

--- a/recipes/hash-library/all/CMakeLists.txt
+++ b/recipes/hash-library/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(hash-library LANGUAGES CXX)
 
 add_library(hash-library

--- a/recipes/http_parser/all/CMakeLists.txt
+++ b/recipes/http_parser/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(http_parser LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/recipes/irrxml/all/CMakeLists.txt
+++ b/recipes/irrxml/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(IrrXML LANGUAGES CXX)
 
 include(GNUInstallDirs)

--- a/recipes/jxrlib/all/CMakeLists.txt
+++ b/recipes/jxrlib/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(jxrlib LANGUAGES C)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
For the following recipes:

- glslang
- hash-library
- http_parser
- irrxml
- jxrlib

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects