### PR TITLE
Add GeometricTools (header-only) recipe

### DIFF
--- a/recipes/geometrictoolsengine/all/conandata.yml
+++ b/recipes/geometrictoolsengine/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "8.0":
+    url: "https://www.geometrictools.com/Downloads/GeometricToolsEngine8p0.zip"
+    sha256: "A945468A95036BCF1787E6DE6FE5FF51D2349CB33C059F58B0CD25748A44D656"

--- a/recipes/geometrictoolsengine/all/conanfile.py
+++ b/recipes/geometrictoolsengine/all/conanfile.py
@@ -1,0 +1,41 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+class GeometricToolsRecipe(ConanFile):
+    name = "geometrictoolsengine"
+    description = "Geometric Tools Engine"
+    topics = ("gte", "geometry", "graphics", "mathematics")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.geometrictools.com/"
+    license = "BSL-1.0"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    # Automatically manage the package ID clearing of settings and options
+    implements = ["auto_header_only"]
+
+    def layout(self):
+        basic_layout(self)
+    
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "*.h", src=os.path.join(self.source_folder, "GTE/Mathematics"),
+            dst=os.path.join(self.package_folder, "include/Mathematics"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "GeometricToolsEngine")
+        # Using an explicit target name ('Mathematics') for future expansion to
+        # multiple components ('MathematicsGPU', etc.)
+        self.cpp_info.set_property("cmake_target_name", "GeometricToolsEngine::Mathematics")
+
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+

--- a/recipes/geometrictoolsengine/all/conanfile.py
+++ b/recipes/geometrictoolsengine/all/conanfile.py
@@ -1,24 +1,41 @@
 from conan import ConanFile
-from conan.tools.files import copy, get
+from conan.tools.files import copy, export_conandata_patches, get
 from conan.tools.layout import basic_layout
 import os
+
+required_conan_version = ">=2.0"
 
 class GeometricToolsRecipe(ConanFile):
     name = "geometrictoolsengine"
     description = "Geometric Tools Engine"
-    topics = ("gte", "geometry", "graphics", "mathematics")
+    topics = ("gte", "geometry", "graphics", "mathematics", "header-only")
+    license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.geometrictools.com/"
-    license = "BSL-1.0"
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+
+    options = {
+        "use_column_major": [True, False],
+        "use_vector_matrix": [True, False]
+    }
+
+    default_options = {
+        "use_column_major": False,
+        "use_vector_matrix": False
+    }
+
+    options_descriptions = {
+        "use_column_major": "Use column-major (rather than row-major) matrix storage",
+        "use_vector_matrix": "Use vector-on-the-left convention (V*A) rather than vector-on-the-right (A*V) for vector-matrix multiplication"
+    }
 
     # Automatically manage the package ID clearing of settings and options
     implements = ["auto_header_only"]
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
     
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -35,6 +52,16 @@ class GeometricToolsRecipe(ConanFile):
         # Using an explicit target name ('Mathematics') for future expansion to
         # multiple components ('MathematicsGPU', etc.)
         self.cpp_info.set_property("cmake_target_name", "GeometricToolsEngine::Mathematics")
+
+        if self.settings.os == "Windows":
+            self.cpp_info.defines.append("GTE_USE_MSWINDOWS")
+        else:
+            self.cpp_info.defines.append("GTE_USE_LINUX")
+
+        if self.options.use_column_major:
+            self.cpp_info.defines.append("GTE_USE_COL_MAJOR")
+        if self.options.use_vector_matrix:
+            self.cpp_info.defines.append("GTE_USE_VEC_MAT")
 
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []

--- a/recipes/geometrictoolsengine/all/test_package/CMakeLists.txt
+++ b/recipes/geometrictoolsengine/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(GeometricToolsEngine CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE GeometricToolsEngine::Mathematics)

--- a/recipes/geometrictoolsengine/all/test_package/conanfile.py
+++ b/recipes/geometrictoolsengine/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class geometrictoolsTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/geometrictoolsengine/all/test_package/test_package.cpp
+++ b/recipes/geometrictoolsengine/all/test_package/test_package.cpp
@@ -1,0 +1,19 @@
+#include <Mathematics/AlignedBox.h>
+#include <Mathematics/DistAlignedBoxAlignedBox.h>
+#include <iostream>
+
+int main() {
+    gte::AlignedBox3<double> box1({0.0, 0.0, 0.0}, {2.0, 2.0, 2.0});
+    gte::AlignedBox3<double> box2({3.0, 0.0, 0.0}, {5.0, 5.0, 5.0});
+
+    gte::DCPQuery<double, gte::AlignedBox3<double>, gte::AlignedBox3<double>> query;
+    const double distance = query(box1, box2).distance;
+    const double expectedDistance = 1.0;
+
+    if (std::abs(distance - expectedDistance) > 1e-10) {
+        std::cerr << "Error: expected " << expectedDistance << ", got " << distance << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/recipes/geometrictoolsengine/all/test_package/test_package.cpp
+++ b/recipes/geometrictoolsengine/all/test_package/test_package.cpp
@@ -2,6 +2,16 @@
 #include <Mathematics/DistAlignedBoxAlignedBox.h>
 #include <iostream>
 
+#ifdef _WIN32
+    #ifndef GTE_USE_MSWINDOWS
+        #error "Missing GTE_USE_MSWINDOWS definition for Windows platform."
+    #endif
+#else
+    #ifndef GTE_USE_LINUX
+        #error "Missing GTE_USE_LINUX definition for Non-Windows platform."
+    #endif
+#endif
+
 int main() {
     gte::AlignedBox3<double> box1({0.0, 0.0, 0.0}, {2.0, 2.0, 2.0});
     gte::AlignedBox3<double> box2({3.0, 0.0, 0.0}, {5.0, 5.0, 5.0});

--- a/recipes/geometrictoolsengine/config.yml
+++ b/recipes/geometrictoolsengine/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "8.0":
+    folder: all


### PR DESCRIPTION
### Summary
Adds a new package for the [Geometric Tools Engine](https://www.geometrictools.com/), providing the header-only mathematics functionality for the latest version (8.0)

#### Motivation
The author (David Eberly) is well-known in the computational geometry field. This library implements the concepts in his books, and is used in the industry (including my workplace of 3000+ devs, which is transitioning to Conan).

Before merging, I intend to reach out to Mr. Eberly to inform him of the submission and cross-check my choices for package name, etc.

#### Details

- New package: "geometrictoolsengine"
- Header-only functionality (the mathematics library)
  - In the future, the package could be expanded to include the other libraries (GPU acceleration, graphics engine, application framework)
- Two options (corresponding to the preprocessor symbols identified in section 1.3 of the [Installation Manual](https://github.com/davideberly/GeometricTools/blob/master/GTE/Gte8p0InstallationRelease.pdf))

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
