### PR TITLE
[expat] Add version 2.7.0 to libexpat

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.7.0":
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_7_0/expat-2.7.0.tar.xz"
+    sha256: "25df13dd2819e85fb27a1ce0431772b7047d72af81ae78dc26b4c6e0805f48d1"
   "2.6.4":
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_6_4/expat-2.6.4.tar.xz"
     sha256: "a695629dae047055b37d50a0ff4776d1d45d0a4c842cf4ccee158441f55ff7ee"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.7.0":
+    folder: all
   "2.6.4":
     folder: all
   "2.6.3":


### PR DESCRIPTION
Expat 2.7.0 has a few security fixes CVE-2024-8176
 Release notes at: https://github.com/libexpat/libexpat/blob/R_2_7_0/expat/Changes
 for details.


### Summary
Changes to recipe:  **expat/2.7.0**
Accommodate the new version.

#### Motivation
CVE-2024-8176
as per [release notes](https://github.com/libexpat/libexpat/blob/R_2_7_0/expat/Changes)

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
