### PR TITLE
cyrus-sasl: Patch version 2.1.28

### DIFF
--- a/recipes/cyrus-sasl/all/conandata.yml
+++ b/recipes/cyrus-sasl/all/conandata.yml
@@ -11,6 +11,9 @@ patches:
       patch_source: https://github.com/cyrusimap/cyrus-sasl/commit/06f41c41e5c0f62ed5c1d703a9e2da42dfdb71f6
       patch_description: "Fix https://github.com/cyrusimap/cyrus-sasl/issues/831"
       patch_type: "official"
+    - patch_file: "patches/time-h.patch"
+      patch_description: "Include time.h"
+      patch_type: "official"
   "2.1.27":
     - patch_file: "patches/0001-use-attr-on-gnu.patch"
       patch_source: https://github.com/cyrusimap/cyrus-sasl/commit/06f41c41e5c0f62ed5c1d703a9e2da42dfdb71f6

--- a/recipes/cyrus-sasl/all/patches/time-h.patch
+++ b/recipes/cyrus-sasl/all/patches/time-h.patch
@@ -1,0 +1,28 @@
+diff --git a/configure.ac b/configure.ac
+index 2d89fdaa..2e1e697d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1231,7 +1231,7 @@ AC_CHECK_HEADERS_ONCE([sys/time.h])
+ 
+ AC_HEADER_DIRENT
+ AC_HEADER_SYS_WAIT
+-AC_CHECK_HEADERS(crypt.h des.h dlfcn.h fcntl.h limits.h malloc.h paths.h strings.h sys/file.h sys/time.h syslog.h unistd.h inttypes.h sys/uio.h sys/param.h sysexits.h stdarg.h varargs.h krb5.h)
++AC_CHECK_HEADERS(crypt.h des.h dlfcn.h fcntl.h limits.h malloc.h paths.h strings.h sys/file.h sys/time.h syslog.h time.h unistd.h inttypes.h sys/uio.h sys/param.h sysexits.h stdarg.h varargs.h krb5.h)
+ 
+ IPv6_CHECK_SS_FAMILY()
+ IPv6_CHECK_SA_LEN()
+diff --git a/plugins/cram.c b/plugins/cram.c
+index d02e9baa..695aaa91 100644
+--- a/plugins/cram.c
++++ b/plugins/cram.c
+@@ -53,6 +53,10 @@
+ #endif
+ #include <fcntl.h>
+ 
++#ifdef HAVE_TIME_H
++#include <time.h>
++#endif
++
+ #include <sasl.h>
+ #include <saslplug.h>
+ #include <saslutil.h>


### PR DESCRIPTION
### Summary
Changes to recipe:  **cyrus-sasl/2.1.28**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The PR is needed because cyrus-sasl cannot be compiled with clang versions 16 above due to implicit-function-declaration becoming an error. https://www.redhat.com/en/blog/new-warnings-and-errors-clang-16
The fix is already in the master but the team hasn't released a new version from more than 2 years.


#### Details
time.h header isn't included in one of the files. 
Corresponds to this commit https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262#diff-48095a05ca80c959fcb0088e16b576b687f9c1dc43634179da397750b71f3f65

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
