### PR TITLE
soci/4.1.2: disable autodetect lto optimization by default to avoid issues in release builds

### DIFF
--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -84,6 +84,7 @@ class SociConan(ConanFile):
         tc.cache_variables["SOCI_STATIC"] = not self.options.shared
         tc.cache_variables["SOCI_TESTS"] = False
         tc.cache_variables["SOCI_EMPTY"] = self.options.empty
+        tc.cache_variables["SOCI_LTO"] = False
         tc.cache_variables["{}_SQLITE3".format(backend_prefix)] = self.options.with_sqlite3
         tc.cache_variables["{}_DB2".format(backend_prefix)] = False
         tc.cache_variables["{}_ODBC".format(backend_prefix)] = self.options.with_odbc


### PR DESCRIPTION
### Summary
Changes to recipe:  **soci/4.1.2**

#### Motivation
4.1.2: introduced automatic way to detect LTO.
However to enable LTO soci library does not consider internal checks for supported versions, in the setup with clang-18/cmake 3.28.3 any release builds such as RelWithDebInfo/Release produce corrupted artifacts, so that final linking is failing with following:

```
/usr/bin/ld: /mnt/d/cache/wsl/conan2/b/socicef571bafca39/p/lib/libsoci_postgresql.a: error adding symbols: file format not recognized                                                       
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

4.0.3 library has SOCI_LTO equal False by default,

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
