### PR TITLE
llvm-openmp: add version 20.1.6

### DIFF
--- a/recipes/llvm-openmp/all/conandata.yml
+++ b/recipes/llvm-openmp/all/conandata.yml
@@ -1,4 +1,11 @@
 sources:
+  "20.1.6":
+    openmp:
+      url: "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.6/openmp-20.1.6.src.tar.xz"
+      sha256: "ff8dabd89212cd41b4fc5c26433bcde368873e4f10ea0331792e6b6e7707eff9"
+    cmake:
+      url: "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.6/cmake-20.1.6.src.tar.xz"
+      sha256: "b4b3efa5d5b01b3f211f1ba326bb6f0c318331f828202d332c95b7f30fca5f8c"
   "17.0.6":
     openmp:
       url: "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/openmp-17.0.6.src.tar.xz"
@@ -49,6 +56,10 @@ sources:
     url: "https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/openmp-8.0.1.src.tar.xz"
     sha256: "3e85dd3cad41117b7c89a41de72f2e6aa756ea7b4ef63bb10dcddf8561a7722c"
 patches:
+  "20.1.6":
+    - patch_file: "patches/20/0001-disable-build-testing.patch"
+      patch_description: "Disable building of tools, gdb-plugin, tests and docs"
+      patch_type: "conan"
   "17.0.4":
     - patch_file: "patches/17/0001-disable-build-testing.patch"
       patch_description: "Disable building of tools, gdb-plugin, tests and docs"

--- a/recipes/llvm-openmp/all/patches/20/0001-disable-build-testing.patch
+++ b/recipes/llvm-openmp/all/patches/20/0001-disable-build-testing.patch
@@ -1,0 +1,50 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,14 +92,6 @@
+ include(config-ix)
+ include(HandleOpenMPOptions)
+ 
+-# Set up testing infrastructure.
+-include(OpenMPTesting)
+-
+-set(OPENMP_TEST_FLAGS "" CACHE STRING
+-  "Extra compiler flags to send to the test compiler.")
+-set(OPENMP_TEST_OPENMP_FLAGS ${OPENMP_TEST_COMPILER_OPENMP_FLAGS} CACHE STRING
+-  "OpenMP compiler flag to use for testing OpenMP runtime libraries.")
+-
+ set(ENABLE_LIBOMPTARGET ON)
+ # Currently libomptarget cannot be compiled on Windows or MacOS X.
+ # Since the device plugins are only supported on Linux anyway,
+@@ -125,32 +117,3 @@
+ # Build host runtime library, after LIBOMPTARGET variables are set since they are needed
+ # to enable time profiling support in the OpenMP runtime.
+ add_subdirectory(runtime)
+-
+-set(ENABLE_OMPT_TOOLS ON)
+-# Currently tools are not tested well on Windows or MacOS X.
+-if (APPLE OR WIN32)
+-  set(ENABLE_OMPT_TOOLS OFF)
+-endif()
+-
+-option(OPENMP_ENABLE_OMPT_TOOLS "Enable building ompt based tools for OpenMP."
+-       ${ENABLE_OMPT_TOOLS})
+-if (OPENMP_ENABLE_OMPT_TOOLS)
+-  add_subdirectory(tools)
+-endif()
+-
+-# Propagate OMPT support to offload
+-if(NOT ${OPENMP_STANDALONE_BUILD})
+-  set(LIBOMP_HAVE_OMPT_SUPPORT ${LIBOMP_HAVE_OMPT_SUPPORT} PARENT_SCOPE)
+-  set(LIBOMP_OMP_TOOLS_INCLUDE_DIR ${LIBOMP_OMP_TOOLS_INCLUDE_DIR} PARENT_SCOPE)
+-endif()
+-
+-option(OPENMP_MSVC_NAME_SCHEME "Build dll with MSVC naming scheme." OFF)
+-
+-# Build libompd.so
+-add_subdirectory(libompd)
+-
+-# Build documentation
+-add_subdirectory(docs)
+-
+-# Now that we have seen all testsuites, create the check-openmp target.
+-construct_check_openmp_target()

--- a/recipes/llvm-openmp/config.yml
+++ b/recipes/llvm-openmp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.1.6":
+    folder: all
   "17.0.6":
     folder: all
   "17.0.4":


### PR DESCRIPTION
### Summary
Add llvm-openmp version 20.1.6 (latest as of today)

#### Motivation

Apple has recently released AppleClang 17.
That version and llvm-openmp/18.1.8 from Conan Center fail to link with the following error:

```
Undefined symbols for architecture arm64:
  "___kmpc_dispatch_deinit", referenced from:
      bool load() (.omp_outlined) in instantiations.cpp.o
      ...
ld: symbol(s) not found for architecture arm64
c++: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR adds the latest version of llvm-openmp, which fixes the linker error.

#### Details
* Added the new version
* Adapted the patch for CMakeLists.txt

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
