### PR TITLE
Add c-ares 1.34.5

### DIFF
--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.34.5":
+    url: "https://github.com/c-ares/c-ares/releases/download/v1.34.5/c-ares-1.34.5.tar.gz"
+    sha256: "7d935790e9af081c25c495fd13c2cfcda4792983418e96358ef6e7320ee06346"
   "1.34.3":
     url: "https://github.com/c-ares/c-ares/releases/download/v1.34.3/c-ares-1.34.3.tar.gz"
     sha256: "26e1f7771da23e42a18fdf1e58912a396629e53a2ac71b130af93bbcfb90adbe"

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.34.5":
+    folder: all
   "1.34.3":
     folder: all
   "1.34.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **c-ares/[1.34.5]**

#### Motivation
Version bump. 1.34.5 fixes CVE-2025-31498. Requested in #27225.

#### Details
Adds 1.34.5.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
