### PR TITLE
sqlitecpp: version range for sqlite3

### DIFF
--- a/recipes/sqlitecpp/all/conanfile.py
+++ b/recipes/sqlitecpp/all/conanfile.py
@@ -43,7 +43,7 @@ class SQLiteCppConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("sqlite3/3.45.0")
+        self.requires("sqlite3/[>=3.45.0 <4]")
 
     def validate(self):
         if Version(self.version) >= "3.0.0" and self.info.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlitecpp**

#### Motivation
version 3.45.0 not available anymore in sqlite3 conandata.yml, poco also uses version range

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
