### PR TITLE
libcap: add version 2.75

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.75":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.75.tar.xz"
+    sha256: "de4e7e064c9ba451d5234dd46e897d7c71c96a9ebf9a0c445bc04f4742d83632"
   "2.73":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.73.tar.xz"
     sha256: "6405f6089cf4cdd8c271540cd990654d78dd0b1989b2d9bda20f933a75a795a5"
@@ -39,6 +42,13 @@ sources:
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.45.tar.xz"
     sha256: "d66639f765c0e10557666b00f519caf0bd07a95f867dddaee131cd284fac3286"
 patches:
+  "2.75":
+    - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
+      patch_description: "allow to configure fPIC option from conan recipe"
+      patch_type: "conan"
+    - patch_file: "patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch"
+      patch_description: "allow to override compiler via environment variables"
+      patch_type: "conan"
   "2.73":
     - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
       patch_description: "allow to configure fPIC option from conan recipe"


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcap/2,75**

#### Motivation
A new version of libcap is available. Full diff between 2.73 and 2.75: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/diff/?id=libcap-2.75&id2=libcap-2.73

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
