### PR TITLE
Updated hazelcast-cpp-client with the latest patch version 5.4.0 release

### DIFF
--- a/recipes/hazelcast-cpp-client/all/conandata.yml
+++ b/recipes/hazelcast-cpp-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.4.0":
+    url: "https://github.com/hazelcast/hazelcast-cpp-client/archive/v5.4.0.tar.gz"
+    sha256: "20c6a6b749ff2e28b57bbfa520988daecf446966a6f52ab62c91da7b7cd3779c"
   "5.3.0":
     url: "https://github.com/hazelcast/hazelcast-cpp-client/archive/v5.3.0.tar.gz"
     sha256: "5d38710d027b6311a479c2e4c42f9ac2a04c831a3eb673d4539a2221c8ff8015"

--- a/recipes/hazelcast-cpp-client/config.yml
+++ b/recipes/hazelcast-cpp-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.4.0":
+    folder: all
   "5.3.0":
     folder: all
   "5.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe: **hazelcast-cpp-client/[5.4.0]**

#### Motivation
Updated `hazelcast-cpp-client` with the latest `5.4.0` patch release. This release:
- fixes `unused parameter warnings` bug 
- adds new feature `on_cancel callback handler for the reliable_listener` 

The new `5.4.0` release is available at [repo](https://github.com/hazelcast/hazelcast-cpp-client/releases/tag/v5.4.0).

#### Details
Add new `hazelcast-cpp-client` patch release `5.4.0` to the list of supported versions

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
