### PR TITLE
xtensor: Use CMake to generate aggregated header

### DIFF
--- a/recipes/xtensor/all/conandata.yml
+++ b/recipes/xtensor/all/conandata.yml
@@ -8,23 +8,3 @@ sources:
   "0.24.7":
     url: "https://github.com/xtensor-stack/xtensor/archive/0.24.7.tar.gz"
     sha256: "0fbbd524dde2199b731b6af99b16063780de6cf1d0d6cb1f3f4d4ceb318f3106"
-  "0.24.6":
-    url: "https://github.com/xtensor-stack/xtensor/archive/0.24.6.tar.gz"
-    sha256: "f87259b51aabafdd1183947747edfff4cff75d55375334f2e81cee6dc68ef655"
-  "0.23.10":
-    url: "https://github.com/xtensor-stack/xtensor/archive/0.23.10.tar.gz"
-    sha256: "2e770a6d636962eedc868fef4930b919e26efe783cd5d8732c11e14cf72d871c"
-  "0.21.5":
-    url: "https://github.com/xtensor-stack/xtensor/archive/0.21.5.tar.gz"
-    sha256: "30cb896b6686683ddaefb12c98bf1109fdfe666136dd027aba1a1e9aa825c241"
-patches:
-  "0.23.10":
-    - patch_file: "patches/0.23.9-cxx11-abi.patch"
-      patch_description: "has_trivial_default_constructor has been removed from libstdc++ since version 7"
-      patch_type: "bugfix"
-      patch_source: "https://github.com/xtensor-stack/xtensor/pull/2459"
-  "0.21.5":
-    - patch_file: "patches/0.21.5-cxx11-abi.patch"
-      patch_description: "has_trivial_default_constructor has been removed from libstdc++ since version 7"
-      patch_type: "bugfix"
-      patch_source: "https://github.com/xtensor-stack/xtensor/pull/2459"

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -49,10 +49,8 @@ class XtensorConan(ConanFile):
             self.requires("onetbb/2021.10.0")
 
     def build_requirements(self):
-        # Older versions of xtensor require CMake < 3.5,
-        # so use this to both avoid CMake 4 support,
-        # and support newer versions of xtensor having 3.29
-        self.tool_requires("cmake/[>=3.29 <4]")
+        # required by newer versions of xtensor
+        self.tool_requires("cmake/[>=3.29]")
 
     def package_id(self):
         self.info.clear()
@@ -80,9 +78,7 @@ class XtensorConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.configure()
-        # This generates a xtensor.hpp file that includes all the headers
-        # Otherwise, this is still a header-only library,
-        # no need to set specific build flags
+        cmake.build()
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
+from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
@@ -29,26 +30,15 @@ class XtensorConan(ConanFile):
         "openmp": False,
     }
 
-    def export_sources(self):
-        export_conandata_patches(self)
-
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
         # https://github.com/xtensor-stack/xtensor?tab=readme-ov-file#dependencies
-        if Version(self.version) < "0.26.0":
-            self.requires("xtl/0.7.5")
-        else:
-            self.requires("xtl/0.8.0")
+        self.requires("xtl/0.8.0")
         self.requires("nlohmann_json/3.11.3")
         if self.options.xsimd:
-            if Version(self.version) < "0.24.0":
-                self.requires("xsimd/7.5.0")
-            elif Version(self.version) < "0.26.0":
-                self.requires("xsimd/13.0.0")
-            else:
-                self.requires("xsimd/13.2.0")
+            self.requires("xsimd/13.2.0")
         if self.options.tbb:
             self.requires("onetbb/2021.10.0")
 
@@ -67,12 +57,26 @@ class XtensorConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version],
             destination=self.source_folder, strip_root=True)
 
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if Version(self.version) < "0.26.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
     def build(self):
