### PR TITLE
fix: patch onnx define protobuf dependencies

### DIFF
--- a/recipes/onnx/all/conandata.yml
+++ b/recipes/onnx/all/conandata.yml
@@ -23,3 +23,16 @@ sources:
   "1.13.1":
     url: "https://github.com/onnx/onnx/archive/refs/tags/v1.13.1.tar.gz"
     sha256: "090d3e10ec662a98a2a72f1bf053f793efc645824f0d4b779e0ce47468a0890e"
+patches:
+  "1.17.0":
+    - patch_description: "Fix CMakelist.txt to allow protobuf to get its own dependencies"
+      patch_file: "patches/0001-1.17.0-fix-protobuf-dependencies.patch"
+  "1.16.2":
+    - patch_description: "Fix CMakelist.txt to allow protobuf to get its own dependencies"
+      patch_file: "patches/0001-1.16.2-fix-protobuf-dependencies.patch"
+  "1.16.1":
+    - patch_description: "Fix CMakelist.txt to allow protobuf to get its own dependencies"
+      patch_file: "patches/0001-1.16.2-fix-protobuf-dependencies.patch"
+  "1.15.0":
+    - patch_description: "Fix CMakelist.txt to allow protobuf to get its own dependencies"
+      patch_file: "patches/0001-1.15.0-fix-protobuf-dependencies.patch"

--- a/recipes/onnx/all/patches/0001-1.15.0-fix-protobuf-dependencies.patch
+++ b/recipes/onnx/all/patches/0001-1.15.0-fix-protobuf-dependencies.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0372c54..bfccb9d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -177,7 +177,7 @@ else()
+     find_package(Protobuf)
+     if (Protobuf_FOUND)
+       set(Build_Protobuf OFF)
+-      if ("${Protobuf_VERSION}" VERSION_GREATER_EQUAL "4.22.0")
++      if (0)
+         # There are extra dependencies for protobuf.
+         find_package(absl REQUIRED)
+         find_package(utf8_range REQUIRED)

--- a/recipes/onnx/all/patches/0001-1.16.2-fix-protobuf-dependencies.patch
+++ b/recipes/onnx/all/patches/0001-1.16.2-fix-protobuf-dependencies.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b666eec..15f24c3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -178,7 +178,7 @@ else()
+       set(PROTOBUF_DIR "${_PROTOBUF_INSTALL_PREFIX}")
+       set(PROTOBUF_INCLUDE_DIR "${_PROTOBUF_INSTALL_PREFIX}/include")
+       set(Build_Protobuf OFF)
+-      if ("${Protobuf_VERSION}" VERSION_GREATER_EQUAL "4.22.0")
++      if (0)
+         # There are extra dependencies for protobuf.
+         find_package(absl REQUIRED)
+         find_package(utf8_range REQUIRED)

--- a/recipes/onnx/all/patches/0001-1.17.0-fix-protobuf-dependencies.patch
+++ b/recipes/onnx/all/patches/0001-1.17.0-fix-protobuf-dependencies.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d15d97e..f34a060 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -177,7 +177,7 @@ else()
+       set(PROTOBUF_DIR "${_PROTOBUF_INSTALL_PREFIX}")
+       set(PROTOBUF_INCLUDE_DIR "${_PROTOBUF_INSTALL_PREFIX}/include")
+       set(Build_Protobuf OFF)
+-      if ("${Protobuf_VERSION}" VERSION_GREATER_EQUAL "4.22.0")
++      if (0)
+         # There are extra dependencies for protobuf.
+         find_package(absl REQUIRED)
+         find_package(utf8_range REQUIRED)


### PR DESCRIPTION
### Summary
`Onnx` defines the dependencies of `protobuf` in its CMakeLists. This behaviour can generate a problem when someone consumes `onnx` and `protobuf` from the same recipe.

#### Motivation
close: https://github.com/conan-io/conan/issues/17315
