### PR TITLE
Add a new recipe: suitesparse

### DIFF
--- a/recipes/suitesparse/all/conandata.yml
+++ b/recipes/suitesparse/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "7.10.3":
+    url: "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.10.3.tar.gz"
+    sha256: "09E7BCC8E5DE0A5B55D2AE9FD6378D5F4DC1B85A933593339A0872B24E2CC102"
+patches:         
+  "7.10.3":
+    - patch_file: "patches/suitesparse-7.10.3-0001-cuda-fix.patch"
+      patch_type: "bug-fix"          
+    - patch_file: "patches/suitesparse-7.10.3-0002-fix-openmp-error-intel-llvm.patch"
+      patch_type: "bug-fix"            

--- a/recipes/suitesparse/all/conanfile.py
+++ b/recipes/suitesparse/all/conanfile.py
@@ -1,0 +1,165 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.files import collect_libs, get, apply_conandata_patches, export_conandata_patches, copy
+from conan.errors import ConanException
+import os
+import shutil
+import platform
+import re
+import warnings
+
+class SuitesparseConan(ConanFile):
+    name = "suitesparse"
+    license = "SPEX"
+    url = "https://github.com/DrTimothyAldenDavis/SuiteSparse"
+    description = "SuiteSparse: A Suite of Sparse matrix packages at https://github.com/DrTimothyAldenDavis/SuiteSparse"
+    homepage = "https://github.com/DrTimothyAldenDavis/SuiteSparse"
+    topics = ("suitesparse", "sparse", "linear-algebra", "numerical", "matrix", "graph", "umfpack", "cholmod", "spqr", "btf", "amd", "colamd", "camd", "klu", "util", "cuda", "gpu")
+    package_type = "library"   
+    settings = "os", "arch", "compiler", "build_type"  
+    options = {
+        "shared": [True, False], 
+        "cuda_archs": [None, "ANY"], # Example: 50;75;80 min. 50
+        "use_cuda": [True, False],
+        "blas_vendor": [None, "ANY"],
+        "use_fortran": [True, False],
+        "use_blascpp": [True, False],
+        "use_lapackcpp": [True, False],
+        "build_testing": [True, False]
+    } 
+    default_options = {
+        "shared": True, 
+        "cuda_archs": None,
+        "use_cuda": False,
+        "use_fortran": False,
+        "use_blascpp": False,
+        "use_lapackcpp": False,
+        "build_testing": False,
+        "blas_vendor": "conan-OpenBLAS" # Please add path to CMAKE_PREFIX_PATH using env if you use external blas implementation library such like as OpenBLAS. See https://cmake.org/cmake/help/latest/module/FindBLAS.html
+    }    
+    requires = [
+        "gmp/[>=6.3.0 <7]",
+        "mpfr/[>=4.2.1 <5]",    
+    ]   
+    intel_bla_vendors = ["Intel", "Intel10_32","Intel10_64lp", "Intel10_64lp_seq", "Intel10_64ilp", "Intel10_64ilp_seq", "Intel10_64_dyn"]
+    use_intel_mkl = False
+                
+    @property          
+    def intel_mkl_path(self):
+        return os.environ.get("MKLROOT", None)
+        
+    def validate_cuda_archs(self):
+        raw = self.options.cuda_archs
+        if raw is None:
+            raise ConanException("“The cuda_archs option must be set when the use_cuda option is enabled.")  
+        items = raw if isinstance(raw, (list, tuple)) else str(raw).split(";")
+        try:
+            vals = [int(x) for x in items]
+        except ValueError:
+            raise ConanException(f"Bad format: cuda_archs={raw}")
+        if not vals or any(v < 50 for v in vals):
+            raise ConanException(f"cuda_archs must be integer(s) > 50, got {vals}")
+        
+    def validate(self):
+        if self.options.use_cuda:
+            self.validate_cuda_archs()
+  
+    def requirements(self): 
+        # OpenBLAS from conan center package
+        if self.options.blas_vendor == 'conan-OpenBLAS':
+            if self.settings.os in ["Windows"]:
+                raise ConanException("OpenBLAS from conan center is not supported on Windows. Try using Intel MKL and set BLA_VENDOR eg. Intel10_64ilp_seq")       
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.requires("gfortran/[>=10.2]")
+                self.requires("openblas/[>=0.3.27 <1]")
+                
+        # OpenBLAS from intel MKL
+        self.use_intel_mkl = self.options.blas_vendor in self.intel_bla_vendors                       
+        if self.use_intel_mkl and not self.intel_mkl_path:
+            raise ConanException("Not found MKLROOT enviromment path. MKLROOT is required to obtain OpenBLAS library directory.")
+        elif self.intel_mkl_path:
+            self.output.info(f"Found Intel MKL at: {self.intel_mkl_path}")
+              
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+        
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)  
+        
+    def export_sources(self):
+        export_conandata_patches(self)
+        
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.set_property("gmp", "cmake_file_name", "GMP")
+        deps.set_property("gmp", "cmake_target_name", "GMP::GMP")
+        deps.set_property("mpfr", "cmake_file_name", "MPFR")
+        deps.set_property("mpfr", "cmake_target_name", "MPFR::MPFR")
+        
+        deps.generate()
+        tc = CMakeToolchain(self)
+             
+        # CUDA:
+        tc.variables["SUITESPARSE_USE_CUDA"] = self.options.use_cuda
+        tc.variables["SUITESPARSE_CUDA_ARCHITECTURES"] = self.options.cuda_archs
+        
+        # OpenBLAS from conan center:
+        if self.options.blas_vendor == 'conan-OpenBLAS':
+            libdirs = self.dependencies["openblas"].cpp_info.libdirs       
+            openblas_lib = next((
+                os.path.join(root, file).replace("\\", "/")
+                for libdir in libdirs
+                for root, dirs, files in os.walk(libdir)
+                for file in files
+                if "openblas" in file.lower() and file.endswith(('.a', '.so', '.lib'))
+            ), "")
+                   
+            tc.variables["BLAS_LIBRARIES"] = openblas_lib
+            tc.variables["LAPACK_LIBRARIES"] = openblas_lib
+            tc.variables["BLA_VENDOR"] = 'OpenBLAS'
+            
+        # Other BLAS implementation:
+        else:
+            tc.variables["BLA_VENDOR"] = self.options.blas_vendor
+            
+        # Others:
+        tc.blocks.remove("vs_runtime") # fix msvc bug
+        tc.variables["BUILD_TESTING"] = self.options.build_testing
+        
+        # Other dependencies:
+        tc.variables["SUITESPARSE_USE_FORTRAN"] = self.options.use_fortran
+        tc.variables["BLAS++"] = self.options.use_blascpp
+        tc.variables["LAPACK++"] = self.options.use_lapackcpp  
+        
+        tc.generate()
+
+    def build(self):    
+        apply_conandata_patches(self)
+        
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE.txt",
+         dst=os.path.join(self.package_folder, "licenses"),
+         src=self.source_folder)
+    
+        cmake = CMake(self)
+        cmake.install()
+
+        
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "SuiteSparse")
+        self.cpp_info.set_property("cmake_target_name", "SuiteSparse::SuiteSparse")
+        self.cpp_info.set_property("pkg_config_name", "SuiteSparse")
+        self.cpp_info.libs = collect_libs(self)
+        self.cpp_info.bindirs = ["bin"]            
+       
+        if self.use_intel_mkl:
+            intel_bindir = os.path.join(str(self.intel_mkl_path), "bin").replace("\\", "/")
+            intel_libdir = os.path.join(str(self.intel_mkl_path), "bin").replace("\\", "/")
+        
+            self.cpp_info.bindirs.append(intel_bindir)
+            self.cpp_info.libdirs.append(intel_libdir)
+        

