### PR TITLE
fruit: CMake 4 support

### DIFF
--- a/recipes/fruit/all/conanfile.py
+++ b/recipes/fruit/all/conanfile.py
@@ -4,13 +4,13 @@ import tarfile
 from fnmatch import fnmatch
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, download, export_conandata_patches, get
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class FruitConan(ConanFile):
@@ -100,6 +100,9 @@ class FruitConan(ConanFile):
         tc.variables["CMAKE_CXX_STANDARD"] = 11
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "3.7.1": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()


### PR DESCRIPTION
fruit: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
