### PR TITLE
Add catch2/3.8.1

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.8.1":
+    url: "https://github.com/catchorg/Catch2/archive/v3.8.1.tar.gz"
+    sha256: "18b3f70ac80fccc340d8c6ff0f339b2ae64944782f8d2fca2bd705cf47cadb79"
   "3.8.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.8.0.tar.gz"
     sha256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.8.1":
+    folder: 3.x.x
   "3.8.0":
     folder: 3.x.x
   "3.7.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **catch2/3.8.1**

#### Motivation
Version bump
https://github.com/catchorg/Catch2/compare/v3.8.0...v3.8.1

#### Details
config.yml and conandata.yml point to the newly created catch2/3.8.1.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
