### PR TITLE
[libpq] Add Mingw support for Linux

### DIFF
--- a/recipes/libpq/meson/conanfile.py
+++ b/recipes/libpq/meson/conanfile.py
@@ -86,9 +86,8 @@ class LibpqConan(ConanFile):
         self.tool_requires("meson/[>=1.2.3 <2]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/[>=2.2 <3]")
-        if self.settings.os == "Windows":
-            self.tool_requires("strawberryperl/5.32.1.1")
         if self.settings_build.os == "Windows":
+            self.tool_requires("strawberryperl/5.32.1.1")
             self.tool_requires("winflexbison/2.5.25")
         else:
             self.tool_requires("flex/2.6.4")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpq/17.5**

#### Motivation

When trying to cross-build from Linux to Windows, it fails because is trying to consume `strawberry perl` on Linux, which is invalid:

```
======== Computing necessary packages ========
libpq/17.5: Forced build from source
Requirements
    libpq/17.5#2581ed805fba78891a91aa3c759f05ac:30fa8dcf91a98313887a8538d67f74a70ffe118f - Build
    lz4/1.9.4#652b313a0444c8b1d60d1bf9e95fb0a1:726c1053e53f5cbfb929d3ab6761995dd6db21ad#7089c881147c4690019ee9dfb5ef87fa - Cache
    openssl/3.4.1#638c4c4df8ecdef1f7aa73fc0d07fde6:b88d8be022b8b697c98fbdf0a6140844b0a7e487#807add2420aa41484a1edc525c30df64 - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76:726c1053e53f5cbfb929d3ab6761995dd6db21ad#861ee0d701f44834eb69eed5b826e240 - Cache
    zstd/1.5.7#f98394e178ac97e2a7b445ea0ce6bcaf:94caef37312ea13d21b14cb30c7689862e52450b#bdf1e905b8b9b75e92c15992493ceabb - Cache
Build requirements
    bison/3.8.2#ed1ba0c42d2ab7ab64fc3a62e9ecc673:500c2a3f502e0ca7d4a4c65cb2a4a0b0a24994f5#5cb896361e56e9799eac5902503e1efc - Cache
    flex/2.6.4#e35bc44b3fcbcd661e0af0dc5b5b1ad4:b647c43bfefae3f830561ca202b6cfd935b56205#d18545ed84d684e0090595f1eb0d23c5 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2:3593751651824fb813502c69c971267624ced41a#eb16145946d9c9fa95b777969da769ab - Cache
    meson/1.6.0#df190c5b0592572e6f5a1b05999e7e6d:da39a3ee5e6b4b0d3255bfef95601890afd80709#6e4dcc10bd6989a72a3bec7c1c328cfe - Cache
    ninja/1.12.1#fd583651bf0c6a901943495d49878803:3593751651824fb813502c69c971267624ced41a#a89b4f8098ea69d3842a0c5709da0471 - Cache
    pkgconf/2.2.0#6462942a22803086372db44689ba825f:c0b621fd4b3199fe05075171573398833dba85f4#35e5163b1cf42becef616e6b7873202e - Cache
    strawberryperl/5.32.1.1#707032463aa0620fa17ec0d887f5fe41:63fead0844576fc02943e16909f08fcdddd6f44b - Invalid
Skipped binaries
    meson/1.2.2
ERROR: There are invalid packages:
strawberryperl/5.32.1.1: Invalid: strawberryperl/5.32.1.1 is only intended to be used on Windows.
```

My full build log can be viewed here: [libpq-17.5-linux-mingw-static-master.log](https://github.com/user-attachments/files/21053860/libpq-17.5-linux-mingw-static-master.log)


#### Details

The `strawberryperl` is a package that makes Perl available on Windows, but should be consumed only when the build machine is running Windows.

Applying the following patch, I can build on Linux using mingw: [libpq-17.5-linux-mingw-static-patched.log](https://github.com/user-attachments/files/21053878/libpq-17.5-linux-mingw-static-patched.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
