### PR TITLE
arrow: set ARROW_ORC when option with_orc is enabled to build with ORC

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -346,6 +346,7 @@ class ArrowConan(ConanFile):
         if self.options.with_zstd:
             tc.variables["ARROW_ZSTD_USE_SHARED"] = bool(self.dependencies["zstd"].options.shared)
         tc.variables["ORC_SOURCE"] = "SYSTEM"
+        tc.variables["ARROW_ORC"] = bool(self.options.with_orc)
         tc.variables["ARROW_WITH_THRIFT"] = bool(self.options.with_thrift)
         tc.variables["ARROW_THRIFT"] = bool(self.options.with_thrift)
         tc.variables["Thrift_SOURCE"] = "SYSTEM"


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow**

#### Motivation
It seems we are missing to enable the ORC build on Arrow when the with_orc option is enabled, see:
https://github.com/apache/arrow/issues/46221

#### Details
In order to build arrow with ORC support the `ARROW_ORC` CMake flag has to be enabled.


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
