### PR TITLE
[cccl] Fix microsoft.bash configuration usage

### DIFF
--- a/recipes/cccl/all/conandata.yml
+++ b/recipes/cccl/all/conandata.yml
@@ -5,3 +5,14 @@ sources:
   "1.3":
     url: https://github.com/swig/cccl/archive/cccl-1.3.tar.gz
     sha256: 1E34E315CE3AB890D39A75FFABAACCE2E55FE5ED21591F036A45AFDA43A3E989
+patches:
+  "1.3":
+    - patch_file: "patches/0001-uname-detect-msys.patch"
+      patch_type: "official"
+      patch_description: "Use uname to detect MSYS2 intead of MATCHTYPE"
+      patch_source: "https://github.com/swig/cccl/commit/6cc59b3a14fc9c2a2301eae9809c64fbdb1b524d"
+  "1.1":
+    - patch_file: "patches/0001-uname-detect-msys.patch"
+      patch_type: "official"
+      patch_description: "Use uname to detect MSYS2 intead of MATCHTYPE"
+      patch_source: "https://github.com/swig/cccl/commit/6cc59b3a14fc9c2a2301eae9809c64fbdb1b524d"

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -6,6 +6,9 @@ from conan.tools.microsoft import is_msvc
 import os
 
 
+required_conan_version = ">=2.1.0"
+
+
 class CcclConan(ConanFile):
     name = "cccl"
     description = "Unix cc compiler to Microsoft's cl compiler wrapper"
@@ -14,6 +17,7 @@ class CcclConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     license = "GPL-3.0-or-later"
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "application"
     options = {
         "muffle": [True, False],
         "verbose": [True, False],
@@ -80,13 +84,3 @@ class CcclConan(ConanFile):
         self.buildenv_info.define("CC", cccl)
         self.buildenv_info.define("CXX", cccl)
         self.buildenv_info.define("LD", cccl)
-
-        # TODO: Legacy, to be removed on Conan 2.0
-        self.env_info.PATH.append(self._cccl_dir)
-
-        self.output.info(f"Setting CC to '{cccl}'")
-        self.env_info.CC = cccl
-        self.output.info(f"Setting CXX to '{cccl}'")
-        self.env_info.CXX = cccl
-        self.output.info(f"Setting LD to '{cccl}'")
-        self.env_info.LD = cccl

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.files import get, replace_in_file, copy
+from conan.tools.files import get, replace_in_file, copy, export_conandata_patches, apply_conandata_patches
 from conan.tools.layout import basic_layout
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc
@@ -31,6 +31,9 @@ class CcclConan(ConanFile):
     def _cccl_dir(self):
         return os.path.join(self.package_folder, "bin")
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -42,8 +45,8 @@ class CcclConan(ConanFile):
             raise ConanInvalidConfiguration("This recipe only supports msvc/Visual Studio.")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-                  strip_root=True, destination=self.source_folder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def build(self):
         cccl_path = os.path.join(self.source_folder, self.source_folder, "cccl")

--- a/recipes/cccl/all/patches/0001-uname-detect-msys.patch
+++ b/recipes/cccl/all/patches/0001-uname-detect-msys.patch
@@ -1,0 +1,42 @@
+From 6cc59b3a14fc9c2a2301eae9809c64fbdb1b524d Mon Sep 17 00:00:00 2001
+From: William S Fulton <wsf@fultondesigns.co.uk>
+Date: Fri, 7 Mar 2025 19:04:20 +0000
+Subject: [PATCH] Use uname -o to detect msys instead of x86_64-pc-msys
+
+Closes #20
+---
+ README.markdown | 2 ++
+ cccl            | 5 +++--
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/README.markdown b/README.markdown
+index 1b69922..f0c3273 100644
+--- a/README.markdown
++++ b/README.markdown
+@@ -69,8 +69,10 @@ do anything but copy the cccl script, though.
+ 
+ cccl uses and hence requires ports of the following Unix utilities:
+   - bash
++  - grep
+   - sed
+   - tr
++  - uname
+ 
+ cccl is a bash shell script which makes use of these utilities.  Therefore, you
+ will need at the very least a Windows versions of these utilities.  The easiest
+diff --git a/cccl b/cccl
+index 28571fe..d681117 100755
+--- a/cccl
++++ b/cccl
+@@ -30,8 +30,9 @@ given by [OPTIONS] that Unix cc understands into parameters that cl understands.
+ EOF
+ }
+ 
+-case $MACHTYPE in
+-    *-msys)
++operating_system=$(uname -o)
++case $operating_system in
++    Msys)
+         slash="-"
+         ;;
+     *)

--- a/recipes/cccl/all/test_package/conanfile.py
+++ b/recipes/cccl/all/test_package/conanfile.py
@@ -16,18 +16,18 @@ class CcclTestConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             self.tool_requires("msys2/cci.latest")
 
     def build(self):
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             return  # cccl needs a bash if there isn't a bash we can't build
         cxx = "cccl "
         src = os.path.join(self.source_folder, "example.cpp").replace("\\", "/")
         self.run(f"{cxx} {src} -o example", cwd=self.build_folder)
 
     def test(self):
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             return  # cccl needs a bash if there isn't a bash we can't build
         if can_run(self):
             self.run("./example") #test self.run still runs in bash, so it needs "./"; seems weird but okay...

