### PR TITLE
hdf5: add version 1.14.6

### DIFF
--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.14.6":
+    url: "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.6.tar.gz"
+    sha256: "09ee1c671a87401a5201c06106650f62badeea5a3b3941e9b1e2e1e08317357f"
   "1.14.5":
     url: "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.5.tar.gz"
     sha256: "c83996dc79080a34e7b5244a1d5ea076abfd642ec12d7c25388e2fdd81d26350"

--- a/recipes/hdf5/config.yml
+++ b/recipes/hdf5/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.14.6":
+    folder: all
   "1.14.5":
     folder: all
   "1.14.4.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **hdf5/1.14.6**
#27544 

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The HDF5 introduced a bug with 1.14.4 & 1.14.5 for Windows with the handling of UTF-8 file names. 
The 1.14.6 fixes it.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Only added the 1.14.6, no changes to the recipe itself.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
