### PR TITLE
[easyloggingpp] Various fixes and improvements

### DIFF
--- a/recipes/easyloggingpp/all/conandata.yml
+++ b/recipes/easyloggingpp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "9.97.1":
-    url: "https://github.com/amrayn/easyloggingpp/archive/v9.97.1.tar.gz"
+    url: "https://github.com/abumq/easyloggingpp/archive/v9.97.1.tar.gz"
     sha256: "ebe473e17b13f1d1f16d0009689576625796947a711e14aec29530f39560c7c2"
   "9.97.0":
-    url: "https://github.com/amrayn/easyloggingpp/archive/v9.97.0.tar.gz"
+    url: "https://github.com/abumq/easyloggingpp/archive/v9.97.0.tar.gz"
     sha256: "9110638e21ef02428254af8688bf9e766483db8cc2624144aa3c59006907ce22"

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -13,7 +13,7 @@ class EasyloggingppConan(ConanFile):
     description = "Single-header C++ logging library."
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/amrayn/easyloggingpp"
+    homepage = "https://github.com/abumq/easyloggingpp"
     topics = ("logging", "stacktrace", "efficient-logging")
 
     package_type = "static-library"

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -20,10 +20,16 @@ class EasyloggingppConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
+        "enable_unicode": [True, False],
+        "use_winsock2": [True, False],
+        "force_use_std_thread": [True, False],
         "enable_crash_log": [True, False],
         "enable_thread_safe": [True, False],
+        "enable_debug_assert_failure": [True, False],
         "enable_debug_errors": [True, False],
         "enable_default_logfile": [True, False],
+        "enable_default_crash_handling": [True, False],
+        "enable_fresh_logfile": [True, False],
         "disable_logs": [True, False],
         "disable_debug_logs": [True, False],
         "disable_info_logs": [True, False],
@@ -32,14 +38,27 @@ class EasyloggingppConan(ConanFile):
         "disable_fatal_logs": [True, False],
         "disable_verbose_logs": [True, False],
         "disable_trace_logs": [True, False],
+        "disable_log_to_file": [True, False],
+        "disable_custom_format_specifiers": [True, False],
+        "disable_logging_flags_from_arg": [True, False],
+        "disable_log_file_from_arg": [True, False],
+        "disable_check_macros": [True, False],
+        "disable_debug_macros": [True, False],
+        "disable_global_lock": [True, False],
         "lib_utc_datetime": [True, False],
     }
     default_options = {
         "fPIC": True,
+        "enable_unicode": False,
+        "use_winsock2": False,
+        "force_use_std_thread": False,
         "enable_crash_log": False,
         "enable_thread_safe": False,
+        "enable_debug_assert_failure": False,
         "enable_debug_errors": False,
         "enable_default_logfile": True,
+        "enable_default_crash_handling": True,
+        "enable_fresh_logfile": False,
         "disable_logs": False,
         "disable_debug_logs": False,
         "disable_info_logs": False,
@@ -48,6 +67,13 @@ class EasyloggingppConan(ConanFile):
         "disable_fatal_logs": False,
         "disable_verbose_logs": False,
         "disable_trace_logs": False,
+        "disable_log_to_file": False,
+        "disable_custom_format_specifiers": False,
+        "disable_logging_flags_from_arg": False,
+        "disable_log_file_from_arg": False,
+        "disable_check_macros": False,
+        "disable_debug_macros": False,
+        "disable_global_lock": False,
         "lib_utc_datetime": False,
     }
 
@@ -68,14 +94,26 @@ class EasyloggingppConan(ConanFile):
     @property
     def _public_defines(self):
         defines = []
+        if self.options.enable_unicode:
+            defines.append("ELPP_UNICODE")
+        if self.options.use_winsock2:
+            defines.append("ELPP_WINSOCK2")
+        if self.options.force_use_std_thread:
+            defines.append("ELPP_FORCE_USE_STD_THREAD")
         if self.options.enable_crash_log:
             defines.append("ELPP_FEATURE_CRASH_LOG")
         if self.options.enable_thread_safe:
             defines.append("ELPP_THREAD_SAFE")
