### PR TITLE
ittapi: fix CMake target name (ittapi::ittapi → ittapi::ittnotify)

### DIFF
--- a/recipes/ittapi/all/conandata.yml
+++ b/recipes/ittapi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.25.5":
+    url: "https://github.com/intel/ittapi/archive/v3.25.5.tar.gz"
+    sha256: "2d19243e7ac8a7de08bfd005429a308c1db52a18e5b7b66d29a6c19f066946e3"
   "3.24.4":
     url: "https://github.com/intel/ittapi/archive/v3.24.4.tar.gz"
     sha256: "f7341c563f228f4358b645fce526208c742fe13e61fc3ba2c777ba94d36e98f5"

--- a/recipes/ittapi/all/conanfile.py
+++ b/recipes/ittapi/all/conanfile.py
@@ -78,6 +78,8 @@ class IttApiConan(ConanFile):
         copy(self, "GPL-2.0-only.txt", src=os.path.join(self.source_folder, "LICENSES"), dst=os.path.join(self.package_folder, "licenses"))
 
     def package_info(self):
+        # https://github.com/intel/ittapi/blob/03f7260c96d4b437d12dceee7955ebb1e30e85ad/CMakeLists.txt#L176
+        self.cpp_info.set_property("cmake_target_name", "ittapi::ittnotify")
         if self.settings.os == "Windows":
             self.cpp_info.libs = ['libittnotify']
         else:

--- a/recipes/ittapi/all/conanfile.py
+++ b/recipes/ittapi/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.files import copy, get, replace_in_file
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=2.0"
 
 
 class IttApiConan(ConanFile):
@@ -61,6 +61,8 @@ class IttApiConan(ConanFile):
         self._patch_sources()
         toolchain = CMakeToolchain(self)
         toolchain.variables["ITT_API_IPT_SUPPORT"] = self.options.ptmark
+        if Version(self.version) < "3.25.1":
+            toolchain.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
         toolchain.generate()
 
     def build(self):
@@ -80,6 +82,7 @@ class IttApiConan(ConanFile):
     def package_info(self):
         # https://github.com/intel/ittapi/blob/03f7260c96d4b437d12dceee7955ebb1e30e85ad/CMakeLists.txt#L176
         self.cpp_info.set_property("cmake_target_name", "ittapi::ittnotify")
+        self.cpp_info.set_property("cmake_target_aliases", ["ittapi::ittapi"]) # for compatibility with earlier revisions of the recipe
         if self.settings.os == "Windows":
             self.cpp_info.libs = ['libittnotify']
         else:

--- a/recipes/ittapi/all/test_package/CMakeLists.txt
+++ b/recipes/ittapi/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(test_package LANGUAGES CXX)
 find_package(ittapi REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE ittapi::ittapi)
+target_link_libraries(${PROJECT_NAME} PRIVATE ittapi::ittnotify)

--- a/recipes/ittapi/config.yml
+++ b/recipes/ittapi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.25.5":
+    folder: all
   "3.24.4":
     folder: all
   "3.24.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **ittapi/\***

#### Motivation
The target name used by the Conan recipe was different from the target name in the project's official CMake installation. This PR fixes that, and adds the latest version.

#### Details

The target name in the installed ittapiConfig.cmake by the project itself is `ittapi::ittnotify`, whereas Conan used `ittapi::ittapi`.

https://github.com/intel/ittapi/blob/03f7260c96d4b437d12dceee7955ebb1e30e85ad/CMakeLists.txt#L176

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
