### PR TITLE
Bump cmocka to v1.1.8

### DIFF
--- a/recipes/cmocka/all/conandata.yml
+++ b/recipes/cmocka/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.8":
+    url: "https://cmocka.org/files/1.1/cmocka-1.1.8.tar.xz"
+    sha256: "58435b558766d7f4c729ba163bdf3aec38bed3bc766dab684e3526ed0aa7c780"
   "1.1.7":
     url: "https://cmocka.org/files/1.1/cmocka-1.1.7.tar.xz"
     sha256: "810570eb0b8d64804331f82b29ff47c790ce9cd6b163e98d47a4807047ecad82"

--- a/recipes/cmocka/config.yml
+++ b/recipes/cmocka/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.8":
+    folder: all
   "1.1.7":
     folder: all
   "1.1.5":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cmocka/1.1.8**

#### Motivation
<!-- cmocka v.1.18 was released on 2025-07-17 -->

#### Details
Tested working on Linux Mint 22.1 x86-64



