### PR TITLE
podofo: Add version 0.10.4

### DIFF
--- a/recipes/podofo/all/conandata.yml
+++ b/recipes/podofo/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "0.9.7":
     url: "https://netcologne.dl.sourceforge.net/project/podofo/podofo/0.9.7/podofo-0.9.7.tar.gz"
     sha256: "7cf2e716daaef89647c54ffcd08940492fd40c385ef040ce7529396bfadc1eb8"
+  "0.10.4":
+    url: "https://github.com/podofo/podofo/archive/refs/tags/0.10.4.tar.gz"
+    sha256: "6b1b13cdfb2ba5e8bbc549df507023dd4873bc946211bc6942183b8496986904"
 patches:
   "0.9.7":
     - patch_file: "patches/0001-fix-cmake-0.9.7.patch"

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -90,6 +90,10 @@ class PodofoConan(ConanFile):
         if self.options.with_unistring:
             self.requires("libunistring/0.9.10")
 
+    def build_requirements(self):
+        if Version(self.version) >= "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
+            self.tool_requires("cmake/[>=3.15.7]")
+
     def validate(self):
         check_min_cppstd(self, 11)
 

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -55,8 +55,18 @@ class PodofoConan(ConanFile):
         export_conandata_patches(self)
 
     def config_options(self):
+        if (
+            Version(self.version) < "0.10.4"
+        ):  # pylint: disable=conan-condition-evals-to-constant
+            # Not available in older versions
+            self.options.with_lib_only = False
+        else:
+            # Required for this version
+            self.options.with_openssl = True
+
         if self.settings.os == "Windows":
             del self.options.fPIC
+
         if is_msvc(self):
             # libunistring recipe raises for Visual Studio
             # TODO: Enable again when fixed?
@@ -105,7 +115,9 @@ class PodofoConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["PODOFO_BUILD_TOOLS"] = self.options.with_tools
         tc.variables["PODOFO_BUILD_LIB_ONLY"] = self.options.with_lib_only
-        if Version(self.version) < "0.10.0":
+        if (
+            podofo_version < "0.10.0"
+        ):  # pylint: disable=conan-condition-evals-to-constant
             tc.variables["PODOFO_BUILD_SHARED"] = self.options.shared
         tc.variables["PODOFO_BUILD_STATIC"] = not self.options.shared
         if not self.options.threadsafe:

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -73,9 +73,7 @@ class PodofoConan(ConanFile):
     def requirements(self):
         self.requires("freetype/2.13.2")
         self.requires("zlib/[>=1.2.11 <2]")
-        if (
-            Version(self.version) >= "0.10.4"
-        ):  # pylint: disable=conan-condition-evals-to-constant
+        if Version(self.version) >= "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
             self.requires("libxml2/[>2 <3]")
         if self.settings.os != "Windows":
             self.requires("fontconfig/2.15.0")

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -82,7 +82,10 @@ class PodofoConan(ConanFile):
     def requirements(self):
         self.requires("freetype/2.13.2")
         self.requires("zlib/[>=1.2.11 <2]")
-        self.requires("libxml2/[>2 <3]")
+        if (
+            Version(self.version) >= "0.10.4"
+        ):  # pylint: disable=conan-condition-evals-to-constant
+            self.requires("libxml2/[>2 <3]")
         if self.settings.os != "Windows":
             self.requires("fontconfig/2.15.0")
         if self.options.with_openssl:

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -161,14 +161,19 @@ class PodofoConan(ConanFile):
 
     def package_info(self):
         podofo_version = Version(self.version)
-        pkg_config_name = (
-            f"libpodofo-{podofo_version.major}"
-            if podofo_version < "0.9.7"
-            else "libpodofo"
-        )
+        pkg_config_name = "libpodofo"
         self.cpp_info.set_property("pkg_config_name", pkg_config_name)
