### PR TITLE
 Add sqlitemap header-only library

### DIFF
--- a/recipes/sqlitemap/all/conandata.yml
+++ b/recipes/sqlitemap/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1.0":
+    url: "https://github.com/bw-hro/sqlitemap/archive/v1.1.0.tar.gz"
+    sha256: "1a43e0799f95c79fd2633bff1f158fbab99dbd934222fb284e45f34e784faf96"

--- a/recipes/sqlitemap/all/conanfile.py
+++ b/recipes/sqlitemap/all/conanfile.py
@@ -1,0 +1,52 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=2.0"
+
+
+class PackageConan(ConanFile):
+    name = "sqlitemap"
+    description = "sqlitemap - Persistent Map Backed by SQLite"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/bw-hro/sqlitemap"
+    topics = ("sqlite", "database", "hash map", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("sqlite3/[>=3.45.0 <4]")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "sqlitemap")
+        self.cpp_info.set_property("cmake_target_name", "sqlitemap::sqlitemap")
+        self.cpp_info.set_property("pkg_config_name", "sqlitemap")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/sqlitemap/all/test_package/CMakeLists.txt
+++ b/recipes/sqlitemap/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(sqlitemap REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE sqlitemap::sqlitemap)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/sqlitemap/all/test_package/conanfile.py
+++ b/recipes/sqlitemap/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sqlitemap/all/test_package/test_package.cpp
+++ b/recipes/sqlitemap/all/test_package/test_package.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+
+#include <bw/sqlitemap/sqlitemap.hpp>
+
+int main()
+{
+    bw::sqlitemap::sqlitemap db(bw::sqlitemap::config().filename(":memory:").table("items"));
+    db["a"] = "first-item";
+    db["b"] = "second-item";
+    db["c"] = "third-item";
+    db.commit();
+
+    std::cout << db.to_string() << std::endl;
+    std::cout << db.size() << " items saved:" << std::endl;
+    for (const auto &[key, value] : db)
+    {
+        std::cout << key << " = " << value << std::endl;
+    }
+    return 0;
+}

--- a/recipes/sqlitemap/config.yml
+++ b/recipes/sqlitemap/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlitemap/[1.1.0]**

#### Motivation
Add [sqlitemap](https://github.com/bw-hro/sqlitemap)

#### Details
sqlitemap is a lightweight C++ wrapper around SQLite(only dependency) that provides a simple, map-like interface.
It’s designed to make working with key-value storage easy and convenient. The library is implemented as a single-header file and is licensed under the MIT License.

I have tested it successfully on a local Ubuntu with gcc 13 and on a local Windows with MSVC 19.

This is the first time I created a recipe, so hope It match all requirements. In case anything else is needed I'm open for feedback : ) 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
