### PR TITLE
arrow: add version 20.0.0

### DIFF
--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.0.0":
+    url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-20.0.0/apache-arrow-20.0.0.tar.gz?action=download"
+    sha256: "89efbbf852f5a1f79e9c99ab4c217e2eb7f991837c005cba2d4a2fbd35fad212"
   "19.0.1":
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-19.0.1/apache-arrow-19.0.1.tar.gz?action=download"
     sha256: "acb76266e8b0c2fbb7eb15d542fbb462a73b3fd1e32b80fad6c2fafd95a51160"

--- a/recipes/arrow/config.yml
+++ b/recipes/arrow/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.0.0":
+    folder: all
   "19.0.1":
     folder: all
   "18.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/20.0.0**

#### Motivation
Arrow 20.0.0 was released 2025/04/26. This PR updates conan's index with the new release.

#### Details
We fully script these changes and they're minimal so this should be easy to review.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
