### PR TITLE
entt: add version 3.15.0

### DIFF
--- a/recipes/entt/3.x.x/conandata.yml
+++ b/recipes/entt/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.15.0":
+    url: "https://github.com/skypjack/entt/archive/refs/tags/v3.15.0.tar.gz"
+    sha256: "01466fcbf77618a79b62891510c0bbf25ac2804af5751c84982b413852234d66"
   "3.14.0":
     url: "https://github.com/skypjack/entt/archive/refs/tags/v3.14.0.tar.gz"
     sha256: "e31f6e95a30e2977a50449ef9a607a9ff40febe6f9da2a8144a183f8606f7719"

--- a/recipes/entt/config.yml
+++ b/recipes/entt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.15.0":
+    folder: 3.x.x
   "3.14.0":
     folder: 3.x.x
   "3.13.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  entt/3.15.0

#### Motivation
- EnTT 3.15.0 has been released with a bug fix I want

#### Details
- Add EnTT 3.15.0 recipe

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
