### PR TITLE
Update to SQLite3 Multiple Ciphers 2.2.3

### DIFF
--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.2":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.2.2.tar.gz"
+    sha256: "3b3ccfc1d53d7da864f7f73a266b459df88f2ee156817ba176b1233b40939cb5"
   "2.1.0":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.1.0.tar.gz"
     sha256: "e7778297643f613bc2dabbcec8070d38a19e24b50d2faaed71b3d70ef0f0fe84"

--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.2.2":
-    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.2.2.tar.gz"
-    sha256: "3b3ccfc1d53d7da864f7f73a266b459df88f2ee156817ba176b1233b40939cb5"
+  "2.2.3":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.2.3.tar.gz"
+    sha256: "eba448e84aaf78ba5153223adb2072b483f1c28824860a71334e28f133306807"
   "2.1.0":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.1.0.tar.gz"
     sha256: "e7778297643f613bc2dabbcec8070d38a19e24b50d2faaed71b3d70ef0f0fe84"

--- a/recipes/sqlite3mc/all/conanfile.py
+++ b/recipes/sqlite3mc/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMakeDeps, CMakeToolchain, CMake
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, rmdir
 from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
@@ -212,6 +212,7 @@ class sqlite3mc(ConanFile):
         cmake = CMake(self)
         cmake.install()
         copy(self, "LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         if self.options.shared:

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.2":
+    folder: all
   "2.1.0":
     folder: all
   "2.0.2":

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.2.2":
+  "2.2.3":
     folder: all
   "2.1.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3mc**

#### Motivation

**sqlite3mc version 2.2.2** supports the latest SQLite version 3.50.2, and includes an important bug fix affecting systems without AVX hardware support.

#### Details
Version 2.2.2 includes important changes and bug fixes:

- Improved check for Apple platforms
- Improved retrieving of entropy on Apple platforms
- Support for plaintext header option for ciphers _chacha20_, _ascon128_, and _aegis_ in addition to _sqlcipher_ - very important for **iOS** applications
- Simplified specification of raw key and salt
- Fixed bug causing crashes on Linux systems without AVX support

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
