### PR TITLE
qt5: fix macOS cross-building from ARM to Intel

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile, conan_version
 from conan.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.android import android_abi
-from conan.tools.apple import is_apple_os
+from conan.tools.apple import is_apple_os, to_apple_arch
 from conan.tools.build import build_jobs, check_min_cppstd, cross_building
 from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import chdir, copy, get, load, replace_in_file, rm, rmdir, save, export_conandata_patches, apply_conandata_patches
@@ -791,8 +791,8 @@ class QtConan(ConanFile):
             args.append("-psql_config \"%s\"" % os.path.join(self.dependencies["libpq"].package_folder, "bin", "pg_config"))
         if self.settings.os == "Macos":
             args += ["-no-framework"]
-            if self.settings.arch == "armv8":
-                args.append('QMAKE_APPLE_DEVICE_ARCHS="arm64"')
+            if cross_building(self):
+                args.append(f"QMAKE_APPLE_DEVICE_ARCHS={to_apple_arch(self)}")
         elif self.settings.os == "Android":
             args += [f"-android-ndk-platform android-{self.settings.os.api_level}"]
             args += [f"-android-abis {android_abi(self)}"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/5.x**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fixes cross-building from ARM to Intel on macOS

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Existing approach already worked fine for Intel -> ARM cross-building, this PR extends it to cover also the reverse case

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
