### PR TITLE
Add minizip-ng 4.0.10 and enable by default MZ_COMPAT

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.10":
+    url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.10.tar.gz"
+    sha256: "c362e35ee973fa7be58cc5e38a4a6c23cc8f7e652555daf4f115a9eb2d3a6be7"
   "4.0.7":
     url: "https://github.com/zlib-ng/minizip-ng/archive/4.0.7.tar.gz"
     sha256: "a87f1f734f97095fe1ef0018217c149d53d0f78438bcb77af38adc21dff2dfbc"

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -36,7 +36,7 @@ class MinizipNgConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "mz_compatibility": False,
+        "mz_compatibility": True,
         "with_zlib": True,
         "with_bzip2": True,
         "with_lzma": True,
@@ -159,6 +159,7 @@ class MinizipNgConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "minizip")
         self.cpp_info.set_property("cmake_target_name", "MINIZIP::minizip")
+        self.cpp_info.set_property("cmake_target_aliases", ["minizip::minizip"])
         self.cpp_info.set_property("pkg_config_name", "minizip")
 
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
@@ -176,14 +177,12 @@ class MinizipNgConan(ConanFile):
             minizip_dir = "minizip" if self.options.mz_compatibility else "minizip-ng"
             self.cpp_info.components["minizip"].includedirs.append(os.path.join(self.package_folder, "include", minizip_dir))
 
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "minizip"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "minizip"
         self.cpp_info.names["cmake_find_package"] = "MINIZIP"
         self.cpp_info.names["cmake_find_package_multi"] = "MINIZIP"
         self.cpp_info.components["minizip"].names["cmake_find_package"] = "minizip"
         self.cpp_info.components["minizip"].names["cmake_find_package_multi"] = "minizip"
         self.cpp_info.components["minizip"].set_property("cmake_target_name", "MINIZIP::minizip")
+        self.cpp_info.components["minizip"].set_property("cmake_target_aliases", ["minizip::minizip"])
         self.cpp_info.components["minizip"].set_property("pkg_config_name", "minizip")
         if self.options.get_safe("with_zlib"):
             self.cpp_info.components["minizip"].requires.append("zlib::zlib")

--- a/recipes/minizip-ng/all/test_package/CMakeLists.txt
+++ b/recipes/minizip-ng/all/test_package/CMakeLists.txt
@@ -4,5 +4,5 @@ project(test_package LANGUAGES C)
 find_package(minizip REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE MINIZIP::minizip)
+target_link_libraries(${PROJECT_NAME} PRIVATE minizip::minizip)
 target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/minizip-ng/config.yml
+++ b/recipes/minizip-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.10":
+    folder: all
   "4.0.7":
     folder: all
   "4.0.6":


### PR DESCRIPTION
MZ_COMPAT is enabled by default in minizip-ng origin project. In addition add cmake target alias to be compatible with minizip.


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
