### PR TITLE
fast_float: add version 8.0.2

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.0.2":
+    url: "https://github.com/fastfloat/fast_float/archive/v8.0.2.tar.gz"
+    sha256: "e14a33089712b681d74d94e2a11362643bd7d769ae8f7e7caefe955f57f7eacd"
   "8.0.0":
     url: "https://github.com/fastfloat/fast_float/archive/v8.0.0.tar.gz"
     sha256: "f312f2dc34c61e665f4b132c0307d6f70ad9420185fa831911bc24408acf625d"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.0.2":
+    folder: all
   "8.0.0":
     folder: all
   "7.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fast_float/8.0.2**

#### Motivation
There are several improvements since 8.0.0.

#### Details
https://github.com/fastfloat/fast_float/releases/tag/v8.0.2
https://github.com/fastfloat/fast_float/releases/tag/v8.0.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
