### PR TITLE
Disable Control Flow Guard on OpenSSL asm build

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -439,6 +439,15 @@ class OpenSSLConan(ConanFile):
         defines = 'defines => add("%s"),' % defines if defines else ""
         targets = "my %targets"
 
+        # OpenSSL 3's use of assembly is incompatible with Control Flow Guard
+        if is_msvc(self) and not self.options.no_asm:
+            def not_guard_cf(flag):
+                return re.match(r'[-/](?i)(guard:cf)$', flag) is None
+
+            cflags = list(filter(not_guard_cf, cflags))
+            cxxflags = list(filter(not_guard_cf, cxxflags))
+            ldflags = list(filter(not_guard_cf, ldflags))
+
         if self._asm_target:
             ancestor = f'[ "{self._ancestor_target}", asm("{self._asm_target}") ]'
         else:


### PR DESCRIPTION
### Summary
Changes to recipe:  **openssl/3.4.1**

#### Motivation
Allow end-users to build openssl from the Conan center when their global profile add CFG.

#### Details
See also: openssl/openssl#22554

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan

(Tested by applying the patch in a private fork running Conan v1)