### PR TITLE
[linux-headers-generic] Pass ARCH when cross-building

### DIFF
--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import chdir, copy, get
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
+from conan.tools.build import cross_building
 
 required_conan_version = ">=1.53.0"
 
@@ -33,6 +34,26 @@ class LinuxHeadersGenericConan(ConanFile):
     def _is_legacy_one_profile(self):
         return not hasattr(self, "settings_build")
 
+    @property
+    def _conan_arch_to_linux_arch(self):
+        # INFO: Conan architecture to Linux architecture mapping
+        # https://www.kernel.org/doc/html/latest/arch/index.html
+        # https://github.com/torvalds/linux/tree/v6.14/arch
+        arch_mapping = {
+            "armv8": "arm64",
+            "armv7": "arm",
+            "x86": "x86",
+            "ppc": "powerpc",
+            "riscv": "riscv",
+            "mips": "mips",
+            "sparc": "sparc",
+            "s390": "s390",
+            "sh4le": "sh"
+        }
+        arch = str(self.settings.arch)
+        return next((value for prefix, value in arch_mapping.items()
+                    if arch.startswith(prefix)), arch)
+
     def validate(self):
         if self.settings.os != "Linux" or (not self._is_legacy_one_profile and self.settings_build.os != "Linux"):
             raise ConanInvalidConfiguration("linux-headers-generic supports only Linux")
@@ -42,6 +63,10 @@ class LinuxHeadersGenericConan(ConanFile):
 
     def generate(self):
         tc = AutotoolsToolchain(self)
+        if cross_building(self):
+            # INFO: When cross-compiling, the build system needs to know the target architecture
+            # https://github.com/torvalds/linux/blob/v6.14/Makefile#L394
+            tc.make_args.append(f"ARCH={self._conan_arch_to_linux_arch}")
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **linux-headers-generic/6.5.9**

#### Motivation

closes #27205

#### Details

From https://github.com/torvalds/linux/blob/v6.14/Makefile:

> When performing cross compilation for other architectures ARCH shall be set
> to the target architecture. (See arch/* for the possibilities).
> ARCH can be set during invocation of make:
> make ARCH=arm64
> Another way is to have ARCH set in the environment.
> The default ARCH is the host where make is executed.

When generating for same arch (x86_64) vs cross-building to armv8, we have several header files with different content:

```
diff -q -r /home/uilian/.conan2/p/b/linuxbc0bc2d267420/p/include /home/uilian/.conan2/p/b/linux943683da64fec/p/include/
Only in /home/uilian/.conan2/p/b/linuxbc0bc2d267420/p/include/asm: amd_hsmp.h
Only in /home/uilian/.conan2/p/b/linuxbc0bc2d267420/p/include/asm: a.out.h
Files /home/uilian/.conan2/p/b/linuxbc0bc2d267420/p/include/asm/auxvec.h and /home/uilian/.conan2/p/b/linux943683da64fec/p/include/asm/auxvec.h differ
Files /home/uilian/.conan2/p/b/linuxbc0bc2d267420/p/include/asm/bitsperlong.h and /home/uilian/.conan2/p/b/linux943683da64fec/p/include/asm/bitsperlong.h differ
Only in /home/uilian/.conan2/p/b/linuxbc0bc2d267420/p/include/asm: boot.h
Only in /home/uilian/.conan2/p/b/linuxbc0bc2d267420/p/include/asm: bootparam.h
....
```

As example:

```
diff '--color=auto' -r /home/uilian/.conan2/p/b/linuxbc0bc2d267420/p/include/asm/auxvec.h /home/uilian/.conan2/p/b/linux943683da64fec/p/include/asm/auxvec.h
2,3d1
< #ifndef _ASM_X86_AUXVEC_H
< #define _ASM_X86_AUXVEC_H
5,6c3,15
<  * Architecture-neutral AT_ values in 0-17, leave some room
<  * for more of them, start the x86-specific ones at 32.
---
>  * Copyright (C) 2012 ARM Ltd.
>  *
>  * This program is free software; you can redistribute it and/or modify
>  * it under the terms of the GNU General Public License version 2 as
>  * published by the Free Software Foundation.
>  *
>  * This program is distributed in the hope that it will be useful,
>  * but WITHOUT ANY WARRANTY; without even the implied warranty of
>  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
>  * GNU General Public License for more details.
>  *
>  * You should have received a copy of the GNU General Public License
>  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
8,11c17,18
< #ifdef __i386__
< #define AT_SYSINFO            32
< #endif
< #define AT_SYSINFO_EHDR               33
---
> #ifndef __ASM_AUXVEC_H
> #define __ASM_AUXVEC_H
13,18c20,22
< /* entries in ARCH_DLINFO: */
< #if defined(CONFIG_IA32_EMULATION) || !defined(CONFIG_X86_64)
< # define AT_VECTOR_SIZE_ARCH 3
< #else /* else it's non-compat x86-64 */
< # define AT_VECTOR_SIZE_ARCH 2
< #endif
---
> /* vDSO location */
> #define AT_SYSINFO_EHDR       33
> #define AT_MINSIGSTKSZ        51      /* stack needed for signal delivery */
20c24,26
< #endif /* _ASM_X86_AUXVEC_H */
---
> #define AT_VECTOR_SIZE_ARCH 2 /* entries in ARCH_DLINFO */
> 
> #endif
```

Here is my full build log when cross-building on Linux x86_64 to armv8: 
[linux-headers-generic-6.5.9-cross-arm.log](https://github.com/user-attachments/files/19887641/linux-headers-generic-6.5.9-cross-arm.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
