### PR TITLE
[WIP] open62541: Add version 1.4.11.1 and option for NodeSetLoader

### DIFF
--- a/recipes/open62541/all/conandata.yml
+++ b/recipes/open62541/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.11.1":
+    url: "https://github.com/open62541/open62541/archive/v1.4.11.1.tar.gz"
+    sha256: "2979c0f09b766fd6470bdf06c8500c90ed51327aae1c22af132641a44178b722"
   "1.4.6":
     url: "https://github.com/open62541/open62541/archive/v1.4.6.tar.gz"
     sha256: "bc4ad185fec5c257e15fcb813b7fef9607b7aaa5d355de7b665e1f210556d38e"
@@ -18,6 +21,19 @@ sources:
     url: "https://github.com/open62541/open62541/archive/v1.0.6.tar.gz"
     sha256: "299940025c14929533064abe0044d5805ea50d52b32d05ad9bc0e6996569c2a6"
 patches:
+  "1.4.11.1":
+    - patch_file: "patches/0001-disable-sanitizers-1_4_11_1.patch"
+      patch_description: "Disable static code analysis"
+      patch_type: "conan"
+    - patch_file: "patches/1.4.11.1-0001-use-external-mdnsd.patch"
+      patch_description: "Consume mdnsd as external dependency provided by Conan"
+      patch_type: "conan"
+    - patch_file: "patches/0004-include-iphlpapi.patch"
+      patch_description: "Include iphlpapi.h for SecureZeroMemory"
+      patch_type: "conan"
+    - patch_file: "patches/0005-use-external-libxml2.patch"
+      patch_description: "Consume libxml2 as external dependency provided by Conan"
+      patch_type: "conan"
   "1.4.6":
     - patch_file: "patches/0001-disable-sanitizers-1_4_x.patch"
       patch_description: "Disable static code analysis"

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -109,6 +109,8 @@ class Open62541Conan(ConanFile):
         "cpp_compatible": [True, False],
         # UA_ENABLE_STATUSCODE_DESCRIPTIONS=readable_statuscodes
         "readable_statuscodes": [True, False],
+        # UA_ENABLE_NODESETLOADER=nodeset_loader
+        "nodeset_loader": [True, False],
     }
     default_options = {
         "fPIC": True,
@@ -137,6 +139,7 @@ class Open62541Conan(ConanFile):
         "hardening": True,
         "cpp_compatible": False,
         "readable_statuscodes": True,
+        "nodeset_loader": False,
     }
 
     exports = "submoduledata.yml"
@@ -152,6 +155,10 @@ class Open62541Conan(ConanFile):
 
         if Version(self.version) >= "1.3.1":
             del self.options.embedded_profile
+
+        # NodesetLoader has only rudimentary Windows support --> disabling for now. This might change in the future.
+        if Version(self.version) < "1.4.8" or self.settings.os != "Linux": 
+            del self.options.nodeset_loader
 
     def configure(self):
         if self.options.shared:
@@ -170,6 +177,11 @@ class Open62541Conan(ConanFile):
         if self.options.web_socket:
             self.options["libwebsockets"].with_ssl = self.options.encryption
 
+        if self.options.nodeset_loader:
+            self.options["libxml2"].iconv = False
+            self.options["libxml2"].shared = False
+            self.options["libxml2"].with_subunit = False
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -182,6 +194,8 @@ class Open62541Conan(ConanFile):
             self.requires("libwebsockets/4.3.2")
         if self.options.discovery == "With Multicast" or "multicast" in str(self.options.discovery):
             self.requires("pro-mdnsd/0.8.4")
+        if self.options.nodeset_loader:
+            self.requires("libxml2/2.13.4")
 
     def validate(self):
         if not self.options.subscription:
@@ -248,7 +262,8 @@ class Open62541Conan(ConanFile):
                     destination=path,
                     filename=archive_name,
                     strip_root=True)
