### PR TITLE
double-conversion: CMake 4 support

### DIFF
--- a/recipes/double-conversion/all/conanfile.py
+++ b/recipes/double-conversion/all/conanfile.py
@@ -2,9 +2,10 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, rm
 from conan.tools.microsoft import check_min_vs
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class DoubleConversionConan(ConanFile):
@@ -46,6 +47,8 @@ class DoubleConversionConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+        if Version(self.version) <= "3.3.0": # pylint: disable=conan-condition-evals-to-constant
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
double-conversion: fixes to support CMake 4

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

Already fixed on upstream https://github.com/google/double-conversion/pull/240
Version not yet released
