### PR TITLE
boost: add version 1.88.0

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "1.88.0":
+    url:
+      - "https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.bz2"
+      - "https://sourceforge.net/projects/boost/files/boost/1.88.0/boost_1_88_0.tar.bz2"
+    sha256: "46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b"
   "1.87.0":
     url:
       - "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2"
@@ -50,6 +55,10 @@ sources:
       - "https://sourceforge.net/projects/boost/files/boost/1.78.0/boost_1_78_0.tar.bz2"
     sha256: "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
 patches:
+  "1.88.0":
+    - patch_file: "patches/1.88.0-locale-iconv-library-option.patch"
+      patch_description: "Optional flag to specify iconv from either libc of libiconv"
+      patch_type: "conan"
   "1.87.0":
     - patch_file: "patches/1.82.0-locale-iconv-library-option.patch"
       patch_description: "Optional flag to specify iconv from either libc of libiconv"

--- a/recipes/boost/all/dependencies/dependencies-1.88.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.88.0.yml
@@ -1,0 +1,299 @@
+configure_options:
+- atomic
+- charconv
+- chrono
+- cobalt
+- container
+- context
+- contract
+- coroutine
+- date_time
+- exception
+- fiber
+- filesystem
+- graph
+- graph_parallel
+- iostreams
+- json
+- locale
+- log
+- math
+- mpi
+- nowide
+- process
+- program_options
+- python
+- random
+- regex
+- serialization
+- stacktrace
+- system
+- test
+- thread
+- timer
+- type_erasure
+- url
+- wave
+dependencies:
+  atomic: []
+  charconv: []
+  chrono:
+  - system
+  cobalt:
+  - container
+  - context
+  - system
+  container: []
+  context: []
+  contract:
+  - exception
+  - thread
+  coroutine:
+  - context
+  - exception
+  - system
+  date_time: []
+  exception: []
+  fiber:
+  - context
+  - filesystem
+  fiber_numa:
+  - fiber
+  filesystem:
+  - atomic
+  - system
+  graph:
+  - math
+  - random
+  - regex
+  - serialization
+  graph_parallel:
+  - filesystem
+  - graph
+  - mpi
+  - random
+  - serialization
+  iostreams:
+  - random
+  - regex
+  json:
+  - container
+  - system
+  locale:
+  - thread
+  log:
+  - atomic
+  - date_time
+  - exception
+  - filesystem
+  - random
+  - regex
+  - system
+  - thread
+  log_setup:
+  - log
+  math: []
+  math_c99:
+  - math
+  math_c99f:
+  - math
+  math_c99l:
+  - math
+  math_tr1:
+  - math
+  math_tr1f:
+  - math
+  math_tr1l:
+  - math
+  mpi:
+  - graph
+  - serialization
+  mpi_python:
+  - mpi
+  - python
+  nowide:
+  - filesystem
+  numpy:
+  - python
+  prg_exec_monitor:
+  - test
+  process:
+  - filesystem
+  - system
+  - context
+  program_options: []
+  python: []
+  random:
+  - system
+  regex: []
+  serialization: []
+  stacktrace: []
+  stacktrace_addr2line:
+  - stacktrace
+  stacktrace_backtrace:
+  - stacktrace
+  stacktrace_basic:
+  - stacktrace
+  stacktrace_from_exception:
+  - stacktrace
+  stacktrace_noop:
+  - stacktrace
+  stacktrace_windbg:
+  - stacktrace
+  stacktrace_windbg_cached:
+  - stacktrace
+  system: []
+  test:
+  - exception
+  test_exec_monitor:
+  - test
+  thread:
+  - atomic
+  - chrono
+  - container
+  - date_time
+  - exception
+  - system
+  timer: []
+  type_erasure:
+  - thread
+  unit_test_framework:
+  - prg_exec_monitor
+  - test
+  - test_exec_monitor
+  url:
+  - system
+  wave:
+  - filesystem
+  - serialization
+  wserialization:
+  - serialization
+libs:
+  atomic:
+  - boost_atomic
+  charconv:
+  - boost_charconv
+  chrono:
+  - boost_chrono
+  cobalt:
+  - boost_cobalt
+  container:
+  - boost_container
+  context:
+  - boost_context
+  contract:
+  - boost_contract
+  coroutine:
+  - boost_coroutine
+  date_time:
+  - boost_date_time
+  exception:
+  - boost_exception
+  fiber:
+  - boost_fiber
+  fiber_numa:
+  - boost_fiber_numa
+  filesystem:
+  - boost_filesystem
+  graph:
+  - boost_graph
+  graph_parallel:
+  - boost_graph_parallel
+  iostreams:
+  - boost_iostreams
+  json:
+  - boost_json
+  locale:
+  - boost_locale
+  log:
+  - boost_log
+  log_setup:
+  - boost_log_setup
+  math: []
+  math_c99:
+  - boost_math_c99
+  math_c99f:
+  - boost_math_c99f
+  math_c99l:
+  - boost_math_c99l
+  math_tr1:
+  - boost_math_tr1
+  math_tr1f:
+  - boost_math_tr1f
+  math_tr1l:
+  - boost_math_tr1l
+  mpi:
+  - boost_mpi
+  mpi_python:
+  - boost_mpi_python
+  nowide:
+  - boost_nowide
+  numpy:
+  - boost_numpy{py_major}{py_minor}
+  prg_exec_monitor:
+  - boost_prg_exec_monitor
+  process:
+  - boost_process
+  program_options:
+  - boost_program_options
+  python:
+  - boost_python{py_major}{py_minor}
+  random:
+  - boost_random
+  regex:
+  - boost_regex
+  serialization:
+  - boost_serialization
+  stacktrace: []
+  stacktrace_addr2line:
+  - boost_stacktrace_addr2line
+  stacktrace_backtrace:
+  - boost_stacktrace_backtrace
+  stacktrace_basic:
+  - boost_stacktrace_basic
+  stacktrace_from_exception:
+  - boost_stacktrace_from_exception
+  stacktrace_noop:
+  - boost_stacktrace_noop
+  stacktrace_windbg:
+  - boost_stacktrace_windbg
+  stacktrace_windbg_cached:
+  - boost_stacktrace_windbg_cached
+  system:
+  - boost_system
+  test: []
+  test_exec_monitor:
+  - boost_test_exec_monitor
+  thread:
+  - boost_thread
+  timer:
+  - boost_timer
+  type_erasure:
+  - boost_type_erasure
+  unit_test_framework:
+  - boost_unit_test_framework
+  url:
+  - boost_url
+  wave:
+  - boost_wave
+  wserialization:
+  - boost_wserialization
+requirements:
+  iostreams:
+  - bzip2
+  - lzma
+  - zlib
+  - zstd
+  locale:
+  - iconv
+  - icu
+  python:
+  - python
+  regex:
+  - icu
+  stacktrace:
+  - backtrace
+static_only:
+- boost_exception
+- boost_test_exec_monitor
+version: 1.88.0

