### PR TITLE
laslib: CMake 4 support

### DIFF
--- a/recipes/laslib/all/conanfile.py
+++ b/recipes/laslib/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, save
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir
 from conan.tools.build import stdcpp_library, check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
@@ -31,7 +31,7 @@ class LASlibConan(ConanFile):
     @property
     def _min_cppstd(self):
         return 17
-    
+
     @property
     def _compilers_minimum_version(self):
         return {
@@ -73,8 +73,6 @@ class LASlibConan(ConanFile):
 
     def build(self):
         apply_conandata_patches(self)
-        save(self, os.path.join(self.source_folder, "CMakeLists.txt"), "add_subdirectory(LASlib/src)")
-        save(self, os.path.join(self.source_folder, "LASlib", "example", "CMakeLists.txt"), "")
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/laslib/all/patches/0001-build-only-laslib.patch
+++ b/recipes/laslib/all/patches/0001-build-only-laslib.patch
@@ -1,3 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b776cb7..8bbe6a6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+ set(CMAKE_SUPPRESS_REGENERATION true)
+ project("LAStools")
+ 
+@@ -10,12 +10,5 @@ endif()
+ 
+ option(BUILD_SHARED_LIBS "Build LASlib as DLL" OFF)
+ 
+-if (BUILD_SHARED_LIBS AND UNIX AND NOT APPLE)
+-	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/LASlib")
+-endif()
+ 
+ add_subdirectory(LASlib/src)
+-add_subdirectory(src)
+-if (EXISTS src_full)
+-	add_subdirectory(src_full)
+-endif()
 diff --git a/LASlib/src/CMakeLists.txt b/LASlib/src/CMakeLists.txt
 index 1b170bf..6a114eb 100644
 --- a/LASlib/src/CMakeLists.txt


### PR DESCRIPTION
laslib: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Use upstream CMakeList instead of patching it to simple redirect to `LASlib/CMakeList`
* Modified current patch to use CMake minimum 3.5 and `add_subdirectory` directly `LASlib/src` instead of `LASlib/` which allows removing of following lines:
```py
        save(self, os.path.join(self.source_folder, "CMakeLists.txt"), "add_subdirectory(LASlib/src)")
        save(self, os.path.join(self.source_folder, "LASlib", "example", "CMakeLists.txt"), "")
```
