### PR TITLE
openssl: clarify maintained versions

### DIFF
--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -1,28 +1,25 @@
+# Versions to keep:
+#  - The last patch version of the supported releases, as per https://openssl-library.org/source/
+#  - The last patch version of the current LTS release
+#  - The most recent FIPS validated version
+#  Note: please do not maintain multiple patch versions of the same minor,
+#        unless required by the above.
 sources:
   3.4.1:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz"
     sha256: 002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3
-  3.4.0:
-    url: "https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz"
-    sha256: e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf
   3.3.3:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.3.3/openssl-3.3.3.tar.gz"
     sha256: 712590fd20aaa60ec75d778fe5b810d6b829ca7fb1e530577917a131f9105539
-  3.3.2:
-    url: "https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz"
-    sha256: 2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281
   3.2.4:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.2.4/openssl-3.2.4.tar.gz"
     sha256: b23ad7fd9f73e43ad1767e636040e88ba7c9e5775bfa5618436a0dd2c17c3716
-  3.2.3:
-    url: "https://github.com/openssl/openssl/releases/download/openssl-3.2.3/openssl-3.2.3.tar.gz"
-    sha256: 52b5f1c6b8022bc5868c308c54fb77705e702d6c6f4594f99a0df216acf46239
   3.1.8:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.1.8/openssl-3.1.8.tar.gz"
     sha256: d319da6aecde3aa6f426b44bbf997406d95275c5c59ab6f6ef53caaa079f456f
-  3.1.7:
-    url: "https://github.com/openssl/openssl/releases/download/openssl-3.1.7/openssl-3.1.7.tar.gz"
-    sha256: 053a31fa80cf4aebe1068c987d2ef1e44ce418881427c4464751ae800c31d06c
+  3.1.2: # Most recent FIPS validated as of 2025-03-14
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.1.2/openssl-3.1.2.tar.gz"
+    sha256: a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539
   3.0.16: # LTS: keep the most recent 3.0.x until a new LTS is designated
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz"
     sha256: 57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,19 +1,13 @@
 versions:
   "3.4.1":
     folder: "3.x.x"
-  "3.4.0":
-    folder: "3.x.x"
   "3.3.3":
-    folder: "3.x.x"
-  "3.3.2":
     folder: "3.x.x"
   "3.2.4":
     folder: "3.x.x"
-  "3.2.3":
-    folder: "3.x.x"
   "3.1.8":
     folder: "3.x.x"
-  "3.1.7":
+  "3.1.2":
     folder: "3.x.x"
   "3.0.16":
     folder: "3.x.x"


### PR DESCRIPTION
OpenSSL 3.x can take too long to build on CI - and there's diminshing returns in terms of simultaneously maintaining too many versions from the same recipe, considering that as per OpenSSL's policy, OpenSSL 3.x is to remain backwards compatible https://openssl-library.org/policies/releasestrat/index.html)

- Other recipes in Conan Center depend on the version range `openssl/[>=1.1 <4]` (or similar) - which means that they will require the most recent version as soon as it's published
- Align with the supported releases by OpenSSL maintainers

This does *not* mean that those other versions are "deleted" - once a version is published in the Conan Center remote, it remains there, and if it works for a user, it will continue to work.
What this means is that we will not be maintaining the recipe (bugfixes/features) for versions other than the ones as per this policy.