### PR TITLE
bitserializer: add version 0.80

### DIFF
--- a/recipes/bitserializer/all/conandata.yml
+++ b/recipes/bitserializer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.80":
+    url: "https://github.com/PavelKisliak/BitSerializer/archive/v0.80.tar.gz"
+    sha256: "d7606e21dba5212ce4652ce5fec4bde7b4b0e44ac33b56a4ccb485dc4e8efbd2"
   "0.75":
     url: "https://github.com/PavelKisliak/BitSerializer/archive/v0.75.tar.gz"
     sha256: "2df980a59de48a19dee28d81a1c00cae1f60ca4d323a2bdf74be4ee9c9b8db05"
@@ -11,9 +14,3 @@ sources:
   "0.50":
     url: "https://github.com/PavelKisliak/BitSerializer/archive/0.50.tar.gz"
     sha256: "0ba9d57f1546b9c9245a97ced0ed05ec9fb969e0542093da3a8bf9dcfe7f7a6d"
-  "0.44":
-    url: "https://github.com/PavelKisliak/BitSerializer/archive/0.44.tar.gz"
-    sha256: "ab0f74914d8120ee5e7a8ed10b0e9d83ed8135cd9e3356b5d0dcefc1cc88e47f"
-  "0.10":
-    url: "https://github.com/PavelKisliak/BitSerializer/archive/0.10.tar.gz"
-    sha256: "e9b898e453c66742a3c9d762c3e9f64f478fdb79680792b8725f953342fcc348"

--- a/recipes/bitserializer/all/conanfile.py
+++ b/recipes/bitserializer/all/conanfile.py
@@ -7,15 +7,15 @@ from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.51.1"
+required_conan_version = ">=2.4"
 
 
 class BitserializerConan(ConanFile):
     name = "bitserializer"
-    description = "C++ 17 library for serialization to multiple output formats (JSON, XML, YAML, CSV, MsgPack)"
+    description = "Multi-format serialization library (JSON, XML, YAML, CSV, MsgPack)"
     topics = ("serialization", "json", "xml", "yaml", "csv", "msgpack")
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://bitbucket.org/Pavel_Kisliak/bitserializer"
+    homepage = "https://github.com/PavelKisliak/BitSerializer"
     license = "MIT"
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
@@ -46,27 +46,25 @@ class BitserializerConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "gcc": "8",
-            "clang": "7" if Version(self.version) < "0.44" else "8",
+            "clang": "8",
             "Visual Studio": "15",
             "msvc": "191",
             "apple-clang": "12",
         }
 
     def _is_header_only(self, info=False):
-        if Version(self.version) < "0.50":
-            return True
         # All components of library are header-only except csv-archive and msgpack-archive
         options = self.info.options if info else self.options
         return not (options.with_csv or options.get_safe("with_msgpack"))
 
     def config_options(self):
-        if self.settings.os == "Windows" or Version(self.version) < "0.50":
+        if self.settings.os == "Windows":
             del self.options.fPIC
-        if Version(self.version) < "0.50":
-            del self.options.with_rapidyaml
-            del self.options.with_csv
         if Version(self.version) < "0.70":
             del self.options.with_msgpack
+        # The component based on CppRestSdk has been removed since version 0.80
+        if Version(self.version) >= "0.80":
+            del self.options.with_cpprestsdk
 
     def configure(self):
         if self._is_header_only():
@@ -81,14 +79,15 @@ class BitserializerConan(ConanFile):
             cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if self.options.with_cpprestsdk:
+        if self.options.get_safe("with_cpprestsdk"):
             self.requires("cpprestsdk/2.10.19", transitive_headers=True, transitive_libs=True)
-        if self.options.with_rapidjson:
+        if self.options.get_safe("with_rapidjson"):
             self.requires("rapidjson/1.1.0", transitive_headers=True, transitive_libs=True)
-        if self.options.with_pugixml:
-            self.requires("pugixml/1.14", transitive_headers=True, transitive_libs=True)
+        if self.options.get_safe("with_pugixml"):
+            self.requires("pugixml/1.15", transitive_headers=True, transitive_libs=True)
         if self.options.get_safe("with_rapidyaml"):
-            self.requires("rapidyaml/0.5.0", transitive_headers=True, transitive_libs=True)
+            required_rapidyaml = "rapidyaml/0.8.0" if Version(self.version) >= "0.80" else "rapidyaml/0.5.0"
+            self.requires(required_rapidyaml, transitive_headers=True, transitive_libs=True)
 
     def package_id(self):
         if self._is_header_only(info=True):
@@ -118,25 +117,24 @@ class BitserializerConan(ConanFile):
     def generate(self):
         if not self._is_header_only():
             tc = CMakeToolchain(self)
