### PR TITLE
openmvg: add missing transitivity for requirements

### DIFF
--- a/recipes/openmvg/all/conanfile.py
+++ b/recipes/openmvg/all/conanfile.py
@@ -61,7 +61,7 @@ class Openmvgconan(ConanFile):
 
     def requirements(self):
         self.requires("cereal/1.3.2", transitive_headers=True)
-        self.requires("ceres-solver/2.1.0", transitive_headers=True, transitive_libs=True)
+        self.requires("ceres-solver/2.1.0")
         self.requires("coin-clp/1.17.7")
         self.requires("coin-lemon/1.3.1", transitive_headers=True, transitive_libs=True)
         self.requires("coin-osi/0.108.7")


### PR DESCRIPTION
### Summary
Changes to recipe:  **openmvg/\***

#### Motivation and Details

Problem: can't compile code if you do `#include <openmvg/graph/graph.hpp>` and link **openmvg** targets in CMake, because it also requires **coin-lemon** headers which are not available.

PR adds headers and libs transitivity to **coin-lemon** and **ceres-solver** (also missing).
**ceres-solver** headers are available through `openmvg/sfm/sfm_data_BA_ceres_camera_functor.hpp` public header
and **coin-lemon** headers are available through `openmvg/graph/graph.hpp` and some other public headers from `openmvg/graph`.
As both libraries are not header only, we have to add libs transitivity too.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
