### PR TITLE
anyrpc: Restore CMP0042 policy

### DIFF
--- a/recipes/anyrpc/all/conanfile.py
+++ b/recipes/anyrpc/all/conanfile.py
@@ -1,8 +1,9 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -89,7 +90,10 @@ class AnyRPCConan(ConanFile):
         tc.variables["BUILD_PROTOCOL_JSON"] = self.options.with_protocol_json
         tc.variables["BUILD_PROTOCOL_XML"] = self.options.with_protocol_xml
         tc.variables["BUILD_PROTOCOL_MESSAGEPACK"] = self.options.with_protocol_messagepack
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.0.2": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
         deps = CMakeDeps(self)


### PR DESCRIPTION
Policy `CMP0042` was being set to `NEW` before this PR https://github.com/conan-io/conan-center-index/pull/26922/ 

Removing that definition introduces breaking changes as `CMAKE_POLICY_VERSION_MINIMUM` (which enforces `CMP0042` to `NEW`) is only read by CMake 4. 

CMake 3 clients will not be aware of that policy.
