### PR TITLE
mdns: remove pthread for Android recipe

### DIFF
--- a/recipes/mdns/all/conanfile.py
+++ b/recipes/mdns/all/conanfile.py
@@ -38,7 +38,7 @@ class MdnsConan(ConanFile):
 
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ["iphlpapi", "ws2_32"]
-        if str(self.settings.os) in ["Linux", "FreeBSD", "Android"]:
+        if str(self.settings.os) in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("pthread")
 
         self.cpp_info.set_property("cmake_file_name", "mdns")


### PR DESCRIPTION
### Summary
Removed incompatible pthread dependency for Android on **mdns/1.4.3**

#### Motivation
Fix issue [#27859](https://github.com/conan-io/conan-center-index/issues/27859)

#### Details
The pthread dependency on Android will cause the error `unable to find library -lpthread` because pthread is a built-in feature of Android libc (Bionic).


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
