### PR TITLE
add new version protobuff/6.30.1

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.30.1":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.30.1.tar.gz"
+    sha256: "c97cc064278ef2b8c4da66c1f85613642ecbd5a0c4217c0defdf7ad1b3de9fa5"
   "5.29.3":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.29.3.tar.gz"
     sha256: "fe35f190d7a63533b06558915d6ee469cbee143de70891e1dd54d197b05f362a"
@@ -30,6 +33,44 @@ patches:
       patch_source: "https://github.com/protocolbuffers/protobuf/pull/10103"
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
+  "6.30.1":
+    - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_optional
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_type_traits
+    - absl_utility
+    - absl_variant
   "5.29.3":
     - absl_absl_check
     - absl_absl_log

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.30.1":
+    folder: all
   "5.29.3":
     folder: all
   "5.28.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuff/6.30.1**

#### Motivation
Close: https://github.com/conan-io/conan-center-index/issues/26876

#### Details
Need: https://github.com/conan-io/conan-center-index/pull/26893

Need the new abseil version `20250127.0` https://github.com/protocolbuffers/protobuf/compare/v5.29.3...v6.30.1#diff-02b58b3ce9a71b92b93137c7a00f4fe64adb1c6a74364f0fe6fda27b45d7808bR15

Use the new option `protobuf_LOCAL_DEPENDENCIES_ONLY ` to "Prevent downloading any dependencies from GitHub": https://github.com/protocolbuffers/protobuf/compare/v5.29.3...v6.30.1#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR39

The `absl_deps` list on the `conandata.yml` is the same as before except for `absl::if_constexpr`: https://github.com/protocolbuffers/protobuf/compare/v29.3...v30.1#diff-b782f2dce4b91d6f74eec44df389d77c415127aa45d8805879bdfa5f2852948fL75




