### PR TITLE
Add tree-sitter/0.25.3

### DIFF
--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.25.3":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.25.3.tar.gz"
+    sha256: "862fac52653bc7bc9d2cd0630483e6bdf3d02bcd23da956ca32663c4798a93e3"
   "0.25.1":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.25.1.tar.gz"
     sha256: "99a2446075c2edf60e82755c48415d5f6e40f2d9aacb3423c6ca56809b70fe59"

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.25.3":
+    folder: all
   "0.25.1":
     folder: all
   "0.24.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-sitter/0.25.3**

#### Motivation
Version bump
https://github.com/tree-sitter/tree-sitter/compare/v0.25.1...v0.25.3

#### Details
config.yml and conandata.yml point to the newly created tree-sitter/0.25.3.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
