### PR TITLE
brotli: Restore CMP0042 policy

### DIFF
--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -79,6 +79,8 @@ class BrotliConan(ConanFile):
         if self.options.enable_log:
             tc.preprocessor_definitions["BROTLI_ENABLE_LOG"] = 1
         if Version(self.version) < "1.1.0":
+            # To install relocatable shared libs on Macos
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 


### PR DESCRIPTION

Policy `CMP0042` was being set to `NEW` before this PR https://github.com/conan-io/conan-center-index/pull/26930/

Removing that definition introduces breaking changes as `CMAKE_POLICY_VERSION_MINIMUM` (which enforces `CMP0042` to `NEW`) is only read by CMake 4.

CMake 3 clients will not be aware of that policy.
