### PR TITLE
multiple recipes: increase cmake_minimum_required (8)

### DIFF
--- a/recipes/miniaudio/all/CMakeLists.txt
+++ b/recipes/miniaudio/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(miniaudio LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/recipes/minizip/all/CMakeLists.txt
+++ b/recipes/minizip/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(minizip LANGUAGES C)
 
 option(MINIZIP_ENABLE_BZIP2 "Build minizip with bzip2 support" ON)

--- a/recipes/mujs/all/CMakeLists.txt
+++ b/recipes/mujs/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(mujs LANGUAGES C)
 
 file(GLOB MUJS_SRC ${MUJS_SRC_DIR}/js*.c ${MUJS_SRC_DIR}/utf*.c ${MUJS_SRC_DIR}/regexp.c)

--- a/recipes/newmat/all/CMakeLists.txt
+++ b/recipes/newmat/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(
   "newmat"
@@ -15,7 +15,7 @@ if (SETUP_C_SUBSCRIPTS)
    add_compile_definitions(SETUP_C_SUBSCRIPTS)
 endif()
 message("Build with C style element access ${SETUP_C_SUBSCRIPTS}")
- 
+
 # -------------
 # target
 # -------------
@@ -80,7 +80,7 @@ install(
     ${include_dir}/newmatrm.h
     ${include_dir}/precisio.h
     ${include_dir}/solution.h
-  DESTINATION 
+  DESTINATION
     include/newmat
 )
 install(

--- a/recipes/pffft/all/CMakeLists.txt
+++ b/recipes/pffft/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(pffft LANGUAGES C)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
For the following recipes:

- miniaudio
- minizip
- mujs
- newmat
- pffft

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects