### PR TITLE
mold: Add version 2.40.1

### DIFF
--- a/recipes/mold/all/conandata.yml
+++ b/recipes/mold/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.40.1":
+    url: "https://github.com/rui314/mold/archive/refs/tags/v2.40.1.tar.gz"
+    sha256: "d1ce09a69941f8158604c3edcc96c7178231e7dba2da66b20f5ef6e112c443b7"
   "2.36.0":
     url: "https://github.com/rui314/mold/archive/refs/tags/v2.36.0.tar.gz"
     sha256: "3f57fe75535500ecce7a80fa1ba33675830b7d7deb1e5ee9a737e2bc43cdb1c7"
@@ -26,3 +29,8 @@ sources:
   "1.11.0":
     url: "https://github.com/rui314/mold/archive/refs/tags/v1.11.0.tar.gz"
     sha256: "99318eced81b09a77e4c657011076cc8ec3d4b6867bd324b8677974545bc4d6f"
+patches:
+  "2.40.1":
+    - patch_file: "patches/2.40.1/0001-patch-enforce-c-11-for-tbb.patch"
+      patch_description: "Fix bundled oneTBB build by enforcing C++11 standard"
+      patch_type: "conan"

--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get, rmdir, apply_conandata_patches, export_conandata_patches
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.scm import Version
 from conan.tools.env import VirtualBuildEnv
@@ -75,8 +75,12 @@ class MoldConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.18.0 <4]")
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/mold/all/patches/2.40.1/0001-patch-enforce-c-11-for-tbb.patch
+++ b/recipes/mold/all/patches/2.40.1/0001-patch-enforce-c-11-for-tbb.patch
@@ -1,0 +1,28 @@
+From 2f29fc752620180d88e82792adb2ff8a1d886bd1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tim=20Friedrich=20Br=C3=BCggemann?=
+ <tim.brueggemann@dampsoft.de>
+Date: Tue, 17 Jun 2025 09:48:43 +0200
+Subject: [PATCH] patch: Enforce C++11 for TBB
+
+---
+ third-party/tbb/CMakeLists.txt | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/third-party/tbb/CMakeLists.txt b/third-party/tbb/CMakeLists.txt
+index 12273b3e..21c4e2ef 100644
+--- a/third-party/tbb/CMakeLists.txt
++++ b/third-party/tbb/CMakeLists.txt
+@@ -77,9 +77,7 @@ include(CMakeDependentOption)
+ # ---------------------------------------------------------------------------------------------------------
+ # Handle C++ standard version.
+ if (NOT MSVC)  # no need to cover MSVC as it uses C++14 by default.
+-    if (NOT CMAKE_CXX_STANDARD)
+-        set(CMAKE_CXX_STANDARD 11)
+-    endif()
++    set(CMAKE_CXX_STANDARD 11)
+ 
+     if (CMAKE_CXX${CMAKE_CXX_STANDARD}_STANDARD_COMPILE_OPTION)  # if standard option was detected by CMake
+         set(CMAKE_CXX_STANDARD_REQUIRED ON)
+-- 
+2.25.1
+

--- a/recipes/mold/config.yml
+++ b/recipes/mold/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.40.1":
+    folder: all
   "2.36.0":
     folder: all
   "2.34.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mold/2.40.1**

#### Motivation
Add new version alongside a needed patch since Mold commit `b990467c1634a2f909600c8f1848af4839dbd95d`.

#### Details
The patch provided is needed as otherwise the bundled OneTBB library tries to build with `CMAKE_CXX_STANDARD` set to 20, which fails. See [this issue](https://github.com/rui314/mold/issues/1473) for more information.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
