### PR TITLE
pbtools: CMake 4 support

### DIFF
--- a/recipes/pbtools/all/conanfile.py
+++ b/recipes/pbtools/all/conanfile.py
@@ -1,12 +1,13 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
+from conan.tools.scm import Version
 
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class PbtoolsConan(ConanFile):
@@ -47,6 +48,9 @@ class PbtoolsConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "0.47.0": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
pbtools: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

