### PR TITLE
roaring: CMake 4 support

### DIFF
--- a/recipes/roaring/all/conanfile.py
+++ b/recipes/roaring/all/conanfile.py
@@ -77,6 +77,8 @@ class RoaringConan(ConanFile):
         tc.variables["ENABLE_ROARING_TESTS"] = False
         # Relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) < "3.0.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):


### PR DESCRIPTION


roaring: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0


