### PR TITLE
libpq 17.5: fix issue with flex/m4 on Linux

### DIFF
--- a/recipes/libpq/meson/conandata.yml
+++ b/recipes/libpq/meson/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "17.5":
     url: "https://ftp.postgresql.org/pub/source/v17.5/postgresql-17.5.tar.bz2"
     sha256: "fcb7ab38e23b264d1902cb25e6adafb4525a6ebcbd015434aeef9eda80f528d8"
+patches:
+  "17.5":
+    - patch_file : "patches/17.5-pgflex-preserve-environment-variables.patch"

--- a/recipes/libpq/meson/conanfile.py
+++ b/recipes/libpq/meson/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
@@ -94,8 +94,12 @@ class LibpqConan(ConanFile):
             self.tool_requires("flex/2.6.4")
             self.tool_requires("bison/3.8.2")
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         def feature(v):

--- a/recipes/libpq/meson/patches/17.5-pgflex-preserve-environment-variables.patch
+++ b/recipes/libpq/meson/patches/17.5-pgflex-preserve-environment-variables.patch
@@ -1,0 +1,14 @@
+diff --git a/src/tools/pgflex b/src/tools/pgflex
+index baabe2d..f309c1a 100755
+--- a/src/tools/pgflex
++++ b/src/tools/pgflex
+@@ -51,7 +51,8 @@ os.chdir(args.privatedir)
+ # contents. Set FLEX_TMP_DIR to the target private directory to avoid
+ # that. That environment variable isn't consulted on other platforms, so we
+ # don't even need to make this conditional.
+-env = {'FLEX_TMP_DIR': args.privatedir}
++env = os.environ.copy()
++env['FLEX_TMP_DIR'] =  args.privatedir
+ 
+ # build flex invocation
+ command = [args.flex, '-o', args.output_file]


### PR DESCRIPTION
### Summary
Fix issue when `flex` is invoked so that it is able to find the `m4` executable (both are correctly `tool_requires`)


#### Motivation
Recipe may fail to build on Linux otherwise:

```
INFO: calculating backend command to run: /root/.conan2/p/b/ninja881afb3341f16/p/bin/ninja -j 8
[31/1715] Generating src/fe_utils/psqlscan with a custom command
FAILED: [code=243] src/fe_utils/psqlscan.c 
/usr/bin/python3 ../src/src/tools/pgflex --builddir . --srcdir ../src --privatedir src/fe_utils/psqlscan.c.p --flex /root/.conan2/p/b/flexd456ae513f05e/p/bin/flex --perl /usr/bin/perl -i ../src/src/fe_utils/psqlscan.l -o src/fe_utils/psqlscan.c --no-backup --fix-warnings -- -Cfe -p -p
flex: fatal internal error, exec of m4 failed
[38/1715] Generating src/include/catalog/generated_catalog_headers with a custom command
ninja: build stopped: subcommand failed.
```

`flex: fatal internal error, exec of m4 failed` 

#### Details
There's a python script used to invoke `flex`, which requires the `m4` executable to be discoverible. An environment variable is passed via the `env` argument to `subprocess.run()`, which causes the sub-process to no longer have access to all the required variables defined in the build context by Conan (the fix in the path should be self-explanaitory)

---
