### PR TITLE
zeus_expected: add version 1.3.0

### DIFF
--- a/recipes/zeus_expected/all/conandata.yml
+++ b/recipes/zeus_expected/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.0":
+    url: "https://github.com/zeus-cpp/expected/archive/refs/tags/v1.3.0.tar.gz"
+    sha256: "d45bd4a38bde787577d16983ba8efee25e8d445af711510619f7b49ef60f1e72"
   "1.2.0":
     url: "https://github.com/zeus-cpp/expected/archive/refs/tags/v1.2.0.tar.gz"
     sha256: "460da641f212c793f46a5a8f29107c9b9540a17a91f197e2dc396dac0269a2b5"

--- a/recipes/zeus_expected/config.yml
+++ b/recipes/zeus_expected/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.0":
+    folder: all
   "1.2.0":
     folder: all
   "1.1.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **zeus_expected/1.3.0**

#### Motivation
Add a new upstream version.

#### Details
https://github.com/zeus-cpp/expected/releases/tag/v1.3.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
