### PR TITLE
SDL: package java sources in Android builds

### DIFF
--- a/recipes/sdl/3.x/conanfile.py
+++ b/recipes/sdl/3.x/conanfile.py
@@ -7,6 +7,7 @@ from conan.tools.microsoft import is_msvc
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
 
 import os
+import shutil
 
 required_conan_version = ">=2"
 
@@ -337,6 +338,12 @@ class SDLConan(ConanFile):
 
     def package(self):
         copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        if self.settings.os == "Android":
+            # too much hassle via mkdir+copy due to amount of subdirectories
+            shutil.copytree(
+                os.path.join(self.source_folder, "android-project", "app", "src", "main", "java"),
+                os.path.join(self.package_folder, "src-java"))
+
         cmake = CMake(self)
         cmake.install()
 

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -8,6 +8,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.env import Environment
 
 import os
+import shutil
 
 required_conan_version = ">=1.55.0"
 
@@ -353,6 +354,11 @@ class SDLConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "libdata"))
         rmdir(self, os.path.join(self.package_folder, "share"))
+        if self.settings.os == "Android":
+            # too much hassle via mkdir+copy due to amount of subdirectories
+            shutil.copytree(
+                os.path.join(self.source_folder, "android-project", "app", "src", "main", "java"),
+                os.path.join(self.package_folder, "src-java"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "SDL2")


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
For Android, SDL also provides java platform code that must be built by an app using it. If you copy this code to your project, this means you must always synchronise it with SDL version used, which for Conan means that version range can't be used. By providing the java sources as part of Conan package the synchronisation is achieved automatically and you can easily use version range, then you can inject this path to Gradle via a property.

Btw Qt uses a similar approach, but it creates respective Gradle property automatically when using `androiddeployqt` tool.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
The new `src-java` directory will contain java files in `org/libsdl/app` directory.

Copying the directory structure properly via `mkdir`+`copy` tools would be way more verbose, so I used the `shutil.copytree` shortcut.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
