### PR TITLE
multiple recipes: increase cmake_minimum_required (9)

### DIFF
--- a/recipes/poly2tri/all/CMakeLists.txt
+++ b/recipes/poly2tri/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(poly2tri LANGUAGES CXX)
 
 include(GNUInstallDirs)

--- a/recipes/pystring/all/CMakeLists.txt
+++ b/recipes/pystring/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(pystring LANGUAGES CXX)
 
 include(GNUInstallDirs)

--- a/recipes/quickjs/all/CMakeLists.txt
+++ b/recipes/quickjs/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(quickjs C)
 
 option(USE_BIGNUM "Use bignum" ON)

--- a/recipes/quirc/all/CMakeLists.txt
+++ b/recipes/quirc/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.15)
 project(quirc LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/recipes/r8brain-free-src/all/CMakeLists.txt
+++ b/recipes/r8brain-free-src/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(r8brain-free-src LANGUAGES C CXX)
 
 add_library(r8brain)
@@ -30,18 +30,18 @@ install(
 file(GLOB PUBLIC_HEADERS ${R8BRAIN_SRC_DIR}/*.h ${R8BRAIN_SRC_DIR}/*.inc)
 install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 if(R8BRAIN_WITH_PFFFT_DOUBLE)
-  list(APPEND PFFFT_DOUBLE_HEADERS 
+  list(APPEND PFFFT_DOUBLE_HEADERS
     ${R8BRAIN_SRC_DIR}/pffft_double/pffft_double.h
   )
   install(FILES ${PFFFT_DOUBLE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pffft_double)
 
-  list(APPEND PFFFT_DOUBLE_SIMD_HEADERS 
+  list(APPEND PFFFT_DOUBLE_SIMD_HEADERS
     ${R8BRAIN_SRC_DIR}/pffft_double/simd/pf_avx_double.h
     ${R8BRAIN_SRC_DIR}/pffft_double/simd/pf_double.h
     ${R8BRAIN_SRC_DIR}/pffft_double/simd/pf_neon_double.h
     ${R8BRAIN_SRC_DIR}/pffft_double/simd/pf_neon_double_from_avx.h
     ${R8BRAIN_SRC_DIR}/pffft_double/simd/pf_scalar_double.h
-    ${R8BRAIN_SRC_DIR}/pffft_double/simd/pf_sse2_double.h 
+    ${R8BRAIN_SRC_DIR}/pffft_double/simd/pf_sse2_double.h
   )
   install(FILES ${PFFFT_DOUBLE_SIMD_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pffft_double/simd)
 endif()


### PR DESCRIPTION
For the following recipes:

- poly2tri
- pystring
- quickjs
- quirc
- r8brain-free-src

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects