### PR TITLE
bzip2: Add mirrors.

### DIFF
--- a/recipes/bzip2/all/conandata.yml
+++ b/recipes/bzip2/all/conandata.yml
@@ -1,9 +1,15 @@
 sources:
   "1.0.8":
-    url: "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+    url:
+    - "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+    - "https://mirrors.kernel.org/sourceware/bzip2/bzip2-1.0.8.tar.gz"
+    - "https://www.mirrorservice.org/sites/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
     sha256: "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
   "1.0.6":
-    url: "https://sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz"
+    url:
+    - "https://sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz"
+    - "https://mirrors.kernel.org/sourceware/bzip2/bzip2-1.0.6.tar.gz"
+    - "https://www.mirrorservice.org/sites/sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz"
     sha256: "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd"
 patches:
   "1.0.6":


### PR DESCRIPTION
### Summary
Add mirrors to recipe:  **bzip2/1.0.8 and bzip/1.0.6**

#### Motivation
As sourceware states themselves: "The master sourceware.org server (…) is usually overloaded."
https://sourceware.org/mirrors.html
Our CI pipeline has intermittent trouble accessing sourceware.com.

#### Details
I added official mirrors from https://sourceware.org/mirrors.html


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
