### PR TITLE
Update supported GCC versions for fast-dds

### DIFF
--- a/recipes/fast-dds/all/conanfile.py
+++ b/recipes/fast-dds/all/conanfile.py
@@ -53,7 +53,6 @@ class FastDDSConan(ConanFile):
             "gcc": "8",
             "clang": "12",
             "apple-clang": "12",
-            "Visual Studio": "15",
             "msvc": "191",
         }
 

--- a/recipes/fast-dds/all/conanfile.py
+++ b/recipes/fast-dds/all/conanfile.py
@@ -49,18 +49,13 @@ class FastDDSConan(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
-        if Version(self.version) < "2.11.0":
-            return {
-                "gcc": "8",
-                "clang": "12",
-                "apple-clang": "12",
-            }
-        else:
-            return {
-                "gcc": "9",
-                "clang": "15",
-                "apple-clang": "15",
-            }
+        return {
+            "gcc": "8",
+            "clang": "12",
+            "apple-clang": "12",
+            "Visual Studio": "15",
+            "msvc": "191",
+        }
 
     def export_sources(self):
         export_conandata_patches(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **fast-dds/2.11.2**

#### Motivation

Closes #27885 

#### Details

Reduced required compiler versions for fast-dds


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
