### PR TITLE
valijson: fix library name and update version 1.0.5

### DIFF
--- a/recipes/valijson/all/conandata.yml
+++ b/recipes/valijson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.5":
+    url: "https://github.com/tristanpenman/valijson/archive/v1.0.5.tar.gz"
+    sha256: "1ef7ea6f49f0eb59da131b9148fcb7ebb8f0d4d970bcd80d21c0ad77968eb619"
   "1.0.3":
     url: "https://github.com/tristanpenman/valijson/archive/v1.0.3.tar.gz"
     sha256: "0fbd3cd2312b441c6373ee116e9a162c400f9e3cd79f6b32665cdd22fa11ac3f"

--- a/recipes/valijson/all/conanfile.py
+++ b/recipes/valijson/all/conanfile.py
@@ -54,8 +54,8 @@ class ValijsonConan(ConanFile):
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         # self.cpp_info.filenames["cmake_find_package"] = "valijson" # TBA: There's no installed config file
         # self.cpp_info.filenames["cmake_find_package_multi"] = "valijson" # TBA: There's no installed config file
-        self.cpp_info.names["cmake_find_package"] = "ValiJSON"
-        self.cpp_info.names["cmake_find_package_multi"] = "ValiJSON"
+        self.cpp_info.names["cmake_find_package"] = "valijson"
+        self.cpp_info.names["cmake_find_package_multi"] = "valijson"
         self.cpp_info.components["libvalijson"].names["cmake_find_package"] = "valijson"
         self.cpp_info.components["libvalijson"].names["cmake_find_package_multi"] = "valijson"
         self.cpp_info.components["libvalijson"].set_property("cmake_target_name", "ValiJSON::valijson")

--- a/recipes/valijson/all/test_package/CMakeLists.txt
+++ b/recipes/valijson/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(ValiJSON REQUIRED CONFIG)
+find_package(valijson REQUIRED CONFIG)
 find_package(nlohmann_json REQUIRED CONFIG)
 find_package(picojson REQUIRED CONFIG)
 find_package(RapidJSON REQUIRED CONFIG)

--- a/recipes/valijson/config.yml
+++ b/recipes/valijson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.5":
+    folder: "all"
   "1.0.3":
     folder: "all"
   "1.0.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **valijson/[1.0.5]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Fix the library name and update the version

This library has never been named **ValiJSON** [https://github.com/tristanpenman/valijson/blob/master/CMakeLists.txt](https://github.com/tristanpenman/valijson/blob/master/CMakeLists.txt) (as I see it)

2020

add_library(valijson INTERFACE)

create alias, so that user could always write target_link_libraries(... ValiJSON::valijson)
despite of valijson target is imported or not
add_library(ValiJSON::valijson ALIAS valijson)
...
install(TARGETS valijson
    EXPORT valijsonConfig
    DESTINATION ${CMAKE_INSTALL_LIBDIR}
)

install(EXPORT valijsonConfig
    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/valijson"
)

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

recipes/valijson/all/conandata.yml
recipes/valijson/all/conanfile.py
recipes/valijson/all/test_package/CMakeLists.txt
recipes/valijson/config.yml

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

 conan create . --version=1.0.5