### PR TITLE
msys2: clear package cache

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -144,6 +144,7 @@ class MSYS2Conan(ConanFile):
             for package in ['pkgconf']:
                 if self.run(f'bash -l -c "pacman -Qq {package}"', ignore_errors=True, quiet=True) == 0:
                     self.run(f'bash -l -c "pacman -Rs -d -d {package} --noconfirm"')
+            self.run(f'bash -l -c "pacman -Scc --noconfirm"')
 
         self._kill_pacman()
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **msys2/cci.latest**

#### Motivation
it removes the content of bin\msys64\var\cache\pacman\pkg saving more than 100MB

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
