### PR TITLE
robin-hood-hashing: fix missing include

### DIFF
--- a/recipes/robin-hood-hashing/all/conandata.yml
+++ b/recipes/robin-hood-hashing/all/conandata.yml
@@ -21,6 +21,10 @@ sources:
     url: "https://github.com/martinus/robin-hood-hashing/archive/refs/tags/3.7.0.tar.gz"
     sha256: "1c4a107865becbabc0da337f9cf06f3aa6112f733efcbed0703238362a25b330"
 patches:
+  "3.11.5":
+    - patch_file: "patches/3.11.5-0001-fix-missing-stdint-include.patch"
+      patch_description: "Add missing stdint include"
+      patch_type: "portability"
   "3.11.1":
     - patch_file: "patches/3.11.1-0001-fix-missing-limits-include.patch"
       patch_description: "Add missing limits include"

--- a/recipes/robin-hood-hashing/all/patches/3.11.5-0001-fix-missing-stdint-include.patch
+++ b/recipes/robin-hood-hashing/all/patches/3.11.5-0001-fix-missing-stdint-include.patch
@@ -1,0 +1,12 @@
+diff --git a/src/include/robin_hood.h b/src/include/robin_hood.h
+index 0af031f..1017479 100644
+--- a/src/include/robin_hood.h
++++ b/src/include/robin_hood.h
+@@ -39,6 +39,7 @@
+ #define ROBIN_HOOD_VERSION_PATCH 5  // for backwards-compatible bug fixes
+ 
+ #include <algorithm>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>


### PR DESCRIPTION
### Summary
Changes to recipe:  **robin-hood-hashing/3.11.5**

#### Motivation
Build fails with GCC 15

#### Details
patch missing include

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
