### PR TITLE
jwt-cpp: add new version 0.7.1

### DIFF
--- a/recipes/jwt-cpp/all/conandata.yml
+++ b/recipes/jwt-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7.1":
+    url: "https://github.com/Thalhammer/jwt-cpp/archive/v0.7.1.tar.gz"
+    sha256: "e52f247d5e62fac5da6191170998271a70ce27f747f2ce8fde9b09f96a5375a4"
   "0.7.0":
     url: "https://github.com/Thalhammer/jwt-cpp/archive/v0.7.0.tar.gz"
     sha256: "b9eb270e3ba8221e4b2bc38723c9a1cb4fa6c241a42908b9a334daff31137406"
@@ -18,6 +21,10 @@ sources:
     url: "https://github.com/Thalhammer/jwt-cpp/archive/v0.3.1.tar.gz"
     sha256: "399345e81883f2959df658cd945de39548ddfefdab2acf7b23ee07b9e9a02938"
 patches:
+  "0.7.1":
+    - patch_file: "patches/0005-fix-picojson-header-location-for-conan.patch"
+      patch_description: "Remove picojson namespace from its include"
+      patch_type: "conan"
   "0.7.0":
     - patch_file: "patches/0005-fix-picojson-header-location-for-conan.patch"
       patch_description: "Remove picojson namespace from its include"

--- a/recipes/jwt-cpp/config.yml
+++ b/recipes/jwt-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.7.1":
+    folder: all
   "0.7.0":
     folder: all
   "0.6.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  jwt-cpp/0.7.1

#### Motivation
New minor version has been released: https://github.com/Thalhammer/jwt-cpp/releases/tag/v0.7.1

#### Details
There are several important changes, like enabling creation of cryptographic objects directly from specific JWK claims.
Full changelog: https://github.com/Thalhammer/jwt-cpp/compare/v0.7.0...v0.7.1


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
