### PR TITLE
lzfse: CMake 4 support

### DIFF
--- a/recipes/lzfse/all/conanfile.py
+++ b/recipes/lzfse/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class LzfseConan(ConanFile):
@@ -50,6 +50,7 @@ class LzfseConan(ConanFile):
         tc.variables["LZFSE_DISABLE_TESTS"] = False
         # Relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -67,6 +68,3 @@ class LzfseConan(ConanFile):
         self.cpp_info.libs = ["lzfse"]
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.defines.append("LZFSE_DLL")
-
-        # TODO: to remove in conan v2
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
lzfse: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code

This library is no longer maintained so no need to worry about a new release