### PR TITLE
protobuf: version 6.31.1

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.31.1":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v6.31.1.tar.gz"
+    sha256: "597071a340acc5346494c119ba3a541825c3f81071fc783521b24e29a485d60f"
   "6.30.1":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.30.1.tar.gz"
     sha256: "c97cc064278ef2b8c4da66c1f85613642ecbd5a0c4217c0defdf7ad1b3de9fa5"
@@ -33,6 +36,44 @@ patches:
       patch_source: "https://github.com/protocolbuffers/protobuf/pull/10103"
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
+  "6.31.1":
+    - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_optional
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_type_traits
+    - absl_utility
+    - absl_variant
   "6.30.1":
     - absl_absl_check
     - absl_absl_log

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -36,7 +36,7 @@ class ProtobufConan(ConanFile):
         "with_zlib": True,
         "with_rtti": True,
         "lite": False,
-        "upb": False,
+        "upb": True,
         "debug_suffix": True,
     }
 

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.31.1":
+    folder: all
   "6.30.1":
     folder: all
   "5.29.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuf/[6.31.1]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Add the new version

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

recipes/protobuf/all/conandata.yml
recipes/protobuf/config.yml

[https://github.com/protocolbuffers/protobuf/compare/v6.30.1...v6.31.1](https://github.com/protocolbuffers/protobuf/compare/v6.30.1...v6.31.1)

The version 6.31.1 is not compiled without this flag because the libupb header cannot be found.

[https://github.com/protocolbuffers/protobuf/blob/main/CMakeLists.txt](https://github.com/protocolbuffers/protobuf/blob/main/CMakeLists.txt)
option(protobuf_BUILD_LIBUPB "Build libupb" ON)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
