### PR TITLE
nmslib: CMake 4 support

### DIFF
--- a/recipes/nmslib/all/conandata.yml
+++ b/recipes/nmslib/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
     - patch_file: patches/0002-cmake-fix-install.patch
     - patch_file: patches/0003-cmake-fix-flags.patch
     - patch_file: patches/0004-missing-utils-header.patch
+    - patch_file: patches/0005-cmake4-compatible.patch
+      patch_description: "CMP0025 (Compiler id for Apple Clang is now AppleClang instead of Clang). CMake 4 forces CMP0025 to NEW. Thus a patch is needed to MATCH Clang or AppleClang"

--- a/recipes/nmslib/all/conanfile.py
+++ b/recipes/nmslib/all/conanfile.py
@@ -1,12 +1,13 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file
 from conan.tools.microsoft import is_msvc, check_min_vs
+from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class Nmslib(ConanFile):
@@ -75,6 +76,9 @@ class Nmslib(ConanFile):
         tc.variables["WITHOUT_TESTS"] = True
         # Relocatable shared libs on macOS
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "2.1.1": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/nmslib/all/patches/0005-cmake4-compatible.patch
+++ b/recipes/nmslib/all/patches/0005-cmake4-compatible.patch
@@ -1,0 +1,11 @@
+--- similarity_search/CMakeLists.txt
++++ similarity_search/CMakeLists.txt
+@@ -55,7 +55,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+     endif()
+     set (CMAKE_CXX_FLAGS_RELEASE "-Wall -Wunreachable-code -Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread")
+     set (CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wunreachable-code -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread")
+-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
++elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+     if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+         # MACOSX
+         set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread")


### PR DESCRIPTION
nmslib: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Created a patch to support CMake 4: `CMP0025` (Compiler id for Apple Clang is now `AppleClang` instead of `Clang`). CMake 4 forces `CMP0025` to NEW. Thus a patch is needed to `MATCH` Clang or AppleClang
