### PR TITLE
protobuf: add version 6.30.2

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.30.2":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.30.2.tar.gz"
+    sha256: "13392d0ce5cbe2259fe67513f938b1be902d6f9d0d44033ea995db1d43d45388"
   "6.30.1":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.30.1.tar.gz"
     sha256: "c97cc064278ef2b8c4da66c1f85613642ecbd5a0c4217c0defdf7ad1b3de9fa5"
@@ -33,6 +36,44 @@ patches:
       patch_source: "https://github.com/protocolbuffers/protobuf/pull/10103"
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
+  "6.30.2":
+    - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_optional
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_type_traits
+    - absl_utility
+    - absl_variant
   "6.30.1":
     - absl_absl_check
     - absl_absl_log

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.30.2":
+    folder: all
   "6.30.1":
     folder: all
   "5.29.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuf/6.30.2**

#### Motivation
Make a new version available through conan 

#### Details
Adds version 6.30.2 of protobuf


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
