### PR TITLE
ginkgo: add missing cmake option

### DIFF
--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -92,6 +92,7 @@ class GinkgoConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -116,7 +117,6 @@ class GinkgoConan(ConanFile):
         tc.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -34,6 +34,7 @@ class GinkgoConan(ConanFile):
         "openmp": [True, False],
         "cuda": [True, False],
         "half": [True, False],
+        "bfloat16": [True, False],
     }
     default_options = {
         "shared": False,
@@ -41,6 +42,7 @@ class GinkgoConan(ConanFile):
         "openmp": False,
         "cuda": False,
         "half": True,
+        "bfloat16": True,
     }
 
     def export_sources(self):
@@ -56,6 +58,9 @@ class GinkgoConan(ConanFile):
             # option not supported for msvc/mingw (build system forces it to OFF anyway)
             # see https://github.com/ginkgo-project/ginkgo/blob/d7e1450b6ba9ee90dbaa839f4b4b5a5ad59e28cc/CMakeLists.txt#L46-L51
             del self.options.half
+            # option was added in 1.10.0
+            # same reason to force it of as for half
+            del self.options.bfloat16
 
     def configure(self):
         if self.options.shared:
@@ -106,6 +111,8 @@ class GinkgoConan(ConanFile):
         tc.variables["GINKGO_BUILD_MPI"] = False
         if "half" in self.options:
             tc.variables["GINKGO_ENABLE_HALF"] = self.options.half
+        if "bfloat16" in self.options:
+            tc.variables["GINKGO_ENABLE_BFLOAT16"] = self.options.bfloat16
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **ginkgo/1.10.0**

#### Motivation
A new CMake option is missing, which the user might want to activate or deactivate. The option is on by default, which is the same behavior as upstream.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
