### PR TITLE
open62541: Remove duplicate patch_type-keys introduced by bump to 1.4.13

### DIFF
--- a/recipes/open62541/all/conandata.yml
+++ b/recipes/open62541/all/conandata.yml
@@ -22,7 +22,6 @@ patches:
     - patch_file: "patches/0004-include-iphlpapi.patch"
       patch_description: "Include iphlpapi.h for SecureZeroMemory"
       patch_type: "conan"
-      patch_type: "portability"
     - patch_file: "patches/0008-fix-posix-qnx.patch"
       patch_description: "Ensure posix is default architecture"
       patch_type: "portability"


### PR DESCRIPTION
### Summary
Changes to recipe:  **open62541/1.4.13**

#### Motivation
Duplicate keys fixed in conandata.yml, as pointed out by @ericLemanissier 

#### Details
Removed duplicate patch_type-key in the list of patches for 1.4.13

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
