### PR TITLE
add risc-v support for boost recipe

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1183,7 +1183,7 @@ class BoostConan(ConanFile):
 
     @property
     def _b2_address_model(self):
-        if self.settings.arch in ("x86_64", "ppc64", "ppc64le", "mips64", "armv8", "armv8.3", "sparcv9", "s390x"):
+        if self.settings.arch in ("x86_64", "ppc64", "ppc64le", "mips64", "armv8", "armv8.3", "sparcv9", "s390x", "riscv64"):
             return "64"
 
         return "32"
@@ -1219,6 +1219,8 @@ class BoostConan(ConanFile):
             return "mips1"
         if str(self.settings.arch).startswith("s390"):
             return "s390x"
+        if str(self.settings.arch).startswith("riscv"):
+            return "riscv"
 
         return None
 
@@ -1232,6 +1234,8 @@ class BoostConan(ConanFile):
             return "aapcs"
         if str(self.settings.arch).startswith("mips"):
             return "o32"
+        if str(self.settings.arch).startswith("riscv"):
+            return "sysv"
 
         return None
 
@@ -1473,6 +1477,8 @@ class BoostConan(ConanFile):
         elif arch.startswith("ppc"):
             pass
         elif arch.startswith("mips"):
+            pass
+        elif arch.startswith("riscv"):
             pass
         else:
             self.output.warning(f"Unable to detect the appropriate ABI for {arch} architecture.")


### PR DESCRIPTION
### Summary
Changes to recipe:  boost for riscv support

#### Motivation
This change aims to add support for building Boost recipes on the RISC-V architecture in the ConanCenter repository. By enabling Boost to work on RISC-V, developers targeting this platform will be able to easily include and use Boost in their projects, just as they do on other architectures.

#### Details
This pull request updates the `recipes/boost/all/conanfile.py` file to add support for the `riscv` architecture. The changes ensure that the appropriate configurations, such as address model, architecture, ABI, and cross-building flags, are handled correctly for `riscv`.

### Support for `riscv` architecture:

* **Address Model**: Added `riscv64` to the list of architectures that use a 64-bit address model in the `_b2_address_model` method.
* **Architecture Identification**: Added logic to return `"riscv"` for architectures starting with `riscv` in the `_b2_architecture` method.
* **ABI Configuration**: Added logic to return `"sysv"` for architectures starting with `riscv` in the `_b2_abi` method.
* **Cross-Building Flags**: Added a placeholder for handling `riscv` in the `_build_cross_flags` method to avoid warnings during cross-building.

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
