### PR TITLE
Add vulkan memory allocator 3.2.1

### DIFF
--- a/recipes/vulkan-memory-allocator/all/conandata.yml
+++ b/recipes/vulkan-memory-allocator/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "cci.20231120":
     url: "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/5e43c795daf43dd09398d8307212e85025215052.tar.gz"
     sha256: "1ee9922fb059bc3b1dc5bbf71020e7a590b6ceb27fc3025d746e15be53fe31b7"
+  "3.2.1":
+    url: https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/refs/tags/v3.2.1.zip
+    sha256: "46d5f8c529b9102f2d3dd933beba38f3873a59896b249a90dcad009ecca4bfff"
   "3.0.1":
     url: "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/refs/tags/v3.0.1.tar.gz"
     sha256: "2a84762b2d10bf540b9dc1802a198aca8ad1f3d795a4ae144212c595696a360c"

--- a/recipes/vulkan-memory-allocator/all/conanfile.py
+++ b/recipes/vulkan-memory-allocator/all/conanfile.py
@@ -29,7 +29,7 @@ class VulkanMemoryAllocatorConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("vulkan-headers/1.3.243.0")
+        self.requires("vulkan-headers/[>=1, <2]")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-memory-allocator/3.2.1**

#### Motivation

Adding a new version 3.2.1, which also supports Vulkan 1.4 (from 3.2.0).

#### Details

`vulkan-memory-allocator` shouldn't be locked to a specific version of Vulkan. [See here](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/master/include/vk_mem_alloc.h#L135-L147):

The supported Vulkan version are from Vulkan 1.0. Note that Vulkan always preserve backward compatibility, so version 1.4 is compatible with 1.3.

```C++
#if !defined(VMA_VULKAN_VERSION)
    #if defined(VK_VERSION_1_4)
        #define VMA_VULKAN_VERSION 1004000
    #elif defined(VK_VERSION_1_3)
        #define VMA_VULKAN_VERSION 1003000
    #elif defined(VK_VERSION_1_2)
        #define VMA_VULKAN_VERSION 1002000
    #elif defined(VK_VERSION_1_1)
        #define VMA_VULKAN_VERSION 1001000
    #else
        #define VMA_VULKAN_VERSION 1000000
    #endif
#endif
```

I tested locally with clang-20 on Ubuntu 24.04.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X[ Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
