### PR TITLE
libtool: depend on automake

### DIFF
--- a/recipes/libtool/all/conanfile.py
+++ b/recipes/libtool/all/conanfile.py
@@ -42,6 +42,9 @@ class LibtoolConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
+    def requirements(self):
+        self.requires("automake/1.16.5")
+
     def build_requirements(self):
         self.tool_requires("automake/1.16.5")
         self.tool_requires("m4/1.4.19")               # Needed by configure

--- a/recipes/libtool/all/test_package/conanfile.py
+++ b/recipes/libtool/all/test_package/conanfile.py
@@ -67,7 +67,7 @@ class TestPackageConan(ConanFile):
         env = tc.environment()
         if is_msvc(self):
             for key, value in msvc_vars.items():
-                env.append(key, value)
+                env.define(key, value)
         tc.generate(env)
 
         # "sis" subfder: project to test building shared library using libtool
@@ -79,7 +79,7 @@ class TestPackageConan(ConanFile):
         env = tc.environment()
         if is_msvc(self):
             for key, value in msvc_vars.items():
-                env.append(key, value)
+                env.define(key, value)
         tc.generate(env)
 
         # Note: Using AutotoolsDeps causes errors on Windows when configure tries to determine compiler


### PR DESCRIPTION
Quite a few recipes that perform `autoreconf` were inadvertently relying on a `tool_requires` against `libtool` to bring in automake to be able to call autoreconf. Those recipes should encode the correct direct `tool_requires`, however partially reverting the change to minimise disruption

Close https://github.com/conan-io/conan-center-index/issues/26926
