### PR TITLE
yasm: CMake 4 support

### DIFF
--- a/recipes/yasm/all/conanfile.py
+++ b/recipes/yasm/all/conanfile.py
@@ -41,6 +41,8 @@ class YASMConan(ConanFile):
         del self.info.settings.compiler
 
     def build_requirements(self):
+        self.tool_requires("cmake/[>=3.0 <4]")
+
         if self._settings_build.os == "Windows" and not is_msvc(self):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):

--- a/recipes/yasm/all/conanfile.py
+++ b/recipes/yasm/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.4"
 
 
 class YASMConan(ConanFile):
@@ -19,17 +19,10 @@ class YASMConan(ConanFile):
     topics = ("yasm", "installer", "assembler")
     license = "BSD-2-Clause"
     settings = "os", "arch", "compiler", "build_type"
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
+    languages = ["C"]
 
     def export_sources(self):
         export_conandata_patches(self)
-
-    def configure(self):
-        self.settings.rm_safe("compiler.cppstd")
-        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         if is_msvc(self):
@@ -41,9 +34,8 @@ class YASMConan(ConanFile):
         del self.info.settings.compiler
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.0 <4]")
-
-        if self._settings_build.os == "Windows" and not is_msvc(self):
+        self.tool_requires("cmake/[>=4]")
+        if self.settings_build.os == "Windows" and not is_msvc(self):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
@@ -108,7 +100,3 @@ class YASMConan(ConanFile):
     def package_info(self):
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
-
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info(f"Appending PATH environment variable: {bin_path}")
-        self.env_info.PATH.append(bin_path)

--- a/recipes/yasm/all/conanfile.py
+++ b/recipes/yasm/all/conanfile.py
@@ -34,7 +34,6 @@ class YASMConan(ConanFile):
         del self.info.settings.compiler
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=4]")
         if self.settings_build.os == "Windows" and not is_msvc(self):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):

--- a/recipes/yasm/all/patches/0001-cmake-updates.patch
+++ b/recipes/yasm/all/patches/0001-cmake-updates.patch
@@ -1,7 +1,7 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,5 +1,5 @@
-+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
  PROJECT(yasm)
 -CMAKE_MINIMUM_REQUIRED(VERSION 2.4)
  if (COMMAND cmake_policy)


### PR DESCRIPTION
fixes #27893

### Summary
Changes to recipe:  **yasm/1.3.0**

#### Motivation
When using CMake 4 building this recipe fails with an error
`Compatibility with CMake < 3.5 has been removed from CMake`
Original project has a CMake 2.4 minimum, patch increases it to 3.0. Support for newer versions of CMake, like CMake < 3.20, will probably be revoked in the future releases too.

#### Details
Add a CMake version requirement, min and max, so that CMake generation succeeds.