### PR TITLE
norm: CMake 4 support

### DIFF
--- a/recipes/norm/all/conandata.yml
+++ b/recipes/norm/all/conandata.yml
@@ -9,3 +9,6 @@ patches:
     - patch_file: "patches/0003-cpp20-compat.patch"
       patch_description: "C++20 compatibility: Fix ambiguous overloaded operator =="
       patch_type: "portability"
+    - patch_file: "patches/0004-cmake4-support.patch"
+      patch_description: "Increase cmake_minimum_required on protolib submodule to 3.5, minimum version supporting CMake 4"
+      patch_type: "portability"

--- a/recipes/norm/all/conanfile.py
+++ b/recipes/norm/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class NormConan(ConanFile):

--- a/recipes/norm/all/patches/0004-cmake4-support.patch
+++ b/recipes/norm/all/patches/0004-cmake4-support.patch
@@ -1,0 +1,8 @@
+--- a/protolib/CMakeLists.txt
++++ b/protolib/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+ cmake_policy(SET CMP0077 NEW)
+ 
+ # set the project name


### PR DESCRIPTION
norm: fixes to support CMake 4

Created a new patch file which increases `cmake_minimum_required` on `protolib/CMakeLists.txt` submodule to 3.5, minimum version supporting CMake 4

There is only one version in CCI, so updating `required_conan_version` will no compile more versions than needed `1.5.9`