### PR TITLE
add asio_1.34.2

### DIFF
--- a/recipes/asio/all/conandata.yml
+++ b/recipes/asio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.34.2":
+    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-34-2.tar.gz"
+    sha256: "f3bac015305fbb700545bd2959fbc52d75a1ec2e05f9c7f695801273ceb78cf5"
   "1.32.0":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-32-0.tar.gz"
     sha256: "f1b94b80eeb00bb63a3c8cef5047d4e409df4d8a3fe502305976965827d95672"

--- a/recipes/asio/all/test_package/CMakeLists.txt
+++ b/recipes/asio/all/test_package/CMakeLists.txt
@@ -3,6 +3,33 @@ project(test_package LANGUAGES CXX)
 
 find_package(asio REQUIRED CONFIG)
 
+if (WIN32)
+  execute_process(
+    COMMAND cmd /c ver
+    OUTPUT_VARIABLE _win_ver
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if (_win_ver MATCHES "\[5\\.1]")
+    add_definitions(-D_WIN32_WINNT=0x0501) # Windows XP
+  elseif (_win_ver MATCHES "\[5\\.2]")
+    add_definitions(-D_WIN32_WINNT=0x0502) # Windows Server 2003
+  elseif (_win_ver MATCHES "\[6\\.0]")
+    add_definitions(-D_WIN32_WINNT=0x0600) # Windows Vista
+  elseif (_win_ver MATCHES "\[6\\.1]")
+    add_definitions(-D_WIN32_WINNT=0x0601) # Windows 7
+  elseif (_win_ver MATCHES "\[6\\.2]")
+    add_definitions(-D_WIN32_WINNT=0x0602) # Windows 8
+  elseif (_win_ver MATCHES "\[6\\.3]")
+    add_definitions(-D_WIN32_WINNT=0x0603) # Windows 8.1
+  elseif (_win_ver MATCHES "\[10\\.0]")
+    add_definitions(-D_WIN32_WINNT=0x0A00) # Windows 10
+  else()
+    message(WARNING "Unknown Windows version: ${_win_ver}, defaulting to Windows 10")
+    add_definitions(-D_WIN32_WINNT=0x0A00)
+  endif ()
+endif ()
+
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE asio::asio)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/asio/all/test_package/CMakeLists.txt
+++ b/recipes/asio/all/test_package/CMakeLists.txt
@@ -3,33 +3,6 @@ project(test_package LANGUAGES CXX)
 
 find_package(asio REQUIRED CONFIG)
 
-if (WIN32)
-  execute_process(
-    COMMAND cmd /c ver
-    OUTPUT_VARIABLE _win_ver
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-  if (_win_ver MATCHES "\[5\\.1]")
-    add_definitions(-D_WIN32_WINNT=0x0501) # Windows XP
-  elseif (_win_ver MATCHES "\[5\\.2]")
-    add_definitions(-D_WIN32_WINNT=0x0502) # Windows Server 2003
-  elseif (_win_ver MATCHES "\[6\\.0]")
-    add_definitions(-D_WIN32_WINNT=0x0600) # Windows Vista
-  elseif (_win_ver MATCHES "\[6\\.1]")
-    add_definitions(-D_WIN32_WINNT=0x0601) # Windows 7
-  elseif (_win_ver MATCHES "\[6\\.2]")
-    add_definitions(-D_WIN32_WINNT=0x0602) # Windows 8
-  elseif (_win_ver MATCHES "\[6\\.3]")
-    add_definitions(-D_WIN32_WINNT=0x0603) # Windows 8.1
-  elseif (_win_ver MATCHES "\[10\\.0]")
-    add_definitions(-D_WIN32_WINNT=0x0A00) # Windows 10
-  else()
-    message(WARNING "Unknown Windows version: ${_win_ver}, defaulting to Windows 10")
-    add_definitions(-D_WIN32_WINNT=0x0A00)
-  endif ()
-endif ()
-
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE asio::asio)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/asio/all/test_package/test_package.cpp
+++ b/recipes/asio/all/test_package/test_package.cpp
@@ -2,6 +2,11 @@
 
 int main()
 {
-	auto && service = asio::io_service{};
+#if __has_include(<asio/io_service.hpp>)
+	auto &&service = asio::io_service{};
 	(void)service;
+#else
+	auto &&context = asio::io_context{};
+	(void)context;
+#endif
 }

--- a/recipes/asio/config.yml
+++ b/recipes/asio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.34.2":
+    folder: all
   "1.32.0":
     folder: all
   "1.31.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **asio/[1.34.2]**

#### Motivation
add new version

#### Details
1. add version 1.34.2
2. ~add platform check for win10 build(asio rely on windows sdk)~
3. fix test_package.cpp as 1.34.2 has removed io_service, which has been deprecated from several versions ago


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
