### PR TITLE
libcap: add version 2.77

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.76":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.76.tar.xz"
+    sha256: "629da4ab29900d0f7fcc36227073743119925fd711c99a1689bbf5c9b40c8e6f"
   "2.75":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.75.tar.xz"
     sha256: "de4e7e064c9ba451d5234dd46e897d7c71c96a9ebf9a0c445bc04f4742d83632"
@@ -42,6 +45,13 @@ sources:
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.45.tar.xz"
     sha256: "d66639f765c0e10557666b00f519caf0bd07a95f867dddaee131cd284fac3286"
 patches:
+  "2.76":
+    - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
+      patch_description: "allow to configure fPIC option from conan recipe"
+      patch_type: "conan"
+    - patch_file: "patches/2.76/0001-Make.Rules-Make-compile-tools-configurable.patch"
+      patch_description: "allow to override compiler via environment variables"
+      patch_type: "conan"
   "2.75":
     - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
       patch_description: "allow to configure fPIC option from conan recipe"

--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.76":
-    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.76.tar.xz"
-    sha256: "629da4ab29900d0f7fcc36227073743119925fd711c99a1689bbf5c9b40c8e6f"
+  "2.77":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.77.tar.xz"
+    sha256: "897bc18b44afc26c70e78cead3dbb31e154acc24bee085a5a09079a88dbf6f52"
   "2.75":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.75.tar.xz"
     sha256: "de4e7e064c9ba451d5234dd46e897d7c71c96a9ebf9a0c445bc04f4742d83632"
@@ -45,13 +45,9 @@ sources:
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.45.tar.xz"
     sha256: "d66639f765c0e10557666b00f519caf0bd07a95f867dddaee131cd284fac3286"
 patches:
-  "2.76":
+  "2.77":
     - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
-      patch_description: "allow to configure fPIC option from conan recipe"
-      patch_type: "conan"
-    - patch_file: "patches/2.76/0001-Make.Rules-Make-compile-tools-configurable.patch"
-      patch_description: "allow to override compiler via environment variables"
-      patch_type: "conan"
+    - patch_file: "patches/2.77/0001-Make.Rules-Make-compile-tools-configurable.patch"
   "2.75":
     - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
       patch_description: "allow to configure fPIC option from conan recipe"

--- a/recipes/libcap/all/patches/2.76/0001-Make.Rules-Make-compile-tools-configurable.patch
+++ b/recipes/libcap/all/patches/2.76/0001-Make.Rules-Make-compile-tools-configurable.patch
@@ -1,0 +1,33 @@
+From b1c65354a8321e0288882b03b3313f26ed484d93 Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Sun, 22 Dec 2024 20:52:43 +0700
+Subject: [PATCH] Make.Rules: Make compile tools configurable
+
+Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+---
+ Make.Rules | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Make.Rules b/Make.Rules
+index a6b7742..b345d24 100644
+--- a/Make.Rules
++++ b/Make.Rules
+@@ -65,11 +65,11 @@ LIBCAP_INCLUDES = -I$(KERNEL_HEADERS) -I$(topdir)/libcap/include
+ DEFINES := -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ 
+ SUDO := sudo
+-CC := $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD := $(CC) -Wl,-x -shared -Wl,-shared
+-AR := $(CROSS_COMPILE)ar
+-RANLIB := $(CROSS_COMPILE)ranlib
+-OBJCOPY := $(CROSS_COMPILE)objcopy
++AR ?= $(CROSS_COMPILE)ar
++RANLIB ?= $(CROSS_COMPILE)ranlib
++OBJCOPY ?= $(CROSS_COMPILE)objcopy
+ 
+ # Reference:
+ #   CPPFLAGS used for building .o files from .c & .h files
+-- 
+2.49.0
+

--- a/recipes/libcap/all/patches/2.77/0001-Make.Rules-Make-compile-tools-configurable.patch
+++ b/recipes/libcap/all/patches/2.77/0001-Make.Rules-Make-compile-tools-configurable.patch
@@ -1,9 +1,9 @@
 From b1c65354a8321e0288882b03b3313f26ed484d93 Mon Sep 17 00:00:00 2001
-From: Sergey Bobrenok <bobrofon@gmail.com>
+From: Sergey Bobrenok
 Date: Sun, 22 Dec 2024 20:52:43 +0700
 Subject: [PATCH] Make.Rules: Make compile tools configurable
 
-Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+Signed-off-by: Sergey Bobrenok
 ---
  Make.Rules | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.76":
+    folder: all
   "2.75":
     folder: all
   "2.73":

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.76":
+  "2.77":
     folder: all
   "2.75":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcap/2.76**

#### Motivation
A new version of libcap is available. Full diff between 2.75 and 2.76: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/diff/?id=libcap-2.76&id2=libcap-2.75

#### Details
Since `Make.Rules` was changed in commit [4425764 ("Nothing references the SYSTEM_HEADERS make variable.")](https://git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?id=4425764d96626640df846cf21a83ac200d7af42f), the `patch` cannot apply `patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch` without 3-way merge. So I have rebased this patch as `patches/2.76/0001-Make.Rules-Make-compile-tools-configurable.patch`.
The original error:
```
libcap/2.76: Apply patch (conan): allow to configure fPIC option from conan recipe
libcap/2.76: Apply patch (conan): allow to override compiler via environment variables
libcap/2.76: WARN: patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch: file 1/1:   b'Make.Rules'
libcap/2.76: WARN: patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch:  hunk no.1 doesn't match source file at line 66
libcap/2.76: WARN: patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch:   expected: b'SYSTEM_HEADERS = /usr/include'
libcap/2.76: WARN: patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch:   actual  : b''
libcap/2.76: patches/2.73/0002-Make.Rules-Make-compile-tools-configurable.patch: source file is different - b'Make.Rules'
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
