### PR TITLE
Added reflect-cpp 0.19.0

### DIFF
--- a/recipes/reflect-cpp/all/conandata.yml
+++ b/recipes/reflect-cpp/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "0.18.0":
     url: "https://github.com/getml/reflect-cpp/archive/refs/tags/v0.18.0.tar.gz"
     sha256: "c8df46550d787105ce695ea8f99425dc47475f5377c5253d412dd63f622dc7c7"
+  "0.19.0":
+    url: "https://github.com/getml/reflect-cpp/archive/refs/tags/v0.19.0.tar.gz"
+    sha256: "aad9e010a0e716ecf643a95cec2047c74ce4311accfe42b4cf888672267ab8cd"

--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -93,7 +93,7 @@ class ReflectCppConan(ConanFile):
         if self.options.with_msgpack:
             self.requires("msgpack-c/6.0.0", transitive_headers=True)
         if self.options.with_toml:
-            if Version(self.version) >= Version("0.18.0"):
+            if Version(self.version) == Version("0.18.0"):
                 self.requires("toml11/4.4.0", transitive_headers=True)
             else:
                 self.requires("tomlplusplus/3.4.0", transitive_headers=True)

--- a/recipes/reflect-cpp/config.yml
+++ b/recipes/reflect-cpp/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "0.18.0":
     folder: all
+  "0.19.0":
+    folder: all


### PR DESCRIPTION
### Summary
Adds version for recipe:  **reflect-cpp/0.19.0**

#### Motivation
Addresses #27868 

#### Details

The only change to dependencies in this version is reverting to a different toml package as detailed here: https://github.com/getml/reflect-cpp/commit/d73d98f1c85fa0de593a26944c76d4f91fabe2c2

Tested successfully with:

```
conan create all/conanfile.py  --version=0.19.0 -s compiler.cppstd=20 --build=yyjson/0.10.0 --build=reflect-cpp/0.19.0 -o with_toml=True
```
---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
