### PR TITLE
dcmtk: small maintenance fixes

### DIFF
--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -167,6 +167,10 @@ class DCMTKConan(ConanFile):
             tc.variables["DCMTK_ICONV_FLAGS_ANALYZED"] = True
             tc.variables["DCMTK_COMPILE_WIN32_MULTITHREADED_DLL"] = not is_msvc_static_runtime(self)
 
+        # Prevent libnsl from the system (and not from Conan) from being picked up
+        tc.cache_variables["HAVE_LIBNSL_MAIN"] = False
+        tc.cache_variable["HAVE_LIBNSL"] = False
+
         if Version(self.version) >= "3.6.7" and cross_building(self):
             # See https://support.dcmtk.org/redmine/projects/dcmtk/wiki/Cross_Compiling
             tc.cache_variables["DCMTK_NO_TRY_RUN"] = True
@@ -383,7 +387,7 @@ class DCMTKConan(ConanFile):
         if self.settings.os == "Windows":
             system_libs = ["iphlpapi", "ws2_32", "netapi32", "wsock32"]
         elif self.settings.os in ["Linux", "FreeBSD"]:
-            system_libs = ["m", "nsl"]
+            system_libs = ["m"]
             if self.options.with_multithreading:
                 system_libs.append("pthread")
             if Version(self.version) >= "3.6.8":

--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -169,7 +169,7 @@ class DCMTKConan(ConanFile):
 
         # Prevent libnsl from the system (and not from Conan) from being picked up
         tc.cache_variables["HAVE_LIBNSL_MAIN"] = False
-        tc.cache_variable["HAVE_LIBNSL"] = False
+        tc.cache_variables["HAVE_LIBNSL"] = False
 
         if Version(self.version) >= "3.6.7" and cross_building(self):
             # See https://support.dcmtk.org/redmine/projects/dcmtk/wiki/Cross_Compiling

--- a/recipes/dcmtk/all/patches/3.6.7-0001-cmake-robust-deps-handling.patch
+++ b/recipes/dcmtk/all/patches/3.6.7-0001-cmake-robust-deps-handling.patch
@@ -76,8 +76,9 @@
    # Find libXML2
    if(DCMTK_WITH_XML)
 -    find_package(LibXml2 QUIET)
-+    find_package(LibXml2 REQUIRED MODULE)
-     if(NOT LIBXML2_FOUND)
+-    if(NOT LIBXML2_FOUND)
++    find_package(LibXml2 REQUIRED)
++    if(NOT LibXml2_FOUND)
        message(STATUS "Warning: XML support will be disabled because libxml2 was not found.")
        set(WITH_LIBXML "")
 @@ -99,13 +81,13 @@ if(DCMTK_USE_FIND_PACKAGE)

--- a/recipes/dcmtk/all/patches/3.6.8-0001-cmake-robust-deps-handling.patch
+++ b/recipes/dcmtk/all/patches/3.6.8-0001-cmake-robust-deps-handling.patch
@@ -72,8 +72,9 @@
    # Find libXML2
    if(DCMTK_WITH_XML)
 -    find_package(LibXml2 QUIET)
-+    find_package(LibXml2 REQUIRED MODULE)
-     if(NOT LIBXML2_FOUND)
+-    if(NOT LIBXML2_FOUND)
++    find_package(LibXml2 REQUIRED)
++    if(NOT LibXml2_FOUND)
        message(STATUS "Warning: XML support will be disabled because libxml2 was not found.")
        set(WITH_LIBXML "")
 @@ -103,13 +91,13 @@

--- a/recipes/dcmtk/all/patches/3.6.9-0001-cmake-robust-deps-handling.patch
+++ b/recipes/dcmtk/all/patches/3.6.9-0001-cmake-robust-deps-handling.patch
@@ -73,8 +73,9 @@
    # Find libXML2
    if(DCMTK_WITH_XML)
 -    find_package(LibXml2 QUIET)
-+    find_package(LibXml2 REQUIRED MODULE)
-     if(NOT LIBXML2_FOUND)
+-    if(NOT LIBXML2_FOUND)
++    find_package(LibXml2 REQUIRED)
++    if(NOT LibXml2_FOUND)
        message(STATUS "Warning: XML support will be disabled because libxml2 was not found.")
        set(WITH_LIBXML "")
 @@ -104,13 +91,13 @@ if(DCMTK_USE_FIND_PACKAGE)


### PR DESCRIPTION
### Summary
* Prevent autodetection of `nsl`, which causes the test package to fail on a Linux system where nsl is not yet installed. This was only in the recipe because the autodetection was picking it up on our CI. 
* Switch to using CONFIG for libxml2 find package, as find modules will not be available moving forward (e.g. CMakeConfigDeps)
