### PR TITLE
scip: Update to 9.2.3

### DIFF
--- a/recipes/scip/all/conandata.yml
+++ b/recipes/scip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "9.2.3":
+    url: "https://github.com/scipopt/scip/archive/refs/tags/v923.tar.gz"
+    sha256: "876227c75475a295e586871996281582d10cfdebf5792c10183e1c336a197d11"
   "9.2.0":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v920.tar.gz"
     sha256: "a22dc20f44e99bfec071889fd5af2bfc57c4af14b76d777d1312006616346f7c"
@@ -20,6 +23,9 @@ patches:
       patch_description: "Change hard-coded paths to conan includes"
       patch_type: "conan"
 version_mappings:
+  "9.2.3":
+    soplex: "7.1.5"
+    default_sym: "snauty"
   "9.2.0":
     soplex: "7.1.2"
     default_sym: "snauty"

--- a/recipes/scip/config.yml
+++ b/recipes/scip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "9.2.3":
+    folder: all
   "9.2.0":
     folder: all
   "9.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **scip/9.2.3**

#### Motivation
New version of SCIP released

#### Details
SCIP is not only the name of the library (which uses soplex) but also of the whole optimization suite. In this suite, SCIP v9.2.3 includes soplex 7.1.5, see https://www.scipopt.org/index.php#download

Makes #26493 obsolete

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
