### PR TITLE
picobench: CMake 4 support

### DIFF
--- a/recipes/picobench/all/conanfile.py
+++ b/recipes/picobench/all/conanfile.py
@@ -2,9 +2,10 @@ from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
 from conan.tools.files import copy, get, apply_conandata_patches, export_conandata_patches
 from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.1"
 
 
 class PicobenchConan(ConanFile):
@@ -46,6 +47,8 @@ class PicobenchConan(ConanFile):
         tc.variables["PICOBENCH_BUILD_TOOLS"] = self.options.with_cli
         tc.variables["PICOBENCH_BUILD_TESTS"] = False
         tc.variables["PICOBENCH_BUILD_EXAMPLES"] = False
+        if Version(self.version) < "2.06": # pylint: disable=conan-condition-evals-to-constant
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -61,12 +64,6 @@ class PicobenchConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        if self.options.with_cli:
-            # TODO: Legacy, to be removed on Conan 2.0
-            binpath = os.path.join(self.package_folder, "bin")
-            self.output.info("Appending PATH env var: {}".format(binpath))
-            self.env_info.PATH.append(binpath)
-        else:
+        if not self.options.with_cli:
             self.cpp_info.bindirs = []
-
         self.cpp_info.libdirs = []


### PR DESCRIPTION
picobench: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code


