### PR TITLE
[fix] Boost 1.88.0 locale requires boost charconv always

### DIFF
--- a/recipes/boost/all/dependencies/dependencies-1.88.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.88.0.yml
@@ -121,6 +121,7 @@ dependencies:
   process:
   - filesystem
   - system
+  - context
   program_options: []
   python: []
   random:
@@ -285,6 +286,7 @@ requirements:
   - zlib
   - zstd
   locale:
+  - iconv
   - icu
   python:
   - python


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.88.0**

#### Motivation

The issue https://github.com/conan-io/conan-center-index/issues/26890 addresses two different problems with Boost modules dependencies. One of them, Boost 1.88.0 module locale added charconv as its dependency: https://github.com/boostorg/locale/compare/boost-1.87.0...boost-1.88.0#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR55

The problem was reported here: https://github.com/conan-io/conan-center-index/issues/26890#issuecomment-2928023992

#### Details

I executed the script `recipes/boost/all/rebuild-dependencies.py -d 1.88.0 -v 1.88.0` to check if any other requirements are missing. Fortunately, only charconv is listed as new module.

/cc @tkhyn

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
