### PR TITLE
wxpdfdoc: Add new recipe

### DIFF
--- a/recipes/wxpdfdoc/all/conandata.yml
+++ b/recipes/wxpdfdoc/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.3.1":
+    url: "https://github.com/utelle/wxpdfdoc/archive/refs/tags/v1.3.1.tar.gz"
+    sha256: "b0708a1fa12ed0848d58a4dc84d556e2a276c94468241197bb7329467ff6a75f"

--- a/recipes/wxpdfdoc/all/conanfile.py
+++ b/recipes/wxpdfdoc/all/conanfile.py
@@ -1,0 +1,103 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import collect_libs, copy, get, rmdir
+from conan.tools.gnu import Autotools
+from conan.tools.layout import basic_layout
+from conan.tools.premake import Premake, PremakeDeps, PremakeToolchain
+
+required_conan_version = ">=2.19.0"
+
+
+class WxPdfDocConan(ConanFile):
+    name = "wxpdfdoc"
+    description = "wxPdfDocument allows wxWidgets applications to generate PDF documents."
+    license = "WxWindows-exception-3.1"
+    url = "https://github.com/utelle/wxpdfdoc"
+    homepage = "https://utelle.github.io/wxpdfdoc/"
+    topics = ("wxwidgets", "pdf")
+    settings = "os", "compiler", "build_type", "arch"
+    exports_sources = '*'
+    package_type = "library"
+    options = { "shared": [True, False] }
+    default_options = { "shared": False }
+    generators = "AutotoolsDeps", "AutotoolsToolchain"
+
+    def layout(self):
+        basic_layout(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def requirements(self):
+        # Supports 3.0.x, 3.1.x and 3.2.x as defined in the repository readme
+        self.requires("wxwidgets/[>=3.0.0 <3.3]", transitive_headers=True, transitive_libs=True)
+
+    def build_requirements(self):
+        self.tool_requires("premake/5.0.0-beta7")
+
+    def generate(self):
+        if self.settings.os == "Windows":
+            deps = PremakeDeps(self)
+            deps.generate()
+            tc = PremakeToolchain(self)
+            tc.generate()
+
+    def _arch_to_msbuild_platform(self, arch) -> str:
+        platform_map = {
+            "x86": "Win32",
+            "x86_64": "Win64",
+        }
+        platform = platform_map.get(str(arch))
+        if not platform:
+            raise ConanInvalidConfiguration(f"Unsupported architecture: {arch}")
+        return platform
+
+    def _msvc_version_str(self) -> str:
+        version_map = {
+            "193": "vc17",
+        }
+        version = version_map.get(str(self.settings.compiler.version))
+        if not version:
+            raise ConanInvalidConfiguration(f"Unimplemented compiler version: {self.settings.compiler.version}")
+        return version
+
+    def build(self):
+        if self.settings.os == "Windows":
+            premake = Premake(self)
+            premake.configure()
+            platform = self._arch_to_msbuild_platform(self.settings.arch)
+            premake.build(workspace=f"wxpdfdoc_{self._msvc_version_str()}", targets=["wxpdfdoc"], msbuild_platform=platform)
+        else:
+            wxwidgets_root = self.dependencies["wxwidgets"].package_folder
+            autotools = Autotools(self)
+            autotools.autoreconf()
+            wx_config = os.path.join(wxwidgets_root, "bin", "wx-config")
+            autotools.configure(args=[f"--with-wx-config={wx_config}"])
+            autotools.make()
+
+    def package(self):
+        if self.settings.os == "Windows":
+            copy(self, "*", os.path.join(self.source_folder, "include"), os.path.join(self.package_folder, "include"))
+            lib_dir = os.path.join(self.source_folder, "lib")
+            subdirs = [d for d in os.listdir(lib_dir) if os.path.isdir(os.path.join(lib_dir, d))]
+            # Expecting one directory named something similar to "vc14x_x64_lib" and "fonts"
+            assert len(subdirs) == 2, f"Expected exactly two subdirectories in {lib_dir}, found: {subdirs}"
+            subdirs = sorted([d for d in subdirs if d.endswith("_lib")])
+            copy(self, "*", os.path.join(self.source_folder, "lib", subdirs[0]), os.path.join(self.package_folder, "lib"))
+            platform = self._arch_to_msbuild_platform(self.settings.arch)
+            copy(self, "*", os.path.join(self.source_folder, "build-release", "lib", self._msvc_version_str(), platform, str(self.settings.build_type)), os.path.join(self.package_folder, "lib"))
+        else:
+            autotools = Autotools(self)
+            autotools.install()
+            rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+        copy(self, "LICENCE.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+
+    def package_info(self):
+        if self.settings.os == "Windows":
+            self.cpp_info.libs = ["wxpdfdoc", "libwoff2", "libzint"]
+        else:
+            # Collect libraries with names like "wxcode_gtk2u_pdfdoc-3.2"
+            self.cpp_info.libs = collect_libs(self, folder="lib")

--- a/recipes/wxpdfdoc/all/test_package/CMakeLists.txt
+++ b/recipes/wxpdfdoc/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(wxpdfdoc REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE wxpdfdoc::wxpdfdoc)

--- a/recipes/wxpdfdoc/all/test_package/conanfile.py
+++ b/recipes/wxpdfdoc/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/wxpdfdoc/all/test_package/test_package.cpp
+++ b/recipes/wxpdfdoc/all/test_package/test_package.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+
+// For compilers that support precompilation, includes "wx/wx.h".
+#include "wx/wxprec.h"
+
+#ifdef __BORLANDC__
+#pragma hdrstop
+#endif
+
+#ifndef WX_PRECOMP
+#include "wx/wx.h"
+#endif
+
+#include <wx/pdfdoc.h>
+#include <wx/pdfdoc_version.h>
+
+int main()
+{
+    std::cout << PDFDOC_VERSION_STRING << std::endl;
+
+    wxPdfDocument pdf;
+
+    return 0;
+}

--- a/recipes/wxpdfdoc/config.yml
+++ b/recipes/wxpdfdoc/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.3.1":
+    folder: all


### PR DESCRIPTION
Add [wxPdfDoc](https://github.com/utelle/wxpdfdoc) recipe.

Some notes about the recipe:
- Windows builds are Premake based (tested on Windows 11 (23H2) x64)
- Linux builds are Autotools based (tested on Ubuntu 24.04 x64)
- Other operating systems like MacOS have not been tested but are expected to work with Autotools out of the box

Note that this PR requires Conan fix https://github.com/conan-io/conan/pull/18572 which is expected to be contained in version 2.19.0. In case you want to test this recipe before the new Conan package is released make sure to install Conan's latest development version with `pip install git+https://github.com/conan-io/conan.git`.
