### PR TITLE
protobuf: add version 6.31.1

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.31.1":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.31.1.tar.gz"
+    sha256: "597071a340acc5346494c119ba3a541825c3f81071fc783521b24e29a485d60f"
   "6.30.1":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.30.1.tar.gz"
     sha256: "c97cc064278ef2b8c4da66c1f85613642ecbd5a0c4217c0defdf7ad1b3de9fa5"
@@ -33,6 +36,42 @@ patches:
       patch_source: "https://github.com/protocolbuffers/protobuf/pull/10103"
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
+  "6.31.1":
+    - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_type_traits
+    - absl_utility
   "6.30.1":
     - absl_absl_check
     - absl_absl_log

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -36,7 +36,6 @@ class ProtobufConan(ConanFile):
         "with_zlib": True,
         "with_rtti": True,
         "lite": False,
-        "upb": False,
         "debug_suffix": True,
     }
 
@@ -62,6 +61,9 @@ class ProtobufConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+        if self.options.upb == None:
+            self.options.upb = self._protobuf_release >= "31.1" and self.settings.os != "tvOS"
 
     def configure(self):
         if self.options.shared:
@@ -121,6 +123,9 @@ class ProtobufConan(ConanFile):
             abseil_cppstd = self.dependencies.host['abseil'].info.settings.compiler.cppstd
             if abseil_cppstd != self.settings.compiler.cppstd:
                 raise ConanInvalidConfiguration(f"Protobuf and abseil must be built with the same compiler.cppstd setting")
+
+        if self._protobuf_release >= "31.1" and self.settings.os != "tvOS" and not self.options.get_safe("upb"):
+            raise ConanInvalidConfiguration("upb must be build as it is a dependency of libprotoc.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.31.1":
+    folder: all
   "6.30.1":
     folder: all
   "5.29.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuf/[6.31.1]**

#### Motivation
Add version 6.31.1 of protobuf.

#### Details
libupb has become a dependency of libprotoc due to this change: https://github.com/protocolbuffers/protobuf/commit/dce6b0f14bd264d2fc9d92a7f5005d7a87b80b02. This means the the upb setting is not useful anymore. It is kept for backwards compatibility. 

Note we don't build libprotoc on tvOS and thus we need conditional logic.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
