### PR TITLE
gettext: change order of conanbuild_msvc generation

### DIFF
--- a/recipes/gettext/all/conanfile.py
+++ b/recipes/gettext/all/conanfile.py
@@ -105,7 +105,10 @@ class GetTextConan(ConanFile):
             iconv_libdir = unix_path(self, libiconv.cpp_info.aggregated_components().libdirs[0])
             tc.extra_cflags.append(f"-I{iconv_includedir}")
             tc.extra_ldflags.append(f"-L{iconv_libdir}")
+        tc.generate()
 
+        if is_msvc(self):
+            # Generate this _after_ AutotoolsToolchain to ensure we override the CC variable
             env = Environment()
             compile_wrapper = self.dependencies.build["automake"].conf_info.get("user.automake:compile-wrapper")
             lib_wrapper = self.dependencies.build["automake"].conf_info.get("user.automake:lib-wrapper")
@@ -123,8 +126,6 @@ class GetTextConan(ConanFile):
             windres_arch = {"x86": "i686", "x86_64": "x86-64"}[str(self.settings.arch)]
             env.define("RC", f"windres --target=pe-{windres_arch}")
             env.vars(self).save_script("conanbuild_msvc")
-
-        tc.generate()
 
     def build(self):
         apply_conandata_patches(self)


### PR DESCRIPTION
Fix https://github.com/conan-io/conan-center-index/issues/27642

After https://github.com/conan-io/conan/pull/16875/files, AutotoolsToolchain sets CC/CXX (if not set in the compilers conf) - causing the values set in this recipe to be overwritten due to the order in which the files are generated. This PR fixes the issue.

Note that while while newer versions of gettext were also "affected" - the newer gettext has its own compile wrapper that actually worked fine - there's a chance that for some recipes/versions, the entire msvc handling logic is not needed.

