### PR TITLE
[ceres-solver] Pull sources from github

### DIFF
--- a/recipes/ceres-solver/all/conandata.yml
+++ b/recipes/ceres-solver/all/conandata.yml
@@ -1,16 +1,16 @@
 sources:
   "2.2.0":
-    url: "http://ceres-solver.org/ceres-solver-2.2.0.tar.gz"
-    sha256: "48b2302a7986ece172898477c3bcd6deb8fb5cf19b3327bc49969aad4cede82d"
+    url: "https://github.com/ceres-solver/ceres-solver/archive/refs/tags/2.2.0.tar.gz"
+    sha256: "12efacfadbfdc1bbfa203c236e96f4d3c210bed96994288b3ff0c8e7c6f350d4"
   "2.1.0":
-    url: "http://ceres-solver.org/ceres-solver-2.1.0.tar.gz"
-    sha256: "f7d74eecde0aed75bfc51ec48c91d01fe16a6bf16bce1987a7073286701e2fc6"
+    url: "https://github.com/ceres-solver/ceres-solver/archive/refs/tags/2.1.0.tar.gz"
+    sha256: "ccbd716a93f65d4cb017e3090ae78809e02f5426dce16d0ee2b4f8a4ba2411a8"
   "2.0.0":
-    url: "http://ceres-solver.org/ceres-solver-2.0.0.tar.gz"
-    sha256: "10298a1d75ca884aa0507d1abb0e0f04800a92871cd400d4c361b56a777a7603"
+    url: "https://github.com/ceres-solver/ceres-solver/archive/refs/tags/2.0.0.tar.gz"
+    sha256: "2ab0348e0f65fdf43bebcd325a1c73f7e8999691ee75e2a2981281931c42e9fa"
   "1.14.0":
-    url: "http://ceres-solver.org/ceres-solver-1.14.0.tar.gz"
-    sha256: "4744005fc3b902fed886ea418df70690caa8e2ff6b5a90f3dd88a3d291ef8e8e"
+    url: "https://github.com/ceres-solver/ceres-solver/archive/refs/tags/1.14.0.tar.gz"
+    sha256: "1296330fcf1e09e6c2f926301916f64d4a4c5c0ff12d460a9bc5d4c48411518f"
 patches:
   "2.2.0":
     - patch_file: "patches/2.2.0-0001-find-libraries-conan.patch"


### PR DESCRIPTION
### Summary
Changes to recipe:  **ceres-solver/all**

#### Motivation
Currently we pull the sources from the official website, `http://ceres-solver.org` , but it looks like only the latest tarball is available there now so I can't build older releases. Furthermore this site is currently being flagged as "insecure", at least by chrome. This may be related to the issues I'm seeing.

The main repo for this project is https://ceres-solver.googlesource.com/ceres-solver, but I can't properly download tarballs from it. Each time I download the tarball it has a different sha256sum, so it looks like they're generated on the fly and they include a timestamp or something?

But since ceres also maintains a github mirror, we can pull the sources from it. This is an official mirror, it is mentioned on the docs site:
>[ceres-solver@googlegroups.com](https://groups.google.com/forum/?fromgroups#!forum/ceres-solver) is the place for discussions and questions about Ceres Solver. We use the [GitHub Issue Tracker](https://github.com/ceres-solver/ceres-solver/issues) to manage bug reports and feature requests.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
