### PR TITLE
json-c: CMake 4 support

### DIFF
--- a/recipes/json-c/all/conanfile.py
+++ b/recipes/json-c/all/conanfile.py
@@ -47,8 +47,13 @@ class JSONCConan(ConanFile):
         if Version(self.version) >= "0.15":
             tc.variables["BUILD_STATIC_LIBS"] = not self.options.shared
             tc.variables["DISABLE_STATIC_FPIC"] = not self.options.get_safe("fPIC", True)
-        # To install relocatable shared libs on Macos
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["BUILD_TESTING"] = False
+        if Version(self.version) < "0.17":
+            # To install relocatable shared libs on Macos
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        else:
+            tc.cache_variables["BUILD_APPS"] = False
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
json-c: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Disable compilation of tests and, in newer versions, the application compilation (`json_parse`) which is a demo application never installed by cmake. 