### PR TITLE
re2: add version 20250722

### DIFF
--- a/recipes/re2/all/conandata.yml
+++ b/recipes/re2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20250722":
+    url: "https://github.com/google/re2/releases/download/2025-07-22/re2-2025-07-22.tar.gz"
+    sha256: "f54c29f1c3e13e12693e3d6d1230554df3ab3a1066b2e1f28c5330bfbf6db1e3"
   "20240702":
     url: "https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.tar.gz"
     sha256: "eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b"

--- a/recipes/re2/config.yml
+++ b/recipes/re2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20250722":
+    folder: all
   "20240702":
     folder: all
   "20240301":


### PR DESCRIPTION
### Summary
Changes to recipe:  **re2/20250722**

#### Motivation
new upstream version

#### Details
https://github.com/google/re2/compare/2024-07-02...2025-07-22

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
