### PR TITLE
cpython >=3.12: prevent picking up system gdbm when with_gdbm=False

### DIFF
--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -413,6 +413,14 @@ class CPythonConan(ConanFile):
             replace_in_file(self, os.path.join(self.source_folder, "configure"),
                             'OPENSSL_LIBS="-lssl -lcrypto"',
                             'OPENSSL_LIBS="-lssl -lcrypto -lz"')
+        if Version(self.version) >= "3.12":
+            if not self.options.get_safe("with_gdbm", False):
+                for src in ["gdbm/ndbm.h", "gdbm-ndbm.h", "gdbm.h", "ndbm.h", "db.h"]:
+                    self._regex_replace_in_file(
+                        os.path.join(self.source_folder, "configure"),
+                        re.compile("\\b(?<![-/])" + src.replace(".", "\\.") + "\\b"),
+                        f"{src}.disabled")
+
         if is_msvc(self):
             runtime_library = {
                 "MT": "MultiThreaded",


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpython/[>=3.12]**

#### Motivation
When gdbm devel package is installed in the system and **with_gdbm=False**, cpython picks up system gdbm and uses it for building, which we obviously do not want when we've just disabled it.
Similar problem with other system package was already described:

> Edit: After removing `libncurses-dev` and other dev packages (unsure why they were installed, but besides the point), all options now work in all versions. So some of them are affected by the system packages, ideally they shouldn't be. 

 _Originally posted by @Ahajha in [#23151](https://github.com/conan-io/conan-center-index/issues/23151#issuecomment-2044132582)_

#### Details
Prerequisites: gdbm devel package is installed in the system.

##### Before the fix
Full build log:
[build_log_before_fix.txt](https://github.com/user-attachments/files/20725011/build_log_before_fix.txt)

Configure script finds gdbm:
```
build	13-May-2025 11:49:14	checking for gdbm.h... yes
build	13-May-2025 11:49:14	checking for gdbm_open in -lgdbm... yes
build	13-May-2025 11:49:14	checking for ndbm.h... yes
build	13-May-2025 11:49:14	checking for library containing dbm_open... -lgdbm_compat
build	13-May-2025 11:49:14	checking for ndbm presence and linker args... yes (-lgdbm_compat)
build	13-May-2025 11:49:14	checking for gdbm/ndbm.h... yes
build	13-May-2025 11:49:14	checking for gdbm-ndbm.h... no
build	13-May-2025 11:49:14	checking for library containing dbm_open... -lgdbm_compat
build	13-May-2025 11:49:14	checking for db.h... yes
build	13-May-2025 11:49:14	checking for libdb... yes
build	13-May-2025 11:49:14	checking for --with-dbmliborder... gdbm:ndbm:bdb
build	13-May-2025 11:49:14	checking for _dbm module CFLAGS and LIBS... -DUSE_GDBM_COMPAT -lgdbm_compat
```

Test package fails:
```
build	13-May-2025 11:50:06	cpython/3.12.7 (test package): RUN: /root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/.conan/p/b/cpyth9e4a8329a316e/p/bin/python3.12 "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/test_package.py" -b "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/build/gcc-10-x86_64-17-release" -t gdbm
build	13-May-2025 11:50:06	cpython/3.12.7 (test package): Full command: . "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/build/gcc-10-x86_64-17-release/generators/conanrun.sh" && /root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/.conan/p/b/cpyth9e4a8329a316e/p/bin/python3.12 "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/test_package.py" -b "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/build/gcc-10-x86_64-17-release" -t gdbm
build	13-May-2025 11:50:06	testing gdbm
build	13-May-2025 11:50:06	keys read from gdbm.db are [b'key2', b'key1']
build	13-May-2025 11:50:06	
build	13-May-2025 11:50:07	Traceback (most recent call last):
build	13-May-2025 11:50:07	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/.nox/root/lib/python3.9/site-packages/conan/internal/errors.py", line 35, in conanfile_exception_formatter
build	13-May-2025 11:50:07	    yield
build	13-May-2025 11:50:07	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/.nox/root/lib/python3.9/site-packages/conan/api/subapi/local.py", line 113, in test
build	13-May-2025 11:50:07	    conanfile.test()
build	13-May-2025 11:50:07	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/conanfile.py", line 143, in test
build	13-May-2025 11:50:07	    self._test_module("gdbm", self._cpython_option("with_gdbm"))
build	13-May-2025 11:50:07	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/conanfile.py", line 124, in _test_module
build	13-May-2025 11:50:07	    raise ConanException(f"Module '{module}' works, but should not have worked")
build	13-May-2025 11:50:07	conan.errors.ConanException: Module 'gdbm' works, but should not have worked
```

##### After the fix

Full build log:
[build_log_after_fix.txt](https://github.com/user-attachments/files/20725069/build_log_after_fix.txt)

Configure script doesn't find gdbm:
```
build	26-May-2025 22:12:26	checking for gdbm.h.disabled... no
build	26-May-2025 22:12:26	checking for ndbm.h.disabled... no
build	26-May-2025 22:12:26	checking for ndbm presence and linker args...  ()
build	26-May-2025 22:12:26	checking for gdbm/ndbm.h.disabled... no
build	26-May-2025 22:12:26	checking for gdbm-ndbm.h.disabled... no
build	26-May-2025 22:12:26	checking for db.h.disabled... no
build	26-May-2025 22:12:26	checking for --with-dbmliborder... gdbm:ndbm:bdb
build	26-May-2025 22:12:26	checking for _dbm module CFLAGS and LIBS...  
```

Test package succeeds:
```
build	26-May-2025 22:13:18	cpython/3.12.7 (test package): RUN: /root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/.conan/p/b/cpytha199c935e6240/p/bin/python3.12 "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/test_package.py" -b "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/build/gcc-10-x86_64-17-release" -t gdbm
build	26-May-2025 22:13:18	cpython/3.12.7 (test package): Full command: . "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/build/gcc-10-x86_64-17-release/generators/conanrun.sh" && /root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/.conan/p/b/cpytha199c935e6240/p/bin/python3.12 "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/test_package.py" -b "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/build/gcc-10-x86_64-17-release" -t gdbm
build	26-May-2025 22:13:18	testing gdbm
build	26-May-2025 22:13:18	Traceback (most recent call last):
build	26-May-2025 22:13:18	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/test_package.py", line 203, in <module>
build	26-May-2025 22:13:18	    main()
build	26-May-2025 22:13:18	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/test_package.py", line 199, in main
build	26-May-2025 22:13:18	    ALL_TESTS[ns.test_module]()
build	26-May-2025 22:13:18	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/test_package.py", line 22, in inner_fn
build	26-May-2025 22:13:18	    fn()
build	26-May-2025 22:13:18	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/recipes/cpython/all/test_package/test_package.py", line 59, in test_gdbm
build	26-May-2025 22:13:18	    import dbm.gnu as gdbm
build	26-May-2025 22:13:18	  File "/root/bamboo-agent-home/xml-data/build-dir/C2-KF5036-J0/.conan/p/b/cpytha199c935e6240/p/lib/python3.12/dbm/gnu.py", line 3, in <module>
build	26-May-2025 22:13:18	    from _gdbm import *
build	26-May-2025 22:13:18	ModuleNotFoundError: No module named '_gdbm'
build	26-May-2025 22:13:18	
build	26-May-2025 22:13:18	cpython/3.12.7 (test package): Module failed as expected
```

The fix is silly but it works great and doesn't require heavy patching of configure script or it's template.
CPython <=3.10, 3.11 and >=3.12 use different build scripts and this fix is intended for >=3.12 only.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
