### PR TITLE
antlr4-cppruntime: Upgrade to 4.13.2 and Fix the compiler errors reported by MSVC 19.43.34808

### DIFF
--- a/recipes/antlr4-cppruntime/all/conandata.yml
+++ b/recipes/antlr4-cppruntime/all/conandata.yml
@@ -21,6 +21,26 @@ sources:
     url: "https://github.com/antlr/antlr4/archive/refs/tags/4.9.3.tar.gz"
     sha256: "efe4057d75ab48145d4683100fec7f77d7f87fa258707330cadd1f8e6f7eecae"
 patches:
+  "4.13.2":
+    - patch_file: "patches/0005-update-IncludeChronoForMSVC.patch"
+      patch_description: "Fix the compiler errors reported by Visual Studio 2022 17.13 (MSVC 19.43.34808)."
+      patch_type: "portability"
+      patch_source: "https://github.com/antlr/antlr4/pull/4738"
+  "4.13.1":
+    - patch_file: "patches/0005-update-IncludeChronoForMSVC.patch"
+      patch_description: "Fix the compiler errors reported by Visual Studio 2022 17.13 (MSVC 19.43.34808)."
+      patch_type: "portability"
+      patch_source: "https://github.com/antlr/antlr4/pull/4738"
+  "4.13.0":
+    - patch_file: "patches/0005-update-IncludeChronoForMSVC.patch"
+      patch_description: "Fix the compiler errors reported by Visual Studio 2022 17.13 (MSVC 19.43.34808)."
+      patch_type: "portability"
+      patch_source: "https://github.com/antlr/antlr4/pull/4738"
+  "4.12.0":
+    - patch_file: "patches/0005-update-IncludeChronoForMSVC.patch"
+      patch_description: "Fix the compiler errors reported by Visual Studio 2022 17.13 (MSVC 19.43.34808)."
+      patch_type: "portability"
+      patch_source: "https://github.com/antlr/antlr4/pull/4738"
   "4.11.1":
     - patch_file: "patches/0002-update-FlatHashSet.patch"
       patch_description: "Fix the compiler errors reported by GCC 7 due to the new type FlatHashSet introduced in 4.11."
@@ -30,6 +50,10 @@ patches:
       patch_description: "Fix the compiler errors reported by GCC 7 due to the new type FlatHashMap introduced in 4.11."
       patch_type: "portability"
       patch_source: "https://github.com/antlr/antlr4/pull/3885"
+    - patch_file: "patches/0005-update-IncludeChronoForMSVC.patch"
+      patch_description: "Fix the compiler errors reported by Visual Studio 2022 17.13 (MSVC 19.43.34808)."
+      patch_type: "portability"
+      patch_source: "https://github.com/antlr/antlr4/pull/4738"
   "4.10.1":
     - patch_file: "patches/0004-update-DropLibuuid-4.10.x-1.patch"
       patch_description: "Revise the CMakeLists.txt to remove the dependency on libuuid (#1) which is not used since 4.9."
@@ -39,6 +63,10 @@ patches:
       patch_description: "Revise the CMakeLists.txt to remove the dependency on libuuid (#2) which is not used since 4.9."
       patch_type: "backport"
       patch_source: "https://github.com/antlr/antlr4/pull/3787"
+    - patch_file: "patches/0005-update-IncludeChronoForMSVC.patch"
+      patch_description: "Fix the compiler errors reported by Visual Studio 2022 17.13 (MSVC 19.43.34808)."
+      patch_type: "portability"
+      patch_source: "https://github.com/antlr/antlr4/pull/4738"
   "4.9.3":
     - patch_file: "patches/0001-update-cmakelist.patch"
     - patch_file: "patches/0004-update-DropLibuuid-4.9.3-1.patch"
@@ -49,3 +77,7 @@ patches:
       patch_description: "Revise the CMakeLists.txt to remove the dependency on libuuid (#2) which is not used since 4.9."
       patch_type: "backport"
       patch_source: "https://github.com/antlr/antlr4/pull/3787"
+    - patch_file: "patches/0005-update-IncludeChronoForMSVC.patch"
+      patch_description: "Fix the compiler errors reported by Visual Studio 2022 17.13 (MSVC 19.43.34808)."
+      patch_type: "portability"
+      patch_source: "https://github.com/antlr/antlr4/pull/4738"

--- a/recipes/antlr4-cppruntime/all/conandata.yml
+++ b/recipes/antlr4-cppruntime/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.13.2":
+    url: "https://github.com/antlr/antlr4/archive/refs/tags/4.13.2.tar.gz"
+    sha256: "9f18272a9b32b622835a3365f850dd1063d60f5045fb1e12ce475ae6e18a35bb"
   "4.13.1":
     url: "https://github.com/antlr/antlr4/archive/refs/tags/4.13.1.tar.gz"
     sha256: "da20d487524d7f0a8b13f73a8dc326de7fc2e5775f5a49693c0a4e59c6b1410c"

--- a/recipes/antlr4-cppruntime/all/patches/0005-update-IncludeChronoForMSVC.patch
+++ b/recipes/antlr4-cppruntime/all/patches/0005-update-IncludeChronoForMSVC.patch
@@ -1,0 +1,10 @@
+--- runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
++++ runtime/Cpp/runtime/src/atn/ProfilingATNSimulator.cpp
+@@ -10,6 +10,7 @@
+ #include "support/CPPUtils.h"
+ 
+ #include "atn/ProfilingATNSimulator.h"
++#include <chrono>
+ 
+ using namespace antlr4;
+ using namespace antlr4::atn;

--- a/recipes/antlr4-cppruntime/config.yml
+++ b/recipes/antlr4-cppruntime/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.13.2":
+    folder: all
   "4.13.1":
     folder: all
   "4.13.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **antlr4-cppruntime/4.13.2**

#### Motivation
- Upgrade to the runtime library to 4.13.2.
- Fix the compiler errors reported by Visual Studio 2022 v17.13 (MSVC 19.43.34808).
   - This is done by providing a patch, which applies to 4.9.3, 4.10.x, 4.11.x, 4.12.x and 4.13.x.

#### Details
Related PR: https://github.com/antlr/antlr4/pull/4738
Related Issue: https://github.com/antlr/antlr4/issues/4784

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
