### PR TITLE
influxdb-cxx: Added 0.7.4. Stopped publishing older version.

### DIFF
--- a/recipes/influxdb-cxx/all/conandata.yml
+++ b/recipes/influxdb-cxx/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.7.2":
-    url: "https://github.com/offa/influxdb-cxx/archive/refs/tags/v0.7.2.tar.gz"
-    sha256: "951e067df5731cb23b72f53fcbea8e56920819c6191b6885ea180168eb1950d9"
+  "0.7.4":
+    url: "https://github.com/offa/influxdb-cxx/archive/refs/tags/v0.7.4.tar.gz"
+    sha256: "9ad46d311889a145f74768dc1676ac3e9f6248b7ca3258cf4f04f5b3c2a0db30"

--- a/recipes/influxdb-cxx/all/conanfile.py
+++ b/recipes/influxdb-cxx/all/conanfile.py
@@ -1,10 +1,9 @@
-from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import get, copy, rmdir
-from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import get, copy, rmdir
 
 required_conan_version = ">=1.53.0"
 

--- a/recipes/influxdb-cxx/all/test_package/CMakeLists.txt
+++ b/recipes/influxdb-cxx/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(InfluxDB REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(test_package PRIVATE InfluxData::InfluxDB)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/recipes/influxdb-cxx/config.yml
+++ b/recipes/influxdb-cxx/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.7.2":
+  "0.7.4":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **influxdb-cxx/**

#### Motivation

Discussion: https://github.com/conan-io/conan-center-index/discussions/28037

#### Details

* Added 0.7.4 version. Stopped publishing 0.7.2 revisions.
* Requires C++20.
* Added version ranges for boost and cpr (only patches for this).

#### Tested

With both `shared=False` and `shared=True`

* Linux  Ubuntu noble 24.04
```ini
[settings]
arch=armv8
build_type=Release
compiler=gcc
compiler.cppstd=gnu20
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux
```
* Windows 11
```ini
[settings]
arch=armv8
build_type=Release
compiler=msvc
compiler.cppstd=20
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.version=194
os=Windows
```
* OSX 15.4.1
```ini
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=20
compiler.libcxx=libc++
compiler.version=16
os=Macos
```
