### PR TITLE
package(mpg123): Update to 1.33.0 to fix compilation with GCC 15

### DIFF
--- a/recipes/mpg123/all/conandata.yml
+++ b/recipes/mpg123/all/conandata.yml
@@ -14,16 +14,9 @@ sources:
       - "https://sourceforge.net/projects/mpg123/files/mpg123/1.29.3/mpg123-1.29.3.tar.bz2"
       - "https://www.mpg123.de/download/mpg123-1.29.3.tar.bz2"
     sha256: "963885d8cc77262f28b77187c7d189e32195e64244de2530b798ddf32183e847"
-  "1.26.4":
-    url:
-      - "https://sourceforge.net/projects/mpg123/files/mpg123/1.26.4/mpg123-1.26.4.tar.bz2"
-      - "https://www.mpg123.de/download/mpg123-1.26.4.tar.bz2"
-    sha256: "081991540df7a666b29049ad870f293cfa28863b36488ab4d58ceaa7b5846454"
 
 patches:
   "1.31.2":
-    - patch_file: "patches/0001-msvc-export-symbols.patch"
-  "1.26.4":
     - patch_file: "patches/0001-msvc-export-symbols.patch"
   "1.29.3":
     - patch_file: "patches/0001-msvc-export-symbols.patch"

--- a/recipes/mpg123/all/conandata.yml
+++ b/recipes/mpg123/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "1.32.10":
+  "1.33.0":
     url:
-      - "https://sourceforge.net/projects/mpg123/files/mpg123/1.32.10/mpg123-1.32.10.tar.bz2"
-      - "https://www.mpg123.de/download/mpg123-1.32.10.tar.bz2"
-    sha256: "87b2c17fe0c979d3ef38eeceff6362b35b28ac8589fbf1854b5be75c9ab6557c"
+      - "https://sourceforge.net/projects/mpg123/files/mpg123/1.33.0/mpg123-1.33.0.tar.bz2"
+      - "https://www.mpg123.de/download/mpg123-1.33.0.tar.bz2"
+    sha256: "2290e3aede6f4d163e1a17452165af33caad4b5f0948f99429cfa2d8385faa9d"
   "1.31.2":
     url:
       - "https://sourceforge.net/projects/mpg123/files/mpg123/1.31.2/mpg123-1.31.2.tar.bz2"

--- a/recipes/mpg123/all/conandata.yml
+++ b/recipes/mpg123/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "1.32.10":
+    url:
+      - "https://sourceforge.net/projects/mpg123/files/mpg123/1.32.10/mpg123-1.32.10.tar.bz2"
+      - "https://www.mpg123.de/download/mpg123-1.32.10.tar.bz2"
+    sha256: "87b2c17fe0c979d3ef38eeceff6362b35b28ac8589fbf1854b5be75c9ab6557c"
   "1.31.2":
     url:
       - "https://sourceforge.net/projects/mpg123/files/mpg123/1.31.2/mpg123-1.31.2.tar.bz2"

--- a/recipes/mpg123/all/conanfile.py
+++ b/recipes/mpg123/all/conanfile.py
@@ -8,6 +8,7 @@ from conan.tools.files import get, copy, export_conandata_patches, apply_conanda
 from conan.tools.microsoft import is_msvc
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.build import cross_building
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -163,7 +164,7 @@ class Mpg123Conan(ConanFile):
             cmake.configure(build_script_folder=os.path.join(self.source_folder, "ports", "cmake"))
             cmake.build()
         else:
-            if self.settings.compiler == "apple-clang" and cross_building(self):
+            if Version(self.version) < "1.33.0" and self.settings.compiler == "apple-clang" and cross_building(self):
                 # when testing if the assembler supports avx - propagate cflags (CFLAGS) to the assembler
                 # (which should contain "-arch x86_64" when crossbuilding with appleclang)
                 replace_in_file(self, os.path.join(self.source_folder, "configure"),
@@ -185,7 +186,7 @@ class Mpg123Conan(ConanFile):
             rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-        
+
         fix_apple_shared_install_name(self)
 
     def package_info(self):

--- a/recipes/mpg123/config.yml
+++ b/recipes/mpg123/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.32.10":
+  "1.33.0":
     folder: "all"
   "1.31.2":
     folder: "all"

--- a/recipes/mpg123/config.yml
+++ b/recipes/mpg123/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.32.10":
+    folder: "all"
   "1.31.2":
     folder: "all"
   "1.29.3":

--- a/recipes/mpg123/config.yml
+++ b/recipes/mpg123/config.yml
@@ -5,5 +5,3 @@ versions:
     folder: "all"
   "1.29.3":
     folder: "all"
-  "1.26.4":
-    folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **mpg123/1.33.0**

#### Motivation
Fixes compilation when using gcc 15.
Update to latest version, fixing several issues in the library

#### Details
Add version 1.33.0
Skip 1.32.10 since that fails to link on Windows due to using strtok_r
Remove ancient 1.26.4 since it fails on Windows using current MSVC

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
