### PR TITLE
pybind11: CMake 4 support

### DIFF
--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.scm import Version
 import os
 
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.1"
 
 
 class PyBind11Conan(ConanFile):
@@ -34,6 +34,8 @@ class PyBind11Conan(ConanFile):
         tc.variables["PYBIND11_INSTALL"] = True
         tc.variables["PYBIND11_TEST"] = False
         tc.variables["PYBIND11_CMAKECONFIG_INSTALL_DIR"] = "lib/cmake/pybind11"
+        if Version(self.version) < "2.11.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -64,13 +66,10 @@ class PyBind11Conan(ConanFile):
         self.cpp_info.components["headers"].includedirs = ["include"]
         self.cpp_info.components["pybind11_"].set_property("cmake_target_name", "pybind11::pybind11")
         self.cpp_info.components["pybind11_"].set_property("cmake_module_file_name", "pybind11")
-        self.cpp_info.components["pybind11_"].names["cmake_find_package"] = "pybind11"
         self.cpp_info.components["pybind11_"].builddirs = [cmake_base_path]
         self.cpp_info.components["pybind11_"].requires = ["headers"]
         cmake_file = os.path.join(cmake_base_path, "pybind11Common.cmake")
         self.cpp_info.set_property("cmake_build_modules", [cmake_file])
-        for generator in ["cmake_find_package", "cmake_find_package_multi"]:
-            self.cpp_info.components["pybind11_"].build_modules[generator].append(cmake_file)
         self.cpp_info.components["embed"].requires = ["pybind11_"]
         self.cpp_info.components["module"].requires = ["pybind11_"]
         self.cpp_info.components["python_link_helper"].requires = ["pybind11_"]


### PR DESCRIPTION

pybind11: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code

