### PR TITLE
multiple recipes: increase cmake_minimum_required (10)

### DIFF
--- a/recipes/ragel/all/CMakeLists.txt
+++ b/recipes/ragel/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 project(ragel LANGUAGES CXX)
 
 file(GLOB HEADERS

--- a/recipes/rg-etc1/all/CMakeLists.txt
+++ b/recipes/rg-etc1/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 if(WIN32 AND BUILD_SHARED_LIBS)

--- a/recipes/rmlui/4.x/CMakeLists.txt
+++ b/recipes/rmlui/4.x/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper LANGUAGES CXX)
 
 include(conanbuildinfo.cmake)

--- a/recipes/rply/all/CMakeLists.txt
+++ b/recipes/rply/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(rply LANGUAGES C)
 
 add_library(rply ${RPLY_SRC_DIR}/rply.c)

--- a/recipes/sdl_image/all/CMakeLists.txt
+++ b/recipes/sdl_image/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(SDL2_image LANGUAGES C)
 
 find_package(SDL2 REQUIRED CONFIG)


### PR DESCRIPTION
For the following recipes:

- ragel
- rg-etc1
- rmlui/4.x
- rply
- sdl_image

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects