### PR TITLE
log4cxx: add 1.4.0

### DIFF
--- a/recipes/log4cxx/all/conandata.yml
+++ b/recipes/log4cxx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://archive.apache.org/dist/logging/log4cxx/1.4.0/apache-log4cxx-1.4.0.tar.gz"
+    sha256: "3d2d1f356a546c14562763aaf15fcc3fd59d4ffeb5a2f68fcb0bbd7571ed6f96"
   "1.3.1":
     url: "https://archive.apache.org/dist/logging/log4cxx/1.3.1/apache-log4cxx-1.3.1.tar.gz"
     sha256: "2c4073c0613af7f59a75d8f26365dc6f5b07a22b9636ee5c5f7bfa9771a2c1d0"

--- a/recipes/log4cxx/config.yml
+++ b/recipes/log4cxx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.0":
+    folder: all
   "1.3.1":
     folder: all
   "1.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  log4cxx - none

#### Motivation
log4cxx 1.4.0 was released a month ago - see [release notes](https://logging.apache.org/log4cxx/1.4.0/changelog.html#rel_1_4_0) for changes

#### Details
Add version 1.4.0 

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
