### PR TITLE
mariadb-connector-c: add version 3.4.5

### DIFF
--- a/recipes/mariadb-connector-c/all/conandata.yml
+++ b/recipes/mariadb-connector-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.4.5":
+    url: "https://downloads.mariadb.com/Connectors/c/connector-c-3.4.5/mariadb-connector-c-3.4.5-src.tar.gz"
+    sha256: "b17e193816cb25c3364c2cc92a0ad3f1d0ad9f0f484dc76b8e7bdb5b50eac1a3"
   "3.4.3":
     url: "https://downloads.mariadb.com/Connectors/c/connector-c-3.4.3/mariadb-connector-c-3.4.3-src.tar.gz"
     sha256: "a9033833a88ca74789bd6db565965382c982d06aae1c086097fa9c3e7c7d1eaf"

--- a/recipes/mariadb-connector-c/config.yml
+++ b/recipes/mariadb-connector-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4.5":
+    folder: all
   "3.4.3":
     folder: all
   "3.3.8":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mariadb-connector-c/[3.4.5]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
This PR contains only the new version.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

recipes/mariadb-connector-c/all/conandata.yml (only the version)
recipes/mariadb-connector-c/config.yml (only the version)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

Tested locally:
conan source . --version=3.4.5
conan install . --build=missing --version=3.4.5
conan build . --version=3.4.5
conan export-pkg . --version=3.4.5