### PR TITLE
cjson: CMake 4 support

### DIFF
--- a/recipes/cjson/all/conanfile.py
+++ b/recipes/cjson/all/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 import os
-import textwrap
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class CjsonConan(ConanFile):
@@ -68,8 +68,9 @@ class CjsonConan(ConanFile):
         tc.variables["ENABLE_LOCALES"] = self.options.use_locales
         tc.variables["ENABLE_FUZZING"] = False
         tc.variables["ENABLE_CUSTOM_COMPILER_FLAGS"] = False
-        # Relocatable shared libs on macOS
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.7.18": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):
@@ -85,30 +86,6 @@ class CjsonConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
-        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
-        targets = {"cjson": "cJSON::cjson"}
-        if self.options.utils:
-            targets.update({"cjson_utils": "cJSON::cjson_utils"})
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            targets
-        )
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
-
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "cJSON")
 
@@ -123,18 +100,3 @@ class CjsonConan(ConanFile):
             self.cpp_info.components["cjson_utils"].set_property("pkg_config_name", "libcjson_utils")
             self.cpp_info.components["cjson_utils"].libs = ["cjson_utils"]
             self.cpp_info.components["cjson_utils"].requires = ["_cjson"]
-
-        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
-        self.cpp_info.names["cmake_find_package"] = "cJSON"
-        self.cpp_info.names["cmake_find_package_multi"] = "cJSON"
-        self.cpp_info.components["_cjson"].names["cmake_find_package"] = "cjson"
-        self.cpp_info.components["_cjson"].names["cmake_find_package_multi"] = "cjson"
-        self.cpp_info.components["_cjson"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.components["_cjson"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
-        self.cpp_info.components["_cjson"].names["pkg_config"] = "libcjson"
-        if self.options.utils:
-            self.cpp_info.components["cjson_utils"].names["cmake_find_package"] = "cjson_utils"
-            self.cpp_info.components["cjson_utils"].names["cmake_find_package_multi"] = "cjson_utils"
-            self.cpp_info.components["cjson_utils"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-            self.cpp_info.components["cjson_utils"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
-            self.cpp_info.components["cjson_utils"].names["pkg_config"] = "libcjson_utils"


### PR DESCRIPTION
cjson: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed code related to legacy generators (`_create_cmake_module_alias_targets`)
* Removed conan v1 specific code
