### PR TITLE
minhook: Adds latest version (v1.3.4)

### DIFF
--- a/recipes/minhook/all/conandata.yml
+++ b/recipes/minhook/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.4":
+    url: "https://github.com/TsudaKageyu/minhook/archive/refs/tags/v1.3.4.tar.gz"
+    sha256: "1AEBEAE4CA898330C507860ACC2FCA2EB335FE446A3A2B8444C3BF8B2660A14E"
   "1.3.3.cci.20240629":
     url: "https://github.com/TsudaKageyu/minhook/archive/91cc9466e383d13a43d7cf33c7c8fdccb27095d3.tar.gz"
     sha256: "b84b2ff19afe5fb9430948680146bee2e198392ee6333a71f81e339c36a819f1"

--- a/recipes/minhook/config.yml
+++ b/recipes/minhook/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.3.4":
+    folder: all
   "1.3.3.cci.20240629":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **minhook/1.3.4**

#### Motivation
The one currently available in Conan is slightly outdated. There's a been a few commits that were pushed since then, one of which mitigates an issue related to multithreaded programs.

#### Details
Nothing significant. Just adding a new snapshot to use.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