--- a/recipes/cccl/all/test_package/conanfile.py
+++ b/recipes/cccl/all/test_package/conanfile.py
@@ -11,18 +11,18 @@ class CcclTestConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
-        if not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
             self.tool_requires("msys2/cci.latest")
 
     def build(self):
-        if not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
             return  # cccl needs a bash if there isn't a bash we can't build
         cxx = "cccl "
         src = os.path.join(self.source_folder, "example.cpp").replace("\\", "/")
         self.run(f"{cxx} {src} -o example", cwd=self.build_folder)
 
     def test(self):
-        if not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
             return  # cccl needs a bash if there isn't a bash we can't build
         if can_run(self):
             self.run("./example") #test self.run still runs in bash, so it needs "./"; seems weird but okay...

--- a/recipes/cccl/all/test_package/conanfile.py
+++ b/recipes/cccl/all/test_package/conanfile.py
@@ -9,25 +9,20 @@ class CcclTestConan(ConanFile):
     test_type = "explicit"
     win_bash = True
 
-    @property
-    def _settings_build(self):
-        # TODO: Remove for Conan v2
-        return getattr(self, "settings_build", self.settings)
-
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             self.tool_requires("msys2/cci.latest")
 
     def build(self):
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             return  # cccl needs a bash if there isn't a bash we can't build
         cxx = "cccl "
         src = os.path.join(self.source_folder, "example.cpp").replace("\\", "/")
         self.run(f"{cxx} {src} -o example", cwd=self.build_folder)
 
     def test(self):
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             return  # cccl needs a bash if there isn't a bash we can't build
         if can_run(self):
             self.run("./example") #test self.run still runs in bash, so it needs "./"; seems weird but okay...

--- a/recipes/cccl/all/test_package/conanfile.py
+++ b/recipes/cccl/all/test_package/conanfile.py
@@ -11,18 +11,18 @@ class CcclTestConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
-        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             self.tool_requires("msys2/cci.latest")
 
     def build(self):
-        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             return  # cccl needs a bash if there isn't a bash we can't build
         cxx = "cccl "
         src = os.path.join(self.source_folder, "example.cpp").replace("\\", "/")
         self.run(f"{cxx} {src} -o example", cwd=self.build_folder)
 
     def test(self):
-        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
+        if not self.conf.get("tools.microsoft.bash:path", default="", check_type=str):
             return  # cccl needs a bash if there isn't a bash we can't build
         if can_run(self):
             self.run("./example") #test self.run still runs in bash, so it needs "./"; seems weird but okay...


### PR DESCRIPTION
### Summary
Changes to recipe:  **cccl/1.3**

#### Motivation

The configuration `tools.microsoft.bash:path` should be string, not boolean, it's documented in the official Conan docs: https://docs.conan.io/2/examples/tools/autotools/create_your_first_package_windows.html#id1

The second, about the wrong triplet, by consuming the MATCHTYPE, it was discussed in msys2 issue https://github.com/msys2/MSYS2-packages/issues/5232, and its motivation is well explained on the blog post https://www.msys2.org/news/#2025-02-14-moving-msys2-closer-to-cygwin. They offered a workaround, like using the environment variable `MSYS2_ARG_CONV_EXCL='*'`, but it could break cccl as well, because it really uses `MATCHTYPE` variable.

I'm able to reproduce the ported case as well: [cccl-1.3-msys-conan-center.log](https://github.com/user-attachments/files/19244933/cccl-1.3-msys-conan-center.log)

On the other hand, the case was reported to CCCL as well on the issue https://github.com/swig/cccl/issues/20, and the author provided a hotfix (https://github.com/swig/cccl/commit/6cc59b3a14fc9c2a2301eae9809c64fbdb1b524d) and commented to be present in the version 1.4 (not sure about a release date).

I copied the very same patch and it fits without any change for both 1.1 and 1.3 versions. Instead of using MATCHTYPE variable, it now runs `uname` command to obtain Msys name. 

As the Conan Center does not have the newest MSYS2, but a cached old version, we can reproduce the error in the CI, otherwise, we would need to rebuild the msys2 package. Locally, I re-built msys2 package, so I was able to reproduce the case (reported previously in this description), and when using the patch, the error is gone: 

- [cccl-1.3-msys-newest.log](https://github.com/user-attachments/files/19244763/cccl-1.3-msys-newest.log)
- [cccl-1.1-msys-newest.log](https://github.com/user-attachments/files/19244765/cccl-1.1-msys-newest.log)

Just checked CCI, only `swig` and `genie` recipes are consuming `cccl` as tool requirement. Both are working when consuming this new revision of cccl package. Here are my build logs:

- [swig-4.3.0-windows-msys.log](https://github.com/user-attachments/files/19245463/swig-4.3.0-windows-msys.log)
- [genie-1141-windows-msys.log](https://github.com/user-attachments/files/19245472/genie-1141-windows-msys.log)


close #26845

#### Details

- Some important Conan 2.x items are missing, like `package_type`


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conn-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
