### PR TITLE
zserio: Add new Zserio release 2.17.0

### DIFF
--- a/recipes/zserio/all/conandata.yml
+++ b/recipes/zserio/all/conandata.yml
@@ -1,4 +1,14 @@
 sources:
+  "2.17.0":
+    runtime:
+      url: "https://github.com/ndsev/zserio/releases/download/v2.17.0/zserio-2.17.0-runtime-libs.zip"
+      sha256: "66e5d6f9796ffb2a0781385abe707663c5eafbbeace0e449e4ed0c73b9460ecd"
+    compiler:
+      url: "https://github.com/ndsev/zserio/releases/download/v2.17.0/zserio-2.17.0-bin.zip"
+      sha256: "976cee037a35544854f6019cc0f73c8742ff26c3fffb9341a84cee5d085374d7"
+    license:
+      url: "https://raw.githubusercontent.com/ndsev/zserio/v2.17.0/LICENSE"
+      sha256: "8fd7b040fc223bb07551dfed490df0d55d6af25e331e58bc7c7599163ed1bb5a"
   "2.16.1":
     runtime:
       url: "https://github.com/ndsev/zserio/releases/download/v2.16.1/zserio-2.16.1-runtime-libs.zip"

--- a/recipes/zserio/config.yml
+++ b/recipes/zserio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.17.0":
+    folder: all
   "2.16.1":
     folder: all
   "2.16.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **zserio/2.17.0**

#### Motivation
New release 2.17.0.

#### Details
The only change is the addition of the new released version 2.17.0.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
