### PR TITLE
 gklib: CMake 4 support

### DIFF
--- a/recipes/gklib/all/patches/004-increase-minimum-cmakelists.patch
+++ b/recipes/gklib/all/patches/004-increase-minimum-cmakelists.patch
@@ -13,7 +13,7 @@ index 2bc6f77..9ef8038 100644
 +++ b/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 2.8)
-+cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
  project(GKlib C)
  
  option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" OFF)


### PR DESCRIPTION
Since CMake 4.0 has dropped compatibility with version < 3.5, this needs to be updated.

I don't expect this to break anything (but haven't thoroughly tested).


### Summary
Changes to recipe:  **gklib/5.1.1**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
