### PR TITLE
Add missing cstdint header to robin-hood-hashing

### DIFF
--- a/recipes/robin-hood-hashing/all/conandata.yml
+++ b/recipes/robin-hood-hashing/all/conandata.yml
@@ -21,6 +21,10 @@ sources:
     url: "https://github.com/martinus/robin-hood-hashing/archive/refs/tags/3.7.0.tar.gz"
     sha256: "1c4a107865becbabc0da337f9cf06f3aa6112f733efcbed0703238362a25b330"
 patches:
+  "3.11.5":
+    - patch_file: "patches/3.11.1-0002-fix-missing-cstdint.patch"
+      patch_description: "Add missing limits cstdint include"
+      patch_type: "portability"
   "3.11.1":
     - patch_file: "patches/3.11.1-0001-fix-missing-limits-include.patch"
       patch_description: "Add missing limits include"

--- a/recipes/robin-hood-hashing/all/patches/3.11.1-0002-fix-missing-cstdint.patch
+++ b/recipes/robin-hood-hashing/all/patches/3.11.1-0002-fix-missing-cstdint.patch
@@ -1,0 +1,10 @@
+--- a/src/include/robin_hood.h
++++ b/src/include/robin_hood.h
+@@ -42,6 +42,7 @@
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>
++#include <cstdint>
+ #include <limits>
+ #include <memory> // only to support hash of smart pointers
+ #include <stdexcept>


### PR DESCRIPTION
### Summary
Changes to recipe:  **robin-hood-hashing/3.11.5**

#### Motivation
Compilation cannot complete when cstdint isn't transitively part of the included headers. In some standard libraries, it is; however in others it isn't.

#### Details
The missing header means that macros present in cstdint are not present, specifically `UINT64_C`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
