### PR TITLE
nanomsg: CMake 4 support

### DIFF
--- a/recipes/nanomsg/all/conanfile.py
+++ b/recipes/nanomsg/all/conanfile.py
@@ -1,11 +1,13 @@
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.files import get, copy, rm, rmdir
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
+from conan.tools.scm import Version
 import os
 
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 class NanomsgConan(ConanFile):
     name = "nanomsg"
@@ -55,6 +57,9 @@ class NanomsgConan(ConanFile):
         tc.variables["NN_ENABLE_DOC"] = False
         tc.variables["NN_TESTS"] = False
         tc.variables["NN_TOOLS"] = self.options.enable_tools
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.2.1": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()
@@ -96,7 +101,3 @@ class NanomsgConan(ConanFile):
             self.cpp_info.defines.append("NN_STATIC_LIB")
         if self.options.enable_coverage:
             self.cpp_info.defines.append("NN_ENABLE_COVERAGE")
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.names["cmake_find_package"] = "nanomsg"
-        self.cpp_info.names["cmake_find_package_multi"] = "nanomsg"


### PR DESCRIPTION
nanomsg: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code
