### PR TITLE
feat: add hycan/0.5.0

### DIFF
--- a/recipes/hycan/all/conandata.yml
+++ b/recipes/hycan/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.5.0":
+    url: "https://github.com/RoboMaster-DLMU-CONE/HyCAN/archive/refs/tags/v0.5.0.tar.gz"
+    sha256: "77215e9cf3f1ce56afe9640cbad295dc74179a27a9030b937fbbafebf854500a"

--- a/recipes/hycan/all/conanfile.py
+++ b/recipes/hycan/all/conanfile.py
@@ -1,0 +1,104 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
+from conan.tools.files import copy, get, replace_in_file
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
+
+
+class HyCANConan(ConanFile):
+    name = "hycan"
+    description = "Modern high-performance Linux C++ CAN communication protocol library"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/RoboMaster-DLMU-CONE/HyCAN"
+    topics = ("can", "canbus", "linux", "network")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 20
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "11",
+            "clang": "13",
+        }
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(
+                f"{self.ref} is a Linux-only library. {self.settings.os} is not supported."
+            )
+
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+        minimum_version = self._compilers_minimum_version.get(
+            str(self.settings.compiler)
+        )
+        if (
+            minimum_version
+            and Version(self.settings.compiler.version) < minimum_version
+        ):
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd} support. "
+                f"The current compiler {self.settings.compiler} {self.settings.compiler.version} does not support it."
+            )
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("xtr/2.1.2", transitive_headers=True)
+        self.requires("libnl/3.9.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_HYCAN_EXAMPLE"] = False
+        tc.cache_variables["BUILD_HYCAN_TEST"] = False
+        tc.cache_variables["TEST_HYCAN_LATENCY"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            self.source_folder,
+            os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["hycan"]
+        self.cpp_info.system_libs = ["pthread"]

--- a/recipes/hycan/all/test_package/CMakeLists.txt
+++ b/recipes/hycan/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.27)
+project(test_package CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+
+find_package(hycan REQUIRED)
+
+add_executable(${PROJECT_NAME} example.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE hycan::hycan)

--- a/recipes/hycan/all/test_package/conanfile.py
+++ b/recipes/hycan/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/hycan/all/test_package/example.cpp
+++ b/recipes/hycan/all/test_package/example.cpp
@@ -1,0 +1,8 @@
+#include <hycan/Interface/Interface.hpp>
+
+using HyCAN::Interface;
+
+int main()
+{
+    return 0;
+}

--- a/recipes/hycan/config.yml
+++ b/recipes/hycan/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.5.0":
+    folder: "all"


### PR DESCRIPTION
This commit adds the conan recipe for hycan/0.5.0.


### Summary
Changes to recipe:  **hycan/0.5.0**

#### Motivation
This pull request introduces a new recipe for the `hycan` library, version `0.5.0`. `hycan` is a modern high-performance C++ CAN communication protocol library specifically for Linux systems. Adding this recipe will make `hycan` available to Conan users.

#### Details
- Added a new Conan recipe for `hycan/0.5.0`.
- The library is Linux-only, and this is enforced in the `validate()` method.
- It requires C++20, with minimum compiler versions (GCC 11, Clang 13) specified and validated.
- Dependencies include `xtr/2.1.2` (with `transitive_headers=True` as `hycan`'s public headers include `xtr` headers) and `libnl/3.9.0`.
- The `package_type` is "library".
- CMake build options `BUILD_HYCAN_EXAMPLE`, `BUILD_HYCAN_TEST`, and `TEST_HYCAN_LATENCY` are disabled in the `generate()` method as they are not needed for packaging the library itself.
- The `test_package` has been configured to verify linking and basic functionality without requiring root privileges, as the library's core operations (like Netlink interface creation) need such permissions, which are not available in typical CI environments.
- Standard `fPIC` option and shared/static build options are provided.
- License is BSD-3-Clause.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
