### PR TITLE
GCC 15.1

### DIFF
--- a/recipes/gcc/all/conandata.yml
+++ b/recipes/gcc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "15.1.0":
+    sha256: 51b9919ea69c980d7a381db95d4be27edf73b21254eb13d752a08003b4d013b1
+    url: https://ftp.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.gz
   "12.2.0":
     sha256: ac6b317eb4d25444d87cf29c0d141dedc1323a1833ec9995211b13e1a851261c
     url: https://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz

--- a/recipes/gcc/config.yml
+++ b/recipes/gcc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "15.1.0":
+    folder: all
   "12.2.0":
     folder: all
   "11.3.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gcc/[15.1]**

#### Motivation
Current version at Conan center is quite outdated.

#### Details
This pull request adds gcc 15.1 released last month.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
