### PR TITLE
sdl3: only require libusb if explicitly requested

### DIFF
--- a/recipes/sdl/3.x/conanfile.py
+++ b/recipes/sdl/3.x/conanfile.py
@@ -1,7 +1,7 @@
-from conan import ConanFile, conan_version
+from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
-from conan.tools.files import get, replace_in_file, copy, rmdir
+from conan.tools.files import get, copy, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.microsoft import is_msvc
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps

--- a/recipes/sdl/3.x/conanfile.py
+++ b/recipes/sdl/3.x/conanfile.py
@@ -161,9 +161,9 @@ class SDLConan(ConanFile):
             self.options.rm_safe("xshape")
             self.options.rm_safe("xsync")
 
-        if not self.options.get_safe("hidapi") or self.settings.os in ["iOS", "tvOS", "visionOS", "watchOS"]:
+        if not self.options.get_safe("hidapi") or self.settings.os in ["Android", "iOS", "tvOS", "visionOS", "watchOS"]:
             # libusb is only an option if hidapi is enabled: https://github.com/libsdl-org/SDL/blob/db3a35e9bc3aa245dfbe67585b3f67d7b4b62845/cmake/sdlchecks.cmake#L1111
-            # libusb is not available on iOS/tvOS/visionOS/watchOS https://github.com/libsdl-org/SDL/blob/db3a35e9bc3aa245dfbe67585b3f67d7b4b62845/CMakeLists.txt#L160
+            # libusb is not available on Android/iOS/tvOS/visionOS/watchOS https://github.com/libsdl-org/SDL/blob/db3a35e9bc3aa245dfbe67585b3f67d7b4b62845/CMakeLists.txt#L159-L160
             self.options.rm_safe("libusb")
 
     def validate(self):


### PR DESCRIPTION
* The recipe was making an assumption that libusb is required by default - it is not strictly

* The handling of shared libusb requires knowing the name of the libusb shared library filename, which is only possible with CMake target introspection with the newer CMakeConfigDeps  - comment this out so that it is not attempted (irrespective of whether we have CMakeConfigDeps or not)

* Fix the logic around when libusb is available, by completely removing `_needs_libusb()`

* Set `SDL_HIDAPI_LIBUSB_SHARED` to False unconditionally - it does not mean "libusb is shared", but rather, "libusb will be runtime-loaded via dlopen()`. The build scripts will fall back to _linking_ libusb, so it will be recorded as a dependency of libsdl3 instead. 


We can reconsider these changes if they cause issues.
