### PR TITLE
fixed_math: add version 2.2.0

### DIFF
--- a/recipes/fixed_math/all/conandata.yml
+++ b/recipes/fixed_math/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.0":
+    url: "https://github.com/arturbac/fixed_math/archive/refs/tags/v2.2.0.tar.gz"
+    sha256: "d746306e9e3b94ba30d529087a51acdfadf9bb1429dcb8d6ee05a4f6e41f05e7"
   "2.0.0":
     url: "https://github.com/arturbac/fixed_math/archive/refs/tags/v2.0.0.tar.gz"
     sha256: "a02efd417592f9cb3d21fc39877aba76fe5c37b3e68b11769065202f71242f66"

--- a/recipes/fixed_math/config.yml
+++ b/recipes/fixed_math/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.0":
+    folder: all
   "2.0.0":
     folder: all
   "1.0.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fixed_math/2.2.0**

#### Motivation
There are several new features since 2.0.0.

#### Details
https://github.com/arturbac/fixed_math/releases/tag/v2.2.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
