### PR TITLE
http_parser: CMake 4 support

### DIFF
--- a/recipes/http_parser/all/conanfile.py
+++ b/recipes/http_parser/all/conanfile.py
@@ -1,6 +1,8 @@
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -46,6 +48,9 @@ class HttpParserConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["HTTP_PARSER_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "2.9.4": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
http_parser: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

