### PR TITLE
fix: make re2 use abseil version 20250127.0

### DIFF
--- a/recipes/re2/all/conanfile.py
+++ b/recipes/re2/all/conanfile.py
@@ -62,7 +62,7 @@ class Re2Conan(ConanFile):
         if self.options.get_safe("with_icu"):
             self.requires("icu/73.2")
         if Version(self.version) >= "20230601":
-            self.requires("abseil/20240116.1", transitive_headers=True)
+            self.requires("abseil/20250127.0", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
### Summary
Changes to recipe:  **re2/***

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

On recent Mac OS versions, Abseil did not compile anymore. See also these issues:
https://github.com/GenSpectrum/LAPIS-SILO/issues/774
https://github.com/zeldamods/oead/pull/41

However, as re2 fixes the abseil version, this could not be fixed without changing the recipe

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

This updates the Abseil version which is required by the re2 package.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
