### PR TITLE
Add: gn-20250528

### DIFF
--- a/recipes/gn/all/conandata.yml
+++ b/recipes/gn/all/conandata.yml
@@ -1,5 +1,18 @@
 sources:
+  "cci.20250528":
+    url:
+      - "https://gn.googlesource.com/gn/+archive/afd24ed11bc5fbef775a3ffe46c72e6bdca0fa60.tar.gz"
   "cci.20240611":
     url: "https://gn.googlesource.com/gn/+archive/b2afae122eeb6ce09c52d63f67dc53fc517dbdc8.tar.gz"
   "cci.20210429":
     url: "https://gn.googlesource.com/gn/+archive/6771ce569fb4803dad7a427aa2e2c23e960b917e.tar.gz"
+patches:
+  "cci.20250528":
+    - patch_file: "patches/cci.20250528-fix-cp936.patch"
+      patch_description: "fix cp936 can not recognize"
+  "cci.20240611":
+    - patch_file: "patches/cci.20240611-fix-cp936.patch"
+      patch_description: "fix cp936 can not recognize"
+  "cci.20210429":
+    - patch_file: "patches/cci.20210429-fix-cp936.patch"
+      patch_description: "fix cp936 can not recognize"

--- a/recipes/gn/all/patches/cci.20210429-fix-cp936.patch
+++ b/recipes/gn/all/patches/cci.20210429-fix-cp936.patch
@@ -1,0 +1,37 @@
+diff -Naur a/src/gn/command_gen.cc b/src/gn/command_gen.cc
+--- a/src/gn/command_gen.cc	2025-06-03 17:28:07.000000000 +0800
++++ b/src/gn/command_gen.cc	2025-06-03 17:44:37.819834400 +0800
+@@ -561,11 +561,11 @@
+ 
+   --export-compile-commands[=<target_name1,target_name2...>]
+       Produces a compile_commands.json file in the root of the build directory
+-      containing an array of “command objects”, where each command object
++      containing an array of "command objects", where each command object
+       specifies one way a translation unit is compiled in the project. If a list
+       of target_name is supplied, only targets that are reachable from any
+       target in any build file whose name is target_name will be used for
+-      “command objects” generation, otherwise all available targets will be used.
++      "command objects" generation, otherwise all available targets will be used.
+       This is used for various Clang-based tooling, allowing for the replay of
+       individual compilations independent of the build system.
+       e.g. "foo" will match:
+diff -Naur a/src/gn/escape.h b/src/gn/escape.h
+--- a/src/gn/escape.h	2025-06-03 17:28:07.000000000 +0800
++++ b/src/gn/escape.h	2025-06-03 17:30:59.747216200 +0800
+@@ -6,6 +6,7 @@
+ #define TOOLS_GN_ESCAPE_H_
+ 
+ #include <iosfwd>
++#include <string>
+ #include <string_view>
+ 
+ enum EscapingMode {
+@@ -33,7 +34,7 @@
+   ESCAPE_NINJA_PREFORMATTED_COMMAND,
+ 
+   // Shell escaping as described by JSON Compilation Database spec:
+-  // Parameters use shell quoting and shell escaping of quotes, with ‘"’ and ‘\’
++  // Parameters use shell quoting and shell escaping of quotes, with '"' and '\'
+   // being the only special characters.
+   ESCAPE_COMPILATION_DATABASE,
+ };

--- a/recipes/gn/all/patches/cci.20240611-fix-cp936.patch
+++ b/recipes/gn/all/patches/cci.20240611-fix-cp936.patch
@@ -1,0 +1,20 @@
+diff -Naur a/src/gn/escape.h b/src/gn/escape.h
+--- a/src/gn/escape.h	2025-06-03 17:10:03.000000000 +0800
++++ b/src/gn/escape.h	2025-06-03 17:26:04.873946600 +0800
+@@ -6,6 +6,7 @@
+ #define TOOLS_GN_ESCAPE_H_
+ 
+ #include <iosfwd>
++#include <string>
+ #include <string_view>
+ 
+ enum EscapingMode {
+@@ -33,7 +34,7 @@
+   ESCAPE_NINJA_PREFORMATTED_COMMAND,
+ 
+   // Shell escaping as described by JSON Compilation Database spec:
+-  // Parameters use shell quoting and shell escaping of quotes, with ‘"’ and ‘\’
++  // Parameters use shell quoting and shell escaping of quotes, with '"' and '\'
+   // being the only special characters.
+   ESCAPE_COMPILATION_DATABASE,
+ };

