### PR TITLE
pcre 8.45: support cmake 4

### DIFF
--- a/recipes/pcre/all/conandata.yml
+++ b/recipes/pcre/all/conandata.yml
@@ -2,16 +2,6 @@ sources:
   "8.45":
     url: "https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.tar.bz2"
     sha256: "4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8"
-  "8.44":
-    url: "https://sourceforge.net/projects/pcre/files/pcre/8.44/pcre-8.44.tar.bz2"
-    sha256: "19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d"
-  "8.41":
-    url: "https://sourceforge.net/projects/pcre/files/pcre/8.41/pcre-8.41.tar.bz2"
-    sha256: "e62c7eac5ae7c0e7286db61ff82912e1c0b7a0c13706616e94a7dd729321b530"
 patches:
   "8.45":
     - patch_file: "patches/0001-fix-cmake-8.45.patch"
-  "8.44":
-    - patch_file: "patches/0001-fix-cmake-8.41.patch"
-  "8.41":
-    - patch_file: "patches/0001-fix-cmake-8.41.patch"

--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -106,8 +106,6 @@ class PCREConan(ConanFile):
         tc.variables["PCRE_NO_RECURSE"] = not self.options.with_stack_for_recursion
         if is_msvc(self):
             tc.variables["PCRE_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
-        # Relocatable shared lib on Macos
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         # Honor BUILD_SHARED_LIBS since upstream CMakeLists overrides it as a CACHE variable.
         # Issue quite similar to https://github.com/conan-io/conan/issues/11840
         tc.cache_variables["BUILD_SHARED_LIBS"] = "ON" if self.options.shared else "OFF"
@@ -179,15 +177,9 @@ class PCREConan(ConanFile):
                 self.cpp_info.components["libpcre32"].defines.append("PCRE_STATIC=1")
 
         if self.options.build_pcregrep:
-            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
             # FIXME: This is a workaround to avoid ConanException. zlib and bzip2
             # are optional requirements of pcregrep executable, not of any pcre lib.
             if self.options.with_bzip2:
                 self.cpp_info.components["libpcre"].requires.append("bzip2::bzip2")
             if self.options.with_zlib:
                 self.cpp_info.components["libpcre"].requires.append("zlib::zlib")
-
-        # TODO: to remove in conan v2 once legacy generators removed
-        #       DO NOT port this name to cmake_file_name/cmake_target_name properties, it was a mistake
-        self.cpp_info.names["cmake_find_package"] = "PCRE"
-        self.cpp_info.names["cmake_find_package_multi"] = "PCRE"

--- a/recipes/pcre/all/patches/0001-fix-cmake-8.45.patch
+++ b/recipes/pcre/all/patches/0001-fix-cmake-8.45.patch
@@ -1,17 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 16d89ff..ae10d1d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -71,13 +71,13 @@
+@@ -71,13 +71,14 @@
  # 2021-06-14 PH applied Wolfgang Stöggl's patch for generating pcre-config and
  #            libpcre*.pc files (Bugzilla #2583)
  
 -PROJECT(PCRE C CXX)
++
  
  # Increased minimum to 2.8.5 to support GNUInstallDirs. Set policy
  # CMP0026 to avoid warnings for the use of LOCATION in GET_TARGET_PROPERTY.
  
- CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5)
- CMAKE_POLICY(SET CMP0026 OLD)
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5)
+-CMAKE_POLICY(SET CMP0026 OLD)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 +PROJECT(PCRE C CXX)
++#CMAKE_POLICY(SET CMP0026 OLD)
  
  # For FindReadline.cmake. This was changed to allow setting CMAKE_MODULE_PATH
  # on the command line.
+@@ -485,12 +486,12 @@ OPTION(PCRE_REBUILD_CHARTABLES "Rebuild char tables" OFF)
+ IF(PCRE_REBUILD_CHARTABLES)
+   ADD_EXECUTABLE(dftables dftables.c)
+ 
+-  GET_TARGET_PROPERTY(DFTABLES_EXE dftables LOCATION)
++  #GET_TARGET_PROPERTY(DFTABLES_EXE dftables LOCATION)
+ 
+   ADD_CUSTOM_COMMAND(
+     COMMENT "Generating character tables (pcre_chartables.c) for current locale"
+     DEPENDS dftables
+-    COMMAND ${DFTABLES_EXE}
++    COMMAND $<TARGET_FILE:dftables>
+     ARGS        ${PROJECT_BINARY_DIR}/pcre_chartables.c
+     OUTPUT      ${PROJECT_BINARY_DIR}/pcre_chartables.c
+   )

--- a/recipes/pcre/config.yml
+++ b/recipes/pcre/config.yml
@@ -1,7 +1,3 @@
 versions:
   "8.45":
     folder: all
-  "8.44":
-    folder: all
-  "8.41":
-    folder: all


### PR DESCRIPTION
pcre 8.45: fixes to support CMake 4
* increase cmake minimum required to 3.5, fixes build error when using CMake 4.0
* use `$<TARGET_FILE:dftables>` instead of inspecting the `LOCATION` target property
* remove lines that are a no-op in Conan 2
* remove older versions: this is the last release of pcre 
