### PR TITLE
muparserx: CMake 4 support

### DIFF
--- a/recipes/muparserx/all/conanfile.py
+++ b/recipes/muparserx/all/conanfile.py
@@ -1,10 +1,11 @@
 from conan import ConanFile
+from conan.tools.build import check_max_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, replace_in_file, rmdir
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class MuparserxConan(ConanFile):
@@ -37,6 +38,11 @@ class MuparserxConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def validate(self):
+        if Version(self.version) < "4.0.12":
+            # std::binary_function used in previous versions was removed in C++17
+            check_max_cppstd(self, 14)
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
@@ -47,6 +53,8 @@ class MuparserxConan(ConanFile):
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         # Relocatable shared libs on macOS
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) <= "4.0.12":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
muparserx: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* master branch already in 3.17 https://github.com/beltoforion/muparserx/commit/c605872591d542e1630e3fcc4b292d8a0702acd2
* Extra: added validate method on old version (`4.0.8`) explicitly requiring a maximum `cppstd` version of 14 as `std::binary_function` was removed in C++17. See  https://en.cppreference.com/w/cpp/utility/functional/binary_function
See usage in upstream code: https://github.com/beltoforion/muparserx/blob/v4.0.8/parser/suSortPred.h#L47
This function is in a header file which belongs to the API
