### PR TITLE
tsl-robin-map: Add version 1.4.0

### DIFF
--- a/recipes/tsl-robin-map/all/conandata.yml
+++ b/recipes/tsl-robin-map/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/Tessil/robin-map/archive/v1.4.0.tar.gz"
+    sha256: "7930dbf9634acfc02686d87f615c0f4f33135948130b8922331c16d90a03250c"
   "1.3.0":
     url: "https://github.com/Tessil/robin-map/archive/v1.3.0.tar.gz"
     sha256: "a8424ad3b0affd4c57ed26f0f3d8a29604f0e1f2ef2089f497f614b1c94c7236"

--- a/recipes/tsl-robin-map/config.yml
+++ b/recipes/tsl-robin-map/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.0":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tsl-robin-map/1.4.0**

#### Motivation
Adds a new version, 1.4.0, of tsl-robin-map

#### Details
---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
