### PR TITLE
c-blosc: CMake 4 support

### DIFF
--- a/recipes/c-blosc/all/conanfile.py
+++ b/recipes/c-blosc/all/conanfile.py
@@ -90,8 +90,9 @@ class CbloscConan(ConanFile):
         tc.variables["PREFER_EXTERNAL_ZLIB"] = True
         tc.variables["PREFER_EXTERNAL_ZSTD"] = True
         tc.variables["CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP"] = True
-        # Generate a relocatable shared lib on Macos
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.21.5": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
         deps = CMakeDeps(self)


### PR DESCRIPTION
c-blosc: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4

The upstream issue tracker does not contain any CMake 4 related request and seems to be no plan in the future https://github.com/Blosc/c-blosc/issues