### PR TITLE
etl: add version 20.42.2

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.41.2":
+    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.40.0.tar.gz"
+    sha256: "b47ca70e7394f50dd2d65dddfd088757525488ac2fd934f435705fbf3ffe6d3d"
   "20.40.0":
     url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.40.0.tar.gz"
     sha256: "b47ca70e7394f50dd2d65dddfd088757525488ac2fd934f435705fbf3ffe6d3d"

--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "20.41.2":
-    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.40.0.tar.gz"
-    sha256: "b47ca70e7394f50dd2d65dddfd088757525488ac2fd934f435705fbf3ffe6d3d"
+  "20.41.7":
+    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.41.7.tar.gz"
+    sha256: "10a26f084fcd603bc2b2b8df98221c8896036a558f069acaa1fbaecce7974a39"
   "20.40.0":
     url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.40.0.tar.gz"
     sha256: "b47ca70e7394f50dd2d65dddfd088757525488ac2fd934f435705fbf3ffe6d3d"

--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "20.41.7":
-    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.41.7.tar.gz"
-    sha256: "10a26f084fcd603bc2b2b8df98221c8896036a558f069acaa1fbaecce7974a39"
+  "20.42.2":
+    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.42.2.tar.gz"
+    sha256: "32d16f5daae57b97a4c523aed98975c2760b3e9de4dae770b5b199f4602c050a"
   "20.40.0":
     url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.40.0.tar.gz"
     sha256: "b47ca70e7394f50dd2d65dddfd088757525488ac2fd934f435705fbf3ffe6d3d"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.41.2":
+    folder: all
   "20.40.0":
     folder: all
   "20.39.4":

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "20.41.7":
+  "20.42.2":
     folder: all
   "20.40.0":
     folder: all

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "20.41.2":
+  "20.41.7":
     folder: all
   "20.40.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **etl/20.42.2**

#### Motivation
There are lots of new features since 20.40.0.

#### Details
https://github.com/ETLCPP/etl/releases/tag/20.42.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
