### PR TITLE
enet: CMake 4 support

### DIFF
--- a/recipes/enet/all/conanfile.py
+++ b/recipes/enet/all/conanfile.py
@@ -2,9 +2,10 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class EnetConan(ConanFile):
@@ -49,6 +50,8 @@ class EnetConan(ConanFile):
         tc = CMakeToolchain(self)
         # Relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) < "1.3.18":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
enet: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

Since `1.3.18` upstream supports CMake 4

