### PR TITLE
cpp-jwt: add version 1.5

### DIFF
--- a/recipes/cpp-jwt/all/conandata.yml
+++ b/recipes/cpp-jwt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5":
+    url: "https://github.com/arun11299/cpp-jwt/archive/refs/tags/v1.5.tar.gz"
+    sha256: "44a59d619b0a82cae6334bb7d430d27b7fc7595e872c9f20d46aa96d2301edb2"
   "1.4":
     url: "https://github.com/arun11299/cpp-jwt/archive/refs/tags/v1.4.tar.gz"
     sha256: "1cb8039ee15bf9bf735c26082d7ff50c23d2886d65015dd6b0668c65e17dd20f"
@@ -9,6 +12,8 @@ sources:
     url: "https://github.com/arun11299/cpp-jwt/archive/refs/tags/v1.2.tar.gz"
     sha256: "5d0102d182c48ef520f3fb15412fbaa67e002e1bf90b3ba45d5a2c7f850371f7"
 patches:
+  "1.5":
+    - patch_file: "patches/001-fix-msvc-14-compilation.patch"
   "1.4":
     - patch_file: "patches/001-fix-msvc-14-compilation.patch"
   "1.3":

--- a/recipes/cpp-jwt/config.yml
+++ b/recipes/cpp-jwt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5":
+    folder: all
   "1.4":
     folder: all
   "1.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-jwt/1.5**

#### Motivation
There are security fixes in 1.5.

#### Details
https://github.com/arun11299/cpp-jwt/releases/tag/v1.5

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
