### PR TITLE
Update quant lib to v1.37, fix bug that conan always use static runtime ignoring profile settings

### DIFF
--- a/recipes/quantlib/all/conandata.yml
+++ b/recipes/quantlib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.37":
+    url: "https://github.com/lballabio/QuantLib/releases/download/v1.37/QuantLib-1.37.tar.gz"
+    sha256: "b284e54ef2133c9eccccc23e210ae5b41b2f37c797b3d7257492a391e436ad24"
   "1.30":
     url: "https://github.com/lballabio/QuantLib/releases/download/QuantLib-v1.30/QuantLib-1.30.tar.gz"
     sha256: "10159054b68cb9a39480d9000b87851f49e6f42474a4cb9367e934bece2363f3"
@@ -6,6 +9,8 @@ sources:
     url: "https://github.com/lballabio/QuantLib/releases/download/QuantLib-v1.22/QuantLib-1.22.tar.gz"
     sha256: "85c81816f689f458596dd7073e4da8fd7f596c1e4c8ada81a6300389a39588af"
 patches:
+  "1.37":
+    - patch_file: "patches/1.37-fix-cmake.patch"
   "1.30":
     - patch_file: "patches/1.30-backport-pr-1644.patch"
     - patch_file: "patches/1.30-fix-cmake.patch"

--- a/recipes/quantlib/all/conandata.yml
+++ b/recipes/quantlib/all/conandata.yml
@@ -9,8 +9,6 @@ sources:
     url: "https://github.com/lballabio/QuantLib/releases/download/QuantLib-v1.22/QuantLib-1.22.tar.gz"
     sha256: "85c81816f689f458596dd7073e4da8fd7f596c1e4c8ada81a6300389a39588af"
 patches:
-  "1.37":
-    - patch_file: "patches/1.37-fix-cmake.patch"
   "1.30":
     - patch_file: "patches/1.30-backport-pr-1644.patch"
     - patch_file: "patches/1.30-fix-cmake.patch"

--- a/recipes/quantlib/all/conanfile.py
+++ b/recipes/quantlib/all/conanfile.py
@@ -43,7 +43,7 @@ class QuantlibConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.80.0", transitive_headers=True)
+        self.requires("boost/[>=1.80.0]", transitive_headers=True)
 
     def validate(self):
         if self.info.settings.compiler.get_safe("cppstd"):

--- a/recipes/quantlib/config.yml
+++ b/recipes/quantlib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.37":
+    folder: "all"
   "1.30":
     folder: "all"
   "1.22":


### PR DESCRIPTION
### Summary
Changes to recipe:  **QuantLib/[v1.37]**

#### Motivation
1. Upgrade QuantLib to version v1.37. 
2. Use the official version without patches.
3. Fix bug that the original conanfile.py didn't pass CMAKE_MSVC_RUNTIME_LIBRARY to cmake, then QuantLib will always build QuantLib-x64-mt-s.lib even if conan profiles set c runtime to dynamic. The original version can not be used under any project that use dynamic msvc c runtime.

#### Details
1. Add v1.37 version related
2. Modify conanfile.py to set CMAKE_MSVC_RUNTIME_LIBRARY according to compiler.runtime under MSVC
3. No patches is made, directly use official QuantLib-v1.37 source code

#### Local Build Test results.
1. Linux
```
======== Testing the package: Executing test ========
quantlib/1.37 (test package): Running test()
quantlib/1.37 (test package): RUN: ./test_package

--------------
Exact: 2.6303
Quad: 2.6303
Grid: 2.6303

```
2. Windows MSVC
```
conanvcvars.bat: Activating environment Visual Studio 17 - amd64 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'x64'
[2/2] Linking CXX executable test_package.exe


======== Testing the package: Executing test ========
quantlib/1.37 (test package): Running test()
quantlib/1.37 (test package): RUN: .\test_package

--------------
Exact: 2.6303
Quad: 2.6303
Grid: 2.6303

```

--------
[ x ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
[ x ] Checked that this PR is not a duplicate
[ x ] Tested locally with at least one configuration using a recent version of Conan