### PR TITLE
box2d/3.1.0: Fix debug lib name

### DIFF
--- a/recipes/box2d/all/conanfile.py
+++ b/recipes/box2d/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
 
 class Box2dConan(ConanFile):
@@ -74,6 +74,7 @@ class Box2dConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -92,7 +93,6 @@ class Box2dConan(ConanFile):
             deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -106,9 +106,10 @@ class Box2dConan(ConanFile):
         rm(self, "*.pdb", self.package_folder, recursive=True)
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "box2d"
-        self.cpp_info.names["cmake_find_package_multi"] = "box2d"
-        self.cpp_info.libs = ["box2d"]
+        postfix = ""
+        if Version(self.version) >= "3.1.0" and self.settings.build_type == "Debug":
+            postfix = "d"
+        self.cpp_info.libs = [f"box2d{postfix}"]
         if Version(self.version) >= "3.0.0" and is_msvc(self) and self.options.shared:
             self.cpp_info.defines.append("BOX2D_DLL")
         elif Version(self.version) >= "2.4.1" and self.options.shared:


### PR DESCRIPTION
As reported in the linked issue, the new versions contain https://github.com/erincatto/box2d/blob/main/src/CMakeLists.txt#L88

Closes https://github.com/conan-io/conan-center-index/issues/27847

Successful debug compilation:

<details>

