### PR TITLE
package(libiconv): Update libiconv to 1.18 to fix gcc 15 compile

### DIFF
--- a/recipes/libiconv/all/conandata.yml
+++ b/recipes/libiconv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.18":
+    url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz"
+    sha256: "3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8"
   "1.17":
     url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
     sha256: "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"

--- a/recipes/libiconv/config.yml
+++ b/recipes/libiconv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.18":
+    folder: all
   "1.17":
     folder: all
   "1.16":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libiconv/1.18**

#### Motivation
Add latest version of libiconv
Fixes compilation error when using GCC 15
Fixes #27265

#### Details
Add latest version of libiconv


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
