### PR TITLE
opentelemetry-cpp ability to set ABI version 2

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -295,7 +295,7 @@ class OpenTelemetryCppConan(ConanFile):
         tc.cache_variables["OPENTELEMETRY_INSTALL"] = True
         if not self.settings.compiler.cppstd:
             tc.variables["CMAKE_CXX_STANDARD"] = self._min_cppstd
-        if self.with_abi_v2:
+        if self.options.get_safe("with_abi_v2"):
             tc.variables["WITH_ABI_VERSION_1"] = False
             tc.variables["WITH_ABI_VERSION_2"] = True
         tc.generate()

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -24,6 +24,7 @@ class OpenTelemetryCppConan(ConanFile):
     options = {
         "fPIC": [True, False],
         "shared": [True, False],
+        "with_abi_v2": [True, False],
         "with_no_deprecated_code": [True, False],
         "with_stl": [True, False],
         "with_gsl": [True, False],
@@ -47,6 +48,7 @@ class OpenTelemetryCppConan(ConanFile):
         "fPIC": True,
         "shared": False,
 
+        "with_abi_v2": False,
         "with_no_deprecated_code": False,
         # Enabling this causes stack overflow in the test_package
         "with_stl": False,
@@ -103,6 +105,8 @@ class OpenTelemetryCppConan(ConanFile):
         if Version(self.version) < "1.16.0":
             del self.options.with_otlp_file
             del self.options.with_otlp_http_compression
+        if Version(self.version) < "1.18.0":
+            del self.options.with_abi_v2
 
     def configure(self):
         if self.options.shared:
@@ -291,6 +295,9 @@ class OpenTelemetryCppConan(ConanFile):
         tc.cache_variables["OPENTELEMETRY_INSTALL"] = True
         if not self.settings.compiler.cppstd:
             tc.variables["CMAKE_CXX_STANDARD"] = self._min_cppstd
+        if self.with_abi_v2:
+            tc.variables["WITH_ABI_VERSION_1"] = False
+            tc.variables["WITH_ABI_VERSION_2"] = True
         tc.generate()
 
         deps = CMakeDeps(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentelemetry-cpp/1.18.0**

#### Motivation
The library can be built with experimental ABI support (ABI_V2) and with stable (ABI_V1). There was no way to configure it.

#### Details
I've added option with_abi_v2, that sets WITH_ABI_VERSION_2 and unsets WITH_ABI_VERSION_1 in cmake script.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
