### PR TITLE
Make GNU mirror usage consistent

### DIFF
--- a/recipes/autoconf-archive/all/conandata.yml
+++ b/recipes/autoconf-archive/all/conandata.yml
@@ -1,10 +1,16 @@
 sources:
   "2023.02.20":
-    url: "https://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2023.02.20.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/autoconf-archive/autoconf-archive-2023.02.20.tar.xz"
+      - "http://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2023.02.20.tar.xz"
     sha256: "71d4048479ae28f1f5794619c3d72df9c01df49b1c628ef85fde37596dc31a33"
   "2022.09.03":
-    url: "https://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2022.09.03.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/autoconf-archive/autoconf-archive-2022.09.03.tar.xz"
+      - "http://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2022.09.03.tar.xz"
     sha256: "e07454f00d8cae7907bed42d0747798927809947684d94c37207a4d63a32f423"
   "2021.02.19":
-    url: "https://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2021.02.19.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/autoconf-archive/autoconf-archive-2021.02.19.tar.xz"
+      - "http://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2021.02.19.tar.xz"
     sha256: "e8a6eb9d28ddcba8ffef3fa211653239e9bf239aba6a01a6b7cfc7ceaec69cbd"

--- a/recipes/autoconf/all/conandata.yml
+++ b/recipes/autoconf/all/conandata.yml
@@ -1,13 +1,13 @@
 sources:
   "2.72":
     url:
-      - "https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.xz"
-      - "https://ftp.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz"
+      - "http://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz"
+      - "http://ftp.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz"
     sha256: "ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a"
   "2.71":
     url:
-      - "https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.xz"
-      - "https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.xz"
+      - "http://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.71.tar.xz"
+      - "http://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.xz"
     sha256: "f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4"
 patches:
   "2.72":

--- a/recipes/automake/all/conandata.yml
+++ b/recipes/automake/all/conandata.yml
@@ -1,15 +1,23 @@
 sources:
   "1.16.5":
-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/automake/automake-1.16.5.tar.gz"
+      - "http://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz"
     sha256: "07bd24ad08a64bc17250ce09ec56e921d6343903943e99ccf63bbf0705e34605"
   "1.16.4":
-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.4.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/automake/automake-1.16.4.tar.gz"
+      - "http://ftp.gnu.org/gnu/automake/automake-1.16.4.tar.gz"
     sha256: "8a0f0be7aaae2efa3a68482af28e5872d8830b9813a6a932a2571eac63ca1794"
   "1.16.3":
-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.3.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/automake/automake-1.16.3.tar.gz"
+      - "http://ftp.gnu.org/gnu/automake/automake-1.16.3.tar.gz"
     sha256: "ce010788b51f64511a1e9bb2a1ec626037c6d0e7ede32c1c103611b9d3cba65f"
   "1.16.2":
-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.2.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/automake/automake-1.16.2.tar.gz"
+      - "http://ftp.gnu.org/gnu/automake/automake-1.16.2.tar.gz"
     sha256: "b2f361094b410b4acbf4efba7337bdb786335ca09eb2518635a09fb7319ca5c1"
 patches:
   "1.16.5":

--- a/recipes/binutils/all/conandata.yml
+++ b/recipes/binutils/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "2.42":
-    url: "https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
+      - "http://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
     sha256: "f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800"
   "2.41":
-    url: "https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.41.tar.xz"
+      - "http://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.xz"
     sha256: "ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450"
 patches:
   "2.42":

--- a/recipes/bison/all/conandata.yml
+++ b/recipes/bison/all/conandata.yml
@@ -1,15 +1,23 @@
 sources:
   "3.8.2":
-    url: "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
+      - "http://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
     sha256: "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
   "3.7.6":
-    url: "https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
+      - "http://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
     sha256: "69dc0bb46ea8fc307d4ca1e0b61c8c355eb207d0b0c69f4f8462328e74d7b9ea"
   "3.7.1":
-    url: "https://ftp.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
     sha256: "1dd952839cf0d5a8178c691eeae40dc48fa50d18dcce648b1ad9ae0195367d13"
   "3.5.3":
-    url: "https://ftp.gnu.org/gnu/bison/bison-3.5.3.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/bison/bison-3.5.3.tar.gz"
+      - "http://ftp.gnu.org/gnu/bison/bison-3.5.3.tar.gz"
     sha256: "34e201d963156618a0ea5bc87220f660a1e08403dd3c7c7903d4f38db3f40039"
 patches:
   "3.8.2":

--- a/recipes/gcc/all/conandata.yml
+++ b/recipes/gcc/all/conandata.yml
@@ -1,13 +1,21 @@
 sources:
   "15.1.0":
     sha256: 51b9919ea69c980d7a381db95d4be27edf73b21254eb13d752a08003b4d013b1
-    url: https://ftp.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.gz
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.gz"
   "12.2.0":
     sha256: ac6b317eb4d25444d87cf29c0d141dedc1323a1833ec9995211b13e1a851261c
-    url: https://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz"
   "11.3.0":
     sha256: 98438e6cc7294298b474cf0da7655d9a8c8b796421bb0210531c294a950374ed
-    url: https://ftp.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.gz
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.gz"
   "10.2.0":
     sha256: 27e879dccc639cd7b0cc08ed575c1669492579529b53c9ff27b0b96265fa867d
-    url: https://ftp.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.gz
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.gz"

--- a/recipes/gdbm/all/conandata.yml
+++ b/recipes/gdbm/all/conandata.yml
@@ -1,21 +1,18 @@
 sources:
   "1.23":
-    url: [
-      "https://ftp.gnu.org/gnu/gdbm/gdbm-1.23.tar.gz",
-      "https://mirrors.tripadvisor.com/gnu/gdbm/gdbm-1.23.tar.gz",
-    ]
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gdbm/gdbm-1.23.tar.gz"
+      - "http://ftp.gnu.org/gnu/gdbm/gdbm-1.23.tar.gz"
     sha256: "74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd"
   "1.19":
-    url: [
-      "https://ftp.gnu.org/gnu/gdbm/gdbm-1.19.tar.gz",
-      "https://mirrors.tripadvisor.com/gnu/gdbm/gdbm-1.19.tar.gz",
-    ]
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gdbm/gdbm-1.19.tar.gz"
+      - "http://ftp.gnu.org/gnu/gdbm/gdbm-1.19.tar.gz"
     sha256: "37ed12214122b972e18a0d94995039e57748191939ef74115b1d41d8811364bc"
   "1.18.1":
-    url: [
-      "https://ftp.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz",
-      "https://mirrors.tripadvisor.com/gnu/gdbm/gdbm-1.18.1.tar.gz",
-    ]
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz"
     sha256: "86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc"
 patches:
   "1.18.1":

--- a/recipes/gettext/all/conandata.yml
+++ b/recipes/gettext/all/conandata.yml
@@ -1,12 +1,18 @@
 sources:
   "0.22.5":
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.5.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gettext/gettext-0.22.5.tar.gz"
+      - "http://ftp.gnu.org/gnu/gettext/gettext-0.22.5.tar.gz"
     sha256: "ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0"
   "0.21":
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gettext/gettext-0.21.tar.gz"
+      - "http://ftp.gnu.org/gnu/gettext/gettext-0.21.tar.gz"
     sha256: "c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12"
   "0.20.1":
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gettext/gettext-0.20.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/gettext/gettext-0.20.1.tar.gz"
     sha256: "66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c"
 patches:
   "0.22.5":

--- a/recipes/glpk/all/conandata.yml
+++ b/recipes/glpk/all/conandata.yml
@@ -1,4 +1,6 @@
 sources:
   "5.0":
-    url: "https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
     sha256: "4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15"

--- a/recipes/gmp/all/conandata.yml
+++ b/recipes/gmp/all/conandata.yml
@@ -1,19 +1,27 @@
 sources:
   "6.3.0":
     url:
-      - "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.bz2"
+      - "http://ftpmirror.gnu.org/gnu/gmp/gmp-6.3.0.tar.bz2"
+      - "http://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.bz2"
       - "https://gmplib.org/download/gmp/gmp-6.3.0.tar.bz2"
     sha256: "ac28211a7cfb609bae2e2c8d6058d66c8fe96434f740cf6fe2e47b000d1c20cb"
   "6.2.1":
     url:
-      - "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.bz2"
+      - "http://ftpmirror.gnu.org/gnu/gmp/gmp-6.2.1.tar.bz2"
+      - "http://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.bz2"
       - "https://gmplib.org/download/gmp/gmp-6.2.1.tar.bz2"
     sha256: "eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c"
   "6.2.0":
-    url: "https://gmplib.org/download/gmp/gmp-6.2.0.tar.bz2"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gmp/gmp-6.2.0.tar.bz2"
+      - "http://ftp.gnu.org/gnu/gmp/gmp-6.2.0.tar.bz2"
+      - "https://gmplib.org/download/gmp/gmp-6.2.0.tar.bz2"
     sha256: "f51c99cb114deb21a60075ffb494c1a210eb9d7cb729ed042ddb7de9534451ea"
   "6.1.2":
-    url: "https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2"
+      - "http://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2"
+      - "https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2"
     sha256: "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2"
 patches:
   "6.3.0":

--- a/recipes/gperf/all/conandata.yml
+++ b/recipes/gperf/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "3.1":
-    url: "https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/gperf/gperf-3.1.tar.gz"
     sha256: "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
 patches:
   "3.1":

--- a/recipes/gsl/all/conandata.yml
+++ b/recipes/gsl/all/conandata.yml
@@ -1,12 +1,18 @@
 sources:
   "2.7.1":
-    url: "https://ftpmirror.gnu.org/gsl/gsl-2.7.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gsl/gsl-2.7.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/gsl/gsl-2.7.1.tar.gz"
     sha256: "dcb0fbd43048832b757ff9942691a8dd70026d5da0ff85601e52687f6deeb34b"
   "2.7":
-    url: "https://ftpmirror.gnu.org/gsl/gsl-2.7.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gsl/gsl-2.7.tar.gz"
+      - "http://ftp.gnu.org/gnu/gsl/gsl-2.7.tar.gz"
     sha256: "efbbf3785da0e53038be7907500628b466152dbc3c173a87de1b5eba2e23602b"
   "2.6":
-    url: "https://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gsl/gsl-2.6.tar.gz"
+      - "http://ftp.gnu.org/gnu/gsl/gsl-2.6.tar.gz"
     sha256: "b782339fc7a38fe17689cb39966c4d821236c28018b6593ddb6fd59ee40786a8"
 patches:
   "2.7.1":

--- a/recipes/libgettext/all/conandata.yml
+++ b/recipes/libgettext/all/conandata.yml
@@ -1,13 +1,19 @@
 sources:
   "0.22":
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gettext/gettext-0.22.tar.gz"
+      - "http://ftp.gnu.org/gnu/gettext/gettext-0.22.tar.gz"
     sha256: "49f089be11b490170bbf09ed2f51e5f5177f55be4cc66504a5861820e0fb06ab"
   "0.21":
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gettext/gettext-0.21.tar.gz"
+      - "http://ftp.gnu.org/gnu/gettext/gettext-0.21.tar.gz"
     sha256: "c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12"
   "0.20.1":
     sha256: "66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c"
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gettext/gettext-0.20.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/gettext/gettext-0.20.1.tar.gz"
 patches:
   "0.21":
     - patch_file: "patches/0002-memmove-is-intrinsic-function-on-MSVC.patch"

--- a/recipes/libiberty/all/conandata.yml
+++ b/recipes/libiberty/all/conandata.yml
@@ -1,4 +1,6 @@
 sources:
   "9.1.0":
-    url: "https://ftp.gnu.org/pub/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
     sha256: "be303f7a8292982a35381489f5a9178603cbe9a4715ee4fa4a815d6bcd2b658d"

--- a/recipes/libiconv/all/conandata.yml
+++ b/recipes/libiconv/all/conandata.yml
@@ -1,13 +1,13 @@
 sources:
   "1.18":
     url:
-    - "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz"
-    - "https://ftp.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz"
+    - "http://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz"
+    - "http://ftp.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz"
     sha256: "3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8"
   "1.17":
     url:
-    - "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
-    - "https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
+    - "http://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
+    - "http://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
     sha256: "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"
 patches:
   "1.17":

--- a/recipes/libidn/all/conandata.yml
+++ b/recipes/libidn/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "1.36":
-    url: "https://ftp.gnu.org/gnu/libidn/libidn-1.36.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libidn/libidn-1.36.tar.gz"
+      - "http://ftp.gnu.org/gnu/libidn/libidn-1.36.tar.gz"
     sha256: "14b67108344d81ba844631640df77c9071d9fb0659b080326ff5424e86b14038"
 patches:
   "1.36":

--- a/recipes/libidn2/all/conandata.yml
+++ b/recipes/libidn2/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "2.3.8":
-    url: "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
+      - "http://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
     sha256: "f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
   "2.3.0":
-    url: "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.0.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libidn/libidn2-2.3.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/libidn/libidn2-2.3.0.tar.gz"
     sha256: "e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5"
 patches:
   "2.3.0":

--- a/recipes/libmicrohttpd/all/conandata.yml
+++ b/recipes/libmicrohttpd/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "0.9.77":
-    url: "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.77.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.77.tar.gz"
+      - "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.77.tar.gz"
     sha256: "9e7023a151120060d2806a6ea4c13ca9933ece4eacfc5c9464d20edddb76b0a0"
   "0.9.75":
-    url: "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.75.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.75.tar.gz"
+      - "http://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.75.tar.gz"
     sha256: "9278907a6f571b391aab9644fd646a5108ed97311ec66f6359cebbedb0a4e3bb"
 patches:
   "0.9.75":

--- a/recipes/libtasn1/all/conandata.yml
+++ b/recipes/libtasn1/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "4.16.0":
-    url: "https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.16.0.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libtasn1/libtasn1-4.16.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/libtasn1/libtasn1-4.16.0.tar.gz"
     sha256: "0e0fb0903839117cb6e3b56e68222771bebf22ad7fc2295a0ed7d576e8d4329d"
 patches:
   "4.16.0":

--- a/recipes/libtool/all/conandata.yml
+++ b/recipes/libtool/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "2.4.7":
-    url: "https://ftp.gnu.org/gnu/libtool/libtool-2.4.7.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libtool/libtool-2.4.7.tar.gz"
+      - "http://ftp.gnu.org/gnu/libtool/libtool-2.4.7.tar.gz"
     sha256: "04e96c2404ea70c590c546eba4202a4e12722c640016c12b9b2f1ce3d481e9a8"
   "2.4.6":
-    url: "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
+      - "http://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
     sha256: "e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3"
 patches:
   "2.4.7":

--- a/recipes/libunistring/all/conandata.yml
+++ b/recipes/libunistring/all/conandata.yml
@@ -1,7 +1,11 @@
 sources:
   "1.1":
-    url: "https://ftp.gnu.org/gnu/libunistring/libunistring-1.1.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libunistring/libunistring-1.1.tar.xz"
+      - "http://ftp.gnu.org/gnu/libunistring/libunistring-1.1.tar.xz"
     sha256: "827c1eb9cb6e7c738b171745dac0888aa58c5924df2e59239318383de0729b98"
   "0.9.10":
-    url: "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
+      - "http://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
     sha256: "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"

--- a/recipes/m4/all/conandata.yml
+++ b/recipes/m4/all/conandata.yml
@@ -1,13 +1,13 @@
 sources:
   "1.4.19":
     url:
-      - "https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.xz"
-      - "https://ftpmirror.gnu.org/gnu/m4/m4-1.4.19.tar.xz"
+      - "http://ftpmirror.gnu.org/gnu/m4/m4-1.4.19.tar.xz"
+      - "http://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.xz"
     sha256: "63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96"
   "1.4.18":
     url:
-      - "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz"
-      - "https://ftpmirror.gnu.org/gnu/m4/m4-1.4.18.tar.xz"
+      - "http://ftpmirror.gnu.org/gnu/m4/m4-1.4.18.tar.xz"
+      - "http://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz"
     sha256: "f2c1e86ca0a404ff281631bdc8377638992744b175afb806e25871a24a934e07"
 patches:
   "1.4.19":

--- a/recipes/make/all/conandata.yml
+++ b/recipes/make/all/conandata.yml
@@ -1,15 +1,23 @@
 sources:
   "4.4.1":
-    url: "http://ftpmirror.gnu.org/gnu/make/make-4.4.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/make/make-4.4.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/make/make-4.4.1.tar.gz"
     sha256: "dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3"
   "4.4":
-    url: "http://ftpmirror.gnu.org/gnu/make/make-4.4.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/make/make-4.4.tar.gz"
+      - "http://ftp.gnu.org/gnu/make/make-4.4.tar.gz"
     sha256: "581f4d4e872da74b3941c874215898a7d35802f03732bdccee1d4a7979105d18"
   "4.3":
-    url: "http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz"
+      - "http://ftp.gnu.org/gnu/make/make-4.3.tar.gz"
     sha256: "e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19"
   "4.2.1":
-    url: "http://ftpmirror.gnu.org/gnu/make/make-4.2.1.tar.bz2"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/make/make-4.2.1.tar.bz2"
+      - "http://ftp.gnu.org/gnu/make/make-4.2.1.tar.bz2"
     sha256: "d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589"
 patches:
   "4.4.1":

--- a/recipes/mingw-w64/linux/conandata.yml
+++ b/recipes/mingw-w64/linux/conandata.yml
@@ -5,14 +5,12 @@ sources:
       sha256: "f00cf50951867a356d3dc0dcc7a9a9b422972302e23d54a33fc05ee7f73eee4d"
     binutils:
       url:
-        - "https://mirrors.dotsrc.org/gnu/binutils/binutils-2.35.2.tar.xz"
-        - "https://mirror.kumi.systems/gnu/binutils/binutils-2.35.2.tar.xz"
-        - "https://ftpmirror.gnu.org/binutils/binutils-2.35.2.tar.xz"
+        - "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.35.2.tar.xz"
+        - "http://ftp.gnu.org/gnu/binutils/binutils-2.35.2.tar.xz"
       sha256: "dcd5b0416e7b0a9b24bed76cd8c6c132526805761863150a26d016415b8bdc7b"
     gcc:
       "10.5.0":
         url:
-          - "https://mirrors.dotsrc.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
-          - "https://mirror.kumi.systems/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
-          - "https://ftpmirror.gnu.org/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
+          - "http://ftpmirror.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
+          - "http://ftp.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
         sha256: "25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1"

--- a/recipes/mpc/all/conandata.yml
+++ b/recipes/mpc/all/conandata.yml
@@ -1,12 +1,18 @@
 sources:
   "1.3.1":
-    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
     sha256: "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
   "1.2.0":
-    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz"
     sha256: "e90f2d99553a9c19911abdb4305bf8217106a957e3994436428572c8dfe8fda6"
   "1.1.0":
-    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
     sha256: "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e"
 patches:
   "1.2.0":

--- a/recipes/mpfr/all/conandata.yml
+++ b/recipes/mpfr/all/conandata.yml
@@ -1,18 +1,28 @@
 sources:
   "4.2.2":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
+      - "http://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
     sha256: "b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01"
   "4.2.1":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz"
+      - "http://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz"
     sha256: "277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2"
   "4.2.0":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.0.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.0.tar.xz"
+      - "http://ftp.gnu.org/gnu/mpfr/mpfr-4.2.0.tar.xz"
     sha256: "06a378df13501248c1b2db5aa977a2c8126ae849a9d9b7be2546fb4a9c26d993"
   "4.1.0":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
+      - "http://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
     sha256: "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
   "4.0.2":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz"
+      - "http://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz"
     sha256: "1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a"
 patches:
   "4.2.1":

--- a/recipes/ncurses/all/conandata.yml
+++ b/recipes/ncurses/all/conandata.yml
@@ -1,16 +1,16 @@
 sources:
   "6.5":
     url:
-      - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.5.tar.gz"
-      - "https://invisible-mirror.net/archives/ncurses/ncurses-6.5.tar.gz"
+      - "http://ftpmirror.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz"
+      - "http://ftp.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz"
     sha256: "136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6"
   "6.4":
     url:
-      - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.4.tar.gz"
-      - "https://invisible-mirror.net/archives/ncurses/ncurses-6.4.tar.gz"
+      - "http://ftpmirror.gnu.org/gnu/ncurses/ncurses-6.4.tar.gz"
+      - "http://ftp.gnu.org/gnu/ncurses/ncurses-6.4.tar.gz"
     sha256: "6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
   "6.3":
     url:
-      - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz"
-      - "https://invisible-mirror.net/archives/ncurses/ncurses-6.3.tar.gz"
+      - "http://ftpmirror.gnu.org/gnu/ncurses/ncurses-6.3.tar.gz"
+      - "http://ftp.gnu.org/gnu/ncurses/ncurses-6.3.tar.gz"
     sha256: "97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059"

--- a/recipes/nettle/all/conandata.yml
+++ b/recipes/nettle/all/conandata.yml
@@ -1,13 +1,21 @@
 sources:
   "3.9.1":
-    url: "https://ftp.gnu.org/gnu/nettle/nettle-3.9.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/nettle/nettle-3.9.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/nettle/nettle-3.9.1.tar.gz"
     sha256: "ccfeff981b0ca71bbd6fbcb054f407c60ffb644389a5be80d6716d5b550c6ce3"
   "3.8.1":
-    url: "https://ftp.gnu.org/gnu/nettle/nettle-3.8.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/nettle/nettle-3.8.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/nettle/nettle-3.8.1.tar.gz"
     sha256: "364f3e2b77cd7dcde83fd7c45219c834e54b0c75e428b6f894a23d12dd41cbfe"
   "3.6":
-    url: "https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/nettle/nettle-3.6.tar.gz"
+      - "http://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz"
     sha256: "d24c0d0f2abffbc8f4f34dcf114b0f131ec3774895f3555922fe2f40f3d5e3f1"
   "3.5":
-    url: "https://ftp.gnu.org/gnu/nettle/nettle-3.5.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/nettle/nettle-3.5.tar.gz"
+      - "http://ftp.gnu.org/gnu/nettle/nettle-3.5.tar.gz"
     sha256: "432d98dcd341cbd063a963025524122368c1f2ee9c721bb68d771d5e34674b4f"

--- a/recipes/readline/all/conandata.yml
+++ b/recipes/readline/all/conandata.yml
@@ -1,10 +1,16 @@
 sources:
   "8.0":
-    url: "https://ftp.gnu.org/pub/gnu/readline/readline-8.0.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/readline/readline-8.0.tar.gz"
+      - "http://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz"
     sha256: "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461"
   "8.1.2":
-    url: "https://ftp.gnu.org/pub/gnu/readline/readline-8.1.2.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/readline/readline-8.1.2.tar.gz"
+      - "http://ftp.gnu.org/gnu/readline/readline-8.1.2.tar.gz"
     sha256: "7589a2381a8419e68654a47623ce7dfcb756815c8fee726b98f90bf668af7bc6"
   "8.2":
-    url: "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/readline/readline-8.2.tar.gz"
+      - "http://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz"
     sha256: "3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35"

--- a/recipes/tar/all/conandata.yml
+++ b/recipes/tar/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "1.35":
-    url: "https://ftp.gnu.org/gnu/tar/tar-1.35.tar.xz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/tar/tar-1.35.tar.xz"
+      - "http://ftp.gnu.org/gnu/tar/tar-1.35.tar.xz"
     sha256: "4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16"
   "1.32.90":
     url: "https://alpha.gnu.org/gnu/tar/tar-1.32.90.tar.gz"

--- a/recipes/termcap/all/conandata.yml
+++ b/recipes/termcap/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "1.3.1":
-    url: "https://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz"
+    url:
+      - "http://ftpmirror.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz"
+      - "http://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz"
     sha256: "91a0e22e5387ca4467b5bcb18edf1c51b930262fd466d5fda396dd9d26719100"
 patches:
   "1.3.1":


### PR DESCRIPTION
Make GNU mirror usage consistent.
First use http://ftpmirror.gnu.org/gnu, then http://ftp.gnu.org/gnu.

See #27830

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
