### PR TITLE
iir1: CMake 4 support

### DIFF
--- a/recipes/iir1/all/conanfile.py
+++ b/recipes/iir1/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class Iir1Conan(ConanFile):
@@ -64,6 +64,8 @@ class Iir1Conan(ConanFile):
         tc = CMakeToolchain(self)
         if self.options.get_safe("noexceptions"):
             tc.preprocessor_definitions["IIR1_NO_EXCEPTIONS"] = "1"
+        if Version(self.version) < "1.9.4":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def _patch_sources(self):
@@ -101,10 +103,4 @@ class Iir1Conan(ConanFile):
             self.cpp_info.components["iir"].defines.append("IIR1_NO_EXCEPTIONS")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["iir"].system_libs.append("m")
-
-        # TODO: to remove in conan v2
-        self.cpp_info.names["cmake_find_package"] = "iir"
-        self.cpp_info.names["cmake_find_package_multi"] = "iir"
-        self.cpp_info.components["iir"].names["cmake_find_package"] = name
-        self.cpp_info.components["iir"].names["cmake_find_package_multi"] = name
         self.cpp_info.components["iir"].set_property("cmake_target_name", f"iir::{name}")


### PR DESCRIPTION
iir1: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 deprecated code

