### PR TITLE
openssl: avoid requiring strawberryperl under arm

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -140,7 +140,8 @@ class OpenSSLConan(ConanFile):
             if not self.options.no_asm and self.settings.arch in ["x86", "x86_64"]:
                 self.tool_requires("nasm/2.16.01")
             if self._use_nmake:
-                self.tool_requires("strawberryperl/5.32.1.1")
+                if self.settings.arch in ["x86", "x86_64"]:
+                    self.tool_requires("strawberryperl/5.32.1.1")
             else:
                 self.win_bash = True
                 if not self.conf.get("tools.microsoft.bash:path", check_type=str):
@@ -501,7 +502,7 @@ class OpenSSLConan(ConanFile):
 
     @property
     def _perl(self):
-        if self._use_nmake:
+        if self._use_nmake and self.settings.arch in ["x86", "x86_64"]:
             return self.dependencies.build["strawberryperl"].conf_info.get("user.strawberryperl:perl", check_type=str)
         return "perl"
 


### PR DESCRIPTION

### Summary
Changes to recipe:  **openssl/3.x.x**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

Issue #27752

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

Rely on system perl for arm processors since strawberry perl does not support that platform.

Tested on Github's windows-11-arm runner which has perl preinstalled.

Fixes #27752

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
