### PR TITLE
libdwarf: Bump to 2.1.0

### DIFF
--- a/recipes/libdwarf/all/conandata.yml
+++ b/recipes/libdwarf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.0":
+    url: "https://github.com/davea42/libdwarf-code/archive/refs/tags/v2.1.0.tar.gz"
+    sha256: 2c893fde2d96b4d465b3ab0cdee21639ae3bb064eb73e2a30af1cc8046dd5eef
   "0.11.1":
     url: "https://github.com/davea42/libdwarf-code/archive/refs/tags/v0.11.1.tar.gz"
     sha256: "dfd24db87c354b3ba6fa72d29a481014f81768fea15ddcde96a8a938b1557c17"

--- a/recipes/libdwarf/config.yml
+++ b/recipes/libdwarf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.0":
+    folder: all
   "0.11.1":
     folder: all
   "0.11.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdwarf/2.1.0**

A new version of libdwarf has been released. Despite the massive major version bumps, libdwarf 2.0 etc is just a continuation of 0.12 etc.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
