### PR TITLE
[libcurl] Allow cross-building from Linux to Windows with mingw

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -320,7 +320,7 @@ class LibcurlConan(ConanFile):
                                   "noinst_LTLIBRARIES = libcurl.la")
             # add directives to build dll
             # used only for native mingw-make
-            if not cross_building(self):
+            if not cross_building(self) or self._is_mingw:
                 # The patch file is located in the base src folder
                 added_content = load(self, os.path.join(self.folders.base_source, "lib_Makefile_add.am"))
                 save(self, lib_makefile, added_content, append=True)

--- a/recipes/libcurl/all/lib_Makefile_add.am
+++ b/recipes/libcurl/all/lib_Makefile_add.am
@@ -6,7 +6,7 @@ LIBCURL_OBJECTS := $(patsubst %.c,%.o,$(strip $(CSOURCES)))
 
 RESOURCE = libcurl.res
 
-RC = windres
+RC ?= windres
 
 all-local: $(libcurl_dll_LIBRARY)
 
@@ -15,7 +15,7 @@ $(libcurl_dll_LIBRARY): $(LIBCURL_OBJECTS) $(RESOURCE) $(libcurl_dll_DEPENDENCIE
 	@$(call DEL, $@)
 	$(CC) $(LDFLAGS) -shared -o $@ \
 	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY) \
-	  $(LIBCURL_OBJECTS) $(RESOURCE) $(LIBCURL_LIBS)
+	  $(LIBCURL_OBJECTS) $(RESOURCE) $(LIBCURL_PC_LIBS_PRIVATE)
 
 %.o: %.c $(PROOT)/include/curl/curlbuild.h
 	$(CC) $(INCLUDES) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcurl/8.12.1**

#### Motivation

It's possible to use Conan to cross-compile libcurl from Linux to Windows with a few adjustments!

I'm able to reproduce the reported scenario #27212 as I commented [here](https://github.com/conan-io/conan-center-index/issues/27212#issuecomment-2802334662).

fix #27212

/cc @gim

#### Details

To be able to build it, I used Arch Linux and installed MinGW GCC 14.2.0 with `pacman -S mingw-w64-gcc mingw-w64-headers`

The `lib_Makefile_add.am` need to be consumed in order to generate the .dll files. 

The RC ?= allows passing `x86_64-w64-mingw32-windres` as executable, otherwise, will only look for `windres` in the system.

Consuming `LIBCURL_PC_LIBS_PRIVATE` links to dependencies:

```
LIBCURL_PC_LIBS_PRIVATE = -lbcrypt -ladvapi32 -lcrypt32 -lssl -lcrypto -lgdi32 -lz -lssl -lcrypto -lz -lcrypt32 -lws2_32 -ladvapi32 -luser32 -lbcrypt
LIBCURL_LIBS = 
```

My full build log: [libcurl-8.12.1-linux-mingw-shared.log](https://github.com/user-attachments/files/19894737/libcurl-8.12.1-linux-mingw-shared.log)

You can see in the log profile that I'm using and it's simple:

```
[settings]
os=Windows
compiler=gcc
compiler.version=14
compiler.libcxx=libstdc++11
arch=x86_64
build_type=Release

[conf]
tools.build:compiler_executables={'c': '/usr/bin/x86_64-w64-mingw32-gcc', 'cpp': '/usr/bin/x86_64-w64-mingw32-g++', 'rc': '/usr/bin/x86_64-w64-mingw32-windres'}
tools.compilation:verbosity=verbose
tools.build:verbosity=verbose
``` 

And, the .dll generated:

```
# file /root/.conan2/p/b/libcu8c65d560a4a18/p/bin/libcurl.dll 
/root/.conan2/p/b/libcu8c65d560a4a18/p/bin/libcurl.dll: PE32+ executable for MS Windows 5.02 (DLL), x86-64, 21 sections
```


I also can build it as static library, only generates .a: [libcurl-8.12.1-linux-mingw-static.log](https://github.com/user-attachments/files/19894909/libcurl-8.12.1-linux-mingw-static.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
