### PR TITLE
mbedtls: Add new TLS 3.6.4

### DIFF
--- a/recipes/mbedtls/all/conandata.yml
+++ b/recipes/mbedtls/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.4":
+    url: "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.4/mbedtls-3.6.4.tar.bz2"
+    sha256: "ec35b18a6c593cf98c3e30db8b98ff93e8940a8c4e690e66b41dfc011d678110"
   "3.6.2":
     url: "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.2/mbedtls-3.6.2.tar.bz2"
     sha256: "8b54fb9bcf4d5a7078028e0520acddefb7900b3e66fec7f7175bb5b7d85ccdca"

--- a/recipes/mbedtls/config.yml
+++ b/recipes/mbedtls/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.4":
+    folder: all
   "3.6.2":
     folder: all
   "3.6.1":


### PR DESCRIPTION
With the end goal to unify all dependants to a version range of some LTS