### PR TITLE
fastpfor: Fix sha256 for 0.2.0 after retagging

### DIFF
--- a/recipes/fastpfor/all/conandata.yml
+++ b/recipes/fastpfor/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
   "0.2.0":
     url: "https://github.com/lemire/FastPFor/archive/refs/tags/v0.2.0.tar.gz"
-    sha256: "d9f0eacf9c3c61866cda23bae35107ca9c5d35fa7b7a96ca9ccc85803d7e753d"
+    sha256: "fe8aca450a5bb35d11b9353660134efd427a8add47afe262df8991c29ab1139c"
 patches:
   "0.2.0":
     - patch_file: "patches/0.2.0-0001-fix-cmake.patch"
-      patch_description: "enable shared build, disable unittest/utility"
+      patch_description: "find cmake deps, disable unittest/utility"
       patch_type: "conan"

--- a/recipes/fastpfor/all/conanfile.py
+++ b/recipes/fastpfor/all/conanfile.py
@@ -45,7 +45,7 @@ class FastPFORConan(ConanFile):
     def validate(self):
         check_min_cppstd(self, 11)
         if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "15.0":
-            raise ConanInvalidConfiguration(f"${self.ref} doesn't support ${self.settings.compiler} < 15.0")
+            raise ConanInvalidConfiguration(f"apple-clang < 15.0 not supported")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/fastpfor/all/conanfile.py
+++ b/recipes/fastpfor/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
@@ -52,11 +52,15 @@ class FastPFORConan(ConanFile):
         apply_conandata_patches(self)
 
     def generate(self):
+        if Version(self.version) > "0.2.0":  # pylint: disable=conan-unreachable-upper-version
+            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc = CMakeToolchain(self)
         tc.variables["WITH_TEST"] = False
         if self._has_simde:
             tc.cache_variables["SUPPORT_NEON"] = True
             tc.preprocessor_definitions["SIMDE_ENABLE_NATIVE_ALIASES"] = 1
+        if Version(self.version) <= "0.2.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()

--- a/recipes/fastpfor/all/conanfile.py
+++ b/recipes/fastpfor/all/conanfile.py
@@ -3,11 +3,10 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.apple import is_apple_os
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
 class FastPFORConan(ConanFile):
     name = "fastpfor"
@@ -46,7 +45,7 @@ class FastPFORConan(ConanFile):
     def validate(self):
         check_min_cppstd(self, 11)
         if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "15.0":
-            raise ConanInvalidConfiguration("${self.ref} doesn't support ${self.settings.compiler} < 15.0")
+            raise ConanInvalidConfiguration(f"${self.ref} doesn't support ${self.settings.compiler} < 15.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
After https://github.com/conan-io/conan-center-index/issues/27684#issuecomment-2978052628, we can confirm that the release was re-tagged and thus the checksum has changed

Closes https://github.com/conan-io/conan-center-index/issues/27684