### PR TITLE
bump gstreamer to 1.26.4 (#27960)

### DIFF
--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.26.4":
+    url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.26.4.tar.xz"
+    sha256: "fe440e41804fabe036e06493b98680e2a8ce76d49879e3cdd6890d72e0614d75"
   "1.24.7":
     url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.24.7.tar.xz"
     sha256: "c0e75b124c52bb7a0c3dcdb734b2ad260ea7286a8745cf2ea629d4c849e6a958"

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.26.4":
+    folder: all
   "1.24.7":
     folder: all
   "1.22.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gstreamer /1.26.4**

#### Motivation
Add version for the current API and ABI stable GStreamer 1.x series.

#### Details
Just added the source link and SHA-256 for 1.26.4. Tested locally with conan 2.18.1 and VS 2022 (v143) without any problems.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Fixes #27960
