### PR TITLE
openssl (3.x.x): Add `-headerpad_max_install_names` to generate method so that `install_name_tool` succeeds on MacOS

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -420,6 +420,11 @@ class OpenSSLConan(ConanFile):
             env.define_path("CROSS_SDK", os.path.basename(xcrun.sdk_path))
             env.define_path("CROSS_TOP", os.path.dirname(os.path.dirname(xcrun.sdk_path)))
 
+        if is_apple_os(self):
+            # Inject -headerpad_max_install_names, otherwise fix_apple_shared_install_name() may fail.
+            # See https://github.com/conan-io/conan-center-index/issues/27424
+            tc.extra_ldflags.append("-headerpad_max_install_names")
+
         self._create_targets(tc.cflags, tc.cxxflags, tc.defines, tc.ldflags)
         tc.generate(env)
 

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -420,8 +420,8 @@ class OpenSSLConan(ConanFile):
             env.define_path("CROSS_SDK", os.path.basename(xcrun.sdk_path))
             env.define_path("CROSS_TOP", os.path.dirname(os.path.dirname(xcrun.sdk_path)))
 
-        if is_apple_os(self):
-            # Inject -headerpad_max_install_names, otherwise fix_apple_shared_install_name() may fail.
+        if is_apple_os(self) and self.options.shared:
+            # Inject -headerpad_max_install_names for shared library, otherwise fix_apple_shared_install_name() may fail.
             # See https://github.com/conan-io/conan-center-index/issues/27424
             tc.extra_ldflags.append("-headerpad_max_install_names")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **openssl/3.x.x**

#### Motivation
Fixes  #27424

#### Details
Adds `-headerpad_max_install_names` behind a `is_apple_os` check in the `generate()` method of the openssl/3.x.x conanfile. This fix allows `install_name_tool` to succeed, which is called by `fix_apple_shared_install_name` in the `package()` step of the conanfile.

I validated this fix by performing the following steps:

1. Cloned my fork.
2. Added my fork as a local repository, as described [here](https://docs.conan.io/2/devops/devops_local_recipes_index.html).
3. Cleared my conan cache.
4. Ran my test command `conan install --requires openssl/3.4.1 --build=missing -o "*:shared=True"`.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
