### PR TITLE
Make Botan take into account compiler executable.

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -364,6 +364,10 @@ class BotanConan(ConanFile):
         if self.options.disable_modules:
             build_flags.append('--disable-modules={}'.format(self.options.disable_modules))
 
+        compiler_executables = self.conf.get("tools.build:compiler_executables")
+        if compiler_executables:
+            build_flags.append("--cc-bin={}".format(compiler_executables["cpp"]))
+
         if self.options.amalgamation:
             build_flags.append('--amalgamation')
 


### PR DESCRIPTION
Not taking into account the compiler generated an error when compiling for android: it took stock x86 clang instead of something different.


### Summary
Changes to recipe:  tested against **botan/3.6.1** 

#### Motivation

Botan will pick the wrong compiler if not specified explicitly. This is a fix *in the recipe*, not in its configure logic with a patch in Botan project. 
#### Details

The fix consists of passing --cc-bin configure flag in the recipe via inspecting `tools.build:compiler_executables['cpp']` variable.

Tested with Conan 2.18.1

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ X] Tested locally with at least one configuration using a recent version of Conan
