### PR TITLE
Add a new recipe : cpp-datetime-library 

### DIFF
--- a/recipes/cpp-datetime-library/all/conandata.yml
+++ b/recipes/cpp-datetime-library/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "1.0.2":
+    url: "https://github.com/jeremydumais/CPP-DateTime-library/archive/refs/tags/v1.0.2.zip"
+    sha256: "d42e6f320ebd3fc7839e3375073f126d7bcd7b2b7a68f7c86163c3fa19ef5882"
+

--- a/recipes/cpp-datetime-library/all/conanfile.py
+++ b/recipes/cpp-datetime-library/all/conanfile.py
@@ -1,0 +1,73 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm, rmdir, replace_in_file
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+import os
+
+
+required_conan_version = ">=2.0.9"
+
+class PackageConan(ConanFile):
+    name = "cpp-datetime-library"
+    description = "A simple Date and time library built in C++"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/jeremydumais/CPP-DateTime-library"
+    topics = ("c", "cpp", "cpp-library", "macos", "windows", "linux", "date", "time")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        check_min_cppstd(self, 14)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if is_msvc(self):
+            tc.cache_variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.libdirs = [os.path.join("lib", "datetime")]
+        self.cpp_info.libs = ["datetime"]
+        self.cpp_info.set_property("cmake_module_file_name", "datetime")
+        self.cpp_info.set_property("cmake_module_target_name", "datetime::datetime")
+        self.cpp_info.set_property("cmake_file_name", "datetime")
+        self.cpp_info.set_property("cmake_target_name", "datetime::datetime")
+        if not self.options.shared:
+            self.cpp_info.defines.append("DATETIME_STATIC")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["m", "pthread", "dl"])

--- a/recipes/cpp-datetime-library/all/test_package/CMakeLists.txt
+++ b/recipes/cpp-datetime-library/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(datetime REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE datetime::datetime)

--- a/recipes/cpp-datetime-library/all/test_package/conanfile.py
+++ b/recipes/cpp-datetime-library/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cpp-datetime-library/all/test_package/test_package.cpp
+++ b/recipes/cpp-datetime-library/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <cstdlib>
+#include "datetime/datetime.h"
+
+
+int main(void) {
+    jed_utils::datetime date1(2025, 01, 02);
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/cpp-datetime-library/config.yml
+++ b/recipes/cpp-datetime-library/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.2":
+    folder: all


### PR DESCRIPTION
### Summary
Add a new recipe: cpp-datetime-library/1.0.2

#### Motivation
I want my C++ datetime library to be easily accessible in users projects.

#### Details
DateTime library is a simple Date and time library built in C++. It is pretty much based on the .NET DateTime Struct.
The library is cross-platform and has been tested on Linux, Windows and macOS.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