-        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        # This generates a xtensor.hpp file that includes all the headers
+        # Otherwise, this is still a header-only library,
+        # no need to set specific build flags
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        copy(self, "*.hpp", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "xtensor")

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -35,10 +35,16 @@ class XtensorConan(ConanFile):
 
     def requirements(self):
         # https://github.com/xtensor-stack/xtensor?tab=readme-ov-file#dependencies
-        self.requires("xtl/0.8.0")
+        if Version(self.version) < "0.26.0":
+            self.requires("xtl/0.7.5")
+        else:
+            self.requires("xtl/0.8.0")
         self.requires("nlohmann_json/3.11.3")
         if self.options.xsimd:
-            self.requires("xsimd/13.2.0")
+            if Version(self.version) < "0.26.0":
+                self.requires("xsimd/13.0.0")
+            else:
+                self.requires("xsimd/13.2.0")
         if self.options.tbb:
             self.requires("onetbb/2021.10.0")
 

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -42,6 +42,12 @@ class XtensorConan(ConanFile):
         if self.options.tbb:
             self.requires("onetbb/2021.10.0")
 
+    def build_requirements(self):
+        # Older versions of xtensor require CMake < 3.5,
+        # so use this to both avoid CMake 4 support,
+        # and support newer versions of xtensor having 3.29
+        self.tool_requires("cmake/[>=3.29 <4]")
+
     def package_id(self):
         self.info.clear()
 

--- a/recipes/xtensor/all/test_package/CMakeLists.txt
+++ b/recipes/xtensor/all/test_package/CMakeLists.txt
@@ -14,7 +14,3 @@ foreach(flag "-march=native" "-mtune=native")
     target_compile_options(${PROJECT_NAME} PRIVATE ${flag})
   endif()
 endforeach()
-
-if (xtensor_VERSION VERSION_LESS "0.26.0")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE "XTENSOR_VERSION_LESS_0_26_0")
-endif()

--- a/recipes/xtensor/all/test_package/CMakeLists.txt
+++ b/recipes/xtensor/all/test_package/CMakeLists.txt
@@ -1,16 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-include(CheckCXXCompilerFlag)
-
-find_package(xtensor REQUIRED CONFIG)
+find_package(xtensor REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE xtensor)
-
-foreach(flag "-march=native" "-mtune=native")
-  check_cxx_compiler_flag(${flag} COMPILER_SUPPORTS_MARCH_NATIVE)
-  if(COMPILER_SUPPORTS_MARCH_NATIVE)
-    target_compile_options(${PROJECT_NAME} PRIVATE ${flag})
-  endif()
-endforeach()

--- a/recipes/xtensor/all/test_package/conanfile.py
+++ b/recipes/xtensor/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/xtensor/all/test_package/test_package.cpp
+++ b/recipes/xtensor/all/test_package/test_package.cpp
@@ -1,12 +1,4 @@
-#ifdef XTENSOR_VERSION_LESS_0_26_0
-#include "xtensor/xarray.hpp"
-#include "xtensor/xio.hpp"
-#include "xtensor/xview.hpp"
-#else
-#include "xtensor/containers/xarray.hpp"
-#include "xtensor/io/xio.hpp"
-#include "xtensor/views/xview.hpp"
-#endif
+#include "xtensor.hpp"
 #include <iostream>
 
 int main(int argc, char *argv[]) {

--- a/recipes/xtensor/config.yml
+++ b/recipes/xtensor/config.yml
@@ -5,9 +5,3 @@ versions:
     folder: all
   "0.24.7":
     folder: all
-  "0.24.6":
-    folder: all
-  "0.23.10":
-    folder: all
-  "0.21.5":
-    folder: all


### PR DESCRIPTION
Closes https://github.com/conan-io/conan-center-index/issues/28105

The recipe now uses CMake to drive the installation, which allows us to generate the aggregated header in the configure step too, which was missing from the copy-file based approach.

I've simplified the requirements, as per the readme in upstream the dependencies should still be compatible if I understood it correctly