### PR TITLE
[libidn2] Bump version to 2.3.8

### DIFF
--- a/recipes/libidn2/all/conandata.yml
+++ b/recipes/libidn2/all/conandata.yml
@@ -8,5 +8,3 @@ sources:
 patches:
   "2.3.0":
     - patch_file: "patches/0001-no-versioning-of-symbols.patch"
-  "2.8.0":
-    - patch_file: "patches/0001-no-versioning-of-symbols.patch"

--- a/recipes/libidn2/all/conandata.yml
+++ b/recipes/libidn2/all/conandata.yml
@@ -1,7 +1,12 @@
 sources:
+  "2.3.8":
+    url: "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
+    sha256: "f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
   "2.3.0":
     url: "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.0.tar.gz"
     sha256: "e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5"
 patches:
   "2.3.0":
+    - patch_file: "patches/0001-no-versioning-of-symbols.patch"
+  "2.8.0":
     - patch_file: "patches/0001-no-versioning-of-symbols.patch"

--- a/recipes/libidn2/config.yml
+++ b/recipes/libidn2/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.3.8":
+    folder: "all"
   "2.3.0":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **libidn2/2.3.8**

#### Motivation

This PR is a replacement for #27305

fixes https://github.com/conan-io/conan-center-index/issues/27192

#### Details

As commented [here](https://github.com/conan-io/conan-center-index/pull/27305#issue-3019851684), enforcing pre-defined values for build and host may result in side-effects for users that are cross-building the project. 

Plus, since the version 2.3.5 there is a rule for "*-windows", which covers the triplet i686-unknown-windows.

This PR was tested cross-building to x86 on Windows: [libidn2-2.3.8-windows-x86.log](https://github.com/user-attachments/files/19909803/libidn2-2.3.8-windows-x86.log)

And its dumpbin result proves be x86 as well: [libidn2-headers.log](https://github.com/user-attachments/files/19909900/libidn2-headers.log)

The only observation is, it's producing `libidn2.a`, not a `.lib` file. 

/cc @zenden2k

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
