### PR TITLE
lucocozz-cargs: add version 1.0.2

### DIFF
--- a/recipes/lucocozz-cargs/all/conandata.yml
+++ b/recipes/lucocozz-cargs/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.2":
+    url: "https://github.com/lucocozz/cargs/archive/refs/tags/v1.0.2.tar.gz"
+    sha256: "15c64c271a109030538e3cb88a6fade49021a05f99bc372edd40fba2ec4cf0b5"

--- a/recipes/lucocozz-cargs/all/conanfile.py
+++ b/recipes/lucocozz-cargs/all/conanfile.py
@@ -1,0 +1,87 @@
+from conan import ConanFile
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+import os
+
+class LucocozzCargsConan(ConanFile):
+    name = "lucocozz-cargs"
+    version = "1.0.2"
+    description = "Modern C library for command-line argument parsing with an elegant, macro-based API"
+    topics = ("conan", "cargs", "lucocozz-cargs", "command-line", "arguments", "parser", "cli", "argparse")
+    url = "https://github.com/lucocozz/cargs"
+    homepage = "https://github.com/lucocozz/cargs"
+    license = "MIT"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "disable_regex": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "disable_regex": False,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        if not self.options.disable_regex:
+            self.requires("pcre2/[>=10.40]")
+
+    def build_requirements(self):
+        self.tool_requires("meson/[>=1.0.0]")
+        self.tool_requires("ninja/[>=1.10.2 <2]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["buildtype"] = str(self.settings.build_type).lower()
+        tc.project_options["disable_regex"] = bool(self.options.disable_regex)
+        tc.project_options["tests"] = False
+        tc.project_options["examples"] = False
+        tc.project_options["benchmarks"] = False
+        if self.settings.build_type == "RelWithDebInfo":
+            tc.project_options["buildtype"] = "release"
+        tc.generate()
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "lucocozz-cargs")
+        self.cpp_info.set_property("cmake_target_name", "lucocozz-cargs::lucocozz-cargs")
+        self.cpp_info.libs = ["cargs"]
+        
+        if not self.options.disable_regex:
+            self.cpp_info.requires = ["pcre2::pcre2"]
+            
+        if self.options.disable_regex:
+            self.cpp_info.defines.append("CARGS_NO_REGEX")
+            
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.append("m")
+            
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.set_property("pkg_config_name", "cargs")

--- a/recipes/lucocozz-cargs/all/test_package/CMakeLists.txt
+++ b/recipes/lucocozz-cargs/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package C)
+
+find_package(lucocozz-cargs REQUIRED)
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package lucocozz-cargs::lucocozz-cargs)

--- a/recipes/lucocozz-cargs/all/test_package/conanfile.py
+++ b/recipes/lucocozz-cargs/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+class LucocozzCargsTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if self.settings.os == "Windows":
+            return
+        if can_run(self):
+            cmd = os.path.join(self.build_folder, "test_package")
+            self.run(f"{cmd} -v", env="conanrun")

--- a/recipes/lucocozz-cargs/all/test_package/test_package.c
+++ b/recipes/lucocozz-cargs/all/test_package/test_package.c
@@ -1,0 +1,29 @@
+#include "cargs.h"
+#include <stdio.h>
+
+CARGS_OPTIONS(
+    options,
+    HELP_OPTION(FLAGS(FLAG_EXIT)),
+    OPTION_FLAG('v', "verbose", HELP("Enable verbose mode")),
+    OPTION_STRING('o', "output", HELP("Output file"), DEFAULT("output.txt"))
+)
+
+int main(int argc, char **argv)
+{
+    cargs_t cargs = cargs_init(options, "test_package", "1.0.0");
+    
+    int status = cargs_parse(&cargs, argc, argv);
+    if (status != CARGS_SUCCESS) {
+        return status;
+    }
+    
+    bool verbose = cargs_get(cargs, "verbose").as_bool;
+    const char *output = cargs_get(cargs, "output").as_string;
+    
+    printf("Test package ran successfully!\n");
+    printf("  Verbose: %s\n", verbose ? "yes" : "no");
+    printf("  Output: %s\n", output);
+    
+    cargs_free(&cargs);
+    return 0;
+}

--- a/recipes/lucocozz-cargs/config.yml
+++ b/recipes/lucocozz-cargs/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.2":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **lucocozz-cargs/1.0.2**

#### Motivation
First release of the lib

#### Details
libcargs is a modern C library for command-line argument parsing with an elegant, macro-based API. It provides features subcommands, validation, and more, offering a more intuitive alternative to getopt and argp.

Key features:
- Automatic help generation
- Git-style nested subcommands
- Advanced validation with regex support
- Array and map (key-value) option types



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
