### PR TITLE
libxslt: Add version 1.1.43 (CVE-2025-24855, CVE-2024-55549)

### DIFF
--- a/recipes/libxslt/all/conandata.yml
+++ b/recipes/libxslt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.43":
+    sha256: "5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a"
+    url: "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.tar.xz"
   "1.1.42":
     sha256: "85ca62cac0d41fc77d3f6033da9df6fd73d20ea2fc18b0a3609ffb4110e1baeb"
     url: "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.42.tar.xz"

--- a/recipes/libxslt/all/conanfile.py
+++ b/recipes/libxslt/all/conanfile.py
@@ -179,7 +179,7 @@ class LibxsltConan(ConanFile):
             autotools.make()
 
     def package(self):
-        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "Copyright", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         if is_msvc(self):
             copy(self, "*.h", src=os.path.join(self.source_folder, "libxslt"),
                               dst=os.path.join(self.package_folder, "include", "libxslt"))

--- a/recipes/libxslt/config.yml
+++ b/recipes/libxslt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.43":
+    folder: all
   "1.1.42":
     folder: all
   "1.1.39":


### PR DESCRIPTION
### Summary
* Changes to recipe:  **libxslt: Add version 1.1.43**

#### Motivation
New upstream releases, known security vulnerabilities

* libxslt
  * https://gitlab.gnome.org/GNOME/libxslt/-/tags
  * https://gitlab.gnome.org/GNOME/libxslt/-/commits/master
  * https://download.gnome.org/sources/libxslt/1.1/

#### Details
Version bumps

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
