### PR TITLE
tracy: restore cmake_target_name from #27888

### DIFF
--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -139,3 +139,5 @@ class TracyConan(ConanFile):
             if switch:
                 self.cpp_info.components["tracyclient"].defines.append(opt)
 
+        self.cpp_info.components["tracyclient"].set_property(
+            "cmake_target_name", "Tracy::TracyClient")


### PR DESCRIPTION
### Summary
Changes to recipe:  **tracy**

#### Motivation
Close #27889 

#### Details

In #27888 the following line was removed:
```py
        self.cpp_info.components["tracyclient"].set_property(
            "cmake_target_name", "Tracy::TracyClient")
```
Even though it is declared above in the global scope: https://github.com/conan-io/conan-center-index/blob/22062acd29a83fe835b026ab866fa131be461838/recipes/tracy/all/conanfile.py?plain=1#L108

If requesting `INTERFACE_INCLUDE_DIRECTORIES` from `Tracy::TracyClient`, as this interface is not in the global scope, it will fail. 

Restore previous behavior.