+        if self.options.enable_debug_assert_failure:
+            defines.append("ELPP_DEBUG_ASSERT_FAILURE")
         if self.options.enable_debug_errors:
             defines.append("ELPP_DEBUG_ERRORS")
         if not self.options.enable_default_logfile:
             defines.append("ELPP_NO_DEFAULT_LOG_FILE")
+        if not self.options.enable_default_crash_handling:
+            defines.append("ELPP_DISABLE_DEFAULT_CRASH_HANDLING")
+        if self.options.enable_fresh_logfile:
+            defines.append("ELPP_FRESH_LOG_FILE")
         if self.options.disable_logs:
             defines.append("ELPP_DISABLE_LOGS")
         if self.options.disable_debug_logs:
@@ -92,6 +130,20 @@ class EasyloggingppConan(ConanFile):
             defines.append("ELPP_DISABLE_VERBOSE_LOGS")
         if self.options.disable_trace_logs:
             defines.append("ELPP_DISABLE_TRACE_LOGS")
+        if self.options.disable_log_to_file:
+            defines.append("ELPP_NO_LOG_TO_FILE")
+        if self.options.disable_custom_format_specifiers:
+            defines.append("ELPP_DISABLE_CUSTOM_FORMAT_SPECIFIERS")
+        if self.options.disable_logging_flags_from_arg:
+            defines.append("ELPP_DISABLE_LOGGING_FLAGS_FROM_ARG")
+        if self.options.disable_log_file_from_arg:
+            defines.append("ELPP_DISABLE_LOG_FILE_FROM_ARG")
+        if self.options.disable_check_macros:
+            defines.append("ELPP_NO_CHECK_MACROS")
+        if self.options.disable_debug_macros:
+            defines.append("ELPP_NO_DEBUG_MACROS")
+        if self.options.disable_global_lock:
+            defines.append("ELPP_NO_GLOBAL_LOCK")
         if self.options.lib_utc_datetime:
             defines.append("ELPP_UTC_DATETIME")
         return defines

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -91,7 +91,7 @@ class EasyloggingppConan(ConanFile):
         if self.options.disable_verbose_logs:
             defines.append("ELPP_DISABLE_VERBOSE_LOGS")
         if self.options.disable_trace_logs:
-            defines.append("lib_utc_datetime")
+            defines.append("ELPP_DISABLE_TRACE_LOGS")
         if self.options.lib_utc_datetime:
             defines.append("ELPP_UTC_DATETIME")
         return defines

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -122,3 +122,6 @@ class EasyloggingppConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["easyloggingpp"]
         self.cpp_info.defines = self._public_defines
+
+        if self.options.enable_thread_safe and self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, replace_in_file
 
@@ -53,6 +54,10 @@ class EasyloggingppConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -74,7 +74,7 @@ class EasyloggingppConan(ConanFile):
             defines.append("ELPP_THREAD_SAFE")
         if self.options.enable_debug_errors:
             defines.append("ELPP_DEBUG_ERRORS")
-        if self.options.enable_default_logfile:
+        if not self.options.enable_default_logfile:
             defines.append("ELPP_NO_DEFAULT_LOG_FILE")
         if self.options.disable_logs:
             defines.append("ELPP_DISABLE_LOGS")


### PR DESCRIPTION
### Summary
Changes to recipe:  **easyloggingpp**

#### Motivation
This fixes a few bugs in the current recipe and adds additional options that are currently missing.

#### Details
* Add check for C++11 or higher (the [README](https://github.com/abumq/easyloggingpp) mentions that the library requires at least C++11)
* Fix the broken option `disable_trace_logs` (this previously set the wrong define)
* Fix the broken option `enable_default_logfile` (this previously behaved in the opposite way as expected)
* Add pthread to system libs on Linux/FreeBSD if option `enable_thread_safe` is enabled (the README mentions that linking with pthread is required in this case)
* Update the homepage and download links (the original links redirect to the new ones)
* Add support for additional options

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
