### PR TITLE
Update: cmaes 0.10.2

### DIFF
--- a/recipes/cmaes/all/conandata.yml
+++ b/recipes/cmaes/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "0.10.0":
     url: "https://github.com/CMA-ES/libcmaes/archive/refs/tags/v0.10.tar.gz"
     sha256: "a77fb892654356c5657dd677161b7c67b196dc732cfb77eaca6708abc4f6cffc"
+  "0.10.2":
+    url: "https://github.com/CMA-ES/libcmaes/archive/refs/tags/v0.10.2.tar.gz"
+    sha256: ""
 patches:
   "0.10.0":
     - patch_file: "patches/0001-remove-flags.patch"

--- a/recipes/cmaes/all/conandata.yml
+++ b/recipes/cmaes/all/conandata.yml
@@ -4,7 +4,7 @@ sources:
     sha256: "a77fb892654356c5657dd677161b7c67b196dc732cfb77eaca6708abc4f6cffc"
   "0.10.2":
     url: "https://github.com/CMA-ES/libcmaes/archive/refs/tags/v0.10.2.tar.gz"
-    sha256: ""
+    sha256: "466e2775db4166f8a0662f0d986c637a7e36c9b8e93bc0c12cb15a884620e23d"
 patches:
   "0.10.0":
     - patch_file: "patches/0001-remove-flags.patch"

--- a/recipes/cmaes/all/conandata.yml
+++ b/recipes/cmaes/all/conandata.yml
@@ -1,10 +1,4 @@
 sources:
-  "0.10.0":
-    url: "https://github.com/CMA-ES/libcmaes/archive/refs/tags/v0.10.tar.gz"
-    sha256: "a77fb892654356c5657dd677161b7c67b196dc732cfb77eaca6708abc4f6cffc"
   "0.10.2":
     url: "https://github.com/CMA-ES/libcmaes/archive/refs/tags/v0.10.2.tar.gz"
     sha256: "466e2775db4166f8a0662f0d986c637a7e36c9b8e93bc0c12cb15a884620e23d"
-patches:
-  "0.10.0":
-    - patch_file: "patches/0001-remove-flags.patch"

--- a/recipes/cmaes/all/conanfile.py
+++ b/recipes/cmaes/all/conanfile.py
@@ -1,5 +1,4 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
 from conan.tools.files import (
     export_conandata_patches,
@@ -9,7 +8,6 @@ from conan.tools.files import (
     apply_conandata_patches,
 )
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.0"
@@ -38,11 +36,6 @@ class CmaesConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
-    def validate_build(self):
-        if Version(self.version) == "0.10.0":
-            if self.settings.compiler == "msvc":
-                raise ConanInvalidConfiguration("cmaes does not support MSVC")
-
     def validate(self):
         check_min_cppstd(self, 11)
 
@@ -64,8 +57,7 @@ class CmaesConan(ConanFile):
         tc.cache_variables["LIBCMAES_USE_OPENMP"] = False
         tc.cache_variables["LIBCMAES_BUILD_PYTHON"] = False
         tc.cache_variables["LIBCMAES_BUILD_TESTS"] = False
-        if Version(self.version) == "0.10.0":
-            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
+
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/cmaes/all/conanfile.py
+++ b/recipes/cmaes/all/conanfile.py
@@ -40,8 +40,8 @@ class CmaesConan(ConanFile):
 
     def validate_build(self):
         if Version(self.version) == "0.10.0":
-          if self.settings.compiler == "msvc":
-              raise ConanInvalidConfiguration("cmaes does not support MSVC")
+            if self.settings.compiler == "msvc":
+                raise ConanInvalidConfiguration("cmaes does not support MSVC")
 
     def validate(self):
         check_min_cppstd(self, 11)
@@ -65,7 +65,7 @@ class CmaesConan(ConanFile):
         tc.cache_variables["LIBCMAES_BUILD_PYTHON"] = False
         tc.cache_variables["LIBCMAES_BUILD_TESTS"] = False
         if Version(self.version) == "0.10.0":
-          tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/cmaes/all/conanfile.py
+++ b/recipes/cmaes/all/conanfile.py
@@ -39,8 +39,9 @@ class CmaesConan(ConanFile):
         export_conandata_patches(self)
 
     def validate_build(self):
-        if self.settings.compiler == "msvc":
-            raise ConanInvalidConfiguration("cmaes does not support MSVC")
+        if Version(self.version) == "0.10.0":
+          if self.settings.compiler == "msvc":
+              raise ConanInvalidConfiguration("cmaes does not support MSVC")
 
     def validate(self):
         check_min_cppstd(self, 11)
@@ -63,9 +64,8 @@ class CmaesConan(ConanFile):
         tc.cache_variables["LIBCMAES_USE_OPENMP"] = False
         tc.cache_variables["LIBCMAES_BUILD_PYTHON"] = False
         tc.cache_variables["LIBCMAES_BUILD_TESTS"] = False
-        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
-        if Version(self.version) > "0.10.0":  # pylint: disable=conan-unreachable-upper-version
-            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
+        if Version(self.version) == "0.10.0":
+          tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/cmaes/all/conanfile.py
+++ b/recipes/cmaes/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.errors import ConanException, ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
 from conan.tools.files import (
     export_conandata_patches,

--- a/recipes/cmaes/config.yml
+++ b/recipes/cmaes/config.yml
@@ -1,3 +1,5 @@
 versions:
   "0.10.0":
     folder: all
+  "0.10.2":
+    folder: all

--- a/recipes/cmaes/config.yml
+++ b/recipes/cmaes/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "0.10.0":
-    folder: all
   "0.10.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cmaes/0.10.2**

Closes #28077 

#### Motivation
This is an update to cmaes/0.10.0.
With this release the compability with Windows and CMake 4 is fixed.

#### Details

Differences between v0.10.0 and v0.10.2 are:
- Support Windows
- Support CMake 4


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
