### PR TITLE
easyloggingpp: add new options

### DIFF
--- a/recipes/easyloggingpp/all/conandata.yml
+++ b/recipes/easyloggingpp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "9.97.1":
-    url: "https://github.com/amrayn/easyloggingpp/archive/v9.97.1.tar.gz"
+    url: "https://github.com/abumq/easyloggingpp/archive/v9.97.1.tar.gz"
     sha256: "ebe473e17b13f1d1f16d0009689576625796947a711e14aec29530f39560c7c2"
   "9.97.0":
-    url: "https://github.com/amrayn/easyloggingpp/archive/v9.97.0.tar.gz"
+    url: "https://github.com/abumq/easyloggingpp/archive/v9.97.0.tar.gz"
     sha256: "9110638e21ef02428254af8688bf9e766483db8cc2624144aa3c59006907ce22"

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -19,10 +19,16 @@ class EasyloggingppConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
+        "enable_unicode": [True, False],
+        "use_winsock2": [True, False],
+        "force_use_std_thread": [True, False],
         "enable_crash_log": [True, False],
         "enable_thread_safe": [True, False],
+        "enable_debug_assert_failure": [True, False],
         "enable_debug_errors": [True, False],
         "enable_default_logfile": [True, False],
+        "enable_default_crash_handling": [True, False],
+        "enable_fresh_logfile": [True, False],
         "disable_logs": [True, False],
         "disable_debug_logs": [True, False],
         "disable_info_logs": [True, False],
@@ -31,14 +37,27 @@ class EasyloggingppConan(ConanFile):
         "disable_fatal_logs": [True, False],
         "disable_verbose_logs": [True, False],
         "disable_trace_logs": [True, False],
+        "disable_log_to_file": [True, False],
+        "disable_custom_format_specifiers": [True, False],
+        "disable_logging_flags_from_arg": [True, False],
+        "disable_log_file_from_arg": [True, False],
+        "disable_check_macros": [True, False],
+        "disable_debug_macros": [True, False],
+        "disable_global_lock": [True, False],
         "lib_utc_datetime": [True, False],
     }
     default_options = {
         "fPIC": True,
+        "enable_unicode": False,
+        "use_winsock2": False,
+        "force_use_std_thread": False,
         "enable_crash_log": False,
         "enable_thread_safe": False,
+        "enable_debug_assert_failure": False,
         "enable_debug_errors": False,
         "enable_default_logfile": True,
+        "enable_default_crash_handling": True,
+        "enable_fresh_logfile": False,
         "disable_logs": False,
         "disable_debug_logs": False,
         "disable_info_logs": False,
@@ -47,6 +66,13 @@ class EasyloggingppConan(ConanFile):
         "disable_fatal_logs": False,
         "disable_verbose_logs": False,
         "disable_trace_logs": False,
+        "disable_log_to_file": False,
+        "disable_custom_format_specifiers": False,
+        "disable_logging_flags_from_arg": False,
+        "disable_log_file_from_arg": False,
+        "disable_check_macros": False,
+        "disable_debug_macros": False,
+        "disable_global_lock": False,
         "lib_utc_datetime": False,
     }
 
@@ -63,14 +89,26 @@ class EasyloggingppConan(ConanFile):
     @property
     def _public_defines(self):
         defines = []
+        if self.options.enable_unicode:
+            defines.append("ELPP_UNICODE")
+        if self.options.use_winsock2:
+            defines.append("ELPP_WINSOCK2")
+        if self.options.force_use_std_thread:
+            defines.append("ELPP_FORCE_USE_STD_THREAD")
         if self.options.enable_crash_log:
             defines.append("ELPP_FEATURE_CRASH_LOG")
         if self.options.enable_thread_safe:
             defines.append("ELPP_THREAD_SAFE")
+        if self.options.enable_debug_assert_failure:
+            defines.append("ELPP_DEBUG_ASSERT_FAILURE")
         if self.options.enable_debug_errors:
             defines.append("ELPP_DEBUG_ERRORS")
         if self.options.enable_default_logfile:
             defines.append("ELPP_NO_DEFAULT_LOG_FILE")
+        if not self.options.enable_default_crash_handling:
+            defines.append("ELPP_DISABLE_DEFAULT_CRASH_HANDLING")
+        if self.options.enable_fresh_logfile:
+            defines.append("ELPP_FRESH_LOG_FILE")
         if self.options.disable_logs:
             defines.append("ELPP_DISABLE_LOGS")
         if self.options.disable_debug_logs:
