### PR TITLE
c-ares: add multithreading option

### DIFF
--- a/recipes/c-ares/all/conanfile.py
+++ b/recipes/c-ares/all/conanfile.py
@@ -21,11 +21,13 @@ class CAresConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "tools": [True, False],
+        "multithreading": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "tools": True,
+        "multithreading": True,
     }
 
     def export_sources(self):
@@ -54,6 +56,7 @@ class CAresConan(ConanFile):
         tc.variables["CARES_BUILD_TESTS"] = False
         tc.variables["CARES_MSVC_STATIC_RUNTIME"] = False
         tc.variables["CARES_BUILD_TOOLS"] = self.options.tools
+        tc.variables["CARES_THREADS"] = self.options.multithreading
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/c-ares**

#### Motivation

There is a `CARES_THREADS` option which allows to build thread-(unsafe) library version. I would be nice to have an option for that in conan receipe.

By default it is thread-safe, as in the master.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
