### PR TITLE
uncrustify: CMake 4 support

### DIFF
--- a/recipes/uncrustify/all/conanfile.py
+++ b/recipes/uncrustify/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=2.1"
 
 
 class UncrustifyConan(ConanFile):
@@ -36,6 +36,8 @@ class UncrustifyConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["NoGitVersionString"] = True
         tc.variables["BUILD_TESTING"] = False
+        if Version(self.version) < "0.78.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -65,6 +67,3 @@ class UncrustifyConan(ConanFile):
     def package_info(self):
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
-
-        # TODO: to remove in conan v2
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
uncrustify: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code

