### PR TITLE
Fix issue#27321 building libcurl

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -209,6 +209,7 @@ class LibcurlConan(ConanFile):
             if self._is_win_x_android:
                 self.tool_requires("ninja/[>=1.10.2 <2]")
         else:
+            self.tool_requires("autoconf/2.71")
             self.tool_requires("libtool/2.4.7")
             if not self.conf.get("tools.gnu:pkg_config", check_type=str):
                 self.tool_requires("pkgconf/[>=2.2 <3]")


### PR DESCRIPTION
Add a tool_requires call for autoconf - builds are failing to find `autoreconf` which is provided by the autoconf package.

https://github.com/conan-io/conan-center-index/issues/27321


### Summary
Changes to recipe:  **libcurl/8.12.1**

#### Motivation

Libcurl's build needs autoconf executables to work - add tool_require for Autoconf provides them

#### Details

Conan 1.x seemed to leak the indirect dependencies down - which is why in Conan 1, tool_requires for libtool would have provided the paths for Autoconf - in Conan 2  this does not (and should not) happen, so it should be explicitly added.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
