### PR TITLE
Fix termcap settings

### DIFF
--- a/recipes/termcap/all/CMakeLists.txt
+++ b/recipes/termcap/all/CMakeLists.txt
@@ -21,7 +21,6 @@ endforeach()
 
 add_definitions(-DSTDC_HEADERS)
 add_definitions(-DTERMCAP_BUILDING)
-add_definitions("-DTERMCAP_FILE=\"${CMAKE_INSTALL_SYSCONFDIR}/termcap\"")
 if(BUILD_SHARED_LIBS)
     add_definitions(-DTERMCAP_SHARED)
 endif()

--- a/recipes/termcap/all/conanfile.py
+++ b/recipes/termcap/all/conanfile.py
@@ -86,7 +86,7 @@ class TermcapConan(ConanFile):
 
     @property
     def _termcap_path(self):
-        return os.path.join(self.package_folder, "bin", "etc", "termcap")
+        return os.path.join(self.package_folder, "etc", "termcap")
 
     def package_info(self):
         self.cpp_info.libs = ["termcap"]

--- a/recipes/termcap/all/conanfile.py
+++ b/recipes/termcap/all/conanfile.py
@@ -61,7 +61,6 @@ class TermcapConan(ConanFile):
         tc.cache_variables["TERMCAP_HEADERS"] = to_cmake_paths(headers)
         tc.cache_variables["TERMCAP_INC_OPTS"] = to_cmake_paths(optional_headers)
         tc.cache_variables["TERMCAP_CAP_FILE"] = os.path.join(self.source_folder, "termcap.src").replace("\\", "/")
-        tc.cache_variables["CMAKE_INSTALL_SYSCONFDIR"] = os.path.join(self.package_folder, "bin", "etc").replace("\\", "/")
         tc.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **termcap/1.3.1**

#### Motivation
This PR makes the recipe comply with the termcap's intended default behaviour:
1. By default install the termcap database into `/etc/termcap`.
2. By default don't `#define TERMCAP_FILE` so that the termcap database is searched under its default location `/etc/termcap`.

#### Details
This PR modifies package settings where by default the termcap database is installed and searched for so that it complied to the default settings that the termcap source code is using.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
