### PR TITLE
crashpad: update mini_chromium-win_helper patch

### DIFF
--- a/recipes/crashpad/all/patches/cci.20220219-0006-mini_chromium-win_helper-py3.patch
+++ b/recipes/crashpad/all/patches/cci.20220219-0006-mini_chromium-win_helper-py3.patch
@@ -81,7 +81,7 @@
        if os.path.exists(vswhere_path):
          installation_path = subprocess.check_output(
 -            [vswhere_path, '-latest', '-property', 'installationPath']).strip()
-+            [vswhere_path, '-latest', '-property', 'installationPath']).strip().decode()
++            [vswhere_path, '-products', '*', '-latest', '-property', 'installationPath']).strip().decode()
          if installation_path:
            return (installation_path,
                    os.path.join('VC', 'Auxiliary', 'Build', 'vcvarsall.bat'))


### PR DESCRIPTION
### Summary
Changes to recipe:  **crashpad/cci.20220219**

#### Motivation
Integrating the improvement from https://github.com/chromium/mini_chromium/commit/aa56c39732fe3056cc342e59f1a5563ed6ba5e5e into the mini_chromium win_helper.py patch to fix Windows build failures.

#### Details
(Copy-paste from https://github.com/chromium/mini_chromium/commit/aa56c39732fe3056cc342e59f1a5563ed6ba5e5e):
On a system with only the Visual Studio Build Tools workload installed
(version 2022/17.13.0), but not Enterprise, Professional, or Community,
`vswhere -latest -property installationPath` was not returning anything,
resulting in this script failing with “Exception: Visual Studio
installation dir not found” during `gn gen`.

Evidently, vswhere by default only looks for
Microsoft.VisualStudio.Product.{Enterprise,Professional,Community}, but
not BuildTools. BuildTools alone (with a suitable SDK) should be
sufficient for Crashpad development. Specifying `-products *` should
allow vswhere to find the products it was previously able to locate, and
also Microsoft.VisualStudio.Product.BuildTools.



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
