### PR TITLE
[boost] Fix: Remove dynamic libs when building with static 

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1709,7 +1709,9 @@ class BoostConan(ConanFile):
                 rename(self, bin_file, os.path.join(self.package_folder, "bin", os.path.basename(bin_file)))
 
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
-        if is_apple_os(self) and not self._shared:
+        if is_apple_os(self) and not self._shared and Version(self.version) >= "1.88.0":
+            # FIXME: Boost 1.88 installs both .a and .dylib files for static libraries
+            # https://github.com/boostorg/boost/issues/1051
             rm(self, "*.dylib", os.path.join(self.package_folder, "lib"))
 
     def _create_emscripten_libs(self):

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1709,6 +1709,8 @@ class BoostConan(ConanFile):
                 rename(self, bin_file, os.path.join(self.package_folder, "bin", os.path.basename(bin_file)))
 
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+        if is_apple_os(self) and not self._shared:
+            rm(self, "*.dylib", os.path.join(self.package_folder, "lib"))
 
     def _create_emscripten_libs(self):
         # Boost Build doesn't create the libraries, but it gets close,


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.88.0**

#### Motivation

When building Boost under Mac and requiring static libraries only, the resulting build will produce both static and dynamic libraries for a few Boost modules.

This reported scenario can be viewed too by the produced build in the last Boost 1.88 PR: https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-27526/3/package_build_logs/build_log_boost_1_88_0_02627a4b63c60cef7daff8b936b121ff_7a20febe5394559edf1d4111f529a5e35161a75e.success.txt

The same does not occur on Linux and Windows, only for Mac.

fixes #27604

#### Details

Something changed in Boost 1.88.0. I was not able to detect the root cause. So far, I tried:

- Use the previous version of b2 (5.2.1)
- Compare Boost 1.88.0 and 1.87.0 build logs: Defines like BOOST_CHARCONV_DYN_LINK are active only in 1.88.0

I opened an issue to Boost directly, reporting the case: https://github.com/boostorg/boost/issues/1051

/cc @akielbas

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
