### PR TITLE
Add new z3 4.14.1 release, fixes newer clang versions compilations

### DIFF
--- a/recipes/z3/all/conandata.yml
+++ b/recipes/z3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.14.1":
+    url: "https://github.com/Z3Prover/z3/archive/z3-4.14.1.tar.gz"
+    sha256: "81a02c2c64c64d6c3df233f59186b95627990ada0c4c2fc901c9c25a7072672a"
   "4.13.0":
     url: "https://github.com/Z3Prover/z3/archive/z3-4.13.0.tar.gz"
     sha256: "01bcc61c8362e37bb89fd2430f7e3385e86df7915019bd2ce45de9d9bd934502"

--- a/recipes/z3/config.yml
+++ b/recipes/z3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.14.1":
+    folder: "all"
   "4.13.0":
     folder: "all"
   "4.12.4":


### PR DESCRIPTION
Diff https://github.com/Z3Prover/z3/compare/z3-4.13.0...z3-4.14.1

Closes https://github.com/conan-io/conan-center-index/issues/27193

Newer clang releases fail to build older versions.


Test package logs showing that even if you compile for C++20, consuming it in C++11 is still posible:

<details>

```
======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/abril/coding/conan-center-index/recipes/z3/all/test_package/build/apple-clang-16-armv8-11-release
z3/4.14.1 (test package): Test package build: build/apple-clang-16-armv8-11-release
z3/4.14.1 (test package): Test package build folder: /Users/abril/coding/conan-center-index/recipes/z3/all/test_package/build/apple-clang-16-armv8-11-release
z3/4.14.1 (test package): Writing generators to /Users/abril/coding/conan-center-index/recipes/z3/all/test_package/build/apple-clang-16-armv8-11-release/generators
z3/4.14.1 (test package): Generator 'CMakeDeps' calling 'generate()'
z3/4.14.1 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(Z3)
    target_link_libraries(... z3::libz3)
z3/4.14.1 (test package): Generator 'CMakeToolchain' calling 'generate()'
z3/4.14.1 (test package): CMakeToolchain generated: conan_toolchain.cmake
z3/4.14.1 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/z3/all/test_package/build/apple-clang-16-armv8-11-release/generators/CMakePresets.json
z3/4.14.1 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/z3/all/test_package/CMakeUserPresets.json
z3/4.14.1 (test package): Generator 'VirtualRunEnv' calling 'generate()'
z3/4.14.1 (test package): Generating aggregated env files
z3/4.14.1 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
z3/4.14.1 (test package): Calling build()
z3/4.14.1 (test package): Running CMake.configure()
z3/4.14.1 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/coding/conan-center-index/recipes/z3/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/abril/coding/conan-center-index/recipes/z3/all/test_package"
-- Using Conan toolchain: /Users/abril/coding/conan-center-index/recipes/z3/all/test_package/build/apple-clang-16-armv8-11-release/generators/conan_toolchain.cmake
-- Conan toolchain: Including user_toolchain: /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f/ccache-autoinject.cmake
-- /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f/bin/ccache found and enabled
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 11 with extensions OFF
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'z3::libz3'
-- Configuring done (0.7s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/abril/coding/conan-center-index/recipes/z3/all/test_package/build/apple-clang-16-armv8-11-release

z3/4.14.1 (test package): Running CMake.build()
z3/4.14.1 (test package): RUN: cmake --build "/Users/abril/coding/conan-center-index/recipes/z3/all/test_package/build/apple-clang-16-armv8-11-release" -- -j12
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
z3/4.14.1 (test package): Running test()
z3/4.14.1 (test package): RUN: ./test_package

simple_example

```

</details>