### PR TITLE
dsp-filters: CMake 4 support

### DIFF
--- a/recipes/dsp-filters/all/conanfile.py
+++ b/recipes/dsp-filters/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.files import copy, get, apply_conandata_patches, export_conanda
 from conan.tools.microsoft import is_msvc
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 class DSPFiltersConan(ConanFile):
     name = "dsp-filters"
@@ -50,11 +50,12 @@ class DSPFiltersConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
         apply_conandata_patches(self)
-        
+
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join(self.source_folder, "shared"))
         cmake.build()


### PR DESCRIPTION
dsp-filters: fixes to support CMake 4

* Increase CMake minimum required to 3.5 fixing build error when using CMake 4.0

Project not maintained for 8 years https://github.com/vinniefalco/DSPFilters
Not adding version check as it is using a `cci.` version