-        self.cpp_info.libs = ["podofo"]
-        if self.settings.os == "Windows" and self.options.shared:
-            self.cpp_info.defines.append("USING_SHARED_PODOFO")
+        if podofo_version < "0.10.0":
+            self.cpp_info.libs = ["podofo"]
+            if self.settings.os == "Windows" and self.options.shared:
+                self.cpp_info.defines.append("USING_SHARED_PODOFO")
+        else:
+            if not self.options.shared:
+                self.cpp_info.libs = ["podofo", "podofo_private"]
+                self.cpp_info.defines.append("PODOFO_STATIC")
+            else:
+                self.cpp_info.libs = ["podofo"]
+                self.cpp_info.defines.append("PODOFO_SHARED")
+
         if self.settings.os in ["Linux", "FreeBSD"] and self.options.threadsafe:
             self.cpp_info.system_libs = ["pthread"]

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -50,7 +50,7 @@ class PodofoConan(ConanFile):
         export_conandata_patches(self)
 
     def config_options(self):
-        if Version(self.version) < "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
+        if Version(self.version) < "0.10.4":
             # Not available in older versions
             del self.options.with_lib_only
 
@@ -72,7 +72,7 @@ class PodofoConan(ConanFile):
     def requirements(self):
         self.requires("freetype/2.13.2")
         self.requires("zlib/[>=1.2.11 <2]")
-        if Version(self.version) >= "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
+        if Version(self.version) >= "0.10.4":
             self.requires("libxml2/[>2 <3]")
         if self.settings.os != "Windows":
             self.requires("fontconfig/2.15.0")
@@ -90,7 +90,7 @@ class PodofoConan(ConanFile):
             self.requires("libunistring/0.9.10")
 
     def build_requirements(self):
-        if Version(self.version) >= "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
+        if Version(self.version) >= "0.10.4":
             self.tool_requires("cmake/[>=3.15.7 <4]")
 
     def validate(self):
@@ -99,7 +99,7 @@ class PodofoConan(ConanFile):
         else:
             check_min_cppstd(self, 17)
             
