### PR TITLE
libqasm: add version 1.2.0

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.0":
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.2.0/libqasm-1.2.0.tar.gz"
+    sha256: "9142085d3782c8b2094f66cf1fc3719040dfadc62f55ab722636fca109e27c20"
   "1.1.0":
     url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.1.0/libqasm-1.1.0.tar.gz"
     sha256: "cf317c465e741360ae147e46346c57294c23882269e3b3dabb3c5d5ac703414a"

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.0":
+    folder: all
   "1.1.0":
     folder: all
   "1.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libqasm/1.2.0**

#### Motivation
Just a version bump.

#### Details
`config.yml` and `conandata.yml` point to the newly created libqasm/1.2.0.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
