### PR TITLE
Add xsimd 13.2.0 version

### DIFF
--- a/recipes/xsimd/all/conandata.yml
+++ b/recipes/xsimd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "13.2.0":
+    url: "https://github.com/xtensor-stack/xsimd/archive/13.2.0.tar.gz"
+    sha256: "edd8cd3d548c185adc70321c53c36df41abe64c1fe2c67bc6d93c3ecda82447a"
   "13.0.0":
     url: "https://github.com/xtensor-stack/xsimd/archive/13.0.0.tar.gz"
     sha256: "8bdbbad0c3e7afa38d88d0d484d70a1671a1d8aefff03f4223ab2eb6a41110a3"

--- a/recipes/xsimd/config.yml
+++ b/recipes/xsimd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "13.2.0":
+    folder: all
   "13.0.0":
     folder: all
   "12.1.1":


### PR DESCRIPTION
### Summary
Add version:  **xsimd/13.2.0**

#### Motivation
This version will be required for bumping the xtensor version to 0.26.0.

#### Details
This just adds the latest version of `xsimd` to the conan registry.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
