### PR TITLE
arrow: fix turning simd off

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -36,8 +36,8 @@ class ArrowConan(ConanFile):
         "filesystem_layer":  [True, False],
         "hdfs_bridgs": [True, False],
         "plasma": [True, False, "deprecated"],
-        "simd_level": [None, "default", "sse4_2", "avx2", "avx512", "neon", ],
-        "runtime_simd_level": [None, "sse4_2", "avx2", "avx512", "max"],
+        "simd_level": [None, "default", "sse4_2", "avx2", "avx512", "neon", "none"],
+        "runtime_simd_level": [None, "sse4_2", "avx2", "avx512", "max", "none"],
         "with_backtrace": [True, False],
         "with_boost": ["auto", True, False],
         "with_csv": [True, False],
@@ -185,8 +185,8 @@ class ArrowConan(ConanFile):
             self.requires("lz4/1.9.4")
         if self.options.with_snappy:
             self.requires("snappy/1.1.9")
-        if self.options.get_safe("simd_level") != None or \
-                self.options.get_safe("runtime_simd_level") != None:
+        if str(self.options.get_safe("simd_level")).lower() != "none" or \
+            str(self.options.get_safe("runtime_simd_level")).lower() != "none":
                 self.requires("xsimd/13.0.0")
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
@@ -536,7 +536,8 @@ class ArrowConan(ConanFile):
             self.cpp_info.components["libarrow"].requires.append("lz4::lz4")
         if self.options.with_snappy:
             self.cpp_info.components["libarrow"].requires.append("snappy::snappy")
-        if self.options.get_safe("simd_level") != None or self.options.get_safe("runtime_simd_level") != None:
+        if str(self.options.get_safe("simd_level")).lower() != "none" or \
+            str(self.options.get_safe("runtime_simd_level")).lower() != "none":
             self.cpp_info.components["libarrow"].requires.append("xsimd::xsimd")
         if self.options.with_zlib:
             self.cpp_info.components["libarrow"].requires.append("zlib::zlib")


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/\***

#### Motivation
It's impossible to set an option to `None` as it's interpreted as a string.

fixes #27886

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
This change adds a `"none"` option to `simd_level` and `runtime_simd_level` while keeping the old `None` value for backward compatibility.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- x ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
