### PR TITLE
intel-dfp: add version 2.3 (#28073)

### DIFF
--- a/recipes/intel-dfp/all/CMakeLists.txt
+++ b/recipes/intel-dfp/all/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(intel-dfp LANGUAGES C)
+enable_testing()
+
+option(CALL_BY_REF "Pass function arguments and return values by reference")
+option(GLOBAL_RND "Store the value of the rounding mode in a global variable")
+option(GLOBAL_EXC "Store the value of the exception status flags in a global variable")
+
+file(GLOB_RECURSE MAIN_SOURCES LIBRARY/src/*.c)
+set(FLOAT128_SOURCES
+    LIBRARY/float128/dpml_exception.c
+    LIBRARY/float128/dpml_four_over_pi.c
+    LIBRARY/float128/dpml_ux_bessel.c
+    LIBRARY/float128/dpml_ux_bid.c
+    LIBRARY/float128/dpml_ux_cbrt.c
+    LIBRARY/float128/dpml_ux_erf.c
+    LIBRARY/float128/dpml_ux_exp.c
+    LIBRARY/float128/dpml_ux_int.c
+    LIBRARY/float128/dpml_ux_inv_hyper.c
+    LIBRARY/float128/dpml_ux_inv_trig.c
+    LIBRARY/float128/dpml_ux_lgamma.c
+    LIBRARY/float128/dpml_ux_log.c
+    LIBRARY/float128/dpml_ux_mod.c
+    LIBRARY/float128/dpml_ux_ops.c
+    LIBRARY/float128/dpml_ux_ops_64.c
+    LIBRARY/float128/dpml_ux_pow.c
+    LIBRARY/float128/dpml_ux_powi.c
+    LIBRARY/float128/dpml_ux_sqrt.c
+    LIBRARY/float128/dpml_ux_trig.c
+    LIBRARY/float128/sqrt_tab_t.c
+)
+
+# Compiler definitions that are common for all files
+add_library(common_definitions INTERFACE)
+target_compile_definitions(common_definitions INTERFACE
+    DECIMAL_CALL_BY_REFERENCE=$<BOOL:${CALL_BY_REF}>
+    DECIMAL_GLOBAL_ROUNDING=$<BOOL:${GLOBAL_RND}>
+    DECIMAL_GLOBAL_EXCEPTION_FLAGS=$<BOOL:${GLOBAL_EXC}>
+    $<UPPER_CASE:${CMAKE_SYSTEM_NAME}>
+    efi2
+)
+
+# Main library files
+add_library(main OBJECT ${MAIN_SOURCES})
+target_compile_definitions(main PRIVATE
+    USE_COMPILER_F128_TYPE=0
+    USE_COMPILER_F80_TYPE=0
+)
+target_link_libraries(main PRIVATE common_definitions)
+
+# Files from the "float128" directory
+add_library(float128 OBJECT ${FLOAT128_SOURCES})
+target_compile_definitions(float128 PRIVATE
+    USE_NATIVE_QUAD_TYPE=0
+    $<LOWER_CASE:${CMAKE_C_COMPILER_ID}>
+)
+target_link_libraries(float128 PRIVATE common_definitions)
+
+# Output static library
+add_library(intel_dfp
+    $<TARGET_OBJECTS:main>
+    $<TARGET_OBJECTS:float128>
+)
+
+include(GNUInstallDirs)
+
+set(HEADERS_TO_INSTALL
+    LIBRARY/src/bid_conf.h
+    LIBRARY/src/bid_functions.h
+)
+set(HEADERS_DEST ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(TARGETS intel_dfp)
+install(
+    FILES ${HEADERS_TO_INSTALL}
+    DESTINATION ${HEADERS_DEST}
+)
+
+# Test targets
+add_executable(readtest TESTS/readtest.c)
+target_compile_definitions(readtest PRIVATE
+    __intptr_t_defined
+    $<UPPER_CASE:${CMAKE_SYSTEM_NAME}>
+    DECIMAL_CALL_BY_REFERENCE=$<BOOL:${CALL_BY_REF}>
+    DECIMAL_GLOBAL_ROUNDING=$<BOOL:${GLOBAL_RND}>
+    DECIMAL_GLOBAL_EXCEPTION_FLAGS=$<BOOL:${GLOBAL_EXC}>
+)
+target_link_libraries(readtest PRIVATE intel_dfp m)
+
+set(TEST_ENTRIES ${PROJECT_SOURCE_DIR}/TESTS/readtest.in)
+add_test(NAME sanity COMMAND sh -c "$<TARGET_FILE:readtest> < ${TEST_ENTRIES}")

--- a/recipes/intel-dfp/all/conandata.yml
+++ b/recipes/intel-dfp/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "2.3":
+    url: "https://www.netlib.org/misc/intel/IntelRDFPMathLib20U3.tar.gz"
+    sha256: "13f6924b2ed71df9b137a7df98706a0dcc3b43c283a0e32f8b6eadca4305136a"
+patches:
+  "2.3":
+    - patch_file: "patches/2.3-0001-fix-readtest.patch"
+      patch_description: "make unit test return meaningful exit code"
+      patch_type: conan

--- a/recipes/intel-dfp/all/conanfile.py
+++ b/recipes/intel-dfp/all/conanfile.py
@@ -1,0 +1,95 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, CMakeDeps
+from conan.tools.files import (get, copy, apply_conandata_patches,
+                               export_conandata_patches)
+
+
+required_conan_version = ">=2.0.9"
+
+
+class IntelDfpConan(ConanFile):
+    name = "intel-dfp"
+    description = "Software decimal floating-point arithmetic implementation"
+    license = "Intel"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = ("https://www.intel.com/content/www/us/en/developer/articles/"
+                "tool/intel-decimal-floating-point-math-library.html")
+    topics = ("decimal", "dfp", "ieee-754", "intel")
+    package_type = "library"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "call_by_reference": [True, False],
+        "global_rounding": [True, False],
+        "global_exception": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "call_by_reference": False,
+        "global_rounding": False,
+        "global_exception": False
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+        copy(self, "CMakeLists.txt", self.recipe_folder,
+             dst=self.export_sources_folder)
+
+    def config_options(self):
+        if self.settings.get_safe("os") == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.12.0]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version])
+        apply_conandata_patches(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.variables["CALL_BY_REF"] = self.options.call_by_reference
+        tc.variables["GLOBAL_RND"] = self.options.global_rounding
+        tc.variables["GLOBAL_EXC"] = self.options.global_exception
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+        if not self.conf.get("tools.build:skip_test", default=False):
+            cmake.build(target="readtest")
+            cmake.ctest()
+
+    def package(self):
+        copy(self, "eula.txt",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["intel_dfp"]
+        self.cpp_info.set_property("cmake_file_name", "intel_dfp")
+        self.cpp_info.set_property("cmake_target_name", "intel_dfp::intel_dfp")
+
+        defs = {"DECIMAL_CALL_BY_REFERENCE": self.options.call_by_reference,
+                "DECIMAL_GLOBAL_ROUNDING": self.options.global_rounding,
+                "DECIMAL_GLOBAL_EXCEPTION_FLAGS":
+                    self.options.global_exception}
+        self.cpp_info.defines = [f"{k}={int(bool(v))}"
+                                 for k, v in defs.items()]
+
+        if self.settings.compiler in ("clang", "gcc"):
+            self.cpp_info.defines.append("_WCHAR_T=__WCHAR_TYPE__")
+        elif self.settings.compiler == "msvc":
+            self.cpp_info.defines.append("_WCHAR_T=_NATIVE_WCHAR_T_DEFINED")

--- a/recipes/intel-dfp/all/patches/2.3-0001-fix-readtest.patch
+++ b/recipes/intel-dfp/all/patches/2.3-0001-fix-readtest.patch
@@ -1,0 +1,13 @@
+diff --git a/TESTS/readtest.c b/TESTS/readtest.c
+index 477bb1b..1503465 100644
+--- a/TESTS/readtest.c
++++ b/TESTS/readtest.c
+@@ -1961,7 +1961,7 @@ main (int argc, char *argv[]) {
+ 
+   printf ("Total tests: %d, failed result: %d, failed status: %d\n",
+ 	  tests, fail_res, fail_status);
+-  return 0;
++  return fail_res || fail_status;
+ 
+ }
+ 

--- a/recipes/intel-dfp/all/test_package/CMakeLists.txt
+++ b/recipes/intel-dfp/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+find_package(intel_dfp REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE intel_dfp::intel_dfp)

--- a/recipes/intel-dfp/all/test_package/conanfile.py
+++ b/recipes/intel-dfp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/intel-dfp/all/test_package/test_package.cpp
+++ b/recipes/intel-dfp/all/test_package/test_package.cpp
@@ -1,0 +1,87 @@
+#include <bid_conf.h>
+#include <bid_functions.h>
+
+static constexpr auto IN {"12345678901234567"};
+static constexpr auto ROUNDING {BID_ROUNDING_DOWN};
+static constexpr auto EXPECTED_FLAGS {BID_INEXACT_EXCEPTION};
+static constexpr BID_UINT64 EXPECTED_OUT {3595107070531779264};
+
+static constexpr int check(BID_UINT64 out, _IDEC_flags flags) {
+    if (flags != EXPECTED_FLAGS)
+        return 1;
+    if (out != EXPECTED_OUT)
+        return 1;
+    return 0;
+}
+
+#if DECIMAL_CALL_BY_REFERENCE && DECIMAL_GLOBAL_ROUNDING && DECIMAL_GLOBAL_EXCEPTION_FLAGS
+int main () {
+    _IDEC_glbround = ROUNDING;
+    BID_UINT64 out{};
+    bid64_from_string(&out, const_cast<char *>(IN));
+    return check(out, _IDEC_glbflags);
+}
+#endif
+
+#if DECIMAL_CALL_BY_REFERENCE && DECIMAL_GLOBAL_ROUNDING && !DECIMAL_GLOBAL_EXCEPTION_FLAGS
+int main () {
+    _IDEC_glbround = ROUNDING;
+    _IDEC_flags flags{};
+    BID_UINT64 out{};
+    bid64_from_string(&out, const_cast<char *>(IN), &flags);
+    return check(out, flags);
+}
+#endif
+
+#if DECIMAL_CALL_BY_REFERENCE && !DECIMAL_GLOBAL_ROUNDING && DECIMAL_GLOBAL_EXCEPTION_FLAGS
+int main () {
+    _IDEC_round round{ROUNDING};
+    BID_UINT64 out{};
+    bid64_from_string(&out, const_cast<char *>(IN), &round);
+    return check(out, _IDEC_glbflags);
+}
+#endif
+
+#if DECIMAL_CALL_BY_REFERENCE && !DECIMAL_GLOBAL_ROUNDING && !DECIMAL_GLOBAL_EXCEPTION_FLAGS
+int main () {
+    _IDEC_round round{ROUNDING};
+    _IDEC_flags flags{};
+    BID_UINT64 out{};
+    bid64_from_string(&out, const_cast<char *>(IN), &round, &flags);
+    return check(out, flags);
+}
+#endif
+
+#if !DECIMAL_CALL_BY_REFERENCE && DECIMAL_GLOBAL_ROUNDING && DECIMAL_GLOBAL_EXCEPTION_FLAGS
+int main() {
+    _IDEC_glbround = ROUNDING;
+    BID_UINT64 out = bid64_from_string(const_cast<char *>(IN));
+    return check(out, _IDEC_glbflags);
+}
+#endif
+
+#if !DECIMAL_CALL_BY_REFERENCE && DECIMAL_GLOBAL_ROUNDING && !DECIMAL_GLOBAL_EXCEPTION_FLAGS
+int main() {
+    _IDEC_glbround = ROUNDING;
+    _IDEC_flags flags{};
+    BID_UINT64 out = bid64_from_string(const_cast<char *>(IN), &flags);
+    return check(out, flags);
+}
+#endif
+
+#if !DECIMAL_CALL_BY_REFERENCE && !DECIMAL_GLOBAL_ROUNDING && DECIMAL_GLOBAL_EXCEPTION_FLAGS
+int main() {
+    _IDEC_round round{ROUNDING};
+    BID_UINT64 out = bid64_from_string(const_cast<char *>(IN), round);
+    return check(out, _IDEC_glbflags);
+}
+#endif
+
+#if !DECIMAL_CALL_BY_REFERENCE && !DECIMAL_GLOBAL_ROUNDING && !DECIMAL_GLOBAL_EXCEPTION_FLAGS
+int main() {
+    _IDEC_round round{ROUNDING};
+    _IDEC_flags flags{};
+    BID_UINT64 out = bid64_from_string(const_cast<char *>(IN), round, &flags);
+    return check(out, flags);
+}
+#endif

--- a/recipes/intel-dfp/config.yml
+++ b/recipes/intel-dfp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.3":
+    folder: all


### PR DESCRIPTION
### Summary
Add new recipe:  **intel-dfp/2.3**

#### Motivation
This PR introduces a new recipe for the [Intel Decimal Floating-Point (DFP) library](www.intel.com/content/www/us/en/developer/articles/tool/intel-decimal-floating-point-math-library.html), an implementation of IEEE 754-2008 decimal floating-point arithmetic.

Although a package named `dfp` already exists in Conan Center, it is a wrapper around this library created by EPAM. My use case requires using the original Intel-maintained implementation directly to ensure full compatibility, traceability, and integration with upstream changes.

#### Details
* The recipe builds the original Intel DFP library from source.
* Supports both static and shared builds.
* The upstream library is written in C and does not include a build system. This recipe provides a custom `CMakeLists.txt` to integrate the library cleanly with CMake-based workflows.
* Ensures compatibility with consumers by defining required preprocessor definitions.
* Includes a `test_package` that verifies integration with a CMake-based consumer project.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
