### PR TITLE
chunkio: CMake 4 support

### DIFF
--- a/recipes/chunkio/all/conanfile.py
+++ b/recipes/chunkio/all/conanfile.py
@@ -2,9 +2,10 @@ from conan import ConanFile
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.scm import Version
+from conan.errors import ConanException
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 class ChunkIOConan(ConanFile):
     name = "chunkio"
@@ -51,9 +52,10 @@ class ChunkIOConan(ConanFile):
         tc.variables["CIO_LIB_STATIC"] = not self.options.shared
         tc.variables["CIO_LIB_SHARED"] = self.options.shared
         tc.variables["CIO_BACKEND_FILESYSTEM"] = self.options.with_filesystem
-        # Relocatable shared libs on macOS
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.5.2": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
chunkio: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4
