### PR TITLE
vulkan-validationlayers: Fix compilation with CMakeConfigDeps

### DIFF
--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, mkdir, rename, replace_in_file, rm
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, mkdir, rename, replace_in_file, rm, save
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.scm import Version
 import functools
@@ -172,10 +172,15 @@ class VulkanValidationLayersConan(ConanFile):
         tc.variables["INSTALL_TESTS"] = False
         tc.variables["BUILD_LAYERS"] = True
         tc.variables["BUILD_LAYER_SUPPORT_FILES"] = True
+        tc.cache_variables["SPIRV-Tools-opt_DIR"] = self.generators_folder.replace("\\", "/")
         tc.generate()
 
         deps = CMakeDeps(self)
         deps.generate()
+
+        save(self, os.path.join(self.generators_folder, "SPIRV-Tools-optConfig.cmake"),
+             """include(CMakeFindDependencyMacro)
+             find_dependency(SPIRV-Tools)""")
 
         if self._needs_pkg_config:
             deps = PkgConfigDeps(self)
@@ -194,13 +199,6 @@ class VulkanValidationLayersConan(ConanFile):
                 self, os.path.join(self.source_folder, "layers", "CMakeLists.txt"),
                 "set(JSON_API_VERSION ${VulkanHeaders_VERSION})",
                 f"set(JSON_API_VERSION \"{sanitized_vk_version}\")",
-            )
-        # FIXME: two CMake module/config files should be generated (SPIRV-ToolsConfig.cmake and SPIRV-Tools-optConfig.cmake),
-        # but it can't be modeled right now in spirv-tools recipe
-        if not os.path.exists(os.path.join(self.generators_folder, "SPIRV-Tools-optConfig.cmake")):
-            shutil.copy(
-                os.path.join(self.generators_folder, "SPIRV-ToolsConfig.cmake"),
-                os.path.join(self.generators_folder, "SPIRV-Tools-optConfig.cmake"),
             )
         if self.settings.os == "Android":
             # INFO: libVkLayer_utils.a: error: undefined symbol: __android_log_print


### PR DESCRIPTION
The recipe currently tries to copy the config file generated for spirv-tools so that upstream can do `find_package(SPIRV-Tools-opt)`, as the current recipe for spriv-tools only generates one filename.

Instead of copying files, patch the find_packages out and assume that all necessary targets come from the global file for spirv-tools `find_package(SPIRV-Tools REQUIRED CONFIG QUIET)`.

(Note that [CMAKE_DISABLE_FIND_PACKAGE_<PackageName>](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html#variable:CMAKE_DISABLE_FIND_PACKAGE_%3CPackageName%3E) is not usable here as all `SPIRV-Tools-opt` calls have a `REQUIRED` attribute, so we can't easily disable it)


Closes https://github.com/conan-io/conan-center-index/issues/27170