### PR TITLE
Add libsysfs recipe

### DIFF
--- a/recipes/libsysfs/all/conandata.yml
+++ b/recipes/libsysfs/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "2.1.1":
+    url: "https://github.com/linux-ras/sysfsutils/archive/refs/tags/v2.1.1.tar.gz"
+    sha256: "f7f669d27c997d3eb3f3e014b4c0aa1aa4d07ce4d6f9e41fa835240f2bf38810"
+

--- a/recipes/libsysfs/all/conanfile.py
+++ b/recipes/libsysfs/all/conanfile.py
@@ -1,0 +1,76 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get, rm, rmdir, chdir
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+import os
+
+
+required_conan_version = ">=2.1"
+
+
+class LibsysfsConan(ConanFile):
+    name = "libsysfs"
+    description = (
+        "Library used in handling linux kernel sysfs mounts and their various files."
+    )
+    license = "LGPL-2.1-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/linux-ras/sysfsutils"
+    topics = ("sysfs",)
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+    languages = ["C"]
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(f"{self.name} only supports Linux")
+
+    def build_requirements(self):
+        self.tool_requires("libtool/2.4.7")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.generate()
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        autotools.configure()
+        with chdir(self, os.path.join(self.source_folder, "lib")):
+            autotools.make()
+
+    def package(self):
+        copy(
+            self,
+            "LGPL",
+            self.source_folder,
+            os.path.join(self.package_folder, "licenses"),
+        )
+        autotools = Autotools(self)
+        with chdir(self, os.path.join(self.source_folder, "lib")):
+            autotools.install()
+        copy(
+            self,
+            "*.h",
+            os.path.join(self.source_folder, "include"),
+            os.path.join(self.package_folder, "include", "sysfs"),
+        )
+
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["sysfs"]
+        self.cpp_info.set_property("pkg_config_name", "libsysfs")

--- a/recipes/libsysfs/all/test_package/CMakeLists.txt
+++ b/recipes/libsysfs/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SYSFS REQUIRED IMPORTED_TARGET libsysfs)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::SYSFS)

--- a/recipes/libsysfs/all/test_package/conanfile.py
+++ b/recipes/libsysfs/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "PkgConfigDeps"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libsysfs/all/test_package/test_package.c
+++ b/recipes/libsysfs/all/test_package/test_package.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <sysfs/libsysfs.h>
+
+int main(void) {
+    char sysfs_mntpath[SYSFS_PATH_MAX];
+    int rc = sysfs_get_mnt_path(sysfs_mntpath, SYSFS_PATH_MAX);
+    if (rc < 0) {
+        puts("Failed");
+        return EXIT_FAILURE;
+    }
+    puts("Success");
+    return EXIT_SUCCESS;
+}

--- a/recipes/libsysfs/config.yml
+++ b/recipes/libsysfs/config.yml
@@ -1,0 +1,4 @@
+versions:
+  "2.1.1":
+    folder: all
+


### PR DESCRIPTION
### Summary
New recipe:  **libsysfs/2.1.1**

#### Motivation
This adds a recipe for the [libsysfs](https://github.com/linux-ras/sysfsutils) library.

This package is used by linux-specific downstream userspace utilities.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
