### PR TITLE
Add OpenBLAS version 0.3.30

### DIFF
--- a/recipes/openblas/all/conandata.yml
+++ b/recipes/openblas/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.3.30":
+    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.30.tar.gz"
+    sha256: "27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d"
   "0.3.27":
     url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.27.tar.gz"
     sha256: "aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897"

--- a/recipes/openblas/all/conandata.yml
+++ b/recipes/openblas/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "0.3.30":
     url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.30.tar.gz"
     sha256: "27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d"
-  "0.3.27":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.27.tar.gz"
-    sha256: "aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897"
   "0.3.26":
     url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.26.tar.gz"
     sha256: "4e6e4f5cb14c209262e33e6816d70221a2fe49eb69eaf0a06f065598ac602c68"
@@ -14,21 +11,3 @@ sources:
   "0.3.24":
     url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.24.tar.gz"
     sha256: "ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132"
-  "0.3.20":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.20.tar.gz"
-    sha256: "8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c"
-  "0.3.17":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.17.tar.gz"
-    sha256: "df2934fa33d04fd84d839ca698280df55c690c86a5a1133b3f7266fce1de279f"
-  "0.3.15":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.15.tar.gz"
-    sha256: "30a99dec977594b387a17f49904523e6bc8dd88bd247266e83485803759e4bbe"
-  "0.3.13":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.13.tar.gz"
-    sha256: "79197543b17cc314b7e43f7a33148c308b0807cd6381ee77f77e15acf3e6459e"
-  "0.3.12":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.12.tar.gz"
-    sha256: "65a7d3a4010a4e3bd5c0baa41a234797cd3a1735449a4a5902129152601dc57b"
-  "0.3.10":
-    url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.10.tar.gz"
-    sha256: "0484d275f87e9b8641ff2eecaa9df2830cbe276ac79ad80494822721de6e1693"

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -126,6 +126,10 @@ class OpenblasConan(ConanFile):
                 self.output.warning(f'Setting OpenBLAS TARGET={target} based on settings.arch. This may result in suboptimal performance. Set the "{self.name}/*:target=XXX" option to silence this warning.')
                 self.options.target = target
 
+    def build_requirements(self):
+        if Version(self.version) >= "0.3.29":
+            self.tool_requires("cmake/[>=3.16 <4]")
+
     def validate(self):
         if Version(self.version) < "0.3.24" and self.settings.arch == "armv8":
             # OpenBLAS fails to detect the appropriate target architecture for armv8 for versions < 0.3.24, as it matches the 32 bit variant instead of 64.

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -3,11 +3,11 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.files import copy, get, rmdir
 from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
 from conan.tools.scm import Version
 import os
-import textwrap
+
 
 required_conan_version = ">=2.1"
 
@@ -108,11 +108,6 @@ class OpenblasConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        # When no Fortran compiler is available, OpenBLAS builds LAPACK from an f2c-converted copy of LAPACK unless the NO_LAPACK option is specified.
-        # This is not available before v0.3.21.
-        if Version(self.version) < "0.3.21":
-            self.options.build_lapack = False
-            self.options.build_relapack = False
 
     def configure(self):
         if self.options.shared:
@@ -131,12 +126,6 @@ class OpenblasConan(ConanFile):
             self.tool_requires("cmake/[>=3.16 <4]")
 
     def validate(self):
-        if Version(self.version) < "0.3.24" and self.settings.arch == "armv8":
-            # OpenBLAS fails to detect the appropriate target architecture for armv8 for versions < 0.3.24, as it matches the 32 bit variant instead of 64.
-            # This was fixed in https://github.com/OpenMathLib/OpenBLAS/pull/4142, which was introduced in 0.3.24.
-            # This would be a reasonably trivial hotfix to backport.
-            raise ConanInvalidConfiguration("armv8 builds are not currently supported for versions lower than 0.3.24. Contributions to support this are welcome.")
-
         if self.options.build_relapack:
             if not self.options.build_lapack:
                 raise ConanInvalidConfiguration(f'"{self.name}/*:build_relapack=True" option requires "{self.name}/*:build_lapack=True"')
@@ -145,11 +134,6 @@ class OpenblasConan(ConanFile):
                 raise ConanInvalidConfiguration(f'"{self.name}/*:build_relapack=True" option is only supported for GCC and Clang')
 
     def validate_build(self):
