### PR TITLE
cppzmq: add version 4.11.0

### DIFF
--- a/recipes/cppzmq/all/conandata.yml
+++ b/recipes/cppzmq/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.11.0":
+    url: "https://github.com/zeromq/cppzmq/archive/refs/tags/v4.11.0.tar.gz"
+    sha256: "0fff4ff311a7c88fdb76fceefba0e180232d56984f577db371d505e4d4c91afd"
   "4.10.0":
     url: "https://github.com/zeromq/cppzmq/archive/refs/tags/v4.10.0.tar.gz"
     sha256: "c81c81bba8a7644c84932225f018b5088743a22999c6d82a2b5f5cd1e6942b74"

--- a/recipes/cppzmq/config.yml
+++ b/recipes/cppzmq/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.11.0":
+    folder: all
   "4.10.0":
     folder: all
   "4.9.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cppzmq/[4.11.0]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Recipe for cppzmq was missing the newest version of the library.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Added the newest version of cppzmq (4.11.0) to the recipe.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
