### PR TITLE
 gmp: add patch to fix build error on cpp 23 due to removal of unprototyped functions

### DIFF
--- a/recipes/gmp/all/conandata.yml
+++ b/recipes/gmp/all/conandata.yml
@@ -19,6 +19,7 @@ patches:
   "6.3.0":
     - patch_file: "patches/0001-msvc-dumpbin-yasm-wrapper.patch"
     - patch_file: "patches/6.x.x-0001-fix-MSVC-next-prime-error.patch"
+    - patch_file: "patches/cpp23-unprototyped-functions.patch"
     - patch_file: "patches/emscripten/0001-configure.patch"
       patch_os: "Emscripten"
       patch_source: "https://github.com/fpelliccioni"

--- a/recipes/gmp/all/patches/cpp23-unprototyped-functions.patch
+++ b/recipes/gmp/all/patches/cpp23-unprototyped-functions.patch
@@ -1,0 +1,12 @@
+--- configure
++++ configure
+@@ -6568,7 +6568,7 @@
+
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+

--- a/recipes/gmp/all/patches/cpp23-unprototyped-functions.patch
+++ b/recipes/gmp/all/patches/cpp23-unprototyped-functions.patch
@@ -5,7 +5,7 @@
  #if defined (__GNUC__) && ! defined (__cplusplus)
  typedef unsigned long long t1;typedef t1*t2;
 -void g(){}
-+void g(int,t1 const*,t1,t2,t1 const*,int){}
++void g(int a,t1 const* b,t1 c,t2 d,t1 const* e,int f){}
  void h(){}
  static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
  {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}


### PR DESCRIPTION
### Summary
Changes to recipe:  **gmp/6.3.0**
Adds patch to fix building on C++ 23.
fixes #27451

#### Motivation
C++ 23 changed the function declaration syntax such that:
void g(){}
no longer means, function with unknown parameters and now reads as function that takes no parameters. Therefore in C++ 23:
void g(){}
is no equivalent to 
void g(void){}

Current GMP relies on this in a single test, causing the build to fail if compiled from source on C++ 23, as seen in the [mailing list](https://gmplib.org/list-archives/gmp-bugs/2024-November/005550.html)


#### Details
Add a patch to correctly define the function using the new declaration syntax


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
