### PR TITLE
add plibpq transitive_headers into soci build

### DIFF
--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -68,7 +68,7 @@ class SociConan(ConanFile):
         if self.options.with_mysql:
             self.requires("libmysqlclient/8.1.0")
         if self.options.with_postgresql:
-            self.requires("libpq/15.4")
+            self.requires("libpq/15.4", transitive_headers=True)
         if self.options.with_boost:
             self.requires("boost/1.83.0")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **soci/4.0.3**

#### Motivation
CMake cache does not provide INCLUDE_DIRS, while libpq is used in soci headers

#### Details

this is primarily to address #27505, however still not clear how to consume recipe without this if dependent library required in consuming project.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
