### PR TITLE
sqlite3: add 3.49.2 and 3.50.3

### DIFF
--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -167,16 +167,32 @@ if(NOT OMIT_LOAD_EXTENSION)
     target_link_libraries(${PROJECT_NAME}  PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
+set(SQLITE3_LIBRARY_NEEDS_MATH FALSE)
 if(ENABLE_FTS5 OR ENABLE_MATH_FUNCTIONS)
+    set(SQLITE3_LIBRARY_NEEDS_MATH TRUE)
+endif()
+
+set(SQLITE3_EXECUTABLE_NEEDS_MATH FALSE)
+if(SQLITE3_BUILD_EXECUTABLE AND SQLITE3_VERSION VERSION_GREATER_EQUAL "3.49.2")
+    set(SQLITE3_EXECUTABLE_NEEDS_MATH TRUE)
+endif()
+
+set(NEED_MATH_LIBRARY FALSE)
+if(SQLITE3_LIBRARY_NEEDS_MATH OR SQLITE3_EXECUTABLE_NEEDS_MATH)
+    set(NEED_MATH_LIBRARY TRUE)
+endif()
+
+if(NEED_MATH_LIBRARY)
     include(CheckLibraryExists)
     # Check if math functionality is on the separate 'libm' library,
     # otherwise assume that it is already part of the C runtime.
     # The `m` library is part of the compiler toolchain, this checks
     # if the compiler can successfully link against the library.
     check_library_exists(m log "" HAVE_MATH_LIBRARY)
-    if(HAVE_MATH_LIBRARY)
-        target_link_libraries(${PROJECT_NAME} PRIVATE m)
-    endif()
+endif()
+
+if(SQLITE3_LIBRARY_NEEDS_MATH AND HAVE_MATH_LIBRARY)
+    target_link_libraries(${PROJECT_NAME} PRIVATE m)
 endif()
 
 include(GNUInstallDirs)
@@ -191,6 +207,9 @@ install(DIRECTORY ${SQLITE3_SRC_DIR}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 if(SQLITE3_BUILD_EXECUTABLE)
     add_executable(sqlite3-bin ${SQLITE3_SRC_DIR}/shell.c)
     target_link_libraries(sqlite3-bin PRIVATE ${PROJECT_NAME})
+    if(SQLITE3_EXECUTABLE_NEEDS_MATH AND HAVE_MATH_LIBRARY)
+        target_link_libraries(sqlite3-bin PRIVATE m)
+    endif()
     if(ENABLE_DBPAGE_VTAB)
         target_compile_definitions(sqlite3-bin PRIVATE SQLITE_ENABLE_DBPAGE_VTAB)
     endif()

--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "3.50.4":
     url: "https://sqlite.org/2025/sqlite-amalgamation-3500400.zip"
-    sha256: "f131b68e6ba5fb891cc13ebb5ff9555054c77294cb92d8d1268bad5dba4fa2a1"
+    sha256: "1d3049dd0f830a025a53105fc79fd2ab9431aea99e137809d064d8ee8356b032"
   "3.49.2":
     url: "https://sqlite.org/2025/sqlite-amalgamation-3490200.zip"
     sha256: "921fc725517a694df7df38a2a3dfede6684024b5788d9de464187c612afb5918"

--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "3.50.3":
+    url: "https://sqlite.org/2025/sqlite-amalgamation-3500300.zip"
+    sha256: "9ad6d16cbc1df7cd55c8b55127c82a9bca5e9f287818de6dc87e04e73599d754"
+  "3.49.2":
+    url: "https://sqlite.org/2025/sqlite-amalgamation-3490200.zip"
+    sha256: "921fc725517a694df7df38a2a3dfede6684024b5788d9de464187c612afb5918"
   "3.49.1":
     url: "https://sqlite.org/2025/sqlite-amalgamation-3490100.zip"
     sha256: "6cebd1d8403fc58c30e93939b246f3e6e58d0765a5cd50546f16c00fd805d2c3"

--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -1,22 +1,10 @@
 sources:
-  "3.50.3":
-    url: "https://sqlite.org/2025/sqlite-amalgamation-3500300.zip"
-    sha256: "9ad6d16cbc1df7cd55c8b55127c82a9bca5e9f287818de6dc87e04e73599d754"
+  "3.50.4":
+    url: "https://sqlite.org/2025/sqlite-amalgamation-3500400.zip"
+    sha256: "f131b68e6ba5fb891cc13ebb5ff9555054c77294cb92d8d1268bad5dba4fa2a1"
   "3.49.2":
     url: "https://sqlite.org/2025/sqlite-amalgamation-3490200.zip"
     sha256: "921fc725517a694df7df38a2a3dfede6684024b5788d9de464187c612afb5918"
-  "3.49.1":
-    url: "https://sqlite.org/2025/sqlite-amalgamation-3490100.zip"
-    sha256: "6cebd1d8403fc58c30e93939b246f3e6e58d0765a5cd50546f16c00fd805d2c3"
-  "3.48.0":
-    url: "https://sqlite.org/2025/sqlite-amalgamation-3480000.zip"
-    sha256: "d9a15a42db7c78f88fe3d3c5945acce2f4bfe9e4da9f685cd19f6ea1d40aa884"
-  "3.47.2":
-    url: "https://sqlite.org/2024/sqlite-amalgamation-3470200.zip"
-    sha256: "aa73d8748095808471deaa8e6f34aa700e37f2f787f4425744f53fdd15a89c40"
-  "3.46.1":
-    url: "https://sqlite.org/2024/sqlite-amalgamation-3460100.zip"
-    sha256: "77823cb110929c2bcb0f5d48e4833b5c59a8a6e40cdea3936b99e199dbbe5784"
   "3.45.3":
     url: "https://sqlite.org/2024/sqlite-amalgamation-3450300.zip"
     sha256: "ea170e73e447703e8359308ca2e4366a3ae0c4304a8665896f068c736781c651"

--- a/recipes/sqlite3/config.yml
+++ b/recipes/sqlite3/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "3.50.3":
+    folder: all
+  "3.49.2":
+    folder: all
   "3.49.1":
     folder: all
   "3.48.0":

--- a/recipes/sqlite3/config.yml
+++ b/recipes/sqlite3/config.yml
@@ -1,15 +1,7 @@
 versions:
-  "3.50.3":
+  "3.50.4":
     folder: all
   "3.49.2":
-    folder: all
-  "3.49.1":
-    folder: all
-  "3.48.0":
-    folder: all
-  "3.47.2":
-    folder: all
-  "3.46.1":
     folder: all
   "3.45.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3/all**

#### Motivation
New version is available

#### Details
https://sqlite.org/releaselog/3_49_2.html
https://sqlite.org/releaselog/3_50_3.html
https://github.com/sqlite/sqlite/compare/version-3.49.1...version-3.49.2

https://github.com/sqlite/sqlite/compare/version-3.49.2...version-3.50.0
https://github.com/sqlite/sqlite/compare/version-3.50.0...version-3.50.1
https://github.com/sqlite/sqlite/compare/version-3.50.1...version-3.50.2
https://github.com/sqlite/sqlite/compare/version-3.50.2...version-3.50.3

shell.c now uses functions from math.h so I've added "m" to list of libraries for executable

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