--- a/recipes/boost/all/patches/1.88.0-locale-iconv-library-option.patch
+++ b/recipes/boost/all/patches/1.88.0-locale-iconv-library-option.patch
@@ -1,0 +1,12 @@
+diff --git a/libs/locale/build.jam b/libs/locale/build.jam
+index f1321db3..36899cdc 100644
+--- a/libs/locale/build.jam
++++ b/libs/locale/build.jam
+@@ -11,6 +11,7 @@ project /boost/locale
+ # Features
+
+ feature.feature boost.locale.iconv : on off : optional propagated ;
++feature.feature boost.locale.iconv.lib : libc libiconv : optional propagated ;
+ feature.feature boost.locale.icu : on off :  optional propagated ;
+ feature.feature boost.locale.posix : on off : optional propagated ;
+ feature.feature boost.locale.std : on off : optional propagated ;

--- a/recipes/boost/all/test_package/process.cpp
+++ b/recipes/boost/all/test_package/process.cpp
@@ -4,14 +4,21 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // This comes from the following Boost example:
-// https://github.com/boostorg/process/blob/boost-1.86.0/example/v2/intro.cpp
+// https://github.com/boostorg/process/blob/boost-1.88.0/example/intro.cpp
 
 // clang-format: off
 #include <boost/asio/read.hpp>
 #include <boost/asio/readable_pipe.hpp>
 // clang-format: on
 
+#include <boost/version.hpp>
+#define BOOST_PROCESS_V2_DEFAULT (BOOST_VERSION / 100 % 1000 >= 88)
+
+#if BOOST_PROCESS_V2_DEFAULT
+#include <boost/process.hpp>
+#else
 #include <boost/process/v2.hpp>
+#endif
 #include <boost/system/error_code.hpp>
 
 #include <string>
@@ -21,8 +28,12 @@
 namespace boost = BOOST_NAMESPACE;
 #endif
 
-namespace proc   = boost::process::v2;
-namespace asio   = boost::asio;
+#if BOOST_PROCESS_V2_DEFAULT
+namespace proc  = boost::process;
+#else
+namespace proc  = boost::process::v2;
+#endif
+namespace asio  = boost::asio;
 
 int main()
 {

--- a/recipes/boost/config.yml
+++ b/recipes/boost/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.88.0":
+    folder: all
   "1.87.0":
     folder: all
   "1.86.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  boost/1.88.0

#### Motivation
Update Boost recipe to build version 1.88.0

#### Details
1. `1.82.0-locale-iconv-library-option.patch` had to be updated since the Jamfile location has changed. `1.88.0-locale-iconv-library-option.patch` is the updated patch.
2. `test_package/process.cpp` has been updated to work with Boost.ProcessV2 now being the default version. The change is backwards compatible with older versions.
3. I have no idea how to run `rebuild_dependencies.py` so `dependencies-1.88.0.yml` is a copy-paste of `dependencies-1.87.0.yml` with version number updated.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
-- It is a duplicate of #27230 but that PR doesn't seem to be going anywhere
- [x] Tested locally with at least one configuration using a recent version of Conan
-- Tested with Conan 2.16 and gcc-14
