### PR TITLE
strawberryperl: fallback to x86_64 binaries when on arm64

### DIFF
--- a/recipes/strawberryperl/all/conanfile.py
+++ b/recipes/strawberryperl/all/conanfile.py
@@ -24,11 +24,17 @@ class StrawberryPerlConan(ConanFile):
         del self.info.settings.compiler
         del self.info.settings.build_type
 
+    def validate_build(self):
+        if self.settings.arch not in ("x86", "x86_64"):
+            raise ConanInvalidConfiguration(f"{self.ref} is only available for x86 and x86_64 architectures.")
+
     def validate(self):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration(f"{self.ref} is only intended to be used on Windows.")
-        if self.settings.arch not in ("x86", "x86_64"):
-            raise ConanInvalidConfiguration(f"{self.ref} is only available for x86 and x86_64 architectures.")
+        
+    def compatibility(self):
+        if self.settings.arch == "armv8":
+            return [{"settings": [("arch", "x86_64")]}]
 
     def source(self):
         pass


### PR DESCRIPTION
### Summary
`strawberryperl`: only binaries for x86_64 are published, but the recipe can be used on arm64 (due to emulation), to build those libraries that need it (e.g. OpenSSL)

This PR defines the `compatibility()` method so that Conan can retrieve an x86_64 when on a native arm64 build on Windows - without having to define additional settings.

close https://github.com/conan-io/conan-center-index/issues/27752

#### Motivation
Otherwise this requires a Windows arm64 user to add:
`--settings:build=strawberryperl/*:arch=x86_64` to the CLI invocation (or its profile equivalent)

#### Details
* move the architecture validation to `validate_build()` instead of `validate()` - this still prevents a binary with armv8 architecture from being created, as it can't be created
* add `compatibility()` method to allow falling back to x86_64 binary



In the event that there is no binary match in the remotes (e.g. Conan Center remote is not being used), in order to "create" this package locally on a Windows ARM64:
- `conan create . -s arch=x86_64` 
- `conan create . --build-require -s:b arch=x86_64`
- or `conan export` , and then `--build=compatible` when building anything that requires this

