### PR TITLE
flatbush: add release v1.3.0

### DIFF
--- a/recipes/flatbush/all/conandata.yml
+++ b/recipes/flatbush/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.0":
+    url: "https://github.com/chusitoo/flatbush/archive/refs/tags/v1.3.0.zip"
+    sha256: "7c55ca81f5f0850d7c7b86b5ac32baa3c8068c167fc80e38d9620747925bbcdc"
   "1.2.1":
     url: "https://github.com/chusitoo/flatbush/archive/refs/tags/v1.2.1.zip"
     sha256: "7f8226cb9a58cc75c99800a8fb213b1c2c5df81051ec559d5ff7b4ed0e8c097a"

--- a/recipes/flatbush/config.yml
+++ b/recipes/flatbush/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.0":
+    folder: "all"
   "1.2.1":
     folder: "all"
   "1.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **flatbush/v1.3.0**

#### Motivation
These are all minor performance improvements

#### Details
Use median of three to pick pivot for sort function
Introduce move constructor to avoid copying buffer contents
Other random micro-optimizations

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
