### PR TITLE
keystone: CMake 4 support

### DIFF
--- a/recipes/keystone/all/conandata.yml
+++ b/recipes/keystone/all/conandata.yml
@@ -2,3 +2,10 @@ sources:
   "0.9.2":
     url: "https://github.com/keystone-engine/keystone/archive/refs/tags/0.9.2.tar.gz"
     sha256: "c9b3a343ed3e05ee168d29daf89820aff9effb2c74c6803c2d9e21d55b5b7c24"
+
+patches:
+  "0.9.2":
+    - patch_file: "patches/0.9.2-cmake4-support.patch"
+      patch_type: "portability"
+      patch_description: "Remove OLD behavior in CMP0051 and use CMake 3.5 minimum"
+

--- a/recipes/keystone/all/conanfile.py
+++ b/recipes/keystone/all/conanfile.py
@@ -1,8 +1,10 @@
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.build import check_max_cppstd
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.0"
@@ -54,11 +56,14 @@ class KeystoneConan(ConanFile):
         # INFO: include/llvm/ADT/STLExtras.h:54:34: error: no template named 'binary_function' in namespace 'std'
         # The std::binary_function was removed in C++17
         check_max_cppstd(self, 14)
-        
+
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["BUILD_LIBS_ONLY"] = True
         tc.cache_variables["KEYSTONE_BUILD_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "0.9.2": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):

--- a/recipes/keystone/all/conanfile.py
+++ b/recipes/keystone/all/conanfile.py
@@ -1,10 +1,8 @@
 from conan import ConanFile
-from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.build import check_max_cppstd
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.1"

--- a/recipes/keystone/all/conanfile.py
+++ b/recipes/keystone/all/conanfile.py
@@ -1,13 +1,13 @@
 from conan import ConanFile
 from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.build import check_max_cppstd
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=2.0"
+required_conan_version = ">=2.1"
 
 
 class KeystoneConan(ConanFile):
@@ -46,11 +46,15 @@ class KeystoneConan(ConanFile):
     }
     implements = ["auto_shared_fpic"]
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def validate(self):
         # INFO: include/llvm/ADT/STLExtras.h:54:34: error: no template named 'binary_function' in namespace 'std'
@@ -61,9 +65,6 @@ class KeystoneConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.cache_variables["BUILD_LIBS_ONLY"] = True
         tc.cache_variables["KEYSTONE_BUILD_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
-        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
-        if Version(self.version) > "0.9.2": # pylint: disable=conan-unreachable-upper-version
-            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):

--- a/recipes/keystone/all/patches/0.9.2-cmake4-support.patch
+++ b/recipes/keystone/all/patches/0.9.2-cmake4-support.patch
@@ -1,0 +1,39 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # Keystone Assembler Engine (www.keystone-engine.org)
+ # By Nguyen Anh Quynh, 2016
+ 
+-cmake_minimum_required(VERSION 2.8.7)
++cmake_minimum_required(VERSION 3.5)
+ project(keystone)
+ 
+ set(KEYSTONE_VERSION_MAJOR 0)
+@@ -24,7 +24,7 @@ if (POLICY CMP0051)
+   # stripped everywhere that access the SOURCES property, so we just
+   # defer to the OLD behavior of not including generator expressions
+   # in the output for now.
+-  cmake_policy(SET CMP0051 OLD)
++  # cmake_policy(SET CMP0051 OLD)
+ endif()
+ 
+ if (POLICY CMP0063)
+--- a/llvm/CMakeLists.txt
++++ b/llvm/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ # See docs/CMake.html for instructions about how to build LLVM with CMake.
+ 
+-cmake_minimum_required(VERSION 2.8.7)
++cmake_minimum_required(VERSION 3.5)
+ 
+ set(LLVM_INSTALL_TOOLCHAIN_ONLY ON)
+ 
+@@ -19,7 +19,7 @@ if (POLICY CMP0051)
+   # stripped everywhere that access the SOURCES property, so we just
+   # defer to the OLD behavior of not including generator expressions
+   # in the output for now.
+-  cmake_policy(SET CMP0051 OLD)
++  # cmake_policy(SET CMP0051 OLD)
+ endif()
+ 
+ if(CMAKE_VERSION VERSION_LESS 3.1.20141117)


### PR DESCRIPTION
keystone: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* This recipe needed a patch to disable `CMP0051` old policy
