### PR TITLE
onnxruntime: Patch xnnpack link order

### DIFF
--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -232,7 +232,9 @@ class OnnxRuntimeConan(ConanFile):
                 "flatbuffers",
             ]
             if self.options.with_xnnpack:
-                onnxruntime_libs.append("providers_xnnpack")
+                # Static linkning in gcc is order dependent.
+                # session, providers_xnnpack and optimizer needs to link in that order
+                onnxruntime_libs.insert(1, "providers_xnnpack")
             self.cpp_info.libs = [f"onnxruntime_{lib}" for lib in onnxruntime_libs]
 
         if Version(self.version) < "1.16.0" or not self.options.shared:


### PR DESCRIPTION
### Summary
Changes to recipe:  **onnxruntime/[*]**

#### Motivation
Bugfix. Enabling xnnpack on onnxruntime does not link with gcc.

#### Details
Fix the link order. Could also be solved with link groups

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
