### PR TITLE
fix msvc build with ssl option

### DIFF
--- a/recipes/usockets/all/conanfile.py
+++ b/recipes/usockets/all/conanfile.py
@@ -191,6 +191,13 @@ class UsocketsConan(ConanFile):
                     # Otherwise AutotoolsDeps should suffice
                     libuv_includes = self.dependencies["libuv"].cpp_info.aggregated_components().includedirs
                     env.append("CPPFLAGS", " ".join([f"-I{unix_path(self, p)}" for p in libuv_includes]))
+
+                if self.options.with_ssl != False:
+                    # Workaround for: https://github.com/conan-io/conan/issues/12784
+                    # Otherwise AutotoolsDeps should suffice
+                    libssl_includes = self.dependencies[str(self.options.with_ssl)].cpp_info.aggregated_components().includedirs
+                    env.append("CPPFLAGS", " ".join([f"-I{unix_path(self, p)}" for p in libssl_includes]))
+
             tc.generate(env)
 
             deps = AutotoolsDeps(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **usockets**

#### Motivation
When I use the option `with_ssl=openssl` on Windows with MSVC, I run into this error:
```
`-------- Installing package usockets/0.8.8 (45 of 48) --------
usockets/0.8.8: Building from source
usockets/0.8.8: Package usockets/0.8.8:0f98e239a3f252f252cc276c9e65e0299148cb72
usockets/0.8.8: Copying sources to build folder
usockets/0.8.8: Building your package in C:\Users\ContainerUser\.conan2\p\b\usock9dc5490990719\b
usockets/0.8.8: Calling generate()
usockets/0.8.8: Generators folder: C:\Users\ContainerUser\.conan2\p\b\usock9dc5490990719\b\build-release\conan
usockets/0.8.8: Generated aggregated env files: ['conanbuild.sh', 'conanbuild.bat', 'conanrun.bat']
usockets/0.8.8: Calling build()
usockets/0.8.8: Apply patch (portability): remove lto options
usockets/0.8.8: RUN: make default WITH_LTO=0 WITH_OPENSSL=1 WITH_LIBUV=1 -j10
conanvcvars.bat: Activating environment Visual Studio 16 - amd64 - winsdk_version=None - vcvars_ver=14.2
[vcvarsall.bat] Environment initialized for: 'x64'
mkdir: cannot create directory '/dev/shm': Read-only file system

Creating /dev/shm directory failed.
POSIX semaphores and POSIX shared memory will not work

mkdir: cannot create directory '/dev/mqueue': Read-only file system

Creating /dev/mqueue directory failed.
POSIX message queues will not work

rm -f *.o
/c/users/containeruser/.conan2/p/autome371915acf95c/p/res/automake-1.16/compile cl -nologo  -MD -O2 -Ob2 -FS -DLIBUS_USE_OPENSSL -DLIBUS_USE_LIBUV -std=c11 -Isrc  -DNDEBUG -I/c/users/containeruser/.conan2/p/libuvcfe3c1a324c03/p/include /
I/c/users/containeruser/.conan2/p/opens0701e2a2f9221/p/include /I/c/users/containeruser/.conan2/p/libuvcfe3c1a324c03/p/include /I/c/users/containeruser/.conan2/p/zlib462c154a4e854/p/include -O3 -c src/*.c src/eventing/*.c src/crypto/*.c
src/io_uring/*.c
cl : Command line warning D9002 : ignoring unknown option '-std=c11'
cl : Command line warning D9002 : ignoring unknown option '-O3'
cl : Command line warning D9024 : unrecognized source file type 'I:/c/users/containeruser/.conan2/p/opens0701e2a2f9221/p/include', object file assumed
cl : Command line warning D9027 : source file 'I:/c/users/containeruser/.conan2/p/opens0701e2a2f9221/p/include' ignored
cl : Command line warning D9024 : unrecognized source file type 'I:/c/users/containeruser/.conan2/p/libuvcfe3c1a324c03/p/include', object file assumed
cl : Command line warning D9027 : source file 'I:/c/users/containeruser/.conan2/p/libuvcfe3c1a324c03/p/include' ignored
cl : Command line warning D9024 : unrecognized source file type 'I:/c/users/containeruser/.conan2/p/zlib462c154a4e854/p/include', object file assumed
cl : Command line warning D9027 : source file 'I:/c/users/containeruser/.conan2/p/zlib462c154a4e854/p/include' ignored
bsd.c
context.c
loop.c
quic.c
socket.c
udp.c
epoll_kqueue.c
gcd.c
libuv.c
openssl.c
src/crypto/openssl.c(34): fatal error C1083: Cannot open include file: 'openssl/ssl.h': No such file or directory
io_context.c
io_loop.c
io_socket.c
Generating Code...
make: *** [Makefile:77: default] Error 2
``

#### Details
I repeated the same strategy used in the original recipe to include headers of libuv, so I can include headers of openssl.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