-        if Version(self.version) < "0.3.22" and cross_building(self, skip_x64_x86=True):
-            # OpenBLAS CMake builds did not support some of the cross-compilation targets in 0.3.20/21 and earlier.
-            # This was fixed in https://github.com/OpenMathLib/OpenBLAS/pull/3714 and https://github.com/OpenMathLib/OpenBLAS/pull/3958
-            raise ConanInvalidConfiguration(f"Cross-building is not supported for {self.name}/0.3.21 and earlier.")
-
         # If we're cross-compiling, and the user didn't provide the target, and
         # we couldn't infer the target from settings.arch, fail
         if cross_building(self, skip_x64_x86=True) and not self.options.target:
@@ -170,12 +154,9 @@ class OpenblasConan(ConanFile):
         tc.variables["NOFORTRAN"] = not self.options.build_lapack
         # This checks explicit user-specified fortran compiler
         if self.options.build_lapack and not self._fortran_compiler:
-            if Version(self.version) < "0.3.21":
-                self.output.warning("Building with LAPACK support requires a Fortran compiler.")
-            else:
-                tc.variables["C_LAPACK"] = True
-                tc.variables["NOFORTRAN"] = True
-                self.output.info("Building LAPACK without a Fortran compiler")
+            tc.variables["C_LAPACK"] = True
+            tc.variables["NOFORTRAN"] = True
+            self.output.info("Building LAPACK without a Fortran compiler")
 
         tc.variables["BUILD_WITHOUT_LAPACK"] = not self.options.build_lapack
         tc.variables["BUILD_RELAPACK"] = self.options.build_relapack
@@ -198,44 +179,7 @@ class OpenblasConan(ConanFile):
             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
-    def _patch_sources(self):
-        if Version(self.version) <= "0.3.15":
-            replace_in_file(self, os.path.join(self.source_folder, "cmake", "utils.cmake"),
-                "set(obj_defines ${defines_in})", textwrap.dedent("""\
-                 set(obj_defines ${defines_in})
-
-                 list(FIND obj_defines "RC" def_idx)
-                 if (${def_idx} GREATER -1)
-                   list(REMOVE_ITEM obj_defines "RC")
-                   list(APPEND obj_defines "RC=RC")
-                 endif ()
-                 list(FIND obj_defines "CR" def_idx)
-                 if (${def_idx} GREATER -1)
-                   list(REMOVE_ITEM obj_defines "CR")
-                   list(APPEND obj_defines "CR=CR")
-                 endif ()"""))
-        if Version(self.version) < "0.3.21":
-            f_check_cmake = os.path.join(self.source_folder, "cmake", "f_check.cmake")
-            if Version(self.version) >= "0.3.12":
-                replace_in_file(self, f_check_cmake,
-                                'message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")',
-                                'message(FATAL_ERROR "No Fortran compiler found. Cannot build with LAPACK.")')
-            else:
-                replace_in_file(self, f_check_cmake,
-                    "enable_language(Fortran)",
-                    textwrap.dedent("""\
-                        include(CheckLanguage)
-                        check_language(Fortran)
-                        if(CMAKE_Fortran_COMPILER)
-                          enable_language(Fortran)
-                        else()
-                          message(FATAL_ERROR "No Fortran compiler found. Cannot build with LAPACK.")
-                          set (NOFORTRAN 1)
-                          set (NO_LAPACK 1)
-                        endif()"""))
-
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/openblas/config.yml
+++ b/recipes/openblas/config.yml
@@ -1,23 +1,9 @@
 versions:
   "0.3.30":
     folder: all
-  "0.3.27":
-    folder: all
   "0.3.26":
     folder: all
   "0.3.25":
     folder: all
   "0.3.24":
-    folder: all
-  "0.3.20":
-    folder: all
-  "0.3.17":
-    folder: all
-  "0.3.15":
-    folder: all
-  "0.3.13":
-    folder: all
-  "0.3.12":
-    folder: all
-  "0.3.10":
     folder: all

--- a/recipes/openblas/config.yml
+++ b/recipes/openblas/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.3.30":
+    folder: all
   "0.3.27":
     folder: all
   "0.3.26":


### PR DESCRIPTION
New version of OpenBLAS that fixes a compilation issue with GCC 15 (OpenBLAS#5255)

### Summary
Changes to recipe:  openblas/0.3.30

#### Motivation
openblas/0.3.27 has a compilation failure with GCC 15

#### Details
Add new version of OpenBLAS that fixes compilation issue.
Tested working on linux x86_64