### PR TITLE
tiny-aes-c: CMake 4 support

### DIFF
--- a/recipes/tiny-aes-c/all/conanfile.py
+++ b/recipes/tiny-aes-c/all/conanfile.py
@@ -2,9 +2,10 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.1"
 
 
 class TinyAesCConan(ConanFile):
@@ -14,7 +15,7 @@ class TinyAesCConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     description = "Small portable AES128/192/256 in C"
     topics = ("encryption", "crypto", "AES")
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -87,6 +88,8 @@ class TinyAesCConan(ConanFile):
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         # Relocatable shared lib on macOS
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) <= "1.0.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
tiny-aes-c: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Added missing `package_type = "library"`. This recipe only packages a library and no binary

Upstream `master` branch already supports CMake 4, but no release has been published since 2019

I've created an issue requesting a new release here https://github.com/kokke/tiny-AES-c/issues/238

It is expected that if a new release is published, it will have `master` changes. This explains the conditional statement.

