### PR TITLE
#27092 libpqxx: cmake build requirement added

### DIFF
--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -65,6 +65,9 @@ class LibpqxxConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.0.0 <3.30]")
+
     def requirements(self):
         self.requires("libpq/15.4")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpqxx/***

#### Motivation
#27092 

#### Details
This adds cmake as a build requirement. Keeping the version below 3.30 is necessary since it otherwise does not build, failing on 
`Unknown CMake command "cmake_determine_compile_features"`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
