### PR TITLE
[computo] Add computo/0.3.0

### DIFF
--- a/recipes/computo/all/conandata.yml
+++ b/recipes/computo/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.3.0":
+    url: "https://github.com/HarryPehkonen/Computo/archive/refs/tags/v0.3.0.tar.gz"
+    sha256: "c0c2e85e667eb67d569f370207106ad313522dd94f026c950dfc053d0a5289c9"

--- a/recipes/computo/all/conanfile.py
+++ b/recipes/computo/all/conanfile.py
@@ -1,0 +1,106 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.files import get, copy, save
+from conan.tools.scm import Version
+import os
+
+
+class ComputoConan(ConanFile):
+    name = "computo"
+    description = "A functional programming language for data transformations"
+    license = "Unlicense"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/HarryPehkonen/Computo"
+    topics = ("functional-programming", "data-transformation", "json", "lisp")
+    
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("nlohmann_json/3.11.3")
+
+    def build_requirements(self):
+        # readline is system dependency for REPL - always required
+        pass
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], 
+            destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", 
+             src=self.source_folder, 
+             dst=os.path.join(self.package_folder, "licenses"))
+        
+        # Copy headers
+        copy(self, "*.hpp", 
+             src=os.path.join(self.source_folder, "include"), 
+             dst=os.path.join(self.package_folder, "include"), 
+             keep_path=True)
+        
+        # Copy library
+        copy(self, "*.a", 
+             src=self.build_folder, 
+             dst=os.path.join(self.package_folder, "lib"))
+        copy(self, "*.lib", 
+             src=self.build_folder, 
+             dst=os.path.join(self.package_folder, "lib"))
+        copy(self, "*.so", 
+             src=self.build_folder, 
+             dst=os.path.join(self.package_folder, "lib"))
+        copy(self, "*.dylib", 
+             src=self.build_folder, 
+             dst=os.path.join(self.package_folder, "lib"))
+        copy(self, "*.dll", 
+             src=self.build_folder, 
+             dst=os.path.join(self.package_folder, "bin"))
+        
+        # Copy both executables (always built in unified build system)
+        copy(self, "computo*", 
+             src=self.build_folder, 
+             dst=os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "computo")
+        self.cpp_info.set_property("cmake_target_name", "computo::computo")
+        
+        self.cpp_info.libs = ["computo"]
+        
+        # Both executables are always available
+        self.cpp_info.bindirs.append("bin")
+        if self.settings.os != "Windows":
+            self.cpp_info.system_libs.append("readline")
+
+    def package_id(self):
+        # No custom package ID handling needed - unified build always produces same output
+        pass

--- a/recipes/computo/all/test_package/CMakeLists.txt
+++ b/recipes/computo/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(computo REQUIRED)
+find_package(nlohmann_json REQUIRED)
+
+add_executable(test_package src/example.cpp)
+target_link_libraries(test_package computo::computo nlohmann_json::nlohmann_json)
+target_compile_features(test_package PRIVATE cxx_std_17)

--- a/recipes/computo/all/test_package/conanfile.py
+++ b/recipes/computo/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.build import can_run
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+        self.requires("nlohmann_json/3.11.3")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.15]")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/computo/all/test_package/src/example.cpp
+++ b/recipes/computo/all/test_package/src/example.cpp
@@ -1,0 +1,18 @@
+#include <computo.hpp>
+#include <iostream>
+
+int main() {
+    // Simple test of the computo library
+    // Use the json type from computo.hpp which re-exports nlohmann::json
+    auto script = nlohmann::json::array({"+", 2, 3});
+    auto input = nlohmann::json::object();
+    
+    try {
+        auto result = computo::execute(script, input);
+        std::cout << "Test passed: 2 + 3 = " << result << std::endl;
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/recipes/computo/config.yml
+++ b/recipes/computo/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.0":
+    folder: all


### PR DESCRIPTION
Initial recipe for computo.

Computo is a functional programming language for data transformations.

### Summary
**new recipe: computo/0.3.0**

#### Motivation
Adds a Conan recipe for the `computo` library, making it available to the Conan community.

#### Details
This PR adds the complete recipe for `computo/0.3.0`, including the `conanfile.py`, `conandata.yml`, `config.yml`, and a `test_package` to validate the build.

---
- [x] I have read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I have checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240).
- [x] I have tested this recipe locally with at least one configuration using a recent version of Conan.