### PR TITLE
libsigcpp: add version 3.6.0

### DIFF
--- a/recipes/libsigcpp/3.x.x/conandata.yml
+++ b/recipes/libsigcpp/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.0":
+    url: "https://ftp.gnome.org/pub/GNOME/sources/libsigc++/3.6/libsigc++-3.6.0.tar.xz"
+    sha256: "c3d23b37dfd6e39f2e09f091b77b1541fbfa17c4f0b6bf5c89baef7229080e17"
   "3.0.7":
     url: "https://ftp.gnome.org/pub/GNOME/sources/libsigc++/3.0/libsigc++-3.0.7.tar.xz"
     sha256: "bfbe91c0d094ea6bbc6cbd3909b7d98c6561eea8b6d9c0c25add906a6e83d733"
@@ -6,6 +9,8 @@ sources:
     url: "https://ftp.gnome.org/pub/GNOME/sources/libsigc++/3.0/libsigc++-3.0.0.tar.xz"
     sha256: "50a0855c1eb26e6044ffe888dbe061938ab4241f96d8f3754ea7ead38ab8ed06"
 patches:
+  "3.6.0":
+    - patch_file: "patches/3.6.0-0001-libsigcpp.patch"
   "3.0.7":
     - patch_file: "patches/3.0.7-0001-libsigcpp.patch"
   "3.0.0":

--- a/recipes/libsigcpp/3.x.x/patches/3.6.0-0001-libsigcpp.patch
+++ b/recipes/libsigcpp/3.x.x/patches/3.6.0-0001-libsigcpp.patch
@@ -1,0 +1,31 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -91,8 +91,6 @@
+ 
+ 
+ add_subdirectory (sigc++)
+-add_subdirectory (examples)
+-add_subdirectory (tests)
+ 
+ 
+ set (PROJECT_CMAKE_NAME		"${PROJECT_NAME}-3")
+--- sigc++/CMakeLists.txt
++++ sigc++/CMakeLists.txt
+@@ -24,7 +24,7 @@
+ 
+ set (SIGCPP_LIB_NAME sigc-${SIGCXX_API_VERSION})
+ 
+-add_library(${SIGCPP_LIB_NAME} SHARED ${SOURCE_FILES})
++add_library(${SIGCPP_LIB_NAME} ${SOURCE_FILES})
+ 
+ set_property (TARGET ${SIGCPP_LIB_NAME} PROPERTY VERSION ${PACKAGE_VERSION})
+ set_property(TARGET ${SIGCPP_LIB_NAME}  PROPERTY SOVERSION ${LIBSIGCPP_SOVERSION})
+@@ -43,6 +43,8 @@
+ install (
+     TARGETS ${SIGCPP_LIB_NAME}
+     EXPORT "${PROJECT_CMAKE_NAME}Targets"
++    ARCHIVE DESTINATION "lib"
+     LIBRARY DESTINATION "lib"
++    RUNTIME DESTINATION "bin"
+     INCLUDES DESTINATION "${INCLUDE_INSTALL_DIR}"
+ )

--- a/recipes/libsigcpp/config.yml
+++ b/recipes/libsigcpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.0":
+    folder: "3.x.x"
   "3.0.7":
     folder: "3.x.x"
   "3.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsigcpp/3.6.0**

#### Details
Straightforward version bump, except for the updating of line numbers in a patch.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
