### PR TITLE
qtwebengine: fix compatibility with gcc>11

### DIFF
--- a/recipes/qt/6.x.x/patches/c72097e.diff
+++ b/recipes/qt/6.x.x/patches/c72097e.diff
@@ -28,7 +28,7 @@ index a5bc6cd..5cefbfe 100644
 +
 +    //quick workaround if filename length > 255 - ".rsp", just cut the dirs starting from the end
 +    //please note ".$unique_name" is not used at the moment
-+    int pos = 0;
++    std::size_t pos = 0;
 +    std::string delimiter("_");
 +    while (rspfile.length() > 250 && (pos = rspfile.find_last_of(delimiter)) != std::string::npos)
 +        rspfile = rspfile.substr(0,pos);

--- a/recipes/qt/6.x.x/patches/c72097e_6.6.0.diff
+++ b/recipes/qt/6.x.x/patches/c72097e_6.6.0.diff
@@ -28,7 +28,7 @@ index a5bc6cd..5cefbfe 100644
 +
 +    //quick workaround if filename length > 255 - ".rsp", just cut the dirs starting from the end
 +    //please note ".$unique_name" is not used at the moment
-+    int pos = 0;
++    std::size_t pos = 0;
 +    std::string delimiter("_");
 +    while (rspfile.length() > 250 && (pos = rspfile.find_last_of(delimiter)) != std::string::npos)
 +        rspfile = rspfile.substr(0,pos);


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.***

#### Motivation
With gcc 12 and newer, compiling qtwebengine fails with error
```
[109/196] CXX src/gn/ninja_action_target_writer.o
FAILED: src/gn/ninja_action_target_writer.o
/usr/bin/c++ -MMD -MF src/gn/ninja_action_target_writer.o.d -I../../../../../../../../../qte6ce713a78304/s/src/qtwebengine/src/3rdparty/gn/src -I. -DNO_LAST_COMMIT_POSITION -DNDEBUG -O3 -fdata-sections -ffunction-sections -Werror -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -pthread -pipe -fno-exceptions -fno-rtti -fdiagnostics-color -Wall -Wextra -Wno-unused-parameter -Wextra-semi -Wundef -Wno-deprecated-copy -Wno-implicit-fallthrough -Wno-redundant-move -Wno-unused-variable -Wno-format -Wno-strict-aliasing -Wno-cast-function-type -std=gnu++17 -c ../../../../../../../../../qte6ce713a78304/s/src/qtwebengine/src/3rdparty/gn/src/gn/ninja_action_target_writer.cc -o src/gn/ninja_action_target_writer.o
../../../../../../../../../qte6ce713a78304/s/src/qtwebengine/src/3rdparty/gn/src/gn/ninja_action_target_writer.cc: In member function ‘std::string NinjaActionTargetWriter::WriteRuleDefinition()’:
../../../../../../../../../qte6ce713a78304/s/src/qtwebengine/src/3rdparty/gn/src/gn/ninja_action_target_writer.cc:133:78: error: comparison of integer expressions of different signedness: ‘int’ and ‘const std::__cxx11::basic_string<char>::size_type’ {aka ‘const long unsigned int’} [-Werror=sign-compare]
  133 |     while (rspfile.length() > 250 && (pos = rspfile.find_last_of(delimiter)) != std::string::npos)
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
```
which is also described in https://bugreports.qt.io/browse/QTBUG-115981

#### Details
This PR brings https://codereview.qt-project.org/c/yocto/meta-qt6/+/495707 to qt recipe

tested with `conan install --requires qt/6.7.3 -o qt/*:qtwebengine=True -o qt/*:qtshadertools=True -o qt/*:qtdeclarative=True -o qt/*:qtwebchannel=True -o qt/*:with_dbus=True -o */*:shared=True -b missing`

without this change: [failing_log.txt](https://github.com/user-attachments/files/19904638/failing_log.txt)

with this change: [log.txt](https://github.com/user-attachments/files/19904848/log.txt)


additional note: I also faced error 
```
 ERROR at //printing/BUILD.gn:456:16: Script returned non-zero exit code.

          libs = exec_script("cups_config_helper.py",
                 ^----------

  Current dir:
  /home/eric/.conan2/p/b/qtfd75483780ea7/b/build/Release/qtwebengine/src/pdf/Release/x86_64/


  Command: /usr/bin/python3
  /home/eric/.conan2/p/qte6ce713a78304/s/src/qtwebengine/src/3rdparty/chromium/printing/cups_config_helper.py
  --libs-for-gn

  Returned 1.

  stderr:



  Traceback (most recent call last):

    File "/home/eric/.conan2/p/qte6ce713a78304/s/src/qtwebengine/src/3rdparty/chromium/printing/cups_config_helper.py", line 108, in <module>
      sys.exit(main())
               ^^^^^^
    File "/home/eric/.conan2/p/qte6ce713a78304/s/src/qtwebengine/src/3rdparty/chromium/printing/cups_config_helper.py", line 92, in main
      flags = run_cups_config(cups_config, mode)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/eric/.conan2/p/qte6ce713a78304/s/src/qtwebengine/src/3rdparty/chromium/printing/cups_config_helper.py", line 35, in run_cups_config
      cups = subprocess.Popen([cups_config, '--cflags', '--ldflags', '--libs'],
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
      self._execute_child(args, executable, preexec_fn, close_fds,
    File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
      raise child_exception_type(errno_num, err_msg, err_filename)

  FileNotFoundError: [Errno 2] No such file or directory: 'cups-config'
```
which is described in https://bugreports.qt.io/browse/QTBUG-113642 and fixed by running `apt install libcups2-dev`


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
