### PR TITLE
zopfli: CMake 4 support

### DIFF
--- a/recipes/zopfli/all/conanfile.py
+++ b/recipes/zopfli/all/conanfile.py
@@ -1,10 +1,11 @@
-from conan import ConanFile, conan_version
+from conan import ConanFile
+from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class ZopfliConan(ConanFile):
@@ -50,6 +51,9 @@ class ZopfliConan(ConanFile):
         tc.variables["CMAKE_MACOSX_BUNDLE"] = False
         # Generate a relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        if Version(self.version) > "1.0.3": # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 
     def build(self):
@@ -75,8 +79,3 @@ class ZopfliConan(ConanFile):
         self.cpp_info.components["libzopflipng"].set_property("cmake_target_name", "Zopfli::libzopflipng")
         self.cpp_info.components["libzopflipng"].libs = ["zopflipng"]
         self.cpp_info.components["libzopflipng"].requires = ["libzopfli"]
-
-        if Version(conan_version).major < 2:
-            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
-            self.cpp_info.names["cmake_find_package"] = "Zopfli"
-            self.cpp_info.names["cmake_find_package_multi"] = "Zopfli"


### PR DESCRIPTION
zopfli: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code

