### PR TITLE
folly: CMake 4 support

### DIFF
--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -131,13 +131,6 @@ class FollyConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=False)
 
-    def _cppstd_flag_value(self, cppstd):
-        prefix = "c"
-        year = str(cppstd)
-        if year > "17":
-            year = "latest"
-        return f"{prefix}++{year}"
-
     def generate(self):
         env = VirtualBuildEnv(self)
         env.generate()
@@ -168,7 +161,7 @@ class FollyConan(ConanFile):
 
         # 2019.10.21.00 -> either MSVC_ flags or CXX_STD
         if is_msvc(self):
-            cxx_std_value = self._cppstd_flag_value(self.settings.get_safe("compiler.cppstd", self._min_cppstd))
+            cxx_std_value = "c++latest" if str(self.settings.compiler.cppstd) > "17" else f"c++{str(self.settings.compiler.cppstd)}"
             tc.cache_variables["MSVC_LANGUAGE_VERSION"] = cxx_std_value
             tc.cache_variables["MSVC_ENABLE_ALL_WARNINGS"] = False
             tc.cache_variables["MSVC_USE_STATIC_RUNTIME"] = is_msvc_static_runtime(self)

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd, cross_building
 from conan.tools.env import VirtualBuildEnv
@@ -10,7 +10,7 @@ from conan.tools.scm import Version
 import os
 
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class FollyConan(ConanFile):
@@ -132,11 +132,10 @@ class FollyConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=False)
 
     def _cppstd_flag_value(self, cppstd):
-        if is_msvc(self):
-            prefix = "c"
-            year = str(cppstd)
-            if year > "17":
-                year = "latest"
+        prefix = "c"
+        year = str(cppstd)
+        if year > "17":
+            year = "latest"
         return f"{prefix}++{year}"
 
     def generate(self):
@@ -162,6 +161,9 @@ class FollyConan(ConanFile):
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         # Honor Boost_ROOT set by boost recipe
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0074"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "2024.08.12.00": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
 
 
         # 2019.10.21.00 -> either MSVC_ flags or CXX_STD
@@ -292,26 +294,3 @@ class FollyConan(ConanFile):
             self.cpp_info.components["folly_exception_counter"].set_property("pkg_config_name", "libfolly_exception_counter")
             self.cpp_info.components["folly_exception_counter"].libs = ["folly_exception_counter"]
             self.cpp_info.components["folly_exception_counter"].requires = ["folly_exception_tracer"]
-
-        # TODO: to remove in conan v2 once cmake_find_package_* & pkg_config generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "folly"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "folly"
-        self.cpp_info.names["cmake_find_package"] = "Folly"
-        self.cpp_info.names["cmake_find_package_multi"] = "Folly"
-        self.cpp_info.components["libfolly"].names["cmake_find_package"] = "folly"
-        self.cpp_info.components["libfolly"].names["cmake_find_package_multi"] = "folly"
-
-        # TODO: to remove in conan v2 once cmake_find_package_* & pkg_config generators removed
-        self.cpp_info.components["follybenchmark"].names["cmake_find_package"] = "follybenchmark"
-        self.cpp_info.components["follybenchmark"].names["cmake_find_package_multi"] = "follybenchmark"
-        self.cpp_info.components["folly_test_util"].names["cmake_find_package"] = "folly_test_util"
-        self.cpp_info.components["folly_test_util"].names["cmake_find_package_multi"] = "folly_test_util"
-
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            # TODO: to remove in conan v2 once cmake_find_package_* & pkg_config generators removed
-            self.cpp_info.components["folly_exception_tracer_base"].names["cmake_find_package"] = "folly_exception_tracer_base"
-            self.cpp_info.components["folly_exception_tracer_base"].names["cmake_find_package_multi"] = "folly_exception_tracer_base"
-            self.cpp_info.components["folly_exception_tracer"].names["cmake_find_package"] = "folly_exception_tracer"
-            self.cpp_info.components["folly_exception_tracer"].names["cmake_find_package_multi"] = "folly_exception_tracer"
-            self.cpp_info.components["folly_exception_counter"].names["cmake_find_package"] = "folly_exception_counter"
-            self.cpp_info.components["folly_exception_counter"].names["cmake_find_package_multi"] = "folly_exception_counter"


### PR DESCRIPTION
folly: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 deprecated code
* Removed `is_msvc` check in `_cppstd_flag_value` as it is already checked in L169 and linter was reporting `possibly using variable 'prefix' before assignment (possibly-used-before-assignment)`

