### PR TITLE
[libusb] Add libusb 1.0.29

### DIFF
--- a/recipes/libusb/all/conandata.yml
+++ b/recipes/libusb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.29":
+    url: "https://github.com/libusb/libusb/releases/download/v1.0.29/libusb-1.0.29.tar.bz2"
+    sha256: "5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85"
   "1.0.26":
     url: "https://github.com/libusb/libusb/releases/download/v1.0.26/libusb-1.0.26.tar.bz2"
     sha256: "12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5"
@@ -12,6 +15,16 @@ sources:
     url: "https://github.com/libusb/libusb/releases/download/v1.0.23/libusb-1.0.23.tar.bz2"
     sha256: "db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d"
 patches:
+  "1.0.29":
+    - patch_file: "patches/1.0.29-0001-relax-windows-sdk-restriction.patch"
+      patch_description: "Relax Windows SDK restriction"
+      patch_type: "conan"
+    - patch_file: "patches/1.0.29-0002-warnings-not-errors.patch"
+      patch_description: "Do not treat warnings as errors (required for VS2022)"
+      patch_type: "conan"
+    - patch_file: "patches/1.0.29-0003-msvc-disable-whole-program-optimisation.patch"
+      patch_description: "Disable whole-program optimisation on MSVC"
+      patch_type: "conan"
   "1.0.26":
     - patch_file: "patches/1.0.24-0001-relax-windows-sdk-restriction.patch"
       patch_description: "Relax Windows SDK restriction"

--- a/recipes/libusb/all/patches/1.0.29-0001-relax-windows-sdk-restriction.patch
+++ b/recipes/libusb/all/patches/1.0.29-0001-relax-windows-sdk-restriction.patch
@@ -1,0 +1,11 @@
+diff -urw a/msvc/Configuration.Base.props b/msvc/Configuration.Base.props
+--- a/msvc/Configuration.Base.props	2024-03-09 13:00:27
++++ b/msvc/Configuration.Base.props	2025-07-10 14:41:42
+@@ -41,7 +41,4 @@
+     <WindowsTargetPlatformVersion Condition="'$(LibusbPlatformToolsetVersion)'=='141' And $(Platform)=='ARM64'">10.0.19041.0</WindowsTargetPlatformVersion>
+     <WindowsTargetPlatformVersion Condition="'$(LibusbPlatformToolsetVersion)'!='141' Or $(Platform)!='ARM64'">$(WindowsSDKVersion)</WindowsTargetPlatformVersion>
+   </PropertyGroup>
+-  <PropertyGroup Label="Globals" Condition="'$(LibusbPlatformToolsetVersion)'&gt;='142'">
+-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+-  </PropertyGroup>
+ </Project>

--- a/recipes/libusb/all/patches/1.0.29-0002-warnings-not-errors.patch
+++ b/recipes/libusb/all/patches/1.0.29-0002-warnings-not-errors.patch
@@ -1,0 +1,12 @@
+diff --git a/msvc/Base.props b/msvc/Base.props
+--- a/msvc/Base.props
++++ b/msvc/Base.props
+@@ -11,7 +11,7 @@
+       <AdditionalIncludeDirectories>.;..\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>_WIN32_WINNT=_WIN32_WINNT_VISTA;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <WarningLevel>Level4</WarningLevel>
+-      <TreatWarningAsError>true</TreatWarningAsError>
++      <TreatWarningAsError>false</TreatWarningAsError>
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+       <!--Treat sources as utf-8-->

--- a/recipes/libusb/all/patches/1.0.29-0003-msvc-disable-whole-program-optimisation.patch
+++ b/recipes/libusb/all/patches/1.0.29-0003-msvc-disable-whole-program-optimisation.patch
@@ -1,0 +1,11 @@
+diff -urw a/msvc/Base.props b/msvc/Base.props
+--- a/msvc/Base.props	2024-03-09 13:00:27
++++ b/msvc/Base.props	2025-07-10 15:28:30
+@@ -34,7 +34,6 @@
+       <OmitFramePointers>true</OmitFramePointers>
+       <StringPooling>true</StringPooling>
+       <AdditionalOptions>/Gw %(AdditionalOptions)</AdditionalOptions>
+-      <WholeProgramOptimization>true</WholeProgramOptimization>
+     </ClCompile>
+     <!--Link Base-->
+     <Link>

--- a/recipes/libusb/config.yml
+++ b/recipes/libusb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.29":
+    folder: all
   "1.0.26":
     folder: all
   "1.0.25":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libusb/1.0.29**

#### Motivation

Add the latest libusb release, which includes several bugfixes and some new API (since 1.0.26).

#### Details

The msvc build system got rewritten upstream, so the patch had to be adapted. The old patch removed the SDK from the msvc 2019 build files, so for the new patch I made the equivalent change of removing it for VS 2019 onwards.

The reorganisation of msvc files also required adapting the ad-hoc patching in the conanfile. The new changes are simpler, so I pulled them out into another patch to try to keep the conanfile from getting too complex. I also removed the comment that referred to a closed MR (it was decided not to implement the referenced feature).

The third patch just suppresses a warning seen on VS 2022 with libusb 1.0.29.

Builds tested locally:

- 1.0.23 on VS 2022
- 1.0.26 on VS 2022
- 1.0.29 on VS 2022
- 1.0.29 on Xcode 15

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

Fixes #27901.
