### PR TITLE
Fix sha256 hash for CMake v3.31.8 for Windows armv8

### DIFF
--- a/recipes/cmake/binary/conandata.yml
+++ b/recipes/cmake/binary/conandata.yml
@@ -33,7 +33,7 @@ sources:
     Windows:
       armv8:
         url: "https://cmake.org/files/v3.31/cmake-3.31.8-windows-arm64.zip"
-        sha256: "d37ca89ec60aece080664ee936f7aaffdfdbde0a201b165c45ecfaf68a4c1fa93"
+        sha256: "d37ca89ec60aece080664ee936f7aaffdfdbde0a201b165c45ecfaf68a4c1fa9"
       x86_64:
         url: "https://cmake.org/files/v3.31/cmake-3.31.8-windows-x86_64.zip"
         sha256: "81aa9964dbabd71fe02e7ec50472fd3ad56138c49944515ece9001efbff8d719"


### PR DESCRIPTION
### Summary
Changes to recipe:  **cmake/[3.31.8 ]**

#### Motivation
The sha256 hash for this package introduced in #27717 is incorrect, it has an extra `3` appended to the end, making it 65 characters long instead of 64, which causes installation of this package to fail as the hash does not match the actual package hash.

#### Details
Removes the extra character.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
