### PR TITLE
discount: CMake 4 support

### DIFF
--- a/recipes/discount/all/conanfile.py
+++ b/recipes/discount/all/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class DiscountConan(ConanFile):
@@ -59,6 +60,9 @@ class DiscountConan(ConanFile):
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         # Relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "2.2.7": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):
@@ -79,11 +83,4 @@ class DiscountConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "libmarkdown")
         # TODO: back to global scope in conan v2 once cmake_find_package_* & pkg_config generators removed
         self.cpp_info.components["_discount"].libs = ["markdown"]
-
-        # TODO: to remove in conan v2 once cmake_find_package_* & pkg_config generators removed
-        self.cpp_info.names["cmake_find_package"] = "discount"
-        self.cpp_info.names["cmake_find_package_multi"] = "discount"
-        self.cpp_info.names["pkg_config"] = "libmarkdown"
-        self.cpp_info.components["_discount"].names["cmake_find_package"] = "libmarkdown"
-        self.cpp_info.components["_discount"].names["cmake_find_package_multi"] = "libmarkdown"
         self.cpp_info.components["_discount"].set_property("pkg_config_name", "libmarkdown")


### PR DESCRIPTION
discount: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code
