### PR TITLE
add new version libffi/3.4.8

### DIFF
--- a/recipes/libffi/all/conandata.yml
+++ b/recipes/libffi/all/conandata.yml
@@ -12,6 +12,11 @@ sources:
     url: "https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz"
     sha256: "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056"
 patches:
+  "3.4.8":
+    - patch_file: "patches/0002-3.4.8-fix-libtool-path.patch"
+    - patch_file: "patches/0004-3.4.8-fix-complex-type-msvc.patch"
+    - patch_file: "patches/0005-3.4.4-do-not-install-libraries-to-arch-dependent-directories.patch"
+    - patch_file: "patches/0006-3.4.8-library-no-version-suffix.patch"
   "3.4.6":
     - patch_file: "patches/0002-3.4.6-fix-libtool-path.patch"
     - patch_file: "patches/0004-3.4.6-fix-complex-type-msvc.patch"

--- a/recipes/libffi/all/conandata.yml
+++ b/recipes/libffi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.4.8":
+    url: "https://github.com/libffi/libffi/releases/download/v3.4.8/libffi-3.4.8.tar.gz"
+    sha256: "bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b"
   "3.4.6":
     url: "https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz"
     sha256: "b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e"
@@ -14,6 +17,7 @@ patches:
     - patch_file: "patches/0004-3.4.6-fix-complex-type-msvc.patch"
     - patch_file: "patches/0005-3.4.4-do-not-install-libraries-to-arch-dependent-directories.patch"
     - patch_file: "patches/0006-3.4.6-library-no-version-suffix.patch"
+    - patch_file: "patches/0008-3.4.6-invalid-CFI-advance_loc.patch"
   "3.4.4":
     - patch_file: "patches/0002-3.4.3-fix-libtool-path.patch"
     - patch_file: "patches/0004-3.3-fix-complex-type-msvc.patch"
@@ -23,6 +27,7 @@ patches:
       patch_type: "portability"
       patch_source: "https://github.com/libffi/libffi/pull/764"
       patch_description: "Forward declare the open_temp_exec_file function which is required by the C99 standard"
+    - patch_file: "patches/0008-3.4.4-invalid-CFI-advance_loc.patch"
   "3.3":
     - patch_file: "patches/0002-3.3-fix-libtool-path.patch"
     - patch_file: "patches/0004-3.3-fix-complex-type-msvc.patch"

--- a/recipes/libffi/all/patches/0002-3.4.8-fix-libtool-path.patch
+++ b/recipes/libffi/all/patches/0002-3.4.8-fix-libtool-path.patch
@@ -1,0 +1,20 @@
+--- configure
++++ configure
+@@ -9883,7 +9883,7 @@
+ LIBTOOL_DEPS=$ltmain
+
+ # Always use our own libtool.
+-LIBTOOL='$(SHELL) $(top_builddir)/libtool'
++LIBTOOL='$(SHELL) $(top_builddir)/libtool.sh'
+
+
+
+@@ -9975,7 +9975,7 @@
+ esac
+
+ # Global variables:
+-ofile=libtool
++ofile=libtool.sh
+ can_build_shared=yes
+
+ # All known linkers require a '.a' archive for static linking (except MSVC and

