### PR TITLE
Bump libuv to v1.51.0

### DIFF
--- a/recipes/libuv/all/conandata.yml
+++ b/recipes/libuv/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "1.51.0":
     url: "https://github.com/libuv/libuv/archive/v1.51.0.tar.gz"
     sha256: "27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd"
-  "1.50.0":
-    url: "https://github.com/libuv/libuv/archive/v1.50.0.tar.gz"
-    sha256: "b1ec56444ee3f1e10c8bd3eed16ba47016ed0b94fe42137435aaf2e0bd574579"
   "1.49.2":
     url: "https://github.com/libuv/libuv/archive/v1.49.2.tar.gz"
     sha256: "388ffcf3370d4cf7c4b3a3205504eea06c4be5f9e80d2ab32d19f8235accc1cf"

--- a/recipes/libuv/config.yml
+++ b/recipes/libuv/config.yml
@@ -1,8 +1,6 @@
 versions:
   "1.51.0":
     folder: all
-  "1.50.0":
-    folder: all
   "1.49.2":
     folder: all
   "1.49.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libuv/1.51.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Update libuv to latest 1.51.0 version

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Tested successful on Linux Mint 22.1 x86-64 using `conan create all/conanfile.py --version=1.51.0`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
