### PR TITLE
Add xtl 0.8.0 version

### DIFF
--- a/recipes/xtl/all/conandata.yml
+++ b/recipes/xtl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.0":
+    url: "https://github.com/xtensor-stack/xtl/archive/0.8.0.tar.gz"
+    sha256: "ee38153b7dd0ec84cee3361f5488a4e7e6ddd26392612ac8821cbc76e740273a"
   "0.7.6":
     url: "https://github.com/xtensor-stack/xtl/archive/0.7.6.tar.gz"
     sha256: "dda442dc81f390f77561913062471c39b6ef19ffc6f64d3cd12b5c4b4607c957"

--- a/recipes/xtl/all/conanfile.py
+++ b/recipes/xtl/all/conanfile.py
@@ -1,13 +1,11 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import copy, get, save
+from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
-import textwrap
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=2"
 
 
 class XtlConan(ConanFile):
@@ -21,18 +19,11 @@ class XtlConan(ConanFile):
     package_type = "header-library"
     no_copy_source = True
 
-    @property
-    def _min_cppstd(self):
-        if Version(self.version) < "0.8.0":
-            return "14"
-        return "17"
-
     def package_id(self):
         self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, 14 if Version(self.version) < "0.8" else 17)
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -41,33 +32,9 @@ class XtlConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version],
             destination=self.source_folder, strip_root=True)
 
-    def build(self):
-        pass
-
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "*.hpp", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {"xtl": "xtl::xtl"},
-        )
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "xtl")
@@ -77,7 +44,3 @@ class XtlConan(ConanFile):
         self.cpp_info.frameworkdirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/xtl/all/conanfile.py
+++ b/recipes/xtl/all/conanfile.py
@@ -18,6 +18,7 @@ class XtlConan(ConanFile):
     description = "The x template library"
     topics = ("templates", "containers", "algorithms")
     settings = "os", "arch", "compiler", "build_type"
+    package_type = "header-library"
     no_copy_source = True
 
     @property
@@ -26,42 +27,12 @@ class XtlConan(ConanFile):
             return "14"
         return "17"
 
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "14": {
-                "clang": "3.9",
-                "gcc": "6",
-                "Visual Studio": "15",
-                "msvc": "191",
-            },
-            # https://en.cppreference.com/w/cpp/compiler_support/17
-            "17": {
-                "clang": "4",
-                "gcc": "7",
-                "Visual Studio": "15",
-                "msvc": "191",
-            },
-        }.get(self._min_cppstd, {})
-
     def package_id(self):
         self.info.clear()
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-
-        def loose_lt_semver(v1, v2):
-            lv1 = [int(v) for v in v1.split(".")]
-            lv2 = [int(v) for v in v2.split(".")]
-            min_length = min(len(lv1), len(lv2))
-            return lv1[:min_length] < lv2[:min_length]
-
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and loose_lt_semver(str(self.settings.compiler.version), minimum_version):
-            raise ConanInvalidConfiguration(
-                f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler does not support.",
-            )
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/xtl/all/test_package/CMakeLists.txt
+++ b/recipes/xtl/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(xtl REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE xtl)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/xtl/all/test_package/test_package.cpp
+++ b/recipes/xtl/all/test_package/test_package.cpp
@@ -1,15 +1,14 @@
 #include <iostream>
-#include <xtl/xvariant.hpp>
+#include <xtl/xoptional.hpp>
 
 int main(int argc, char *argv[]) {
-  xtl::variant<int, float> v, w;
+  xtl::xoptional<int, bool> v, w;
 
+  w = v.value_or(0);
   v = 12;
-  int i = xtl::get<int>(v);
-  w = xtl::get<int>(v);
 
-  std::cout << xtl::get<int>(v) << "\n";
-  std::cout << xtl::get<int>(w) << "\n";
+  std::cout << v.value() << "\n";
+  std::cout << w.value() << "\n";
 
   return 0;
 }

--- a/recipes/xtl/config.yml
+++ b/recipes/xtl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.0":
+    folder: all
   "0.7.6":
     folder: all
   "0.7.5":


### PR DESCRIPTION
### Summary
Add version:  **xtl/0.8.0**

#### Motivation

This version will be required for bumping the xtensor version to 0.26.0.

#### Details

The version 0.8.0 required some changes to the conanfile.py. Starting from this version a cppstd >= 17 is required. This also means, that newer compiler versions will be required. I took those exact versions from the cppreference and looked at other packages that use cppstd >= 17.

Further, the xvariant header was removed from that version. So the test_package was updated to test with xoptional instead, which is available in every version.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
