### PR TITLE
Bring all sdl dependencies to same version

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -328,7 +328,7 @@ class FFMpegConan(ConanFile):
         if self.options.with_zeromq:
             self.requires("zeromq/4.3.5")
         if self.options.with_sdl:
-            self.requires("sdl/2.28.5")
+            self.requires("sdl/2.32.2")
         if self.options.with_libx264:
             self.requires("libx264/cci.20240224")
         if self.options.with_libx265:

--- a/recipes/pdcurses/all/conanfile.py
+++ b/recipes/pdcurses/all/conanfile.py
@@ -59,7 +59,7 @@ class PDCursesConan(ConanFile):
 
     def requirements(self):
         if self.options.with_sdl:
-            self.requires("sdl/2.28.5", transitive_libs=True)
+            self.requires("sdl/2.32.2", transitive_libs=True)
         if self.options.get_safe("with_x11"):
             self.requires("xorg/system")
 

--- a/recipes/sdl_mixer/all/conanfile.py
+++ b/recipes/sdl_mixer/all/conanfile.py
@@ -73,7 +73,7 @@ class SDLMixerConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("sdl/2.30.5", transitive_headers=True, transitive_libs=True)
+        self.requires("sdl/2.32.2", transitive_headers=True, transitive_libs=True)
         if self.options.flac:
             self.requires("flac/1.4.2")
         if self.options.mpg123:

--- a/recipes/sdl_mixer/cmake/conanfile.py
+++ b/recipes/sdl_mixer/cmake/conanfile.py
@@ -89,7 +89,7 @@ class SDLMixerConan(ConanFile):
             raise ConanInvalidConfiguration("wavpack is not yet available in CCI, contributions are welcome")
 
     def requirements(self):
-        self.requires("sdl/2.28.5", transitive_headers=True, transitive_libs=True)
+        self.requires("sdl/2.32.2", transitive_headers=True, transitive_libs=True)
         if self.options.flac:
             self.requires("flac/1.4.2")
         elif self.options.gme:
@@ -264,6 +264,3 @@ class SDLMixerConan(ConanFile):
             self.cpp_info.frameworks.extend(["AudioToolbox", "CoreServices", "CoreGraphics", "CoreFoundation"])
             if self.settings.os == "Macos":
                 self.cpp_info.frameworks.extend(["AppKit", "AudioUnit"])
-
-        self.cpp_info.names["cmake_find_package"] = "SDL2_mixer"
-        self.cpp_info.names["cmake_find_package_multi"] = "SDL2_mixer"

--- a/recipes/sdl_net/all/conanfile.py
+++ b/recipes/sdl_net/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.files import copy, get
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.4"
 
 
 class SdlnetConan(ConanFile):
@@ -28,22 +28,15 @@ class SdlnetConan(ConanFile):
 
     exports_sources = "CMakeLists.txt"
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.cppstd")
-        self.settings.rm_safe("compiler.libcxx")
+    implements = ["auto_shared_fpic"]
+    languages = "C"
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
         # SDL_net.h includes SDL.h, SDL_endian.h and SDL_version.h
-        self.requires("sdl/2.28.5", transitive_headers=True)
+        self.requires("sdl/2.32.2", transitive_headers=True)
 
     def validate(self):
         if Version(self.version).major != Version(self.dependencies["sdl"].ref.version).major:
@@ -80,7 +73,3 @@ class SdlnetConan(ConanFile):
         if self.settings.os == "Windows":
             self.cpp_info.system_libs.extend(["ws2_32", "iphlpapi"])
 
-        # TODO: to remove in conan v2
-        self.cpp_info.names["cmake_find_package"] = "SDL2_net"
-        self.cpp_info.names["cmake_find_package_multi"] = "SDL2_net"
-        self.cpp_info.names["pkg_config"] = "SDL2_net"

--- a/recipes/sdl_net/all/test_package/conanfile.py
+++ b/recipes/sdl_net/all/test_package/conanfile.py
@@ -14,7 +14,6 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        self.requires("sdl/2.28.5")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/sdl_ttf/all/conanfile.py
+++ b/recipes/sdl_ttf/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2"
 
 
 class SdlttfConan(ConanFile):
@@ -53,7 +53,7 @@ class SdlttfConan(ConanFile):
     def requirements(self):
         self.requires("freetype/2.13.2")
         # https://github.com/conan-io/conan-center-index/pull/18366#issuecomment-1625464996
-        self.requires("sdl/2.28.3", transitive_headers=True, transitive_libs=True)
+        self.requires("sdl/2.32.2", transitive_headers=True, transitive_libs=True)
         if self.options.get_safe("with_harfbuzz"):
             self.requires("harfbuzz/8.3.0")
 
@@ -73,6 +73,7 @@ class SdlttfConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        self._patch_sources()
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -98,7 +99,6 @@ class SdlttfConan(ConanFile):
                         "find_package(Freetype REQUIRED MODULE)")
 
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -130,9 +130,3 @@ class SdlttfConan(ConanFile):
             self.cpp_info.components["_sdl2_ttf"].frameworks = [
                 "AppKit", "CoreGraphics", "CoreFoundation", "CoreServices"
         ]
-
-        # TODO: to remove in conan v2
-        self.cpp_info.names["cmake_find_package"] = "SDL2_ttf"
-        self.cpp_info.names["cmake_find_package_multi"] = "SDL2_ttf"
-        self.cpp_info.components["_sdl2_ttf"].names["cmake_find_package"] = f"SDL2_ttf{suffix}"
-        self.cpp_info.components["_sdl2_ttf"].names["cmake_find_package_multi"] = f"SDL2_ttf{suffix}"


### PR DESCRIPTION
While reviewing some PRs for SDL, we got hit by several version conflicts when testing (Thanks @perseoGI!)

This PR aims to bring all of the SDL dependants to the same version to avoid issues like this in the future (But note that we can't use version ranges)

The PR also cleans up some code now that we need to regenerate some revisions

* pdcurses and ffmpeg do not have sdl enabled by default, but we didn't want to leave them behind
* ogre and magnum recipes are still only Conan 1, so we skipped those