### PR TITLE
asmjit: add version cci.20250615 (v1.17)

### DIFF
--- a/recipes/asmjit/all/conandata.yml
+++ b/recipes/asmjit/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20250615":
+    url: "https://github.com/asmjit/asmjit/archive/2ff454d41555d16d0759e4d0e95ade3c875b615e.zip"
+    sha256: "e14552c7d6409479d5e354e2a63e87646502335d3cb1d97a7f431bdce04d5903"
   "cci.20241216":
     url: "https://github.com/asmjit/asmjit/archive/cfc9f813cc6ccda63cad872edb32b38e0662bedb.zip"
     sha256: "fc1dd360336e271e915808db513128855c2482d3794e4786757ffc0f31013f80"

--- a/recipes/asmjit/config.yml
+++ b/recipes/asmjit/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20250615":
+    folder: all
   "cci.20241216":
     folder: all
   "cci.20240531":


### PR DESCRIPTION
### Summary
Changes to recipe:  **asmjit/cci.20250615**

#### Motivation
asmjit cci.20250615 (aka version 1.17) has lots of breaking changes.

While the commit message is versioned as v1.17, no official release tag has been applied.
Previous versions of asmjit sometimes introduced breaking changes without specifying a version.
So I think it would be better to avoid specifying version 1.17.

Please let me know if you have any objections.

#### Details
Release notes. (v1.17)
https://github.com/asmjit/asmjit/commit/2ff454d41555d16d0759e4d0e95ade3c875b615e

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
