### PR TITLE
bmx/1.5: Add new version

### DIFF
--- a/recipes/bmx/all/conandata.yml
+++ b/recipes/bmx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5":
+    url: "https://github.com/bbc/bmx/archive/v1.5.tar.gz"
+    sha256: "764c94b4273f94ea9079793abddfc67aa85961024aa85d03afb64364a0e51738"
   "1.3":
     url: "https://github.com/bbc/bmx/releases/download/v1.3/bmx-1.3.tar.gz"
     sha256: "c20cd34f201510affe62c079c7f9079a10dce3a44d7f61b21f9faff624fdaeab"
@@ -6,6 +9,10 @@ sources:
     url: "https://github.com/bbc/bmx/archive/refs/tags/v1.2.tar.gz"
     sha256: "e64d91b2d27478d6b892d72183e1ecf79c99880b079ce04442432f3caed1e259"
 patches:
+  "1.5":
+    - patch_file: "patches/1.3-cmake-fixes.patch"
+      patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"
+      patch_type: "conan"
   "1.3":
     - patch_file: "patches/1.3-cmake-fixes.patch"
       patch_description: "Ensure project builds correctly with Conan (don't pick up disabled dependencies from the system, fix different spelling of libraries)"

--- a/recipes/bmx/config.yml
+++ b/recipes/bmx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5":
+    folder: all
   "1.3":
     folder: all
   "1.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **bmx/1.5**

#### Motivation
The upstream library had two updates recently (1.4 and 1.5) adding some new features bringing support for some more usage modes of the MXF file format.

#### Details
* Release notes are a bit sparse, so here is the changelog file: https://github.com/bbc/bmx/blob/main/CHANGELOG.md#v15
* Besides the changelog, the commit history shows some code cleanups reacting to compiler warnings so making overall improvements too.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan