### PR TITLE
onetbb: Add CMake 4 support for onetbb

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -146,6 +146,9 @@ class OneTBBConan(ConanFile):
                     os.path.join(hwloc_package_folder, "bin", "hwloc.dll").replace("\\", "/")
         if self.options.get_safe("build_apple_frameworks"):
             toolchain.variables["TBB_BUILD_APPLE_FRAMEWORKS"] = True
+        if Version(self.version) <= "2021.10.0":
+            toolchain.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
+
         toolchain.generate()
 
         if self._tbbbind_build and not self._tbbbind_explicit_hwloc:
@@ -221,7 +224,7 @@ class OneTBBConan(ConanFile):
                 tbbproxy = self.cpp_info.components["tbbmalloc_proxy"]
 
                 tbbproxy.set_property("cmake_target_name", "TBB::tbbmalloc_proxy")
-                
+
                 if self.options.get_safe("build_apple_frameworks"):
                     tbbproxy.frameworkdirs.append(os.path.join(self.package_folder, "lib"))
                     tbbproxy.frameworks.append("tbbmalloc_proxy")


### PR DESCRIPTION
Add missing onetbb support for CMake 4 that was missed in the initial pass

See https://github.com/conan-io/conan-center-index/issues/26878