### PR TITLE
cpputest: CMake 4 support

### DIFF
--- a/recipes/cpputest/all/conanfile.py
+++ b/recipes/cpputest/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 import os
 import textwrap
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.1"
 
 
 class CppUTestConan(ConanFile):
@@ -56,6 +56,7 @@ class CppUTestConan(ConanFile):
         tc.variables["LONGLONG"] = True
         tc.variables["COVERAGE"] = False
         tc.variables["TESTS"] = False
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpputest/[4.0]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
CMake 4 has broken my pipeline on GitHub

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
For compatibility

conanfile.py: def generate():
`tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

conan source . --version=4.0
conan install . --build=missing --version=4.0
conan build . --version=4.0
conan export-pkg . --version=4.0