### PR TITLE
avoid duplicated requirement in sentry-native with qt=True

### DIFF
--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -128,7 +128,8 @@ class SentryNativeConan(ConanFile):
                 self.requires("breakpad/cci.20210521")
         if self.options.get_safe("qt"):
             self.requires("qt/5.15.11")
-            self.requires("openssl/[>=1.1 <4]")
+            if not self.options.get_safe("crashpad_with_tls"): # Avoid duplicated requirement
+                self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):
         check_min_cppstd(self, self._min_cppstd)

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -127,7 +127,7 @@ class SentryNativeConan(ConanFile):
             if self.options.with_breakpad == "google":
                 self.requires("breakpad/cci.20210521")
         if self.options.get_safe("qt"):
-            self.requires("qt/5.15.16")
+            self.requires("qt/[>=5.15.16 <7]")
 
     def validate(self):
         check_min_cppstd(self, self._min_cppstd)

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -127,9 +127,7 @@ class SentryNativeConan(ConanFile):
             if self.options.with_breakpad == "google":
                 self.requires("breakpad/cci.20210521")
         if self.options.get_safe("qt"):
-            self.requires("qt/5.15.11")
-            if not self.options.get_safe("crashpad_with_tls"): # Avoid duplicated requirement
-                self.requires("openssl/[>=1.1 <4]")
+            self.requires("qt/5.15.16")
 
     def validate(self):
         check_min_cppstd(self, self._min_cppstd)


### PR DESCRIPTION
### Summary
Changes to recipe:  **sentry-native**

#### Motivation
Close https://github.com/conan-io/conan-center-index/issues/27718

#### Details
```
conan install --requires=sentry-native/0.8.3 -o "&:qt=True" -o "&:crashpad_with_tls=openssl"
```
Gives duplicated requirement

Was introduced in https://github.com/conan-io/conan-center-index/pull/20762
