### PR TITLE
cassandra-cpp-driver: CMake 4 support

### DIFF
--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -1,8 +1,9 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file, rm
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -123,8 +124,9 @@ class CassandraCppDriverConan(ConanFile):
 
         if self.settings.os == "Linux":
             tc.variables["CASS_USE_TIMERFD"] = self.options.use_timerfd
-        # Relocatable shared lib on Macos
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "2.17.1": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
         deps = CMakeDeps(self)


### PR DESCRIPTION
cassandra-cpp-driver: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4

The upstream issue tracker does not contain any CMake 4 related request and there seems to be no plan in the future https://github.com/datastax/cpp-driver/pulls