### PR TITLE
tcl: add library soname

### DIFF
--- a/recipes/tcl/all/conanfile.py
+++ b/recipes/tcl/all/conanfile.py
@@ -90,6 +90,10 @@ class TclConan(ConanFile):
                 "--enable-symbols={}".format(yes_no(self.settings.build_type == "Debug")),
                 "--enable-64bit={}".format(yes_no(self.settings.arch == "x86_64")),
             ])
+            if self.settings.os == "Linux":
+                # Ensure the library has a soname, fix https://github.com/conan-io/conan-center-index/issues/27691
+                # (mirror debian behavior)
+                tc.configure_args.append("TCL_SHLIB_LD_EXTRAS=-Wl,-soname,${TCL_LIB_FILE}")
             tc.generate()
 
             deps = AutotoolsDeps(self)


### PR DESCRIPTION
fix https://github.com/conan-io/conan-center-index/issues/27691


After the fix:
```
Dynamic section at offset 0x1dfc90 contains 29 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-aarch64.so.1]
 0x000000000000000e (SONAME)             Library soname: [libtcl8.6.so]
```

`test_package` executable:

```
Dynamic section at offset 0xfd10 contains 29 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libtcl8.6.so]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
```