### PR TITLE
xxhash: CMake 4 support

### DIFF
--- a/recipes/xxhash/all/conanfile.py
+++ b/recipes/xxhash/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -53,6 +54,8 @@ class XxHashConan(ConanFile):
         tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
         # Generate a relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) < "0.8.3":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -75,13 +78,4 @@ class XxHashConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "libxxhash")
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["libxxhash"].libs = ["xxhash"]
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.names["cmake_find_package"] = "xxHash"
-        self.cpp_info.names["cmake_find_package_multi"] = "xxHash"
-        self.cpp_info.names["pkg_config"] = "libxxhash"
-        self.cpp_info.components["libxxhash"].names["cmake_find_package"] = "xxhash"
-        self.cpp_info.components["libxxhash"].names["cmake_find_package_multi"] = "xxhash"
         self.cpp_info.components["libxxhash"].set_property("cmake_target_name", "xxHash::xxhash")
-        if self.options.utility:
-            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
xxhash: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code
