### PR TITLE
tinyobjloader: CMake 4 support

### DIFF
--- a/recipes/tinyobjloader/all/conanfile.py
+++ b/recipes/tinyobjloader/all/conanfile.py
@@ -1,11 +1,10 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, get, export_conandata_patches, load, replace_in_file, rmdir, save
+from conan.tools.files import apply_conandata_patches, get, export_conandata_patches, load, replace_in_file, rmdir
 from conan.tools.scm import Version
 import os
-import textwrap
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.1"
 
 
 class TinyObjLoaderConan(ConanFile):
@@ -15,7 +14,7 @@ class TinyObjLoaderConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/syoyo/tinyobjloader"
     topics = ("loader", "obj", "3d", "wavefront", "geometry")
-
+    package_type = "library"
     settings = "os", "arch", "build_type", "compiler"
     options = {
         "shared": [True, False],
@@ -27,20 +26,10 @@ class TinyObjLoaderConan(ConanFile):
         "fPIC": True,
         "double": False,
     }
+    implements = ["auto_shared_fpic"]
 
     def export_sources(self):
         export_conandata_patches(self)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -74,33 +63,11 @@ class TinyObjLoaderConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "tinyobjloader"))
         self._remove_implementation(os.path.join(self.package_folder, "include", "tiny_obj_loader.h"))
 
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        cmake_target = "tinyobjloader_double" if self.options.double else "tinyobjloader"
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {cmake_target: "tinyobjloader::tinyobjloader"}
-        )
-
     def _remove_implementation(self, header_fullpath):
         header_content = load(self, header_fullpath)
         begin = header_content.find("#ifdef TINYOBJLOADER_IMPLEMENTATION")
         implementation = header_content[begin:-1]
         replace_in_file(self, header_fullpath, implementation, "")
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     def package_info(self):
         suffix = "_double" if self.options.double else ""
@@ -111,7 +78,3 @@ class TinyObjLoaderConan(ConanFile):
         self.cpp_info.libs = [f"tinyobjloader{suffix}"]
         if self.options.double:
             self.cpp_info.defines.append("TINYOBJLOADER_USE_DOUBLE")
-
-        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/tinyobjloader/all/patches/1.0.x-0001-cmake-minimum-required.patch
+++ b/recipes/tinyobjloader/all/patches/1.0.x-0001-cmake-minimum-required.patch
@@ -4,7 +4,7 @@
  #Tiny Object Loader Cmake configuration file.
  #This configures the Cmake system with multiple properties, depending
  #on the platform and configuration it is set to build in.
-+cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
  project(tinyobjloader)
 -cmake_minimum_required(VERSION 2.8.11)
  set(TINYOBJLOADER_SOVERSION 1)

--- a/recipes/tinyobjloader/all/patches/2.0.0-rc10-0001-cmake-minimum-required.patch
+++ b/recipes/tinyobjloader/all/patches/2.0.0-rc10-0001-cmake-minimum-required.patch
@@ -4,9 +4,9 @@
  #Tiny Object Loader Cmake configuration file.
  #This configures the Cmake system with multiple properties, depending
  #on the platform and configuration it is set to build in.
--project(tinyobjloader)
- cmake_minimum_required(VERSION 3.2)
-+project(tinyobjloader)
++cmake_minimum_required(VERSION 3.5)
+ project(tinyobjloader)
+-cmake_minimum_required(VERSION 3.2)
  set(TINYOBJLOADER_SOVERSION 2)
  set(TINYOBJLOADER_VERSION 2.0.0-rc.10)
  


### PR DESCRIPTION
Fixes to support CMake 4:

* Increase CMake minimum required to 3.5, fixing build error when using CMake 4.0

* Added `package_type = "library"`, no executable packaged, only libs:
```sh
tree /Users/perseo/.conan2/p/b/tinyo70487260e96e5/p                                                                       
/Users/perseo/.conan2/p/b/tinyo70487260e96e5/p
├── conaninfo.txt
├── conanmanifest.txt
├── include
│   └── tiny_obj_loader.h
├── lib
│   └── libtinyobjloader.a
└── licenses
    └── LICENSE
```
* Removed conan v1 specific code


