### PR TITLE
[libsndfile] Bump dependencies

### DIFF
--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1.0"
 
 
 class LibsndfileConan(ConanFile):


### PR DESCRIPTION
### Summary

Changes to recipe: **libsndfile/1.2.2**

#### Motivation

Bump opus dependency to 1.5.2 since 1.4 fails with CMake 4

#### Details

<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
