### PR TITLE
libjpeg-turbo: add version 3.1.1

### DIFF
--- a/recipes/libjpeg-turbo/all/conandata.yml
+++ b/recipes/libjpeg-turbo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.1":
+    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.1/libjpeg-turbo-3.1.1.tar.gz"
+    sha256: "aadc97ea91f6ef078b0ae3a62bba69e008d9a7db19b34e4ac973b19b71b4217c"
   "3.1.0":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.0/libjpeg-turbo-3.1.0.tar.gz"
     sha256: "9564c72b1dfd1d6fe6274c5f95a8d989b59854575d4bbee44ade7bc17aa9bc93"

--- a/recipes/libjpeg-turbo/config.yml
+++ b/recipes/libjpeg-turbo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.1.1":
+    folder: all
   "3.1.0":
     folder: all
   "3.0.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjpeg-turbo/all**

#### Motivation
New upstream version

#### Details
https://github.com/libjpeg-turbo/libjpeg-turbo/compare/3.1.0...3.1.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
