### PR TITLE
arrow: Update rapidjson dependency

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -165,7 +165,7 @@ class ArrowConan(ConanFile):
         if self.options.with_grpc:
             self.requires("grpc/1.50.0")
         if self._requires_rapidjson():
-            self.requires("rapidjson/cci.20230929")
+            self.requires("rapidjson/[>=cci.20230929]")
         if self.options.with_llvm:
             self.requires("llvm-core/13.0.0")
         if self.options.with_openssl:


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/21.0.0**

#### Motivation

Arrow no longer compiles with newer GCC [1].
It depends on 1.1.0 version of RapidJSON which has a bug [2].
The bug was fixed in 2016, but official releases have not been made by RapidJSON upstream since then.

[1]: https://github.com/apache/arrow/issues/47039
[2]: https://github.com/Tencent/rapidjson/issues/2277

#### Details

This change updates the version of RapidJSON used by Arrow to unofficial but newer versions already present in CCI.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
