### PR TITLE
aaf: CMake 4 support

### DIFF
--- a/recipes/aaf/all/conanfile.py
+++ b/recipes/aaf/all/conanfile.py
@@ -60,6 +60,7 @@ class AafConan(ConanFile):
         tc.cache_variables["AAF_NO_STRUCTURED_STORAGE"] = not self.options.structured_storage
         jpeg_res_dirs = ";".join([p.replace("\\", "/") for p in self.dependencies["libjpeg"].cpp_info.aggregated_components().resdirs])
         tc.variables["JPEG_RES_DIRS"] = jpeg_res_dirs
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
aaf: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

This project is no longer maintained. See issue tracker not updated since 2012
https://sourceforge.net/p/aaf/bugs/
