### PR TITLE
wasmtime: add version 31.0.0

### DIFF
--- a/recipes/wasmtime/all/conandata.yml
+++ b/recipes/wasmtime/all/conandata.yml
@@ -1,4 +1,34 @@
 sources:
+  "31.0.0":
+    Windows:
+      "x86_64":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-x86_64-windows-c-api.zip"
+        sha256: "5ac853c5405d859a03a95722195691c397bac8d23a9c7481238453cb8bcb0b0b"
+    MinGW:
+      "x86_64":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-x86_64-mingw-c-api.zip"
+        sha256: "a2b3c4999e911234ff56679058a66c5932a9520bcce45a2ed0bad3240dfea558"
+    Linux:
+      "x86_64":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-x86_64-linux-c-api.tar.xz"
+        sha256: "0e505e7bf4d0172d3bcee9acbc8da1cc3ae93ade98b190541eaf48e35e9f7bcd"
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-aarch64-linux-c-api.tar.xz"
+        sha256: "5d4ee3d1672ecbda498f7850accda26e3dfd7df5dbba4a8575b68e8432e3118d"
+      "s390x":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-s390x-linux-c-api.tar.xz"
+        sha256: "910948923ceb857312b03161aa603f0cdf9ba1786c8f067f29478b46a9d349ce"
+    Macos:
+      "x86_64":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-x86_64-macos-c-api.tar.xz"
+        sha256: "6a97eaa09e23f24bac9746eeaf63a3abff515e1a14e950d907a34dd94ccb1905"
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-aarch64-macos-c-api.tar.xz"
+        sha256: "9a6e65cfb1b3a6827c0692ff1b53ecde91175205016e76b925f56dc178d7a1ea"
+    Android:
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-aarch64-linux-c-api.tar.xz"
+        sha256: "5d4ee3d1672ecbda498f7850accda26e3dfd7df5dbba4a8575b68e8432e3118d"
   "21.0.0":
     Windows:
       "x86_64":

--- a/recipes/wasmtime/all/conanfile.py
+++ b/recipes/wasmtime/all/conanfile.py
@@ -75,7 +75,6 @@ class WasmtimeConan(ConanFile):
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
-    def validate_build(self):
         if Version(self.version) >= "31.0.0" and self._is_glibc_older_than_2_25:
             raise ConanInvalidConfiguration(f"{self.ref} requires glibc 2.25 or later.")
 

--- a/recipes/wasmtime/all/conanfile.py
+++ b/recipes/wasmtime/all/conanfile.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
@@ -49,11 +48,6 @@ class WasmtimeConan(ConanFile):
             return "MinGW"
         return str(self.settings.os)
 
-    @property
-    def _is_glibc_older_than_2_25(self):
-        libver = platform.libc_ver()
-        return self.settings.os == 'Linux' and libver[0] == 'glibc' and Version(libver[1]) < "2.25"
-
     def configure(self):
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
@@ -74,10 +68,6 @@ class WasmtimeConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
-
-    def validate_build(self):
-        if Version(self.version) >= "31.0.0" and self._is_glibc_older_than_2_25:
-            raise ConanInvalidConfiguration(f"{self.ref} requires glibc 2.25 or later.")
 
     def build(self):
         # This is packaging binaries so the download needs to be in build

--- a/recipes/wasmtime/all/conanfile.py
+++ b/recipes/wasmtime/all/conanfile.py
@@ -75,6 +75,7 @@ class WasmtimeConan(ConanFile):
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
+    def validate_build(self):
         if Version(self.version) >= "31.0.0" and self._is_glibc_older_than_2_25:
             raise ConanInvalidConfiguration(f"{self.ref} requires glibc 2.25 or later.")
 

--- a/recipes/wasmtime/config.yml
+++ b/recipes/wasmtime/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "31.0.0":
+    folder: all
   "21.0.0":
     folder: all
   "20.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **wasmtime/31.0.0**

#### Motivation
There are lots of releases since 21.0.0.

#### Details
https://github.com/bytecodealliance/wasmtime/releases/tag/v31.0.0
https://github.com/bytecodealliance/wasmtime/compare/v21.0.0...v31.0.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
