### PR TITLE
easylzma: CMake 4 support

### DIFF
--- a/recipes/easylzma/all/conandata.yml
+++ b/recipes/easylzma/all/conandata.yml
@@ -6,3 +6,4 @@ patches:
   "0.0.7":
     - patch_file: "patches/memleaksfix.patch"
     - patch_file: "patches/cmake-no-cflags.patch"
+    - patch_file: "patches/cmake4-support.patch"

--- a/recipes/easylzma/all/conanfile.py
+++ b/recipes/easylzma/all/conanfile.py
@@ -53,8 +53,7 @@ class EazylzmaConan(ConanFile):
         tc = CMakeToolchain(self)
         # Relocatable shared libs on macOS
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
-        # Silence CMake warning about LOCATION property
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0026"] = "OLD"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):

--- a/recipes/easylzma/all/patches/cmake4-support.patch
+++ b/recipes/easylzma/all/patches/cmake4-support.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 10ef840..1735338 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,4 +51,4 @@ ENDIF ()
+ 
+ ADD_SUBDIRECTORY(src)
+ ADD_SUBDIRECTORY(elzma)
+-ADD_SUBDIRECTORY(test)
++# ADD_SUBDIRECTORY(test)
+diff --git a/elzma/CMakeLists.txt b/elzma/CMakeLists.txt
+index 159b48f..1149176 100644
+--- a/elzma/CMakeLists.txt
++++ b/elzma/CMakeLists.txt
+@@ -33,7 +33,7 @@ ADD_EXECUTABLE(elzma ${SRCS})
+ TARGET_LINK_LIBRARIES(elzma easylzma_s)
+ 
+ # make a hard link (or copy on win32) from unelzma to elzma
+-GET_TARGET_PROPERTY(binPath elzma LOCATION)
++# GET_TARGET_PROPERTY(binPath elzma LOCATION)
+ IF (WIN32)
+   SET(exeExt ".exe") 
+   SET(hardLinkCommand ${CMAKE_COMMAND} -E copy_if_different) 
+@@ -42,6 +42,7 @@ ELSE (WIN32)
+   SET(exeExt ) 
+ ENDIF (WIN32)
+ ADD_CUSTOM_COMMAND(TARGET elzma POST_BUILD
+-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${binPath} ${binDir}
++      # COMMAND ${CMAKE_COMMAND} -E copy_if_different ${binPath} ${binDir}
++      COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:elzma> ${binDir}
+       COMMAND ${hardLinkCommand} elzma${exeExt} unelzma${exeExt}
+       WORKING_DIRECTORY "${binDir}")    


### PR DESCRIPTION
easylzma: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Create a patch to support CMake4 avoiding old `LOCATION` usage
* Removed `CMP0026` policy as the patch already fixes the issue and the OLD flag is no longer required
* Remove `tests` from compilation
