### PR TITLE
libpcap: disable openssl

### DIFF
--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -98,6 +98,7 @@ class LibPcapConan(ConanFile):
                 # to inject this compilation flag themselves
                 tc.variables["USE_STATIC_RT"] = False
             tc.cache_variables["DISABLE_DPDK"] = True
+            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_OpenSSL"] = True
 
             if Version(self.version) >= "1.10.5":
                 self.output.warning("PCAP on Windows is currently built with package capture capabilities - only support is for reading/writing capture files")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpcap/***

With the current recipe, libpcap grabs the system version of openssl if it is detected, because openssl is not in the requirements. Also it ends up making the build fail

cf https://github.com/the-tcpdump-group/libpcap/blob/0276de45b4a6037a31dc557a557d7b8723571d01/CMakeLists.txt#L1571

see in the log below:
`-- Found OpenSSL: optimized;C:/Program Files/OpenSSL/lib/VC/x64/MD/libcrypto.lib;debug;C:/Program Files/OpenSSL/lib/VC/x64/MDd/libcrypto.lib (found version "3.4.1")`

#### Details
<details><summary>failing log</summary>

	Host profile:
	Build profile:
	[settings]
	arch=x86_64
	build_type=Release
	compiler=msvc
	compiler.cppstd=14
	compiler.runtime=dynamic
	compiler.runtime_type=Release
	compiler.version=194
	os=Windows
	[options]
	*/*:shared=True
	[conf]
	tools.system.package_manager:mode=install
	tools.system.package_manager:sudo=True

	[settings]
	arch=x86_64
	build_type=Release
	compiler=msvc
	compiler.cppstd=14
	compiler.runtime=dynamic
	compiler.runtime_type=Release
	compiler.version=194
	os=Windows
	[conf]
	tools.system.package_manager:mode=install
	tools.system.package_manager:sudo=True


	======== Input profiles ========
	Profile host:
	[settings]
	arch=x86_64
	build_type=Release
	compiler=msvc
	compiler.cppstd=14
	compiler.runtime=dynamic
	compiler.runtime_type=Release
	compiler.version=194
	os=Windows
	[options]
	*/*:shared=True
	[conf]
	tools.system.package_manager:mode=install
	tools.system.package_manager:sudo=True

	Profile build:
	[settings]
	arch=x86_64
	build_type=Release
	compiler=msvc
	compiler.cppstd=14
	compiler.runtime=dynamic
	compiler.runtime_type=Release
	compiler.version=194
	os=Windows
	[conf]
	tools.system.package_manager:mode=install
	tools.system.package_manager:sudo=True


	======== Computing dependency graph ========
	winflexbison/2.5.25: Not found in local cache, looking in remotes...
	winflexbison/2.5.25: Checking remote: community
	Connecting to remote 'community' with user 'ericLemanissier'
	winflexbison/2.5.25: Downloaded recipe revision 752283c174ca9cf1eea23db81a22dc13
	Graph root
		cli
	Requirements
		libpcap/1.10.4#bcf0b2ec38621eba66f20b7aeb363dd5 - Cache
	Build requirements
		winflexbison/2.5.25#752283c174ca9cf1eea23db81a22dc13 - Downloaded (community)

	======== Computing necessary packages ========
	libpcap/1.10.4: Forced build from source
	Requirements
		libpcap/1.10.4#bcf0b2ec38621eba66f20b7aeb363dd5:861d236090fe4b9dccc998c9cb1ea66386d9923e - Build
	Build requirements
		winflexbison/2.5.25#752283c174ca9cf1eea23db81a22dc13:723257509aee8a72faf021920c2874abc738e029#9e0dffd2a164d4[45](https://github.com/ericLemanissier/cocorepo/actions/runs/15703238504/job/44242973029#step:5:46)8e903def521df11c - Download (community)

	======== Installing packages ========

	-------- Downloading 1 package --------
	winflexbison/2.5.25: Retrieving package 723257509aee8a72faf021920c2874abc738e029 from remote 'community' 
	winflexbison/2.5.25: Package installed 723257509aee8a72faf021920c2874abc738e029
	winflexbison/2.5.25: Downloaded package revision 9e0dffd2a164d4458e903def521df11c
	winflexbison/2.5.25: Setting LEX environment variable: D:/a/_temp/.c2/p/winfl092863393ccbc/p/bin/win_flex
	winflexbison/2.5.25: Setting YACC environment variable: D:/a/_temp/.c2/p/winfl092863393ccbc/p/bin/win_bison -y
	libpcap/1.10.4: Calling source() in D:\a\_temp\.c2\p\libpcd60518ec4cdfc\s\src
	libpcap/1.10.4: Uncompressing libpcap-1.10.4.tar.gz to .

	-------- Installing package libpcap/1.10.4 (2 of 2) --------
	libpcap/1.10.4: Building from source
	libpcap/1.10.4: Package libpcap/1.10.4:861d236090fe4b9dccc998c9cb1ea66386d9923e
	libpcap/1.10.4: settings: os=Windows arch=x86_64 compiler=msvc compiler.runtime=dynamic compiler.runtime_type=Release compiler.version=194 build_type=Release
	libpcap/1.10.4: options: enable_dbus=False shared=True with_snf=False
	libpcap/1.10.4: Copying sources to build folder
	libpcap/1.10.4: Building your package in D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b
	libpcap/1.10.4: Calling generate()
	libpcap/1.10.4: Generators folder: D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\generators
	libpcap/1.10.4: CMakeToolchain generated: conan_toolchain.cmake
	libpcap/1.10.4: CMakeToolchain generated: D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\generators\CMakePresets.json
	libpcap/1.10.4: CMakeToolchain generated: D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\src\CMakeUserPresets.json
	libpcap/1.10.4: Generating aggregated env files
	libpcap/1.10.4: Generated aggregated env files: ['conanbuild.bat', 'conanrun.bat']
	libpcap/1.10.4: Calling build()
	libpcap/1.10.4: Running CMake.configure()
	libpcap/1.10.4: RUN: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="D:/a/_temp/.c2/p/b/libpcfc892c2c53b4e/p" -DDISABLE_DPDK="ON" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "D:/a/_temp/.c2/p/b/libpcfc892c2c53b4e/b/src"
	CMake Deprecation Warning at CMakeLists.txt:16 (cmake_policy):
	  The OLD behavior for policy CMP0042 will be removed from a future version
	  of CMake.

	  The cmake-policies(7) manual explains that the OLD behaviors of all
	  policies are deprecated and that a policy should be set to OLD only under
	  specific short-term circumstances.  Projects should be ported to the NEW
	  behavior and not rely on setting a policy to OLD.


	-- Using Conan toolchain: D:/a/_temp/.c2/p/b/libpcfc892c2c53b4e/b/build/generators/conan_toolchain.cmake
	-- Conan toolchain: CMAKE_GENERATOR_TOOLSET=v143
	-- Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Release>:MultiThreadedDLL>
	-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
	-- The C compiler identification is MSVC 19.43.34808.0
	-- Detecting C compiler ABI info
	-- Detecting C compiler ABI info - done
	-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe - skipped
	-- Detecting C compile features
	-- Detecting C compile features - done
	-- Building 64-bit
	-- Could NOT find Packet (missing: Packet_INCLUDE_DIR Packet_LIBRARY) 
	-- checking for Npcap's version.h
	-- Looking for WINPCAP_PRODUCT_NAME
	-- Looking for WINPCAP_PRODUCT_NAME - not found
	-- MISSING version.h
	-- Use DYNAMIC runtime
	-- Looking for inttypes.h
	-- Looking for inttypes.h - found
	-- Looking for stdint.h
	-- Looking for stdint.h - found
	-- Looking for unistd.h
	-- Looking for unistd.h - not found
	-- Looking for bitypes.h
	-- Looking for bitypes.h - not found
	-- Performing Test HAVE___ATOMIC_LOAD_N
	-- Performing Test HAVE___ATOMIC_LOAD_N - Failed
	-- Performing Test HAVE___ATOMIC_STORE_N
	-- Performing Test HAVE___ATOMIC_STORE_N - Failed
	-- Looking for strerror
	-- Looking for strerror - found
	-- Looking for strerror_r
	-- Looking for strerror_r - not found
	-- Looking for _wcserror_s
	-- Looking for _wcserror_s - found
	-- Looking for vsnprintf
	-- Looking for vsnprintf - found
	-- Looking for snprintf
	-- Looking for snprintf - found
	-- Looking for strlcpy
	-- Looking for strlcpy - not found
	-- Looking for strlcat
	-- Looking for strlcat - not found
	-- Looking for asprintf
	-- Looking for asprintf - not found
	-- Looking for vasprintf
	-- Looking for vasprintf - not found
	-- Looking for strtok_r
	-- Looking for strtok_r - not found
	-- Looking for getaddrinfo
	-- Looking for getaddrinfo - found
	-- Looking for getnetbyname_r
	-- Looking for getnetbyname_r - not found
	-- Looking for getprotobyname_r
	-- Looking for getprotobyname_r - not found
	-- Looking for sys/types.h
	-- Looking for sys/types.h - found
	-- Looking for stddef.h
	-- Looking for stddef.h - found
	-- Check size of struct sockaddr_storage
	-- Check size of struct sockaddr_storage - done
	-- Check size of socklen_t
	-- Check size of socklen_t - failed
	-- Performing Test HAVE_STRUCT_SOCKADDR_SA_LEN
	-- Performing Test HAVE_STRUCT_SOCKADDR_SA_LEN - Failed
	-- Looking for ffs
	-- Looking for ffs - not found
	-- Looking for ether_hostton
	-- Looking for ether_hostton - not found
	-- Support IPv6
	-- Found OpenSSL: optimized;C:/Program Files/OpenSSL/lib/VC/x64/MD/libcrypto.lib;debug;C:/Program Files/OpenSSL/lib/VC/x64/MDd/libcrypto.lib (found version "3.4.1")
	-- Packet capture mechanism type: null
	-- Performing Test PCAP_SUPPORT_NETMAP
	-- Performing Test PCAP_SUPPORT_NETMAP - Failed
	-- Looking for ibv_get_device_list in ibverbs
	-- Looking for ibv_get_device_list in ibverbs - not found
	-- Could NOT find DAG (missing: DAG_INCLUDE_DIR DAG_LIBRARY DAGCONF_LIBRARY) 
	-- Looking for msg.h
	-- Looking for msg.h - not found
	-- Could NOT find SNF (missing: SNF_INCLUDE_DIR SNF_LIBRARY) 
	-- Could NOT find AirPcap (missing: AirPcap_INCLUDE_DIR AirPcap_LIBRARY) 
	-- Could NOT find TC (missing: TC_INCLUDE_DIR TC_LIBRARY) 
	-- Performing Test HAVE_STRUCT_MSGHDR_MSG_CONTROL
	-- Performing Test HAVE_STRUCT_MSGHDR_MSG_CONTROL - Failed
	-- Performing Test HAVE_STRUCT_MSGHDR_MSG_FLAGS
	-- Performing Test HAVE_STRUCT_MSGHDR_MSG_FLAGS - Failed
	  (compiling source file '../src/pcap-rpcap.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C2059: syntax error: ';' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/pcap-rpcap.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,62): error C2059: syntax error: ',' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/pcap-rpcap.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1993,43): error C2059: syntax error: ')' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/pcap-rpcap.c')
	  
	  grammar.c
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C21[46](https://github.com/ericLemanissier/cocorepo/actions/runs/15703238504/job/44242973029#step:5:47): syntax error: missing ')' before identifier 'offset' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/rpcap-protocol.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,[50](https://github.com/ericLemanissier/cocorepo/actions/runs/15703238504/job/44242973029#step:5:51)): error C2081: 'off_t': name in formal parameter list illegal [D:\a\_temp\.c2\p\b\libpcfc892c2c[53](https://github.com/ericLemanissier/cocorepo/actions/runs/15703238504/job/44242973029#step:5:54)b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/rpcap-protocol.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,[56](https://github.com/ericLemanissier/cocorepo/actions/runs/15703238504/job/44242973029#step:5:57)): error C2061: syntax error: identifier 'offset' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/rpcap-protocol.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C20[59](https://github.com/ericLemanissier/cocorepo/actions/runs/15703238504/job/44242973029#step:5:60): syntax error: ';' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/rpcap-protocol.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,62): error C2059: syntax error: ',' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/rpcap-protocol.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1993,43): error C2059: syntax error: ')' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/rpcap-protocol.c')
	  
	  scanner.c
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C2146: syntax error: missing ')' before identifier 'offset' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sockutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,50): error C2081: 'off_t': name in formal parameter list illegal [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sockutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C2061: syntax error: identifier 'offset' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sockutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C2059: syntax error: ';' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sockutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,62): error C2059: syntax error: ',' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sockutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1993,43): error C2059: syntax error: ')' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sockutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C2146: syntax error: missing ')' before identifier 'offset' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sslutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,50): error C2081: 'off_t': name in formal parameter list illegal [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sslutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C2061: syntax error: identifier 'offset' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sslutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,56): error C2059: syntax error: ';' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sslutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1992,62): error C2059: syntax error: ',' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sslutils.c')
	  
	C:\Program Files\OpenSSL\include\openssl\ssl.h(1993,43): error C2059: syntax error: ')' [D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build\pcap.vcxproj]
	  (compiling source file '../src/sslutils.c')
	  

	libpcap/1.10.4: ERROR: 
	Package '861d23[60](https://github.com/ericLemanissier/cocorepo/actions/runs/15703238504/job/44242973029#step:5:61)90fe4b9dccc998c9cb1ea66386d9923e' build failed
	libpcap/1.10.4: WARN: Build folder D:\a\_temp\.c2\p\b\libpcfc892c2c53b4e\b\build
	ERROR: libpcap/1.10.4: Error in build() method, line 138
		cmake.build()
		ConanException: Error 1 while executing
</details> 

<details><summary>fixed log</summary>

	Host profile:
	Build profile:
	[settings]
	arch=x86_64
	build_type=Release
	compiler=msvc
	compiler.cppstd=14
	compiler.runtime=dynamic
	compiler.runtime_type=Release
	compiler.version=194
	os=Windows
	[options]
	*/*:shared=True
	[conf]
	tools.system.package_manager:mode=install
	tools.system.package_manager:sudo=True

	[settings]
	arch=x86_64
	build_type=Release
	compiler=msvc
	compiler.cppstd=14
	compiler.runtime=dynamic
	compiler.runtime_type=Release
	compiler.version=194
	os=Windows
	[conf]
	tools.system.package_manager:mode=install
	tools.system.package_manager:sudo=True


	======== Input profiles ========
	Profile host:
	[settings]
	arch=x86_64
	build_type=Release
	compiler=msvc
	compiler.cppstd=14
	compiler.runtime=dynamic
	compiler.runtime_type=Release
	compiler.version=194
	os=Windows
	[options]
	*/*:shared=True
	[conf]
	tools.system.package_manager:mode=install
	tools.system.package_manager:sudo=True

	Profile build:
	[settings]
	arch=x86_64
	build_type=Release
	compiler=msvc
	compiler.cppstd=14
	compiler.runtime=dynamic
	compiler.runtime_type=Release
	compiler.version=194
	os=Windows
	[conf]
	tools.system.package_manager:mode=install
	tools.system.package_manager:sudo=True


	======== Computing dependency graph ========
	winflexbison/2.5.25: Not found in local cache, looking in remotes...
	winflexbison/2.5.25: Checking remote: community
	Connecting to remote 'community' with user 'ericLemanissier'
	winflexbison/2.5.25: Downloaded recipe revision 752283c174ca9cf1eea23db81a22dc13
	Graph root
		cli
	Requirements
		libpcap/1.10.4#5793043e49591969c3a688c65b5708df - Cache
	Build requirements
		winflexbison/2.5.25#752283c174ca9cf1eea23db81a22dc13 - Downloaded (community)

	======== Computing necessary packages ========
	libpcap/1.10.4: Forced build from source
	Requirements
		libpcap/1.10.4#5793043e49591969c3a688c65b5708df:861d236090fe4b9dccc998c9cb1ea66386d9923e - Build
	Build requirements
		winflexbison/2.5.25#752283c174ca9cf1eea23db81a22dc13:723257509aee8a72faf021920c2874abc738e029#9e0dffd2a164d4[45](https://github.com/ericLemanissier/cocorepo/actions/runs/15704442202/job/44248240026#step:5:46)8e903def521df11c - Download (community)

	======== Installing packages ========

	-------- Downloading 1 package --------
	winflexbison/2.5.25: Retrieving package 723257509aee8a72faf021920c2874abc738e029 from remote 'community' 
	winflexbison/2.5.25: Package installed 723257509aee8a72faf021920c2874abc738e029
	winflexbison/2.5.25: Downloaded package revision 9e0dffd2a164d4458e903def521df11c
	winflexbison/2.5.25: Setting LEX environment variable: D:/a/_temp/.c2/p/winfl092863393ccbc/p/bin/win_flex
	winflexbison/2.5.25: Setting YACC environment variable: D:/a/_temp/.c2/p/winfl092863393ccbc/p/bin/win_bison -y
	libpcap/1.10.4: Calling source() in D:\a\_temp\.c2\p\libpc17df260f5[46](https://github.com/ericLemanissier/cocorepo/actions/runs/15704442202/job/44248240026#step:5:47)11\s\src
	libpcap/1.10.4: Uncompressing libpcap-1.10.4.tar.gz to .

	-------- Installing package libpcap/1.10.4 (2 of 2) --------
	libpcap/1.10.4: Building from source
	libpcap/1.10.4: Package libpcap/1.10.4:861d236090fe4b9dccc998c9cb1ea66386d9923e
	libpcap/1.10.4: settings: os=Windows arch=x86_64 compiler=msvc compiler.runtime=dynamic compiler.runtime_type=Release compiler.version=194 build_type=Release
	libpcap/1.10.4: options: enable_dbus=False shared=True with_snf=False
	libpcap/1.10.4: Copying sources to build folder
	libpcap/1.10.4: Building your package in D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b
	libpcap/1.10.4: Calling generate()
	libpcap/1.10.4: Generators folder: D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build\generators
	libpcap/1.10.4: CMakeToolchain generated: conan_toolchain.cmake
	libpcap/1.10.4: CMakeToolchain generated: D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build\generators\CMakePresets.json
	libpcap/1.10.4: CMakeToolchain generated: D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\src\CMakeUserPresets.json
	libpcap/1.10.4: Generating aggregated env files
	libpcap/1.10.4: Generated aggregated env files: ['conanbuild.bat', 'conanrun.bat']
	libpcap/1.10.4: Calling build()
	libpcap/1.10.4: Running CMake.configure()
	libpcap/1.10.4: RUN: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p" -DDISABLE_DPDK="ON" -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL="ON" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src"
	CMake Deprecation Warning at CMakeLists.txt:16 (cmake_policy):
	  The OLD behavior for policy CMP0042 will be removed from a future version
	  of CMake.

	  The cmake-policies(7) manual explains that the OLD behaviors of all
	  policies are deprecated and that a policy should be set to OLD only under
	  specific short-term circumstances.  Projects should be ported to the NEW
	  behavior and not rely on setting a policy to OLD.


	-- Using Conan toolchain: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/build/generators/conan_toolchain.cmake
	-- Conan toolchain: CMAKE_GENERATOR_TOOLSET=v143
	-- Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Release>:MultiThreadedDLL>
	-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
	-- The C compiler identification is MSVC 19.43.34808.0
	-- Detecting C compiler ABI info
	-- Detecting C compiler ABI info - done
	-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe - skipped
	-- Detecting C compile features
	-- Detecting C compile features - done
	-- Building 64-bit
	-- Could NOT find Packet (missing: Packet_INCLUDE_DIR Packet_LIBRARY) 
	-- checking for Npcap's version.h
	-- Looking for WINPCAP_PRODUCT_NAME
	-- Looking for WINPCAP_PRODUCT_NAME - not found
	-- MISSING version.h
	-- Use DYNAMIC runtime
	-- Looking for inttypes.h
	-- Looking for inttypes.h - found
	-- Looking for stdint.h
	-- Looking for stdint.h - found
	-- Looking for unistd.h
	-- Looking for unistd.h - not found
	-- Looking for bitypes.h
	-- Looking for bitypes.h - not found
	-- Performing Test HAVE___ATOMIC_LOAD_N
	-- Performing Test HAVE___ATOMIC_LOAD_N - Failed
	-- Performing Test HAVE___ATOMIC_STORE_N
	-- Performing Test HAVE___ATOMIC_STORE_N - Failed
	-- Looking for strerror
	-- Looking for strerror - found
	-- Looking for strerror_r
	-- Looking for strerror_r - not found
	-- Looking for _wcserror_s
	-- Looking for _wcserror_s - found
	-- Looking for vsnprintf
	-- Looking for vsnprintf - found
	-- Looking for snprintf
	-- Looking for snprintf - found
	-- Looking for strlcpy
	-- Looking for strlcpy - not found
	-- Looking for strlcat
	-- Looking for strlcat - not found
	-- Looking for asprintf
	-- Looking for asprintf - not found
	-- Looking for vasprintf
	-- Looking for vasprintf - not found
	-- Looking for strtok_r
	-- Looking for strtok_r - not found
	-- Looking for getaddrinfo
	-- Looking for getaddrinfo - found
	-- Looking for getnetbyname_r
	-- Looking for getnetbyname_r - not found
	-- Looking for getprotobyname_r
	-- Looking for getprotobyname_r - not found
	-- Looking for sys/types.h
	-- Looking for sys/types.h - found
	-- Looking for stddef.h
	-- Looking for stddef.h - found
	-- Check size of struct sockaddr_storage
	-- Check size of struct sockaddr_storage - done
	-- Check size of socklen_t
	-- Check size of socklen_t - failed
	-- Performing Test HAVE_STRUCT_SOCKADDR_SA_LEN
	-- Performing Test HAVE_STRUCT_SOCKADDR_SA_LEN - Failed
	-- Looking for ffs
	-- Looking for ffs - not found
	-- Looking for ether_hostton
	-- Looking for ether_hostton - not found
	-- Support IPv6
	-- Packet capture mechanism type: null
	-- Performing Test PCAP_SUPPORT_NETMAP
	-- Performing Test PCAP_SUPPORT_NETMAP - Failed
	-- Looking for ibv_get_device_list in ibverbs
	-- Looking for ibv_get_device_list in ibverbs - not found
	-- Could NOT find DAG (missing: DAG_INCLUDE_DIR DAG_LIBRARY DAGCONF_LIBRARY) 
	-- Looking for msg.h
	-- Looking for msg.h - not found
	-- Could NOT find SNF (missing: SNF_INCLUDE_DIR SNF_LIBRARY) 
	-- Could NOT find AirPcap (missing: AirPcap_INCLUDE_DIR AirPcap_LIBRARY) 
	-- Could NOT find TC (missing: TC_INCLUDE_DIR TC_LIBRARY) 
	-- Performing Test HAVE_STRUCT_MSGHDR_MSG_CONTROL
	-- Performing Test HAVE_STRUCT_MSGHDR_MSG_CONTROL - Failed
	-- Performing Test HAVE_STRUCT_MSGHDR_MSG_FLAGS
	-- Performing Test HAVE_STRUCT_MSGHDR_MSG_FLAGS - Failed
	-- Checking C compiler flag -wd4646
	-- Performing Test wd4646
	-- Performing Test wd4646 - Success
	-- Lexical analyzer generator: D:/a/_temp/.c2/p/winfl092863393ccbc/p/bin/win_flex.exe
	CMake Warning (dev) at CMakeLists.txt:25[47](https://github.com/ericLemanissier/cocorepo/actions/runs/15704442202/job/44248240026#step:5:48) (add_custom_command):
	  The following keywords are not supported when using
	  add_custom_command(OUTPUT): SOURCE.

	  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
	  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
	  command to set the policy and suppress this warning.
	This warning is for project developers.  Use -Wno-dev to suppress it.

	-- Parser generator: D:/a/_temp/.c2/p/winfl092863393ccbc/p/bin/win_bison.exe
	CMake Warning (dev) at CMakeLists.txt:2622 (add_custom_command):
	  The following keywords are not supported when using
	  add_custom_command(OUTPUT): SOURCE.

	  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
	  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
	  command to set the policy and suppress this warning.
	This warning is for project developers.  Use -Wno-dev to suppress it.

	-- Configuring done (71.1s)
	-- Generating done (0.1s)
	-- Build files have been written to: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/build

	libpcap/1.10.4: Running CMake.build()
	libpcap/1.10.4: RUN: cmake --build "D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build" --config Release
	MSBuild version 17.13.15+18b3035f6 for .NET Framework

	  1>Checking Build System
	  Generating grammar.c, grammar.h
	  Generating scanner.c, scanner.h
	  Building Custom Rule D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src/CMakeLists.txt
	  Building Custom Rule D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src/CMakeLists.txt
	  bpf_dump.c
	  bpf_filter.c
	  bpf_image.c
	  etherent.c
	  fmtutils.c
	  gencode.c
	  nametoaddr.c
	  optimize.c
	  pcap-common.c
	  pcap-usb-linux-common.c
	  pcap-util.c
	  pcap.c
	  savefile.c
	  sf-pcapng.c
	  sf-pcap.c
	  charconv.c
	  win_asprintf.c
	  pcap-null.c
	  pcap-new.c
	  pcap-rpcap.c
	  rpcap-protocol.c
	  sockutils.c
	  sslutils.c
	  grammar.c
	  scanner.c
	  pcap_static.vcxproj -> D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build\Release\pcap_static.lib
	  Building Custom Rule D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src/testprogs/fuzz/CMakeLists.txt
	  onefile.c
	  fuzz_both.c
	  fuzz_both.vcxproj -> D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build\run\Release\fuzz_both.exe
	  Building Custom Rule D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src/testprogs/fuzz/CMakeLists.txt
	  onefile.c
	  fuzz_filter.c
	  fuzz_filter.vcxproj -> D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build\run\Release\fuzz_filter.exe
	  Building Custom Rule D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src/testprogs/fuzz/CMakeLists.txt
	  onefile.c
	  fuzz_pcap.c
	  fuzz_pcap.vcxproj -> D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build\run\Release\fuzz_pcap.exe
	  Building Custom Rule D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src/CMakeLists.txt
	  bpf_dump.c
	  bpf_filter.c
	  bpf_image.c
	  etherent.c
	  fmtutils.c
	  gencode.c
	  nametoaddr.c
	  optimize.c
	  pcap-common.c
	  pcap-usb-linux-common.c
	  pcap-util.c
	  pcap.c
	  savefile.c
	  sf-pcapng.c
	  sf-pcap.c
	  charconv.c
	  win_asprintf.c
	  pcap-null.c
	  pcap-new.c
	  pcap-rpcap.c
	  rpcap-protocol.c
	  sockutils.c
	  sslutils.c
	  grammar.c
	  scanner.c
		 Creating library D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/build/Release/pcap.lib and object D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/build/Release/pcap.exp
	  pcap.vcxproj -> D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build\run\Release\pcap.dll
	  Building Custom Rule D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src/rpcapd/CMakeLists.txt
	  daemon.c
	  fileconf.c
	  log.c
	  rpcapd.c
	  rpcap-protocol.c
	  sockutils.c
	  sslutils.c
	  fmtutils.c
	  win32-svc.c
	  charconv.c
	  getopt.c
	  rpcapd.vcxproj -> D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build\run\Release\rpcapd.exe
	  Building Custom Rule D:/a/_temp/.c2/p/b/libpc6521d97d626a0/b/src/CMakeLists.txt

	libpcap/1.10.4: Package '861d236090fe4b9dccc998c9cb1ea66386d9923e' built
	libpcap/1.10.4: Build folder D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build
	libpcap/1.10.4: Generating the package
	libpcap/1.10.4: Packaging in folder D:\a\_temp\.c2\p\b\libpc6521d97d626a0\p
	libpcap/1.10.4: Calling package()
	libpcap/1.10.4: Running CMake.install()
	libpcap/1.10.4: RUN: cmake --install "D:\a\_temp\.c2\p\b\libpc6521d97d626a0\b\build" --config Release --prefix "D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p"
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/lib/x64/pcap.lib
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/bin/x64/pcap.dll
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/lib/x64/pcap_static.lib
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/bluetooth.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/bpf.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/can_socketcan.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/compiler-tests.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/dlt.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/funcattrs.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/ipnet.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/namedb.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/nflog.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/pcap-inttypes.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/pcap.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/sll.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/socket.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/usb.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap/vlan.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap-bpf.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/include/pcap-namedb.h
	-- Installing: D:/a/_temp/.c2/p/b/libpc6521d97d626a0/p/bin/amd64/rpcapd.exe

	libpcap/1.10.4: package(): Packaged 1 '.dll' file: pcap.dll
	libpcap/1.10.4: package(): Packaged 1 '.exe' file: rpcapd.exe
	libpcap/1.10.4: package(): Packaged 18 '.h' files
	libpcap/1.10.4: package(): Packaged 1 '.lib' file: pcap.lib
	libpcap/1.10.4: package(): Packaged 1 file: LICENSE
	libpcap/1.10.4: Created package revision 1ed5fb1ca1e904c069f15214c83e287e
	libpcap/1.10.4: Package '861d236090fe4b9dccc998c9cb1ea66386d9923e' created
	libpcap/1.10.4: Full package reference: libpcap/1.10.4#5793043e[49](https://github.com/ericLemanissier/cocorepo/actions/runs/15704442202/job/44248240026#step:5:50)591969c3a688c65b5708df:861d236090fe4b9dccc998c9cb1ea66386d9923e#1ed5fb1ca1e904c069f1[52](https://github.com/ericLemanissier/cocorepo/actions/runs/15704442202/job/44248240026#step:5:53)14c83e287e
	libpcap/1.10.4: Package folder D:\a\_temp\.c2\p\b\libpc6521d97d626a0\p

	======== Finalizing install (deploy, generators) ========
	cli: Generating aggregated env files
	cli: Generated aggregated env files: ['conanbuild.bat', 'conanrun.bat']
	Install finished successfully
</details> 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
