### PR TITLE
c-blosc: Restore CMP0042 policy

### DIFF
--- a/recipes/c-blosc/all/conanfile.py
+++ b/recipes/c-blosc/all/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class CbloscConan(ConanFile):
@@ -90,6 +91,8 @@ class CbloscConan(ConanFile):
         tc.variables["PREFER_EXTERNAL_ZLIB"] = True
         tc.variables["PREFER_EXTERNAL_ZSTD"] = True
         tc.variables["CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP"] = True
+        # Generate a relocatable shared lib on Macos
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         if Version(self.version) > "1.21.5": # pylint: disable=conan-unreachable-upper-version
             raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")


### PR DESCRIPTION
Policy `CMP0042` was being set to `NEW` before this PR https://github.com/conan-io/conan-center-index/pull/26931

Removing that definition introduces breaking changes as `CMAKE_POLICY_VERSION_MINIMUM` (which enforces `CMP0042` to `NEW`) is only read by CMake 4.

CMake 3 clients will not be aware of that policy.
