### PR TITLE
Add observable_unique_ptr

### DIFF
--- a/recipes/observable_unique_ptr/all/conandata.yml
+++ b/recipes/observable_unique_ptr/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.7.3":
+    url: "https://github.com/cschreib/observable_unique_ptr/archive/refs/tags/v0.7.3.zip"
+    sha256: "7bb69fb686212441c1bb84eac433278e147fa571f45fb084c8343e4fc3198699"

--- a/recipes/observable_unique_ptr/all/conanfile.py
+++ b/recipes/observable_unique_ptr/all/conanfile.py
@@ -1,0 +1,38 @@
+import os
+
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.build import check_min_cppstd
+
+required_conan_version = ">=2.1"
+
+
+class OupConan(ConanFile):
+    name = "observable_unique_ptr"
+    description = "Unique-ownership smart pointers with observable lifetime."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/cschreib/observable_unique_ptr"
+    topics = ("memory", "smart-pointer")
+    package_type = "header-library"
+    exports_sources = "include/*"
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, pattern="*.hpp", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "oup")
+        self.cpp_info.set_property("cmake_target_name", "oup::oup")
+        self.cpp_info.set_property("pkg_config_name",  "oup")

--- a/recipes/observable_unique_ptr/all/test_package/CMakeLists.txt
+++ b/recipes/observable_unique_ptr/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15..3.31)
+project(test_package LANGUAGES CXX)
+
+find_package(oup REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_compile_features(test_package PRIVATE cxx_std_17)
+target_link_libraries(test_package PRIVATE oup::oup)

--- a/recipes/observable_unique_ptr/all/test_package/conanfile.py
+++ b/recipes/observable_unique_ptr/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/observable_unique_ptr/all/test_package/test_package.cpp
+++ b/recipes/observable_unique_ptr/all/test_package/test_package.cpp
@@ -1,0 +1,40 @@
+#include <oup/observable_unique_ptr.hpp>
+
+#include <string>
+#include <iostream>
+#include <cassert>
+
+int main() {
+    // Non-owning pointer that will outlive the object
+    oup::observer_ptr<std::string> obs_ptr;
+
+    {
+        // Sealed (unique) pointer that owns the object
+        auto owner_ptr = oup::make_observable_sealed<std::string>("hello");
+
+        // A sealed pointer cannot be copied but it can be moved
+        // oup::observable_sealed_ptr<std::string> owner_copied = owner_ptr; // error!
+        oup::observable_sealed_ptr<std::string> owner_moved = std::move(owner_ptr); // OK
+
+        // Make the observer pointer point to the object
+        obs_ptr = owner_moved;
+
+        // The observer pointer is now valid
+        assert(!obs_ptr.expired());
+
+        // It can be used like a regular raw pointer
+        assert(obs_ptr != nullptr);
+        std::cout << *obs_ptr << std::endl;
+
+        // An observer pointer can be copied and moved
+        oup::observer_ptr<std::string> obs_copied = obs_ptr; // OK
+        oup::observer_ptr<std::string> obs_moved = std::move(obs_copied); // OK
+    }
+
+    // The sealed pointer has gone out of scope, the object is deleted,
+    // the observer pointer is now null.
+    assert(obs_ptr.expired());
+    assert(obs_ptr == nullptr);
+
+    return 0;
+}

--- a/recipes/observable_unique_ptr/config.yml
+++ b/recipes/observable_unique_ptr/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.7.3":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **observable_unique_ptr/0.7.3**

#### Motivation
This is a new recipe.

#### Details
 I am the author of the library. This is a C++ header-only library to provide smart pointers with unique ownership (like `std::unique_ptr`) and observable lifetime (like `std::weak_ptr`), a combination not available in the C++ STL. The library has no dependency, and no compile-time options; the smart pointers can be configured using policies provided as C++ templates arguments. Therefore the recipe is really simple.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
