### PR TITLE
add new version abseil 20250127.0

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20250127.0":
+    url: "https://github.com/abseil/abseil-cpp/archive/20250127.0.tar.gz"
+    sha256: "16242f394245627e508ec6bb296b433c90f8d914f73b9c026fddb905e27276e8"
   "20240722.1":
     url: "https://github.com/abseil/abseil-cpp/archive/20240722.1.tar.gz"
     sha256: "40cee67604060a7c8794d931538cb55f4d444073e556980c88b6c49bb9b19bb7"

--- a/recipes/abseil/config.yml
+++ b/recipes/abseil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20250127.0":
+    folder: all
   "20240722.1":
     folder: all
   "20240722.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil/20250127.0**
https://github.com/abseil/abseil-cpp/compare/20240722.1...20250127.0

#### Motivation
It is needed to update protobuf to 6.30.1
https://github.com/protocolbuffers/protobuf/compare/v5.29.3...v6.30.1#diff-02b58b3ce9a71b92b93137c7a00f4fe64adb1c6a74364f0fe6fda27b45d7808bR15


