### PR TITLE
Detours - Replace restriction by warning

### DIFF
--- a/recipes/detours/all/conanfile.py
+++ b/recipes/detours/all/conanfile.py
@@ -40,10 +40,9 @@ class DetoursConan(ConanFile):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only os=Windows is supported")
         if is_msvc(self) and not is_msvc_static_runtime(self):
-            # Debug and/or dynamic runtime is undesired for a hooking library
-            raise ConanInvalidConfiguration("Only static runtime is supported (MT)")
+            self.output.warning("Detours might behave unexpectedly when not built with static runtime (MT)")
         if self.settings.build_type != "Release":
-            raise ConanInvalidConfiguration("Detours only supports the Release build type")
+            self.output.warning("Detours might behave unexpectedly when not built with Release build type")
         try:
             self.output.info(f"target process is {self._target_processor}")
         except KeyError:


### PR DESCRIPTION
Replaces restrictions on build type and runtime by warnings.

### Summary
Changes to recipe:  **detours** (all versions)

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
For further explanation, see issue #27020

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
The unneeded restrictions are replaced by mere warnings, as even though there is no evidence building with dynamic runtime or with debug symbols does any harm it is not particularly testable.
One could imagine the debug build enabling certain optimizations that mess with the address calculation Detours has to do. Or maybe it has an impact on the binary section layout.

We patched the recipe locally for our use cases and did not (yet) run into any issues. Also as elaborated in #27020, our previous package manager did not have these restrictions and we used it successfully for quite a while.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
