### PR TITLE
Added build requirement for cmake <4 

### DIFF
--- a/recipes/pcre2/all/conanfile.py
+++ b/recipes/pcre2/all/conanfile.py
@@ -71,6 +71,9 @@ class PCRE2Conan(ConanFile):
         if self.options.get_safe("with_bzip2"):
             self.requires("bzip2/1.0.8")
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
     def validate(self):
         if not self.options.build_pcre2_8 and not self.options.build_pcre2_16 and not self.options.build_pcre2_32:
             raise ConanInvalidConfiguration("At least one of build_pcre2_8, build_pcre2_16 or build_pcre2_32 must be enabled")


### PR DESCRIPTION
### Summary
Changes to recipe:  **pcre2**

#### Motivation
cmake 4 will no longer build components with `CMAKE_MINIMUM_REQUIRED(VERSION 3.1)`. Thus adding a build requirement for cmake version < 4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
