### PR TITLE
lexbor: CMake 4 support

### DIFF
--- a/recipes/lexbor/all/conandata.yml
+++ b/recipes/lexbor/all/conandata.yml
@@ -11,3 +11,6 @@ sources:
   "2.1.0":
     url: "https://github.com/lexbor/lexbor/archive/v2.1.0.zip"
     sha256: "58d684d19cec689e40d8d443b3b953697cfa677a0ca59a2cf1fc14cd37ac2404"
+patches:
+  "2.1.0":
+    - patch_file: "patches/2.1.0-0000-macos-rpath.patch"

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
-from conan.tools.files import get, copy, rm
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.microsoft import is_msvc
+from conan.tools.files import get, copy
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 class LexborConan(ConanFile):
     name = "lexbor"
@@ -62,6 +63,8 @@ class LexborConan(ConanFile):
         tc.variables["LEXBOR_TESTS_CPP"] = False
         tc.variables["LEXBOR_BUILD_SEPARATELY"] = self.options.build_separately
         tc.variables["LEXBOR_INSTALL_HEADERS"] = True
+        if Version(self.version) < "2.3.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -76,9 +79,6 @@ class LexborConan(ConanFile):
 
     def package_info(self):
         target = "lexbor" if self.options.shared else "lexbor_static"
-        self.cpp_info.names["cmake_find_package"] = "lexbor"
-        self.cpp_info.names["cmake_find_package_multi"] = "lexbor"
-
         self.cpp_info.components["_lexbor"].set_property("cmake_target_name", f"lexbor::{target}")
 
         self.cpp_info.components["_lexbor"].libs = [target]
@@ -90,8 +90,5 @@ class LexborConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["_lexbor"].system_libs.append("m")
 
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.set_property("cmake_file_name", "lexbor")
         self.cpp_info.set_property("cmake_target_name", f"lexbor::{target}")
-        self.cpp_info.components["_lexbor"].names["cmake_find_package"] = target
-        self.cpp_info.components["_lexbor"].names["cmake_find_package_multi"] = target

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc
-from conan.tools.files import get, copy
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.scm import Version
 import os
@@ -36,6 +36,9 @@ class LexborConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
@@ -55,6 +58,7 @@ class LexborConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -64,6 +64,8 @@ class LexborConan(ConanFile):
         tc.variables["LEXBOR_BUILD_SEPARATELY"] = self.options.build_separately
         tc.variables["LEXBOR_INSTALL_HEADERS"] = True
         if Version(self.version) < "2.3.0":
+            # To install relocatable shared lib on Macos by default
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 

--- a/recipes/lexbor/all/patches/2.1.0-0000-macos-rpath.patch
+++ b/recipes/lexbor/all/patches/2.1.0-0000-macos-rpath.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3f271b0..4b5ba64 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,6 +59,9 @@ IF(NOT LEXBOR_MAKE_DISTRO_NUM)
+     set(LEXBOR_MAKE_DISTRO_NUM "1")
+ ENDIF()
+ 
++enable_language(C)
++enable_language(CXX)
++
+ ################
+ ## Version and path
+ #########################
+@@ -78,13 +81,13 @@ set(LEXBOR_INSTALL_DLL_EXE_DIR "bin")
+ ################
+ ## RPATH
+ #########################
+-include(GNUInstallDirs)
+-
+ IF(APPLE)
+     set(CMAKE_MACOSX_RPATH ON)
+ 
+     set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
+-ENDIF(APPLE)
++ELSEIF(UNIX)
++    include(GNUInstallDirs)
++ENDIF()
+ 
+ ################
+ ## lib param


### PR DESCRIPTION
lexbor: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code