--- a/recipes/gn/all/patches/cci.20250528-fix-cp936.patch
+++ b/recipes/gn/all/patches/cci.20250528-fix-cp936.patch
@@ -1,0 +1,12 @@
+diff -Naur a/src/gn/escape.h b/src/gn/escape.h
+--- a/src/gn/escape.h	2025-06-03 15:39:30.000000000 +0800
++++ b/src/gn/escape.h	2025-06-03 15:51:59.207281500 +0800
+@@ -34,7 +34,7 @@
+   ESCAPE_NINJA_PREFORMATTED_COMMAND,
+ 
+   // Shell escaping as described by JSON Compilation Database spec:
+-  // Parameters use shell quoting and shell escaping of quotes, with ‘"’ and ‘\’
++  // Parameters use shell quoting and shell escaping of quotes, with '"' and '\'
+   // being the only special characters.
+   ESCAPE_COMPILATION_DATABASE,
+ };

--- a/recipes/gn/config.yml
+++ b/recipes/gn/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20250528":
+    folder: all
   "cci.20240611":
     folder: all
   "cci.20210429":


### PR DESCRIPTION
fix:
  - 20240611 cp936 can not build
  - 20210429 cp936 can not build


### Summary
Add to recipe: **gn/cci.20250528**
Changes to recipe:  **gn/cci.20240611,gn/cci.20210429**

#### Motivation
- fix **gn/cci.20240611,gn/cci.20210429** can not build pass with system.encode is cp936 with vs2022
- add **gn/cci.20250528** Stay up-to-date

#### Details
- cci.20210429
    - fix src/gn/escape.h line:24 ‘ to ' at 
    - fix src/gn/escape.h line:6 add include #include <string>
- cci.20240611
    - fix src/gn/escape.h line:33 ‘ to ' at 
    - fix src/gn/escape.h line:6 add include #include <string>
- cci.20250528
    -  fix src/gn/escape.h line:34 ‘ to ' at 
- build error info as follow:
- [57/282] ninja -t msvc -- cl.exe /nologo /showIncludes /FC -I..\src -I. /DNOMINMAX /DUNICODE /DWIN32_LEAN_AND_MEAN /DWINVER=0x0A00 /D_CRT_SECURE_NO_DEPRECATE /D_SCL_SECURE_NO_DEPRECATE /D_UNICODE /D_WIN32_WINNT=0x0A00 /FS /W4 /WX /Zi /wd4099 /wd4100 /wd4127 /wd4244 /wd4267 /wd4505 /wd4838 /wd4996 /std:c++17 /GR- /D_HAS_EXCEPTIONS=0 /c ..\src\gn\command_gen.cc /Fosrc/gn/command_gen.obj FAILED: src/gn/command_gen.obj  ninja -t msvc -- cl.exe /nologo /showIncludes /FC -I..\src -I. /DNOMINMAX /DUNICODE /DWIN32_LEAN_AND_MEAN /DWINVER=0x0A00 /D_CRT_SECURE_NO_DEPRECATE /D_SCL_SECURE_NO_DEPRECATE /D_UNICODE /D_WIN32_WINNT=0x0A00 /FS /W4 /WX /Zi /wd4099 /wd4100 /wd4127 /wd4244 /wd4267 /wd4505 /wd4838 /wd4996 /std:c++17 /GR- /D_HAS_EXCEPTIONS=0 /c ..\src\gn\command_gen.cc /Fosrc/gn/command_gen.obj C:\Users\Administrator\.conan2\p\b\gn845a1b4b6b14c\b\src\src\gn\command_gen.cc(1): error C2220: 以下警告被视为错误 C:\Users\Administrator\.conan2\p\b\gn845a1b4b6b14c\b\src\src\gn\command_gen.cc(1): warning C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Tested locally with at least one configuration using a recent version of Conan
- 
