### PR TITLE
argon2: Fix compilation for Android target

### DIFF
--- a/recipes/argon2/all/conandata.yml
+++ b/recipes/argon2/all/conandata.yml
@@ -5,3 +5,5 @@ sources:
 patches:
   "20190702":
     - patch_file: "patches/0001-makefile-no-march.patch"
+    - patch_file: "patches/0002-use-env-AR-if-set.patch"
+    - patch_file: "patches/0003-android.patch"

--- a/recipes/argon2/all/patches/0002-use-env-AR-if-set.patch
+++ b/recipes/argon2/all/patches/0002-use-env-AR-if-set.patch
@@ -1,0 +1,20 @@
+--- a/Makefile
++++ b/Makefile
+@@ -123,6 +123,8 @@ ifdef LINKED_LIB_EXT
+ LINKED_LIB_SH := lib$(LIB_NAME).$(LINKED_LIB_EXT)
+ endif
+ 
++# Some systems don't provide an unprefixed ar when cross-compiling.
++AR ?= ar
+ 
+ LIBRARIES = $(LIB_SH) $(LIB_ST)
+ HEADERS = include/argon2.h
+@@ -182,7 +184,7 @@ $(LIB_SH): 	$(SRC)
+ 		$(CC) $(CFLAGS) $(LIB_CFLAGS) $(LDFLAGS) $(SO_LDFLAGS) $^ -o $@
+ 
+ $(LIB_ST): 	$(OBJ)
+-		ar rcs $@ $^
++		$(AR) rcs $@ $^
+ 
+ .PHONY: clean
+ clean:

--- a/recipes/argon2/all/patches/0003-android.patch
+++ b/recipes/argon2/all/patches/0003-android.patch
@@ -1,0 +1,15 @@
+--- a/Makefile
++++ b/Makefile
+@@ -109,6 +109,12 @@ ifeq ($(KERNEL_NAME), SunOS)
+ 	LIB_CFLAGS := -shared -fPIC
+ 	PC_EXTRA_LIBS ?=
+ endif
++ifeq ($(KERNEL_NAME), Android)
++	LIB_EXT := so
++	LIB_CFLAGS := -shared -fPIC -fvisibility=hidden -DA2_VISCTL=1
++	SO_LDFLAGS := -Wl,-soname,lib$(LIB_NAME).$(LIB_EXT)
++	PC_EXTRA_LIBS ?= -lrt -ldl
++endif
+ 
+ ifeq ($(KERNEL_NAME), Linux)
+ ifeq ($(CC), clang)


### PR DESCRIPTION
### Summary
Changes to recipe:  **argon/20190702**

#### Motivation
Currently Argon2 does not compile for an Android target. I ran into two issues: first it was not able to discover `ar` correctly, after that it tired to compile an executable which resulted in linking errors as there was no `main` defined.

#### Details
Adds patches to the Makefile to deal with Android target correctly.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
