### PR TITLE
boost: fix arm cross compilation

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1256,7 +1256,7 @@ class BoostConan(ConanFile):
 
     @property
     def _build_flags(self):
-        flags = self._build_cross_flags
+        flags = [f'compileflags="{" ".join(self._build_cross_flags)}"']
 
         # Stop at the first error. No need to continue building.
         flags.append("-q")

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1604,7 +1604,7 @@ class BoostConan(ConanFile):
         if cflags.strip():
             contents += f'<cflags>"{cflags.strip()}" '
         if cppflags.strip() or self._build_cross_flags:
-            compiler_flags = cppflags.strip()
+            compiler_flags = cppflags.strip() + " "
             compiler_flags += " ".join(self._build_cross_flags)
             contents += f'<compileflags>"{compiler_flags}" '
         if ldflags.strip():

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1256,7 +1256,9 @@ class BoostConan(ConanFile):
 
     @property
     def _build_flags(self):
-        flags = [f'compileflags="{" ".join(self._build_cross_flags)}"']
+        flags = []
+        if self._build_cross_flags:
+            flags.append(f'compileflags="{" ".join(self._build_cross_flags)}"')
 
         # Stop at the first error. No need to continue building.
         flags.append("-q")
@@ -1601,8 +1603,10 @@ class BoostConan(ConanFile):
             contents += f'<cxxflags>"{cxxflags.strip()}" '
         if cflags.strip():
             contents += f'<cflags>"{cflags.strip()}" '
-        if cppflags.strip():
-            contents += f'<compileflags>"{cppflags.strip()}" '
+        if cppflags.strip() or self._build_cross_flags:
+            compiler_flags = cppflags.strip()
+            compiler_flags += " ".join(self._build_cross_flags)
+            contents += f'<compileflags>"{compiler_flags}" '
         if ldflags.strip():
             contents += f'<linkflags>"{ldflags.strip()}" '
         if asflags.strip():


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost**

#### Motivation
Boost cross compilation fails due to cross compilation args passed directly to b2 without a `compileflags=` prefix.

Closes #27483

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
