### PR TITLE
luau: add version 0.665

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.665":
+    url: "https://github.com/Roblox/luau/archive/0.665.tar.gz"
+    sha256: "18eaa819f892e9175ac6209fdbcb76f83f22e029f0faf09a4b9d6ff6e7818e8a"
   "0.655":
     url: "https://github.com/Roblox/luau/archive/0.655.tar.gz"
     sha256: "1c0ff05ce18493d6c83062a17cf6822a71ce254bfa0db41dd086d313b674ca33"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.665":
+    folder: all
   "0.655":
     folder: all
   "0.650":


### PR DESCRIPTION
### Summary
Changes to recipe:  **luau/0.665**

#### Motivation
There are lots of new features since 0.655.
The last version was released 3 months ago and 10 releases exist.

#### Details
https://github.com/luau-lang/luau/compare/0.655...0.665

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
