### PR TITLE
Limit soxr to using CMake 3 as CMake 4 requires patches

### DIFF
--- a/recipes/soxr/all/conanfile.py
+++ b/recipes/soxr/all/conanfile.py
@@ -44,6 +44,9 @@ class SoxrConan(ConanFile):
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.1 <4]")
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 


### PR DESCRIPTION
fixes #27891

### Summary
Changes to recipe:  **soxr/0.1.3**

#### Motivation
When using CMake 4 building this recipe fails with an error
`Compatibility with CMake < 3.5 has been removed from CMake`
Original project is not maintained it seems. Support for newer versions of CMake, like CMake < 3.20, will probably be revoked in the future releases too.

#### Details
Add a CMake version requirement, min and max, so that CMake generation succeeds.