### PR TITLE
libdwarf: CMake 4 support

### DIFF
--- a/recipes/libdwarf/all/conanfile.py
+++ b/recipes/libdwarf/all/conanfile.py
@@ -71,6 +71,8 @@ class LibdwarfConan(ConanFile):
         if cross_building(self):
             tc.variables["HAVE_UNUSED_ATTRIBUTE_EXITCODE"] = "0"
             tc.variables["HAVE_UNUSED_ATTRIBUTE_EXITCODE__TRYRUN_OUTPUT"] = ""
+        if Version(self.version) < "0.9.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
         dpes = CMakeDeps(self)

--- a/recipes/libdwarf/all/test_package/CMakeLists.txt
+++ b/recipes/libdwarf/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(libdwarf REQUIRED)


### PR DESCRIPTION
libdwarf: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Increase CMake minimum required to 3.15 on `test_package/CMakeLists.txt`