### PR TITLE
grpc: fix compilation for versions 1.50.0, 1.50.1 & 1.54.3

### DIFF
--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -28,7 +28,10 @@ patches:
     - patch_file: "patches/v1.50.x/002-CMake-Add-gRPC_USE_SYSTEMD-option-34384.patch"
       patch_type: "backport"
       patch_source: "https://github.com/grpc/grpc/commit/5c3400e8dc08d0810e3301d7e8cd8a718c82eeed"
+    - patch_file: "patches/v1.54.x/003-remove-obsolete-template-keyword-v1.54.3.patch"
   "1.50.1":
     - patch_file: "patches/v1.50.x/001-disable-cppstd-override.patch"
+    - patch_file: "patches/v1.50.x/003-remove-obsolete-template-keyword.patch"
   "1.50.0":
     - patch_file: "patches/v1.50.x/001-disable-cppstd-override.patch"
+    - patch_file: "patches/v1.50.x/003-remove-obsolete-template-keyword.patch"

--- a/recipes/grpc/all/patches/v1.50.x/003-remove-obsolete-template-keyword.patch
+++ b/recipes/grpc/all/patches/v1.50.x/003-remove-obsolete-template-keyword.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/lib/promise/detail/basic_seq.h b/src/core/lib/promise/detail/basic_seq.h
+index bf9d992bb8..3440ac6f5a 100644
+--- a/src/core/lib/promise/detail/basic_seq.h
++++ b/src/core/lib/promise/detail/basic_seq.h
+@@ -496,7 +496,7 @@ class BasicSeqIter {
+           cur_ = next;
+           state_.~State();
+           Construct(&state_,
+-                    Traits::template CallSeqFactory(f_, *cur_, std::move(arg)));
++                    Traits::CallSeqFactory(f_, *cur_, std::move(arg)));
+           return PollNonEmpty();
+         });
+   }

--- a/recipes/grpc/all/patches/v1.54.x/003-remove-obsolete-template-keyword-v1.54.3.patch
+++ b/recipes/grpc/all/patches/v1.54.x/003-remove-obsolete-template-keyword-v1.54.3.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/lib/promise/detail/basic_seq.h b/src/core/lib/promise/detail/basic_seq.h
+index bf9d992bb8..3440ac6f5a 100644
+--- a/src/core/lib/promise/detail/basic_seq.h
++++ b/src/core/lib/promise/detail/basic_seq.h
+@@ -471,7 +471,7 @@ class BasicSeqIter {
+           cur_ = next;
+           state_.~State();
+           Construct(&state_,
+-                    Traits::template CallSeqFactory(f_, *cur_, std::move(arg)));
++                    Traits::CallSeqFactory(f_, *cur_, std::move(arg)));
+           return PollNonEmpty();
+         });
+   }


### PR DESCRIPTION
Remove obsolete "template" keyword from CallSeqFactory calls in basic_seq.h for versions 1.50.x and 1.54.x to fix compilation issues with modern compilers.


### Summary
Changes to recipe:  **grpc/1.5x.x**

#### Motivation
fixes #27588 

#### Details
Adds patches that remove obsolete keyword


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
