### PR TITLE
pulseaudio: Don't fail on compiler checks that use argless main

### DIFF
--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -4,11 +4,11 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
-from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.files import copy, get, rm, rmdir, replace_in_file
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
 
 class PulseAudioConan(ConanFile):
@@ -90,14 +90,14 @@ class PulseAudioConan(ConanFile):
         self.tool_requires("gettext/0.21")
         self.tool_requires("libtool/2.4.7")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
+            self.tool_requires("pkgconf/[>=2.2 <3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        replace_in_file(self, os.path.join(self.source_folder, "configure"),
+                        "-pedantic -Werror", "-pedantic -Werror -Wno-strict-prototypes")
 
     def generate(self):
-        env = VirtualBuildEnv(self)
-        env.generate()
         if not cross_building(self):
             env = VirtualRunEnv(self)
             env.generate(scope="build")


### PR DESCRIPTION
Closes https://github.com/conan-io/conan-center-index/issues/25075

After investigating this, this does not seem like a bug in Conan, but how Pulseaudio is checking for compiler flags.

If we look into the config.log for the build, we see:

```
/usr/bin/clang -c -fPIC -O3 -pedantic -Werror -std=gnu11 [...]
error: a function declaration without a prototype is deprecated in all versions of C [-Werror, -Wstrict-prototypes]
 | main ()
 |      ^ 
```

Which strongly points to the culprit here: Pulseaudio's `configure.ac` is adding those `-pedantic -Werror` flags to the compilation checks, and Clang is then failing because of it, unrelated to the actual check being performed.

In fact, if I patch out the `-Werror` flag from `configure` (Or add the `-Wno-strict-prototypes` flag to omit this specific warning), the compilation is succesful on my local machine.


I've tested locally and now I can build 14.x with Clang on my machine. 13.x has compilation errors that are not related to this and were present before