### PR TITLE
add risc-v support for boost recipe

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1183,7 +1183,7 @@ class BoostConan(ConanFile):
 
     @property
     def _b2_address_model(self):
-        if self.settings.arch in ("x86_64", "ppc64", "ppc64le", "mips64", "armv8", "armv8.3", "sparcv9", "s390x"):
+        if self.settings.arch in ("x86_64", "ppc64", "ppc64le", "mips64", "armv8", "armv8.3", "sparcv9", "s390x", "riscv64"):
             return "64"
 
         return "32"
@@ -1219,6 +1219,8 @@ class BoostConan(ConanFile):
             return "mips1"
         if str(self.settings.arch).startswith("s390"):
             return "s390x"
+        if str(self.settings.arch).startswith("riscv"):
+            return "riscv"
 
         return None
 
@@ -1232,6 +1234,8 @@ class BoostConan(ConanFile):
             return "aapcs"
         if str(self.settings.arch).startswith("mips"):
             return "o32"
+        if str(self.settings.arch).startswith("riscv"):
+            return "sysv"
 
         return None
 
@@ -1473,6 +1477,8 @@ class BoostConan(ConanFile):
         elif arch.startswith("ppc"):
             pass
         elif arch.startswith("mips"):
+            pass
+        elif arch.startswith("riscv"):
             pass
         else:
             self.output.warning(f"Unable to detect the appropriate ABI for {arch} architecture.")


### PR DESCRIPTION
### Summary
Changes to recipe: riscv support for boost

#### Motivation
This change aims to add support for building Boost recipes on the riscv architecture in the ConanCenter repository. By enabling Boost to work on riscv, developers targeting this platform will be able to easily include and use Boost in their projects, just as they do on other architectures.

closes https://github.com/conan-io/conan-center-index/issues/27856

#### Details

This pull request updates the `recipes/boost/all/conanfile.py` file to add support for the `riscv `architecture. The changes ensure that the appropriate configurations, such as address model, architecture, ABI, and cross-building flags, are handled correctly for `riscv`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
