### PR TITLE
multiple v1 recipes: increase cmake_minimum_required (14) [last one]

### DIFF
--- a/recipes/magnum-extras/all/CMakeLists.txt
+++ b/recipes/magnum-extras/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/magnum-integration/all/CMakeLists.txt
+++ b/recipes/magnum-integration/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/magnum-plugins/all/CMakeLists.txt
+++ b/recipes/magnum-plugins/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 set(CONAN_CMAKE_SILENT_OUTPUT 1)

--- a/recipes/magnum/all/CMakeLists.txt
+++ b/recipes/magnum/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/msgpack/all/CMakeLists.txt
+++ b/recipes/msgpack/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/osgearth/all/CMakeLists.txt
+++ b/recipes/osgearth/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/pdal/all/CMakeLists.txt
+++ b/recipes/pdal/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/qcoro/all/CMakeLists.txt
+++ b/recipes/qcoro/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
 include("conanbuildinfo.cmake")

--- a/recipes/rmlui/3.3/CMakeLists.txt
+++ b/recipes/rmlui/3.3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper LANGUAGES CXX)
 
 include(conanbuildinfo.cmake)


### PR DESCRIPTION
For the following conan v1 recipes:
(Any of this recipes would be built by CI)

- magnum-extras
- magnum-integration
- magnum-plugins
- magnum
- msgpack
- osgearth
- pdal
- qcoro
- rmlui/3.3

These recipes have a `CMakeLists.txt` in the `conan-center-index` repository rather than upstream.
Change the minimum to 3.15 to allow building with the soon to be release CMake 4.0
Fixes the following error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Notes:
* The CMake integrations in Conan 2 require CMake 3.15 at a minimum - 
* We follow the recommendations in "Professional CMake: A Practical Guide" - we know we don't support any version older than 3.15 (for Conan 2+), and these CMakeLists are not included as part of other projects