### PR TITLE
vulkan-memory-allocator: add version 3.3.0.

### DIFF
--- a/recipes/vulkan-memory-allocator/all/conandata.yml
+++ b/recipes/vulkan-memory-allocator/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "cci.20231120":
     url: "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/5e43c795daf43dd09398d8307212e85025215052.tar.gz"
     sha256: "1ee9922fb059bc3b1dc5bbf71020e7a590b6ceb27fc3025d746e15be53fe31b7"
+  "3.3.0":
+    url: "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/refs/tags/v3.3.0.tar.gz"
+    sha256: "c4f6bbe6b5a45c2eb610ca9d231158e313086d5b1a40c9922cb42b597419b14e"
   "3.0.1":
     url: "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/refs/tags/v3.0.1.tar.gz"
     sha256: "2a84762b2d10bf540b9dc1802a198aca8ad1f3d795a4ae144212c595696a360c"

--- a/recipes/vulkan-memory-allocator/config.yml
+++ b/recipes/vulkan-memory-allocator/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.3.0":
+    folder: all
   "cci.20231120":
     folder: all
   "3.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-memory-allocator/3.3.0**

#### Motivation
The [new releases](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/releases) come with more functions and Vulkan 1.4 support.

#### Details
This just adds the latest version. The patches aren't needed for this one, as they are already included upstream.
I haven't tested this on GCC 15.

Tested on GCC 12: [build log](https://bin.linux.pizza/?a8e06427babca758#CjukaET3F32MSvYD3Fg3HnM9DrmGRBSXuXUDwmybXDjj)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
