### PR TITLE
flann: CMake 4 support

### DIFF
--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -3,9 +3,10 @@ from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, save
 from conan.tools.scm import Version
+from conan.errors import ConanException
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class FlannConan(ConanFile):
@@ -65,6 +66,9 @@ class FlannConan(ConanFile):
         tc.variables["USE_OPENMP"] = False
         # Generate a relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.9.2": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
         cd = CMakeDeps(self)
@@ -141,11 +145,3 @@ class FlannConan(ConanFile):
         if not self.options.shared:
             self.cpp_info.components["flann_c"].defines.append("FLANN_STATIC")
         self.cpp_info.components["flann_c"].requires = ["flann_cpp"]
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.names["cmake_find_package"] = "Flann"
-        self.cpp_info.names["cmake_find_package_multi"] = "flann"
-        self.cpp_info.components["flann_cpp"].names["cmake_find_package"] = flann_cpp_lib
-        self.cpp_info.components["flann_cpp"].names["cmake_find_package_multi"] = flann_cpp_lib
-        self.cpp_info.components["flann_c"].names["cmake_find_package"] = flann_c_lib
-        self.cpp_info.components["flann_c"].names["cmake_find_package_multi"] = flann_c_lib


### PR DESCRIPTION
flann: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 deprecated code
