### PR TITLE
libxml2: Add version 2.13.8 (CVE-2025-32414, CVE-2025-32415)

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.13.8":
+    url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.8.tar.xz"
+    sha256: "277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a"
   "2.13.6":
     url: "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.6.tar.xz"
     sha256: "f453480307524968f7a04ec65e64f2a83a825973bcd260a2e7691be82ae70c96"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.13.8":
+    folder: all
   "2.13.6":
     folder: all
   "2.13.4":


### PR DESCRIPTION
### Summary
Changes to recipe: libxml2: Add version 2.13.8

#### Motivation
New upstream releases, known security vulnerabilities

#### Details
libxml2

    https://gitlab.gnome.org/GNOME/libxml2/-/tags
    https://download.gnome.org/sources/libxml2/2.13/


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
