### PR TITLE
msys2: improve compatibility when targetting arm64 Windows

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -51,7 +51,7 @@ class MSYS2Conan(ConanFile):
     }
     default_options = {
         "exclude_files": "*/link.exe",
-        "packages": "base-devel,binutils,gcc",
+        #"packages": "base-devel,binutils,gcc", # see config_options
         "additional_packages": None,
         "no_kill": False,
     }
@@ -64,11 +64,23 @@ class MSYS2Conan(ConanFile):
     def package_id(self):
         del self.info.options.no_kill
 
-    def validate(self):
+    def config_options(self):
+        default_packages = "base-devel,binutils,gcc"
+        if self.settings_target.arch == "armv8":
+            # The mingw-w64-cross-mingwarm64-gcc contains tools required to target arm64
+            default_packages += ",mingw-w64-cross-mingwarm64-gcc"
+        self.options.packages = default_packages
+
+    def validate_build(self):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only Windows supported")
         if self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Only Windows x64 supported")
+        
+    def compatibility(self):
+        if self.settings.arch == "armv8":
+            # Fallback on x86_64 package when natively on Windows arm64
+            return [{"settings": [("arch", "x86_64")]}]
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -191,7 +203,9 @@ class MSYS2Conan(ConanFile):
         self.conf_info.define("tools.microsoft.bash:subsystem", "msys2")
         self.conf_info.define("tools.microsoft.bash:path", os.path.join(msys_bin, "bash.exe"))
 
-        # conan v1 specific stuff
-        self.env_info.MSYS_ROOT = msys_root
-        self.env_info.MSYS_BIN = msys_bin
-        self.env_info.path.append(msys_bin)
+        if self.settings_target.arch == "armv8":
+            # Expose /opt/bin to PATH, so that aarch64-w64-mingw32- prefixed tools can be found
+            # Define autotools host/build triplet so that the right tools are used
+            self.cpp_info.bindirs.insert(0, os.path.join(self.package_folder, "opt", "bin"))
+            self.conf_info.define("tools.gnu:build_triplet", "x86_64-w64-mingw32")
+            self.conf_info.define("tools.gnu:host_triplet", "aarch64-w64-mingw32")

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -66,7 +66,7 @@ class MSYS2Conan(ConanFile):
 
     def config_options(self):
         default_packages = "base-devel,binutils,gcc"
-        if self.settings_target.arch == "armv8":
+        if self.settings_target is not None and self.settings_target.arch == "armv8":
             # The mingw-w64-cross-mingwarm64-gcc contains tools required to target arm64
             default_packages += ",mingw-w64-cross-mingwarm64-gcc"
         self.options.packages = default_packages

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -203,7 +203,7 @@ class MSYS2Conan(ConanFile):
         self.conf_info.define("tools.microsoft.bash:subsystem", "msys2")
         self.conf_info.define("tools.microsoft.bash:path", os.path.join(msys_bin, "bash.exe"))
 
-        if self.settings_target.arch == "armv8":
+        if self.settings_target is not None and self.settings_target.arch == "armv8":
             # Expose /opt/bin to PATH, so that aarch64-w64-mingw32- prefixed tools can be found
             # Define autotools host/build triplet so that the right tools are used
             self.cpp_info.bindirs.insert(0, os.path.join(msys_root, "opt", "bin"))

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -206,6 +206,6 @@ class MSYS2Conan(ConanFile):
         if self.settings_target.arch == "armv8":
             # Expose /opt/bin to PATH, so that aarch64-w64-mingw32- prefixed tools can be found
             # Define autotools host/build triplet so that the right tools are used
-            self.cpp_info.bindirs.insert(0, os.path.join(self.package_folder, "opt", "bin"))
+            self.cpp_info.bindirs.insert(0, os.path.join(msys_root, "opt", "bin"))
             self.conf_info.define("tools.gnu:build_triplet", "x86_64-w64-mingw32")
             self.conf_info.define("tools.gnu:host_triplet", "aarch64-w64-mingw32")


### PR DESCRIPTION
* When targetting arm64 Windows (irrespective if we are cross-building or not), install the `mingw-w64-cross-mingwarm64-gcc` package so that it contains the right tools to target that architecture. This fixes previously reported issues e.g. building libiconv on/for arm64
* Define the `compatibility()` method so allow a x86_64 package to be transparently retrieved on Windows ARM64 - this makes it possible to just download a preexisting package (or build a missing one with `--build=compatible`)


Close https://github.com/conan-io/conan-center-index/issues/26379
Close https://github.com/conan-io/conan-center-index/issues/14279
Close https://github.com/conan-io/conan-center-index/issues/25055
Close https://github.com/conan-io/conan-center-index/issues/18777

### Details

Fixes this (e.g. libiconv):

```
/bin/sh ../libtool --mode=link /c/users/rockd/.conan2/p/b/libic71139687767ac/b/src/build-aux/compile cl -nologo  -MD -O2 -Ob2 -FS  -o libiconv.la -rpath /lib -version-info 8:1:6 -no-undefined iconv.lo localcharset.lo relocatable.lo  libiconv.res.lo
libtool: link: /c/users/rockd/.conan2/p/b/libic71139687767ac/b/src/build-aux/ar-lib lib cr .libs/iconv.lib  iconv.obj localcharset.obj relocatable.obj libiconv.res.obj
libiconv.res.obj : fatal error LNK1112: module machine type 'x64' conflicts with target machine type 'ARM64'
```

by installing and using the right tool:
```
checking for aarch64-w64-mingw32-windres... aarch64-w64-mingw32-windres
checking for aarch64-w64-mingw32-windres... aarch64-w64-mingw32-windres
```
