### PR TITLE
[nasm/2.**] Resolve issue #27266 for package nasm by replacing the servers

### DIFF
--- a/recipes/nasm/all/conandata.yml
+++ b/recipes/nasm/all/conandata.yml
@@ -1,19 +1,10 @@
 sources:
   "2.16.01":
     sha256: "c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.xz"
+    url: "https://gstreamer.freedesktop.org/src/mirror/nasm-2.16.01.tar.xz"
   "2.15.05":
     sha256: "3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
-  "2.14":
-    sha256: "97c615dbf02ef80e4e2b6c385f7e28368d51efc214daa98e600ca4572500eec0"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.14/nasm-2.14.tar.xz"
-  "2.13.02":
-    sha256: "8ac3235f49a6838ff7a8d7ef7c19a4430d0deecc0c2d3e3e237b5e9f53291757"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.xz"
-  "2.13.01":
-    sha256: "aa0213008f0433ecbe07bb628506a5c4be8079be20fc3532a5031fd639db9a5e"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.13.01/nasm-2.13.01.tar.xz"
+    url: "https://gstreamer.freedesktop.org/src/mirror/nasm-2.15.05.tar.xz"
 patches:
   "2.16.01":
     - patch_file: "patches/2.16.01-0001-disable-newly-integrated-dependency-tracking.patch"


### PR DESCRIPTION
Resolve issue #27266 for package nasm by replacing the servers in conandata.yml with live ones. Remove older versions we do not have the urls for.

### Summary
Changes to recipe: 
   **nasm/2.15.05**
   **nasm/2.16.01**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Resolve [issue 27266](https://github.com/conan-io/conan-center-index/issues/27266)

The server in the urls in nasm's conandata.yml has gone dark, change them to a live server.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
I wanted to find replacements for the `url` entries that did not require new checksums,
these two urls fit the bill.


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
