### PR TITLE
libssh2: CMake 4 support

### DIFF
--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -65,6 +65,8 @@ class Libssh2Conan(ConanFile):
         tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
         # To install relocatable shared lib on Macos by default
         tc.variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) < "1.11.1":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         # Workaround until github.com/conan-io/conan/pull/12600 is merged
         if is_msvc(self):
             tc.cache_variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)


### PR DESCRIPTION
libssh2: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

