### PR TITLE
arcticdb-sparrow: add version 0.6.0

### DIFF
--- a/recipes/sparrow/all/conandata.yml
+++ b/recipes/sparrow/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.0":
+    url: "https://github.com/man-group/sparrow/archive/refs/tags/0.6.0.tar.gz"
+    sha256: "586C34C0F46CA878A735DB0D2F3E7C6CE78390A65EB42F028BFE5D34DBEEB7B6"
   "0.5.0":
     url: "https://github.com/man-group/sparrow/archive/refs/tags/0.5.0.tar.gz"
     sha256: "EFEB7258B3B1F7A25CE72CF3F86C6DE98D2AB4F1A6A89CECC1D6D822E98B3AF1"

--- a/recipes/sparrow/all/conanfile.py
+++ b/recipes/sparrow/all/conanfile.py
@@ -26,11 +26,7 @@ class SparrowRecipe(ConanFile):
         "use_date_polyfill": [True, False],
     }
 
-    default_options = {
-        "shared": False,
-        "fPIC": True,
-        "use_date_polyfill": True
-    }
+    default_options = {"shared": False, "fPIC": True, "use_date_polyfill": True}
 
     implements = ["auto_shared_fpic"]
 
@@ -57,8 +53,8 @@ class SparrowRecipe(ConanFile):
         return {
             "apple-clang": "16",
             "clang": "18",
-            "gcc": "12",
-            "msvc": "194"
+            "gcc": "11" if Version(self.version) >= "0.6.0" else "13",
+            "msvc": "194",
         }
 
     def validate(self):

--- a/recipes/sparrow/all/conanfile.py
+++ b/recipes/sparrow/all/conanfile.py
@@ -26,7 +26,11 @@ class SparrowRecipe(ConanFile):
         "use_date_polyfill": [True, False],
     }
 
-    default_options = {"shared": False, "fPIC": True, "use_date_polyfill": True}
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "use_date_polyfill": True
+    }
 
     implements = ["auto_shared_fpic"]
 

--- a/recipes/sparrow/all/conanfile.py
+++ b/recipes/sparrow/all/conanfile.py
@@ -70,6 +70,9 @@ class SparrowRecipe(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.28 <4]")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/sparrow/config.yml
+++ b/recipes/sparrow/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.6.0":
+    folder: "all"
   "0.5.0":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **arcticdb-sparrow/0.6.0**

#### Motivation
Add version 0.6.0

#### Details
Add version 0.6.0, this version is compatible with GCC 11 which was not the case with the version 0.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
