### PR TITLE
qt: add version 6.9.1

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -1,4 +1,26 @@
 sources:
+  "6.9.1":
+    url:
+      - "https://download.qt.io/official_releases/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://download.qt.io/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://mirrors.20i.com/pub/qt.io/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://ftp.nluug.nl/languages/qt/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://mirror.netcologne.de/qtproject/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://qt-mirror.dannhauer.de/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://ftp.fau.de/qtproject/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://mirrors.dotsrc.org/qtproject/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://ftp.icm.edu.pl/packages/qt/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://ftp.acc.umu.se/mirror/qt.io/qtproject/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://www.nic.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://qt.mirror.constant.com/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://mirrors.sau.edu.cn/qt/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://mirrors.cloud.tencent.com/qt/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://mirror.bjtu.edu.cn/qt/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://mirrors.sjtug.sjtu.edu.cn/qt/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://ftp.jaist.ac.jp/pub/qtproject/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+      - "https://ftp.yz.yamagata-u.ac.jp/pub/qtproject/archive/qt/6.9/6.9.1/single/qt-everywhere-src-6.9.1.tar.xz"
+    sha256: "364fde2d7fa42dd7c9b2ea6db3d462dd54f3869e9fd0ca0a0ca62f750cd8329b"
   "6.8.3":
     url:
       - "https://download.qt.io/official_releases/qt/6.8/6.8.3/single/qt-everywhere-src-6.8.3.tar.xz"
@@ -87,6 +109,10 @@ sources:
       - "https://ftp.yz.yamagata-u.ac.jp/pub/qtproject/archive/qt/6.5/6.5.3/single/qt-everywhere-src-6.5.3.tar.xz"
     sha256: "7cda4d119aad27a3887329cfc285f2aba5da85601212bcb0aea27bd6b7b544cb"
 patches:
+  "6.9.1":
+    - "base_path": "qtwebengine"
+      "patch_description": "Workaround for too long .rps file name"
+      "patch_file": "patches/c72097e_6.9.1.diff"
   "6.8.3":
     - "base_path": "qtwebengine"
       "patch_description": "Workaround for too long .rps file name"

