### PR TITLE
CMake: add version 4.0.0-rc4

### DIFF
--- a/recipes/cmake/binary/conandata.yml
+++ b/recipes/cmake/binary/conandata.yml
@@ -1,4 +1,23 @@
 sources:
+  "4.0.0-rc4":
+    Linux:
+      armv8:
+        url: "https://cmake.org/files/ReleaseCandidate/cmake-4.0.0-rc4-linux-aarch64.tar.gz"
+        sha256: "d14560f4e96f6bc1525c9867d8d8989291b2ac0adb538705d24aa61b9390d38b"
+      x86_64:
+        url: "https://cmake.org/files/ReleaseCandidate/cmake-4.0.0-rc4-linux-x86_64.tar.gz"
+        sha256: "763b2a3e13c8a824ef2db5ce051efdbddbc3777e79e13d9c73613d99b6d229e0"
+    Macos:
+      universal:
+        url: "https://cmake.org/files/ReleaseCandidate/cmake-4.0.0-rc4-macos-universal.tar.gz"
+        sha256: "2f352ef0469454e7fb270f39373d9869a7290b9ebd1cf8904512c6bfb85d717d"
+    Windows:
+      armv8:
+        url: "https://cmake.org/files/ReleaseCandidate/cmake-4.0.0-rc4-windows-arm64.zip"
+        sha256: "57769269273d95f7f7370c9cfe3acc1eca231c141908f046090e08cf443681af"
+      x86_64:
+        url: "https://cmake.org/files/ReleaseCandidate/cmake-4.0.0-rc4-windows-x86_64.zip"
+        sha256: "71ec6d8f2096ef735681beb514aae523fecbd05b8129d65d907bb86222407c12"
   "3.31.6":
     Linux:
       armv8:

--- a/recipes/cmake/config.yml
+++ b/recipes/cmake/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.0-rc4":
+    folder: "binary"
   "3.31.6":
     folder: "binary"
   "3.31.5":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cmake/4.0.0-rc4**

#### Motivation
Following https://github.com/conan-io/conan-center-index/issues/26878
Adding CMake latest release candidate will facilitate testing recipes.
Also, this is a good opportunity to distinguish from other package managers which does not yet support any v4 CMake version.

Checkout SHAs here: https://cmake.org/files/ReleaseCandidate/cmake-4.0.0-rc4-SHA-256.txt
