### PR TITLE
qt5: bump md4c version

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -464,7 +464,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_atspi"):
             self.requires("at-spi2-core/2.51.0")
         if self.options.get_safe("with_md4c", False):
-            self.requires("md4c/0.4.8")
+            self.requires("md4c/0.5.2")
 
     def package_id(self):
         del self.info.options.cross_compile


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/5.x.x**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Building for iOS fails without manual version override

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
md4c can be built for iOS starting with v0.5

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
