### PR TITLE
libffi: fix windows arm64

### DIFF
--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -87,18 +87,6 @@ class LibffiConan(ConanFile):
 
         env = tc.environment()
         if self.settings_build.os == "Windows" and self.settings.get_safe("compiler.runtime"):
-            build = "{}-{}-{}".format(
-                "x86_64" if self.settings_build.arch == "x86_64" else "i686",
-                "pc" if self.settings_build.arch == "x86" else "win64",
-                "mingw64")
-            host = "{}-{}-{}".format(
-                "x86_64" if self.settings.arch == "x86_64" else "i686",
-                "pc" if self.settings.arch == "x86" else "win64",
-                "mingw64")
-            tc.update_configure_args({
-                "--build": build,
-                "--host": host
-                })
 
             if is_msvc(self) and check_min_vs(self, "180", raise_invalid=False):
                 # https://github.com/conan-io/conan/issues/6514
@@ -115,6 +103,8 @@ class LibffiConan(ConanFile):
                     architecture_flag = "-m64"
                 elif self.settings.arch == "x86":
                     architecture_flag = "-m32"
+                elif self.settings.arch == "armv8":
+                    architecture_flag = "-marm64"
             elif self.settings.compiler == "clang":
                 architecture_flag = "-clang-cl"
 


### PR DESCRIPTION
- Rely on Conan to  pass `--build` and `--host` (back in the day Conan was not passing the right values, so recipes had to override them)
- Pass the correct architecture flag

Close https://github.com/conan-io/conan-center-index/issues/21502