### PR TITLE
[ripper37-libbase] Add a new recipe (v1.1.2)

### DIFF
--- a/recipes/ripper37-libbase/all/conandata.yml
+++ b/recipes/ripper37-libbase/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "1.1.2":
+    url: "https://github.com/RippeR37/libbase/archive/refs/tags/v1.1.2.tar.gz"
+    sha256: "cee3263a62c9c632cc7fe5103f88321039535b793a5f2da7d606ca442e85110b"
+    strip_root: true

--- a/recipes/ripper37-libbase/all/conanfile.py
+++ b/recipes/ripper37-libbase/all/conanfile.py
@@ -1,0 +1,115 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, export_conandata_patches, get, rm, rmdir
+
+
+required_conan_version = ">=2.0.9"
+
+
+class LibbaseConan(ConanFile):
+    name = "ripper37-libbase"
+    description = "Standalone reimplementation of //base module from Chromium"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/RippeR37/libbase"
+    topics = ("Chromium", "base", "net", "multithreading", "async")
+
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "module_net": [True, False],
+        "module_win": [True, False],
+        "module_wx": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "module_net": True,
+        "module_win": True,
+        "module_wx": False,
+    }
+
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+        else:
+            del self.options.module_win
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("glog/0.7.1", transitive_headers=True, transitive_libs=True)
+        if self.options.module_net:
+            self.requires("libcurl/[>=8.12 <9.0]")
+        if self.options.module_wx:
+            self.requires("wxwidgets/3.2.6")
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+        if self.settings.os not in ["Windows", "Linux", "Macos"]:
+            raise ConanInvalidConfiguration(f"{self.ref} not supported on {self.settings.os}")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version])
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Modules
+        tc.cache_variables["LIBBASE_BUILD_MODULE_NET"] = self.options.module_net
+        tc.cache_variables["LIBBASE_BUILD_MODULE_WIN"] = self.options.get_safe("module_win", False)
+        tc.cache_variables["LIBBASE_BUILD_MODULE_WX"] = self.options.module_wx
+        # Internal development options
+        tc.cache_variables["LIBBASE_BUILD_EXAMPLES"] = False
+        tc.cache_variables["LIBBASE_BUILD_TESTS"] = False
+        tc.cache_variables["LIBBASE_BUILD_PERFORMANCE_TESTS"] = False
+        tc.cache_variables["LIBBASE_CLANG_TIDY"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        # Core `libbase`
+        self.cpp_info.set_property("cmake_file_name", "libbase")
+        self.cpp_info.set_property("cmake_target_name", "libbase::libbase")
+        self.cpp_info.requires = ["core"]
+        self.cpp_info.components["core"].libs = ["libbase"]
+        self.cpp_info.components["core"].set_property("cmake_target_name", "libbase::libbase")
+        self.cpp_info.components["core"].defines = [f"LIBBASE_IS_{str(self.settings.os).upper()}"]
+        self.cpp_info.components["core"].includedirs = ["include/libbase"]
+        self.cpp_info.components["core"].requires = ["glog::glog"]
+
+        # Optional components
+        components_info = [
+            ("net", ["libcurl::libcurl"]),
+            ("win", []),
+            ("wx",  ["wxwidgets::wxwidgets"]),
+        ]
+        for comp, deps in components_info:
+            if self.options.get_safe(f"module_{comp}", False):
+                self.cpp_info.components[comp].libs = [f"libbase_{comp}"]
+                self.cpp_info.components[comp].set_property("cmake_target_name", f"libbase::libbase_{comp}")
+                self.cpp_info.components[comp].defines = [f"LIBBASE_MODULE_{comp.upper()}"]
+                self.cpp_info.components[comp].requires = ["core"] + deps

--- a/recipes/ripper37-libbase/all/test_package/CMakeLists.txt
+++ b/recipes/ripper37-libbase/all/test_package/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+# Required core lib and optional modules
+find_package(libbase CONFIG REQUIRED OPTIONAL_COMPONENTS net win wx)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+
+# Required core target
+target_link_libraries(${PROJECT_NAME} PRIVATE libbase::libbase)
+# Optional module targets
+if(TARGET libbase::libbase_net)
+  target_link_libraries(${PROJECT_NAME} PRIVATE libbase::libbase_net)
+endif()
+if(TARGET libbase::libbase_win)
+  target_link_libraries(${PROJECT_NAME} PRIVATE libbase::libbase_win)
+endif()
+if(TARGET libbase::libbase_wx)
+  target_link_libraries(${PROJECT_NAME} PRIVATE libbase::libbase_wx)
+endif()

--- a/recipes/ripper37-libbase/all/test_package/conanfile.py
+++ b/recipes/ripper37-libbase/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/ripper37-libbase/all/test_package/test_package.cpp
+++ b/recipes/ripper37-libbase/all/test_package/test_package.cpp
@@ -1,0 +1,68 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "base/callback.h"
+#include "base/init.h"
+
+#if defined(LIBBASE_MODULE_NET)
+#include "base/net/init.h"
+#include "base/net/simple_url_loader.h"
+#include "base/net/resource_request.h"
+#include "base/net/resource_response.h"
+#endif  // defined(LIBBASE_MODULE_NET)
+
+#if defined(LIBBASE_MODULE_WIN)
+#include "base/message_loop/win/win_message_loop_attachment.h"
+#endif  // defined(LIBBASE_MODULE_WIN)
+
+#if defined(LIBBASE_MODULE_WX)
+#include "base/message_loop/wx/wx_message_loop_attachment.h"
+#endif // defined(LIBBASE_MODULE_WX)
+
+int main(int argc, char* argv[]) {
+  base::Initialize(argc, argv, {});
+#if defined(LIBBASE_MODULE_NET)
+  base::net::Initialize({});
+#endif  // defined(LIBBASE_MODULE_NET)
+
+  base::BindOnce([]() { std::cout << "Hello World!" << std::endl; }).Run();
+
+  std::vector<std::string> enabled_components;
+  enabled_components.push_back("core");
+#if defined(LIBBASE_MODULE_NET)
+  // Dummy code to check linkage
+  if (argc < 0) {
+    base::net::SimpleUrlLoader::DownloadUnbounded(
+      base::net::ResourceRequest{"https://example.com"},
+      base::BindOnce([](base::net::ResourceResponse) {}));
+  }
+  enabled_components.push_back("net");
+#endif  // defined(LIBBASE_MODULE_NET)
+#if defined(LIBBASE_MODULE_WIN)
+  // Dummy code to check linkage
+  if (argc < 0) {
+    auto ml_attachment = base::win::WinMessageLoopAttachment::TryCreate();
+  }
+  enabled_components.push_back("win");
+#endif  // defined(LIBBASE_MODULE_WIN)
+#if defined(LIBBASE_MODULE_WX)
+  // Dummy code to check linkage
+  if (argc < 0) {
+    auto ml_attachment = base::wx::WxMessageLoopAttachment{nullptr};
+  }
+  enabled_components.push_back("wx");
+#endif  // defined(LIBBASE_MODULE_WX)
+
+  std::cout << "Enabled components:";
+  for (const auto& component : enabled_components) {
+    std::cout << " " << component;
+  }
+  std::cout << std::endl;
+
+#if defined(LIBBASE_MODULE_NET)
+  base::net::Deinitialize();
+#endif  // defined(LIBBASE_MODULE_NET)
+  base::Deinitialize();
+  return 0;
+}

--- a/recipes/ripper37-libbase/config.yml
+++ b/recipes/ripper37-libbase/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.1":
+    folder: all


### PR DESCRIPTION
### Summary

This commit adds a new recipe for `libbase` library. To avoid name clashes and match name with `vcpkg` port (already existing) I've chosen to use `ripper37-libbase` recipe name.

Tested locally on Linux and Windows with different modules combinations.

#### Motivation

Publish new package for easier importing into projects for its users.

#### Details

I'm the author of `libbase` project that is a reimplementation of `//base` module from Chromium. I've recently updated the project and currently aim to make it easier to use for everyone by improving CMake build/installation and publishing it to vcpkg and Conan. The library is modular and allows its users to select which parts of it they want to reduce needed dependencies.

----

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
  - Tested on Windows and Linux platforms with all applicable configurations:
  - `&:module_net=[True|False]` x `&:module_win=[True/False]` x `&:module_wx=[True/False]`