### PR TITLE
nsync: CMake 4 support

### DIFF
--- a/recipes/nsync/all/conanfile.py
+++ b/recipes/nsync/all/conanfile.py
@@ -1,10 +1,12 @@
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file, rmdir
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.scm import Version
 import os
 
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class NsyncConan(ConanFile):
@@ -50,6 +52,9 @@ class NsyncConan(ConanFile):
             tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         # Relocatable shared libs on macOS
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.29.2": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
nsync: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0



