### PR TITLE
botan: Don't use the Amalgamation by Default

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -61,7 +61,7 @@ class BotanConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "amalgamation": True,
+        "amalgamation": False,
         "with_bzip2": False,
         "with_openssl": False,
         "with_sqlite3": False,


### PR DESCRIPTION
### Summary

Changes the default for `botan/*:amalgamation` to `False`

#### Motivation

The amalgamation build is useful to integrate Botan as a single header/cpp file into downstream projects. When using the library through Conan it does not pose a relevant advantage. On the contrary, we saw miscompilations when using GCC 13 with the amalgamation. Hence, it does not seem to be a good default.

#### Details

See also: https://github.com/randombit/botan/pull/5011

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
