### PR TITLE
Add a new recipe: qc-hash

### DIFF
--- a/recipes/qc-hash/all/conandata.yml
+++ b/recipes/qc-hash/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.0.3":
+    url: "https://github.com/Daskie/qc-hash/archive/refs/tags/v3.0.3.tar.gz"
+    sha256: "402B33C06850C92ECEC7981CAC599993DFE5CEB02D8A1EB41C354AFF2D09FC6B"

--- a/recipes/qc-hash/all/conanfile.py
+++ b/recipes/qc-hash/all/conanfile.py
@@ -1,0 +1,57 @@
+import os
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=2.1"
+
+
+class QcHashConan(ConanFile):
+    name = "qc-hash"
+    license = "MIT"
+    homepage = "https://github.com/Daskie/qc-hash"
+    url = "https://github.com/Daskie/qc-hash"
+    description = "QC Hash - Extremely fast unordered map and set library for C++20"
+    topics = (
+        "geometry",
+        "mesh-processing",
+        "polygon-mesh",
+        "hash-table",
+        "unordered-map",
+        "unordered-set",
+    )
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+    generators = "CMakeToolchain", "CMakeDeps"
+    package_type = "header-library"
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            dst=os.path.join(self.package_folder, "licenses"),
+            src=self.source_folder,
+        )
+        copy(
+            self,
+            "qc-hash.hpp",
+            self.source_folder,
+            os.path.join(self.package_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+    def package_id(self):
+        self.info.clear()

--- a/recipes/qc-hash/all/test_package/CMakeLists.txt
+++ b/recipes/qc-hash/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(qc-hash REQUIRED CONFIG)
+
+add_executable(test_package main.cpp)
+target_link_libraries(test_package qc-hash::qc-hash)

--- a/recipes/qc-hash/all/test_package/conanfile.py
+++ b/recipes/qc-hash/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestQcHashConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/qc-hash/all/test_package/main.cpp
+++ b/recipes/qc-hash/all/test_package/main.cpp
@@ -1,0 +1,20 @@
+#include <qc-hash.hpp>
+#include <cassert>
+#include <iostream>
+#include <string>
+
+int main()
+{
+    qc::hash::RawMap<unsigned int, std::string> m{};
+
+    m.insert({42, "foo"});
+    m.insert({7, "bar"});
+
+    assert(m.contains(42));
+    assert(m.at(42) == "foo");
+    assert(m.contains(7));
+    assert(m.at(7) == "bar");
+
+    std::cout << "OK" << std::endl;
+    return 0;
+}

--- a/recipes/qc-hash/config.yml
+++ b/recipes/qc-hash/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.0.3":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **qc-hash/3.0.3**

#### Motivation
It’s worth adding QC Hash to conan-center-index because it offers an extremely fast, C++20-compliant “meta-less” implementation of unordered maps and sets, dramatically accelerating hash operations in C++ projects.

#### Details
QC Hash - Extremely fast unordered map and set library for C++20
https://github.com/Daskie/qc-hash

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
