### PR TITLE
commata: add version 1.1.0

### DIFF
--- a/recipes/commata/all/conandata.yml
+++ b/recipes/commata/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/furfurylic/commata/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "5fcc9779efd85e83c5a98a3532625a15351808d62507d0b2ff81771bca363f93"
   "1.0.2":
     url: "https://github.com/furfurylic/commata/archive/refs/tags/v1.0.2.tar.gz"
     sha256: "55999ba71e167fa05055069a1e02e79b4ce6b9c1c98f5c0b64db93b5fcec8f1a"

--- a/recipes/commata/config.yml
+++ b/recipes/commata/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.2":
     folder: all
   "1.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **commata/1.1.0**

#### Motivation
The new feature was added at 1.1.0.

#### Details
https://github.com/furfurylic/commata/releases/tag/v1.1.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
