### PR TITLE
imgui: add option to build binary_to_compressed_c

### DIFF
--- a/recipes/imgui/all/CMakeLists.txt
+++ b/recipes/imgui/all/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(imgui LANGUAGES CXX)
 
+option(BUILD_BINARY_TO_COMPRESSED_C "Build the binary_to_compressed_c executable" ON)
+
 set(MISC_DIR ${IMGUI_SRC_DIR}/misc)
 set(EXTRA_FONTS_DIR ${MISC_DIR}/fonts)
 set(IMGUI_EXPORT_HEADERS imgui_export_headers.h)
@@ -23,10 +25,11 @@ if (MSVC)
     file(GLOB EXTRA_NATVIS_FILES ${MISC_DIR}/natvis/*.natvis)
 endif()
 
-set(BINARY_TO_COMPRESSED_BIN binary_to_compressed_c)
-
-add_executable(${BINARY_TO_COMPRESSED_BIN} ${EXTRA_FONTS_DIR}/binary_to_compressed_c.cpp)
-target_compile_features(${BINARY_TO_COMPRESSED_BIN} PRIVATE cxx_std_11)
+if(BUILD_BINARY_TO_COMPRESSED_C)
+    set(BINARY_TO_COMPRESSED_BIN binary_to_compressed_c)
+    add_executable(${BINARY_TO_COMPRESSED_BIN} ${EXTRA_FONTS_DIR}/binary_to_compressed_c.cpp)
+    target_compile_features(${BINARY_TO_COMPRESSED_BIN} PRIVATE cxx_std_11)
+endif()
 
 add_library(${PROJECT_NAME} ${SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES
@@ -51,8 +54,10 @@ install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(TARGETS ${BINARY_TO_COMPRESSED_BIN}
+if(BUILD_BINARY_TO_COMPRESSED_C)
+    install(TARGETS ${BINARY_TO_COMPRESSED_BIN}
         DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 install(FILES ${HEADER_FILES} ${CMAKE_CURRENT_BINARY_DIR}/${IMGUI_EXPORT_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)

--- a/recipes/imgui/all/conanfile.py
+++ b/recipes/imgui/all/conanfile.py
@@ -20,12 +20,14 @@ class IMGUIConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "enable_test_engine": [True, False]
+        "enable_test_engine": [True, False],
+        "enable_binary_to_compressed_c": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "enable_test_engine": False
+        "enable_test_engine": False,
+        "enable_binary_to_compressed_c": True,
     }
 
     def export_sources(self):
@@ -61,6 +63,7 @@ class IMGUIConan(ConanFile):
             tc.preprocessor_definitions["IMGUI_TEST_ENGINE_ENABLE_COROUTINE_STDTHREAD_IMPL"] = "1"
             tc.variables["IMGUI_ENABLE_TEST_ENGINE"] = "ON"
             tc.variables["IMGUI_TEST_ENGINE_DIR"] = os.path.join(self.source_folder, "test_engine").replace("\\", "/")
+        tc.variables["BUILD_BINARY_TO_COMPRESSED_C"] = self.options.enable_binary_to_compressed_c
         tc.generate()
 
     def _patch_sources(self):
@@ -106,6 +109,7 @@ class IMGUIConan(ConanFile):
             self.cpp_info.system_libs.append("imm32")
         self.cpp_info.srcdirs = [os.path.join("res", "bindings")]
 
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH env var with : {}".format(bin_path))
-        self.env_info.PATH.append(bin_path)
+        if self.options.enable_binary_to_compressed_c:
+            bin_path = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH env var with : {}".format(bin_path))
+            self.env_info.PATH.append(bin_path)


### PR DESCRIPTION
### Summary
Changes to recipe:  **imgui**

#### Motivation
Fixes #26935
Building `imgui` with Xcode fails due to a missing bundle identifier for the `binary_to_compressed_c` target:

```
imgui.xcodeproj: error: Bundle identifier is missing. binary_to_compressed_c doesn't have a bundle identifier. Add a value for PRODUCT_BUNDLE_IDENTIFIER in the build settings editor. (in target 'binary_to_compressed_c' from project 'imgui')
```

#### Details
Adds a CMake option `BUILD_BINARY_TO_COMPRESSED_C` to allow disabling the build for `binary_to_compressed_c` executable.
Exposes this option in `conanfile.py`, so the target can be skipped when building with Conan, resolving the Xcode build issue.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
