### PR TITLE
serial: CMake 4 support

### DIFF
--- a/recipes/serial/all/conanfile.py
+++ b/recipes/serial/all/conanfile.py
@@ -1,11 +1,13 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
+from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class ConanRecipe(ConanFile):
@@ -49,6 +51,9 @@ class ConanRecipe(ConanFile):
         tc = CMakeToolchain(self)
         # Relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.2.1": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
serial: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

Even though CCI has a custom `CMakeLists.txt` with a greater `cmake_minimum_required` than needed for CMake 4.
That `CMakeLists.txt` is calling [upstream `CMakeLists.txt`](https://github.com/wjwwood/serial/blob/main/CMakeLists.txt#L1) which is still in 2.8 and have not been updated for 6 years 