### PR TITLE
Fixed several `openscenegraph` build failures.

### DIFF
--- a/recipes/openscenegraph/all/conandata.yml
+++ b/recipes/openscenegraph/all/conandata.yml
@@ -36,3 +36,13 @@ patches:
       patch_source:
         - https://github.com/openscenegraph/OpenSceneGraph/pull/1296
         - https://github.com/openscenegraph/OpenSceneGraph/pull/951
+    - patch_file: patches/fix-MSVC-_FPOSOFF-removal.patch
+      patch_description: _FPOSOFF identifier not found
+      patch_type: bugfix
+      patch_source:
+        - https://github.com/openscenegraph/OpenSceneGraph/issues/1323
+        - https://github.com/microsoft/vcpkg/pull/38666/files
+    - patch_file: patches/fix-MSVC-unnamed-typedef-struct.patch
+      patch_description: fix MSVC unnamed typedef struct in C++20 standard
+      patch_type: bugfix
+      patch_source: https://github.com/openscenegraph/OpenSceneGraph/commit/3e7bdc07abdf1a8bf02ac062d42e0e9f111107dd

--- a/recipes/openscenegraph/all/conanfile.py
+++ b/recipes/openscenegraph/all/conanfile.py
@@ -147,7 +147,7 @@ class OpenSceneGraphConanFile(ConanFile):
         if self.options.with_jasper:
             self.requires("jasper/4.2.0")
         if self.options.get_safe("with_jpeg") == "libjpeg":
-            self.requires("libjpeg/9e")
+            self.requires("libjpeg/9f")
         elif self.options.get_safe("with_jpeg") == "libjpeg-turbo":
             self.requires("libjpeg-turbo/3.0.2")
         elif self.options.get_safe("with_jpeg") == "mozjpeg":

--- a/recipes/openscenegraph/all/patches/fix-MSVC-_FPOSOFF-removal.patch
+++ b/recipes/openscenegraph/all/patches/fix-MSVC-_FPOSOFF-removal.patch
@@ -1,0 +1,13 @@
+diff --git a/src/osgPlugins/osga/OSGA_Archive.cpp b/src/osgPlugins/osga/OSGA_Archive.cpp
+index b9f518a..19186a7 100644
+--- a/src/osgPlugins/osga/OSGA_Archive.cpp
++++ b/src/osgPlugins/osga/OSGA_Archive.cpp
+@@ -77,7 +77,7 @@ inline OSGA_Archive::pos_type ARCHIVE_POS( const std::streampos & pos )
+ #else // older Dinkumware (eg: one included in Win Server 2003 Platform SDK )
+ 	fpos_t position = pos.get_fpos_t();
+ #endif
+-    std::streamoff offset = pos.operator std::streamoff( ) - _FPOSOFF( position );
++    std::streamoff offset = 0;
+ 
+     return OSGA_Archive::pos_type( position + offset );
+ }

--- a/recipes/openscenegraph/all/patches/fix-MSVC-unnamed-typedef-struct.patch
+++ b/recipes/openscenegraph/all/patches/fix-MSVC-unnamed-typedef-struct.patch
@@ -1,0 +1,15 @@
+Apply fix commit from https://github.com/openscenegraph/OpenSceneGraph/commit/3e7bdc07abdf1a8bf02ac062d42e0e9f111107dd
+
+diff --git a/src/osgPlugins/x/types.h b/src/osgPlugins/x/types.h
+index 33768c5308a..48cbf24640d 100644
+--- a/src/osgPlugins/x/types.h
++++ b/src/osgPlugins/x/types.h
+@@ -38,7 +38,7 @@ namespace DX {
+      */
+
+     // Vector
+-    typedef struct {
++    typedef struct Vector_struct {
+         float x,y,z;
+
+         inline void normalize() {


### PR DESCRIPTION
### Summary
Changes to recipe:  **openscenegraph/3.6.5**

#### Motivation
Normally, patches for third-party libraries which have essentially been abandoned (such as `openscenegraph`) are rejected, as @jcar87 describes in [this comment](https://github.com/conan-io/conan-center-index/pull/26231#issuecomment-2566509064). However, these patches are necessary in order to support the build of `osgearth`, which - despite its reliance on `openscenegraph` -  is still in active development.

In particular, this PR essentially blocks #28101.

#### Details
This PR includes several additional patch files in order to resolve build failures which occurred when attempting to build `openscenegraph` v3.6.5 with the MSVC. An adjustment was also made to the declared required `libjpeg` version; this was done to resolve a dependency conflict for #28101.

I should mention that I have not done any significant analysis regarding the implications of increasing the `libjpeg` version requirement. This change resolves the aforementioned dependency conflict, but it could also theoretically introduce new ones. It may be better to replace this with a version range, instead.

### Known Conflicts
- #26231 - This PR contains the same patch to `openscenegraph` as the one given in #26231. The former is essentially a strict superset of the latter; if we merge this PR, then we can close #26231.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
