### PR TITLE
ninja and m4: fix test package when cross building

### DIFF
--- a/recipes/m4/all/test_package/conanfile.py
+++ b/recipes/m4/all/test_package/conanfile.py
@@ -3,7 +3,6 @@ from conan.tools.build import can_run
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualBuildEnv"
     test_type = "explicit"
 
     def requirements(self):

--- a/recipes/m4/all/test_package/conanfile.py
+++ b/recipes/m4/all/test_package/conanfile.py
@@ -7,9 +7,9 @@ class TestPackageConan(ConanFile):
     test_type = "explicit"
 
     def requirements(self):
-        self.requirements(self.tested_reference_str)
+        self.requires(self.tested_reference_str)
 
     def test(self):
         if can_run(self):
             extension = ".exe" if self.settings.os == "Windows" else ""
-            self.run(f"m4{extension} --version")
+            self.run(f"m4{extension} --version", env="conanrun")

--- a/recipes/m4/all/test_package/conanfile.py
+++ b/recipes/m4/all/test_package/conanfile.py
@@ -1,14 +1,15 @@
 from conan import ConanFile
-
+from conan.tools.build import can_run
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "VirtualBuildEnv"
     test_type = "explicit"
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requirements(self.tested_reference_str)
 
     def test(self):
-        extension = ".exe" if self.settings.os == "Windows" else ""
-        self.run(f"m4{extension} --version")
+        if can_run(self):
+            extension = ".exe" if self.settings.os == "Windows" else ""
+            self.run(f"m4{extension} --version")

--- a/recipes/ninja/all/test_package/conanfile.py
+++ b/recipes/ninja/all/test_package/conanfile.py
@@ -1,12 +1,13 @@
 from conan import ConanFile
-
+from conan.tools.build import can_run
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     test_type = "explicit"
 
-    def build_requirements(self):
+    def requirements(self):
         self.requires(self.tested_reference_str)
 
     def test(self):
-        self.run("ninja --version", env="conanrun")
+        if can_run(self):
+            self.run("ninja --version", env="conanrun")


### PR DESCRIPTION
Ensure the built reference is tested, rather than potentially a different one that matches the build profile.