### PR TITLE
multiple recipes: increase cmake_minimum_required (6)

### DIFF
--- a/recipes/liblsl/all/CMakeLists.txt
+++ b/recipes/liblsl/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/libnoise/all/CMakeLists.txt
+++ b/recipes/libnoise/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(noise LANGUAGES CXX)
 
 set(NOISE_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/noise/src)

--- a/recipes/librttopo/all/CMakeLists.txt
+++ b/recipes/librttopo/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(rttopo LANGUAGES C)
 
 set(RTTOPO_HDR_DIR ${LIBRTTOPO_SRC_DIR}/headers)

--- a/recipes/libstudxml/1.1.x/CMakeLists.txt
+++ b/recipes/libstudxml/1.1.x/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(libstudxml LANGUAGES C CXX)
 
 find_package(EXPAT REQUIRED MODULE)

--- a/recipes/libsvm/all/CMakeLists.txt
+++ b/recipes/libsvm/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(svm C CXX)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
For the following recipes:

- liblsl
- libnoise
- librttopo
- libstudxml
- libsvm

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects