### PR TITLE
libgcrypt: version 1.11.1

### DIFF
--- a/recipes/libgcrypt/all/conandata.yml
+++ b/recipes/libgcrypt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.1":
+    url: "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.10.3.tar.gz"
+    sha256: "946f7e56f795ba2ea88b842a8c6b8f469360cda42c1d3d191f7ac7e9aa8239f8"
   "1.10.3":
     url: "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.10.3.tar.gz"
     sha256: "946f7e56f795ba2ea88b842a8c6b8f469360cda42c1d3d191f7ac7e9aa8239f8"

--- a/recipes/libgcrypt/config.yml
+++ b/recipes/libgcrypt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.11.1":
+    folder: all
   "1.10.3":
     folder: all
   "1.8.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libgcrypt/[1.11.1]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Add the new version

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

recipes/libgcrypt/all/conandata.yml
recipes/libgcrypt/config.yml

[https://github.com/gpg/libgcrypt/compare/libgcrypt-1.10.3...libgcrypt-1.11.1](https://github.com/gpg/libgcrypt/compare/libgcrypt-1.10.3...libgcrypt-1.11.1)

1.55
need to update dependency on libgpg-error [https://github.com/conan-io/conan-center-index/pull/27723](https://github.com/conan-io/conan-center-index/pull/27723) to have recent error codes (Error codes used by GnuPG)

self.requires("libgpg-error/1.36", transitive_headers=True)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
