### PR TITLE
Add sol2 version 3.5.0

### DIFF
--- a/recipes/sol2/all/conandata.yml
+++ b/recipes/sol2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.0":
+    url: "https://github.com/ThePhD/sol2/archive/v3.5.0.tar.gz"
+    sha256: "86c0f6d2836b184a250fc2907091c076bf53c9603dd291eaebade36cc342e13c"
   "3.3.1":
     url: "https://github.com/ThePhD/sol2/archive/v3.3.1.tar.gz"
     sha256: "ad121461047d52b449aa84234a6b578fa3ed95d67d1a0703902eba72417f61bb"

--- a/recipes/sol2/config.yml
+++ b/recipes/sol2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5.0":
+    folder: "all"
   "3.3.1":
     folder: "all"
   "3.3.0":


### PR DESCRIPTION
### Summary
Add version:  **sol2/3.5.0**

#### Motivation
This was released a few weeks ago. Let's make it available through conan.

#### Details
- https://github.com/ThePhD/sol2/releases/tag/v3.5.0
- https://github.com/ThePhD/sol2/commit/9190880c593dfb018ccf5cc9729ab87739709862
- https://github.com/ThePhD/sol2/issues/1680

cc @ErniGH (as you most recently merged something in the `sol2` dir)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
