### PR TITLE
Updating yaml-cpp recipe to work with CMake 4.0

### DIFF
--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -62,7 +62,7 @@ class YamlCppConan(ConanFile):
         tc.variables["YAML_CPP_INSTALL"] = True
         tc.variables["YAML_BUILD_SHARED_LIBS"] = self.options.shared
         if Version(self.version) <= "0.8.0": # pylint: disable=conan-condition-evals-to-constant
-             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         if is_msvc(self):
             tc.variables["YAML_MSVC_SHARED_RT"] = not is_msvc_static_runtime(self)
             tc.preprocessor_definitions["_NOEXCEPT"] = "noexcept"

--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -6,7 +6,6 @@ from conan.tools.files import apply_conandata_patches, collect_libs, copy, expor
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
-import textwrap
 
 required_conan_version = ">=2.1"
 
@@ -82,10 +81,6 @@ class YamlCppConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "CMake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "yaml-cpp")

--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, rmdir, save
+from conan.tools.files import apply_conandata_patches, collect_libs, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
@@ -82,23 +82,6 @@ class YamlCppConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "CMake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {"yaml-cpp": "yaml-cpp::yaml-cpp"}
-        )
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
 
     @property
     def _module_file_rel_path(self):

--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.scm import Version
 import os
 import textwrap
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class YamlCppConan(ConanFile):
@@ -61,6 +61,8 @@ class YamlCppConan(ConanFile):
         tc.variables["YAML_CPP_BUILD_TOOLS"] = False
         tc.variables["YAML_CPP_INSTALL"] = True
         tc.variables["YAML_BUILD_SHARED_LIBS"] = self.options.shared
+        if Version(self.version) <= "0.8.0": # pylint: disable=conan-condition-evals-to-constant
+             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         if is_msvc(self):
             tc.variables["YAML_MSVC_SHARED_RT"] = not is_msvc_static_runtime(self)
             tc.preprocessor_definitions["_NOEXCEPT"] = "noexcept"
@@ -118,7 +120,3 @@ class YamlCppConan(ConanFile):
         else:
             if not self.options.shared:
                 self.cpp_info.defines.append("YAML_CPP_STATIC_DEFINE")
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]


### PR DESCRIPTION
Changes to recipe:  **yaml-cpp**

Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

There is already [yaml-cpp PR](https://github.com/jbeder/yaml-cpp/pull/1351) but it's not merged yet