### PR TITLE
Add MbedTLS 2.28.10

### DIFF
--- a/recipes/mbedtls/all/conandata.yml
+++ b/recipes/mbedtls/all/conandata.yml
@@ -17,6 +17,9 @@ sources:
   "3.2.1":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-3.2.1.tar.gz"
     sha256: "5850089672560eeaca03dc36678ee8573bb48ef6e38c94f5ce349af60c16da33"
+  "2.28.10":
+    url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v2.28.10.tar.gz"
+    sha256: "0f2e0525903a89ae1d39ce439d858be66933bda54c5b6102b72a29ed8fe7c088"
   "2.28.4":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v2.28.4.tar.gz"
     sha256: "578c4dcd15bbff3f5cd56aa07cd4f850fc733634e3d5947be4f7157d5bfd81ac"

--- a/recipes/mbedtls/all/conandata.yml
+++ b/recipes/mbedtls/all/conandata.yml
@@ -18,8 +18,8 @@ sources:
     url: "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-3.2.1.tar.gz"
     sha256: "5850089672560eeaca03dc36678ee8573bb48ef6e38c94f5ce349af60c16da33"
   "2.28.10":
-    url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v2.28.10.tar.gz"
-    sha256: "0f2e0525903a89ae1d39ce439d858be66933bda54c5b6102b72a29ed8fe7c088"
+    url: "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-2.28.10/mbedtls-2.28.10.tar.bz2"
+    sha256: "19e5b81fdac0fe22009b9e2bdcd52d7dcafbf62bc67fc59cf0a76b5b5540d149"
   "2.28.4":
     url: "https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v2.28.4.tar.gz"
     sha256: "578c4dcd15bbff3f5cd56aa07cd4f850fc733634e3d5947be4f7157d5bfd81ac"

--- a/recipes/mbedtls/config.yml
+++ b/recipes/mbedtls/config.yml
@@ -13,6 +13,9 @@ versions:
   # keep 3.2.1 for libcoap, libgit2, lief
   "3.2.1":
     folder: all
+  # final 2.28.x (old LTS) version
+  "2.28.10":
+    folder: all
   # keep 2.28.4 for libssh2
   "2.28.4":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **mbedtls/2.28.10**

#### Motivation
Add the final 2.28.x (old LTS) version, to minimize security issues with outdated projects still on this branch.

See https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-2.28.10

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
