### PR TITLE
ode: CMake 4 support

### DIFF
--- a/recipes/ode/all/conanfile.py
+++ b/recipes/ode/all/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.build import stdcpp_library
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class OdeConan(ConanFile):
@@ -79,6 +80,9 @@ class OdeConan(ConanFile):
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         # Avoid a warning
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0075"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "0.16.4": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -119,9 +123,3 @@ class OdeConan(ConanFile):
             libcxx = stdcpp_library(self)
             if libcxx:
                 self.cpp_info.system_libs.append(libcxx)
-
-        # TODO: to remove in conan v2 once legacy generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "ode"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "ode"
-        self.cpp_info.names["cmake_find_package"] = "ODE"
-        self.cpp_info.names["cmake_find_package_multi"] = "ODE"


### PR DESCRIPTION
ode: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code
