### PR TITLE
tcl & tk: Install libs as writable

### DIFF
--- a/recipes/tcl/all/conandata.yml
+++ b/recipes/tcl/all/conandata.yml
@@ -11,7 +11,10 @@ sources:
 patches:
   "8.6.13":
     - patch_file: "patches/0001-8.6.11-no-read-only-data.patch"
+    - patch_file: "patches/0002-8.6.13-make-libs-owner-writable.patch"
   "8.6.11":
     - patch_file: "patches/0001-8.6.11-no-read-only-data.patch"
+    - patch_file: "patches/0002-8.6.11-make-libs-owner-writable.patch"
   "8.6.10":
     - patch_file: "patches/0001-8.6.10-no-read-only-data.patch"
+    - patch_file: "patches/0002-8.6.10-make-libs-owner-writable.patch"

--- a/recipes/tcl/all/patches/0002-8.6.10-make-libs-owner-writable.patch
+++ b/recipes/tcl/all/patches/0002-8.6.10-make-libs-owner-writable.patch
@@ -1,0 +1,11 @@
+--- unix/Makefile.in
++++ unix/Makefile.in
+@@ -893,7 +893,7 @@
+ 	    done;
+ 	@echo "Installing $(LIB_FILE) to $(DLL_INSTALL_DIR)/"
+ 	@@INSTALL_LIB@
+-	@chmod 555 "$(DLL_INSTALL_DIR)/$(LIB_FILE)"
++	@chmod 755 "$(DLL_INSTALL_DIR)/$(LIB_FILE)"
+ 	@echo "Installing ${TCL_EXE} as $(BIN_INSTALL_DIR)/tclsh$(VERSION)${EXE_SUFFIX}"
+ 	@$(INSTALL_PROGRAM) ${TCL_EXE} "$(BIN_INSTALL_DIR)/tclsh$(VERSION)${EXE_SUFFIX}"
+ 	@echo "Installing tclConfig.sh to $(CONFIG_INSTALL_DIR)/"

--- a/recipes/tcl/all/patches/0002-8.6.11-make-libs-owner-writable.patch
+++ b/recipes/tcl/all/patches/0002-8.6.11-make-libs-owner-writable.patch
@@ -1,0 +1,11 @@
+--- unix/Makefile.in
++++ unix/Makefile.in
+@@ -891,7 +891,7 @@
+ 	    done;
+ 	@echo "Installing $(LIB_FILE) to $(DLL_INSTALL_DIR)/"
+ 	@@INSTALL_LIB@
+-	@chmod 555 "$(DLL_INSTALL_DIR)/$(LIB_FILE)"
++	@chmod 755 "$(DLL_INSTALL_DIR)/$(LIB_FILE)"
+ 	@echo "Installing ${TCL_EXE} as $(BIN_INSTALL_DIR)/tclsh$(VERSION)${EXE_SUFFIX}"
+ 	@$(INSTALL_PROGRAM) ${TCL_EXE} "$(BIN_INSTALL_DIR)/tclsh$(VERSION)${EXE_SUFFIX}"
+ 	@echo "Installing tclConfig.sh to $(CONFIG_INSTALL_DIR)/"

--- a/recipes/tcl/all/patches/0002-8.6.13-make-libs-owner-writable.patch
+++ b/recipes/tcl/all/patches/0002-8.6.13-make-libs-owner-writable.patch
@@ -1,0 +1,11 @@
+--- unix/Makefile.in
++++ unix/Makefile.in
+@@ -900,7 +900,7 @@
+ 	done
+ 	@echo "Installing $(LIB_FILE) to $(DLL_INSTALL_DIR)/"
+ 	@@INSTALL_LIB@
+-	@chmod 555 "$(DLL_INSTALL_DIR)/$(LIB_FILE)"
++	@chmod 755 "$(DLL_INSTALL_DIR)/$(LIB_FILE)"
+ 	@echo "Installing ${TCL_EXE} as $(BIN_INSTALL_DIR)/tclsh$(VERSION)${EXE_SUFFIX}"
+ 	@$(INSTALL_PROGRAM) ${TCL_EXE} "$(BIN_INSTALL_DIR)/tclsh$(VERSION)${EXE_SUFFIX}"
+ 	@echo "Installing tclConfig.sh to $(CONFIG_INSTALL_DIR)/"

--- a/recipes/tk/all/conandata.yml
+++ b/recipes/tk/all/conandata.yml
@@ -17,3 +17,6 @@ patches:
     - patch_file: "patches/0004-Fix-msvc-shared-build.patch"
       patch_description: "Output an inline file directly to its final destination to avoid a failure in C3I"
       patch_type: "conan"
+    - patch_file: "patches/0005-Owner-writable-libs.patch"
+      patch_description: "Make installed libs writable for owner."
+      patch_type: "portability"

--- a/recipes/tk/all/patches/0005-Owner-writable-libs.patch
+++ b/recipes/tk/all/patches/0005-Owner-writable-libs.patch
@@ -1,0 +1,18 @@
+--- unix/Makefile.in
++++ unix/Makefile.in
+@@ -743,12 +743,12 @@
+ 	    fi
+ 	@echo "Installing $(LIB_FILE) to $(DLL_INSTALL_DIR)/"
+ 	@@INSTALL_LIB@
+-	@chmod 555 "$(DLL_INSTALL_DIR)/$(LIB_FILE)"
++	@chmod 755 "$(DLL_INSTALL_DIR)/$(LIB_FILE)"
+ 	@if test -f "tk${MAJOR_VERSION}${MINOR_VERSION}.dll"; then \
+ 	    $(INSTALL_LIBRARY) "tk${MAJOR_VERSION}${MINOR_VERSION}.dll" "$(DLL_INSTALL_DIR)";\
+-	    chmod 555 "$(DLL_INSTALL_DIR)/tk${MAJOR_VERSION}${MINOR_VERSION}.dll";\
++	    chmod 755 "$(DLL_INSTALL_DIR)/tk${MAJOR_VERSION}${MINOR_VERSION}.dll";\
+ 	    $(INSTALL_LIBRARY) "../win/libtk${MAJOR_VERSION}${MINOR_VERSION}.a" "$(LIB_INSTALL_DIR)";\
+-	    chmod 555 "$(LIB_INSTALL_DIR)/libtk${MAJOR_VERSION}${MINOR_VERSION}.a";\
++	    chmod 755 "$(LIB_INSTALL_DIR)/libtk${MAJOR_VERSION}${MINOR_VERSION}.a";\
+ 	fi
+ 	@echo "Installing ${WISH_EXE} as $(BIN_INSTALL_DIR)/wish$(VERSION)${EXE_SUFFIX}"
+ 	@$(INSTALL_PROGRAM) ${WISH_EXE} "$(BIN_INSTALL_DIR)/wish$(VERSION)${EXE_SUFFIX}"


### PR DESCRIPTION
### Summary
Changes to recipe:  **tcl/8.6.x and tk/8.6.10**

#### Motivation
Issue #28050. Makes `conan cache restore` work for tcl and tk.