### PR TITLE
metal-cpp: Add version 15.2

### DIFF
--- a/recipes/metal-cpp/all/conandata.yml
+++ b/recipes/metal-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "15.2":
+    url: "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15.2_iOS18.2.zip"
+    sha256: "3437e4abfbd3d45217f34772ef3502f31ba3358e5fb6ac9d0ca952a047bcfe25"
   "15":
     url: "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15_iOS18.zip"
     sha256: "0433df1e0ab13c2b0becbd78665071e3fa28381e9714a3fce28a497892b8a184"
@@ -15,6 +18,10 @@ sources:
     url: "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS13_iOS16.zip"
     sha256: "6f741894229e9c750add1afc3797274fc008c7507e2ae726370c17c34b7c6a68"
 minimum_os_version:
+  "15.2":
+    "Macos": "15.2"
+    "iOS": "18.2"
+    "tvOS": "18.2"
   "15":
     "Macos": "15"
     "iOS": "18"

--- a/recipes/metal-cpp/config.yml
+++ b/recipes/metal-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "15.2":
+    folder: all
   "15":
     folder: all
   "14.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **metal-cpp/15.2**

#### Motivation
New version of 15.2 supports bug fixes related to `NS::Bundle` introspection.
Link to the issue: https://developer.apple.com/forums/thread/775258

#### Details
Apple does not publish detailed changelog, so unfortunately I could only refer to an issue that I've personally stumbled upon (cannot iterate over `NS::Bundle` frameworks).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
