### PR TITLE
multiple recipes: increase cmake_minimum_required (11)

### DIFF
--- a/recipes/sdl_net/all/CMakeLists.txt
+++ b/recipes/sdl_net/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(SDL2_net LANGUAGES C)
 
 find_package(SDL2 REQUIRED CONFIG)

--- a/recipes/seasocks/all/CMakeLists.txt
+++ b/recipes/seasocks/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/semver.c/all/CMakeLists.txt
+++ b/recipes/semver.c/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(semver.c LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/recipes/sofa/all/CMakeLists.txt
+++ b/recipes/sofa/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.15)
 project(sofa C)
 
 include(GNUInstallDirs)

--- a/recipes/ssht/all/CMakeLists.txt
+++ b/recipes/ssht/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)


### PR DESCRIPTION
For the following recipes:

- sdl_net
- seasocks
- semver.c
- sofa
- ssht

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects