### PR TITLE
rocksdb: add folly support, add version 10.2.1

### DIFF
--- a/recipes/rocksdb/all/conandata.yml
+++ b/recipes/rocksdb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "10.2.1":
+    url: "https://github.com/facebook/rocksdb/archive/refs/tags/v10.2.1.tar.gz"
+    sha256: "D1DDFD3551E649F7E2D180D5A6A006D90CFDE56DCFE1E548C58D95B7F1C87049"
   "10.0.1":
     url: "https://github.com/facebook/rocksdb/archive/refs/tags/v10.0.1.tar.gz"
     sha256: "3fdc9ca996971c4c039959866382c4a3a6c8ade4abf888f3b2ff77153e07bf28"
@@ -21,6 +24,16 @@ sources:
     url: "https://github.com/facebook/rocksdb/archive/refs/tags/v6.29.5.tar.gz"
     sha256: "ddbf84791f0980c0bbce3902feb93a2c7006f6f53bfd798926143e31d4d756f0"
 patches:
+  "10.2.1":
+    - patch_file: "patches/10.x.x-0001-fix-folly.patch"
+      patch_description: "Fix folly check"
+      patch_type: "conan"
+    - patch_file: "patches/10.x.x-0001-fix-msvc-coroutines.patch"
+      patch_description: "Fix coroutines on msvc"
+      patch_type: "portability"
+    - patch_file: "patches/9.x.x-0001-exclude-thirdparty.patch"
+      patch_description: "Do not include thirdparty.inc"
+      patch_type: "portability"
   "10.0.1":
     - patch_file: "patches/9.x.x-0001-exclude-thirdparty.patch"
       patch_description: "Do not include thirdparty.inc"

--- a/recipes/rocksdb/all/patches/10.x.x-0001-fix-folly.patch
+++ b/recipes/rocksdb/all/patches/10.x.x-0001-fix-folly.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -607,7 +607,7 @@
+   find_package(folly)
+   # If cmake could not find the folly-config.cmake file, fall back
+   # to looking in third-party/folly for folly and its dependencies
+-  if(NOT FOLLY_LIBRARIES)
++  if(NOT folly_LIBRARIES)
+     exec_program(python3 ${PROJECT_SOURCE_DIR}/third-party/folly ARGS
+     build/fbcode_builder/getdeps.py show-inst-dir OUTPUT_VARIABLE
+     FOLLY_INST_PATH)

--- a/recipes/rocksdb/all/patches/10.x.x-0001-fix-msvc-coroutines.patch
+++ b/recipes/rocksdb/all/patches/10.x.x-0001-fix-msvc-coroutines.patch
@@ -1,0 +1,23 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -586,11 +586,15 @@
+     message(FATAL_ERROR "Please specify exactly one of USE_COROUTINES,"
+     " USE_FOLLY, and USE_FOLLY_LITE")
+   endif()
+-  set(CMAKE_CXX_STANDARD 20)
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines -Wno-maybe-uninitialized")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-redundant-move")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-memory-model")
++  if( NOT DEFINED CMAKE_CXX_STANDARD )
++    set(CMAKE_CXX_STANDARD 20)
++  endif()
++  if (NOT MSVC)
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines -Wno-maybe-uninitialized")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-redundant-move")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-memory-model")
++  endif()
+   add_compile_definitions(USE_COROUTINES)
+   set(USE_FOLLY 1)
+ endif()

--- a/recipes/rocksdb/config.yml
+++ b/recipes/rocksdb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "10.2.1":
+    folder: all
   "10.0.1":
     folder: all
   "9.10.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **rocksdb**

#### Motivation
Support for folly and coroutines can further speed up rocksdb, and we like speed.

For version ranges:

- Using version ranges for common dependencies (snappy, lz4, zlib, zstd) allows us to avoid issues when using rocksdb in combination with one of the many other packages that also depend on any of those.
- Using a version range for folly allows us to update folly later (as the only version on CC is getting relatively old now) without having to update this again; I imagine we would want to switch many of folly's dependencies to version ranges as well.
- gflags has not gotten a new release in a long time, so I did not think it necessary to switch to a version range.
- jemalloc has been recently archived for unknown reasons, and the latest release is also a long time ago, so ditto.
- TBB I didn't test so I dared not touch it, but I would assume newer versions would work just fine, assuming the current integration works at all.

The two patches:

- fix-folly fixes rocksdb's cmakelists check to see if it found folly to use the conan-provided folly_LIBRARIES.
- fix-msvc-coroutines avoids adding gcc flags to msvc which would make it error out, as well as avoids overriding the CMAKE_CXX_STANDARD provided by conan

#### Details
Added support and options for coroutines and folly, and patches as needed 
Condition some older options that were removed to not apply to newer versions
Switch some dependencies to version ranges
Add the latest release

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
