### PR TITLE
libmodplug: CMake 4 support

### DIFF
--- a/recipes/libmodplug/all/conanfile.py
+++ b/recipes/libmodplug/all/conanfile.py
@@ -1,10 +1,12 @@
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.build import stdcpp_library
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class LibmodplugConan(ConanFile):
@@ -48,6 +50,10 @@ class LibmodplugConan(ConanFile):
         tc.preprocessor_definitions["HAVE_SINF"] = 1
         # Relocatable shared libs on macOS
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "0.8.9.0": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
+
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
libmodplug: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
