### PR TITLE
pcl: add version 1.15.0

### DIFF
--- a/recipes/pcl/all/conandata.yml
+++ b/recipes/pcl/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "1.13.1":
     url: https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.13.1.tar.gz
     sha256: 8ab98a9db371d822de0859084a375a74bdc7f31c96d674147710cf4101b79621
+  "1.15.0":
+    url: https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.15.0.tar.gz
+    sha256: e90c981c21e89c45201c5083db8308e099f34c1782f92fd65a0a4eb0b72c6fbf
 patches:
   "1.13.1":
     - patch_file: "patches/1.13.1-0001-cmake_use_conan_targets.patch"
@@ -25,3 +28,10 @@ patches:
       patch_description: "Compatibility with clang-19"
       patch_source: "https://github.com/PointCloudLibrary/pcl/pull/6113"
       patch_type: "portability"
+  "1.15.0":
+    - patch_file: "patches/1.15.0-0001-outofcore-without-visualization.patch"
+      patch_description: "outofcore module without visualization"
+      patch_type: "conan"
+    - patch_file: "patches/1.15.0-0002-musl-libc.patch"
+      patch_description: "musl libc support"
+      patch_type: "conan"

--- a/recipes/pcl/config.yml
+++ b/recipes/pcl/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.13.1":
     folder: all
+  "1.15.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **pcl**

#### Motivation
* Adds PCL 1.15.0 (previously only 1.13.1 is available)
* Enables the `oufofcore` module (with one method removed)
* Enables building on Alpine Linux (set `os.distro` to `alpine`, see also https://github.com/conan-io/conan/issues/16179)

#### Details

Includes two patches:
* Allow building the `outofcore` module without the `visualization` dependency (which would require VTK) - only one `outofcore` method actually needed the `visualization` module.
* Allow building on Alpine Linux (more specifically, against `musl` libc)

I plan to upstream & discuss these patches with the PCL maintainers.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
