### PR TITLE
wxwidgets: Fix cmake tool_requires version range

### DIFF
--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -123,7 +123,7 @@ class wxWidgetsConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("ninja/1.11.1")
-        self.tool_requires("cmake/[>=3.17]")
+        self.tool_requires("cmake/[>=3.17 <4]")
 
     # TODO: add support for gtk non system version when it's ready for Conan 2
     def requirements(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **wxwidgets**

#### Motivation
wxwidgets recipe is currently broken due to the introduction of CMake 4 Conan packages to Conan Center and the `tool_requires` not properly bounding the upper limit of CMake versions and breaking changes between CMake 3 and 4 that are utilized in the project's CMakeLists.txt

Fixes #27335

#### Details
Recipe `tool_requires` was fixed to bound the CMake version to be <4


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
