### PR TITLE
trantor: use requires explicitly to avoid issues with openssl

### DIFF
--- a/recipes/trantor/all/conanfile.py
+++ b/recipes/trantor/all/conanfile.py
@@ -126,6 +126,13 @@ class TrantorConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "Trantor::Trantor")
         self.cpp_info.libs = ["trantor"]
 
+        self.cpp_info.requires = ["openssl::ssl", "openssl::crypto"]
+
+        if self.options.with_c_ares:
+            self.cpp_info.requires.append("c-ares::cares")
+        if self.options.get_safe("with_spdlog"):
+            self.cpp_info.requires.append("spdlog::spdlog_header_only")
+
         if self.settings.os == "Windows":
             self.cpp_info.system_libs.append("ws2_32")
         if self.settings.os in ["Linux", "FreeBSD"]:


### PR DESCRIPTION
### Summary
Changes to recipe:  **trantor/[version]**

#### Motivation
In some cases (e.g. cross-compilation), if openSSL is not present, the cmake target is incorrectly communicated as having the alias openssl::openssl. This change makes sure that the correct openSSL names are propagated to the consumers. I had already posted an issue #27497 .

#### Details
When cross-compiling as a consumer of the library there can be issues with openSSL being correctly detected through its targets. When I tried cross compiling drogon that depends on trantor, I got an error on CMake which basically said that `openssl::openssl` is not a declared target.

When not cross-compiling that worked fine. That's most likely because my native (x64) configuration had openSSL installed while the cross-compiled host config did not. 

The change explicitly sets the names of the dependencies so that the conan-generated `openssl::openssl` is avoided. This of course means that all the requirements must be explicitly set in `package_info()`.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