-            tc.variables["BUILD_CPPRESTJSON_ARCHIVE"] = self.options.with_cpprestsdk
-            tc.variables["BUILD_RAPIDJSON_ARCHIVE"] = self.options.with_rapidjson
-            tc.variables["BUILD_PUGIXML_ARCHIVE"] = self.options.with_pugixml
-            tc.variables["BUILD_RAPIDYAML_ARCHIVE"] = self.options.with_rapidyaml
-            tc.variables["BUILD_CSV_ARCHIVE"] = self.options.with_csv
+            tc.variables["BUILD_CPPRESTJSON_ARCHIVE"] = self.options.get_safe("with_cpprestsdk")
+            tc.variables["BUILD_RAPIDJSON_ARCHIVE"] = self.options.get_safe("with_rapidjson")
+            tc.variables["BUILD_PUGIXML_ARCHIVE"] = self.options.get_safe("with_pugixml")
+            tc.variables["BUILD_RAPIDYAML_ARCHIVE"] = self.options.get_safe("with_rapidyaml")
+            tc.variables["BUILD_CSV_ARCHIVE"] = self.options.get_safe("with_csv")
             tc.variables["BUILD_MSGPACK_ARCHIVE"] = self.options.get_safe("with_msgpack")
             tc.generate()
             deps = CMakeDeps(self)
             deps.generate()
 
     def _patch_sources(self):
-        if Version(self.version) >= "0.50":
-            # Remove 'ryml' subdirectory from #include
-            replace_in_file(
-                self, 
-                os.path.join(self.source_folder, "include", "bitserializer", "rapidyaml_archive.h"),
-                "#include <ryml/", 
-                "#include <",
-            )
+        # Remove 'ryml' subdirectory from #include
+        replace_in_file(
+            self,
+            os.path.join(self.source_folder, "include", "bitserializer", "rapidyaml_archive.h"),
+            "#include <ryml/" if Version(self.version) < "0.80" else "#include \"ryml/",
+            "#include <" if Version(self.version) < "0.80" else "#include \"",
+        )
 
     def build(self):
         self._patch_sources()
@@ -168,21 +166,21 @@ class BitserializerConan(ConanFile):
                 self.cpp_info.components["bitserializer-core"].system_libs = ["stdc++fs"]
 
         # cpprestjson-archive
-        if self.options.with_cpprestsdk:
+        if self.options.get_safe("with_cpprestsdk"):
             self.cpp_info.components["bitserializer-cpprestjson"].set_property("cmake_target_name", "BitSerializer::cpprestjson-archive")
             self.cpp_info.components["bitserializer-cpprestjson"].bindirs = []
             self.cpp_info.components["bitserializer-cpprestjson"].libdirs = []
             self.cpp_info.components["bitserializer-cpprestjson"].requires = ["bitserializer-core", "cpprestsdk::cpprestsdk"]
 
         # rapidjson-archive
-        if self.options.with_rapidjson:
+        if self.options.get_safe("with_rapidjson"):
             self.cpp_info.components["bitserializer-rapidjson"].set_property("cmake_target_name", "BitSerializer::rapidjson-archive")
             self.cpp_info.components["bitserializer-rapidjson"].bindirs = []
             self.cpp_info.components["bitserializer-rapidjson"].libdirs = []
             self.cpp_info.components["bitserializer-rapidjson"].requires = ["bitserializer-core", "rapidjson::rapidjson"]
 
         # pugixml-archive
-        if self.options.with_pugixml:
+        if self.options.get_safe("with_pugixml"):
             self.cpp_info.components["bitserializer-pugixml"].set_property("cmake_target_name", "BitSerializer::pugixml-archive")
             self.cpp_info.components["bitserializer-pugixml"].bindirs = []
             self.cpp_info.components["bitserializer-pugixml"].libdirs = []
@@ -200,37 +198,11 @@ class BitserializerConan(ConanFile):
             self.cpp_info.components["bitserializer-csv"].set_property("cmake_target_name", "BitSerializer::csv-archive")
             self.cpp_info.components["bitserializer-csv"].requires = ["bitserializer-core"]
             self.cpp_info.components["bitserializer-csv"].bindirs = []
-            self.cpp_info.components["bitserializer-csv"].libs = [f"csv-archive{lib_suffix}"]
+            self.cpp_info.components["bitserializer-csv"].libs = [f"csv-archive{lib_suffix}" if Version(self.version) < "0.80" else f"bitserializer-csv{lib_suffix}"]
 
         # msgpack-archive
         if self.options.get_safe("with_msgpack"):
             self.cpp_info.components["bitserializer-msgpack"].set_property("cmake_target_name", "BitSerializer::msgpack-archive")
             self.cpp_info.components["bitserializer-msgpack"].requires = ["bitserializer-core"]
             self.cpp_info.components["bitserializer-msgpack"].bindirs = []
