### PR TITLE
zlib: add test to check for vsnprintf support

### DIFF
--- a/recipes/zlib/all/test_package/CMakeLists.txt
+++ b/recipes/zlib/all/test_package/CMakeLists.txt
@@ -3,5 +3,10 @@ project(test_package LANGUAGES C)
 
 find_package(ZLIB REQUIRED)
 
+if(WITH_TEST_VSNPRINTF)
+    message(STATUS "Testing for vsnprintf support")
+    add_compile_definitions(WITH_TEST_VSNPRINTF)
+endif()
+
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)

--- a/recipes/zlib/all/test_package/conanfile.py
+++ b/recipes/zlib/all/test_package/conanfile.py
@@ -1,19 +1,32 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
+
+    options = {
+        "with_test_vsnprinft": [True, False],
+    }
+
+    default_options = {
+        "with_test_vsnprinft": True,
+    }
 
     def layout(self):
         cmake_layout(self)
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["WITH_TEST_VSNPRINTF"] = self.options.with_test_vsnprinft
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/zlib/all/test_package/test_package.c
+++ b/recipes/zlib/all/test_package/test_package.c
@@ -3,9 +3,32 @@
 
 #include <zlib.h>
 
+int zlib_test_vsnprintf(void) {
+#ifdef WITH_TEST_VSNPRINTF
+    // 25th bit indicates vsnprinft support
+    // 26th bit indicates whether vnsprinft returned void at compile time (i.e. doesn't work correctly)
+    // from the zlib.h header:
+    // > 25: 0 = *nprintf, 1 = *printf -- 1 means gzprintf() not secure!
+    // > 26: 0 = returns value, 1 = void -- 1 means inferred string length returned
+    uLong flags = zlibCompileFlags();
+
+    uLong flag_vsnprintf_support = 1L << 25;
+    uLong flag_vsnprintf_void_ret = 1L << 26;
+
+    if ((flags & flag_vsnprintf_support) == flag_vsnprintf_support || (flags & flag_vsnprintf_void_ret) == flag_vsnprintf_void_ret) {
+        printf("ZLIB is not compiled with vnsprinft support\n");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+#else
+    return EXIT_SUCCESS;
+#endif
+}
+
 int main(void) {
 
     printf("ZLIB VERSION: %s\n", zlibVersion());
 
-    return EXIT_SUCCESS;
+    return zlib_test_vsnprintf();
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **zlib/*** (test)

#### Motivation
Depending on the build system, zlib may or may not still be vulnerable to CVE-2003-0107. `gzprintf()` is vulnerable to a buffer overflow if the library has been compiled on a system that does not support `*nprintf` functions (specifically `vsnprintf()`, `gzprintf()` falls back to `vsprintf()` if there is no support for the former). I implemented a simple test to check against this as it was deemed a necessity to comply to our security enforcement at work. I wanted to upstream it in case other people are also dependent on this, and since I had to do the work anyway.

#### Details
The zlib test, instead of just checking the current version, now also checks for compile flags using zlib-provided functionality. We check for whether or not `vsnprinft()` support is compiled into the lib, and whether it behaves correctly. It returns a failure code upon exit if any of the 2 flags indicate undesired results.
The test is toggle-able through an option in its Conanfile. Currently, it's set to be enabled by default, but I'm open to changing this behavior. It was simply easier for us to enable the test by default, which is why I opted to do so.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
