### PR TITLE
Fix pdfium build on new versions of gcc

### DIFF
--- a/recipes/pdfium/all/conandata.yml
+++ b/recipes/pdfium/all/conandata.yml
@@ -16,5 +16,5 @@ sources:
 patches:
   "95.0.4629":
     - patch_file: "patches/95.0.4629-0001-include-cstdint.patch"
-      patch_description: "Avoids build failure on newer gcc versions"
+      patch_description: "Add missing standard include which affects newer versions of gcc"
       patch_type: "conan"

--- a/recipes/pdfium/all/conandata.yml
+++ b/recipes/pdfium/all/conandata.yml
@@ -13,3 +13,8 @@ sources:
     chromium_build:
       url: "https://chromium.googlesource.com/chromium/src/build/+archive/95667421554b672f9330df8efb8148b6c2d00594.tar.gz"
       # sha256 is volatile on googlesource, no up-to-date github fork
+patches:
+  "95.0.4629":
+    - patch_file: "patches/95.0.4629-0001-include-cstdint.patch"
+      patch_description: "Avoids build failure on newer gcc versions"
+      patch_type: "conan"

--- a/recipes/pdfium/all/conandata.yml
+++ b/recipes/pdfium/all/conandata.yml
@@ -15,6 +15,7 @@ sources:
       # sha256 is volatile on googlesource, no up-to-date github fork
 patches:
   "95.0.4629":
-    - patch_file: "patches/95.0.4629-0001-include-cstdint.patch"
+    - patch_file: "patches/95.0.4629-0001-include-stdint.patch"
       patch_description: "Add missing standard include which affects newer versions of gcc"
-      patch_type: "conan"
+      patch_source: "https://pdfium.googlesource.com/pdfium/+/6dd81921398c1a44abf4eac7ce04446efee74169"
+      patch_type: "official"

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.scm import Version
 
@@ -32,6 +32,9 @@ class PdfiumConan(ConanFile):
         "fPIC": True,
         "with_libjpeg": "libjpeg",
     }
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -96,6 +99,7 @@ class PdfiumConan(ConanFile):
         deps.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join("pdfium-cmake", "cmake"))
         cmake.build()

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -1,15 +1,13 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
 from conan.tools.gnu import PkgConfigDeps
-from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class PdfiumConan(ConanFile):
@@ -59,22 +57,11 @@ class PdfiumConan(ConanFile):
             self.requires("libjpeg-turbo/3.0.1")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, 14)
-        minimum_compiler_versions = {
-            "gcc": "8",
-            "msvc": "191",
-            "Visual Studio": "15",
-        }
-        min_compiler_version = minimum_compiler_versions.get(str(self.settings.compiler))
-        if min_compiler_version and Version(self.settings.compiler.version) < min_compiler_version:
-            raise ConanInvalidConfiguration(
-                f"pdfium needs at least compiler version {min_compiler_version}"
-            )
+        check_min_cppstd(self, 14)
 
     def build_requirements(self):
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.0.3")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version]["pdfium-cmake"],
@@ -85,6 +72,7 @@ class PdfiumConan(ConanFile):
             destination=os.path.join(self.source_folder, "base", "trace_event", "common"))
         get(self, **self.conan_data["sources"][self.version]["chromium_build"],
             destination=os.path.join(self.source_folder, "build"))
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -99,7 +87,6 @@ class PdfiumConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join("pdfium-cmake", "cmake"))
         cmake.build()

--- a/recipes/pdfium/all/patches/95.0.4629-0001-include-cstdint.patch
+++ b/recipes/pdfium/all/patches/95.0.4629-0001-include-cstdint.patch
@@ -1,0 +1,10 @@
+--- a/core/fxcodec/fx_codec.h
++++ b/core/fxcodec/fx_codec.h
+@@ -7,6 +7,7 @@
+ #ifndef CORE_FXCODEC_FX_CODEC_H_
+ #define CORE_FXCODEC_FX_CODEC_H_
+ 
++#include <cstdint>
+ #include <map>
+ 
+ #include "third_party/base/optional.h"

--- a/recipes/pdfium/all/patches/95.0.4629-0001-include-stdint.patch
+++ b/recipes/pdfium/all/patches/95.0.4629-0001-include-stdint.patch
@@ -3,8 +3,8 @@
 @@ -7,6 +7,7 @@
  #ifndef CORE_FXCODEC_FX_CODEC_H_
  #define CORE_FXCODEC_FX_CODEC_H_
- 
-+#include <cstdint>
+
++#include <stdint.h>
  #include <map>
- 
+
  #include "third_party/base/optional.h"


### PR DESCRIPTION
### Summary
Changes to recipe:  **pdfium/95.0.4692**

#### Motivation
The build is currently broken on newer versions of gcc because of a missing include. See #23529

#### Details
- Added a patch to introduce the missing include.
- Also added the code for applying patches. 

fixes #23529

---
- [ x ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x ] Tested locally with at least one configuration using a recent version of Conan
