### PR TITLE
azure-sdk-for-cpp: allow macos and clang in conanfile

### DIFF
--- a/recipes/azure-sdk-for-cpp/all/conanfile.py
+++ b/recipes/azure-sdk-for-cpp/all/conanfile.py
@@ -51,16 +51,18 @@ class AzureSDKForCppConan(ConanFile):
             check_min_cppstd(self, 14)
 
         # Open to contributions for windows and apple
-        if self.settings.os != "Linux":
+        if self.settings.os != "Linux" and self.settings.os != "Macos":
             raise ConanInvalidConfiguration(
                 f"{self.ref} Conan recipe in ConanCenter still does not support {self.settings.os}, contributions to the recipe welcome.")
 
-        if self.settings.compiler != "gcc":
+        if self.settings.compiler != "gcc" and self.settings.compiler != "clang":
             raise ConanInvalidConfiguration(
                 f"{self.ref} Conan recipe in ConanCenter still does not support {self.settings.compiler}, contributions to the recipe welcome.")
 
         if self.settings.compiler == 'gcc' and Version(self.settings.compiler.version) < "6":
             raise ConanInvalidConfiguration("Building requires GCC >= 6")
+        if self.settings.compiler == 'clang' and Version(self.settings.compiler.version) < "10":
+            raise ConanInvalidConfiguration("Building requires Clang >= 10")
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -77,6 +79,7 @@ class AzureSDKForCppConan(ConanFile):
         tc.cache_variables["BUILD_WINDOWS_UWP"] = "ON"
         tc.cache_variables["DISABLE_AZURE_CORE_OPENTELEMETRY"] = "ON"
         tc.cache_variables["BUILD_TRANSPORT_CURL"] = "ON"
+        tc.cache_variables["WARNINGS_AS_ERRORS"] = "OFF"
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/azure-sdk-for-cpp/all/conanfile.py
+++ b/recipes/azure-sdk-for-cpp/all/conanfile.py
@@ -55,13 +55,13 @@ class AzureSDKForCppConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} Conan recipe in ConanCenter still does not support {self.settings.os}, contributions to the recipe welcome.")
 
-        if self.settings.compiler != "gcc" and self.settings.compiler != "clang":
+        if self.settings.compiler != "gcc" and self.settings.compiler != "clang" and self.settings.compiler != "apple-clang":
             raise ConanInvalidConfiguration(
                 f"{self.ref} Conan recipe in ConanCenter still does not support {self.settings.compiler}, contributions to the recipe welcome.")
 
         if self.settings.compiler == 'gcc' and Version(self.settings.compiler.version) < "6":
             raise ConanInvalidConfiguration("Building requires GCC >= 6")
-        if self.settings.compiler == 'clang' and Version(self.settings.compiler.version) < "10":
+        if (self.settings.compiler == 'clang' or self.settings.compiler == "apple-clang") and Version(self.settings.compiler.version) < "10":
             raise ConanInvalidConfiguration("Building requires Clang >= 10")
 
     def generate(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **azure-sdk-for-cpp/all**

#### Motivation
We are using this package with AppleClang-16 on MacOS and Clang-17 on Ubuntu, and this is upstreaming our local patch.

There is a single warning that Clang finds for which we don't have a patch that we are confident in, and as such we're disabling warnings-as-errors while building this package as a dependency.

#### Details
We loosened the checks in the conanfile.py to allow building with clang and on macos. The check for clang-10 is to give an early error for very old versions; we have only tested with 16 and 17 but want to avoid a sequence of "actually this works on 15", "actually ..." PRs after this.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