@@ -87,6 +125,20 @@ class EasyloggingppConan(ConanFile):
             defines.append("ELPP_DISABLE_VERBOSE_LOGS")
         if self.options.disable_trace_logs:
             defines.append("lib_utc_datetime")
+        if self.options.disable_log_to_file:
+            defines.append("ELPP_NO_LOG_TO_FILE")
+        if self.options.disable_custom_format_specifiers:
+            defines.append("ELPP_DISABLE_CUSTOM_FORMAT_SPECIFIERS")
+        if self.options.disable_logging_flags_from_arg:
+            defines.append("ELPP_DISABLE_LOGGING_FLAGS_FROM_ARG")
+        if self.options.disable_log_file_from_arg:
+            defines.append("ELPP_DISABLE_LOG_FILE_FROM_ARG")
+        if self.options.disable_check_macros:
+            defines.append("ELPP_NO_CHECK_MACROS")
+        if self.options.disable_debug_macros:
+            defines.append("ELPP_NO_DEBUG_MACROS")
+        if self.options.disable_global_lock:
+            defines.append("ELPP_NO_GLOBAL_LOCK")
         if self.options.lib_utc_datetime:
             defines.append("ELPP_UTC_DATETIME")
         return defines

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -12,7 +12,7 @@ class EasyloggingppConan(ConanFile):
     description = "Single-header C++ logging library."
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/amrayn/easyloggingpp"
+    homepage = "https://github.com/abumq/easyloggingpp"
     topics = ("logging", "stacktrace", "efficient-logging")
 
     package_type = "static-library"


### PR DESCRIPTION
### Summary
Changes to recipe:  **easyloggingpp/9.97.1**

#### Motivation
The current recipe only offers a small subset of the many options offered by the library, see https://github.com/abumq/easyloggingpp?tab=readme-ov-file#configuration-macros.

This PR adds a subset of the remaining options that were previously not available in the recipe.


#### Details
The following additional options are proposed to be added:

| Package option | Preprocessor macro | Description |
|--------|--------|--------|
| enable_unicode | ELPP_UNICODE | Enables Unicode logging support. |
| use_winsock2 | ELPP_WINSOCK2 | Uses winsock2 header instead of winsock. winsock and winsock2 cannot be mixed in a project. If the consumer application uses winsock2 elsewhere, easylogging++ must use winsock2, as well. |
| force_use_std_thread | ELPP_FORCE_USE_STD_THREAD | Always use std::thread over pthreads. |
| enable_debug_assert_failure | ELPP_DEBUG_ASSERT_FAILURE | Intended for debugging purposes to show assertion failurs. |
| enable_default_crash_handling | !ELPP_DISABLE_DEFAULT_CRASH_HANDLING | The default crash handler may not be desired, this allows it to be deactivated. |
| enable_fresh_logfile | ELPP_FRESH_LOG_FILE | Overwrite logs instead of appending them. |
| disable_log_to_file | ELPP_NO_LOG_TO_FILE | By default, easylogging++ logs to a file. This allows to disable it. |
| disable_custom_format_specifiers | ELPP_DISABLE_CUSTOM_FORMAT_SPECIFIERS | Disables custom format specifiers. |
| disable_logging_flags_from_arg | ELPP_DISABLE_LOGGING_FLAGS_FROM_ARG | Disables ability to change logging flags via command-line args. |
| disable_log_file_from_arg | ELPP_DISABLE_LOG_FILE_FROM_ARG | Disables ability to change the log file name via command-line args. |
| disable_check_macros | ELPP_NO_CHECK_MACROS | By default, easylogging++ defines a set of CHECK macros. If those are not needed or clash with other macros, this disables them. |
| disable_debug_macros | ELPP_NO_DEBUG_MACROS | By default, easylogging++ defines a set of DEBUG macros. If those are not needed or clash with other macros, this disables them. |
| disable_global_lock | ELPP_NO_GLOBAL_LOCK | Disables a lock that reduces performance overhead but can lead to problems in some cases. |

Some of these may only be useful in very specific cases or for debugging. If you prefer not adding so many options, I suggest to at least go with these:

* enable_unicode
* use_winsock2
* enable_default_crash_handling

These are the ones that I personally require in a project. I included the other options in this PR because I thought other library users may want to use them.

This PR has been split off https://github.com/conan-io/conan-center-index/pull/27261.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
