### PR TITLE
seasocks: CMake 4 support

### DIFF
--- a/recipes/seasocks/all/conanfile.py
+++ b/recipes/seasocks/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 class SeasocksConan(ConanFile):
     name = "seasocks"
@@ -15,6 +15,7 @@ class SeasocksConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/mattgodbolt/seasocks"
     topics = ("embeddable", "webserver", "websockets")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -86,6 +87,8 @@ class SeasocksConan(ConanFile):
         tc.variables["SEASOCKS_SHARED"] = self.options.shared
         tc.variables["SEASOCKS_EXAMPLE_APP"] = False
         tc.variables["UNITTESTS"] = False
+        if Version(self.version) < "1.4.6":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -114,11 +117,6 @@ class SeasocksConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libseasocks"].system_libs.extend(["pthread", "m"])
 
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.names["cmake_find_package"] = "Seasocks"
-        self.cpp_info.names["cmake_find_package_multi"] = "Seasocks"
-        self.cpp_info.components["libseasocks"].names["cmake_find_package"] = "seasocks"
-        self.cpp_info.components["libseasocks"].names["cmake_find_package_multi"] = "seasocks"
         self.cpp_info.components["libseasocks"].set_property("cmake_target_name", "Seasocks::seasocks")
         if self.options.with_zlib:
             self.cpp_info.components["libseasocks"].requires = ["zlib::zlib"]


### PR DESCRIPTION


seasocks: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code
* Added `library` as `package_type`. This recipe does not package any executable

