### PR TITLE
bzip2: Add support for CMake 4

### DIFF
--- a/recipes/bzip2/all/CMakeLists.txt
+++ b/recipes/bzip2/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(bzip2 LANGUAGES C)
 
 include(GNUInstallDirs)

--- a/recipes/bzip2/all/CMakeLists.txt
+++ b/recipes/bzip2/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(bzip2 LANGUAGES C)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Our custom CMakeLists had a min required version of 3.4. Bumping it to 3.5 will allow this to build with CMake 4

Successful configure/build logs for CMake 4:

<details>

```
$ conan create . --version=1.0.6 -b=missing

======== Exporting recipe to the cache ========
bzip2/1.0.6: Exporting package recipe: /Users/abril/coding/conan-center-index/recipes/bzip2/all/conanfile.py
bzip2/1.0.6: exports: File 'conandata.yml' found. Exporting it...
bzip2/1.0.6: Calling export_sources()
bzip2/1.0.6: Copied 1 '.py' file: conanfile.py
bzip2/1.0.6: Copied 1 '.yml' file: conandata.yml
bzip2/1.0.6: Copied 1 '.txt' file: CMakeLists.txt
bzip2/1.0.6: Copied 1 '.patch' file: 0001-fix-sys-stat-include.patch
bzip2/1.0.6: Exported to cache folder: /Users/abril/.conan2/p/bzip2f2aa593c0cba6/e
bzip2/1.0.6: Exported: bzip2/1.0.6#f37b6d2b44c00c5d81c1fbac89f7e1ec (2025-03-28 23:31:06 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=16
os=Macos
[tool_requires]
*: cmake/4.0.0-rc4
[platform_tool_requires]
cmake/3.31.6
meson/1.7.0
[replace_tool_requires]
meson/*: meson/[*]
pkgconf/*: pkgconf/[*]
[conf]


Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=16
os=Macos
[tool_requires]
*: cmake/4.0.0-rc4
[platform_tool_requires]
cmake/3.31.6
meson/1.7.0
[replace_tool_requires]
meson/*: meson/[*]
pkgconf/*: pkgconf/[*]
[conf]



======== Computing dependency graph ========
cmake/4.0.0-rc4: Not found in local cache, looking in remotes...
cmake/4.0.0-rc4: Checking remote: conancenter
Connecting to remote 'conancenter' anonymously
cmake/4.0.0-rc4: Downloaded recipe revision accb3d2ae07ba0a3c609902d8cc54b1c
Graph root
    cli
Requirements
    bzip2/1.0.6#f37b6d2b44c00c5d81c1fbac89f7e1ec - Cache
Build requirements
    cmake/4.0.0-rc4#accb3d2ae07ba0a3c609902d8cc54b1c - Downloaded (conancenter)

======== Computing necessary packages ========
bzip2/1.0.6: Main binary package '1b365626531995eab090d0d1b1d474dd9a356923' missing
bzip2/1.0.6: Checking 1 compatible configurations
bzip2/1.0.6: Compatible configurations not found in cache, checking servers
bzip2/1.0.6: 'a8fb9158e8f911ce0e9a69916033d3c06f6abea5': compiler.version=13
Requirements
    bzip2/1.0.6#f37b6d2b44c00c5d81c1fbac89f7e1ec:1b365626531995eab090d0d1b1d474dd9a356923 - Build
Build requirements
    cmake/4.0.0-rc4#accb3d2ae07ba0a3c609902d8cc54b1c:9e5323c65b94ae38c3c733fe12637776db0119a5#3503a7f237be5f111b7f3570a76e036a - Download (conancenter)

======== Installing packages ========

-------- Downloading 1 package --------
cmake/4.0.0-rc4: Retrieving package 9e5323c65b94ae38c3c733fe12637776db0119a5 from remote 'conancenter' 
cmake/4.0.0-rc4: Downloading 78.5MB 621a804be9df4c286a40961daeb042de3dd4fdfd5a607fce9346456341e39502
cmake/4.0.0-rc4: Decompressing 78.5MB conan_package.tgz
cmake/4.0.0-rc4: Package installed 9e5323c65b94ae38c3c733fe12637776db0119a5
cmake/4.0.0-rc4: Downloaded package revision 3503a7f237be5f111b7f3570a76e036a
cmake/4.0.0-rc4: Appending PATH environment variable: /Users/abril/.conan2/p/cmake75628d69ffde7/p/CMake.app/Contents/bin
cmake/4.0.0-rc4: Appending PATH environment variable: /Users/abril/.conan2/p/cmake75628d69ffde7/p/CMake.app/Contents/bin
bzip2/1.0.6: Calling source() in /Users/abril/.conan2/p/bzip2f2aa593c0cba6/s/src
bzip2/1.0.6: Source https://sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz retrieved from local download cache
bzip2/1.0.6: Unzipping bzip2-1.0.6.tar.gz to .

-------- Installing package bzip2/1.0.6 (2 of 2) --------
bzip2/1.0.6: Building from source
bzip2/1.0.6: Package bzip2/1.0.6:1b365626531995eab090d0d1b1d474dd9a356923
bzip2/1.0.6: Copying sources to build folder
bzip2/1.0.6: Building your package in /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b
bzip2/1.0.6: Calling generate()
bzip2/1.0.6: Generators folder: /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b/build/Release/generators
bzip2/1.0.6: CMakeToolchain generated: conan_toolchain.cmake
bzip2/1.0.6: CMakeToolchain generated: /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b/build/Release/generators/CMakePresets.json
bzip2/1.0.6: Generating aggregated env files
bzip2/1.0.6: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
bzip2/1.0.6: Calling build()
bzip2/1.0.6: Apply patch (file): patches/0001-fix-sys-stat-include.patch
bzip2/1.0.6: Running CMake.configure()
bzip2/1.0.6: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b/src/.."
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Using Conan toolchain: /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done (0.9s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b/build/Release

bzip2/1.0.6: Running CMake.build()
bzip2/1.0.6: RUN: cmake --build "/Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b/build/Release" -- -j12
[ 10%] Building C object CMakeFiles/bz2.dir/src/blocksort.c.o
[ 20%] Building C object CMakeFiles/bz2.dir/src/bzlib.c.o
[ 30%] Building C object CMakeFiles/bz2.dir/src/huffman.c.o
[ 40%] Building C object CMakeFiles/bz2.dir/src/decompress.c.o
[ 50%] Building C object CMakeFiles/bz2.dir/src/randtable.c.o
[ 60%] Building C object CMakeFiles/bz2.dir/src/compress.c.o
[ 70%] Building C object CMakeFiles/bz2.dir/src/crctable.c.o
[ 80%] Linking C static library libbz2.a
[ 80%] Built target bz2
[ 90%] Building C object CMakeFiles/bzip2.dir/src/bzip2.c.o
[100%] Linking C executable bzip2
[100%] Built target bzip2

bzip2/1.0.6: Package '1b365626531995eab090d0d1b1d474dd9a356923' built
bzip2/1.0.6: Build folder /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b/build/Release
bzip2/1.0.6: Generating the package
bzip2/1.0.6: Packaging in folder /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/p
bzip2/1.0.6: Calling package()
bzip2/1.0.6: Running CMake.install()
bzip2/1.0.6: RUN: cmake --install "/Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/b/build/Release" --prefix "/Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/p"
-- Install configuration: "Release"
-- Installing: /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/p/lib/libbz2.a
-- Installing: /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/p/include/bzlib.h
-- Installing: /Users/abril/.conan2/p/b/bzip260ce45b9e9cd7/p/bin/bzip2

bzip2/1.0.6: package(): Packaged 2 files: bzip2, LICENSE
bzip2/1.0.6: package(): Packaged 1 '.h' file: bzlib.h
bzip2/1.0.6: package(): Packaged 1 '.a' file: libbz2.a
bzip2/1.0.6: package(): Packaged 1 '.cmake' file: conan-official-bzip2-variables.cmake
bzip2/1.0.6: Created package revision b8b33317c97614295a2407175d71ba89
```

</details>