### PR TITLE
dlib: CMake 4 support

### DIFF
--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.errors import ConanInvalidConfiguration
 import os
 
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class DlibConan(ConanFile):
@@ -177,6 +177,8 @@ class DlibConan(ConanFile):
                 tc.variables["USE_SSE4_INSTRUCTIONS"] = self.options.with_sse4
             if self.options.with_avx != "auto":
                 tc.variables["USE_AVX_INSTRUCTIONS"] = self.options.with_avx
+        if Version(self.version) < "19.24.2":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()


### PR DESCRIPTION
dlib: fixes to support CMake 4

* Increase CMake minimum required to 3.5 on versions less than 19.24.2 fixing build error when using CMake 4.0

