### PR TITLE
tmxlite: CMake 4 support

### DIFF
--- a/recipes/tmxlite/all/conanfile.py
+++ b/recipes/tmxlite/all/conanfile.py
@@ -1,12 +1,12 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class TmxliteConan(ConanFile):
@@ -66,6 +66,9 @@ class TmxliteConan(ConanFile):
         tc.variables["USE_RTTI"] = True
         if Version(self.version) >= "1.4.1":
             tc.variables["USE_EXTLIBS"] = True
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.4.4": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
         deps = CMakeDeps(self)
         if Version(self.version) >= "1.4.1":


### PR DESCRIPTION
tmxlite: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

~Depends on https://github.com/conan-io/conan-center-index/pull/27115 if compiling with CMake 4~