```
$ conan create . --version=3.1.0 -b=missing -s="&:build_type=Debug"

======== Exporting recipe to the cache ========
box2d/3.1.0: Exporting package recipe: /Users/abril/coding/conan-center-index/recipes/box2d/all/conanfile.py
box2d/3.1.0: exports: File 'conandata.yml' found. Exporting it...
box2d/3.1.0: Calling export_sources()
box2d/3.1.0: Copied 1 '.py' file: conanfile.py
box2d/3.1.0: Copied 1 '.yml' file: conandata.yml
box2d/3.1.0: Copied 1 '.patch' file: 3.1.0-0003-remove-compile-warnings-as-error.patch
box2d/3.1.0: Exported to cache folder: /Users/abril/.conan2/p/box2def39806b10fa7/e
box2d/3.1.0: Exported: box2d/3.1.0#2bb79836f8c122ed8dc134d0039cf6dd (2025-07-02 20:11:25 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=16
os=Macos
&:build_type=Debug
[tool_requires]
*: ccache/4.10.2
[platform_tool_requires]
cmake/4.0.2
meson/1.8.2
ninja/1.12.1
[replace_tool_requires]
meson/*: meson/[*]
pkgconf/*: pkgconf/[*]
ninja/*: ninja/[*]
cmake/*: cmake/[*]
[conf]
tools.cmake.cmaketoolchain:generator=Ninja

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu17
compiler.libcxx=libc++
compiler.version=16
os=Macos
[tool_requires]
*: ccache/4.10.2
[platform_tool_requires]
cmake/4.0.2
meson/1.8.2
ninja/1.12.1
[replace_tool_requires]
meson/*: meson/[*]
pkgconf/*: pkgconf/[*]
ninja/*: ninja/[*]
cmake/*: cmake/[*]
[conf]
tools.cmake.cmaketoolchain:generator=Ninja


======== Computing dependency graph ========
Graph root
    cli
Requirements
    box2d/3.1.0#2bb79836f8c122ed8dc134d0039cf6dd - Cache
Build requirements
    ccache/4.10.2#846894d0be2d48c603bcad2753e7980d - Cache
    cmake/4.0.2 - Platform
Replaced requires
    cmake/[>=3.22 <4]: cmake/[*]

======== Computing necessary packages ========
Connecting to remote 'conancenter' anonymously
box2d/3.1.0: Main binary package '8b20b4ce12c5bd08ea0a0f1d249dbb0d7215faba' missing
box2d/3.1.0: Checking 1 compatible configurations
box2d/3.1.0: Compatible configurations not found in cache, checking servers
box2d/3.1.0: 'd5b2c6cb2f165ca5b73811786cc7bd00b5255bc2': compiler.version=13
Requirements
    box2d/3.1.0#2bb79836f8c122ed8dc134d0039cf6dd:8b20b4ce12c5bd08ea0a0f1d249dbb0d7215faba - Build
Build requirements
    ccache/4.10.2#846894d0be2d48c603bcad2753e7980d:9e5323c65b94ae38c3c733fe12637776db0119a5#91a23a70e21cbe629f9b7acb3bb83d42 - Cache
    cmake/4.0.2 - Platform

======== Installing packages ========
ccache/4.10.2: Already installed! (1 of 2)
ccache/4.10.2: Finalized folder /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f
ccache/4.10.2: Finalized folder /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f
box2d/3.1.0: Calling source() in /Users/abril/.conan2/p/box2def39806b10fa7/s/src
box2d/3.1.0: Source https://github.com/erincatto/box2d/archive/refs/tags/v3.1.0.tar.gz retrieved from local download cache
box2d/3.1.0: Uncompressing v3.1.0.tar.gz to .
box2d/3.1.0: Apply patch (conan): remove warnings as errors

-------- Installing package box2d/3.1.0 (2 of 2) --------
box2d/3.1.0: Building from source
box2d/3.1.0: Package box2d/3.1.0:8b20b4ce12c5bd08ea0a0f1d249dbb0d7215faba
box2d/3.1.0: settings: os=Macos arch=armv8 compiler=apple-clang compiler.version=16 build_type=Debug
box2d/3.1.0: options: fPIC=True shared=False
box2d/3.1.0: Copying sources to build folder
box2d/3.1.0: Building your package in /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b
box2d/3.1.0: Calling generate()
box2d/3.1.0: Generators folder: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug/generators
box2d/3.1.0: CMakeToolchain generated: conan_toolchain.cmake
box2d/3.1.0: CMakeToolchain generated: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug/generators/CMakePresets.json
box2d/3.1.0: CMakeToolchain generated: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/src/CMakeUserPresets.json
box2d/3.1.0: Generating aggregated env files
box2d/3.1.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
box2d/3.1.0: Calling build()
box2d/3.1.0: Running CMake.configure()
box2d/3.1.0: RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/.conan2/p/b/box2d352f12e46a9a2/p" -DCMAKE_POLICY_DEFAULT_CMP0077="NEW" -DCMAKE_COMPILE_WARNING_AS_ERROR="OFF" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Debug" "/Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/src"
-- Using Conan toolchain: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug/generators/conan_toolchain.cmake
-- Conan toolchain: Including user_toolchain: /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f/ccache-autoinject.cmake
-- /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f/bin/ccache found and enabled
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is AppleClang 17.0.0.17000013
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CMake C compiler: AppleClang
-- CMake C++ compiler: AppleClang
-- CMake system name: Darwin
-- CMake host system processor: arm64
-- Box2D on Apple
-- Skipping Box2D unit tests
-- Configuring done (1.2s)
-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_POLICY_DEFAULT_CMP0077


-- Build files have been written to: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug

box2d/3.1.0: Running CMake.build()
box2d/3.1.0: RUN: cmake --build "/Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug" -- -j12
[36/36] Linking C static library src/libbox2dd.a

box2d/3.1.0: Package '8b20b4ce12c5bd08ea0a0f1d249dbb0d7215faba' built
box2d/3.1.0: Build folder /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug
box2d/3.1.0: Generating the package
box2d/3.1.0: Packaging in folder /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p
box2d/3.1.0: Calling package()
box2d/3.1.0: Running CMake.configure()
box2d/3.1.0: RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/.conan2/p/b/box2d352f12e46a9a2/p" -DCMAKE_POLICY_DEFAULT_CMP0077="NEW" -DCMAKE_COMPILE_WARNING_AS_ERROR="OFF" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Debug" "/Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/src"
-- Using Conan toolchain: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug/generators/conan_toolchain.cmake
-- Conan toolchain: Including user_toolchain: /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f/ccache-autoinject.cmake
-- /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f/bin/ccache found and enabled
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- CMake C compiler: AppleClang
-- CMake C++ compiler: AppleClang
-- CMake system name: Darwin
-- CMake host system processor: arm64
-- Box2D on Apple
-- Skipping Box2D unit tests
-- Configuring done (0.1s)
-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_TOOLCHAIN_FILE


-- Build files have been written to: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug

box2d/3.1.0: Running CMake.install()
box2d/3.1.0: RUN: cmake --install "/Users/abril/.conan2/p/b/box2d352f12e46a9a2/b/build/Debug" --prefix "/Users/abril/.conan2/p/b/box2d352f12e46a9a2/p"
-- Install configuration: "Debug"
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/lib/libbox2dd.a
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/lib/cmake/box2d/box2dConfig.cmake
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/lib/cmake/box2d/box2dConfig-debug.cmake
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/include/box2d/base.h
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/include/box2d/box2d.h
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/include/box2d/collision.h
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/include/box2d/id.h
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/include/box2d/math_functions.h
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/include/box2d/types.h
-- Installing: /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p/lib/cmake/box2d/box2dConfigVersion.cmake

box2d/3.1.0: package(): Packaged 1 file: LICENSE
box2d/3.1.0: package(): Packaged 6 '.h' files
box2d/3.1.0: package(): Packaged 1 '.a' file: libbox2dd.a
box2d/3.1.0: Created package revision 72c73e4239201333943b759e22e006a3
box2d/3.1.0: Package '8b20b4ce12c5bd08ea0a0f1d249dbb0d7215faba' created
box2d/3.1.0: Full package reference: box2d/3.1.0#2bb79836f8c122ed8dc134d0039cf6dd:8b20b4ce12c5bd08ea0a0f1d249dbb0d7215faba#72c73e4239201333943b759e22e006a3
box2d/3.1.0: Package folder /Users/abril/.conan2/p/b/box2d352f12e46a9a2/p

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    box2d/3.1.0 (test package): /Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/conanfile.py
Requirements
    box2d/3.1.0#2bb79836f8c122ed8dc134d0039cf6dd - Cache
Build requirements
    ccache/4.10.2#846894d0be2d48c603bcad2753e7980d - Cache
    cmake/4.0.2 - Platform
Replaced requires
    cmake/[>=3.21 <4]: cmake/[*]
    cmake/[>=3.22 <4]: cmake/[*]

======== Computing necessary packages ========
Requirements
    box2d/3.1.0#2bb79836f8c122ed8dc134d0039cf6dd:8b20b4ce12c5bd08ea0a0f1d249dbb0d7215faba#72c73e4239201333943b759e22e006a3 - Cache
Build requirements
    ccache/4.10.2#846894d0be2d48c603bcad2753e7980d:9e5323c65b94ae38c3c733fe12637776db0119a5#91a23a70e21cbe629f9b7acb3bb83d42 - Cache
    cmake/4.0.2 - Platform

======== Installing packages ========
ccache/4.10.2: Already installed! (1 of 2)
ccache/4.10.2: Finalized folder /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f
box2d/3.1.0: Already installed! (2 of 2)

======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/build/apple-clang-16-armv8-gnu17-debug
box2d/3.1.0 (test package): Test package build: build/apple-clang-16-armv8-gnu17-debug
box2d/3.1.0 (test package): Test package build folder: /Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/build/apple-clang-16-armv8-gnu17-debug
box2d/3.1.0 (test package): Writing generators to /Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/build/apple-clang-16-armv8-gnu17-debug/generators
box2d/3.1.0 (test package): Generator 'CMakeDeps' calling 'generate()'
box2d/3.1.0 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(box2d)
    target_link_libraries(... box2d::box2d)
box2d/3.1.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
box2d/3.1.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
box2d/3.1.0 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/build/apple-clang-16-armv8-gnu17-debug/generators/CMakePresets.json
box2d/3.1.0 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/CMakeUserPresets.json
box2d/3.1.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
box2d/3.1.0 (test package): Generating aggregated env files
box2d/3.1.0 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
box2d/3.1.0 (test package): Calling build()
box2d/3.1.0 (test package): Running CMake.configure()
box2d/3.1.0 (test package): RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/coding/conan-center-index/recipes/box2d/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Debug" "/Users/abril/coding/conan-center-index/recipes/box2d/all/test_package"
-- Using Conan toolchain: /Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/build/apple-clang-16-armv8-gnu17-debug/generators/conan_toolchain.cmake
-- Conan toolchain: Including user_toolchain: /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f/ccache-autoinject.cmake
-- /Users/abril/.conan2/p/b/ccach1e6bed495b8dd/f/bin/ccache found and enabled
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is AppleClang 17.0.0.17000013
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'box2d::box2d'
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/build/apple-clang-16-armv8-gnu17-debug

box2d/3.1.0 (test package): Running CMake.build()
box2d/3.1.0 (test package): RUN: cmake --build "/Users/abril/coding/conan-center-index/recipes/box2d/all/test_package/build/apple-clang-16-armv8-gnu17-debug" -- -j12
[2/2] Linking C executable test_package


======== Testing the package: Executing test ========
box2d/3.1.0 (test package): Running test()
box2d/3.1.0 (test package): RUN: ./test_package
```

</details>