### PR TITLE
multiple recipes: increase cmake_minimum_required (13)

### DIFF
--- a/recipes/tree-sitter-c/all/CMakeLists.txt
+++ b/recipes/tree-sitter-c/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 project(tree-sitter-c LANGUAGES C)
 
 find_package(tree-sitter REQUIRED CONFIG)

--- a/recipes/tree-sitter/all/CMakeLists.txt
+++ b/recipes/tree-sitter/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(tree-sitter LANGUAGES C)
 
 # Use cmake script instead of Makefile to support MSVC + follow fPIC option

--- a/recipes/tsil/all/CMakeLists.txt
+++ b/recipes/tsil/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(TSIL LANGUAGES C)
 
 add_library(tsil

--- a/recipes/voropp/all/CMakeLists.txt
+++ b/recipes/voropp/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(voro++ LANGUAGES CXX)
 
 add_library(${PROJECT_NAME} ${VOROPP_SRC_DIR}/src/voro++.cc)


### PR DESCRIPTION
For the following recipes:

- tree-sitter-c
- tree-sitter
- tsil
- voropp

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects