### PR TITLE
soci: fix sqlite3 regression

### DIFF
--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -94,6 +94,7 @@ class SociConan(ConanFile):
         deps.set_property("mysql", "cmake_file_name", "MYSQL")
         deps.set_property("libpq", "cmake_file_name", "POSTGRESQL")
         deps.set_property("sqlite3", "cmake_file_name", "SQLite3")
+        deps.set_property("sqlite3", "cmake_additional_variables_prefixes", ["SQLITE3"])
         deps.generate()
 
     def build(self):


### PR DESCRIPTION
Fix regression introduced in https://github.com/conan-io/conan-center-index/pull/27513

Fixes error:
```
soci/4.0.3: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/root/.conan2/p/b/soci75a423422f08d/p" -DCMAKE_POLICY_DEFAULT_CMP0042="NEW" -DSOCI_SHARED="OFF" -DSOCI_STATIC="ON" -DSOCI_TESTS="OFF" -DSOCI_CXX11="ON" -DSOCI_EMPTY="OFF" -DWITH_SQLITE3="ON" -DWITH_DB2="OFF" -DWITH_ODBC="OFF" -DWITH_ORACLE="OFF" -DWITH_FIREBIRD="OFF" -DWITH_MYSQL="OFF" -DWITH_POSTGRESQL="OFF" -DWITH_BOOST="OFF" -DCMAKE_POLICY_VERSION_MINIMUM="3.5" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/root/.conan2/p/b/soci75a423422f08d/b/src"
CMake Deprecation Warning at CMakeLists.txt:13 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Using Conan toolchain: /root/.conan2/p/b/soci75a423422f08d/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: C++ Standard 17 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test SOCI_HAVE_VISIBILITY_SUPPORT
-- Performing Test SOCI_HAVE_VISIBILITY_SUPPORT - Success
-- gcc / clang visibility enabled
-- Looking for __i386__
-- Looking for __i386__ - not found
-- Looking for __x86_64__
-- Looking for __x86_64__ - not found
-- Looking for __arm__
-- Looking for __arm__ - not found
-- Configuring SOCI: 
-- SOCI_VERSION                             = 4.0.3 
-- SOCI_ABI_VERSION                         = 4.0 
-- SOCI_SHARED                              = OFF 
-- SOCI_STATIC                              = ON 
-- SOCI_TESTS                               = OFF 
-- SOCI_ASAN                                = OFF 
-- SOCI_CXX11                               = ON 
-- LIB_SUFFIX                               =  
-- Looking for SOCI dependencies: 
-- Threads: 
-- CMAKE_THREAD_LIBS_INIT                   =  
-- Boost: disabled, since WITH_BOOST=OFF 
-- MySQL: disabled, since WITH_MYSQL=OFF 
-- ODBC: disabled, since WITH_ODBC=OFF 
-- Oracle: disabled, since WITH_ORACLE=OFF 
-- PostgreSQL: disabled, since WITH_POSTGRESQL=OFF 
-- SQLite3: 
-- Conan: Component target declared 'SQLite::SQLite3'
-- SQLite3_INCLUDE_DIR                      = /root/.conan2/p/b/sqlit2f27ca75fb92d/p/include 
-- SQLite3_LIBRARIES                        = SQLite::SQLite3 
-- Firebird: disabled, since WITH_FIREBIRD=OFF 
-- DB2: disabled, since WITH_DB2=OFF 
-- Configuring SOCI core library: 
-- SOCI_CORE_TARGET                         = soci_core 
-- SOCI_CORE_TARGET_OUTPUT_NAME             = soci_core 
-- SOCI_CORE_DEPS_LIBS                      = /usr/lib/aarch64-linux-gnu/libdl.a 
-- SOCI_CORE_INCLUDE_DIRS                   = /root/.conan2/p/b/soci75a423422f08d/b/build/Release /root/.conan2/p/b/soci75a423422f08d/b/src/include /root/.conan2/p/b/soci75a423422f08d/b/build/Release/include /root/.conan2/p/b/soci75a423422f08d/b/src/include/private /root/.conan2/p/b/soci75a423422f08d/b/build/Release/src/core 
-- WITH_BOOST                               = OFF 
-- COMPILE_DEFINITIONS                      = SOCI_ABI_VERSION="4.0" HAVE_DL=1 SOCI_LIB_PREFIX="libsoci_" SOCI_LIB_SUFFIX=".so" SOCI_DEBUG_POSTFIX="" 
-- 
-- Configuring SOCI backend libraries: 
-- SQLite3 - SOCI backend for SQLite 3 
-- SOCI_SQLITE3                             = ON 
-- SOCI_SQLITE3_TARGET                      = soci_sqlite3 
-- SOCI_SQLITE3_OUTPUT_NAME                 = soci_sqlite3 
-- SOCI_SQLITE3_COMPILE_DEFINITIONS         = SOCI_ABI_VERSION="4.0" HAVE_DL=1 
-- SOCI_SQLITE3_INCLUDE_DIRECTORIES         = /root/.conan2/p/b/soci75a423422f08d/b/build/Release /root/.conan2/p/b/soci75a423422f08d/b/src/include /root/.conan2/p/b/soci75a423422f08d/b/build/Release/include /root/.conan2/p/b/soci75a423422f08d/b/src/include/private /root/.conan2/p/b/soci75a423422f08d/b/src/include/private 
-- 
-- 
-- Configuring done (0.4s)
-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_POLICY_VERSION_MINIMUM


-- Build files have been written to: /root/.conan2/p/b/soci75a423422f08d/b/build/Release

soci/4.0.3: Running CMake.build()
soci/4.0.3: RUN: cmake --build "/root/.conan2/p/b/soci75a423422f08d/b/build/Release" -- -j8
[  3%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/backend-loader.cpp.o
[ 15%] Building CXX object src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/blob.cpp.o
[ 21%] Building CXX object src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/row-id.cpp.o
[ 21%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/connection-parameters.cpp.o
[ 21%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/common.cpp.o
[ 24%] Building CXX object src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/factory.cpp.o
[ 21%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/blob.cpp.o
[ 21%] Building CXX object src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/error.cpp.o
In file included from /root/.conan2/p/b/soci75a423422f08d/b/src/src/backends/sqlite3/row-id.cpp:9:
/root/.conan2/p/b/soci75a423422f08d/b/src/include/soci/sqlite3/soci-sqlite3.h:38:10: fatal error: sqlite3.h: No such file or directory
   38 | #include <sqlite3.h>
      |          ^~~~~~~~~~~
In file included from /root/.conan2/p/b/soci75a423422f08d/b/src/src/backends/sqlite3/blob.cpp:9:
/root/.conan2/p/b/soci75a423422f08d/b/src/include/soci/sqlite3/soci-sqlite3.h:38:10: fatal error: sqlite3.h: No such file or directory
   38 | #include <sqlite3.h>
      |          ^~~~~~~~~~~
In file included from /root/.conan2/p/b/soci75a423422f08d/b/src/src/backends/sqlite3/error.cpp:9:
/root/.conan2/p/b/soci75a423422f08d/b/src/include/soci/sqlite3/soci-sqlite3.h:38:10: fatal error: sqlite3.h: No such file or directory
   38 | #include <sqlite3.h>
      |          ^~~~~~~~~~~
compilation terminated.
compilation terminated.
In file included from /root/.conan2/p/b/soci75a423422f08d/b/src/src/backends/sqlite3/factory.cpp:9:
/root/.conan2/p/b/soci75a423422f08d/b/src/include/soci/sqlite3/soci-sqlite3.h:38:10: fatal error: sqlite3.h: No such file or directory
   38 | #include <sqlite3.h>
      |          ^~~~~~~~~~~
compilation terminated.
compilation terminated.
gmake[2]: *** [src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/build.make:76: src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/blob.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[2]: *** [src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/build.make:104: src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/factory.cpp.o] Error 1
gmake[2]: *** [src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/build.make:90: src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/error.cpp.o] Error 1
gmake[2]: *** [src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/build.make:118: src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/row-id.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:172: src/backends/sqlite3/CMakeFiles/soci_sqlite3_static.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[ 33%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/error.cpp.o
[ 33%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/logger.cpp.o
[ 33%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/connection-pool.cpp.o
[ 36%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/into-type.cpp.o
[ 39%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/once-temp-type.cpp.o
[ 42%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/prepare-temp-type.cpp.o
[ 45%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/procedure.cpp.o
[ 48%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/ref-counted-prepare-info.cpp.o
[ 51%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/ref-counted-statement.cpp.o
[ 54%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/row.cpp.o
[ 57%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/rowid.cpp.o
[ 60%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/session.cpp.o
[ 63%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/soci-simple.cpp.o
[ 66%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/statement.cpp.o
[ 69%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/transaction.cpp.o
[ 72%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/use-type.cpp.o
[ 75%] Building CXX object src/core/CMakeFiles/soci_core_static.dir/values.cpp.o
[ 78%] Linking CXX static library ../../lib/libsoci_core.a
[ 78%] Built target soci_core_static
gmake: *** [Makefile:136: all] Error 2

soci/4.0.3: ERROR: 
Package '5762c898023c5736cd6385b69bccad07a8de63c2' build failed
soci/4.0.3: WARN: Build folder /root/.conan2/p/b/soci75a423422f08d/b/build/Release
ERROR: soci/4.0.3: Error in build() method, line 102
        cmake.build()
        ConanException: Error 2 while executing
```
