### PR TITLE
libpq: Fix zlib usage when enabling openssl in order libpq

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -174,6 +174,14 @@ class LibpqConan(ConanFile):
                 replace_in_file(self,config_default_pl,
                                       openssl_entry,
                                       "openssl   => '%s'" % openssl.package_folder.replace("\\", "/"))
+            if "zlib" in self.dependencies.host:
+                zlib = self.dependencies["zlib"]
+                replace_in_file(self, solution_pm, "zdll.lib", f"{zlib.cpp_info.libs[0]}.lib")
+                zlib_entry = "zlib => undef" if Version(self.version) >= "16.0" else "zlib      => undef"
+                replace_in_file(self, config_default_pl,
+                                zlib_entry,
+                                "zlib   => '%s'" % zlib.package_folder.replace("\\", "/"))
+
             if self.options.with_icu:
                 libicu = self.dependencies["icu"]
                 iculibdir = libicu.cpp_info.components["icu"].libdirs[0]
@@ -313,6 +321,3 @@ class LibpqConan(ConanFile):
             self.cpp_info.components["pgcommon"].system_libs = ["m"]
         elif self.settings.os == "Windows":
             self.cpp_info.components["pq"].system_libs = ["ws2_32", "secur32", "advapi32", "shell32", "crypt32", "wldap32"]
-
-        self.cpp_info.names["cmake_find_package"] = "PostgreSQL"
-        self.cpp_info.names["cmake_find_package_multi"] = "PostgreSQL"


### PR DESCRIPTION
This would fail for missmatching linkage, it's probable that for shared we were finding system-wide zlib