### PR TITLE
geographiclib: do not build tools when option tools=False, fixes #27433

### DIFF
--- a/recipes/geographiclib/all/conanfile.py
+++ b/recipes/geographiclib/all/conanfile.py
@@ -118,6 +118,9 @@ class GeographiclibConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["GEOGRAPHICLIB_LIB_TYPE"] = "SHARED" if self.options.shared else "STATIC"
         tc.variables["GEOGRAPHICLIB_PRECISION"] = self._cmake_option_precision
+        if (not self.options.tools) and (Version(self.version) >= "2.3"):
+            # https://github.com/geographiclib/geographiclib/pull/39#issuecomment-2885315450
+            tc.variables["BINDIR"] = "OFF"
         tc.generate()
 
         VirtualBuildEnv(self).generate()
@@ -152,7 +155,7 @@ class GeographiclibConan(ConanFile):
         ]:
             rmdir(self, os.path.join(os.path.join(self.package_folder, folder)))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
-        if not self.options.tools:
+        if (not self.options.tools) and (Version(self.version) < "2.3"):
             rmdir(self, os.path.join(self.package_folder, "sbin"))
             bin_files = [it for it in os.listdir(os.path.join(self.package_folder, "bin")) if not it.endswith(".dll")]
             for it in bin_files:


### PR DESCRIPTION
### Summary
Changes to recipe:  **geographiclib/\***

#### Motivation
Fix #27433

#### Details
When the boolean option `tools` is `False`, do not build the tools. Uses a mostly undocumented cmake mechanism, maintainer comment here: https://github.com/geographiclib/geographiclib/pull/39#issuecomment-2885315450


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
