### PR TITLE
openssl: add 3.5.2

### DIFF
--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -5,9 +5,9 @@
 #  Note: please do not maintain multiple patch versions of the same minor,
 #        unless required by the above.
 sources:
-  3.5.1: # LTS: keep until next LTS is designed
-    url: "https://github.com/openssl/openssl/releases/download/openssl-3.5.1/openssl-3.5.1.tar.gz"
-    sha256: 529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f
+  3.5.2: # LTS: keep until next LTS is designed
+    url: "https://github.com/openssl/openssl/releases/download/openssl-3.5.2/openssl-3.5.2.tar.gz"
+    sha256: c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec
   3.4.2:
     url: "https://github.com/openssl/openssl/releases/download/openssl-3.4.2/openssl-3.4.2.tar.gz"
     sha256: 17b02459fc28be415470cccaae7434f3496cac1306b86b52c83886580e82834c

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.5.1":
+  "3.5.2":
     folder: "3.x.x"
   "3.4.2":
     folder: "3.x.x"


### PR DESCRIPTION
### Summary
Changes to recipe:  **openssl/3.5.2**

#### Motivation
New version is available

#### Details
https://github.com/openssl/openssl/releases/tag/openssl-3.5.2
https://github.com/openssl/openssl/compare/openssl-3.5.1...openssl-3.5.2


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
