### PR TITLE
tinyspline: CMake 4 support

### DIFF
--- a/recipes/tinyspline/all/conanfile.py
+++ b/recipes/tinyspline/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.scm import Version
 import os
 import textwrap
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 class TinysplineConan(ConanFile):
     name = "tinyspline"
@@ -17,7 +17,7 @@ class TinysplineConan(ConanFile):
     topics = ("tinyspline ", "nurbs", "b-splines", "bezier")
     homepage = "https://github.com/msteinbeck/tinyspline"
     url = "https://github.com/conan-io/conan-center-index"
-
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -162,9 +162,3 @@ class TinysplineConan(ConanFile):
             # Workaround to always provide a global target or pkg-config file with all components
             self.cpp_info.set_property("cmake_target_name", "tinyspline-do-not-use")
             self.cpp_info.set_property("pkg_config_name", "tinyspline-do-not-use")
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.components["libtinyspline"].names["cmake_find_package"] = "tinyspline"
-        if self.options.cxx:
-            self.cpp_info.components["libtinysplinecxx"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-            self.cpp_info.components["libtinysplinecxx"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/tinyspline/all/test_package/conanfile.py
+++ b/recipes/tinyspline/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
 
@@ -25,12 +25,10 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
-            bin_c_path = os.path.join(self.cpp.build.bindirs[0], "test_package_c")
-            self.run(bin_c_path, run_environment=True)
+        if can_run(self):
+            bin_c_path = os.path.join(self.cpp.build.bindir, "test_package_c")
+            self.run(bin_c_path, env="conanrun")
 
-            # TODO: rely on self.dependencies["tinyspline"].options.cxx in CONAN_V2 mode
-            # see https://github.com/conan-io/conan/issues/11940#issuecomment-1223940786
-            bin_cpp_path = os.path.join(self.cpp.build.bindirs[0], "test_package_cpp")
-            if os.path.exists(bin_cpp_path):
-                self.run(bin_cpp_path, run_environment=True)
+            if self.dependencies["tinyspline"].options.cxx:
+                bin_cpp_path = os.path.join(self.cpp.build.bindir, "test_package_cpp")
+                self.run(bin_cpp_path, env="conanrun")


### PR DESCRIPTION
tinyspline: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code
* Added missing `package_type = "library"`. This recipe only packages a library and no binary
* Fix `test_package/conanfile.py` which was not ported to conan v2 yet (tested locally)

```
======== Testing the package: Executing test ========
tinyspline/0.3.0 (test package): Running test()
tinyspline/0.3.0 (test package): RUN: ./test_package_c

tinyspline/0.3.0 (test package): RUN: ./test_package_cpp
```