--- a/recipes/suitesparse/all/patches/suitesparse-7.10.3-0001-cuda-fix.patch
+++ b/recipes/suitesparse/all/patches/suitesparse-7.10.3-0001-cuda-fix.patch
@@ -1,0 +1,16 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -21,8 +21,11 @@
+ # CMakeLists.txt files are used to build any package in SuiteSparse.
+ cmake_minimum_required ( VERSION 3.22 )
+ 
+-project ( "SuiteSparse" )
+-
++project ( "SuiteSparse" LANGUAGES CXX)
++if(SUITESPARSE_USE_CUDA)
++
++  enable_language(CUDA)
++endif()
+ #-------------------------------------------------------------------------------
+ # SuiteSparse policies
+ #-------------------------------------------------------------------------------

--- a/recipes/suitesparse/all/patches/suitesparse-7.10.3-0002-fix-openmp-error-intel-llvm.patch
+++ b/recipes/suitesparse/all/patches/suitesparse-7.10.3-0002-fix-openmp-error-intel-llvm.patch
@@ -1,0 +1,21 @@
+diff --git a/CHOLMOD/CMakeLists.txt b/CHOLMOD/CMakeLists.txt
+index 89640b443..b3cf64a21 100644
+--- a/CHOLMOD/CMakeLists.txt
++++ b/CHOLMOD/CMakeLists.txt
+@@ -523,10 +523,14 @@ if ( CHOLMOD_HAS_OPENMP )
+     message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS}" )
+     message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS}" )
+     if ( BUILD_SHARED_LIBS )
+-        target_link_libraries ( CHOLMOD PRIVATE OpenMP::OpenMP_C )
++        target_link_libraries ( CHOLMOD PRIVATE    
++				$<$<LINK_LANGUAGE:CXX>:OpenMP::OpenMP_CXX>
++                $<$<LINK_LANGUAGE:C>:OpenMP::OpenMP_C>)
+     endif ( )
+     if ( BUILD_STATIC_LIBS )
+-        target_link_libraries ( CHOLMOD_static PRIVATE OpenMP::OpenMP_C )
++        target_link_libraries ( CHOLMOD_static PRIVATE
++				$<$<LINK_LANGUAGE:CXX>:OpenMP::OpenMP_CXX>
++                $<$<LINK_LANGUAGE:C>:OpenMP::OpenMP_C>)
+         list ( APPEND CHOLMOD_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
+     endif ( )
+ else ( )

--- a/recipes/suitesparse/all/test_package/CMakeLists.txt
+++ b/recipes/suitesparse/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(SuiteSparse REQUIRED)
+
+add_executable(test_package main.cpp)
+target_link_libraries(test_package PRIVATE SuiteSparse::SuiteSparse)

--- a/recipes/suitesparse/all/test_package/conanfile.py
+++ b/recipes/suitesparse/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.errors import ConanException
+
+class TestSuiteSparseConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = self.cpp.build.bindirs[0]
+        exe = os.path.join(bin_path, "test_package")
+        if not os.path.exists(exe):
+            raise ConanException(f"Not found test_package in {bin_path}")
+        self.run(exe, env="conanrun")

--- a/recipes/suitesparse/all/test_package/main.cpp
+++ b/recipes/suitesparse/all/test_package/main.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include <suitesparse/cholmod.h>
+
+int main() {
+    cholmod_common c;
+    cholmod_start(&c);
+
+    std::cout << "SuiteSparse CHOLMOD OK\n";
+
+    cholmod_finish(&c);
+    return 0;
+}

--- a/recipes/suitesparse/config.yml
+++ b/recipes/suitesparse/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "7.10.3":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **suitesparse/7.10.3**

#### Motivation
I need it to compile ceres-solver conan recipe with the SuiteSparse support.

#### Details
This PR introduces full Conan Center support for SuiteSparse **7.10.3**, including:

- **`conandata.yml`**  
  - Adds the SuiteSparse 7.10.3 source archive URL and SHA-256 checksum.  
  - Declares two patches for this version:
    1. **`cuda-fix`**: enables CUDA language support in the top-level `CMakeLists.txt` when `SUITESPARSE_USE_CUDA` is on.  
    2. **`fix-openmp-error-intel-llvm`**: corrects OpenMP target‐link logic in `CHOLMOD/CMakeLists.txt`, using generator expressions for C and C++ libraries.

- **`conanfile.py`**  
  - Defines the `suitesparse` package with options for shared/static build, CUDA support (`use_cuda` + `cuda_archs`), BLAS vendor selection (OpenBLAS or Intel MKL), Fortran, BLAS++/LAPACK++, and build‐testing.  
  - Pulls in dependencies: GMP, MPFR, GFortran/OpenBLAS (when using `conan-OpenBLAS`), or Intel MKL (when `blas_vendor` matches Intel names).  
  - Implements `validate()` to enforce that `cuda_archs` is set when CUDA is enabled.  
  - Configures CMake toolchain (`CMakeToolchain`) to pass all relevant options and fix the MSVC runtime block.  
  - Applies patches, runs CMake configure/build/install, and exports package info for CMake and pkg-config consumers.
- It would be beneficial to modify the Conan OpenBLAS recipe to support a full Fortran implementation on Windows as well, not just on Linux.

- **Patches**  
  1. **`suitesparse-7.10.3-0001-cuda-fix.patch`**  
     - Wraps `enable_language(CUDA)` in a `SUITESPARSE_USE_CUDA` guard in the root `CMakeLists.txt`.  
  2. **`suitesparse-7.10.3-0002-fix-openmp-error-intel-llvm.patch`**  
     - Updates `target_link_libraries` for `CHOLMOD` and `CHOLMOD_static` to use `<LINK_LANGUAGE>` generator expressions for both C and C++ OpenMP libraries.

- **`test_package`**  
  - **`CMakeLists.txt`** and **`conanfile.py`** to build and run a minimal CHOLMOD test.  
  - **`main.cpp`** calls `cholmod_start`/`cholmod_finish` and prints a success message, ensuring correct linkage.

- **`config.yml`**  
  - Maps version “7.10.3” to the `all/` folder for automatic CI recipes.



---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
