### PR TITLE
libcorrect: CMake 4 support

### DIFF
--- a/recipes/libcorrect/all/conanfile.py
+++ b/recipes/libcorrect/all/conanfile.py
@@ -1,9 +1,11 @@
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.1"
 
 
 class LibcorrectConan(ConanFile):
@@ -13,7 +15,7 @@ class LibcorrectConan(ConanFile):
     homepage = "https://github.com/quiet/libcorrect"
     description = "C library for Convolutional codes and Reed-Solomon"
     topics = ("fec", "reed-solomon", "viterbi", "convolutional")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -60,6 +62,9 @@ class LibcorrectConan(ConanFile):
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         # Honor BUILD_SHARED_LIBS from conan_toolchain (see https://github.com/conan-io/conan/issues/11840)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "20181010": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
libcorrect: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Added `package_type = "library"`. This recipe only generates a library (no apps or toolchains)
