### PR TITLE
LibRaw: Add 0.21.4 and snapshot

### DIFF
--- a/recipes/libraw/all/CMakeLists.txt
+++ b/recipes/libraw/all/CMakeLists.txt
@@ -59,6 +59,10 @@ if (LIBRAW_WITH_JASPER)
     target_link_libraries(raw PUBLIC Jasper::Jasper)
 endif ()
 
+if (LIBRAW_MAX_CR3_RAW_FILE_SIZE)
+    target_compile_definitions(raw PUBLIC "-DLIBRAW_MAX_CR3_RAW_FILE_SIZE=${LIBRAW_MAX_CR3_RAW_FILE_SIZE}LL")
+endif ()
+
 include(GNUInstallDirs)
 if(LIBRAW_BUILD_THREAD_SAFE)
     add_library(raw_r ${libraw_LIB_SRCS})

--- a/recipes/libraw/all/conandata.yml
+++ b/recipes/libraw/all/conandata.yml
@@ -1,16 +1,13 @@
 sources:
+  "0.21.4":
+    url: "https://github.com/LibRaw/LibRaw/archive/0.21.4.tar.gz"
+    sha256: "8baeb5253c746441fadad62e9c5c43ff4e414e41b0c45d6dcabccb542b2dff4b"
   "0.21.3":
     url: "https://github.com/LibRaw/LibRaw/archive/0.21.3.tar.gz"
     sha256: "dc3d8b54e333d9d5441336049db255d14b27f19bd326a306cf5aea866806780a"
   "0.21.2":
     url: "https://github.com/LibRaw/LibRaw/archive/0.21.2.tar.gz"
     sha256: "7ac056e0d9e814d808f6973a950bbf45e71b53283eed07a7ea87117a6c0ced96"
-  "0.21.1":
-    url: "https://github.com/LibRaw/LibRaw/archive/0.21.1.tar.gz"
-    sha256: "b63d7ffa43463f74afcc02f9083048c231349b41cc9255dec0840cf8a67b52e0"
   "0.20.2":
     url: "https://github.com/LibRaw/LibRaw/archive/0.20.2.tar.gz"
     sha256: "02df7d403b34602b769bb38e5bf7d4258e075eeefbe980b6832e6e1491989d60"
-  "0.20.0":
-    url: "https://github.com/LibRaw/LibRaw/archive/0.20.0.tar.gz"
-    sha256: "f38cd2620d5adc32d2c9f51cd0dc66d72c75671f1c81dfd13d30c45c6be80d40"

--- a/recipes/libraw/all/conandata.yml
+++ b/recipes/libraw/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.22.0.cci.20250224":
+    url: "https://github.com/LibRaw/LibRaw/archive/8afe44cd0e96611ba3cb73779b83ad05e945634c.tar.gz"
+    sha256: "1a19cbf95a0b35be537c295c31d3bf6a05a0df577b7d2a1ed443e894db942296"
   "0.21.4":
     url: "https://github.com/LibRaw/LibRaw/archive/0.21.4.tar.gz"
     sha256: "8baeb5253c746441fadad62e9c5c43ff4e414e41b0c45d6dcabccb542b2dff4b"

--- a/recipes/libraw/all/conanfile.py
+++ b/recipes/libraw/all/conanfile.py
@@ -1,10 +1,12 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -24,6 +26,11 @@ class LibRawConan(ConanFile):
         "with_jpeg": [False, "libjpeg", "libjpeg-turbo", "mozjpeg"],
         "with_lcms": [True, False],
         "with_jasper": [True, False],
+
+        # Option to override the maximum file size for .CR3 (including .CRM) files.
+        # The default limit of 2 GB can be way too small for canon raw movie files (.CRM).
+        # Value in bytes.
+        "libraw_max_cr3_raw_file_size": [None, "ANY"],
     }
     default_options = {
         "shared": False,
@@ -32,6 +39,7 @@ class LibRawConan(ConanFile):
         "with_jpeg": "libjpeg",
         "with_lcms": True,
         "with_jasper": True,
+        "libraw_max_cr3_raw_file_size": None,
     }
     exports_sources = ["CMakeLists.txt"]
 
@@ -70,6 +78,11 @@ class LibRawConan(ConanFile):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
 
+        if self.options.libraw_max_cr3_raw_file_size and not str(self.options.libraw_max_cr3_raw_file_size).isdigit():
+            raise ConanInvalidConfiguration("-o='libraw/*:libraw_max_cr3_raw_file_size' should be a positive integer")
+        elif self.options.libraw_max_cr3_raw_file_size and Version(self.version) < '0.22.0':
+            raise ConanInvalidConfiguration("-o='libraw/*:libraw_max_cr3_raw_file_size' Only supported in libraw 0.22 and newer")
+
     def source(self):
        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
@@ -81,6 +94,8 @@ class LibRawConan(ConanFile):
         tc.variables["LIBRAW_WITH_JPEG"] = bool(self.options.with_jpeg)
         tc.variables["LIBRAW_WITH_LCMS"] = self.options.with_lcms
         tc.variables["LIBRAW_WITH_JASPER"] = self.options.with_jasper
+        if self.options.libraw_max_cr3_raw_file_size:
+            tc.variables["LIBRAW_MAX_CR3_RAW_FILE_SIZE"] = self.options.libraw_max_cr3_raw_file_size
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -106,6 +121,9 @@ class LibRawConan(ConanFile):
             self.cpp_info.components["libraw_"].system_libs.append("ws2_32")
             if not self.options.shared:
                 self.cpp_info.components["libraw_"].defines.append("LIBRAW_NODLL")
+
+        if self.options.libraw_max_cr3_raw_file_size:
+            self.cpp_info.components["libraw_"].defines.append("LIBRAW_MAX_CR3_RAW_FILE_SIZE={}LL".format(self.options.libraw_max_cr3_raw_file_size))
 
         requires = []
         if self.options.with_jpeg == "libjpeg":

--- a/recipes/libraw/config.yml
+++ b/recipes/libraw/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.21.4":
+    folder: all
   "0.21.3":
     folder: all
   "0.21.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libraw/0.21.4** and **libraw/0.22.0 snapshot**

#### Motivation
Add the latest official release and a snapshot "release" from february. As this library is adding many things that land in the development branch to support new camera files & features, it makes sense to use the snapshot provided every few months. This latest snapshot contains support for larger files by setting a specific define which is exposed for newer versions. Tested locally not only by building but also by using it and testing with a very large file (the default size supportet is 2 GB, I tested with a 512 GB file).

The local test in my environment was done with this branch: https://github.com/irieger/conan-center-index/commits/libraw/snapshot.20250516/, but the result should be the same.

#### Details
Release notes for 0.21.4: https://github.com/LibRaw/LibRaw/releases/tag/0.21.4

Snapshot from Snapshot-Commit: https://github.com/LibRaw/LibRaw/commit/8afe44cd0e96611ba3cb73779b83ad05e945634c
(LibRaw is only officially tagging a version every ~1.5 to 3 years and published (untagged) snapshots every now and then. See section "Update policy" https://www.libraw.org/)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
