### PR TITLE
Add xtensor 0.26.0 version

### DIFF
--- a/recipes/xtensor/all/conandata.yml
+++ b/recipes/xtensor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.26.0":
+    url: "https://github.com/xtensor-stack/xtensor/archive/0.26.0.tar.gz"
+    sha256: "f5f42267d850f781d71097b50567a480a82cd6875a5ec3e6238555e0ef987dc6"
   "0.25.0":
     url: "https://github.com/xtensor-stack/xtensor/archive/0.25.0.tar.gz"
     sha256: "32d5d9fd23998c57e746c375a544edf544b74f0a18ad6bc3c38cbba968d5e6c7"

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -45,6 +45,8 @@ class XtensorConan(ConanFile):
         if self.options.xsimd:
             if Version(self.version) < "0.24.0":
                 self.requires("xsimd/7.5.0")
+            elif Version(self.version) < "0.26.0":
+                self.requires("xsimd/13.0.0")
             else:
                 self.requires("xsimd/13.2.0")
         if self.options.tbb:

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -32,17 +32,27 @@ class XtensorConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return "14"
+        if Version(self.version) < "0.26.0":
+            return "14"
+        return "17"
 
     @property
     def _compilers_minimum_version(self):
-        # https://github.com/xtensor-stack/xtensor/blob/master/README.md
         return {
-            "Visual Studio": "14",
-            "msvc": "190",
-            "gcc": "4.9",
-            "clang": "4",
-        }
+            "14": {
+                "Visual Studio": "14",
+                "msvc": "190",
+                "gcc": "4.9",
+                "clang": "4",
+            },
+            # https://en.cppreference.com/w/cpp/compiler_support/17
+            "17": {
+                "Visual Studio": "15",
+                "msvc": "191",
+                "gcc": "7",
+                "clang": "4",
+            },
+        }.get(self._min_cppstd, {})
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -51,13 +61,17 @@ class XtensorConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("xtl/0.7.5")
+        # https://github.com/xtensor-stack/xtensor?tab=readme-ov-file#dependencies
+        if Version(self.version) < "0.26.0":
+            self.requires("xtl/0.7.5")
+        else:
+            self.requires("xtl/0.8.0")
         self.requires("nlohmann_json/3.11.3")
         if self.options.xsimd:
             if Version(self.version) < "0.24.0":
                 self.requires("xsimd/7.5.0")
             else:
-                self.requires("xsimd/13.0.0")
+                self.requires("xsimd/13.2.0")
         if self.options.tbb:
             self.requires("onetbb/2021.10.0")
 

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -1,13 +1,12 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
-import textwrap
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2"
 
 
 class XtensorConan(ConanFile):
@@ -29,30 +28,6 @@ class XtensorConan(ConanFile):
         "tbb": False,
         "openmp": False,
     }
-
-    @property
-    def _min_cppstd(self):
-        if Version(self.version) < "0.26.0":
-            return "14"
-        return "17"
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "14": {
-                "Visual Studio": "14",
-                "msvc": "190",
-                "gcc": "4.9",
-                "clang": "4",
-            },
-            # https://en.cppreference.com/w/cpp/compiler_support/17
-            "17": {
-                "Visual Studio": "15",
-                "msvc": "191",
-                "gcc": "7",
-                "clang": "4",
-            },
-        }.get(self._min_cppstd, {})
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -84,20 +59,7 @@ class XtensorConan(ConanFile):
                 "The options 'tbb' and 'openmp' can not be used together."
             )
 
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
-
-        def loose_lt_semver(v1, v2):
-            lv1 = [int(v) for v in v1.split(".")]
-            lv2 = [int(v) for v in v2.split(".")]
-            min_length = min(len(lv1), len(lv2))
-            return lv1[:min_length] < lv2[:min_length]
-
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and loose_lt_semver(str(self.settings.compiler.version), minimum_version):
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
-            )
+        check_min_cppstd(self, 14 if Version(self.version) < "0.26.0" else 17)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -109,27 +71,6 @@ class XtensorConan(ConanFile):
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "*.hpp", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
-
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {"xtensor": "xtensor::xtensor"}
-        )
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "xtensor")
@@ -143,7 +84,3 @@ class XtensorConan(ConanFile):
             self.cpp_info.defines.append("XTENSOR_USE_TBB")
         if self.options.openmp:
             self.cpp_info.defines.append("XTENSOR_USE_OPENMP")
-
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/xtensor/all/test_package/CMakeLists.txt
+++ b/recipes/xtensor/all/test_package/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(xtensor REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE xtensor)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 foreach(flag "-march=native" "-mtune=native")
   check_cxx_compiler_flag(${flag} COMPILER_SUPPORTS_MARCH_NATIVE)
@@ -15,3 +15,7 @@ foreach(flag "-march=native" "-mtune=native")
     target_compile_options(${PROJECT_NAME} PRIVATE ${flag})
   endif()
 endforeach()
+
+if (xtensor_VERSION VERSION_LESS "0.26.0")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "XTENSOR_VERSION_LESS_0_26_0")
+endif()

--- a/recipes/xtensor/all/test_package/CMakeLists.txt
+++ b/recipes/xtensor/all/test_package/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(xtensor REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE xtensor)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 foreach(flag "-march=native" "-mtune=native")
   check_cxx_compiler_flag(${flag} COMPILER_SUPPORTS_MARCH_NATIVE)

--- a/recipes/xtensor/all/test_package/test_package.cpp
+++ b/recipes/xtensor/all/test_package/test_package.cpp
@@ -1,6 +1,12 @@
+#ifdef XTENSOR_VERSION_LESS_0_26_0
 #include "xtensor/xarray.hpp"
 #include "xtensor/xio.hpp"
 #include "xtensor/xview.hpp"
+#else
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/io/xio.hpp"
+#include "xtensor/views/xview.hpp"
+#endif
 #include <iostream>
 
 int main(int argc, char *argv[]) {

--- a/recipes/xtensor/config.yml
+++ b/recipes/xtensor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.26.0":
+    folder: all
   "0.25.0":
     folder: all
   "0.24.7":


### PR DESCRIPTION
### Summary
Add version:  **xtensor/0.26.0**

#### Motivation

This version adds support for clang 19 and above.

#### Details

The version 0.26.0 required some changes to the conanfile.py. Starting from this version a cppstd >= 17 is required. This also means, that newer compiler versions will be required. I took those exact versions from the cppreference and looked at other packages that use cppstd >= 17.

Further, code was restructured between this and the last version and with that include paths changed. The changes to the test_package make sure that the test still works with all versions.

Requires:
- https://github.com/conan-io/conan-center-index/pull/27016
- https://github.com/conan-io/conan-center-index/pull/27019

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
