### PR TITLE
cctz: CMake 4 support

### DIFF
--- a/recipes/cctz/all/conanfile.py
+++ b/recipes/cctz/all/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import check_min_vs
 from conan.tools.scm import Version
-from conan.errors import ConanException
 import os
 
 required_conan_version = ">=2.1"
@@ -58,9 +57,10 @@ class CCTZConan(ConanFile):
         tc.variables["BUILD_BENCHMARK"] = False
         # For shared msvc
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support (master branch already has 3.16)
-        if Version(self.version) > "2.4": # pylint: disable=conan-unreachable-upper-version
-            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
+        # Relocatable shared lib on Macos
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) <= "2.4":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support (master branch already has 3.16)
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
cctz: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4
* Removed conan v1 deprecated code

Upstream master [CMakeLists.txt](https://github.com/google/cctz/blob/master/CMakeLists.txt#L3) already supports CMake 4.