--- a/recipes/libffi/all/patches/0004-3.4.8-fix-complex-type-msvc.patch
+++ b/recipes/libffi/all/patches/0004-3.4.8-fix-complex-type-msvc.patch
@@ -1,0 +1,56 @@
+diff --git a/src/types.c b/src/types.c
+index c1c27f3..d5d52bb 100644
+--- a/src/types.c
++++ b/src/types.c
+@@ -31,6 +31,8 @@
+ #include <ffi.h>
+ #include <ffi_common.h>
+ 
++#include <complex.h>
++
+ /* Type definitions */
+ 
+ #define FFI_TYPEDEF(name, type, id, maybe_const)\
+@@ -45,17 +47,17 @@ maybe_const ffi_type ffi_type_##name = {	\
+   id, NULL					\
+ }
+ 
+-#define FFI_COMPLEX_TYPEDEF(name, type, maybe_const)	\
++#define FFI_COMPLEX_TYPEDEF(name, complex_type, maybe_const)	\
+ static ffi_type *ffi_elements_complex_##name [2] = {	\
+ 	(ffi_type *)(&ffi_type_##name), NULL		\
+ };							\
+ struct struct_align_complex_##name {			\
+   char c;						\
+-  _Complex type x;					\
++  complex_type x;					\
+ };							\
+ FFI_EXTERN						\
+ maybe_const ffi_type ffi_type_complex_##name = {	\
+-  sizeof(_Complex type),				\
++  sizeof(complex_type),				\
+   offsetof(struct struct_align_complex_##name, x),	\
+   FFI_TYPE_COMPLEX,					\
+   (ffi_type **)ffi_elements_complex_##name		\
+@@ -99,8 +101,18 @@ const ffi_type ffi_type_longdouble = { 16, 16, 4, NULL };
+ FFI_TYPEDEF(longdouble, long double, FFI_TYPE_LONGDOUBLE, FFI_LDBL_CONST);
+ #endif
+ 
++#ifdef _MSC_VER
++#  define FLOAT_COMPLEX _C_float_complex
++#  define DOUBLE_COMPLEX _C_double_complex
++#  define LDOUBLE_COMPLEX _C_ldouble_complex
++#else
++#  define FLOAT_COMPLEX float _Complex
++#  define DOUBLE_COMPLEX double _Complex
++#  define LDOUBLE_COMPLEX long double _Complex
++#endif
++
+ #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
+-FFI_COMPLEX_TYPEDEF(float, float, const);
+-FFI_COMPLEX_TYPEDEF(double, double, const);
+-FFI_COMPLEX_TYPEDEF(longdouble, long double, FFI_LDBL_CONST);
++FFI_COMPLEX_TYPEDEF(float, FLOAT_COMPLEX, const);
++FFI_COMPLEX_TYPEDEF(double, DOUBLE_COMPLEX, const);
++FFI_COMPLEX_TYPEDEF(longdouble, LDOUBLE_COMPLEX, FFI_LDBL_CONST);
+ #endif

--- a/recipes/libffi/all/patches/0006-3.4.8-library-no-version-suffix.patch
+++ b/recipes/libffi/all/patches/0006-3.4.8-library-no-version-suffix.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index a12c11b..dbbbc49 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -619,7 +619,7 @@ AM_CFLAGS = $(am__append_3)
+ @LIBFFI_BUILD_VERSIONED_SHLIB_FALSE@libffi_version_dep = 
+ @LIBFFI_BUILD_VERSIONED_SHLIB_GNU_TRUE@@LIBFFI_BUILD_VERSIONED_SHLIB_TRUE@libffi_version_dep = libffi.map
+ @LIBFFI_BUILD_VERSIONED_SHLIB_SUN_TRUE@@LIBFFI_BUILD_VERSIONED_SHLIB_TRUE@libffi_version_dep = libffi.map-sun
+-libffi_version_info = -version-info `grep -v '^\#' $(srcdir)/libtool-version`
++libffi_version_info = -avoid-version
+ libffi_la_LDFLAGS = -no-undefined $(libffi_version_info) $(libffi_version_script) $(LTLDFLAGS) $(AM_LTLDFLAGS)
+ libffi_la_DEPENDENCIES = $(libffi_la_LIBADD) $(libffi_version_dep)
+ AM_CPPFLAGS = -I. -I$(top_srcdir)/include -Iinclude -I$(top_srcdir)/src

--- a/recipes/libffi/all/patches/0008-3.4.4-invalid-CFI-advance_loc.patch
+++ b/recipes/libffi/all/patches/0008-3.4.4-invalid-CFI-advance_loc.patch
@@ -1,0 +1,34 @@
+diff --git a/src/aarch64/sysv.S b/src/aarch64/sysv.S
+index eeaf3f8..213c079 100644
+--- a/src/aarch64/sysv.S
++++ b/src/aarch64/sysv.S
+@@ -76,8 +76,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+    x5 closure
+ */
+ 
+-	cfi_startproc
+ CNAME(ffi_call_SYSV):
++    cfi_startproc
+ 	/* Sign the lr with x1 since that is where it will be stored */
+ 	SIGN_LR_WITH_REG(x1)
+ 
+@@ -268,8 +268,8 @@ CNAME(ffi_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_closure_SYSV):
++    cfi_startproc
+ 	SIGN_LR
+ 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+ 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
+@@ -500,8 +500,8 @@ CNAME(ffi_go_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_go_closure_SYSV):
++    cfi_startproc
+ 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+ 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
+ 	cfi_rel_offset (x29, 0)

--- a/recipes/libffi/all/patches/0008-3.4.6-invalid-CFI-advance_loc.patch
+++ b/recipes/libffi/all/patches/0008-3.4.6-invalid-CFI-advance_loc.patch
@@ -1,0 +1,34 @@
+diff --git a/src/aarch64/sysv.S b/src/aarch64/sysv.S
+index fdd0e8b..7d79bf0 100644
+--- a/src/aarch64/sysv.S
++++ b/src/aarch64/sysv.S
+@@ -89,8 +89,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+    x5 closure
+ */
+ 
+-	cfi_startproc
+ CNAME(ffi_call_SYSV):
++    cfi_startproc
+ 	BTI_C
+ 	/* Sign the lr with x1 since that is where it will be stored */
+ 	SIGN_LR_WITH_REG(x1)
+@@ -347,8 +347,8 @@ CNAME(ffi_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_closure_SYSV):
++    cfi_startproc
+ 	BTI_C
+ 	SIGN_LR
+ 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+@@ -643,8 +643,8 @@ CNAME(ffi_go_closure_SYSV_V):
+ #endif
+ 
+ 	.align	4
+-	cfi_startproc
+ CNAME(ffi_go_closure_SYSV):
++    cfi_startproc
+ 	BTI_C
+ 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+ 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)

--- a/recipes/libffi/config.yml
+++ b/recipes/libffi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4.8":
+    folder: "all"
   "3.4.6":
     folder: "all"
   "3.4.4":


### PR DESCRIPTION
New version libffi/3.4.8

patch from: https://github.com/libffi/libffi/pull/857
close: https://github.com/conan-io/conan-center-index/issues/27533

https://github.com/libffi/libffi/releases/tag/v3.4.8
https://github.com/libffi/libffi/compare/v3.4.6...v3.4.8
