### PR TITLE
libcbor: Bump to 0.12.0

### DIFF
--- a/recipes/libcbor/all/conandata.yml
+++ b/recipes/libcbor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.12.0":
+    url: "https://github.com/PJK/libcbor/archive/v0.12.0.tar.gz"
+    sha256: "5368add109db559f546d7ed10f440f39a273b073daa8da4abffc83815069fa7f"
   "0.11.0":
     url: "https://github.com/PJK/libcbor/archive/v0.11.0.tar.gz"
     sha256: "89e0a83d16993ce50651a7501355453f5250e8729dfc8d4a251a78ea23bb26d7"

--- a/recipes/libcbor/config.yml
+++ b/recipes/libcbor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.12.0":
+    folder: "all"
   "0.11.0":
     folder: "all"
   "0.10.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcbor/0.12.0**

#### Motivation
Make most recent version of libcbor available. Released on May 03, 2025.

#### Details
- Added url and sha256 checksum of libcbor/0.12.0 to conandata.yml
- Added version 0.12.0 to config.yml

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
