### PR TITLE
resiprocate: add 1.13.2

### DIFF
--- a/recipes/resiprocate/cmake/conandata.yml
+++ b/recipes/resiprocate/cmake/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.13.2":
+    url: "https://github.com/resiprocate/resiprocate/archive/refs/tags/resiprocate-1.13.2.tar.gz"
+    sha256: "059fda8f63c456fd61130d468a67655cfeafb5ba8ff5c1d0a55dc383f83e4fba"
   "1.13.1":
     url: "https://github.com/resiprocate/resiprocate/archive/refs/tags/resiprocate-1.13.1.tar.gz"
     sha256: "df8d0cbf17793077d59c2863b23a6da8e9c77aba88327d1a494accaded1ef605"

--- a/recipes/resiprocate/config.yml
+++ b/recipes/resiprocate/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.13.2":
+    folder: cmake
   "1.13.1":
     folder: cmake
   "1.12.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **resiprocate/[1.13.2]**

#### Motivation
The `1.13.2` patch release fixes a lot of issues: https://github.com/resiprocate/resiprocate/releases/tag/resiprocate-1.13.2 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
