### PR TITLE
cpuinfo: add version cci.20250110

### DIFF
--- a/recipes/cpuinfo/all/conandata.yml
+++ b/recipes/cpuinfo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20250110":
+    url: "https://github.com/pytorch/cpuinfo/archive/8a1772a0c5c447df2d18edf33ec4603a8c9c04a6.tar.gz"
+    sha256: "37bb2fd2d1e87102baea8d131a0c550c4ceff5a12fba61faeb1bff63868155f1"
   "cci.20231129":
     url: "https://github.com/pytorch/cpuinfo/archive/9d809924011af8ff49dadbda1499dc5193f1659c.tar.gz"
     sha256: "0d769b7e3cc7d16205f4cc8988f869910db19f2d274db005c1ed74e961936d34"

--- a/recipes/cpuinfo/config.yml
+++ b/recipes/cpuinfo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20250110":
+    folder: all
   "cci.20231129":
     folder: all
   "cci.20230118":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpuinfo/cci.20250110**

#### Motivation
This is the version required by onnxruntime 1.21.1 in order to build with xnnpack

#### Details
https://github.com/pytorch/cpuinfo/compare/9d809924011af8ff49dadbda1499dc5193f1659c..8a1772a0c5c447df2d18edf33ec4603a8c9c04a6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
