### PR TITLE
ccache: Add version 4.11.3

### DIFF
--- a/recipes/ccache/all/conandata.yml
+++ b/recipes/ccache/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.11.3":
+    url: "https://github.com/ccache/ccache/releases/download/v4.11.3/ccache-4.11.3.tar.gz"
+    sha256: "28a407314f03a7bd7a008038dbaffa83448bc670e2fc119609b1d99fb33bb600"
   "4.11":
     url: "https://github.com/ccache/ccache/releases/download/v4.11/ccache-4.11.tar.gz"
     sha256: "7dba208540dc61cedd5c93df8c960055a35f06e29a0a3cf766962251d4a5c766"

--- a/recipes/ccache/config.yml
+++ b/recipes/ccache/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.11.3":
+    folder: all
   "4.11":
     folder: all
   "4.10.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **ccache/[4.11.3]**

#### Motivation
Just updating to the latest public release of ccache.

#### Details
Adds new build and hash for 4.11.3, which fixes a few MacOS and Windows bugs.

This obviates the need for https://github.com/conan-io/conan-center-index/pull/27291 which was never merged for some reason.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan (MacOS 15.5, Conan 2.19.0)
