### PR TITLE
abseil: add version 20250512.1

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20250512.1":
+    url: "https://github.com/abseil/abseil-cpp/archive/20250512.1.tar.gz"
+    sha256: "9b7a064305e9fd94d124ffa6cc358592eb42b5da588fb4e07d09254aa40086db"
   "20250127.0":
     url: "https://github.com/abseil/abseil-cpp/archive/20250127.0.tar.gz"
     sha256: "16242f394245627e508ec6bb296b433c90f8d914f73b9c026fddb905e27276e8"

--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -45,7 +45,8 @@ class AbseilConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def validate(self):
-        check_min_cppstd(self, 14)
+        minimum_cppstd = 17 if self.version >= Version("20250512.1") else 14
+        check_min_cppstd(self, minimum_cppstd)
 
         if self.options.shared and is_msvc(self) and Version(self.version) < "20230802.1":
             # upstream tries its best to export symbols, but it's broken for the moment

--- a/recipes/abseil/config.yml
+++ b/recipes/abseil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20250512.1":
+    folder: all
   "20250127.0":
     folder: all
   "20240722.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil/20250512.1**

#### Motivation
Closes #28069 

#### Details
New version requires at least C++17
https://github.com/abseil/abseil-cpp/releases/tag/20250512.1
https://github.com/abseil/abseil-cpp/compare/20250127.0...20250512.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
