### PR TITLE
b2: Fix compiler errors in the Intel Linux toolset

### DIFF
--- a/recipes/b2/portable/conandata.yml
+++ b/recipes/b2/portable/conandata.yml
@@ -32,3 +32,8 @@ sources:
   "5.3.2":
     url: "https://github.com/bfgroup/b2/releases/download/5.3.2/b2-5.3.2.tar.bz2"
     sha256: "881827649356dfa59caa30e169931424993c72a1626a502abb7ea474484eac26"
+patches:  
+  "5.3.2":
+    - patch_file: "patches/5.3.2-intel-linux-pch-fix.patch"
+      patch_description: "Fix intel-linux compiler errors"
+      patch_type: "conan"

--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import chdir, copy, get
+from conan.tools.files import chdir, copy, get, apply_conandata_patches
 from conan.tools.layout import basic_layout
 
 from contextlib import contextmanager
@@ -79,6 +79,7 @@ class B2Conan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     @property
     def _b2_dir(self):

--- a/recipes/b2/portable/patches/5.3.2-intel-linux-pch-fix.patch
+++ b/recipes/b2/portable/patches/5.3.2-intel-linux-pch-fix.patch
@@ -1,0 +1,20 @@
+--- src/tools/intel-linux.jam
++++ src/tools/intel-linux.jam
+@@ -288,7 +288,7 @@
+ #
+ actions compile.c++.pch
+ {
+-    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -pch-create "$(<)" "$(>)"
++	rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -Xclang -emit-pch -o "$(<)" "$(>)"
+ }
+ 
+ actions compile.fortran
+@@ -298,7 +298,7 @@
+ 
+ actions compile.c.pch
+ {
+-    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -pch-create "$(<)" "$(>)"
++    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -Xclang -emit-pch -o "$(<)" "$(>)"
+ }
+ 
+ rule link ( targets * : sources * : properties * )


### PR DESCRIPTION
### Summary
Changes to recipe:  **b2/5.3.2**

#### Motivation
When building Boost with the Intel LLVM compiler (icpx) on Ubuntu via Conan, the default b2 recipe (version 5.3.2) emits unsupported PCH flags (-pch-create) and mis-invokes the frontend, leading to errors like:

```
icpx: error: unsupported argument 'h-create' to option '-pc'
icpx: error: no such file or directory: '…/intl-lnx-2025./rls/…'
```

This contradicts Intel’s own “Building Boost with oneAPI” guidelines (https://www.intel.com/content/www/us/en/developer/articles/technical/building-boost-with-oneapi.html) and prevents successful boost compiling.

#### Details
- Conan recipe: in recipes/b2/portable/conanfile.py, call apply_conandata_patches(self) after get(...) so our patch is applied.
- Patch (patches/5.3.2-intel-linux-pch-fix.patch): in src/tools/intel-linux.jam
    - Replace -pch-create with Clang-style -Xclang -emit-pch -o for both C and C++ headers.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
