### PR TITLE
clipper2: add version 1.5.3

### DIFF
--- a/recipes/clipper2/all/conandata.yml
+++ b/recipes/clipper2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.3":
+    url: "https://github.com/AngusJohnson/Clipper2/archive/refs/tags/Clipper2_1.5.3.tar.gz"
+    sha256: "27942b1e8c02c73717158f965da59f99b4811ab0bb08e7061e14c206dc55ff40"
   "1.4.0":
     url: "https://github.com/AngusJohnson/Clipper2/archive/refs/tags/Clipper2_1.4.0.tar.gz"
     sha256: "b83f71bb6a338f4f82116089c5ae867dbc43a2d651b5441380970dd966edd959"

--- a/recipes/clipper2/config.yml
+++ b/recipes/clipper2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.3":
+    folder: all
   "1.4.0":
     folder: all
   "1.3.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **clipper2/1.5.3**

#### Motivation
There are lots of bugfixes since 1.4.0.


#### Details
https://github.com/AngusJohnson/Clipper2/releases/tag/Clipper2_1.5.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
