### PR TITLE
libx265: CMake 4 support

### DIFF
--- a/recipes/libx265/all/conandata.yml
+++ b/recipes/libx265/all/conandata.yml
@@ -8,7 +8,7 @@ sources:
 patches:
   "3.4":
     - patch_file: "patches/3.2.1-0001-remove_register_classifier.patch"
-    - patch_file: "patches/3.2.1-0002-cmake-min-required.patch"
+    - patch_file: "patches/3.4-0002-cmake-min-required.patch"
     - patch_file: "patches/3.4-0001-numa.patch"
   "3.2.1":
     - patch_file: "patches/3.2.1-0001-remove_register_classifier.patch"

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class Libx265Conan(ConanFile):

--- a/recipes/libx265/all/patches/3.2.1-0002-cmake-min-required.patch
+++ b/recipes/libx265/all/patches/3.2.1-0002-cmake-min-required.patch
@@ -1,6 +1,6 @@
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
-@@ -1,10 +1,4 @@
+@@ -1,11 +1,6 @@
 -# vim: syntax=cmake
 -if(NOT CMAKE_BUILD_TYPE)
 -    # default to Release build for GCC builds
@@ -8,12 +8,17 @@
 -        "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel."
 -        FORCE)
 -endif()
-+cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
  message(STATUS "cmake version ${CMAKE_VERSION}")
++if(0)
  if(POLICY CMP0025)
      cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
-@@ -17,7 +11,6 @@ if(POLICY CMP0054)
  endif()
+@@ -15,9 +10,9 @@ endif()
+ if(POLICY CMP0054)
+     cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
+ endif()
++endif()
  
  project (x265)
 -cmake_minimum_required (VERSION 2.8.8) # OBJECT libraries require 2.8.8

--- a/recipes/libx265/all/patches/3.4-0001-numa.patch
+++ b/recipes/libx265/all/patches/3.4-0001-numa.patch
@@ -1,6 +1,6 @@
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
-@@ -90,20 +90,10 @@ if(UNIX)
+@@ -88,20 +88,10 @@ if(UNIX)
      endif()
      option(ENABLE_LIBNUMA "Enable libnuma usage (Linux only)" ON)
      if(ENABLE_LIBNUMA)

--- a/recipes/libx265/all/patches/3.4-0002-cmake-min-required.patch
+++ b/recipes/libx265/all/patches/3.4-0002-cmake-min-required.patch
@@ -1,0 +1,22 @@
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -6,18 +6,9 @@ if(NOT CMAKE_BUILD_TYPE)
+         FORCE)
+ endif()
+ message(STATUS "cmake version ${CMAKE_VERSION}")
+-if(POLICY CMP0025)
+-    cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
+-endif()
+-if(POLICY CMP0042)
+-    cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
+-endif()
+-if(POLICY CMP0054)
+-    cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
+-endif()
+ 
+ project (x265)
+-cmake_minimum_required (VERSION 2.8.8) # OBJECT libraries require 2.8.8
++cmake_minimum_required (VERSION 3.5) # OBJECT libraries require 2.8.8
+ include(CheckIncludeFiles)
+ include(CheckFunctionExists)
+ include(CheckSymbolExists)


### PR DESCRIPTION
libx265: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0:
  * Modified existing patch `3.2.1-0002-cmake-min-required.patch` supporting CMake 3.5
  * Created a new patch `3.4-0002-cmake-min-required.patch` which disables OLD policies incompatible with CMake 4 and forces CMake min 3.5
