### PR TITLE
cnats: add version 3.10.1

### DIFF
--- a/recipes/cnats/all/conandata.yml
+++ b/recipes/cnats/all/conandata.yml
@@ -17,3 +17,6 @@ sources:
   "3.9.3":
     url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.9.3.tar.gz"
     sha256: "b5dd3971b72fa5fc4c5b6d71c6900dc0a8a20465824fc23c0054f7f319e97952"
+  "3.10.1":
+    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.10.1.tar.gz"
+    sha256: "1765533bbc1270ab7c89e3481b4778db7d1e7b4db2fa906b6602cd5c02846222"

--- a/recipes/cnats/all/conanfile.py
+++ b/recipes/cnats/all/conanfile.py
@@ -23,13 +23,15 @@ class PackageConan(ConanFile):
         "with_tls": [True, False],
         "with_sodium": [True, False],
         "enable_streaming": [True, False],
+        "with_experimental" : [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_tls": True,
         "with_sodium": False,
-        "enable_streaming": False
+        "enable_streaming": False,
+        "with_experimental" : False,
     }
 
     def config_options(self):
@@ -68,6 +70,7 @@ class PackageConan(ConanFile):
         if self.options.with_tls:
             tc.variables["NATS_BUILD_TLS_USE_OPENSSL_1_1_API"] = Version(self.dependencies["openssl"].ref.version) >= "1.1"
         tc.variables["NATS_BUILD_STREAMING"] = self.options.enable_streaming
+        tc.variables["NATS_WITH_EXPERIMENTAL"] = self.options.with_experimental
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()
@@ -101,6 +104,8 @@ class PackageConan(ConanFile):
 
         if self.options.enable_streaming:
             self.cpp_info.defines.append("NATS_HAS_STREAMING")
+        if self.options.with_experimental:
+            self.cpp_info.defines.append("NATS_WITH_EXPERIMENTAL")
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.defines.append("nats_IMPORTS")
 

--- a/recipes/cnats/config.yml
+++ b/recipes/cnats/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "3.9.3":
     folder: all
+  "3.10.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cnats/3.10.1**

#### Motivation
Nats.c introduced release 3.10.0, but there was problem about cmake definition, now it is fixed (https://github.com/nats-io/nats.c/pull/860) and releases in 3.10.1. 

#### Details
I just add option for experimental API and turn off it by default. I think one CMAKE option and C definition for older versions no make sense. Of course, I think you can advice more interesting solutions (I thought about using self.version for disabling definition for older packages version, but I think it is should make recipe more readable).

P.S. add trailing comma for default opts =)

I read about Experimental - it will bail off if TLS if off, but this flag for all unstable API, and I believe we shouldn't link it with TLS option

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
