### PR TITLE
chunkio: Restore CMP0042 policy

### DIFF
--- a/recipes/chunkio/all/conanfile.py
+++ b/recipes/chunkio/all/conanfile.py
@@ -52,6 +52,8 @@ class ChunkIOConan(ConanFile):
         tc.variables["CIO_LIB_STATIC"] = not self.options.shared
         tc.variables["CIO_LIB_SHARED"] = self.options.shared
         tc.variables["CIO_BACKEND_FILESYSTEM"] = self.options.with_filesystem
+        # Relocatable shared lib on Macos
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         if Version(self.version) > "1.5.2": # pylint: disable=conan-unreachable-upper-version


### PR DESCRIPTION

Policy `CMP0042` was being set to `NEW` before this PR https://github.com/conan-io/conan-center-index/pull/26942/

Removing that definition introduces breaking changes as `CMAKE_POLICY_VERSION_MINIMUM` (which enforces `CMP0042` to `NEW`) is only read by CMake 4.

CMake 3 clients will not be aware of that policy.
