### PR TITLE
ade: CMake 4 support

### DIFF
--- a/recipes/ade/all/conanfile.py
+++ b/recipes/ade/all/conanfile.py
@@ -1,9 +1,10 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file, rmdir, save
+from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.scm import Version
+from conan.errors import ConanException
 import os
-import textwrap
 
 required_conan_version = ">=1.50.0"
 
@@ -33,14 +34,16 @@ class AdeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, 11)
+        check_min_cppstd(self, 11)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "0.1.2d": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):
@@ -55,34 +58,9 @@ class AdeConan(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "share"))
 
-        # TODO: to remove in conan v2 once legacy generators removed
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {"ade": "ade::ade"}
-        )
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
-
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "ade")
         self.cpp_info.set_property("cmake_target_name", "ade")
         self.cpp_info.libs = ["ade"]
         if self.settings.os == "Windows" and self.settings.compiler == "gcc":
             self.cpp_info.system_libs.append("ssp")
-
-        # TODO: to remove in conan v2 once legacy generators removed
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]


### PR DESCRIPTION
ade: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed code related to legacy generators
* Removed conan v1 specific code

Upstream issue tracker: https://github.com/opencv/ade/issues
Shows no recent activity and no intention of upgrading CMake minimum version.