### PR TITLE
libxslt: define cmake additional variable prefixes

### DIFF
--- a/recipes/libxslt/all/conanfile.py
+++ b/recipes/libxslt/all/conanfile.py
@@ -190,6 +190,7 @@ class LibxsltConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "LibXslt")
+        self.cpp_info.set_property("cmake_additional_variables_prefixes", ["LIBXSLT"])
         self.cpp_info.set_property("pkg_config_name", "none") # see the two standalone ones instead
 
         prefix = "lib" if is_msvc(self) else ""

--- a/recipes/libxslt/all/test_package/CMakeLists.txt
+++ b/recipes/libxslt/all/test_package/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(LibXslt REQUIRED)
+if(NOT DEFINED LIBXSLT_INCLUDE_DIR)
+    message(FATAL_ERROR "LIBXSLT_INCLUDE_DIR variable not defined, expected to be set by Conan-generated CMake files")
+endif()
+
 find_package(LibXml2 REQUIRED)
 
 add_executable(${PROJECT_NAME} libxslt_tutorial.c)


### PR DESCRIPTION
- Define `cmake_additional_variable_prefixes` so that variables prefixed with all upper case `LIBXSLT` are added in the generated config files, to match the legacy behaviour of https://cmake.org/cmake/help/latest/module/FindLibXslt.html

Close https://github.com/conan-io/conan-center-index/issues/27923