### PR TITLE
[libtins] Add compability to CMake 4.x and fix missing defines

### DIFF
--- a/recipes/libtins/all/conanfile.py
+++ b/recipes/libtins/all/conanfile.py
@@ -58,7 +58,8 @@ class LibTinsConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libpcap/1.10.4", transitive_headers=True, transitive_libs=True)
+        # pcap.h is largely imported in public headers: tins/packet_writer.h, tins/sniffer.h
+        self.requires("libpcap/1.10.4", transitive_headers=True)
         if self.options.with_ack_tracker or self.options.with_tcp_stream_custom_data:
             # Used in two public headers:
             # - https://github.com/mfontanini/libtins/blob/v4.4/include/tins/tcp_ip/ack_tracker.h#L38

--- a/recipes/libtins/all/conanfile.py
+++ b/recipes/libtins/all/conanfile.py
@@ -59,7 +59,7 @@ class LibTinsConan(ConanFile):
 
     def requirements(self):
         # pcap.h is largely imported in public headers: tins/packet_writer.h, tins/sniffer.h
-        self.requires("libpcap/1.10.4", transitive_headers=True)
+        self.requires("libpcap/1.10.5", transitive_headers=True)
         if self.options.with_ack_tracker or self.options.with_tcp_stream_custom_data:
             # Used in two public headers:
             # - https://github.com/mfontanini/libtins/blob/v4.4/include/tins/tcp_ip/ack_tracker.h#L38

--- a/recipes/libtins/all/conanfile.py
+++ b/recipes/libtins/all/conanfile.py
@@ -85,6 +85,7 @@ class LibTinsConan(ConanFile):
         tc.variables["LIBTINS_ENABLE_WPA2"] = self.options.with_wpa2
         tc.variables["LIBTINS_ENABLE_DOT11"] = self.options.with_dot11
         tc.variables["PCAP_LIBRARY"] = "libpcap::libpcap"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
         tc.generate()
         deps = CMakeDeps(self)
         deps.set_property("libpcap", "cmake_file_name", "PCAP")

--- a/recipes/libtins/all/conanfile.py
+++ b/recipes/libtins/all/conanfile.py
@@ -121,3 +121,7 @@ class LibTinsConan(ConanFile):
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.defines.append("TINS_STATIC")
             self.cpp_info.system_libs.extend(["ws2_32", "iphlpapi"])
+        if self.options.with_tcp_stream_custom_data:
+            self.cpp_info.defines.append("TINS_HAVE_TCP_STREAM_CUSTOM_DATA")
+        if self.options.with_ack_tracker:
+            self.cpp_info.defines.append("TINS_HAVE_ACK_TRACKER")

--- a/recipes/libtins/all/conanfile.py
+++ b/recipes/libtins/all/conanfile.py
@@ -76,15 +76,15 @@ class LibTinsConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["LIBTINS_BUILD_EXAMPLES"] = False
-        tc.variables["LIBTINS_BUILD_TESTS"] = False
-        tc.variables["LIBTINS_BUILD_SHARED"] = self.options.shared
-        tc.variables["LIBTINS_ENABLE_CXX11"] = True
-        tc.variables["LIBTINS_ENABLE_ACK_TRACKER"] = self.options.with_ack_tracker
-        tc.variables["LIBTINS_ENABLE_TCP_STREAM_CUSTOM_DATA"] = self.options.with_tcp_stream_custom_data
-        tc.variables["LIBTINS_ENABLE_WPA2"] = self.options.with_wpa2
-        tc.variables["LIBTINS_ENABLE_DOT11"] = self.options.with_dot11
-        tc.variables["PCAP_LIBRARY"] = "libpcap::libpcap"
+        tc.cache_variables["LIBTINS_BUILD_EXAMPLES"] = False
+        tc.cache_variables["LIBTINS_BUILD_TESTS"] = False
+        tc.cache_variables["LIBTINS_BUILD_SHARED"] = self.options.shared
+        tc.cache_variables["LIBTINS_ENABLE_CXX11"] = True
+        tc.cache_variables["LIBTINS_ENABLE_ACK_TRACKER"] = self.options.with_ack_tracker
+        tc.cache_variables["LIBTINS_ENABLE_TCP_STREAM_CUSTOM_DATA"] = self.options.with_tcp_stream_custom_data
+        tc.cache_variables["LIBTINS_ENABLE_WPA2"] = self.options.with_wpa2
+        tc.cache_variables["LIBTINS_ENABLE_DOT11"] = self.options.with_dot11
+        tc.cache_variables["PCAP_LIBRARY"] = "libpcap::libpcap"
         tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
         tc.generate()
         deps = CMakeDeps(self)

--- a/recipes/libtins/all/test_package/test_package.cpp
+++ b/recipes/libtins/all/test_package/test_package.cpp
@@ -1,4 +1,6 @@
 #include <tins/tins.h>
+#include <tins/data_link_type.h>
+#include <tins/tcp_ip/ack_tracker.h>
 
 using namespace Tins;
 


### PR DESCRIPTION

Changes to recipe:  **libtins/4.5.[version]**

#### Motivation

When updating the OusterSDK recipe in the PR https://github.com/conan-io/conan-center-index/pull/26108, it resulted in failure due to missing libtins in Conan Center. The last change in libtins recipes was in 2023, and when reviewing the recipe again, there were a few points that slipped out of my hands. This PR fixes those important points.

#### Details

- libtins' CMakeLists.txt there is no `cmake_minium_required` listed. We need to pass `CMAKE_POLICY_VERSION_MINIMUM=3.5` in order to make it compatible with CMake 4.x
- Use `cache_variables` instead of `CMakeToolchain.variables`. It's CMakeLists.txt has no `project()`
- From PR #17470 there is no evidence of needed transitive libs for pcap. Checking the public headers, only a few defines and `pcap_t` (an opaque struct) are used. 
- The public header [ack_tracker.h](https://github.com/mfontanini/libtins/blob/v4.5/include/tins/tcp_ip/ack_tracker.h#L35) checks the define `TINS_HAVE_ACK_TRACKER`
- The public header [stream.h](https://github.com/mfontanini/libtins/blob/v4.5/include/tins/tcp_ip/stream.h#L47) checks the define `TINS_HAVE_TCP_STREAM_CUSTOM_DATA` to use or not Boost.
- Bumped lipcap to 1.10.5 (patch version), so we can align with OusterSDK PR and both use the latest version.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
