### PR TITLE
added enable_builtin option for libpsl versions >= 0.21.5

### DIFF
--- a/recipes/libpsl/all/conanfile.py
+++ b/recipes/libpsl/all/conanfile.py
@@ -24,11 +24,13 @@ class LibPslConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_idna": [False, "icu", "libidn", "libidn2"],
+        "enable_builtin": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_idna": "icu",
+        "enable_builtin": True,
     }
 
     def export_sources(self):
@@ -43,6 +45,8 @@ class LibPslConan(ConanFile):
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
+        if Version(self.version) < "0.21.5":
+            self.options.rm_safe("enable_builtin")
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -76,7 +80,7 @@ class LibPslConan(ConanFile):
         tc = MesonToolchain(self)
         tc.project_options["runtime"] = self._idna_option
         if Version(self.version) >= "0.21.5":
-            tc.project_options["builtin"] = "true" if self.options.with_idna else "false"
+            tc.project_options["builtin"] = self.options.enable_builtin
             tc.project_options["tests"] = "false"  # disable tests and fuzzes
         else:
             tc.project_options["builtin"] = self._idna_option


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpsl/0.21.5**

#### Motivation
Version 0.21.5 introduces enable_builtin / disable_builtin options but the current recipe only supports the deprecated behaviour which cannot enable built-in PSL data when the "with_dna" option is not set:
https://github.com/rockdaboot/libpsl/blob/490bd6f98a2addcade55028ea60c36cce07e21e4/configure.ac#L174

#### Details
I've added direct control over the enable_builtin / disable_builtin options as supported by libpsl/0.21.5

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
