### PR TITLE
Minizip-ng: Add version 4.0.10 + update libiconv dependency to 1.18

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.10":
+    url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.10.tar.gz"
+    sha256: "c362e35ee973fa7be58cc5e38a4a6c23cc8f7e652555daf4f115a9eb2d3a6be7"
   "4.0.7":
     url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.7.tar.gz"
     sha256: "a87f1f734f97095fe1ef0018217c149d53d0f78438bcb77af38adc21dff2dfbc"

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -90,7 +90,10 @@ class MinizipNgConan(ConanFile):
             self.requires("openssl/[>=1.1 <4]")
         if self.settings.os != "Windows":
             if self.options.get_safe("with_iconv"):
-                self.requires("libiconv/1.17")
+                if Version(self.version) <= "4.0.7":
+                    self.requires("libiconv/1.17")
+                else:
+                    self.requires("libiconv/1.18")
 
     def build_requirements(self):
         if self._needs_pkg_config:

--- a/recipes/minizip-ng/config.yml
+++ b/recipes/minizip-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.10":
+    folder: all
   "4.0.7":
     folder: all
   "4.0.6":


### PR DESCRIPTION
### Summary
I added version 4.0.10 of minizip-ng to the recipe.
I also updated one of its depedencies (libiconv) to a newer version

#### Motivation
For me the important change is the updated libiconv version. 
After updating to gcc-15 I was not able to build minizip-ng anymore due to the issue described in https://github.com/conan-io/conan-center-index/issues/27413.

#### Details
I checked in the minizip-ng repo if a certain version of libiconv is used there, but they seem to simply use whatever find_package finds (https://github.com/zlib-ng/minizip-ng/blob/0969e94b7b88132d9a4623dc2aef43492886eb26/CMakeLists.txt#L586). 

I tried to update libiconv so that older packages remain unchanged.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
