### PR TITLE
snappy: CMake 4 support

### DIFF
--- a/recipes/snappy/all/conanfile.py
+++ b/recipes/snappy/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class SnappyConan(ConanFile):
@@ -72,6 +72,8 @@ class SnappyConan(ConanFile):
                 tc.variables["SNAPPY_HAVE_BMI2"] = self.options.with_bmi2
             if self.options.with_ssse3 != "auto":
                 tc.variables["SNAPPY_HAVE_SSSE3"] = self.options.with_ssse3
+        if Version(self.version) < "1.2.2": # pylint: disable=conan-condition-evals-to-constant
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -98,9 +100,4 @@ class SnappyConan(ConanFile):
             if libcxx:
                 self.cpp_info.components["snappylib"].system_libs.append(libcxx)
 
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.names["cmake_find_package"] = "Snappy"
-        self.cpp_info.names["cmake_find_package_multi"] = "Snappy"
-        self.cpp_info.components["snappylib"].names["cmake_find_package"] = "snappy"
-        self.cpp_info.components["snappylib"].names["cmake_find_package_multi"] = "snappy"
         self.cpp_info.components["snappylib"].set_property("cmake_target_name", "Snappy::snappy")


### PR DESCRIPTION


snappy: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code

