### PR TITLE
gas-preprocessor use sha256

### DIFF
--- a/recipes/gas-preprocessor/all/conanfile.py
+++ b/recipes/gas-preprocessor/all/conanfile.py
@@ -18,9 +18,9 @@ class GasPreprocessorConan(ConanFile):
 
     def source(self):
         download(self,
-                  url=self.conan_data["sources"][self.version]['url'],
-                  filename="gas-preprocessor.pl")
-        
+                 url=self.conan_data["sources"][self.version]['url'],
+                 filename="gas-preprocessor.pl", sha256=self.conan_data["sources"][self.version]["sha256"])
+
     def export_sources(self):
         copy(self, "gpl-2.0.txt", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **gas-preprocessor** 

#### Motivation
gas-preprocessor is not using the sha256 provided by the conandata

