### PR TITLE
Updated cuda-api-wrappers with version 0.8.1

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.1":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.1.tar.gz"
+    sha256: "f5ccadf51455fa1154a0ac730c5dc3894d339ae87413c39f63bd5fa27a48ddba"
   "0.8.0":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.0.tar.gz"
     sha256: "16c68e450e553d2839f00503a44e85b32c4f4e08f154e9f7c85f706bc5c79bf3"

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.1":
+    folder: all
   "0.8.0":
     folder: all
   "0.7.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cuda-api-wrappers/[0.8.1]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

Adding support for version 0.8.1

Resolving #27984 

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

Added `0.8.1` to `versions` list
Added `0.8.1` source and sha256 hash

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
