### PR TITLE
Add Botan 3.7.1 (with BSI compliance patches)

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "3.8.1":
     url: "https://github.com/randombit/botan/archive/3.8.1.tar.gz"
     sha256: "8eb79a49c1a3f7e5e7563c13752a37557de935cdac48d9221ea4b580158e8965"
+  "3.7.1":
+    url: "https://github.com/randombit/botan/archive/3.7.1.tar.gz"
+    sha256: "8d2a072c7cdca6cadd16f89bb966fce1b3ec77cb4614bf1d87dec1337a3d2330"
   "3.6.1":
     url: "https://github.com/randombit/botan/archive/3.6.1.tar.gz"
     sha256: "a6c4e8dcb6c7f4b9b67e2c8b43069d65b548970ca17847e3b1e031d3ffdd874a"
@@ -17,3 +20,13 @@ sources:
   "2.19.5":
     url: "https://github.com/randombit/botan/archive/2.19.5.tar.gz"
     sha256: "8d4a3826787f9febbdc225172ad2d39d7d3960346c5721fe46cb27d480d7e1de"
+patches:
+  "3.7.1":
+    - patch_file: "patches/enforce-that-ecc-keys-are-non-zero-non-identity.patch"
+      patch_description: "Ensure compliance with BSI's TR-02102-1 Section 2.3.6"
+      patch_type: "backport"
+      patch_source: "https://github.com/randombit/botan/pull/4794"
+    - patch_file: "patches/reject-ecdh-agreement-when-peer-sent-the-identity.patch"
+      patch_description: "Ensure compliance with BSI's TR-03111 Section 4.3.1"
+      patch_type: "backport"
+      patch_source: "https://github.com/randombit/botan/pull/4794"

