### PR TITLE
Add a new version of libpng - 1.6.48

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.48":
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.48/libpng-1.6.48.tar.xz"
+    sha256: "46fd06ff37db1db64c0dc288d78a3f5efd23ad9ac41561193f983e20937ece03"
   "1.6.47":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.47/libpng-1.6.47.tar.xz"
     sha256: "b213cb381fbb1175327bd708a77aab708a05adde7b471bc267bd15ac99893631"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.48":
+    folder: all
   "1.6.47":
     folder: all
   "1.6.46":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpng/1.6.48**
Add a new version of libpng - 1.6.48

#### Motivation
new version of libpng

#### Details
add 1.6.48 using the hash from the release announcement

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
