### PR TITLE
utf8proc: CMake 4 support

### DIFF
--- a/recipes/utf8proc/all/conanfile.py
+++ b/recipes/utf8proc/all/conanfile.py
@@ -2,9 +2,10 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class Utf8ProcConan(ConanFile):
@@ -44,6 +45,8 @@ class Utf8ProcConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) < "2.10.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
utf8proc: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0