### PR TITLE
expected-lite: add version 0.9.0

### DIFF
--- a/recipes/expected-lite/all/conandata.yml
+++ b/recipes/expected-lite/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.0":
+    url: "https://github.com/martinmoene/expected-lite/archive/v0.9.0.tar.gz"
+    sha256: "e1b3ac812295ef8512c015d8271204105a71957323f8ab4e75f6856d71b8868d"
   "0.8.0":
     url: "https://github.com/martinmoene/expected-lite/archive/v0.8.0.tar.gz"
     sha256: "27649f30bd9d4fe7b193ab3eb6f78c64d0f585c24c085f340b4722b3d0b5e701"

--- a/recipes/expected-lite/config.yml
+++ b/recipes/expected-lite/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.0":
+    folder: all
   "0.8.0":
     folder: all
   "0.7.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **expected-lite/0.9.0**

#### Motivation
There is a new version available of expected-lite, make it available for Conan.

#### Details
Added version 0.9.0 to the recipe


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
