### PR TITLE
libjuice: Do not add a debug suffix to the library

### DIFF
--- a/recipes/libjuice/all/conanfile.py
+++ b/recipes/libjuice/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import copy, get, rm, rmdir
 from conan.tools.microsoft import is_msvc
 from conan.tools.apple import fix_apple_shared_install_name
 
-required_conan_version = ">=2.1"
+required_conan_version = ">=2.4"
 
 class libjuiceConan(ConanFile):
     name = "libjuice"
@@ -27,13 +27,11 @@ class libjuiceConan(ConanFile):
         "fPIC": True,
     }
 
+    languages = "C"
     implements = ["auto_shared_fpic"]
 
     def layout(self):
         cmake_layout(self, src_folder="src")
-
-    def validate(self):
-        check_min_cppstd(self, 11)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -62,10 +60,7 @@ class libjuiceConan(ConanFile):
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
-        suffix = ""
-        if is_msvc(self) and self.settings.build_type == "Debug":
-            suffix = "d"
-        self.cpp_info.libs = ["juice" + suffix]
+        self.cpp_info.libs = ["juice"]
         self.cpp_info.set_property("cmake_file_name", "LibJuice")
         if self.options.shared:
             self.cpp_info.set_property("cmake_target_name", "LibJuice::LibJuice")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjuice/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Closes https://github.com/conan-io/conan-center-index/issues/26979 by fixing the `package_info` of the library. The upstream CMakeLists.txt does not add a suffix to the debug configuration at any point, which was causing issues when used as a dependency in `libdatachannel` when built as debug

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Upstream CMakeLists.txt does not add the suffix when building a debug configuration with msvc. It's my bad that I didn't originally detect this in the original https://github.com/conan-io/conan-center-index/pull/25993 PR, so I'm fixing it now :)

Also fixes the fact that this is a C library, but we weren't deleting the corresponding cppstd settings, and asked for a min cppstd when it's not necessary