### PR TITLE
[boost] Do not install shared libraries for static build on Linux

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1715,10 +1715,11 @@ class BoostConan(ConanFile):
                 rename(self, bin_file, os.path.join(self.package_folder, "bin", os.path.basename(bin_file)))
 
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
-        if is_apple_os(self) and not self._shared and Version(self.version) >= "1.88.0":
+        if (is_apple_os(self) or self.settings.os == "Linux") and not self._shared and Version(self.version) >= "1.88.0":
             # FIXME: Boost 1.88 installs both .a and .dylib files for static libraries
             # https://github.com/boostorg/boost/issues/1051
             rm(self, "*.dylib", os.path.join(self.package_folder, "lib"))
+            rm(self, "*.so*", os.path.join(self.package_folder, "lib"))
 
     def _create_emscripten_libs(self):
         # Boost Build doesn't create the libraries, but it gets close,


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.88.0**

#### Motivation

fixes #27955

/cc @Nekto89

#### Details

When building Boost 1.88.0 on both Linux and Mac, as static library, it produces and installs some shared libraries as well. On Windows it does not happen.

Build logs from the upstream issue can be found here:

- https://github.com/boostorg/boost/issues/1051#issuecomment-3095281390
- https://github.com/boostorg/boost/issues/1051#issuecomment-3095416042

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
