### PR TITLE
[libtiff] Use version range for zstd

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -77,7 +77,7 @@ class LibtiffConan(ConanFile):
         if self.options.jbig:
             self.requires("jbig/20160605")
         if self.options.zstd:
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/[~1.5]")
         if self.options.webp:
             self.requires("libwebp/1.3.2")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libtiff/4.7.0**

#### Motivation

Related to the PR #27877. There is a conflict involving `zstd` (transitive dependency). The `libtiff` wants `zstd/1.5.5`, but `elfutils` wants `zstd/1.5.7`.

The graph conflict can be visualized by the `conan graph info`: [graph.html.txt](https://github.com/user-attachments/files/21116525/graph.html.txt)

#### Details

The `zstd` in ConanCenterIndex is using version already: https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/dependencies.md#version-ranges

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
