### PR TITLE
nasm: use GitHub as download location after nasm.us being offline

### DIFF
--- a/recipes/nasm/all/conandata.yml
+++ b/recipes/nasm/all/conandata.yml
@@ -1,19 +1,22 @@
 sources:
-  "2.16.01":
-    sha256: "c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.xz"
+  "2.16.03":
+    sha256: "e525fa6fdc3df33cec6b499111f44afa78ce50bf260158580dcf014015a21ba9"
+    url: "https://github.com/netwide-assembler/nasm/archive/refs/tags/nasm-2.16.03.tar.gz"
   "2.15.05":
-    sha256: "3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
-  "2.14":
-    sha256: "97c615dbf02ef80e4e2b6c385f7e28368d51efc214daa98e600ca4572500eec0"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.14/nasm-2.14.tar.xz"
+    sha256: "f575c516b5c1c28d5d64efdc26ed52b137ad36bfbd2d855d4782f050ca964245"
+    url: "https://github.com/netwide-assembler/nasm/archive/refs/tags/nasm-2.15.05.tar.gz"
+  "2.14.02":
+    sha256: "3b581dcd89cad8171c959787cf813fa4ca132eafee78750f1147f923aa8a4791"
+    url: "https://github.com/netwide-assembler/nasm/archive/refs/tags/nasm-2.14.02.tar.gz"
+  "2.13.03":
+    sha256: "98720da7ad3310b883e42e2e581063b8eefb3e3bb16105f4685fb9d4e733032a"
+    url: "https://github.com/netwide-assembler/nasm/archive/refs/tags/nasm-2.13.03.tar.gz"
   "2.13.02":
-    sha256: "8ac3235f49a6838ff7a8d7ef7c19a4430d0deecc0c2d3e3e237b5e9f53291757"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.xz"
+    sha256: "c5dcdb1a64322380d1830f2c0c927f0a866ccb943071f3d21204b0b42a28d4e2"
+    url: "https://github.com/netwide-assembler/nasm/archive/refs/tags/nasm-2.13.02.tar.gz"
   "2.13.01":
-    sha256: "aa0213008f0433ecbe07bb628506a5c4be8079be20fc3532a5031fd639db9a5e"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.13.01/nasm-2.13.01.tar.xz"
+    sha256: "5355af0ef3c4ad441046f30f915ca17b45aee453c679e411b432b777c3fdb961"
+    url: "https://github.com/netwide-assembler/nasm/archive/refs/tags/nasm-2.13.01.tar.gz"
 patches:
   "2.16.01":
     - patch_file: "patches/2.16.01-0001-disable-newly-integrated-dependency-tracking.patch"


### PR DESCRIPTION
### Summary
Changes to recipe:  **application/nasm**

#### Motivation
nasm.us is down ... get the sources from GitHub

#### Details
Change URL and hashes


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
