### PR TITLE
easyloggingpp: various fixes

### DIFF
--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -91,7 +91,7 @@ class EasyloggingppConan(ConanFile):
         if self.options.disable_verbose_logs:
             defines.append("ELPP_DISABLE_VERBOSE_LOGS")
         if self.options.disable_trace_logs:
-            defines.append("lib_utc_datetime")
+            defines.append("ELPP_DISABLE_TRACE_LOGS")
         if self.options.lib_utc_datetime:
             defines.append("ELPP_UTC_DATETIME")
         return defines

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -122,3 +122,6 @@ class EasyloggingppConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["easyloggingpp"]
         self.cpp_info.defines = self._public_defines
+
+        if self.options.enable_thread_safe and self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, replace_in_file
 
@@ -53,6 +54,10 @@ class EasyloggingppConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -74,7 +74,7 @@ class EasyloggingppConan(ConanFile):
             defines.append("ELPP_THREAD_SAFE")
         if self.options.enable_debug_errors:
             defines.append("ELPP_DEBUG_ERRORS")
-        if self.options.enable_default_logfile:
+        if not self.options.enable_default_logfile:
             defines.append("ELPP_NO_DEFAULT_LOG_FILE")
         if self.options.disable_logs:
             defines.append("ELPP_DISABLE_LOGS")

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, replace_in_file
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class EasyloggingppConan(ConanFile):
@@ -56,8 +56,7 @@ class EasyloggingppConan(ConanFile):
             del self.options.fPIC
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, 11)
+        check_min_cppstd(self, 11)
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
### Summary
Changes to recipe:  **easyloggingpp/9.97.1**

#### Motivation
This fixes a few bugs in the current recipe.

#### Details
* Add check for C++11 or higher (the [README](https://github.com/abumq/easyloggingpp) mentions that the library requires at least C++11)
* Fix the broken option `disable_trace_logs` (this previously set the wrong define)
* Fix the broken option `enable_default_logfile` (this previously behaved in the opposite way as expected)
* Add pthread to system libs on Linux/FreeBSD if option `enable_thread_safe` is enabled (the README mentions that linking with pthread is required in this case)

This PR has been split up from https://github.com/conan-io/conan-center-index/pull/27261.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