--- a/recipes/botan/all/patches/enforce-that-ecc-keys-are-non-zero-non-identity.patch
+++ b/recipes/botan/all/patches/enforce-that-ecc-keys-are-non-zero-non-identity.patch
@@ -1,0 +1,100 @@
+diff --git a/src/lib/pubkey/ecc_key/ec_key_data.cpp b/src/lib/pubkey/ecc_key/ec_key_data.cpp
+index ffea08b3b..3ca3ff942 100644
+--- a/src/lib/pubkey/ecc_key/ec_key_data.cpp
++++ b/src/lib/pubkey/ecc_key/ec_key_data.cpp
+@@ -10,15 +10,23 @@
+ 
+ namespace Botan {
+ 
+-EC_PublicKey_Data::EC_PublicKey_Data(EC_Group group, std::span<const uint8_t> bytes) :
+-      m_group(std::move(group)), m_point(m_group, bytes) {
++EC_PublicKey_Data::EC_PublicKey_Data(EC_Group group, EC_AffinePoint pt) :
++      m_group(std::move(group)), m_point(std::move(pt)) {
+ #if defined(BOTAN_HAS_LEGACY_EC_POINT)
+    m_legacy_point = m_point.to_legacy_point();
+ #endif
++
++   // Checking that the point lies on the curve is done in the deserialization
++   // of EC_AffinePoint.
++   BOTAN_ARG_CHECK(!m_point.is_identity(), "ECC public key cannot be point at infinity");
+ }
+ 
+ EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, EC_Scalar x) :
+-      m_group(std::move(group)), m_scalar(std::move(x)), m_legacy_x(m_scalar.to_bigint()) {}
++      m_group(std::move(group)), m_scalar(std::move(x)), m_legacy_x(m_scalar.to_bigint()) {
++   // Checking that the scalar is lower than the group order is ensured in the
++   // deserialization of the EC_Scalar or during the random generation respectively.
++   BOTAN_ARG_CHECK(m_scalar.is_nonzero(), "ECC private key cannot be zero");
++}
+ 
+ namespace {
+ 
+@@ -49,10 +57,8 @@ EC_Scalar decode_ec_secret_key_scalar(const EC_Group& group, std::span<const uin
+ 
+ }  // namespace
+ 
+-EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, std::span<const uint8_t> bytes) :
+-      m_group(std::move(group)),
+-      m_scalar(decode_ec_secret_key_scalar(m_group, bytes)),
+-      m_legacy_x(m_scalar.to_bigint()) {}
++EC_PrivateKey_Data::EC_PrivateKey_Data(const EC_Group& group, std::span<const uint8_t> bytes) :
++      Botan::EC_PrivateKey_Data(group, decode_ec_secret_key_scalar(group, bytes)) {}
+ 
+ std::shared_ptr<EC_PublicKey_Data> EC_PrivateKey_Data::public_key(RandomNumberGenerator& rng,
+                                                                   bool with_modular_inverse) const {
+diff --git a/src/lib/pubkey/ecc_key/ec_key_data.h b/src/lib/pubkey/ecc_key/ec_key_data.h
+index 81ec019ed..f3169be64 100644
+--- a/src/lib/pubkey/ecc_key/ec_key_data.h
++++ b/src/lib/pubkey/ecc_key/ec_key_data.h
+@@ -23,13 +23,10 @@ class RandomNumberGenerator;
+ 
+ class EC_PublicKey_Data final {
+    public:
+-      EC_PublicKey_Data(EC_Group group, EC_AffinePoint pt) : m_group(std::move(group)), m_point(std::move(pt)) {
+-#if defined(BOTAN_HAS_LEGACY_EC_POINT)
+-         m_legacy_point = m_point.to_legacy_point();
+-#endif
+-      }
++      EC_PublicKey_Data(EC_Group group, EC_AffinePoint pt);
+ 
+-      EC_PublicKey_Data(EC_Group group, std::span<const uint8_t> bytes);
++      EC_PublicKey_Data(const EC_Group& group, std::span<const uint8_t> bytes) :
++            EC_PublicKey_Data(group, EC_AffinePoint(group, bytes)) {}
+ 
+       const EC_Group& group() const { return m_group; }
+ 
+@@ -51,7 +48,7 @@ class EC_PrivateKey_Data final {
+    public:
+       EC_PrivateKey_Data(EC_Group group, EC_Scalar x);
+ 
+-      EC_PrivateKey_Data(EC_Group group, std::span<const uint8_t> bytes);
++      EC_PrivateKey_Data(const EC_Group& group, std::span<const uint8_t> bytes);
+ 
+       std::shared_ptr<EC_PublicKey_Data> public_key(RandomNumberGenerator& rng, bool with_modular_inverse) const;
+ 
+diff --git a/src/tests/test_ecdh.cpp b/src/tests/test_ecdh.cpp
+index 40fcc5001..d6b64a639 100644
+--- a/src/tests/test_ecdh.cpp
++++ b/src/tests/test_ecdh.cpp
+@@ -71,6 +71,18 @@ class ECDH_AllGroups_Tests : public Test {
+             try {
+                const auto group = Botan::EC_Group::from_name(group_name);
+ 
++               // Regression test: prohibit loading an all-zero private key
++               result.test_throws<Botan::Invalid_Argument>("all-zero private key is unacceptable", [&] {
++                  const auto one = Botan::EC_Scalar::one(group);
++                  Botan::ECDH_PrivateKey(group, one - one);
++               });
++
++               // Regression test: prohibit loading a public point that is the identity (point at infinity)
++               result.test_throws<Botan::Invalid_Argument>("point at infinity isn't a valid public key", [&] {
++                  const auto infinity = Botan::EC_AffinePoint::identity(group);
++                  Botan::ECDH_PublicKey(group, infinity);
++               });
++
+                for(size_t i = 0; i != 100; ++i) {
+                   const Botan::ECDH_PrivateKey a_priv(rng(), group);
+                   const auto a_pub = a_priv.public_value();
+-- 
+2.43.0
+

--- a/recipes/botan/all/patches/reject-ecdh-agreement-when-peer-sent-the-identity.patch
+++ b/recipes/botan/all/patches/reject-ecdh-agreement-when-peer-sent-the-identity.patch
@@ -1,0 +1,68 @@
+diff --git a/src/lib/pubkey/ecdh/ecdh.cpp b/src/lib/pubkey/ecdh/ecdh.cpp
+index 2995afee4..c0e1d3caf 100644
+--- a/src/lib/pubkey/ecdh/ecdh.cpp
++++ b/src/lib/pubkey/ecdh/ecdh.cpp
+@@ -33,20 +33,33 @@ class ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
+       size_t agreed_value_size() const override { return m_group.get_p_bytes(); }
+ 
+       secure_vector<uint8_t> raw_agree(const uint8_t w[], size_t w_len) override {
+-         if(m_group.has_cofactor()) {
++         const auto input_point = [&] {
++            if(m_group.has_cofactor()) {
+ #if defined(BOTAN_HAS_LEGACY_EC_POINT)
+-            EC_AffinePoint input_point(m_group, m_group.get_cofactor() * m_group.OS2ECP(w, w_len));
+-            return input_point.mul_x_only(m_l_times_priv, m_rng, m_ws);
++               return EC_AffinePoint(m_group, m_group.get_cofactor() * m_group.OS2ECP(w, w_len));
+ #else
+-            throw Not_Implemented("Support for DH with cofactor adjustment not available in this build configuration");
++               throw Not_Implemented(
++                  "Support for DH with cofactor adjustment not available in this build configuration");
+ #endif
+-         } else {
+-            if(auto input_point = EC_AffinePoint::deserialize(m_group, {w, w_len})) {
+-               return input_point->mul_x_only(m_l_times_priv, m_rng, m_ws);
+             } else {
+-               throw Decoding_Error("ECDH - Invalid elliptic curve point");
++               if(auto point = EC_AffinePoint::deserialize(m_group, {w, w_len})) {
++                  return *point;
++               } else {
++                  throw Decoding_Error("ECDH - Invalid elliptic curve point: not on curve");
++               }
+             }
++         }();
++
++         // Typical specs (such as BSI's TR-03111 Section 4.3.1) require that
++         // we check the resulting point of the multiplication to not be the
++         // point at infinity. However, since we ensure that our ECC private
++         // scalar can never be zero, checking the peer's input point is
++         // equivalent.
++         if(input_point.is_identity()) {
++            throw Decoding_Error("ECDH - Invalid elliptic curve point: identity");
+          }
++
++         return input_point.mul_x_only(m_l_times_priv, m_rng, m_ws);
+       }
+ 
+    private:
+diff --git a/src/tests/test_ecdh.cpp b/src/tests/test_ecdh.cpp
+index d6b64a639..5461735fd 100644
+--- a/src/tests/test_ecdh.cpp
++++ b/src/tests/test_ecdh.cpp
+@@ -83,6 +83,14 @@ class ECDH_AllGroups_Tests : public Test {
+                   Botan::ECDH_PublicKey(group, infinity);
+                });
+ 
++               // Regression test: prohibit ECDH-agreement with all-zero public value
++               result.test_throws<Botan::Decoding_Error>("ECDH public value is point-at-infinity", [&] {
++                  const auto sk = Botan::ECDH_PrivateKey(rng(), group);
++                  Botan::PK_Key_Agreement ka(sk, rng(), kdf);
++                  const auto sec1_infinity = std::array{uint8_t(0x00)};
++                  const auto a_ss = ka.derive_key(0, sec1_infinity);
++               });
++
+                for(size_t i = 0; i != 100; ++i) {
+                   const Botan::ECDH_PrivateKey a_priv(rng(), group);
+                   const auto a_pub = a_priv.public_value();
+-- 
+2.43.0
+

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -1,6 +1,8 @@
 versions:
   "3.8.1":
     folder: all
+  "3.7.1":
+    folder: all
   "3.6.1":
     folder: all
   "3.5.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **botan/3.7.1**

#### Motivation

This is the latest version of the library that was audited and approved by the German Federal Office for Information Security (BSI). The contained patches were backported from Botan 3.8 by request of BSI for compliance with their technical guidelines. As a result, this Conan recipe is source-compatible with the officially endorsed version Botan 3.7.1-RSCS1 and may be used in security products that target an official BSI approval for classified communication (VS-NfD) in Germany.

The latest version of Botan is currently 3.8.1 which is available in conan-center already. Nevertheless, this version may be of interest for vendors of security products in Germany as described above.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
