### PR TITLE
vaapi: Setting components pkg_config_name

### DIFF
--- a/recipes/vaapi/all/conanfile.py
+++ b/recipes/vaapi/all/conanfile.py
@@ -52,4 +52,5 @@ class SysConfigVAAPIConan(ConanFile):
                 pkg_config = PkgConfig(self, name)
                 self.cpp_info.components[name].includedirs = []
                 self.cpp_info.components[name].libdirs = []
+                self.cpp_info.components[name].set_property("pkg_config_name", name)
                 pkg_config.fill_cpp_info(self.cpp_info.components[name])


### PR DESCRIPTION
### Summary
Changes to recipe:  **vaapi/system**
Closes: https://github.com/conan-io/conan-center-index/issues/27939

#### Motivation
Let's set the component's name without adding the prefix `vaapi` to each `*.pc` file

#### Details

Normally, vaapi's components are required without adding the lib name as prefix. For instance:

* **ffmpeg**: https://github.com/FFmpeg/FFmpeg/blob/e6af82c49895825d0cbea71e24c77be6b16571c4/configure#L7388
* **libfreenect2**: https://github.com/OpenKinect/libfreenect2/blob/fd64c5d9b214df6f6a55b4419357e51083f15d93/CMakeLists.txt#L197
* **gst-plugins-bad**: https://github.com/GStreamer/gst-plugins-bad/blob/ca8068c6d793d7aaa6f2e2cc6324fdedfe2f33fa/sys/va/meson.build#L38

In CCI, ffmpeg and libfreenect2 require vaapi components, but they are not failing because these components are already present in the system. For instance, this trace shows the link libraries for libfreenect2:

```
-- /usr/lib/aarch64-linux-gnu/libva-drm.so;/usr/lib/aarch64-linux-gnu/libva.so
```