### PR TITLE
[boost] Do not populate libdir and bindir when building header-only

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1746,6 +1746,9 @@ class BoostConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "Boost"
         self.cpp_info.names["cmake_find_package_multi"] = "Boost"
 
+        if self.options.header_only:
+            self.cpp_info.libdirs = []
+
         # - Use 'headers' component for all includes + defines
         # - Use '_libboost' component to attach extra system_libs, ...
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1748,6 +1748,7 @@ class BoostConan(ConanFile):
 
         if self.options.header_only:
             self.cpp_info.libdirs = []
+            self.cpp_info.bindirs = []
 
         # - Use 'headers' component for all includes + defines
         # - Use '_libboost' component to attach extra system_libs, ...


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.88.0**

#### Motivation

fixes https://github.com/conan-io/conan-center-index/issues/27829

#### Details

As the global `cpp_info.libdirs` and `cpp_info.bindirs` are not changed, it will have `lib` and `bin` when using the option value `boost/*:header_only=True`, resulting in empty folders. 

The following log demonstrates the .pc content resultant: 

[boost-1.88.0-header-only-pc.log](https://github.com/user-attachments/files/21659078/boost-1.88.0-header-only-pc.log)


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
