### PR TITLE
xlsxio: CMake 4 support

### DIFF
--- a/recipes/xlsxio/all/conanfile.py
+++ b/recipes/xlsxio/all/conanfile.py
@@ -1,11 +1,11 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class XlsxioConan(ConanFile):
@@ -82,6 +82,9 @@ class XlsxioConan(ConanFile):
         tc.variables["WITH_WIDE"] = self.options.with_wide
         # Relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "0.2.34": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
         tc = CMakeDeps(self)
@@ -140,15 +143,3 @@ class XlsxioConan(ConanFile):
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["xlsxio_readw"].system_libs.append("pthread")
             self.cpp_info.components["xlsxio_readw"].defines.append(xlsxio_macro)
-
-        # TODO: to remove in conan v2
-        self.cpp_info.names["cmake_find_package"] = "xlsxio"
-        self.cpp_info.names["cmake_find_package_multi"] = "xlsxio"
-        self.cpp_info.components["xlsxio_read"].names["cmake_find_package"] = "xlsxio_read"
-        self.cpp_info.components["xlsxio_read"].names["cmake_find_package_multi"] = "xlsxio_read"
-        self.cpp_info.components["xlsxio_write"].names["cmake_find_package"] = "xlsxio_write"
-        self.cpp_info.components["xlsxio_write"].names["cmake_find_package_multi"] = "xlsxio_write"
-        if self.options.with_wide:
-            self.cpp_info.components["xlsxio_readw"].names["cmake_find_package"] = "xlsxio_readw"
-            self.cpp_info.components["xlsxio_readw"].names["cmake_find_package_multi"] = "xlsxio_readw"
-


### PR DESCRIPTION
xlsxio: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code

