### PR TITLE
Add apple-clang support for protopuf

### DIFF
--- a/recipes/protopuf/all/conanfile.py
+++ b/recipes/protopuf/all/conanfile.py
@@ -2,12 +2,13 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import get, copy
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+
 import os
 
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=2.1"
 
 
 class ProtopufConan(ConanFile):
@@ -18,21 +19,6 @@ class ProtopufConan(ConanFile):
     homepage = "https://github.com/PragmaTwice/protopuf"
     topics = ("serialization", "protobuf", "metaprogramming", "header-only")
     settings = "os", "arch", "compiler", "build_type"
-    no_copy_source = True
-
-    @property
-    def _minimum_cpp_standard(self):
-        return 20
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "Visual Studio": "16",
-            "msvc": "192",
-            "gcc": "10",
-            "clang": "12",
-            "apple-clang": "12",
-        }
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -41,12 +27,11 @@ class ProtopufConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        if self.settings.get_safe("compiler.cppstd"):
-            check_min_cppstd(self, self._minimum_cpp_standard)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.get_safe("compiler.version")) < minimum_version:
+        check_min_cppstd(self, 20)
+        if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "17":
+            # there are specific C++20 features used in this library that require apple-clang 17 or higher
             raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support."
+                f"apple-clang 17 or higher is required"
             )
 
     def source(self):

--- a/recipes/protopuf/all/conanfile.py
+++ b/recipes/protopuf/all/conanfile.py
@@ -31,6 +31,7 @@ class ProtopufConan(ConanFile):
             "msvc": "192",
             "gcc": "10",
             "clang": "12",
+            "apple-clang": "12",
         }
 
     def layout(self):
@@ -40,11 +41,6 @@ class ProtopufConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        if self.settings.compiler == "apple-clang":
-            raise ConanInvalidConfiguration(
-                f"{self.ref} does not yet support apple-clang."
-            )
-
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)


### PR DESCRIPTION
### Summary
Changes to recipe:  **protopuf/**

#### Motivation

I've tried the library on mac os x (apple-clang-17) and it works perfectly: all tests do pass as well as library internal tests.

I asked the author to mention "os x support" in readme ( https://github.com/PragmaTwice/protopuf/issues/51 ).

The code itself has no any specifics to hardware/compiler, probably author has no access to apple hardware. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
