### PR TITLE
mfast: CMake 4 support

### DIFF
--- a/recipes/mfast/all/patches/0001-fix-cmake-1.2.2.patch
+++ b/recipes/mfast/all/patches/0001-fix-cmake-1.2.2.patch
@@ -1,5 +1,14 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -16,7 +16,7 @@ if(NOT CMAKE_BUILD_TYPE)
+ endif(NOT CMAKE_BUILD_TYPE)
+ 
+ if(POLICY CMP0054)
+-    cmake_policy(SET CMP0054 OLD)
++    # cmake_policy(SET CMP0054 OLD)
+ endif()
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 @@ -60,9 +60,11 @@ if(BUILD_PACKAGES)
  
  endif(BUILD_PACKAGES)


### PR DESCRIPTION
mfast: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0
* Removed conan v1 specific code

Updated patch `0001-fix-cmake-1.2.2.patch` removing the `CMP0054` OLD policy behavior, which is not compatible with CMake 4.
The previous version, `1.2.1`, does not need this patch.

Upstream `master` branch already supports CMake 4 https://github.com/objectcomputing/mFAST/blob/master/CMakeLists.txt#L5 

TODO: check `std::unary_function` issue with macos compiler. 
apple-clang, compiling `1.2.1` with `gnu17` fails:
```
error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
```
This is an expected behavior as `std::binary_function` is not included in STL since `std17` (https://en.cppreference.com/w/cpp/utility/functional/unary_function)

But `gcc13` does not complain. Consider adding a `check_max_cppstd(self, 14)` 