### PR TITLE
paho-mqtt-cpp: patch non standard string usage

### DIFF
--- a/recipes/paho-mqtt-cpp/all/conandata.yml
+++ b/recipes/paho-mqtt-cpp/all/conandata.yml
@@ -16,6 +16,10 @@ patches:
     - patch_file: "patches/1.4.1-0001-fix-cmake.patch"
       patch_description: "CMake: Honor fPIC option"
       patch_type: "conan"
+    - patch_file: "patches/1.4.1-0002-llvm-char-traits.patch"
+      patch_description: "Replace non-standard STL string usage (removed in LLVM 19)"
+      patch_type: "portability"
+      patch_source: https://github.com/eclipse-paho/paho.mqtt.cpp/pull/544
   "1.4.0":
     - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
       patch_description: "CMake: Honor fPIC option"

--- a/recipes/paho-mqtt-cpp/all/patches/1.4.1-0002-llvm-char-traits.patch
+++ b/recipes/paho-mqtt-cpp/all/patches/1.4.1-0002-llvm-char-traits.patch
@@ -1,0 +1,57 @@
+diff --git a/include/mqtt/ssl_options.h b/include/mqtt/ssl_options.h
+index cc20531..f401322 100644
+--- a/include/mqtt/ssl_options.h
++++ b/include/mqtt/ssl_options.h
+@@ -101,7 +101,7 @@ private:
+ 	psk_handler pskHandler_;
+ 
+ 	/** ALPN protocol list, in wire format */
+-	std::basic_string<unsigned char> protos_;
++	std::vector<unsigned char> protos_;
+ 
+ 	/** Callbacks from the C library */
+ 	static int on_error(const char *str, size_t len, void *context);
+diff --git a/src/ssl_options.cpp b/src/ssl_options.cpp
+index 845e0f2..02e9960 100644
+--- a/src/ssl_options.cpp
++++ b/src/ssl_options.cpp
+@@ -126,7 +126,7 @@ void ssl_options::update_c_struct()
+ 
+ 	if (!protos_.empty()) {
+ 		opts_.protos = protos_.data();
+-		opts_.protos_len = unsigned(protos_.length());
++		opts_.protos_len = unsigned(protos_.size());
+ 	}
+ 	else {
+ 		opts_.protos = nullptr;
+@@ -303,7 +303,7 @@ void ssl_options::set_psk_handler(psk_handler cb)
+ std::vector<string> ssl_options::get_alpn_protos() const
+ {
+ 	std::vector<string> protos;
+-	size_t i = 0, n = protos_.length();
++	size_t i = 0, n = protos_.size();
+ 
+ 	while (i < n) {
+ 		size_t sn = protos_[i++];
+@@ -328,7 +328,7 @@ void ssl_options::set_alpn_protos(const std::vector<string>& protos)
+ 	using uchar = unsigned char;
+ 
+ 	if (!protos.empty()) {
+-		std::basic_string<uchar> protoBin;
++		std::vector<uchar> protoBin;
+ 		for (const auto& proto : protos) {
+ 			protoBin.push_back(uchar(proto.length()));
+ 			for (const char c : proto)
+@@ -337,10 +337,10 @@ void ssl_options::set_alpn_protos(const std::vector<string>& protos)
+ 		protos_ = std::move(protoBin);
+ 
+ 		opts_.protos = protos_.data();
+-		opts_.protos_len = unsigned(protos_.length());
++		opts_.protos_len = unsigned(protos_.size());
+ 	}
+ 	else {
+-		protos_ = std::basic_string<uchar>();
++		protos_ = std::vector<uchar>();
+ 		opts_.protos = nullptr;
+ 		opts_.protos_len = 0;
+ 	}


### PR DESCRIPTION
### Summary
Changes to recipe:  **paho-mqtt-cpp/1.4.1**

#### Motivation
Library does not compile with LLVM-19 based compilers (Clang 19 and AppleClang 17)

#### Details
LLVM removed entirely the non-standard `char_traits<unsigned char>` from the libc++ sources. Libraries using `basic_string<unsigned char>` without defining a custom traits class will no longer compile.

See the related PR https://github.com/eclipse-paho/paho.mqtt.cpp/pull/544

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan