### PR TITLE
foxglove-websocket: add version 1.4.1; deprecate

### DIFF
--- a/recipes/foxglove-websocket/all/conandata.yml
+++ b/recipes/foxglove-websocket/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  1.4.1:
+    url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v1.4.1.tar.gz
+    sha256: e93e7e7bb3e4d0c045556810aa5e1c073aed3cb2da33c31548ee0be61844713f
   1.4.0:
     url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v1.4.0.tar.gz
     sha256: 2257383f1ae39c775fb624c78efa2faa4b3aa22c24f84c0b9940aa7848270cfc

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -11,6 +11,7 @@ required_conan_version = ">=1.53.0"
 
 class FoxgloveWebSocketConan(ConanFile):
     name = "foxglove-websocket"
+    deprecated = "foxglove-sdk"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/foxglove/ws-protocol"
     description = "A C++ server implementation of the Foxglove WebSocket Protocol"

--- a/recipes/foxglove-websocket/config.yml
+++ b/recipes/foxglove-websocket/config.yml
@@ -1,4 +1,6 @@
 versions:
+  1.4.1:
+    folder: all
   1.4.0:
     folder: all
   1.3.1:


### PR DESCRIPTION
### Summary
Changes to recipe:  **foxglove-websocket/1.4.1**

#### Motivation

This marks the foxglove-websocket package as deprecated.

#### Details

Foxglove is putting future development efforts behind its SDK (https://docs.foxglove.dev/docs/sdk) which provides a superset of the foxglove-websocket server functionality.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
