### PR TITLE
Bump cpr 1.12.0

### DIFF
--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.12.0":
+    url: "https://github.com/libcpr/cpr/archive/refs/tags/1.12.0.tar.gz"
+    sha256: "f64b501de66e163d6a278fbb6a95f395ee873b7a66c905dd785eae107266a709"
   "1.11.2":
     url: "https://github.com/libcpr/cpr/archive/refs/tags/1.11.2.tar.gz"
     sha256: "3795a3581109a9ba5e48fbb50f9efe3399a3ede22f2ab606b71059a615cd6084"
@@ -24,6 +27,10 @@ sources:
     url: "https://github.com/libcpr/cpr/archive/refs/tags/1.7.2.tar.gz"
     sha256: "aa38a414fe2ffc49af13a08b6ab34df825fdd2e7a1213d032d835a779e14176f"
 patches:
+  "1.12.0":
+    - patch_file: "patches/008-1.12.0-remove-warning-flags.patch"
+      patch_description: "disable warning flags and warning as error"
+      patch_type: "portability"
   "1.11.2":
     - patch_file: "patches/008-1.11.2-remove-warning-flags.patch"
       patch_description: "disable warning flags and warning as error"

--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -31,6 +31,9 @@ patches:
     - patch_file: "patches/008-1.12.0-remove-warning-flags.patch"
       patch_description: "disable warning flags and warning as error"
       patch_type: "portability"
+    - patch_file: "patches/009-1.12.0-windows-msvc-runtime.patch"
+      patch_description: "dont hardcode value of CMAKE_MSVC_RUNTIME_LIBRARY and use from conan toolchain instead"
+      patch_type: "conan"
   "1.11.2":
     - patch_file: "patches/008-1.11.2-remove-warning-flags.patch"
       patch_description: "disable warning flags and warning as error"

--- a/recipes/cpr/all/patches/008-1.12.0-remove-warning-flags.patch
+++ b/recipes/cpr/all/patches/008-1.12.0-remove-warning-flags.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 70d3296..eb020b4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -394,14 +394,14 @@ if(CPR_BUILD_TESTS)
+     restore_variable(DESTINATION CMAKE_CXX_CLANG_TIDY BACKUP CMAKE_CXX_CLANG_TIDY_BKP)
+ endif()
+ 
+-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+-else()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
+-    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+-        # Disable C++98 compatibility support in clang: https://github.com/libcpr/cpr/issues/927
+-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-nonportable-system-include-path -Wno-exit-time-destructors -Wno-undef -Wno-global-constructors -Wno-switch-enum -Wno-old-style-cast -Wno-covered-switch-default -Wno-undefined-func-template")
+-    endif()
+-endif()
++# if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
++# else()
++#     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror")
++#     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
++#         # Disable C++98 compatibility support in clang: https://github.com/libcpr/cpr/issues/927
++#         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-nonportable-system-include-path -Wno-exit-time-destructors -Wno-undef -Wno-global-constructors -Wno-switch-enum -Wno-old-style-cast -Wno-covered-switch-default -Wno-undefined-func-template")
++#     endif()
++# endif()
+ 
+ add_subdirectory(cpr)
+ add_subdirectory(include)

--- a/recipes/cpr/all/patches/009-1.12.0-windows-msvc-runtime.patch
+++ b/recipes/cpr/all/patches/009-1.12.0-windows-msvc-runtime.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3f6e1d0..ba830cb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -78,7 +78,7 @@ cpr_option(CPR_DEBUG_SANITIZER_FLAG_UB "Enables the UndefinedBehaviorSanitizer f
+ cpr_option(CPR_DEBUG_SANITIZER_FLAG_ALL "Enables all sanitizers for debug builds except the ThreadSanitizer since it is incompatible with the other sanitizers." OFF)
+ message(STATUS "=======================================================")
+ 
+-if (MSVC)
++if (0)
+     if (BUILD_SHARED_LIBS)
+         message(STATUS "Build windows dynamic libs.")
+     else()

--- a/recipes/cpr/config.yml
+++ b/recipes/cpr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.12.0":
+    folder: all
   "1.11.2":
     folder: all
   "1.11.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpr/1.12.0**

#### Motivation
Requested [here](https://github.com/conan-io/conan-center-index/issues/27759)


#### Details
Version bump to 1.12.0 with re-use of slightly adapted patches.
They apply cleanly (now), but I haven't tested with MSVC.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

Tested with conan 2.17.0 and gcc 11

```
Local Cache
  cpr
    cpr/1.12.0
      revisions
        b588be43c30df182c479089dbe6f1eb4 (2025-06-24 07:16:33 UTC)
          packages
            6fe3b8731fbd142a61a987a111c5e7b2c52e2b72
              info
                settings
                  arch: x86_64
                  build_type: Release
                  compiler: gcc
                  compiler.cppstd: gnu17
                  compiler.libcxx: libstdc++11
                  compiler.version: 11
                  os: Linux
                options
                  fPIC: True
                  shared: False
                  signal: True
                  verbose_logging: False
                  with_ssl: openssl
                requires
                  libcurl/8.10.Z
                  openssl/3.3.Z
                  zlib/1.3.Z
```
