### PR TITLE
console_bridge: CMake 4 support

### DIFF
--- a/recipes/console_bridge/all/conanfile.py
+++ b/recipes/console_bridge/all/conanfile.py
@@ -53,6 +53,7 @@ class PackageConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
         CMakeDeps(self).generate()
 


### PR DESCRIPTION
console_bridge: fixes to support CMake 4

    Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

An issue has been created regarding this: https://github.com/ros/console_bridge/issues/100

However, considering the date of the last commit, I think it's reasonable to fix the recipe.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
