### PR TITLE
Update sqlite_orm -> sqlite3 dependency to range

### DIFF
--- a/recipes/sqlite_orm/all/conanfile.py
+++ b/recipes/sqlite_orm/all/conanfile.py
@@ -40,7 +40,7 @@ class SqliteOrmConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("sqlite3/3.45.0", transitive_headers=True, transitive_libs=True)
+        self.requires("sqlite3/[^3.45]", transitive_headers=True, transitive_libs=True)
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION

### Summary
Changes to recipe:  **sqlite_orm/1.9**

#### Motivation
See #26873

#### Details
Update `sqlite3` dependency to be a range. Note: sqlite_orm does not mention specific compatibility, just that [you should install sqlite3](https://github.com/fnc12/sqlite_orm?tab=readme-ov-file#requirements). What I take away from this is that they intend to support any (modern?) sqlite3 version.

The version could also just be bumped without turning it into a range, but this seems fine by me?

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
