### PR TITLE
[libmount] Add option to disable year2038 support.

### DIFF
--- a/recipes/libmount/all/conanfile.py
+++ b/recipes/libmount/all/conanfile.py
@@ -24,10 +24,12 @@ class LibmountConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "year2038": [ True, False ],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "year2038": True,
     }
 
     def configure(self):
@@ -53,6 +55,10 @@ class LibmountConan(ConanFile):
             "--enable-libmount",
             "--enable-libblkid",
         ])
+        if not self.options.year2038:
+            tc.configure_args.extend([
+                "--disable-year2038",
+            ])
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libmount/2.40.2**

#### Motivation
In order to cross-compile libmount with an (old) ArmV5 toolchain I needed to configure libmount with the `--disable-year2038` option.

#### Details
On legacy platforms sometimes the only way to get libmount compiled is to disable year2038 support.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
