### PR TITLE
wayland-protocols: Added version 1.42

### DIFF
--- a/recipes/wayland-protocols/all/conandata.yml
+++ b/recipes/wayland-protocols/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.42":
+    url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.42/downloads/wayland-protocols-1.42.tar.xz"
+    sha256: "23ba80d410d1200a86fe29592c19766eae8f1c350b67289999e9e7ea12d9f7aa"
   "1.36":
     url: "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.36/downloads/wayland-protocols-1.36.tar.xz"
     sha256: "71fd4de05e79f9a1ca559fac30c1f8365fa10346422f9fe795f74d77b9ef7e92"

--- a/recipes/wayland-protocols/all/conanfile.py
+++ b/recipes/wayland-protocols/all/conanfile.py
@@ -35,7 +35,7 @@ class WaylandProtocolsConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True, verify=False)
+            destination=self.source_folder, strip_root=True)
 
     def generate(self):
         tc = MesonToolchain(self)

--- a/recipes/wayland-protocols/all/conanfile.py
+++ b/recipes/wayland-protocols/all/conanfile.py
@@ -35,7 +35,7 @@ class WaylandProtocolsConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+            destination=self.source_folder, strip_root=True, verify=False)
 
     def generate(self):
         tc = MesonToolchain(self)
@@ -43,8 +43,6 @@ class WaylandProtocolsConan(ConanFile):
         tc.project_options["datadir"] = "res"
         tc.project_options["tests"] = "false"
         tc.generate()
-        virtual_build_env = VirtualBuildEnv(self)
-        virtual_build_env.generate()
 
     def _patch_sources(self):
         if Version(self.version) <= "1.23":
@@ -52,6 +50,10 @@ class WaylandProtocolsConan(ConanFile):
             replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
                             "dep_scanner = dependency('wayland-scanner', native: true)",
                             "#dep_scanner = dependency('wayland-scanner', native: true)")
+        elif Version(self.version) >= "1.42":
+            replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
+                            "dep_scanner = dependency('wayland-scanner',",
+                            "dep_scanner = dependency('wayland-scanner', required: false, disabler: true,")
 
     def build(self):
         self._patch_sources()

--- a/recipes/wayland-protocols/all/test_package/conanfile.py
+++ b/recipes/wayland-protocols/all/test_package/conanfile.py
@@ -38,8 +38,6 @@ class TestPackageConan(ConanFile):
             pkg_config_deps.build_context_activated = ["wayland"]
             pkg_config_deps.build_context_suffix = {"wayland": "_BUILD"}
         pkg_config_deps.generate()
-        virtual_build_env = VirtualBuildEnv(self)
-        virtual_build_env.generate()
 
     def build(self):
         meson = Meson(self)

--- a/recipes/wayland-protocols/config.yml
+++ b/recipes/wayland-protocols/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.42":
+    folder: all
   "1.36":
     folder: all
   "1.33":


### PR DESCRIPTION
### Summary
Changes to recipe:  **wayland-protocols/1.42**

#### Motivation
Closes: https://github.com/conan-io/conan-center-index/issues/26861

#### Details
* Removed usage of `VirtualBuildEnv`.
* No breaking changes: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/compare/1.36...1.42?from_project_id=2891