### PR TITLE
OpenEXR: Add version 3.3.4

### DIFF
--- a/recipes/openexr/3.x/conandata.yml
+++ b/recipes/openexr/3.x/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.3.3":
-    url: "https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.3.3/openexr-3.3.3.tar.gz"
-    sha256: "d819b9f76cbe63cc6b7476267659900f00aab79b636a83f0ecac2be669ca97b5"
+  "3.3.4":
+    url: "https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.3.4/openexr-3.3.4.tar.gz"
+    sha256: "73a6d83edcc68333afb95e133f6e12012073815a854bc41abc1a01c1db5f124c"
   "3.3.2":
     url: "https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.3.2/openexr-3.3.2.tar.gz"
     sha256: "4fb4c643b39f04b67e8f4138e4d5a7804b62fdc15b8f6bcdd32ccc8ecd515683"

--- a/recipes/openexr/config.yml
+++ b/recipes/openexr/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.3.3":
+  "3.3.4":
     folder: "3.x"
   "3.3.2":
     folder: "3.x"


### PR DESCRIPTION
### Summary
Changes to recipe:  **openexr/3.3.4**

#### Motivation
Newest release has several bugfixes for several file modes and performance improvements.
3.3.3 isn't used yet by other recipes, so the thought there was to keep things clean be keeping 3.3.2 which is used and replacing 3.3.3 with 3.3.4

#### Details
https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.3.4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
