### PR TITLE
glew: CMake 4 support

### DIFF
--- a/recipes/glew/all/conanfile.py
+++ b/recipes/glew/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class GlewConan(ConanFile):

--- a/recipes/glew/all/patches/0001-fix-cmake-2.1.0.patch
+++ b/recipes/glew/all/patches/0001-fix-cmake-2.1.0.patch
@@ -1,7 +1,7 @@
 --- a/build/cmake/CMakeLists.txt
 +++ b/build/cmake/CMakeLists.txt
 @@ -1,10 +1,10 @@
-+cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.5)
 +project (glew C)
  if ( NOT DEFINED CMAKE_BUILD_TYPE )
    set( CMAKE_BUILD_TYPE Release CACHE STRING "Build type" )

--- a/recipes/glew/all/patches/0001-fix-cmake-2.2.0.patch
+++ b/recipes/glew/all/patches/0001-fix-cmake-2.2.0.patch
@@ -1,7 +1,7 @@
 --- a/build/cmake/CMakeLists.txt
 +++ b/build/cmake/CMakeLists.txt
 @@ -1,10 +1,10 @@
-+cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.5)
 +project (glew C)
  if ( NOT DEFINED CMAKE_BUILD_TYPE )
    set( CMAKE_BUILD_TYPE Release CACHE STRING "Build type" )


### PR DESCRIPTION
### Summary
Changes to recipe:  **glew/2.2.0**

#### Motivation
CMake 4.0 Removes compatibility with CMake < 3.5.

#### Details
Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
