### PR TITLE
eigen: Expose legacy variables following upstream config file

### DIFF
--- a/recipes/eigen/all/test_package/CMakeLists.txt
+++ b/recipes/eigen/all/test_package/CMakeLists.txt
@@ -1,7 +1,17 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(test_package LANGUAGES CXX)
 
 find_package(Eigen3 REQUIRED CONFIG)
+
+message(STATUS "Eigen versions:")
+
+message(STATUS "EIGEN3_VERSION_MAJOR: ${EIGEN3_VERSION_MAJOR}")
+message(STATUS "EIGEN3_VERSION_MINOR: ${EIGEN3_VERSION_MINOR}")
+message(STATUS "EIGEN3_VERSION_PATCH: ${EIGEN3_VERSION_PATCH}")
+
+message(STATUS "Eigen3_VERSION_MAJOR: ${Eigen3_VERSION_MAJOR}")
+message(STATUS "Eigen3_VERSION_MINOR: ${Eigen3_VERSION_MINOR}")
+message(STATUS "Eigen3_VERSION_PATCH: ${Eigen3_VERSION_PATCH}")
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen)

--- a/recipes/eigen/all/test_package/conanfile.py
+++ b/recipes/eigen/all/test_package/conanfile.py
@@ -4,6 +4,7 @@ from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 
+
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"


### PR DESCRIPTION
In its upstream [`Eigen3Config.cmake` file](https://gitlab.com/libeigen/eigen/-/blob/3.4.0/cmake/Eigen3Config.cmake.in), Eigen exposes `EIGEN3_VERSION_MAJOR` etc., which the current recipe does not (Note that the default-generated ones `Eigen3_VERSION_MAJOR` etc. do work just fine)

This PR lets Conan also expose those versions, so that for example opencv/4.12.0 can use them as necessary