### PR TITLE
wasm-micro-runtime: add `disable_hw_bound_check` and `disable_write_gs_base`

### DIFF
--- a/recipes/wasm-micro-runtime/all/conanfile.py
+++ b/recipes/wasm-micro-runtime/all/conanfile.py
@@ -32,6 +32,8 @@ class WasmMicroRuntimeConan(ConanFile):
         "with_wasi_threads": [True, False],
         "with_tail_call": [True, False],
         "with_simd": [True, False],
+        "disable_hw_bound_check": [None, True, False],
+        "disable_write_gs_base": [None, True, False],
     }
     default_options = {
         "shared": False,
@@ -47,6 +49,8 @@ class WasmMicroRuntimeConan(ConanFile):
         "with_wasi_threads": False,
         "with_tail_call": False,
         "with_simd": True,
+        "disable_hw_bound_check": None,
+        "disable_write_gs_base": None,
     }
 
     def export_sources(self):
@@ -114,6 +118,10 @@ class WasmMicroRuntimeConan(ConanFile):
         tc.variables["WAMR_BUILD_LIB_WASI_THREADS"] = is_enabled(self.options.with_wasi_threads)
         tc.variables["WAMR_BUILD_TAIL_CALL"] = is_enabled(self.options.with_tail_call)
         tc.variables["WAMR_BUILD_SIMD"] = is_enabled(self.options.with_simd)
+        if self.options.disable_hw_bound_check is not None:
+            tc.variables["WAMR_DISABLE_HW_BOUND_CHECK"] = is_enabled(self.options.disable_hw_bound_check)
+        if self.options.disable_write_gs_base is not None:
+            tc.variables["WAMR_DISABLE_WRITE_GS_BASE"] = is_enabled(self.options.disable_write_gs_base)
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Resolves #27260.

### Summary
Changes to recipe:  **wasm-micro-runtime**
Adds the ability to set CMake options `WAMR_DISABLE_HW_BOUND_CHECK` and `WAMR_DISABLE_WRITE_GS_BASE` using Conan options. These variables are normally determined at configuration time by the project. This PR allows the user to specify them explicitly.

#### Motivation
There are reasons a consumer of this library would want to explicitly set these build options. For example, performance benefits or compatibility with other tools like `valgrind`.

#### Details
When the options are unset, the build should behave as normal and allow the project to determine the flag setting. When the library consumer sets them, it should be passed to the CMake configuration stage.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