-        if Version(self.version) >= "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
+        if Version(self.version) >= "0.10.4":
             if not self.options.with_openssl:
                 raise ConanInvalidConfiguration(
                     f"{self.ref} requires option 'with_openssl' to be set to True.",
@@ -116,7 +116,7 @@ class PodofoConan(ConanFile):
         tc.variables["PODOFO_BUILD_TOOLS"] = self.options.with_tools
         if self.options.with_lib_only is not None:
             tc.variables["PODOFO_BUILD_LIB_ONLY"] = self.options.with_lib_only
-        if podofo_version < "0.10.0":  # pylint: disable=conan-condition-evals-to-constant
+        if podofo_version < "0.10.0":
             tc.variables["PODOFO_BUILD_SHARED"] = self.options.shared
         tc.variables["PODOFO_BUILD_STATIC"] = not self.options.shared
         if not self.options.threadsafe:
@@ -138,7 +138,7 @@ class PodofoConan(ConanFile):
             if self.options.with_openssl and ("no_rc4" in self.dependencies["openssl"].options):
                 tc.variables["PODOFO_HAVE_OPENSSL_NO_RC4"] = self.dependencies["openssl"].options.no_rc4
 
-        if podofo_version < "0.10.0": # pylint: disable=conan-condition-evals-to-constant
+        if podofo_version < "0.10.0"
             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
 
         tc.generate()

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -114,7 +114,7 @@ class PodofoConan(ConanFile):
 
         tc = CMakeToolchain(self)
         tc.variables["PODOFO_BUILD_TOOLS"] = self.options.with_tools
-        if self.options.with_lib_only is not None:
+        if self.options.get_safe("with_lib_only") is not None:
             tc.variables["PODOFO_BUILD_LIB_ONLY"] = self.options.with_lib_only
         if podofo_version < "0.10.0":
             tc.variables["PODOFO_BUILD_SHARED"] = self.options.shared

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -51,7 +51,7 @@ class PodofoConan(ConanFile):
     def config_options(self):
         if Version(self.version) < "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
             # Not available in older versions
-            self.options.with_lib_only = False
+            del self.options.with_lib_only
         else:
             # Required for this version
             self.options.with_openssl = True
@@ -109,7 +109,8 @@ class PodofoConan(ConanFile):
 
         tc = CMakeToolchain(self)
         tc.variables["PODOFO_BUILD_TOOLS"] = self.options.with_tools
-        tc.variables["PODOFO_BUILD_LIB_ONLY"] = self.options.with_lib_only
+        if self.options.with_lib_only is not None:
+            tc.variables["PODOFO_BUILD_LIB_ONLY"] = self.options.with_lib_only
         if podofo_version < "0.10.0":  # pylint: disable=conan-condition-evals-to-constant
             tc.variables["PODOFO_BUILD_SHARED"] = self.options.shared
         tc.variables["PODOFO_BUILD_STATIC"] = not self.options.shared

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -138,7 +138,6 @@ class PodofoConan(ConanFile):
             if self.options.with_openssl and ("no_rc4" in self.dependencies["openssl"].options):
                 tc.variables["PODOFO_HAVE_OPENSSL_NO_RC4"] = self.dependencies["openssl"].options.no_rc4
 
-        if podofo_version < "0.10.0"
         if podofo_version < "0.10.0":
             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
 

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -95,9 +95,10 @@ class PodofoConan(ConanFile):
             self.tool_requires("cmake/[>=3.15.7 <4]")
 
     def validate(self):
-        check_min_cppstd(self, 11)
-        if Version(self.version) >= "0.10.4":
-            check_min_cppstd(self, "17")
+        if Version(self.version) < "0.10.4":
+            check_min_cppstd(self, 11)
+        else:
+            check_min_cppstd(self, 17)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -96,6 +96,8 @@ class PodofoConan(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 11)
+        if Version(self.version) >= "0.10.4":
+            check_min_cppstd(self, "17")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -92,7 +92,7 @@ class PodofoConan(ConanFile):
 
     def build_requirements(self):
         if Version(self.version) >= "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
-            self.tool_requires("cmake/[>=3.15.7]")
+            self.tool_requires("cmake/[>=3.15.7 <4]")
 
     def validate(self):
         check_min_cppstd(self, 11)

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=2.1"
@@ -52,12 +53,10 @@ class PodofoConan(ConanFile):
         if Version(self.version) < "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
             # Not available in older versions
             del self.options.with_lib_only
-        else:
-            # Required for this version
-            self.options.with_openssl = True
 
         if self.settings.os == "Windows":
             del self.options.fPIC
+
         if is_msvc(self):
             # libunistring recipe raises for Visual Studio
             # TODO: Enable again when fixed?
@@ -99,6 +98,12 @@ class PodofoConan(ConanFile):
             check_min_cppstd(self, 11)
         else:
             check_min_cppstd(self, 17)
+            
+        if Version(self.version) >= "0.10.4":  # pylint: disable=conan-condition-evals-to-constant
+            if not self.options.with_openssl:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires option 'with_openssl' to be set to True.",
+                )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -139,6 +139,7 @@ class PodofoConan(ConanFile):
                 tc.variables["PODOFO_HAVE_OPENSSL_NO_RC4"] = self.dependencies["openssl"].options.no_rc4
 
         if podofo_version < "0.10.0"
+        if podofo_version < "0.10.0":
             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
 
         tc.generate()

--- a/recipes/podofo/config.yml
+++ b/recipes/podofo/config.yml
@@ -1,3 +1,5 @@
 versions:
   "0.9.7":
     folder: all
+  "0.10.4":
+    folder: all


### PR DESCRIPTION
### Summary
Adds recipe for `podofo/0.10.4`

#### Motivation
There was a big API shift from `podofo/0.9.*` to `podofo/0.10.*` so these are very distinct versions. I would argue both should be available.
Also see https://github.com/podofo/podofo/issues/87 and https://github.com/conan-io/conan-center-index/issues/18323

#### Details
Changes in `conandata.yml`:
- Add version 0.10.4, using the correct github location of source

Changes in `conanfile.py`:
- Automated formatting (I can revert if it's unwanted, it was not my intention)
- Add `with_lib_only` option, which is a shorthand for removing tools, tests, and playground
- Fix for podofo/0.9.7 when `with_openssl` is `False`
- Forced some options based on version
- Remove `PODOFO_BUILD_SHARED` with the new version, will cause configure error
- Adjust libs and defines to correctly link statically on new version

Both versions still build and test successfully.

---
- [ x ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x ] Tested locally with at least one configuration using a recent version of Conan
