### PR TITLE
arrow: `filesystem_layer = True` as default value. Removed dead code.

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -1,3 +1,5 @@
+import os
+
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.build import check_min_cppstd, cross_building
@@ -6,10 +8,8 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 
-import os
-import glob
-
 required_conan_version = ">=2.1.0"
+
 
 class ArrowConan(ConanFile):
     name = "arrow"
@@ -80,7 +80,7 @@ class ArrowConan(ConanFile):
         "dataset_modules": False,
         "deprecated": True,
         "encryption": False,
-        "filesystem_layer": False,
+        "filesystem_layer": True,
         "hdfs_bridgs": False,
         "plasma": "deprecated",
         "simd_level": "default",
@@ -120,7 +120,7 @@ class ArrowConan(ConanFile):
     def _min_cppstd(self):
         # arrow >= 10.0.0 requires C++17.
         # https://github.com/apache/arrow/pull/13991
-        return "11" if Version(self.version) < "10.0.0" else "17"
+        return "17"
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -129,8 +129,6 @@ class ArrowConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if Version(self.version) < "8.0.0":
-            del self.options.substrait
         if is_msvc(self):
             self.options.with_boost = True
         if Version(self.version) >= "19.0.0":
@@ -189,9 +187,6 @@ class ArrowConan(ConanFile):
             self.requires("snappy/1.1.9")
         if self.options.get_safe("simd_level") != None or \
                 self.options.get_safe("runtime_simd_level") != None:
-            if Version(self.version) < 8:
-                self.requires("xsimd/9.0.1")
-            else:
                 self.requires("xsimd/13.0.0")
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
@@ -232,15 +227,6 @@ class ArrowConan(ConanFile):
 
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
-
-        if (
-            Version(self.version) < "10.0.0"
-            and self.settings.compiler == "clang"
-            and Version(self.settings.compiler.version) < "3.9"
-        ):
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++11, which needs at least clang-3.9"
-            )
 
         if self.options.get_safe("skyhook", False):
             raise ConanInvalidConfiguration("CCI has no librados recipe (yet)")
@@ -390,24 +376,6 @@ class ArrowConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        if Version(self.version) < "10.0.0":
-            for filename in glob.glob(os.path.join(self.source_folder, "cpp", "cmake_modules", "Find*.cmake")):
-                if os.path.basename(filename) not in [
-                    "FindArrow.cmake",
-                    "FindArrowAcero.cmake",
-                    "FindArrowCUDA.cmake",
-                    "FindArrowDataset.cmake",
-                    "FindArrowFlight.cmake",
-                    "FindArrowFlightSql.cmake",
-                    "FindArrowFlightTesting.cmake",
-                    "FindArrowPython.cmake",
-                    "FindArrowPythonFlight.cmake",
-                    "FindArrowSubstrait.cmake",
-                    "FindArrowTesting.cmake",
-                    "FindGandiva.cmake",
-                    "FindParquet.cmake",
-                ]:
-                    os.remove(filename)
 
     def build(self):
         self._patch_sources()
@@ -424,29 +392,6 @@ class ArrowConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-
-        cmake_suffix = "shared" if self.options.shared else "static"
-
-        alias_map = { f"Arrow::arrow_{cmake_suffix}": f"arrow::arrow_{cmake_suffix}" }
-
-        if self.options.parquet:
-            alias_map[f"Parquet::parquet_{cmake_suffix}"] = f"arrow::parquet_{cmake_suffix}"
-
-        if self.options.get_safe("substrait"):
-            alias_map[f"Arrow::arrow_substrait_{cmake_suffix}"] = f"arrow::arrow_substrait_{cmake_suffix}"
-
-        if self.options.acero:
-            alias_map[f"Arrow::arrow_acero_{cmake_suffix}"] = f"arrow::arrow_acero_{cmake_suffix}"
-
-        if self.options.gandiva:
-            alias_map[f"Gandiva::gandiva_{cmake_suffix}"] = f"arrow::gandiva_{cmake_suffix}"
-
-        if self.options.with_flight_rpc:
-            alias_map[f"ArrowFlight::arrow_flight_sql_{cmake_suffix}"] = f"arrow::arrow_flight_sql_{cmake_suffix}"
-
-    @property
-    def _module_subfolder(self):
-        return os.path.join("lib", "cmake")
 
     def package_info(self):
         # FIXME: fix CMake targets of components


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/[*]**

#### Motivation

Closes: https://github.com/conan-io/conan-center-index/issues/27420

`filesystem_layer` represents `ARROW_FILESYSTEM ` variable upstream. It is `False` by default, but I think it's worth having it as `True`.

Why:
* It does not introduce new dependencies.
* It does not introduce a new component as it's part of the `libarrow` binary. In terms of weight:

`arrow` with `filesystem_layer = True`:

```
-rw-r--r-- 1 root root 32M May 15 13:14 libarrow.a
```

`arrow` with `filesystem_layer = False`:

```
-rw-r--r-- 1 root root 30M May 15 13:30 libarrow.a
```

Notice that it only adds 2M more.

And several headers:

```
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/api.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/azurefs.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/filesystem.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/filesystem_library.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/gcsfs.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/hdfs.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/localfs.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/mockfs.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/path_util.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/s3_test_util.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/s3fs.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/test_util.h
-- Installing: /root/.conan2/p/b/arrow84b75e3ac2694/p/include/arrow/filesystem/type_fwd.h
```

* It does not depend on newer or different C++ features.
* It only includes several new API functions
* Also, we could build the latest versions of GDAL and avoid missing binaries: https://github.com/conan-io/conan-center-index/pull/27002

Apart from that, I just removed dead code. The oldest version in `conandata.yml` is the `14.0.2` one.