### PR TITLE
[libpq] OpenSSL option is none when disabled

### DIFF
--- a/recipes/libpq/meson/conanfile.py
+++ b/recipes/libpq/meson/conanfile.py
@@ -106,7 +106,7 @@ class LibpqConan(ConanFile):
             return "enabled" if v else "disabled"
 
         tc = MesonToolchain(self)
-        tc.project_options["ssl"] = "openssl" if self.options.with_openssl else "disabled"
+        tc.project_options["ssl"] = "openssl" if self.options.with_openssl else "none"
         tc.project_options["icu"] = feature(self.options.with_icu)
         # Why did the old version disable this explicitly?
         tc.project_options["zlib"] = feature(self.options.with_zlib)


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpq/17.5**

#### Motivation

When cross-building libpq and disabling openssl for libpq 17.5, it resulted in:

```
conan create meson --version=17.5  -o "&:with_openssl=False" 

======== Exporting recipe to the cache ========
libpq/17.5: Exporting package recipe: /home/uilian/Development/conan/conan-center-index/recipes/libpq/meson/conanfile.py
libpq/17.5: exports: File 'conandata.yml' found. Exporting it...
libpq/17.5: Calling export_sources()
libpq/17.5: Copied 1 '.py' file: conanfile.py
libpq/17.5: Copied 1 '.yml' file: conandata.yml
libpq/17.5: Copied 1 '.patch' file: 17.5-pgflex-preserve-environment-variables.patch
libpq/17.5: Exported to cache folder: /home/uilian/.conan2/p/libpq07ec98de5bcfd/e
libpq/17.5: Exported: libpq/17.5#2581ed805fba78891a91aa3c759f05ac (2025-07-04 07:07:45 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux
[options]
&:with_openssl=False
[conf]
tools.build:verbosity=verbose
tools.cmake.cmaketoolchain:generator=Ninja
tools.compilation:verbosity=verbose
tools.system.package_manager:mode=install
tools.system.package_manager:sudo=true

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux
[conf]
tools.build:verbosity=verbose
tools.cmake.cmaketoolchain:generator=Ninja
tools.compilation:verbosity=verbose
tools.system.package_manager:mode=install
tools.system.package_manager:sudo=true


======== Computing dependency graph ========
Graph root
    cli
Requirements
    libiconv/1.17#1ae2f60ab5d08de1643a22a81b360c59 - Cache
    libpq/17.5#2581ed805fba78891a91aa3c759f05ac - Cache
    libxml2/2.13.6#6771e0f3decae544bc94f16259438684 - Cache
    libxslt/1.1.42#c1b4db9ead063bd275a7227d85cf519e - Cache
    lz4/1.9.4#652b313a0444c8b1d60d1bf9e95fb0a1 - Cache
    readline/8.2#7ff1c228c561d494406f59707dcf28a9 - Cache
    termcap/1.3.1#1986f84bf21dd07ea774b027a3201fcb - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76 - Cache
    zstd/1.5.7#f98394e178ac97e2a7b445ea0ce6bcaf - Cache
Build requirements
    bison/3.8.2#ed1ba0c42d2ab7ab64fc3a62e9ecc673 - Cache
    flex/2.6.4#e35bc44b3fcbcd661e0af0dc5b5b1ad4 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    meson/1.2.2#21b73818ba96d9eea465b310b5bbc993 - Cache
    meson/1.6.0#df190c5b0592572e6f5a1b05999e7e6d - Cache
    ninja/1.12.1#fd583651bf0c6a901943495d49878803 - Cache
    pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605 - Cache
    pkgconf/2.2.0#6462942a22803086372db44689ba825f - Cache
Resolved version ranges
    libxml2/[>=2.12.5 <3]: libxml2/2.13.6
    libxslt/[^1.1]: libxslt/1.1.42
    meson/[>=1.2.3 <2]: meson/1.6.0
    ninja/[>=1.10.2 <2]: ninja/1.12.1
    pkgconf/[>=2.2 <3]: pkgconf/2.2.0
    zlib/[>=1.2.11 <2]: zlib/1.3.1
    zstd/[>=1.5 <1.6]: zstd/1.5.7

======== Computing necessary packages ========
libpq/17.5: Forced build from source
Requirements
    libiconv/1.17#1ae2f60ab5d08de1643a22a81b360c59:b647c43bfefae3f830561ca202b6cfd935b56205#fbd617c1c877b4e09c958d977c165986 - Cache
    libpq/17.5#2581ed805fba78891a91aa3c759f05ac:8b48accf4263f9c7e45eaebf96dcc88f73a4ba88 - Build
    libxml2/2.13.6#6771e0f3decae544bc94f16259438684:e17cb9b87b96eccd0a54114ea0bb80ffb5bc2662#798b4797c874a83a388de88a8c867fdb - Cache
    libxslt/1.1.42#c1b4db9ead063bd275a7227d85cf519e:3ad3afd1fa0a87472a2e6f8039200e7462ad4246#4aeea09f264fdebdc83f21620576d4c8 - Cache
    lz4/1.9.4#652b313a0444c8b1d60d1bf9e95fb0a1:b647c43bfefae3f830561ca202b6cfd935b56205#33c306a6f6feabb2e61f84e3b64a3b81 - Cache
    readline/8.2#7ff1c228c561d494406f59707dcf28a9:6afa678f41cf89ab24f74731ded73ad4e7c9581d#6a402227a661215e5b858889cb57e0bf - Cache
    termcap/1.3.1#1986f84bf21dd07ea774b027a3201fcb:b647c43bfefae3f830561ca202b6cfd935b56205#bd6824288d66d459b5ba7bbfc63890b9 - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76:b647c43bfefae3f830561ca202b6cfd935b56205#fee20b6da94c4580b0c84ca5ce203fdc - Cache
    zstd/1.5.7#f98394e178ac97e2a7b445ea0ce6bcaf:c1b14c3945d5adf1e5ae440c43c12f88117f2edc#06c674188ad93a35623649672ce9c4bf - Cache
Build requirements
    bison/3.8.2#ed1ba0c42d2ab7ab64fc3a62e9ecc673:500c2a3f502e0ca7d4a4c65cb2a4a0b0a24994f5#5cb896361e56e9799eac5902503e1efc - Cache
    flex/2.6.4#e35bc44b3fcbcd661e0af0dc5b5b1ad4:b647c43bfefae3f830561ca202b6cfd935b56205#d18545ed84d684e0090595f1eb0d23c5 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2:3593751651824fb813502c69c971267624ced41a#eb16145946d9c9fa95b777969da769ab - Cache
    meson/1.6.0#df190c5b0592572e6f5a1b05999e7e6d:da39a3ee5e6b4b0d3255bfef95601890afd80709#6e4dcc10bd6989a72a3bec7c1c328cfe - Cache
    ninja/1.12.1#fd583651bf0c6a901943495d49878803:3593751651824fb813502c69c971267624ced41a#a89b4f8098ea69d3842a0c5709da0471 - Cache
    pkgconf/2.2.0#6462942a22803086372db44689ba825f:c0b621fd4b3199fe05075171573398833dba85f4#35e5163b1cf42becef616e6b7873202e - Cache
Skipped binaries
    meson/1.2.2, pkgconf/2.1.0

======== Installing packages ========
libiconv/1.17: Already installed! (1 of 15)
lz4/1.9.4: Already installed! (2 of 15)
m4/1.4.19: Already installed! (3 of 15)
ninja/1.12.1: Already installed! (4 of 15)
termcap/1.3.1: Already installed! (5 of 15)
zlib/1.3.1: Already installed! (6 of 15)
zstd/1.5.7: Already installed! (7 of 15)
flex/2.6.4: Already installed! (8 of 15)
flex/2.6.4: Appending PATH environment variable: /home/uilian/.conan2/p/flex3e76cfacb0c1a/p/bin
flex/2.6.4: Setting LEX environment variable: /home/uilian/.conan2/p/flex3e76cfacb0c1a/p/bin/flex
pkgconf/2.2.0: Already installed! (9 of 15)
pkgconf/2.2.0: WARN: deprecated: The use of 'unix_path_legacy_compat' is deprecated in Conan 2.0 and does not perform path conversions. This is retained for compatibility with Conan 1.x and will be removed in a future version.
meson/1.6.0: Already installed! (10 of 15)
meson/1.6.0: Finalized folder /home/uilian/.conan2/p/meson70f304e27b046/f
readline/8.2: Already installed! (11 of 15)
bison/3.8.2: Already installed! (12 of 15)
libxml2/2.13.6: Already installed! (13 of 15)
libxml2/2.13.6: Appending PATH environment variable: /home/uilian/.conan2/p/libxm074a36348435c/p/bin
libxslt/1.1.42: Already installed! (14 of 15)
libpq/17.5: Calling source() in /home/uilian/.conan2/p/libpq07ec98de5bcfd/s/src
libpq/17.5: Source https://ftp.postgresql.org/pub/source/v17.5/postgresql-17.5.tar.bz2 retrieved from local download cache
libpq/17.5: Uncompressing postgresql-17.5.tar.bz2 to .
libpq/17.5: Apply patch (file): patches/17.5-pgflex-preserve-environment-variables.patch

-------- Installing package libpq/17.5 (15 of 15) --------
libpq/17.5: Building from source
libpq/17.5: Package libpq/17.5:8b48accf4263f9c7e45eaebf96dcc88f73a4ba88
libpq/17.5: settings: os=Linux arch=x86_64 compiler=gcc compiler.version=11 build_type=Release
libpq/17.5: options: disable_rpath=False fPIC=True shared=False with_icu=False with_libxml2=True with_lz4=True with_openssl=False with_readline=True with_xslt=True with_zlib=True with_zstd=True
libpq/17.5: requires: zstd/1.5.Z lz4/1.9.Z libxslt/1.1.Z libxml2/2.13.Z zlib/1.3.Z libiconv/1.17.Z readline/8.2.Z termcap/1.3.Z
libpq/17.5: Copying sources to build folder
libpq/17.5: Building your package in /home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b
libpq/17.5: Calling generate()
libpq/17.5: Generators folder: /home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/build-release/conan
libpq/17.5: MesonToolchain generated: conan_meson_native.ini
libpq/17.5: Generating aggregated env files
libpq/17.5: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
libpq/17.5: Calling build()
libpq/17.5: Meson configure cmd: meson setup --native-file "/home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/build-release/conan/conan_meson_native.ini" "/home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/build-release" "/home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/src" --prefix=/
libpq/17.5: RUN: meson setup --native-file "/home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/build-release/conan/conan_meson_native.ini" "/home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/build-release" "/home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/src" --prefix=/
The Meson build system
Version: 1.6.0
Source dir: /home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/src
Build dir: /home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/build-release
Build type: native build

../src/meson.build:9:0: ERROR: Value "disabled" (of type "string") for option "ssl" is not one of the choices. Possible choices are (as string): "auto", "none", "openssl".

A full log can be found at /home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/build-release/meson-logs/meson-log.txt

libpq/17.5: ERROR: 
Package '8b48accf4263f9c7e45eaebf96dcc88f73a4ba88' build failed
libpq/17.5: WARN: Build folder /home/uilian/.conan2/p/b/libpqeb75a0a037a3d/b/build-release
ERROR: libpq/17.5: Error in build() method, line 129
	meson.configure()
	ConanException: Error 1 while executing

```

#### Details

The Meson options for openssl option uses `none` instead of `disabled` as usually we see for most of options: https://github.com/postgres/postgres/blob/REL_17_5/meson_options.txt#L148

After building with following change, I can build without errors:
[libpq-17.5-linux-gcc-static-no-openssl.log](https://github.com/user-attachments/files/21052183/libpq-17.5-linux-gcc-static-no-openssl.log)



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