--- a/recipes/qt/6.x.x/patches/c72097e_6.9.1.diff
+++ b/recipes/qt/6.x.x/patches/c72097e_6.9.1.diff
@@ -1,0 +1,42 @@
+From c72097e8790553771daf3231124c3fbe1a438379 Mon Sep 17 00:00:00 2001
+From: Samuli Piippo <samuli.piippo@qt.io>
+Date: Thu, 30 Mar 2017 11:37:24 +0300
+Subject: [PATCH] chromium: workaround for too long .rps file name
+
+Ninja may fail when the build directory is too long:
+
+ninja: error: WriteFile(__third_party_WebKit_Source_bindings_modules_\
+interfaces_info_individual_modules__home_qt_work_build_build-nitrogen\
+6x_tmp_work_cortexa9hf-neon-mx6qdl-poky-linux-gnueabi_qtwebengine_5.9\
+.0_gitAUTOINC_29afdb0a34_049134677a-r0_build_src_toolchain_target__ru\
+le.rsp): Unable to create file. File name too long
+
+Task-number: QTBUG-59769
+Change-Id: I73c5e64ae5174412be2a675e35b0b6047f2bf4c1
+---
+ src/3rdparty/gn/src/gn/ninja_action_target_writer.cc | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/3rdparty/gn/src/gn/ninja_action_target_writer.cc b/src/3rdparty/gn/src/gn/ninja_action_target_writer.cc
+index a5bc6cd..5cefbfe 100644
+--- a/src/3rdparty/gn/src/gn/ninja_action_target_writer.cc
++++ b/src/3rdparty/gn/tosrcols/gn/ninja_action_target_writer.cc
+@@ -155,6 +155,14 @@ std::string NinjaActionTargetWriter::WriteRuleDefinition() {
+     // strictly necessary for regular one-shot actions, but it's easier to
+     // just always define unique_name.
+     std::string rspfile = custom_rule_name;
++
++    //quick workaround if filename length > 255 - ".rsp", just cut the dirs starting from the end
++    //please note ".$unique_name" is not used at the moment
++    std::size_t pos = 0;
++    std::string delimiter("_");
++    while (rspfile.length() > 250 && (pos = rspfile.find_last_of(delimiter)) != std::string::npos)
++        rspfile = rspfile.substr(0,pos);
++
+     if (!target_->sources().empty())
+       rspfile += ".$unique_name";
+     rspfile += ".rsp";
++
+     out_ << "  rspfile = " << rspfile << std::endl;
+
+     // Response file contents.

--- a/recipes/qt/6.x.x/qtmodules6.9.1.conf
+++ b/recipes/qt/6.x.x/qtmodules6.9.1.conf
@@ -1,0 +1,339 @@
+[submodule "qtbase"]
+	path = qtbase
+	url = ../qtbase.git
+	branch = 6.9.1
+	status = essential
+[submodule "qtsvg"]
+	depends = qtbase
+	path = qtsvg
+	url = ../qtsvg.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtdeclarative"]
+	depends = qtbase
+	recommends = qtimageformats qtshadertools qtsvg qtlanguageserver
+	path = qtdeclarative
+	url = ../qtdeclarative.git
+	branch = 6.9.1
+	status = essential
+[submodule "qtactiveqt"]
+	depends = qtbase
+	path = qtactiveqt
+	url = ../qtactiveqt.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtmultimedia"]
+	depends = qtbase qtshadertools
+	recommends = qtdeclarative qtquick3d
+	path = qtmultimedia
+	url = ../qtmultimedia.git
+	branch = 6.9.1
+	status = addon
+[submodule "qttools"]
+	depends = qtbase
+	recommends = qtdeclarative qtactiveqt
+	path = qttools
+	url = ../qttools.git
+	branch = 6.9.1
+	status = essential
+[submodule "qtxmlpatterns"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtxmlpatterns
+	url = ../qtxmlpatterns.git
+	branch = dev
+	status = ignore
+[submodule "qttranslations"]
+	depends = qttools
+	path = qttranslations
+	url = ../qttranslations.git
+	branch = 6.9.1
+	status = essential
+	priority = 30
+[submodule "qtdoc"]
+	depends = qtdeclarative qttools
+	recommends = qtmultimedia qtshadertools qtwebengine
+	path = qtdoc
+	url = ../qtdoc.git
+	branch = 6.9.1
+	status = essential
+	priority = 40
+[submodule "qtrepotools"]
+	path = qtrepotools
+	url = ../qtrepotools.git
+	branch = master
+	status = essential
+	project = -
+[submodule "qtqa"]
+	depends = qtbase
+	path = qtqa
+	url = ../qtqa.git
+	branch = 6.9.1
+	status = essential
+	priority = 50
+[submodule "qtlocation"]
+	depends = qtbase qtpositioning
+	recommends = qtdeclarative
+	path = qtlocation
+	url = ../qtlocation.git
+	branch = 6.9.1
+	status = preview
+[submodule "qtpositioning"]
+	depends = qtbase
+	recommends = qtdeclarative qtserialport
+	path = qtpositioning
+	url = ../qtpositioning.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtsensors"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtsensors
+	url = ../qtsensors.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtsystems"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtsystems
+	url = ../qtsystems.git
+	branch = dev
+	status = ignore
+[submodule "qtfeedback"]
+	depends = qtdeclarative
+	recommends = qtmultimedia
+	path = qtfeedback
+	url = ../qtfeedback.git
+	branch = master
+	status = ignore
+[submodule "qtpim"]
+	depends = qtdeclarative
+	path = qtpim
+	url = ../qtpim.git
+	branch = dev
+	status = ignore
+[submodule "qtconnectivity"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtconnectivity
+	url = ../qtconnectivity.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtwayland"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtwayland
+	url = ../qtwayland.git
+	branch = 6.9.1
+	status = addon
+[submodule "qt3d"]
+	depends = qtbase
+	recommends = qtdeclarative qtshadertools qtmultimedia
+	path = qt3d
+	url = ../qt3d.git
+	branch = 6.9.1
+	status = deprecated
+[submodule "qtimageformats"]
+	depends = qtbase
+	path = qtimageformats
+	url = ../qtimageformats.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtserialbus"]
+	depends = qtbase
+	recommends = qtserialport
+	path = qtserialbus
+	url = ../qtserialbus.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtserialport"]
+	depends = qtbase
+	path = qtserialport
+	url = ../qtserialport.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtwebsockets"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtwebsockets
+	url = ../qtwebsockets.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtwebchannel"]
+	depends = qtbase
+	recommends = qtdeclarative qtwebsockets
+	path = qtwebchannel
+	url = ../qtwebchannel.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtwebengine"]
+	depends = qtdeclarative
+	recommends = qtwebchannel qttools qtpositioning
+	path = qtwebengine
+	url = ../qtwebengine.git
+	branch = 6.9.1
+	status = addon
+	priority = 10
+[submodule "qtcanvas3d"]
+	depends = qtdeclarative
+	path = qtcanvas3d
+	url = ../qtcanvas3d.git
+	branch = dev
+	status = ignore
+[submodule "qtwebview"]
+	depends = qtdeclarative
+	recommends = qtwebengine
+	path = qtwebview
+	url = ../qtwebview.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtcharts"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtcharts
+	url = ../qtcharts.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtdatavis3d"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtdatavis3d
+	url = ../qtdatavis3d.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtvirtualkeyboard"]
+	depends = qtbase qtdeclarative qtsvg
+	recommends = qtmultimedia
+	path = qtvirtualkeyboard
+	url = ../qtvirtualkeyboard.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtgamepad"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtgamepad
+	url = ../qtgamepad.git
+	branch = dev
+	status = ignore
+[submodule "qtscxml"]
+	depends = qtbase qtdeclarative
+	path = qtscxml
+	url = ../qtscxml.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtspeech"]
+	depends = qtbase qtmultimedia
+	recommends = qtdeclarative
+	path = qtspeech
+	url = ../qtspeech.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtnetworkauth"]
+	depends = qtbase
+	path = qtnetworkauth
+	url = ../qtnetworkauth.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtremoteobjects"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtremoteobjects
+	url = ../qtremoteobjects.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtwebglplugin"]
+	depends = qtbase qtwebsockets
+	recommends = qtdeclarative
+	path = qtwebglplugin
+	url = ../qtwebglplugin.git
+	branch = dev
+	status = ignore
+[submodule "qtlottie"]
+	depends = qtbase qtdeclarative
+	path = qtlottie
+	url = ../qtlottie.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtquicktimeline"]
+	depends = qtbase qtdeclarative
+	path = qtquicktimeline
+	url = ../qtquicktimeline
+	branch = 6.9.1
+	status = addon
+[submodule "qtquick3d"]
+	depends = qtbase qtdeclarative qtshadertools
+	recommends = qtquicktimeline
+	path = qtquick3d
+	url = ../qtquick3d.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtshadertools"]
+	depends = qtbase
+	path = qtshadertools
+	url = ../qtshadertools.git
+	branch = 6.9.1
+	status = addon
+[submodule "qt5compat"]
+	depends = qtbase qtdeclarative
+	path = qt5compat
+	url = ../qt5compat.git
+	branch = 6.9.1
+	status = deprecated
+[submodule "qtcoap"]
+	depends = qtbase
+	path = qtcoap
+	url = ../qtcoap.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtmqtt"]
+	depends = qtbase qtdeclarative
+	recommends = qtwebsockets
+	path = qtmqtt
+	url = ../qtmqtt.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtopcua"]
+	depends = qtbase qtdeclarative
+	path = qtopcua
+	url = ../qtopcua.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtlanguageserver"]
+	depends = qtbase
+	path = qtlanguageserver
+	url = ../qtlanguageserver.git
+	branch = 6.9.1
+	status = preview
+[submodule "qthttpserver"]
+	depends = qtbase
+	recommends = qtwebsockets
+	path = qthttpserver
+	url = ../qthttpserver.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtquick3dphysics"]
+	depends = qtbase qtdeclarative qtquick3d qtshadertools
+	path = qtquick3dphysics
+	url = ../qtquick3dphysics.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtgrpc"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtgrpc
+	url = ../qtgrpc.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtquickeffectmaker"]
+	depends = qtbase qtdeclarative qtshadertools
+	recommends = qtquick3d
+	path = qtquickeffectmaker
+	url = ../qtquickeffectmaker.git
+	branch = 6.9.1
+	status = addon
+[submodule "qtgraphs"]
+	depends = qtbase qtdeclarative qtquick3d
+	path = qtgraphs
+	url = ../qtgraphs.git
+	branch = 6.9.1
+	status = addon

--- a/recipes/qt/config.yml
+++ b/recipes/qt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.9.1":
+    folder: 6.x.x
   "6.8.3":
     folder: 6.x.x
   "6.7.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/[6.9.1]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

Add the new version

[https://code.qt.io/cgit/qt/qt5.git/tree/.gitmodules?h=v6.9.1](https://code.qt.io/cgit/qt/qt5.git/tree/.gitmodules?h=v6.9.1)

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

recipes/qt/6.x.x/conandata.yml
recipes/qt/6.x.x/conanfile.py
recipes/qt/6.x.x/patches/c72097e_6.9.1.diff
recipes/qt/6.x.x/qtmodules6.9.1.conf
recipes/qt/config.yml

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
