### PR TITLE
Add podofo/0.10.5 and podofo/1.0.0

### DIFF
--- a/recipes/podofo/all/conandata.yml
+++ b/recipes/podofo/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "0.10.5":
     url: "https://github.com/podofo/podofo/archive/refs/tags/0.10.5.tar.gz"
     sha256: "49b159e88ba177ad2561b5cf6cbd68ecbe83272f5488bc527e44f97dbf695273"
+  "1.0.0":
+    url: "https://github.com/podofo/podofo/archive/refs/tags/1.0.0.tar.gz"
+    sha256: "e44276d927838034b51c4c79001e7ae5c3fef90b6844824004c77f160c1a22ea"
 patches:
   "0.9.7":
     - patch_file: "patches/0001-fix-cmake-0.9.7.patch"

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -166,6 +166,9 @@ class PodofoConan(ConanFile):
             if not self.options.shared:
                 self.cpp_info.libs = ["podofo", "podofo_private"]
                 self.cpp_info.defines.append("PODOFO_STATIC")
+
+                if Version(self.version) >= "1.0.0":
+                    self.cpp_info.libs += ["podofo_3rdparty"]
             else:
                 self.cpp_info.libs = ["podofo"]
                 self.cpp_info.defines.append("PODOFO_SHARED")

--- a/recipes/podofo/config.yml
+++ b/recipes/podofo/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "0.10.5":
     folder: all
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **podofo/0.10.5** and **podofo/1.0.0**

#### Motivation
Two weeks ago PoDoFo released v0.10.5[1](#user-content-fn-1-b145b392c9503adc6a72878c349d8a24) and v1.0.0[2](#user-content-fn-2-b145b392c9503adc6a72878c349d8a24).

The first being the final patch for pre-1.0.0 and the latter being the first somewhat API-stable release.

Also refer to https://github.com/podofo/podofo/issues/87

#### Details
- Added sources for v0.10.5 and v1.0.0
- Added another target to link against for v1.0.0, namely `podofo_3rdparty`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
