### PR TITLE
multiple recipes: increase cmake_minimum_required (7)

### DIFF
--- a/recipes/lmdb/all/CMakeLists.txt
+++ b/recipes/lmdb/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(lmdb LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/recipes/lodepng/all/CMakeLists.txt
+++ b/recipes/lodepng/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(lodepng LANGUAGES CXX)
 
 add_library(lodepng ${LODEPNG_SRC_DIR}/lodepng.cpp)

--- a/recipes/microprofile/all/CMakeLists.txt
+++ b/recipes/microprofile/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(microprofile)
 
 option(MICROPROFILE_USE_CONFIG_FILE "Use user provided configuration in microprofile.config.h file." ON)

--- a/recipes/microtar/all/CMakeLists.txt
+++ b/recipes/microtar/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(microtar LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/recipes/mikktspace/all/CMakeLists.txt
+++ b/recipes/mikktspace/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(mikktspace LANGUAGES C)
 
 add_library(mikktspace ${MIKKTSPACE_SRC_DIR}/mikktspace.c)


### PR DESCRIPTION
For the following recipes:

- lmdb
- lodepng
- microprofile
- microtar
- mikktspace

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects