### PR TITLE
libfreenect: CMake 4 support

### DIFF
--- a/recipes/libfreenect/all/conanfile.py
+++ b/recipes/libfreenect/all/conanfile.py
@@ -1,9 +1,10 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class LibfreenectConan(ConanFile):
@@ -61,6 +62,8 @@ class LibfreenectConan(ConanFile):
         tc.variables["BUILD_OPENNI2_DRIVER"] = False
         # Relocatable shared libs on macOS
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) < "0.7.5": # pylint: disable=conan-condition-evals-to-constant
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
libfreenect: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
