### PR TITLE
cpython: add python3.dll to the install for wheels

### DIFF
--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -588,6 +588,7 @@ class CPythonConan(ConanFile):
             "--include-pip",
             "--include-venv",
             "--include-dev",
+            "--include-stable"
         ]
         if self.options.with_tkinter:
             layout_args.append("--include-tcltk")


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpython/*** to improve compatiblity with wheels.

#### Motivation
I was struggling with the prebuilt cryptography pypi package that was failing with the following error:

```
>>> import paramiko
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\ANSYSDev\SpeosOneConan\build\Release\venv\3.10.16\lib\site-packages\paramiko\__init__.py", line 22, in <module>
    from paramiko.transport import (
  File "C:\ANSYSDev\SpeosOneConan\build\Release\venv\3.10.16\lib\site-packages\paramiko\transport.py", line 33, in <module>
    from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
  File "C:\ANSYSDev\SpeosOneConan\build\Release\venv\3.10.16\lib\site-packages\cryptography\hazmat\primitives\ciphers\__init__.py", line 11, in <module>
    from cryptography.hazmat.primitives.ciphers.base import (
  File "C:\ANSYSDev\SpeosOneConan\build\Release\venv\3.10.16\lib\site-packages\cryptography\hazmat\primitives\ciphers\base.py", line 10, in <module>
    from cryptography.hazmat.bindings._rust import openssl as rust_openssl
ImportError: DLL load failed while importing _rust: The specified module could not be found.
```

After spending a while debugging I found out that the _rust.pyd file was trying to load python3.dll which is the stable interface required by some wheels.

#### Details

Added "--include-stable" to the arguments of layout/main.py to supply the file.

This include add the python3.dll right next to the python3xx.dll

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan (2.15.0)
