### PR TITLE
[b2] Add support for Conan config for Compiler and CXX Flags

### DIFF
--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 import os
 from io import StringIO
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=2.0.4"
 
 
 class B2Conan(ConanFile):
@@ -169,9 +169,27 @@ class B2Conan(ConanFile):
             cxxflags_env = envvars.get("CXXFLAGS")
             if cxxflags_env:
                 cxxflags = f"{cxxflags} {cxxflags_env}"
+        else:
+            cxx_conf = self.conf.get("tools.build:compiler_executables", check_type=dict, default={"cpp": None})["cpp"]
+            if cxx_conf:
+                command += f" --cxx={cxx_conf}"
+                self._write_project_config(cxx_conf)
+            cxxflags_conf = " ".join(self.conf.get("tools.build:cxxflags", check_type=list, default=[]))
+            if cxxflags_conf:
+                cxxflags = f"{cxxflags} {cxxflags_conf}"
 
         if cxxflags:
             command += f' --cxxflags="{cxxflags}"'
+
+        defines = " ".join(self.conf.get("tools.build:defines", check_type=list, default=[]))
+        if defines:
+            command += f' defines="{defines}"'
+
+        exelinkflags = " ".join(self.conf.get("tools.build:exelinkflags", check_type=list, default=[]))
+        if exelinkflags:
+            command += f' linkflags="{exelinkflags}"'
+
+        command += " --verbose"
 
         if b2_toolset != 'auto':
             command += " "+str(b2_toolset)

--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -181,15 +181,8 @@ class B2Conan(ConanFile):
         if cxxflags:
             command += f' --cxxflags="{cxxflags}"'
 
-        defines = " ".join(self.conf.get("tools.build:defines", check_type=list, default=[]))
-        if defines:
-            command += f' defines="{defines}"'
-
-        exelinkflags = " ".join(self.conf.get("tools.build:exelinkflags", check_type=list, default=[]))
-        if exelinkflags:
-            command += f' linkflags="{exelinkflags}"'
-
-        command += " --verbose"
+        if self.conf.get("tools.build:verbosity", check_type=str, default="quiet") == "verbose":
+            command += " --verbose"
 
         if b2_toolset != 'auto':
             command += " "+str(b2_toolset)


### PR DESCRIPTION
### Summary
Changes to recipe:  **b2/(any version in portable folder)**

Currently, the recipe has only support for env vars, but requires to active an option, which makes it difficult for those who are using Conan conf feature already.

This PR adds support for compiler, cxxflags and verbose, by using Conan conf.

#### Motivation

fixes https://github.com/conan-io/conan-center-index/issues/18776
fixes https://github.com/conan-io/conan-center-index/issues/24020
related to https://github.com/conan-io/conan-center-index/issues/28072

#### Details

When building `b2`, we should use the bootstrap script [build](https://www.boost.org/doc/libs/1_88_0/tools/build/doc/html/index.html#jam.building). That script has some support to forward the compiler that should be used and extra cxx flags

Further features like defines and linker flags don't have an option in the build script, so they should be embedded in the cxxflags altogether.

I built locally using a second compiler (GCC13) configured via `tools.build:compiler_executables`, and I just passed some dummy flags to the compiler as well: `-c tools.build:cxxflags="['-Wall', '-Wpedantic', '-DFOOBAR=1', '-DCONANRULES=1']" -c tools.build:verbosity=verbose`

[b2-5.3.3-linux-gcc13-conf.log](https://github.com/user-attachments/files/21618092/b2-5.3.3-linux-gcc13-conf.log)



---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
