### PR TITLE
lua: CMake 4 support

### DIFF
--- a/recipes/lua/all/CMakeLists.txt
+++ b/recipes/lua/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(lua)
 
 # The following was originally taken from: https://raw.githubusercontent.com/microsoft/vcpkg/master/ports/lua/CMakeLists.txt

--- a/recipes/lua/all/CMakeLists.txt
+++ b/recipes/lua/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(lua)
 
 # The following was originally taken from: https://raw.githubusercontent.com/microsoft/vcpkg/master/ports/lua/CMakeLists.txt

--- a/recipes/lua/all/conanfile.py
+++ b/recipes/lua/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import get, copy, load, save, export_conandata_patches, a
 from conan.tools.apple import fix_apple_shared_install_name
 
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class LuaConan(ConanFile):


### PR DESCRIPTION
lua: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

