### PR TITLE
[libsigcpp] Use GNOME repository for source downloading

### DIFF
--- a/recipes/libsigcpp/2.x.x/conandata.yml
+++ b/recipes/libsigcpp/2.x.x/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.10.8":
-    url: "https://ftp2.nluug.nl/windowing/gnome/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz"
+    url: "https://download.gnome.org/sources/libsigc++/2.10/libsigc%2B%2B-2.10.8.tar.xz"
     sha256: "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a"


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsigcpp/2.10.8**

#### Motivation

close #26899

#### Details

Both the old and the new URLs provide the very same source package, including the same SHA-256. The version 3.x of this project is using GNOME for source downloading already. 

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