-
+        self._patch_sources()
+        
     def _get_log_level(self):
         return {
             "Fatal": "600",
@@ -356,6 +371,8 @@ class Open62541Conan(ConanFile):
         # Honor BUILD_SHARED_LIBS from conan_toolchain (see https://github.com/conan-io/conan/issues/11840)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
 
+        if Version(self.version) >= "1.4.8":
+            tc.variables["UA_ENABLE_NODESETLOADER"]=self.options.nodeset_loader
         tc.generate()
         tc = CMakeDeps(self)
         tc.set_property("mbedtls", "cmake_additional_variables_prefixes", ["MBEDTLS"])
@@ -363,11 +380,10 @@ class Open62541Conan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        if Version(self.version) >= "1.3.1":
+        if Version(self.version) >= "1.3.1" and Version(self.version) <="1.4.7":
             os.unlink(os.path.join(self.source_folder, "tools", "cmake", "FindPython3.cmake"))
 
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/open62541/all/patches/0001-disable-sanitizers-1_4_11_1.patch
+++ b/recipes/open62541/all/patches/0001-disable-sanitizers-1_4_11_1.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bc3f94b54..4253efd3b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -663,18 +663,18 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+     set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "") # cmake sets -rdynamic by default
+ 
+     # Debug
+-    if(UA_ENABLE_DEBUG_SANITIZER AND BUILD_TYPE_LOWER_CASE STREQUAL "debug" AND UNIX AND NOT UA_BUILD_OSS_FUZZ AND
+-       CMAKE_C_COMPILER_ID STREQUAL "Clang" AND NOT UA_ENABLE_UNIT_TESTS_MEMCHECK)
+-        # Add default sanitizer settings when using clang and Debug build.
+-        # This allows e.g. CLion to find memory locations for SegFaults
+-        message(STATUS "Sanitizer enabled")
+-        set(SANITIZER_FLAGS "-g -fno-omit-frame-pointer -gline-tables-only -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=leak -fsanitize=undefined")
+-        if(CMAKE_CXX_COMPILER_VERSION AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
+-            set(SANITIZER_FLAGS "${SANITIZER_FLAGS} -fsanitize-coverage=trace-pc-guard")
+-        endif()
+-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZER_FLAGS}")
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZER_FLAGS}")
+-    endif()
++    # if(UA_ENABLE_DEBUG_SANITIZER AND BUILD_TYPE_LOWER_CASE STREQUAL "debug" AND UNIX AND NOT UA_BUILD_OSS_FUZZ AND
++    #    CMAKE_C_COMPILER_ID STREQUAL "Clang" AND NOT UA_ENABLE_UNIT_TESTS_MEMCHECK)
++    #     # Add default sanitizer settings when using clang and Debug build.
++    #     # This allows e.g. CLion to find memory locations for SegFaults
++    #     message(STATUS "Sanitizer enabled")
++    #     set(SANITIZER_FLAGS "-g -fno-omit-frame-pointer -gline-tables-only -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=leak -fsanitize=undefined")
++    #     if(CMAKE_CXX_COMPILER_VERSION AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
++    #         set(SANITIZER_FLAGS "${SANITIZER_FLAGS} -fsanitize-coverage=trace-pc-guard")
++    #     endif()
++    #     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZER_FLAGS}")
++    #     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZER_FLAGS}")
++    # endif()
+ 
+     if(NOT MINGW AND UA_ENABLE_HARDENING AND ((CMAKE_BUILD_TYPE STREQUAL "Release") OR (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")))
+         check_add_cc_flag("-D_FORTIFY_SOURCE=2") # run-time buffer overflow detection (needs at least -O1)

--- a/recipes/open62541/all/patches/0005-use-external-libxml2.patch
+++ b/recipes/open62541/all/patches/0005-use-external-libxml2.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1092,7 +1092,8 @@ if(UA_ENABLE_NODESETLOADER)
+     list(APPEND lib_sources ${NODESETLOADER_SOURCES})
+     list(APPEND plugin_headers ${PROJECT_SOURCE_DIR}/plugins/include/open62541/plugin/nodesetloader.h)
+     list(APPEND plugin_sources ${PROJECT_SOURCE_DIR}/plugins/ua_nodesetloader.c)
+-    list(APPEND open62541_LIBRARIES ${NODESETLOADER_DEPS_LIBS})
++    find_package(LibXml2 REQUIRED)
++    list(APPEND open62541_LIBRARIES LibXml2::LibXml2)
+ 
+     if(UA_ENABLE_AMALGAMATION)
+         list(APPEND exported_headers ${NODESETLOADER_PUBLIC_HEADERS})
+diff --git a/deps/nodesetLoader/CMakeLists.txt b/deps/nodesetLoader/CMakeLists.txt
+--- a/deps/nodesetLoader/CMakeLists.txt
++++ b/deps/nodesetLoader/0005-use-external-libxml2.patchCMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.0...3.13)
+ 
+ project(nodesetLoader)
+ 

--- a/recipes/open62541/all/patches/1.4.11.1-0001-use-external-mdnsd.patch
+++ b/recipes/open62541/all/patches/1.4.11.1-0001-use-external-mdnsd.patch
@@ -1,0 +1,111 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bc3f94b54..8ac553589 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -746,23 +746,24 @@ file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src_generated")
+ configure_file(include/open62541/config.h.in ${PROJECT_BINARY_DIR}/src_generated/open62541/config.h)
+ 
+ if(UA_ENABLE_DISCOVERY_MULTICAST)
+-  include(GenerateExportHeader)
+-    set(MDNSD_LOGLEVEL 300 CACHE STRING "Level at which logs shall be reported" FORCE)
+-    
+-    # create a "fake" empty library to generate the export header macros
+-    if (APPLE)
+-    	add_library(libmdnsd INTERFACE ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
+-    else()
+-    	add_library(libmdnsd ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
+-    endif()
+-    
+-    set_property(TARGET libmdnsd PROPERTY LINKER_LANGUAGE C)
+-    set_property(TARGET libmdnsd PROPERTY DEFINE_SYMBOL "MDNSD_DYNAMIC_LINKING_EXPORT")
+-    configure_file("deps/mdnsd/libmdnsd/mdnsd_config_extra.in"
+-                   "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config_extra")
+-    file(READ "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config_extra" MDNSD_CONFIG_EXTRA)
+-    generate_export_header(libmdnsd EXPORT_FILE_NAME "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h"
+-                           BASE_NAME MDNSD DEFINE_NO_DEPRECATED CUSTOM_CONTENT_FROM_VARIABLE MDNSD_CONFIG_EXTRA)
++#   include(GenerateExportHeader)
++#     set(MDNSD_LOGLEVEL 300 CACHE STRING "Level at which logs shall be reported" FORCE)
++#    
++#     # create a "fake" empty library to generate the export header macros
++#     if (APPLE)
++#     	add_library(libmdnsd INTERFACE ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
++#     else()
++#     	add_library(libmdnsd ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
++#     endif()
++#    
++#     set_property(TARGET libmdnsd PROPERTY LINKER_LANGUAGE C)
++#     set_property(TARGET libmdnsd PROPERTY DEFINE_SYMBOL "MDNSD_DYNAMIC_LINKING_EXPORT")
++#     configure_file("deps/mdnsd/libmdnsd/mdnsd_config_extra.in"
++#                    "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config_extra")
++#     file(READ "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config_extra" MDNSD_CONFIG_EXTRA)
++#     generate_export_header(libmdnsd EXPORT_FILE_NAME "${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h"
++#                            BASE_NAME MDNSD DEFINE_NO_DEPRECATED CUSTOM_CONTENT_FROM_VARIABLE MDNSD_CONFIG_EXTRA)
++  find_package(mdnsd REQUIRED)
+ endif()
+ 
+ # Exported headers
+@@ -940,19 +941,8 @@ if(UA_DEBUG_DUMP_PKGS)
+ endif()
+ 
+ if(UA_ENABLE_DISCOVERY_MULTICAST)
+-    # prepend in list, otherwise it complains that winsock2.h has to be included before windows.h
+-    list(APPEND lib_headers
+-         ${PROJECT_BINARY_DIR}/src_generated/mdnsd_config.h
+-         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/1035.h
+-         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/xht.h
+-         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/sdtxt.h
+-         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.h)
+-    list(APPEND lib_sources
+-         ${PROJECT_SOURCE_DIR}/src/server/ua_discovery_mdns.c
+-         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/1035.c
+-         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/xht.c
+-         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/sdtxt.c
+-         ${PROJECT_SOURCE_DIR}/deps/mdnsd/libmdnsd/mdnsd.c)
++  set(lib_sources ${PROJECT_SOURCE_DIR}/src/server/ua_discovery_mdns.c
++   ${lib_sources})
+ endif()
+ 
+ if(UA_BUILD_FUZZING OR UA_BUILD_OSS_FUZZ)
+@@ -1365,6 +1355,14 @@ else()
+ 
+     add_library(open62541 $<TARGET_OBJECTS:open62541-object> $<TARGET_OBJECTS:open62541-plugins>)
+ 
++    if(UA_ENABLE_DISCOVERY_MULTICAST)
++        target_include_directories(open62541-object PUBLIC ${mdnsd_INCLUDE_DIRS})
++    endif()
++
++    if(UA_ENABLE_DISCOVERY_MULTICAST)
++        list(APPEND open62541_LIBRARIES mdnsd::mdnsd)
++    endif()
++
+     if(UA_ENABLE_ENCRYPTION_LIBRESSL)
+         # Prevent Wincrypt override warning.
+         target_compile_definitions(open62541-plugins PUBLIC NOCRYPT=1)
+diff --git a/src/server/ua_discovery.h b/src/server/ua_discovery.h
+index b0031c732..154ba32cd 100644
+--- a/src/server/ua_discovery.h
++++ b/src/server/ua_discovery.h
+@@ -44,7 +44,7 @@ typedef struct {
+ 
+ #ifdef UA_ENABLE_DISCOVERY_MULTICAST
+ 
+-#include "mdnsd/libmdnsd/mdnsd.h"
++#include "libmdnsd/mdnsd.h"
+ #define UA_MAXMDNSRECVSOCKETS 8
+ 
+ /**
+diff --git a/src/server/ua_discovery_mdns.c b/src/server/ua_discovery_mdns.c
+index 27a7adab6..725082eb8 100644
+--- a/src/server/ua_discovery_mdns.c
++++ b/src/server/ua_discovery_mdns.c
+@@ -13,8 +13,8 @@
+ #ifdef UA_ENABLE_DISCOVERY_MULTICAST
+ 
+ #ifndef UA_ENABLE_AMALGAMATION
+-#include "mdnsd/libmdnsd/xht.h"
+-#include "mdnsd/libmdnsd/sdtxt.h"
++#include "libmdnsd/xht.h"
++#include "libmdnsd/sdtxt.h"
+ #endif
+ 
+ #include "../deps/mp_printf.h"

--- a/recipes/open62541/all/submoduledata.yml
+++ b/recipes/open62541/all/submoduledata.yml
@@ -1,4 +1,13 @@
 submodules:
+  "1.4.11.1":
+    deps/ua-nodeset:
+      url: "https://github.com/OPCFoundation/UA-Nodeset/archive/Machinery-1.03.0-2023-08-01.zip"
+      sha256: "b1677e7114004f44103159ae7a2fb220958e6f645177c9d140f6acfe469b8eb8"
+      archive_pattern: "UA-Nodeset-{version}"
+    deps/nodesetLoader:
+      url: "https://github.com/open62541/open62541-nodeset-loader/archive/76e0994cff81d8c9d2eca9f7f6a9d14519d3e49e.tar.gz"
+      sha256: "0337b1611713d140cc7979da88a14d3bb9c4ced54c424df23e7c1c8f51fdce52"
+      archive_pattern: "open62541-nodeset-loader-{sha256}"
   "1.4.6":
     deps/ua-nodeset:
       url: "https://github.com/OPCFoundation/UA-Nodeset/archive/Machinery-1.03.0-2023-08-01.zip"

--- a/recipes/open62541/config.yml
+++ b/recipes/open62541/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.11.1":
+    folder: all
   "1.4.6":
     folder: all
   "1.3.9":


### PR DESCRIPTION
# Summary
This pull request adds support for version 1.4.11.1 of open62541, introducing a new Conan option for enabling the NodesetLoader feature. This feature allows users to optionally include the NodesetLoader functionality.

# Motivation
The addition of the NodesetLoader option allows Conan users to utilize the NodesetLoader feature.

# Details
- **conanfile.py**:
    - Add a boolean option `nodeset_loader` to enable or disable the NodesetLoader feature.
    - Conditionally add libxml2 as a dependency when `nodeset_loader` is enabled.
- **CMakeLists.txt**:
    - Update to use the libxml2 dependency provided by Conan when the NodesetLoader option is enabled.
- **submoduledata.yml**:
    - Add NodesetLoader sources to support the new feature.

-------------------------------------------------

 - [x] Read the [CONTRIBUTING.md](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
 - [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
       ⚠️ Found [PR #26457](https://github.com/conan-io/conan-center-index/pull/26457): This PR also upgrades open62541 to version 1.4.11.1 but introduces a different Conan option (QNX support).
 - [x] Tested locally with at least one configuration using a recent version of Conan

# Open Questions
- **Which version of NodesetLoader should be used?**: I raised this question in the upstream open62541 repository ([open62541 issue #7249](https://github.com/open62541/open62541/issues/7249)).
- **How to proceed with the partially duplicate PR?**: I suggest waiting for PR #26457 to be merged before proceeding with this pull request.