### PR TITLE
multiple recipes: increase cmake_minimum_required (12)

### DIFF
--- a/recipes/termcap/all/CMakeLists.txt
+++ b/recipes/termcap/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(conan_termcap LANGUAGES C)
 
 include(CheckIncludeFile)

--- a/recipes/tgc/all/CMakeLists.txt
+++ b/recipes/tgc/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(tgc LANGUAGES C)
 
 add_library(tgc ${TGC_SRC_DIR}/tgc.c)

--- a/recipes/tiny-bignum-c/all/CMakeLists.txt
+++ b/recipes/tiny-bignum-c/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(tiny-bignum-c LANGUAGES C)
 
 add_library(tiny-bignum-c ${TINY_BIGNUM_C_SRC_DIR}/bn.c)

--- a/recipes/tiny-regex-c/all/CMakeLists.txt
+++ b/recipes/tiny-regex-c/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(tiny-regex-c LANGUAGES C)
 
 add_library(${PROJECT_NAME} ${TINY_REGEX_C_SRC_DIR}/re.c)

--- a/recipes/tinyxml/all/CMakeLists.txt
+++ b/recipes/tinyxml/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(tinyxml LANGUAGES CXX)
 
 option(TINYXML_WITH_STL "Compile TinyXML with STL" OFF)


### PR DESCRIPTION
For the following recipes:

- termcap
- tgc
- tiny-bignum-c
- tiny-regex-c
- tinyxml

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects