### PR TITLE
[tz] Add deprecated attribute to the recipe

### DIFF
--- a/recipes/tz/all/conanfile.py
+++ b/recipes/tz/all/conanfile.py
@@ -15,6 +15,7 @@ class TzConan(ConanFile):
     description = "The Time Zone Database contains data that represent the history of local time for many representative locations around the globe."
     topics = ("tz", "tzdb", "time", "zone", "date")
     settings = "os", "build_type", "arch", "compiler"
+    deprecated = True
 
     @property
     def _settings_build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **tz/***

#### Motivation
Remove the tz recipe in the future as it is not used and no longer going to be used by the date recipe as per the last comment at https://github.com/conan-io/conan-center-index/issues/16204#issuecomment-3164227528

#### Details
Added the deprecation attribute


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
