### PR TITLE
libcurl: fix and simplify test package

### DIFF
--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -35,24 +35,3 @@ class TestPackageConan(ConanFile):
             self.run(self._test_executable, env="conanrun")
             if self.dependencies[self.tested_reference_str].options.build_executable:
                 self.run("curl --version", env="conanrun")
-        else:
-            # We will dump information for the generated executable
-            if self.settings.os in ["Android", "iOS"]:
-                # FIXME: Check output for these hosts
-                return
-
-            output = subprocess.check_output(["file", self._test_executable]).decode()
-
-            if self.settings.os == "Macos" and self.settings.arch == "armv8":
-                assert "Mach-O 64-bit executable arm64" in output, f"Not found in output: {output}"
-
-            elif self.settings.os == "Linux":
-                if self.settings.arch == "armv8_32":
-                    assert re.search(r"Machine:\s+ARM", output), f"Not found in output: {output}"
-                elif "armv8" in self.settings.arch:
-                    assert re.search(r"Machine:\s+AArch64", output), f"Not found in output: {output}"
-                elif "arm" in self.settings.arch:
-                    assert re.search(r"Machine:\s+ARM", output), f"Not found in output: {output}"
-
-            elif self.settings.os == "Windows": # FIXME: It satisfies not only MinGW
-                assert re.search(r"PE32.*executable.*Windows", output), f"Not found in output: {output}"

--- a/recipes/libcurl/all/test_package/test_package.c
+++ b/recipes/libcurl/all/test_package/test_package.c
@@ -3,39 +3,6 @@
 
 int main(void)
 {
-  CURL *curl;
-  int retval = 0;
-  const char *const *proto;
-  const char *const *feat;
-  curl_version_info_data* id = curl_version_info(CURLVERSION_NOW);
-  if (!id)
-    return 1;
-
-  printf("protocols: ");
-  for(proto = id->protocols; *proto; proto++) {
-    printf("%s ", *proto);
-  }
-  printf("\nversion: %s\nssl version: %s\n", id->version, id->ssl_version);
-
-  printf("features: ");
-  for(feat = id->feature_names; *feat; feat++) {
-    printf("%s ", *feat);
-  }
-
-  curl = curl_easy_init();
-  if(curl) {
-    char errbuf[CURL_ERROR_SIZE];
-
-    /* provide a buffer to store errors in */
-    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
-
-    /* always cleanup */
-    curl_easy_cleanup(curl);
-    printf("Succeed\n");
-  } else {
-    printf("Failed to init curl\n");
-    retval = 3;
-  }
-
-  return retval;
+  printf("libcurl version %s\n", curl_version());
+  return 0;
 }


### PR DESCRIPTION
* test_package.c : call a single function (anything else is superfluous in the context of the test package)
* `test_package/conanfile.py`: don't inspect files when cross-building and can't run - this fixes an issue cross-building the Windows arm64 package from x86_64 (`file` is not a Windows command).  If the recipe was generating binaries with the wrong architecture, the linking phase of the test package CMake would fail for mixing different architectures. 
* (for this PR: build and publish Windows ARM64 binaries for  `libcurl/8.12.1`)

When cross-building on Windows, to any platform where `file` is not installed or exposed, fixes the following error:

```
======== Testing the package: Executing test ========
libcurl/8.12.1 (test package): Running test()
ERROR: libcurl/8.12.1 (test package): Error in test() method, line 44
	output = subprocess.check_output(["file", self._test_executable]).decode()
	FileNotFoundError: [WinError 2] The system cannot find the file specified
```