### PR TITLE
Adding libsafec 3.9.1

### DIFF
--- a/recipes/libsafec/all/conandata.yml
+++ b/recipes/libsafec/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.9.1":
+    url: "https://github.com/rurban/safeclib/releases/download/v3.9.1/safeclib-3.9.1.tar.gz"
+    sha256: "167502713a4f1a37017b8b830535b31b5762be4bef512bebe19072f17f436dd4"
   "3.7.1":
     url: "https://github.com/rurban/safeclib/archive/v3.7.1.tar.gz"
     sha256: "baac28b60f8f46ae0f273155f4968b20e84380016629247ed2a4d7e3fbeb4d98"

--- a/recipes/libsafec/all/conanfile.py
+++ b/recipes/libsafec/all/conanfile.py
@@ -90,9 +90,7 @@ class LibSafeCConan(ConanFile):
     def generate(self):
         env = VirtualBuildEnv(self)
         env.generate()
-
         tc = AutotoolsToolchain(self)
-
         yes_no = lambda v: "yes" if v else "no"
         tc.configure_args += [
             f"--enable-debug={yes_no(self.settings.build_type == 'Debug')}",
@@ -101,14 +99,6 @@ class LibSafeCConan(ConanFile):
             f"--enable-strmax={self.options.strmax}",
             f"--enable-memmax={self.options.memmax}",
         ]
-
-        if is_apple_os(self) and self.settings.arch in ["x86_64", "armv8"]:
-            tc.configure_args += [
-                "--disable-hardening",
-            ]
-            # create a universal binary
-            tc.extra_cflags.extend(["-arch", "arm64", "-arch", "x86_64"])
-            tc.extra_cxxflags.extend(["-arch", "arm64", "-arch", "x86_64"])
         tc.generate()
 
     def build(self):

--- a/recipes/libsafec/all/conanfile.py
+++ b/recipes/libsafec/all/conanfile.py
@@ -95,7 +95,6 @@ class LibSafeCConan(ConanFile):
         is_apple_silicon = is_apple_os(self) and self.settings.arch == "armv8"
 
         tc = AutotoolsToolchain(self)
-        tc_env = tc.environment()
 
         yes_no = lambda v: "yes" if v else "no"
         tc.configure_args += [
@@ -111,11 +110,9 @@ class LibSafeCConan(ConanFile):
                 "--disable-hardening",
             ]
             # create a universal binary
-            tc_env.define("CC", "clang -arch arm64 -arch x86_64")
-            tc_env.define("CXX", "clang -arch arm64 -arch x86_64")
-            tc_env.define("CPP", "clang -E")
-            tc_env.define("CXXCPP", "clang -E")
-        tc.generate(tc_env)
+            tc.extra_cflags.extend(["-arch", "arm64", "-arch", "x86_64"])
+            tc.extra_cxxflags.extend(["-arch", "arm64", "-arch", "x86_64"])
+        tc.generate()
 
     def build(self):
         with chdir(self, self.source_folder):

--- a/recipes/libsafec/all/conanfile.py
+++ b/recipes/libsafec/all/conanfile.py
@@ -91,9 +91,6 @@ class LibSafeCConan(ConanFile):
         env = VirtualBuildEnv(self)
         env.generate()
 
-        # Apple Silicon
-        is_apple_silicon = is_apple_os(self) and self.settings.arch == "armv8"
-
         tc = AutotoolsToolchain(self)
 
         yes_no = lambda v: "yes" if v else "no"
@@ -105,7 +102,7 @@ class LibSafeCConan(ConanFile):
             f"--enable-memmax={self.options.memmax}",
         ]
 
-        if is_apple_silicon:
+        if is_apple_os(self) and self.settings.arch in ["x86_64", "armv8"]:
             tc.configure_args += [
                 "--disable-hardening",
             ]

--- a/recipes/libsafec/config.yml
+++ b/recipes/libsafec/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.9.1":
+    folder: all
   "3.7.1":
     folder: all
   "3.6.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsafec/3.9.1**

#### Motivation
This is to make `libsafec` 3.9.1 available on conan-center-index.

#### Details
- adding the URL and SHA256 of libsafec 3.9.1's source archive
- start supporting Apple Silicon by building universal binaries from 3.9.1
  - build universal binaries in both x86_64 and armv8
  - NOTE: all of the flags are straight from the package https://github.com/rurban/safeclib/blob/v3.9.1/README.md#userspace-library

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
