### PR TITLE
openh264: Add version 2.6.0

### DIFF
--- a/recipes/openh264/all/conandata.yml
+++ b/recipes/openh264/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.0":
+    url: "https://github.com/cisco/openh264/archive/refs/tags/v2.6.0.tar.gz"
+    sha256: "558544ad358283a7ab2930d69a9ceddf913f4a51ee9bf1bfb9e377322af81a69"
   "2.5.0":
     url: "https://github.com/cisco/openh264/archive/refs/tags/v2.5.0.tar.gz"
     sha256: "94c8ca364db990047ec4ec3481b04ce0d791e62561ef5601443011bdc00825e3"

--- a/recipes/openh264/config.yml
+++ b/recipes/openh264/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.6.0":
+    folder: all
   "2.5.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openh264/2.6.0**

#### Motivation
Doing Debug builds on macOS breaks my pipeline due to -Werror together with a seemingly intentional warning inside the code via pragma: https://github.com/cisco/openh264/pull/3809

Contains some more fixes but that -Werror is the one that made me update now.

#### Details
https://github.com/cisco/openh264/releases/tag/v2.6.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
