### PR TITLE
libkml: CMake 4 support

### DIFF
--- a/recipes/libkml/all/conanfile.py
+++ b/recipes/libkml/all/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile, conan_version
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 import os
-import textwrap
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class LibkmlConan(ConanFile):
@@ -51,7 +51,7 @@ class LibkmlConan(ConanFile):
     def validate(self):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration(f"{self.ref} shared with Visual Studio and MT runtime is not supported")
-        
+
     def package_id(self):
         cppstd = self.info.settings.get_safe("compiler.cppstd")
         if cppstd and cppstd not in ['98', 'gnu98', '11', 'gnu11', '14', 'gnu14']:
@@ -80,6 +80,9 @@ class LibkmlConan(ConanFile):
 
         # To install relocatable shared libs on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.3.0": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
@@ -97,39 +100,10 @@ class LibkmlConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "cmake"))
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {
-                "kmlbase": "LibKML::kmlbase",
-                "kmlxsd": "LibKML::kmlxsd",
-                "kmldom": "LibKML::kmldom",
-                "kmlengine": "LibKML::kmlengine",
-                "kmlconvenience": "LibKML::kmlconvenience",
-                "kmlregionator": "LibKML::kmlregionator",
-            }
-        )
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "LibKML")
         self.cpp_info.set_property("pkg_config_name", "libkml")
-
-        self.cpp_info.names["cmake_find_package"] = "LibKML"
-        self.cpp_info.names["cmake_find_package_multi"] = "LibKML"
 
         self._register_components({
             "kmlbase": {
@@ -162,10 +136,6 @@ class LibkmlConan(ConanFile):
             system_libs = values.get("system_libs", [])
             requires = values.get("requires", [])
             self.cpp_info.components[comp_cmake_lib_name].set_property("cmake_target_name", comp_cmake_lib_name)
-            self.cpp_info.components[comp_cmake_lib_name].names["cmake_find_package"] = comp_cmake_lib_name
-            self.cpp_info.components[comp_cmake_lib_name].names["cmake_find_package_multi"] = comp_cmake_lib_name
-            self.cpp_info.components[comp_cmake_lib_name].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-            self.cpp_info.components[comp_cmake_lib_name].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
             self.cpp_info.components[comp_cmake_lib_name].libs = [comp_cmake_lib_name]
             self.cpp_info.components[comp_cmake_lib_name].defines = defines
             self.cpp_info.components[comp_cmake_lib_name].system_libs = system_libs


### PR DESCRIPTION
libkml: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed code related to legacy generators
* Removed conan v1 specific code