-            self.cpp_info.components["bitserializer-msgpack"].libs = [f"msgpack-archive{lib_suffix}"]
-
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "bitserializer"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "bitserializer"
-        self.cpp_info.names["cmake_find_package"] = "BitSerializer"
-        self.cpp_info.names["cmake_find_package_multi"] = "BitSerializer"
-        self.cpp_info.components["bitserializer-core"].names["cmake_find_package"] = "core"
-        self.cpp_info.components["bitserializer-core"].names["cmake_find_package_multi"] = "core"
-        if self.options.with_cpprestsdk:
-            self.cpp_info.components["bitserializer-cpprestjson"].names["cmake_find_package"] = "cpprestjson-archive"
-            self.cpp_info.components["bitserializer-cpprestjson"].names["cmake_find_package_multi"] = "cpprestjson-archive"
-        if self.options.with_rapidjson:
-            self.cpp_info.components["bitserializer-rapidjson"].names["cmake_find_package"] = "rapidjson-archive"
-            self.cpp_info.components["bitserializer-rapidjson"].names["cmake_find_package_multi"] = "rapidjson-archive"
-        if self.options.with_pugixml:
-            self.cpp_info.components["bitserializer-pugixml"].names["cmake_find_package"] = "pugixml-archive"
-            self.cpp_info.components["bitserializer-pugixml"].names["cmake_find_package_multi"] = "pugixml-archive"
-        if self.options.get_safe("with_rapidyaml"):
-            self.cpp_info.components["bitserializer-rapidyaml"].names["cmake_find_package"] = "rapidyaml-archive"
-            self.cpp_info.components["bitserializer-rapidyaml"].names["cmake_find_package_multi"] = "rapidyaml-archive"
-        if self.options.get_safe("with_csv"):
-            self.cpp_info.components["bitserializer-csv"].names["cmake_find_package"] = "csv-archive"
-            self.cpp_info.components["bitserializer-csv"].names["cmake_find_package_multi"] = "csv-archive"
-        if self.options.get_safe("with_msgpack"):
-            self.cpp_info.components["bitserializer-msgpack"].names["cmake_find_package"] = "msgpack-archive"
-            self.cpp_info.components["bitserializer-msgpack"].names["cmake_find_package_multi"] = "msgpack-archive"
+            self.cpp_info.components["bitserializer-msgpack"].libs = [f"msgpack-archive{lib_suffix}" if Version(self.version) < "0.80" else f"bitserializer-msgpack{lib_suffix}"]

--- a/recipes/bitserializer/all/conanfile.py
+++ b/recipes/bitserializer/all/conanfile.py
@@ -42,7 +42,7 @@ class BitserializerConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "gcc": "8",
-            "clang": "7" if Version(self.version) < "0.44" else "8",
+            "clang": "8",
             "Visual Studio": "15",
             "msvc": "191",
             "apple-clang": "12",

--- a/recipes/bitserializer/all/conanfile.py
+++ b/recipes/bitserializer/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2"
 
 
 class BitserializerConan(ConanFile):
@@ -37,20 +37,6 @@ class BitserializerConan(ConanFile):
         "with_csv": False,
         "with_msgpack": False,
     }
-
-    @property
-    def _min_cppstd(self):
-        return "17"
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "8",
-            "clang": "8",
-            "Visual Studio": "15",
-            "msvc": "191",
-            "apple-clang": "12",
-        }
 
     def _is_header_only(self, info=False):
         # All components of library are header-only except csv-archive and msgpack-archive
@@ -94,14 +80,7 @@ class BitserializerConan(ConanFile):
             self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
-
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
-            )
+        check_min_cppstd(self, 17)
 
         # Check stdlib ABI compatibility
         compiler_name = str(self.settings.compiler)

--- a/recipes/bitserializer/all/test_package/conanfile.py
+++ b/recipes/bitserializer/all/test_package/conanfile.py
@@ -18,9 +18,9 @@ class TestPackageConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         bitserializerOptions = self.dependencies[self.tested_reference_str].options
-        tc.variables["WITH_CPPRESTSDK"] = bitserializerOptions.with_cpprestsdk
-        tc.variables["WITH_RAPIDJSON"] = bitserializerOptions.with_rapidjson
-        tc.variables["WITH_PUGIXML"] = bitserializerOptions.with_pugixml
+        tc.variables["WITH_CPPRESTSDK"] = bitserializerOptions.get_safe("with_cpprestsdk", False)
+        tc.variables["WITH_RAPIDJSON"] = bitserializerOptions.get_safe("with_rapidjson", False)
+        tc.variables["WITH_PUGIXML"] = bitserializerOptions.get_safe("with_pugixml", False)
         tc.variables["WITH_RAPIDYAML"] = bitserializerOptions.get_safe("with_rapidyaml", False)
         tc.variables["WITH_CSV"] = bitserializerOptions.get_safe("with_csv", False)
         tc.variables["WITH_MSGPACK"] = bitserializerOptions.get_safe("with_msgpack", False)

--- a/recipes/bitserializer/config.yml
+++ b/recipes/bitserializer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.80":
+    folder: "all"
   "0.75":
     folder: "all"
   "0.70":
@@ -6,8 +8,4 @@ versions:
   "0.65":
     folder: "all"
   "0.50":
-    folder: "all"
-  "0.44":
-    folder: "all"
-  "0.10":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **bitserializer/0.80**

#### Motivation
New version of BitSerializer 0.80 has been released ([Release notes](https://github.com/PavelKisliak/BitSerializer/releases)).

#### Details
- Add new version of library to recipe
- Remove too old versions (allows to simplify the recipe a bit)
- Remove support of "cmake_find_package*" generators

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
