### PR TITLE
llhttp: Update to version 9.3.0

### DIFF
--- a/recipes/llhttp/all/conandata.yml
+++ b/recipes/llhttp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "9.3.0":
+    url: https://github.com/nodejs/llhttp/archive/refs/tags/release/v9.3.0.tar.gz
+    sha256: "1a2b45cb8dda7082b307d336607023aa65549d6f060da1d246b1313da22b685a"
   "9.1.3":
     url: https://github.com/nodejs/llhttp/archive/refs/tags/release/v9.1.3.tar.gz
     sha256: "49405a7bcb4312b29b91408ee1395de3bc3b29e3bdd10380dc4eb8210912f295"
@@ -9,6 +12,8 @@ sources:
     url: https://github.com/nodejs/llhttp/archive/refs/tags/release/v6.0.6.tar.gz
     sha256: "14023d0efce07a996a197d3b6b15020b26526605277e521f5aa10dacc3af67ad"
 patches:
+  "9.3.0":
+    - patch_file: "patches/v9.3.0-cmake_remove_pcfiles.patch"
   "9.1.3":
     - patch_file: "patches/v9.1.3-cmake_remove_pcfiles.patch"
   "8.1.0":

--- a/recipes/llhttp/all/patches/v9.3.0-cmake_remove_pcfiles.patch
+++ b/recipes/llhttp/all/patches/v9.3.0-cmake_remove_pcfiles.patch
@@ -1,0 +1,14 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -67,11 +67,6 @@ function(config_library target)
+     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+   )
+ 
+-  install(FILES
+-    ${CMAKE_CURRENT_SOURCE_DIR}/libllhttp.pc
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+-  )
+-
+   # This is required to work with FetchContent
+   install(EXPORT llhttp
+     FILE llhttp-config.cmake

--- a/recipes/llhttp/config.yml
+++ b/recipes/llhttp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "9.3.0":
+    folder: all
   "9.1.3":
     folder: all
   "8.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **llhttp/[9.3.0]**

#### Motivation
The latest Node.js LTS version (22.17.1) uses llhttp 9.3.0. We maintain a downstream recipe for building libnode (Node.js as shared library), so this PR is just upstreaming the llhttp update I already needed to do.

#### Details
The
```
RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
```
that is part of the patch for the older 9.1.3 version isn't required anymore, as upstream already has the same line nowadays.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
