### PR TITLE
Thrift/0.22.0

### DIFF
--- a/recipes/thrift/all/conandata.yml
+++ b/recipes/thrift/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.22.0":
+    url: "http://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz"
+    sha256: "794a0e455787960d9f27ab92c38e34da27e8deeda7a5db0e59dc64a00df8a1e5"
   "0.21.0":
     url: "http://archive.apache.org/dist/thrift/0.21.0/thrift-0.21.0.tar.gz"
     sha256: "9a24f3eba9a4ca493602226c16d8c228037db3b9291c6fc4019bfe3bd39fc67c"
@@ -24,6 +27,16 @@ sources:
     url: "https://archive.apache.org/dist/thrift/0.14.1/thrift-0.14.1.tar.gz"
     sha256: "13da5e1cd9c8a3bb89778c0337cc57eb0c29b08f3090b41cf6ab78594b410ca5"
 patches:
+  "0.22.0":
+    - patch_file: "patches/cmake-0.21.0-001-install-dir.patch"
+      patch_description: "Patch install dir on MSVC"
+      patch_type: "conan"
+    - patch_file: "patches/cmake-0.22.0-002-conan-libs.patch"
+      patch_description: "Parts of cmake-0.16.0.patch that does not need changing"
+      patch_type: "conan"
+    - patch_file: "patches/cmake-0.21.0-003-conan-libs.patch"
+      patch_description: "Patch conan libs in the thrift lib cmake"
+      patch_type: "conan"
   "0.21.0":
     - patch_file: "patches/cmake-0.21.0-001-install-dir.patch"
     - patch_file: "patches/cmake-0.21.0-002-conan-libs.patch"

--- a/recipes/thrift/all/patches/cmake-0.22.0-002-conan-libs.patch
+++ b/recipes/thrift/all/patches/cmake-0.22.0-002-conan-libs.patch
@@ -1,0 +1,67 @@
+diff --git a/build/cmake/DefineOptions.cmake b/build/cmake/DefineOptions.cmake
+index 3cca31e..ffc2811 100644
+--- a/build/cmake/DefineOptions.cmake
++++ b/build/cmake/DefineOptions.cmake
+@@ -39,11 +39,6 @@ option(BUILD_LIBRARIES "Build Thrift libraries" ON)
+ # and enables the library if all are found. This means the default is to build as
+ # much as possible but leaving out libraries if their dependencies are not met.
+
+-if (NOT Boost_USE_STATIC_LIBS)
+-    add_definitions(-DBOOST_ALL_DYN_LINK)
+-    add_definitions(-DBOOST_TEST_DYN_LINK)
+-endif()
+-
+ # as3
+ option(WITH_AS3 "Build ActionScript 3 Thrift Library" ON)
+ if (WITH_AS3)
+@@ -90,6 +85,7 @@ if(WITH_CPP OR WITH_C_GLIB)
+     find_package(OpenSSL)
+     CMAKE_DEPENDENT_OPTION(WITH_OPENSSL "Build with OpenSSL support" ON
+                         "OPENSSL_FOUND" OFF)
++    OPTION(WITH_OPENSSL "Build with OpenSSL support" ON)
+ endif()
+
+ # Java
+@@ -106,14 +102,10 @@ else()
+ endif()
+
+ # Javascript
+-option(WITH_JAVASCRIPT "Build Javascript Thrift library" ON)
+-CMAKE_DEPENDENT_OPTION(BUILD_JAVASCRIPT "Build Javascript library" ON
+-                       "BUILD_LIBRARIES;WITH_JAVASCRIPT;NOT WIN32; NOT CYGWIN" OFF)
++option(WITH_JAVASCRIPT "Build Javascript Thrift library" OFF)
+
+ # NodeJS
+-option(WITH_NODEJS "Build NodeJS Thrift library" ON)
+-CMAKE_DEPENDENT_OPTION(BUILD_NODEJS "Build NodeJS library" ON
+-                       "BUILD_LIBRARIES;WITH_NODEJS" OFF)
++option(WITH_NODEJS "Build NodeJS Thrift library" OFF)
+
+ # Python
+ option(WITH_PYTHON "Build Python Thrift library" ON)
+diff --git a/lib/c_glib/CMakeLists.txt b/lib/c_glib/CMakeLists.txt
+index 218f7dd..b879830 100644
+--- a/lib/c_glib/CMakeLists.txt
++++ b/lib/c_glib/CMakeLists.txt
+@@ -71,7 +71,8 @@ set(thrift_c_glib_zlib_SOURCES
+ )
+
+ # If OpenSSL is not found just ignore the OpenSSL stuff
+-if(OPENSSL_FOUND AND WITH_OPENSSL)
++if(WITH_OPENSSL)
++    find_package(OpenSSL REQUIRED)
+     list(APPEND thrift_c_glib_SOURCES
+ 	    src/thrift/c_glib/transport/thrift_ssl_socket.c
+     )
+@@ -83,8 +84,7 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
+             list(APPEND SYSLIBS OpenSSL::Crypto)
+         endif()
+     else()
+-        include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+-        list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
++        list(APPEND SYSLIBS OpenSSL::SSL OpenSSL::Crypto)
+     endif()
+ endif()
+
+
+

--- a/recipes/thrift/config.yml
+++ b/recipes/thrift/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.22.0":
+    folder: all
   "0.21.0":
     folder: all
   "0.20.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **thrift/0.21.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
New version which adds new feature: Support for a UUID type for the C++ Compiler

#### Details
1. Add the new version 
   - Update and fix patches as needed
 2. Sensible example 
    - The previous example had a nonsense thrift file and checked in files that the thrift compiler must generate
    - This example removes the checked in files and generates them, then builds the test executable 
    - It does not check comms, just that the compiler compiles the file and the package can be build and will run

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
