### PR TITLE
grpc: Add frameworks only when on apple os

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -143,7 +143,7 @@ class GrpcConan(ConanFile):
 
     def build_requirements(self):
         # cmake >=3.25 required to use `cmake -E env --modify` below
-        # note: grpc 1.69.0 requires cmake >=3.16 
+        # note: grpc 1.69.0 requires cmake >=3.16
         self.tool_requires("cmake/[>=3.25 <4]")
         self.tool_requires("protobuf/<host_version>")
         if cross_building(self):
@@ -347,7 +347,8 @@ class GrpcConan(ConanFile):
             self.cpp_info.components[component].libs = [lib]
             self.cpp_info.components[component].requires = values.get("requires", [])
             self.cpp_info.components[component].system_libs = values.get("system_libs", [])
-            self.cpp_info.components[component].frameworks = values.get("frameworks", [])
+            if is_apple_os(self):
+                self.cpp_info.components[component].frameworks = values.get("frameworks", [])
 
         # Executable imported targets are added through custom CMake module files,
         # since conan generators don't know how to emulate these kind of targets.


### PR DESCRIPTION
This is needed as the new CMakeConfigDeps generator does not expect frameworks in non-apple OS,

as per @memsharded:

> The generator assumes that dependencies do not add frameworks information for other systems different than Apple, in the same way that dependencies shouldn't add any libraries, flags, pre-processor definitions, etc that don't work for other systems.

Closes https://github.com/conan-io/conan-center-index/issues/27206 