### PR TITLE
flatbuffers: add version 25.2.10

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "25.2.10":
+    url: "https://github.com/google/flatbuffers/archive/v25.2.10.tar.gz"
+    sha256: "b9c2df49707c57a48fc0923d52b8c73beb72d675f9d44b2211e4569be40a7421"
   "24.12.23":
     url: "https://github.com/google/flatbuffers/archive/v24.12.23.tar.gz"
     sha256: "7e2ef35f1af9e2aa0c6a7d0a09298c2cb86caf3d4f58c0658b306256e5bcab10"

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "25.2.10":
+    folder: all
   "24.12.23":
     folder: all
   "24.3.25":


### PR DESCRIPTION
This PR adds flatbuffers version 25.2.10 to the conan-center-index.

Changes:
- Added version 25.2.10 to config.yml
- Added source URL and SHA256 checksum for v25.2.10 in conandata.yml

The SHA256 checksum was verified: `b9c2df49707c57a48fc0923d52b8c73beb72d675f9d44b2211e4569be40a7421`