### PR TITLE
upa-url: new recipe version 2.0.0

### DIFF
--- a/recipes/upa-url/all/conandata.yml
+++ b/recipes/upa-url/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.0.0":
+    url: "https://github.com/upa-url/upa/archive/refs/tags/v2.0.0.tar.gz"
+    sha256: "50e0d7c9cad853c794f9b12aded960dbdcf3ba6baa8bc9896da52fe526cc014e"

--- a/recipes/upa-url/all/conanfile.py
+++ b/recipes/upa-url/all/conanfile.py
@@ -1,0 +1,65 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+from conan.tools.files import copy, get, rmdir
+import os
+
+required_conan_version = ">=2.0"
+
+class upa_urlRecipe(ConanFile):
+    name = "upa-url"
+    package_type = "library"
+
+    # Optional metadata
+    license = "BSD-2-Clause"
+    author = "Rimas Misevičius <rmisev3@gmail.com>"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "An implementation of the WHATWG URL Standard in C++"
+    topics = ("url", "parser", "psl", "whatwg")
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # Equivalent to:
+        # data = self.conan_data["sources"][self.version]
+        # get(self, data["url"], sha256=data["sha256"], strip_root=data["strip_root"])
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["UPA_BUILD_TESTS"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # Remove unused files
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "upa")
+        self.cpp_info.set_property("cmake_target_name", "upa::url")
+        self.cpp_info.libs = ["upa_url"]

--- a/recipes/upa-url/all/test_package/CMakeLists.txt
+++ b/recipes/upa-url/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(upa CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} upa::url)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/upa-url/all/test_package/conanfile.py
+++ b/recipes/upa-url/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class upa_urlTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/upa-url/all/test_package/test_package.cpp
+++ b/recipes/upa-url/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include "upa/url.h"
+#include <iostream>
+
+int main() {
+    try {
+        upa::url url{ "https://upa-url.github.io/docs/", "about:blank" };
+        std::cout << url.href() << '\n';
+        return 0;
+    }
+    catch (...) {
+        return 1;
+    }
+}

--- a/recipes/upa-url/config.yml
+++ b/recipes/upa-url/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.0":
+    folder: all


### PR DESCRIPTION
### Summary
Add new recipe:  **upa-url/2.0.0**

#### Motivation
Fix: https://github.com/conan-io/conan-center-index/issues/27249

#### Details
Add the recipe of the Upa URL library from https://github.com/upa-url/upa

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
