### PR TITLE
nasm: Update download URLs, stop publishing new revisions for older version 

### DIFF
--- a/recipes/nasm/all/conandata.yml
+++ b/recipes/nasm/all/conandata.yml
@@ -1,10 +1,14 @@
 sources:
   "2.16.01":
     sha256: "c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"
-    url: "https://www.nasm.dev/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.xz"
+    url:
+      - "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.xz"
+      - "https://www.nasm.dev/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.xz"
   "2.15.05":
     sha256: "3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f"
-    url: "https://www.nasm.dev/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
+    url:
+      - "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
+      - "https://www.nasm.dev/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
 patches:
   "2.16.01":
     - patch_file: "patches/2.16.01-0001-disable-newly-integrated-dependency-tracking.patch"

--- a/recipes/nasm/all/conandata.yml
+++ b/recipes/nasm/all/conandata.yml
@@ -1,19 +1,10 @@
 sources:
   "2.16.01":
     sha256: "c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.xz"
+    url: "https://www.nasm.dev/pub/nasm/releasebuilds/2.16.01/nasm-2.16.01.tar.xz"
   "2.15.05":
     sha256: "3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
-  "2.14":
-    sha256: "97c615dbf02ef80e4e2b6c385f7e28368d51efc214daa98e600ca4572500eec0"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.14/nasm-2.14.tar.xz"
-  "2.13.02":
-    sha256: "8ac3235f49a6838ff7a8d7ef7c19a4430d0deecc0c2d3e3e237b5e9f53291757"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.xz"
-  "2.13.01":
-    sha256: "aa0213008f0433ecbe07bb628506a5c4be8079be20fc3532a5031fd639db9a5e"
-    url: "https://www.nasm.us/pub/nasm/releasebuilds/2.13.01/nasm-2.13.01.tar.xz"
+    url: "https://www.nasm.dev/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
 patches:
   "2.16.01":
     - patch_file: "patches/2.16.01-0001-disable-newly-integrated-dependency-tracking.patch"

--- a/recipes/nasm/config.yml
+++ b/recipes/nasm/config.yml
@@ -3,9 +3,3 @@ versions:
     folder: all
   "2.15.05":
     folder: all
-  "2.14":
-    folder: all
-  "2.13.02":
-    folder: all
-  "2.13.01":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **nasm/***

#### Motivation
* nasm.us is down
* Pointing to new server available
* Stop publishing new revisions for older version


Supersed: https://github.com/conan-io/conan-center-index/pull/27279 https://github.com/conan-io/conan-center-index/pull/27294
Closes: https://github.com/conan-io/conan-center-index/issues/27266