### PR TITLE
Qt5: fix cross-compilation on Windows

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -354,7 +354,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_fontconfig", False) and not self.options.get_safe("with_freetype", False):
             raise ConanInvalidConfiguration("with_fontconfig cannot be enabled if with_freetype is disabled.")
 
-        if not self.options.with_doubleconversion and str(self.settings.compiler.libcxx) != "libc++":
+        if not self.options.with_doubleconversion and self.settings.get_safe("compiler.libcxx") != "libc++":
             raise ConanInvalidConfiguration("Qt without libc++ needs qt:with_doubleconversion. "
                                             "Either enable qt:with_doubleconversion or switch to libc++")
 

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -527,7 +527,7 @@ class QtConan(ConanFile):
         ms.generate()
         vbe = VirtualBuildEnv(self)
         vbe.generate()
-        if not cross_building(self):
+        if not cross_building(self) or self.settings.os == "Windows":
             vre = VirtualRunEnv(self)
             vre.generate(scope="build")
         env = Environment()


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/5.x.x**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
- fixes cross-compilation on Windows, e.g. x64 -> x86 with msvc
- fixes accessing an unavailable property in the recipe

Closes #15403 with the final fix

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
I started using Conan in Windows builds and noticed that x64 build succeeds, but x64 -> x86 fails with a rather cryptic error, an example can be seen [here](https://github.com/vcmi/vcmi-dependencies/actions/runs/15064116693):

> rcc C:\Users\runneradmin\.conan2\p\qtc879bf41d37a5\s\qt5\qtbase\src\gui\painting\qpdf.qrc 
> jom: C:\Users\runneradmin\.conan2\p\b\qt239c4430fe06b\b\build_folder\qtbase\src\gui\Makefile.Release [.rcc\release\qrc_qpdf.cpp] Error 2

After some time, I figured out that `rcc.exe` links to `zlib` and I'm building zlib as shared library. #17030 had handled this case when not cross-compiling, but Windows is rather special here.

Also, when testing my fix, I noticed an exception regarding accessing `settings.compiler.libcxx`, so fixed it as well. The exception was:

```
ERROR: qt/5.15.16: Error in validate() method, line 357
        if not self.options.with_doubleconversion and str(self.settings.compiler.libcxx) != "libc++":
        ConanException: 'settings.compiler.libcxx' doesn't exist for 'msvc'
'settings.compiler' possible configurations are ['cppstd', 'runtime', 'runtime_type', 'toolset', 'update', 'version']
```

Successfully built 5.15.16 locally in the following configuration:

```
Profile host:
[settings]
arch=x86
build_type=Release
compiler=msvc
compiler.cppstd=14
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows
[options]
qt/*:openssl=False
qt/*:shared=True
qt/*:widgets=False
qt/*:with_atspi=False
qt/*:with_dbus=False
qt/*:with_freetype=False
qt/*:with_glib=False
qt/*:with_gstreamer=False
qt/*:with_harfbuzz=False
qt/*:with_libjpeg=False
qt/*:with_libpng=False
qt/*:with_md4c=False
qt/*:with_mysql=False
qt/*:with_odbc=False
qt/*:with_openal=False
qt/*:with_pcre2=False
qt/*:with_pq=False
qt/*:with_pulseaudio=False
qt/*:with_sqlite3=False
qt/*:with_vulkan=False
qt/*:with_zstd=False
zlib/*:shared=True
[platform_tool_requires]
cmake/3.31.0
jom/1.1.3
ninja/1.12.1
[conf]
tools.cmake.cmaketoolchain:generator=Ninja

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=msvc
compiler.cppstd=14
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows
[platform_tool_requires]
cmake/3.31.0
jom/1.1.3
ninja/1.12.1
[conf]
tools.cmake.cmaketoolchain:generator=Ninja
```

P.S. In Qt 6 `rcc.exe` links to `zstd` instead, but may need a similar fix (haven't checked the current state).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
