### PR TITLE
xtr: bump to 3.0.0

### DIFF
--- a/recipes/xtr/all/conandata.yml
+++ b/recipes/xtr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.0":
+    url: "https://github.com/choll/xtr/archive/refs/tags/3.0.0.tar.gz"
+    sha256: "3d249e5bdd34e7135c413ef56d7f0997f51ca4aa188357ee03b1e77ca3d3655f"
   "2.1.2":
     url: "https://github.com/choll/xtr/archive/refs/tags/2.1.2.tar.gz"
     sha256: "81ff3511e877db68882d01be9e521d317c8222838b0793e48cfd631f405bb3e8"

--- a/recipes/xtr/config.yml
+++ b/recipes/xtr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.0":
+    folder: all
   "2.1.2":
     folder: all
   "2.1.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **xtr/3.0.0**

#### Motivation
Bump xtr recipe to 3.0.0

#### Details
Bump xtr recipe to 3.0.0 only, no recipe changes


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
