### PR TITLE
add extra_flags option to OpenSSL

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -89,12 +89,14 @@ class OpenSSLConan(ConanFile):
         "no_zlib": [True, False],
         "openssldir": [None, "ANY"],
         "tls_security_level": [None, 0, 1, 2, 3, 4, 5],
+        "extra_flags": [None, "ANY"],
     }
     default_options = {key: False for key in options.keys()}
     default_options["fPIC"] = True
     default_options["no_md2"] = True
     default_options["openssldir"] = None
     default_options["tls_security_level"] = None
+    default_options["extra_flags"] = None
 
     @property
     def _is_clang_cl(self):
@@ -409,6 +411,9 @@ class OpenSSLConan(ConanFile):
             if self.options.get_safe(option_name, False) and option_name not in ("shared", "fPIC", "openssldir", "tls_security_level", "capieng_dialog", "enable_capieng", "zlib", "no_fips", "no_md2"):
                 self.output.info(f"Activated option: {option_name}")
                 args.append(option_name.replace("_", "-"))
+
+        if str(self.options.extra_flags) != "None":
+            args.append(self.options.extra_flags)
         return args
 
     def generate(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **openssl/3.4.1**

#### Motivation
the recipe is missing some build flags as options, so having extra_flags enables working around that.

#### Details
looking at https://git.symas.net/symas-public/openssl/-/blob/openssl-3.4/INSTALL.md?ref_type=heads#enable-and-disable-features
some flags are missing, for example: no-http, no-scrypt, no-siphash, ...

haven't tested it locally.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
