### PR TITLE
hiredis: add version 1.3.0

### DIFF
--- a/recipes/hiredis/all/conandata.yml
+++ b/recipes/hiredis/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.0":
+    url: "https://github.com/redis/hiredis/archive/v1.3.0.tar.gz"
+    sha256: "25cee4500f359cf5cad3b51ed62059aadfc0939b05150c1f19c7e2829123631c"
   "1.2.0":
     url: "https://github.com/redis/hiredis/archive/v1.2.0.tar.gz"
     sha256: "82ad632d31ee05da13b537c124f819eb88e18851d9cb0c30ae0552084811588c"
@@ -12,6 +15,10 @@ sources:
     url: "https://github.com/redis/hiredis/archive/v1.0.0.tar.gz"
     sha256: "2a0b5fe5119ec973a0c1966bfc4bd7ed39dbce1cb6d749064af9121fe971936f"
 patches:
+  "1.3.0":
+    - patch_file: "patches/0002-fix-aix.patch"
+      patch_description: "support AIX build"
+      patch_type: "portability"
   "1.2.0":
     - patch_file: "patches/0002-fix-aix.patch"
       patch_description: "support AIX build"

--- a/recipes/hiredis/config.yml
+++ b/recipes/hiredis/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.0":
+    folder: all
   "1.2.0":
     folder: all
   "1.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **hiredis/1.3.0**

#### Motivation
hiredis/1.3.0 supports RSP3 attribute types.

#### Details
https://github.com/redis/hiredis/releases/tag/v1.3.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
