### PR TITLE
spirv-tools: backport patch to fix clang-10, fix compiler.cppstd validation

### DIFF
--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -24,3 +24,16 @@ sources:
   "1.2.198.0":
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/sdk-1.2.198.0.tar.gz"
     sha256: "e8a9fec946f8473129374ad6b98ee690ac9a4574ace7cb3b46bbeb4eddfdc33b"
+patches:
+  "1.4.309.0":
+    - patch_file: "patches/0001-fix-clang-20-build-issue.patch"
+      patch_description: "fix clang-20 build issue"
+      patch_type: "backport"
+  "1.3.268.0":
+    - patch_file: "patches/0001-fix-clang-20-build-issue.patch"
+      patch_description: "fix clang-20 build issue"
+      patch_type: "backport"
+  "1.3.261.1":
+    - patch_file: "patches/0001-fix-clang-20-build-issue.patch"
+      patch_description: "fix clang-20 build issue"
+      patch_type: "backport"

--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -25,6 +25,10 @@ sources:
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/sdk-1.2.198.0.tar.gz"
     sha256: "e8a9fec946f8473129374ad6b98ee690ac9a4574ace7cb3b46bbeb4eddfdc33b"
 patches:
+  "1.4.313.0":
+    - patch_file: "patches/0001-fix-clang-20-build-issue.patch"
+      patch_description: "fix clang-20 build issue"
+      patch_type: "backport"
   "1.4.309.0":
     - patch_file: "patches/0001-fix-clang-20-build-issue.patch"
       patch_description: "fix clang-20 build issue"

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy, get, replace_in_file, rm, rmdir, save
+from conan.tools.files import copy, get, replace_in_file, rm, rmdir, save, apply_conandata_patches, export_conandata_patches
 from conan.tools.scm import Version
 import os
 import textwrap
@@ -49,6 +49,9 @@ class SpirvtoolsConan(ConanFile):
                 "Visual Studio": "15",
             }
         }.get(self._min_cppstd, {})
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -125,6 +128,7 @@ class SpirvtoolsConan(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
+        apply_conandata_patches(self)
         # CMAKE_POSITION_INDEPENDENT_CODE was set ON for the entire
         # project in the lists file.
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -1,12 +1,10 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir, save, apply_conandata_patches, export_conandata_patches
 from conan.tools.scm import Version
 import os
-import textwrap
 
 required_conan_version = ">=2.1"
 
@@ -34,22 +32,6 @@ class SpirvtoolsConan(ConanFile):
 
     short_paths = True
 
-    @property
-    def _min_cppstd(self):
-        return "11" if Version(self.version) < "1.3.243" else "17"
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "17": {
-                "apple-clang": "10",
-                "clang": "7" if Version(self.version) >= "1.3.250" else "5",
-                "gcc": "8" if Version(self.version) >= "1.3.250" else "7",
-                "msvc": "191",
-                "Visual Studio": "15",
-            }
-        }.get(self._min_cppstd, {})
-
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -67,15 +49,13 @@ class SpirvtoolsConan(ConanFile):
     def requirements(self):
         self.requires(f"spirv-headers/{self.version}")
 
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
+    def validate_build(self):
+        # newer versions of the library require C++17 for internals
+        check_min_cppstd(self, 11 if Version(self.version) < "1.3.243" else 17)
 
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
+    def validate(self):
+        # The interface requires C++11
+        check_min_cppstd(self, 11)
 
     def build_requirements(self):
         if Version(self.version) >= "1.3.239":

