### PR TITLE
plutosvg: Fix static library name in msvc

### DIFF
--- a/recipes/plutosvg/all/conanfile.py
+++ b/recipes/plutosvg/all/conanfile.py
@@ -1,9 +1,10 @@
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.files import copy, get, rename, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.microsoft import is_msvc
 import os
 
 required_conan_version = ">=2.4"
@@ -66,6 +67,11 @@ class PlutoSVGConan(ConanFile):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         meson = Meson(self)
         meson.install()
+
+        # https://github.com/mesonbuild/meson/issues/1412
+        if is_msvc(self) and not self.options.shared:
+            rename(self, os.path.join(self.package_folder, "lib", "libplutosvg.a"),
+                os.path.join(self.package_folder, "lib", "plutosvg.lib"))
 
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))

--- a/recipes/plutosvg/all/test_package/conanfile.py
+++ b/recipes/plutosvg/all/test_package/conanfile.py
@@ -1,29 +1,23 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.layout import basic_layout
-from conan.tools.meson import Meson
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    generators = "CMakeDeps", "CMakeToolchain"
     test_type = "explicit"
 
     def layout(self):
-        basic_layout(self)
+        cmake_layout(self)
 
     def requirements(self):
         self.requires(self.tested_reference_str)
 
-    def build_requirements(self):
-        self.tool_requires("meson/[>=1.2.3 <2]")
-        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/[>=2.2 <3]")
-
     def build(self):
-        meson = Meson(self)
-        meson.configure()
-        meson.build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
         if can_run(self):

--- a/recipes/plutosvg/all/test_package/meson.build
+++ b/recipes/plutosvg/all/test_package/meson.build
@@ -1,5 +1,0 @@
-project('test_package', 'c')
-package_dep = dependency('plutosvg')
-executable('test_package',
-            sources : ['test_package.c'],
-            dependencies : [package_dep])


### PR DESCRIPTION
### Summary
Changes to recipe:  **plutosvg/0.0.7**

#### Motivation
Fixes issue at https://github.com/conan-io/conan-center-index/pull/27166

#### Details
meson does generate .a libs for windows static that cmake does not recognize


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
