### PR TITLE
Add vulkan-utility-libraries recipe

### DIFF
--- a/recipes/vulkan-utility-libraries/all/conandata.yml
+++ b/recipes/vulkan-utility-libraries/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.4.313.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/vulkan-sdk-1.4.313.0.tar.gz"
+    sha256: "3e04f32c6023997c153ad4b63e2fd344257e40a57ff5229ab7373e08a4fa2dd2"

--- a/recipes/vulkan-utility-libraries/all/conanfile.py
+++ b/recipes/vulkan-utility-libraries/all/conanfile.py
@@ -15,14 +15,12 @@ class VulkanUtilityLibraries(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
     topics = ("vulkan")
-    package_type = "library"
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
-        "shared": [True, False],
         "fPIC": [True, False],
     }
     default_options = {
-        "shared": False,
         "fPIC": True,
     }
     implements = ["auto_shared_fpic"]

--- a/recipes/vulkan-utility-libraries/all/conanfile.py
+++ b/recipes/vulkan-utility-libraries/all/conanfile.py
@@ -1,0 +1,74 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm, rmdir
+import os
+
+
+required_conan_version = ">=2.0.9"
+
+
+class VulkanUtilityLibraries(ConanFile):
+    name = "vulkan-utility-libraries"
+    description = "Code shared across various Vulkan repositories, for Vulkan SDK developers and users."
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
+    topics = ("vulkan")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires(f"vulkan-headers/{self.version}", transitive_headers=True)
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.22.1]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "VulkanUtilityLibraries")
+        for component in ["SafeStruct", "LayerSettings", "UtilityHeaders"]:
+            self.cpp_info.components[component].set_property("cmake_target_name", f"Vulkan::{component}")
+            self.cpp_info.components[component].requires = ["vulkan-headers::vulkanheaders"]
+            if component != "UtilityHeaders":
+                self.cpp_info.components[component].libs = [f"Vulkan{component}"]
+            else:
+                self.cpp_info.components[component].libdirs = []
+                self.cpp_info.components[component].bindirs = []

--- a/recipes/vulkan-utility-libraries/all/conanfile.py
+++ b/recipes/vulkan-utility-libraries/all/conanfile.py
@@ -55,7 +55,9 @@ class VulkanUtilityLibraries(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        license_folder = os.path.join(self.package_folder, "licenses")
+        copy(self, "LICENSE.md", self.source_folder, license_folder)
+        copy(self, "LICENSES/*", self.source_folder, license_folder, keep_path=False)
         cmake = CMake(self)
         cmake.install()
 

--- a/recipes/vulkan-utility-libraries/all/test_package/CMakeLists.txt
+++ b/recipes/vulkan-utility-libraries/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(VulkanUtilityLibraries REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE Vulkan::LayerSettings Vulkan::SafeStruct Vulkan::UtilityHeaders)

--- a/recipes/vulkan-utility-libraries/all/test_package/conanfile.py
+++ b/recipes/vulkan-utility-libraries/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/vulkan-utility-libraries/all/test_package/test_package.cpp
+++ b/recipes/vulkan-utility-libraries/all/test_package/test_package.cpp
@@ -1,0 +1,25 @@
+#include <vulkan/layer/vk_layer_settings.h>
+#include <vulkan/utility/vk_safe_struct.hpp>
+#include <vulkan/utility/vk_struct_helper.hpp>
+
+
+int main() {
+    vku::safe_VkInstanceCreateInfo safe_info;
+    VkApplicationInfo app = vku::InitStructHelper();
+    app.pApplicationName = "test";
+    app.applicationVersion = 42;
+
+    VkDebugUtilsMessengerCreateInfoEXT debug_ci = vku::InitStructHelper();
+    debug_ci.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+
+    VkInstanceCreateInfo info = vku::InitStructHelper();
+    info.pApplicationInfo = &app;
+    info.pNext = &debug_ci;
+
+    safe_info.initialize(&info);
+
+    VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vkuCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
+
+    return 0;
+}

--- a/recipes/vulkan-utility-libraries/config.yml
+++ b/recipes/vulkan-utility-libraries/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.4.313.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-utility-libraries/1.4.313.0**

#### Motivation
The [vulkan utility libraries](https://github.com/KhronosGroup/Vulkan-Utility-Libraries) are a requirement of the vulkan validation layers

#### Details
new recipe. Previous recipes were added by #21059 and #27484 but were both abandoned.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