--- a/recipes/spirv-tools/all/patches/0001-fix-clang-20-build-issue.patch
+++ b/recipes/spirv-tools/all/patches/0001-fix-clang-20-build-issue.patch
@@ -1,0 +1,26 @@
+From 4b46b76c7c68f838f18906c6d3ca275eef207ca7 Mon Sep 17 00:00:00 2001
+From: Elvis Dukaj <elvis.dukaj@dynatrace.com>
+Date: Thu, 24 Apr 2025 14:36:21 +0200
+Subject: [PATCH] fix clang-20 build issue
+
+---
+ tools/diff/diff.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tools/diff/diff.cpp b/tools/diff/diff.cpp
+index d60edb2e..349ec092 100644
+--- a/tools/diff/diff.cpp
++++ b/tools/diff/diff.cpp
+@@ -87,7 +87,8 @@ std::unique_ptr<spvtools::opt::IRContext> load_module(const char* path) {
+     return spvtools::BuildModule(
+         kDefaultEnvironment, spvtools::utils::CLIMessageConsumer,
+         std::string(contents.begin(), contents.end()),
+-        spvtools::SpirvTools::kDefaultAssembleOption |
++        static_cast<spv_text_to_binary_options_t>(
++            spvtools::SpirvTools::kDefaultAssembleOption) |
+             SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+   }
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
### Summary
Changes to recipe:  **spirv-tools/1.3.236.0+**

#### Motivation
Trying to build the library using clang-20 results in a build issue. I submitted a PR upstream as well. If this PR is merged we can backport the fix here as well.

#### Details

Before: 

The output before this PR:

```
======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=clang
compiler.cppstd=26
compiler.libcxx=libc++
compiler.version=20
os=Linux
[tool_requires]
*: cmake/3.31.6
[conf]
tools.cmake.cmake_layout:build_folder_vars=['settings.os', 'settings.arch', 'settings.compiler', 'settings.compiler.version']
tools.cmake.cmaketoolchain:extra_variables={'CMAKE_EXPORT_COMPILE_COMMANDS': 'TRUE', 'CMAKE_EXPERIMENTAL_CXX_IMPORT_STD': '0e5b6991-d74f-4b3d-a41c-cf096e0b2508'}
tools.cmake.cmaketoolchain:generator=Ninja
[buildenv]
CC=/usr/bin/clang-20
CXX=/usr/bin/clang++-20

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=23
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux


======== Computing dependency graph ========
spirv-tools/1.4.309.0: Not found in local cache, looking in remotes...
spirv-tools/1.4.309.0: Checking remote: conancenter
Connecting to remote 'conancenter' anonymously
spirv-tools/1.4.309.0: Downloaded recipe revision 47a0255f75b23f14408c156f32386fa1
spirv-headers/1.4.309.0: Not found in local cache, looking in remotes...
spirv-headers/1.4.309.0: Checking remote: conancenter
spirv-headers/1.4.309.0: Downloaded recipe revision c286b13a6f57f4da633b34730b23547d
Graph root
    conanfile.txt: /home/elvisdukaj/projects/dev/The-Modern-Vulkan-Cookbook/conanfile.txt
Requirements
    spirv-headers/1.4.309.0#c286b13a6f57f4da633b34730b23547d - Downloaded (conancenter)
    spirv-tools/1.4.309.0#47a0255f75b23f14408c156f32386fa1 - Downloaded (conancenter)
    vulkan-headers/1.4.309.0#2f581b3b123240016ffaf61d3dd6816f - Cache
    vulkan-loader/1.4.309.0#514f7fa2e866e59c43523869a7a23905 - Cache
    xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4 - Cache
Build requirements
    cmake/3.31.6#ed0e6c1d49bd564ce6fed1a19653b86d - Cache
    meson/1.2.2#21b73818ba96d9eea465b310b5bbc993 - Cache
    ninja/1.12.1#fd583651bf0c6a901943495d49878803 - Cache
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
Resolved version ranges
    ninja/[>=1.10.2 <2]: ninja/1.12.1

======== Computing necessary packages ========
spirv-tools/1.4.309.0: Main binary package '0e543983c395b65265a0e9925636dc99665a968d' missing
spirv-tools/1.4.309.0: Checking 7 compatible configurations
spirv-tools/1.4.309.0: Compatible configurations not found in cache, checking servers
spirv-tools/1.4.309.0: 'c33aa3e237e9fe146dd0012993efc1c48306154e': compiler.cppstd=17
spirv-tools/1.4.309.0: '5d895be9a44cbe11eda6a17dd94c316c8875f485': compiler.cppstd=gnu17
spirv-tools/1.4.309.0: '4cf7d94b87f0bfea30f36db04aed2eda5a389586': compiler.cppstd=20
spirv-tools/1.4.309.0: 'a022e2fe3d80cc747c7ac38b72269e0f27f47579': compiler.cppstd=gnu20
spirv-tools/1.4.309.0: '0c6d14a097dbd3df7d6c7d05dcb4e46732b56014': compiler.cppstd=23
spirv-tools/1.4.309.0: '8337d622e0e020f265e39a3038930c3fbc707826': compiler.cppstd=gnu23
spirv-tools/1.4.309.0: '8818ea85e68994aa92311154a8d96dfee1cb7ce0': compiler.cppstd=gnu26
Requirements
    spirv-headers/1.4.309.0#c286b13a6f57f4da633b34730b23547d:da39a3ee5e6b4b0d3255bfef95601890afd80709#6a61acf313669d21cd5e7bcee4aa086f - Download (conancenter)
    spirv-tools/1.4.309.0#47a0255f75b23f14408c156f32386fa1:0e543983c395b65265a0e9925636dc99665a968d - Build
    vulkan-headers/1.4.309.0#2f581b3b123240016ffaf61d3dd6816f:da39a3ee5e6b4b0d3255bfef95601890afd80709#b160e51c88c0c3dd18cd706eac7a762d - Cache
    vulkan-loader/1.4.309.0#514f7fa2e866e59c43523869a7a23905:46e0a637bc8a67876ed2d46b9c31082a9f292032#03053d86844d4b82437f187bef9d37e8 - Cache
    xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Cache
Build requirements
    cmake/3.31.6#ed0e6c1d49bd564ce6fed1a19653b86d:63fead0844576fc02943e16909f08fcdddd6f44b#6ec4ca55f1a1a1a6716d3c898d6624f1 - Cache
Skipped binaries
    meson/1.2.2, ninja/1.12.1, pkgconf/2.1.0
xorg/system: System requirements:  already installed
xorg/system: System requirements:  already installed

======== Installing packages ========

-------- Downloading 1 package --------
spirv-headers/1.4.309.0: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter'
spirv-headers/1.4.309.0: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
spirv-headers/1.4.309.0: Downloaded package revision 6a61acf313669d21cd5e7bcee4aa086f
cmake/3.31.6: Already installed! (1 of 6)
cmake/3.31.6: Appending PATH environment variable: /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/bin
cmake/3.31.6: Appending PATH environment variable: /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/bin
vulkan-headers/1.4.309.0: Already installed! (3 of 6)
xorg/system: Already installed! (4 of 6)
spirv-tools/1.4.309.0: Calling source() in /home/elvisdukaj/.conan2/p/spirv31b3b3b467338/s/src
spirv-tools/1.4.309.0: Unzipping vulkan-sdk-1.4.309.0.tar.gz to .

-------- Installing package spirv-tools/1.4.309.0 (5 of 6) --------
spirv-tools/1.4.309.0: Building from source
spirv-tools/1.4.309.0: Package spirv-tools/1.4.309.0:0e543983c395b65265a0e9925636dc99665a968d
spirv-tools/1.4.309.0: Copying sources to build folder
spirv-tools/1.4.309.0: Building your package in /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b
spirv-tools/1.4.309.0: Calling generate()
spirv-tools/1.4.309.0: Generators folder: /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/build/Release/generators
spirv-tools/1.4.309.0: CMakeToolchain generated: conan_toolchain.cmake
spirv-tools/1.4.309.0: CMakeToolchain generated: /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/build/Release/generators/CMakePresets.json
spirv-tools/1.4.309.0: CMakeToolchain generated: /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/CMakeUserPresets.json
spirv-tools/1.4.309.0: Generating aggregated env files
spirv-tools/1.4.309.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
spirv-tools/1.4.309.0: Calling build()
spirv-tools/1.4.309.0: Running CMake.configure()
spirv-tools/1.4.309.0: RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src"
-- Using Conan toolchain: /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 26 with extensions OFF
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is Clang 20.1.3
-- The CXX compiler identification is Clang 20.1.3
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang-20 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++-20 - skipped
-- Detecting CXX compile features
CMake Warning (dev) at /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/share/cmake-3.31/Modules/Compiler/CMakeCommonCompilerMacros.cmake:248 (cmake_language):
  CMake's support for `import std;` in C++23 and newer is experimental.  It
  is meant only for experimentation and feedback to CMake developers.
Call Stack (most recent call first):
  /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/share/cmake-3.31/Modules/CMakeDetermineCompilerSupport.cmake:113 (cmake_create_cxx_import_std)
  /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/share/cmake-3.31/Modules/CMakeTestCXXCompiler.cmake:83 (CMAKE_DETERMINE_COMPILER_SUPPORT)
  CMakeLists.txt:17 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Detecting CXX compile features - done
-- Found Python3: /home/elvisdukaj/.local/share/virtualenvs/dev-aXgxtNH9/bin/python3.12 (found version "3.12.9") found components: Interpreter
-- Configuring done (1.1s)
-- Generating done (0.1s)
-- Build files have been written to: /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/build/Release

spirv-tools/1.4.309.0: Running CMake.build()
spirv-tools/1.4.309.0: RUN: cmake --build "/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/build/Release" -- -j24
[328/373] Building CXX object tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o
FAILED: tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o
/usr/bin/clang++-20 -DSPIRV_COLOR_TERMINAL -DSPIRV_TIMER_ENABLED -I/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src -I/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/build/Release -I/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/include -I/home/elvisdukaj/.conan2/p/spirva7c686f153c5c/p/include -m64 -stdlib=libc++ -O3 -DNDEBUG -std=c++26 -fPIE -Wextra-semi -Wall -Wextra -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-self-assign -Wno-long-long -Wshadow -Wundef -Wconversion -Wno-sign-conversion -fno-exceptions -ftemplate-depth=1024 -MD -MT tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o -MF tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o.d -o tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o -c /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/tools/diff/diff.cpp
/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/tools/diff/diff.cpp:90:54: error: invalid bitwise operation between different enumeration types ('spvtools::SpirvTools::(unnamed enum at /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/include/spirv-tools/libspirv.hpp:299:3)' and 'spv_text_to_binary_options_t')
   90 |         spvtools::SpirvTools::kDefaultAssembleOption |
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
   91 |             SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[351/373] Building CXX object source/diff/CMakeFiles/SPIRV-Tools-diff.dir/diff.cpp.o
ninja: build stopped: subcommand failed.

spirv-tools/1.4.309.0: ERROR:
Package '0e543983c395b65265a0e9925636dc99665a968d' build failed
spirv-tools/1.4.309.0: WARN: Build folder /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/build/Release
ERROR: spirv-tools/1.4.309.0: Error in build() method, line 137
        cmake.build()
        ConanException: Error 1 while executing
```

After:

```
======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=clang
compiler.cppstd=26
compiler.libcxx=libc++
compiler.version=20
os=Linux
[tool_requires]
*: cmake/3.31.6
[conf]
tools.cmake.cmake_layout:build_folder_vars=['settings.os', 'settings.arch', 'settings.compiler', 'settings.compiler.version']
tools.cmake.cmaketoolchain:extra_variables={'CMAKE_EXPORT_COMPILE_COMMANDS': 'TRUE', 'CMAKE_EXPERIMENTAL_CXX_IMPORT_STD': '0e5b6991-d74f-4b3d-a41c-cf096e0b2508'}
tools.cmake.cmaketoolchain:generator=Ninja
[buildenv]
CC=/usr/bin/clang-20
CXX=/usr/bin/clang++-20

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=23
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux


======== Computing dependency graph ========
Graph root
    conanfile.txt: /home/elvisdukaj/projects/dev/The-Modern-Vulkan-Cookbook/conanfile.txt
Requirements
    spirv-headers/1.4.309.0#c286b13a6f57f4da633b34730b23547d - Cache
    spirv-tools/1.4.309.0#a3c6ac024446cfb07cfa18b5e71b8b2a - Cache
    vulkan-headers/1.4.309.0#2f581b3b123240016ffaf61d3dd6816f - Cache
    vulkan-loader/1.4.309.0#514f7fa2e866e59c43523869a7a23905 - Cache
    xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4 - Cache
Build requirements
    cmake/3.31.6#ed0e6c1d49bd564ce6fed1a19653b86d - Cache
    meson/1.2.2#21b73818ba96d9eea465b310b5bbc993 - Cache
    ninja/1.12.1#fd583651bf0c6a901943495d49878803 - Cache
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
Resolved version ranges
    ninja/[>=1.10.2 <2]: ninja/1.12.1

======== Computing necessary packages ========
Connecting to remote 'conancenter' anonymously
spirv-tools/1.4.309.0: Main binary package '0e543983c395b65265a0e9925636dc99665a968d' missing
spirv-tools/1.4.309.0: Checking 7 compatible configurations
spirv-tools/1.4.309.0: Compatible configurations not found in cache, checking servers
spirv-tools/1.4.309.0: 'c33aa3e237e9fe146dd0012993efc1c48306154e': compiler.cppstd=17
spirv-tools/1.4.309.0: '5d895be9a44cbe11eda6a17dd94c316c8875f485': compiler.cppstd=gnu17
spirv-tools/1.4.309.0: '4cf7d94b87f0bfea30f36db04aed2eda5a389586': compiler.cppstd=20
spirv-tools/1.4.309.0: 'a022e2fe3d80cc747c7ac38b72269e0f27f47579': compiler.cppstd=gnu20
spirv-tools/1.4.309.0: '0c6d14a097dbd3df7d6c7d05dcb4e46732b56014': compiler.cppstd=23
spirv-tools/1.4.309.0: '8337d622e0e020f265e39a3038930c3fbc707826': compiler.cppstd=gnu23
spirv-tools/1.4.309.0: '8818ea85e68994aa92311154a8d96dfee1cb7ce0': compiler.cppstd=gnu26
Requirements
    spirv-headers/1.4.309.0#c286b13a6f57f4da633b34730b23547d:da39a3ee5e6b4b0d3255bfef95601890afd80709#6a61acf313669d21cd5e7bcee4aa086f - Cache
    spirv-tools/1.4.309.0#a3c6ac024446cfb07cfa18b5e71b8b2a:0e543983c395b65265a0e9925636dc99665a968d - Build
    vulkan-headers/1.4.309.0#2f581b3b123240016ffaf61d3dd6816f:da39a3ee5e6b4b0d3255bfef95601890afd80709#b160e51c88c0c3dd18cd706eac7a762d - Cache
    vulkan-loader/1.4.309.0#514f7fa2e866e59c43523869a7a23905:46e0a637bc8a67876ed2d46b9c31082a9f292032#03053d86844d4b82437f187bef9d37e8 - Cache
    xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Cache
Build requirements
    cmake/3.31.6#ed0e6c1d49bd564ce6fed1a19653b86d:63fead0844576fc02943e16909f08fcdddd6f44b#6ec4ca55f1a1a1a6716d3c898d6624f1 - Cache
Skipped binaries
    meson/1.2.2, ninja/1.12.1, pkgconf/2.1.0
xorg/system: System requirements:  already installed
xorg/system: System requirements:  already installed

======== Installing packages ========
cmake/3.31.6: Already installed! (1 of 6)
cmake/3.31.6: Appending PATH environment variable: /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/bin
cmake/3.31.6: Appending PATH environment variable: /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/bin
spirv-headers/1.4.309.0: Already installed! (2 of 6)
vulkan-headers/1.4.309.0: Already installed! (3 of 6)
xorg/system: Already installed! (4 of 6)
spirv-tools/1.4.309.0: Calling source() in /home/elvisdukaj/.conan2/p/spirv842f29fc8a66a/s/src
spirv-tools/1.4.309.0: Unzipping vulkan-sdk-1.4.309.0.tar.gz to .

-------- Installing package spirv-tools/1.4.309.0 (5 of 6) --------
spirv-tools/1.4.309.0: Building from source
spirv-tools/1.4.309.0: Package spirv-tools/1.4.309.0:0e543983c395b65265a0e9925636dc99665a968d
spirv-tools/1.4.309.0: Copying sources to build folder
spirv-tools/1.4.309.0: Building your package in /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b
spirv-tools/1.4.309.0: Calling generate()
spirv-tools/1.4.309.0: Generators folder: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/build/Release/generators
spirv-tools/1.4.309.0: CMakeToolchain generated: conan_toolchain.cmake
spirv-tools/1.4.309.0: CMakeToolchain generated: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/build/Release/generators/CMakePresets.json
spirv-tools/1.4.309.0: CMakeToolchain generated: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/src/CMakeUserPresets.json
spirv-tools/1.4.309.0: Generating aggregated env files
spirv-tools/1.4.309.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
spirv-tools/1.4.309.0: Calling build()
spirv-tools/1.4.309.0: Apply patch (backport): fix clang-20 build issue
spirv-tools/1.4.309.0: Running CMake.configure()
spirv-tools/1.4.309.0: RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/src"
-- Using Conan toolchain: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 26 with extensions OFF
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is Clang 20.1.3
-- The CXX compiler identification is Clang 20.1.3
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang-20 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++-20 - skipped
-- Detecting CXX compile features
CMake Warning (dev) at /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/share/cmake-3.31/Modules/Compiler/CMakeCommonCompilerMacros.cmake:248 (cmake_language):
  CMake's support for `import std;` in C++23 and newer is experimental.  It
  is meant only for experimentation and feedback to CMake developers.
Call Stack (most recent call first):
  /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/share/cmake-3.31/Modules/CMakeDetermineCompilerSupport.cmake:113 (cmake_create_cxx_import_std)
  /home/elvisdukaj/.conan2/p/cmake7d6336cffc76f/p/share/cmake-3.31/Modules/CMakeTestCXXCompiler.cmake:83 (CMAKE_DETERMINE_COMPILER_SUPPORT)
  CMakeLists.txt:17 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Detecting CXX compile features - done
-- Found Python3: /home/elvisdukaj/.local/share/virtualenvs/dev-aXgxtNH9/bin/python3.12 (found version "3.12.9") found components: Interpreter
-- Configuring done (0.6s)
-- Generating done (0.1s)
-- Build files have been written to: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/build/Release

spirv-tools/1.4.309.0: Running CMake.build()
spirv-tools/1.4.309.0: RUN: cmake --build "/home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/build/Release" -- -j24
[373/373] Linking CXX executable tools/spirv-diff

spirv-tools/1.4.309.0: Package '0e543983c395b65265a0e9925636dc99665a968d' built
spirv-tools/1.4.309.0: Build folder /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/build/Release
spirv-tools/1.4.309.0: Generating the package
spirv-tools/1.4.309.0: Packaging in folder /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p
spirv-tools/1.4.309.0: Calling package()
spirv-tools/1.4.309.0: Running CMake.install()
spirv-tools/1.4.309.0: RUN: cmake --install "/home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/b/build/Release" --prefix "/home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p"
-- Install configuration: "Release"
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/libSPIRV-Tools-opt.a
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-opt/SPIRV-Tools-optTargets.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-opt/SPIRV-Tools-optTargets-release.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-opt/SPIRV-Tools-optConfig.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/libSPIRV-Tools-reduce.a
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceTarget.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceTarget-release.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceConfig.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/libSPIRV-Tools-link.a
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-link/SPIRV-Tools-linkTargets.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-link/SPIRV-Tools-linkTargets-release.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-link/SPIRV-Tools-linkConfig.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/libSPIRV-Tools-lint.a
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintTargets.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintTargets-release.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintConfig.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/libSPIRV-Tools-diff.a
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffTargets.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffTargets-release.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffConfig.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/libSPIRV-Tools.a
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/libSPIRV-Tools-shared.so
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools/SPIRV-ToolsTarget.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools/SPIRV-ToolsTarget-release.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools/SPIRV-ToolsConfig.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-lesspipe.sh
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-as
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-dis
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-val
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-opt
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-cfg
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-link
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-lint
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-objdump
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/bin/spirv-reduce
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsTargets.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsTargets-release.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsConfig.cmake
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/include/spirv-tools/libspirv.h
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/include/spirv-tools/libspirv.hpp
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/include/spirv-tools/optimizer.hpp
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/include/spirv-tools/linker.hpp
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/pkgconfig/SPIRV-Tools.pc
-- Installing: /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p/lib/pkgconfig/SPIRV-Tools-shared.pc

spirv-tools/1.4.309.0: package(): Packaged 3 '.hpp' files: linker.hpp, libspirv.hpp, optimizer.hpp
spirv-tools/1.4.309.0: package(): Packaged 1 '.h' file: libspirv.h
spirv-tools/1.4.309.0: package(): Packaged 10 files
spirv-tools/1.4.309.0: package(): Packaged 1 '.sh' file: spirv-lesspipe.sh
spirv-tools/1.4.309.0: package(): Packaged 6 '.a' files
spirv-tools/1.4.309.0: Created package revision 2ef530038ebe8cf244f90383790d9a4a
spirv-tools/1.4.309.0: Package '0e543983c395b65265a0e9925636dc99665a968d' created
spirv-tools/1.4.309.0: Full package reference: spirv-tools/1.4.309.0#a3c6ac024446cfb07cfa18b5e71b8b2a:0e543983c395b65265a0e9925636dc99665a968d#2ef530038ebe8cf244f90383790d9a4a
spirv-tools/1.4.309.0: Package folder /home/elvisdukaj/.conan2/p/b/spirvfd3aa087b5c93/p
vulkan-loader/1.4.309.0: Already installed! (6 of 6)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'env_info' used in: cmake/3.31.6
WARN: deprecated:     'cpp_info.names' used in: spirv-headers/1.4.309.0, vulkan-headers/1.4.309.0
WARN: deprecated:     'cpp_info.filenames' used in: vulkan-headers/1.4.309.0

======== Finalizing install (deploy, generators) ========
conanfile.txt: Writing generators to /home/elvisdukaj/projects/dev/The-Modern-Vulkan-Cookbook/build/linux-x86_64-clang-20/Release/generators
conanfile.txt: Generator 'CMakeDeps' calling 'generate()'
conanfile.txt: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(VulkanLoader)
    find_package(VulkanHeaders)
    find_package(SPIRV-Tools)
    target_link_libraries(... Vulkan::Loader vulkan-headers::vulkan-headers spirv-tools::spirv-tools)
conanfile.txt: Generator 'CMakeToolchain' calling 'generate()'
conanfile.txt: CMakeToolchain generated: conan_toolchain.cmake
conanfile.txt: CMakeToolchain: Preset 'conan-linux-x86_64-clang-20-release' added to CMakePresets.json.
    (cmake>=3.23) cmake --preset conan-linux-x86_64-clang-20-release
    (cmake<3.23) cmake <path> -G Ninja -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake  -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release
conanfile.txt: CMakeToolchain generated: /home/elvisdukaj/projects/dev/The-Modern-Vulkan-Cookbook/build/linux-x86_64-clang-20/Release/generators/CMakePresets.json
conanfile.txt: CMakeToolchain generated: /home/elvisdukaj/projects/dev/The-Modern-Vulkan-Cookbook/CMakeUserPresets.json
conanfile.txt: Generating aggregated env files
conanfile.txt: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
Install finished successfully
```

### Edit by maintainers
* Fix handling of checking the min cpp std  - the C++17 restriction applies when building, but the interface still only uses C++11

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
