### PR TITLE
Make package info build modules and dirs conditional

### DIFF
--- a/recipes/cyclonedds/all/conanfile.py
+++ b/recipes/cyclonedds/all/conanfile.py
@@ -161,15 +161,13 @@ class CycloneDDSConan(ConanFile):
                 "iphlpapi"
             ]
 
-        build_modules = [
-            os.path.join("lib", "cmake", "CycloneDDS", "CycloneDDS_idlc.cmake"),
-            os.path.join("lib", "cmake", "CycloneDDS", "idlc", "Generate.cmake"),
-        ]
+        build_modules = [ os.path.join("lib", "cmake", "CycloneDDS", "CycloneDDS_idlc.cmake") ]
+        if self._has_idlc():
+            build_modules.append(os.path.join("lib", "cmake", "CycloneDDS", "idlc", "Generate.cmake"))
         self.cpp_info.set_property("cmake_build_modules", build_modules)
-        build_dirs = [
-            os.path.join(self.package_folder, "lib", "cmake", "CycloneDDS"),
-            os.path.join(self.package_folder, "lib", "cmake", "CycloneDDS", "idlc"),
-        ]
+        build_dirs = [ os.path.join(self.package_folder, "lib", "cmake", "CycloneDDS") ]
+        if self._has_idlc():
+            build_dirs.append(os.path.join(self.package_folder, "lib", "cmake", "CycloneDDS", "idlc"))
         self.cpp_info.builddirs = build_dirs
 
         # TODO: to remove in conan v2


### PR DESCRIPTION

### Summary
Changes to recipe:  **cyclonedds/0.10.4**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Not doing this seems to breaks cross compiling when used through cyclonedds-cxx as the `Generate.cmake` file cannot be found.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
make appending the build_modules and build_dirs conditional when idlc is in use.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
