### PR TITLE
legacy libpq 15.x: support Windows arm64

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -158,6 +158,7 @@ class LibpqConan(ConanFile):
                 # Interim solution - recipes should move to using meson-based newer libpq
                 replace_in_file(self, solution_pm, "($output =~ /^\/favor:<.+AMD64/m) ? 'x64' : 'Win32';", "'ARM64';")
                 replace_in_file(self, msbuild_project_pm, "$self->{platform} eq 'Win32' ? 'MachineX86' : 'MachineX64';", "'MachineARM64';")
+                replace_in_file(self, msbuild_project_pm, "<RandomizedBaseAddress>false", "<RandomizedBaseAddress>true")
                 replace_in_file(self, os.path.join(self.source_folder, "src/port/pg_crc32c_sse42.c"), "nmmintrin.h", "intrin.h")
             if self.options.with_openssl:
                 openssl = self.dependencies["openssl"]

--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -154,6 +154,11 @@ class LibpqConan(ConanFile):
             replace_in_file(self,msbuild_project_pm, "'MultiThreadedDLL'", "'%s'" % runtime)
             config_default_pl = os.path.join(self.source_folder, "src", "tools", "msvc", "config_default.pl")
             solution_pm = os.path.join(self.source_folder, "src", "tools", "msvc", "Solution.pm")
+            if self.settings.arch == "armv8":
+                # Interim solution - recipes should move to using meson-based newer libpq
+                replace_in_file(self, solution_pm, "($output =~ /^\/favor:<.+AMD64/m) ? 'x64' : 'Win32';", "'ARM64';")
+                replace_in_file(self, msbuild_project_pm, "$self->{platform} eq 'Win32' ? 'MachineX86' : 'MachineX64';", "'MachineARM64';")
+                replace_in_file(self, os.path.join(self.source_folder, "src/port/pg_crc32c_sse42.c"), "nmmintrin.h", "intrin.h")
             if self.options.with_openssl:
                 openssl = self.dependencies["openssl"]
                 for ssl in ["VC\\libssl32", "VC\\libssl64", "libssl"]:


### PR DESCRIPTION
Need to address this properly in the latest version, and move all downstream recipes to use newer libpq instead, so this is just an interim solution on the legacy build system.
