### PR TITLE
tcsbank-uri-template: CMake 4 support

### DIFF
--- a/recipes/tcsbank-uri-template/all/conanfile.py
+++ b/recipes/tcsbank-uri-template/all/conanfile.py
@@ -4,10 +4,10 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import collect_libs, copy, export_conandata_patches, get, rmdir
+from conan.tools.files import collect_libs, copy, get, rmdir
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class TCSBankUriTemplateConan(ConanFile):
@@ -28,9 +28,6 @@ class TCSBankUriTemplateConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-
-    def export_sources(self):
-        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -82,6 +79,7 @@ class TCSBankUriTemplateConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["URITEMPLATE_BUILD_TESTING"] = False
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -101,7 +99,3 @@ class TCSBankUriTemplateConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "uri-template::uri-template")
         self.cpp_info.set_property("pkg_config_name", "uri-template")
         self.cpp_info.libs = collect_libs(self)
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.names["cmake_find_package"] = "uri-template"
-        self.cpp_info.names["cmake_find_package_multi"] = "uri-template"


### PR DESCRIPTION


tcsbank-uri-template: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code

Archive project https://github.com/Tinkoff/uri-template
