### PR TITLE
exiv2: remove unneeded libiconv dependency on Windows

### DIFF
--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -71,7 +71,8 @@ class Exiv2Conan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libiconv/1.17")
+        if self.settings.os != "Windows":
+            self.requires("libiconv/1.17")
         if self.options.with_png:
             self.requires("libpng/[>=1.6 <2]")
             self.requires("zlib/[>=1.2.11 <2]")
@@ -169,7 +170,8 @@ class Exiv2Conan(ConanFile):
         # component exiv2lib
         self.cpp_info.components["exiv2lib"].set_property("cmake_target_name", "exiv2lib")
         self.cpp_info.components["exiv2lib"].libs = ["exiv2"]
-        self.cpp_info.components["exiv2lib"].requires = [ "libiconv::libiconv"]
+        if self.settings.os != "Windows":
+            self.cpp_info.components["exiv2lib"].requires = [ "libiconv::libiconv"]
         if self.options.with_png:
             self.cpp_info.components["exiv2lib"].requires.extend(["libpng::libpng", "zlib::zlib"])
         if self.options.with_curl:


### PR DESCRIPTION

### Note from Conan Center maintainers:
Whilst iconv is supported by exiv2 also on Windows, the maintainers have expressed that it relies on Windows APis and it is not needed: https://github.com/Exiv2/exiv2/issues/3302#issuecomment-3061542298




### Summary
Changes to recipe:  **Exiv2/all**

#### Motivation
The upstream project's documentation specifically instruct to **not** build and link against iconv for build made under Windows with Visual Studio's toolchain.

If you run this Conan recipe, it will attempt to do so, and fail to build when the libiconv `./configure` script is ran (for example under git bash) because it expect to do very UNIXy/GNU things...


#### Details

See https://github.com/Exiv2/exiv2/blob/main/README.md#dependencies

And specifically https://github.com/Exiv2/exiv2/blob/main/README.md#libiconv

This patch is an attempt to fix https://github.com/Exiv2/exiv2/issues/3302 (and https://github.com/montoyatim01/Filmvert/issues/18 properly, rather than providing a custom modified recipe)

I am unsure if this is the proper way of contributing a modification to a build recipe, or if this is managed by the developers of the upstream project.

I also do not know if we should introduce an option to enable it regardless. The upstream repository's main conanfile does it (disabled by default) https://github.com/Exiv2/exiv2/blob/main/conanfile.py#L14


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan (equivalent changes done here https://github.com/Ybalrid/Filmvert/blob/yba/personal/conan-recipes/exiv2/conanfile.py#L75 and here https://github.com/Ybalrid/Filmvert/blob/yba/personal/conan-recipes/exiv2/conanfile.py#L203)
