### PR TITLE
[boost] math: 1.87.0 no longer builds long double variants on Emscripten

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1929,7 +1929,7 @@ class BoostConan(ConanFile):
                 for name in names:
                     if name in ("boost_stacktrace_windbg", "boost_stacktrace_windbg_cached") and self.settings.os != "Windows":
                         continue
-                    if name in ("boost_math_c99l", "boost_math_tr1l") and str(self.settings.arch).startswith("ppc"):
+                    if name in ("boost_math_c99l", "boost_math_tr1l") and (str(self.settings.arch).startswith("ppc") or (Version(self.version) >= "1.87.0" and self.settings.os == "Emscripten")):
                         continue
                     if name in ("boost_stacktrace_addr2line", "boost_stacktrace_backtrace", "boost_stacktrace_basic") and self.settings.os == "Windows":
                         continue

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND NOT EMSCRIPTEN)
     # use RPATH instead of RUNPATH so that
     # transitive dependencies can be located
     add_link_options("LINKER:--disable-new-dtags")


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.87.0+**

#### Motivation
Boost fails to build on Conan since 1.87.0 on Emscripten with:

    boost/1.87.0: WARN: Boost component 'math_c99l' is missing libraries. Try building boost with '-o boost:without_math_c99l'. (Option is not guaranteed to exist)
    boost/1.87.0: WARN: Boost component 'math_tr1l' is missing libraries. Try building boost with '-o boost:without_math_tr1l'. (Option is not guaranteed to exist)
    ERROR: boost/1.87.0: Error in package_info() method, line 2011
     	raise ConanException(f"These libraries were expected to be built, but were not built: {non_built}")
     	ConanException: These libraries were expected to be built, but were not built: {'boost_math_c99l', 'boost_math_tr1l'}

The [boost math patch notes](https://github.com/boostorg/math/releases/tag/boost-1.87.0) mention: "fix: define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS for emscripten": https://github.com/boostorg/math/pull/1216 . So it makes sense that these libraries are no longer produced.

#### Details
The fix is to no longer expect the long double variants as we already do for PPC architectures.

A minor follow-up fix was to avoid passing "--disable-new-dtags" to the linker, because that flag is not recognized by the Emscripten linker.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
