### PR TITLE
libevent: Fix patch for multi config generators (#2406)

### DIFF
--- a/recipes/libevent/all/patches/fix-cmake-2.1.11.patch
+++ b/recipes/libevent/all/patches/fix-cmake-2.1.11.patch
@@ -1,5 +1,16 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -37,10 +37,6 @@ if(NOT CMAKE_BUILD_TYPE)
+ endif()
+ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
+
+-# get rid of the extra default configurations
+-# what? why would you get id of other useful build types? - Ellzey
+-set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Limited configurations" FORCE)
+-
+ set(EVENT__LIBRARY_TYPE DEFAULT CACHE STRING
+     "Set library type to SHARED/STATIC/BOTH (default SHARED for MSVC, otherwise BOTH)")
+
 @@ -46,7 +46,7 @@ set(EVENT__LIBRARY_TYPE DEFAULT CACHE STRING
  
  project(libevent C)

--- a/recipes/libevent/all/patches/fix-cmake-2.1.12.patch
+++ b/recipes/libevent/all/patches/fix-cmake-2.1.12.patch
@@ -1,5 +1,16 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -37,10 +37,6 @@ if(NOT CMAKE_BUILD_TYPE)
+ endif()
+ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
+
+-# get rid of the extra default configurations
+-# what? why would you get id of other useful build types? - Ellzey
+-set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Limited configurations" FORCE)
+-
+ set(EVENT__LIBRARY_TYPE DEFAULT CACHE STRING
+     "Set library type to SHARED/STATIC/BOTH (default SHARED for MSVC, otherwise BOTH)")
+
 @@ -970,16 +970,15 @@ endif()
  # library exists for historical reasons; it contains the contents of
  # both libevent_core and libevent_extra. You shouldn’t use it; it may


### PR DESCRIPTION
Fixes #2406 

### Summary
Changes to recipe:  **libevent/2.1.11** and **libevent/2.1.12** 

#### Motivation
Building on Windows with MSVC failed when using build types like ``RelWithDebInfo``.

#### Details
The upstream repository overwrites the ``CMAKE_CONFIGURATION_TYPES`` with the fixed values ``Debug`` and ``Release``. Hence, no other builds are possible with multi-configuration generators like MSVC. This restriction was already removed in the upstream repository (not released yet) https://github.com/libevent/libevent/commit/087bbc572c48d9304d8b6b911e6b0cf966ba3c28.
  
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
