### PR TITLE
crossdb: CMake 4 support

### DIFF
--- a/recipes/crossdb/all/conanfile.py
+++ b/recipes/crossdb/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 from conan.tools.microsoft import is_msvc
@@ -7,7 +7,7 @@ from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 class CrossDBConan(ConanFile):
     name = "crossdb"
@@ -35,6 +35,9 @@ class CrossDBConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "0.11.0": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
crossdb: fixes to support CMake 4

* Increase CMake minimum required to 3.5 fixing build error when using CMake 4.0
