### PR TITLE
capnproto: CMake 4 support

### DIFF
--- a/recipes/capnproto/all/conanfile.py
+++ b/recipes/capnproto/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration, ConanException
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd, cross_building
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
@@ -112,9 +112,8 @@ class CapnprotoConan(ConanFile):
             tc.variables["EXTERNAL_CAPNP"] = False
             tc.variables["CAPNP_LITE"] = False
             tc.variables["WITH_OPENSSL"] = self.options.with_openssl
-            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support (v2 branch does not need this)
-            if Version(self.version) > "1.1.0": # pylint: disable=conan-unreachable-upper-version
-                raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
+            if Version(self.version) < "2": # pylint: disable=conan-condition-evals-to-constant
+                tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support (v2 branch does not need this)
             tc.generate()
             deps = CMakeDeps(self)
             deps.generate()


### PR DESCRIPTION
capnproto: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4

Upstream v2 [CMakeLists.txt](https://github.com/capnproto/capnproto/blob/v2/CMakeLists.txt#L1) already supports CMake 4.
