### PR TITLE
Libcurl: libidn fixes

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -129,12 +129,8 @@ class LibcurlConan(ConanFile):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"
 
     @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
-    @property
     def _is_win_x_android(self):
-        return self.settings.os == "Android" and self._settings_build.os == "Windows"
+        return self.settings.os == "Android" and self.settings_build.os == "Windows"
 
     @property
     def _is_using_cmake_build(self):
@@ -192,6 +188,9 @@ class LibcurlConan(ConanFile):
             self.requires("c-ares/[>=1.27 <2]")
         if self.options.get_safe("with_libpsl"):
             self.requires("libpsl/0.21.1")
+        if self.options.with_libidn:
+            self.requires("libidn2/2.3.0")
+
 
     def validate(self):
         if self.options.with_ssl == "schannel" and self.settings.os != "Windows":
@@ -208,14 +207,14 @@ class LibcurlConan(ConanFile):
     def build_requirements(self):
         if self._is_using_cmake_build:
             if self._is_win_x_android:
-                self.tool_requires("ninja/1.11.1")
+                self.tool_requires("ninja/[>=1.10.2 <2]")
         else:
             self.tool_requires("libtool/2.4.7")
             if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-                self.tool_requires("pkgconf/2.1.0")
+                self.tool_requires("pkgconf/[>=2.2 <3]")
             if self.settings.os in [ "tvOS", "watchOS" ]:
                 self.tool_requires("gnu-config/cci.20210814")
-            if self._settings_build.os == "Windows":
+            if self.settings_build.os == "Windows":
                 self.win_bash = True
                 if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                     self.tool_requires("msys2/cci.latest")
@@ -556,6 +555,12 @@ class LibcurlConan(ConanFile):
             else:
                 tc.configure_args.append("--disable-websockets")
 
+        if self.options.with_libidn:
+            path = unix_path(self, self.dependencies["libidn2"].package_folder)
+            tc.configure_args.append(f"--with-libidn2={path}")
+        else:
+            tc.configure_args.append("--without-libidn2")
+
         # Cross building flags
         if cross_building(self):
             if self.settings.os == "Linux" and "arm" in self.settings.arch:
@@ -620,6 +625,7 @@ class LibcurlConan(ConanFile):
         tc.variables["ENABLE_UNICODE"] = True
         tc.variables["BUILD_TESTING"] = False
         tc.variables["BUILD_CURL_EXE"] = False
+        tc.cache_variables["ENABLE_CURL_MANUAL"] = False
         tc.variables["CURL_DISABLE_LDAP"] = not self.options.with_ldap
         tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
         tc.variables["CURL_STATICLIB"] = not self.options.shared
@@ -680,6 +686,10 @@ class LibcurlConan(ConanFile):
         deps = CMakeDeps(self)
         deps.set_property("wolfssl", "cmake_additional_variables_prefixes", ["WolfSSL", "WOLFSSL"])
         deps.set_property("wolfssl", "cmake_file_name", "WolfSSL")
+
+        if self.options.with_libidn:
+            deps.set_property("libidn2", "cmake_file_name", "Libidn2")
+            deps.set_property("libidn2", "cmake_additional_variables_prefixes", ["LIBIDN2"])
         deps.generate()
 
     def package(self):
@@ -714,8 +724,6 @@ class LibcurlConan(ConanFile):
         else:
             self.cpp_info.components["curl"].libs = ["curl"]
             if self.settings.os in ["Linux", "FreeBSD"]:
-                if self.options.with_libidn:
-                    self.cpp_info.components["curl"].libs.append("idn")
                 if self.options.with_librtmp:
                     self.cpp_info.components["curl"].libs.append("rtmp")
 
@@ -723,7 +731,7 @@ class LibcurlConan(ConanFile):
             self.cpp_info.components["curl"].system_libs = ["rt", "pthread"]
         elif self.settings.os == "Windows":
             # used on Windows for VS build, native and cross mingw build
-            self.cpp_info.components["curl"].system_libs = ["ws2_32"]
+            self.cpp_info.components["curl"].system_libs = ["ws2_32", "bcrypt"]
             if self.options.with_ldap:
                 self.cpp_info.components["curl"].system_libs.append("wldap32")
             if self.options.with_ssl == "schannel":
@@ -766,6 +774,8 @@ class LibcurlConan(ConanFile):
             self.cpp_info.components["curl"].requires.append("c-ares::c-ares")
         if self.options.get_safe("with_libpsl"):
             self.cpp_info.components["curl"].requires.append("libpsl::libpsl")
+        if self.options.with_libidn:
+            self.cpp_info.components["curl"].requires.append("libidn2::libidn2")
 
         self.cpp_info.components["curl"].set_property("cmake_target_name", "CURL::libcurl")
         self.cpp_info.components["curl"].set_property("pkg_config_name", "libcurl")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -646,6 +646,11 @@ class LibcurlConan(ConanFile):
         tc.variables["CURL_DISABLE_PROXY"] = not self.options.with_proxy
         tc.variables["USE_LIBRTMP"] = self.options.with_librtmp
         tc.variables["USE_LIBIDN2"] = self.options.with_libidn
+        if self.options.with_libidn:
+            # Conan won't generate this variable as we're setting prefixes,
+            # and CMake might not either as it's looking for Libidn2
+            # Ensure it's there
+            tc.cache_variables["LIBIDN2_FOUND"] = True
         tc.variables["CURL_DISABLE_RTSP"] = not self.options.with_rtsp
         tc.variables["CURL_DISABLE_CRYPTO_AUTH"] = not self.options.with_crypto_auth
         tc.variables["CURL_DISABLE_VERBOSE_STRINGS"] = not self.options.with_verbose_strings

--- a/recipes/libcurl/all/test_package/CMakeLists.txt
+++ b/recipes/libcurl/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(test_package C)
 
 find_package(CURL REQUIRED)

--- a/recipes/libcurl/all/test_package/CMakeLists.txt
+++ b/recipes/libcurl/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(test_package C)
 
 find_package(CURL REQUIRED)


### PR DESCRIPTION
Fixes all libidn usages of libcurl, it's now consumed properly

This option is on by default, but in the spirit of not breaking potential users that expect this to be off by default, I've left the default in the recipe untouched.

I'll submit compilation reports in a bit

Closes https://github.com/conan-io/conan-center-index/issues/27152