### PR TITLE
[ncurses] GCC15 compatibility

### DIFF
--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -176,6 +176,11 @@ class NCursesConan(ConanFile):
         if host:
             tc.configure_args.append(f"ac_cv_host={host}")
             tc.configure_args.append(f"ac_cv_target={host}")
+        if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) >= 15:
+            # FIXME: Workaround to allow building with with GCC15
+            # Upstream has proper but huge patches: https://invisible-island.net/ncurses/NEWS.html#index-t20241207
+            tc.extra_cflags.append("-std=gnu17")
+
         # Allow ncurses to set the include dir with an appropriate subdir
         tc.configure_args.remove("--includedir=${prefix}/include")
         tc.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **ncurses/6.5**

#### Motivation

The issue #28083 enlightens the situation of incompatibility of ncurses 6.5 with GCC15, making it impossible to build it. 

As a workaround, we can pass `-std=gnu17` to `CFLAGS`. This same approach is currently adopted by other package managers too, including:

- Homebrew: https://github.com/Homebrew/homebrew-core/blob/1fa84f286f02574c1f445ef1b1d6cef826af2e6e/Formula/n/ncurses.rb#L55
- Arch Linux: https://gitlab.archlinux.org/archlinux/packaging/packages/ncurses/-/blob/main/PKGBUILD?ref_type=heads#L76
- And Vcpkg too!

#### Details

In the NEWS page is possible to see at least 4 patches directly related to GCC15:

- https://invisible-island.net/ncurses/NEWS.html#index-t20241207
- https://invisible-island.net/ncurses/NEWS.html#index-t20241214
- https://invisible-island.net/ncurses/NEWS.html#index-t20241221
- https://invisible-island.net/ncurses/NEWS.html#index-t20250125

However, their amalgamation into a single patch results in a huge patch, with extra non-related changes. For instance, only a single 20240117 patch: https://ncurses.scripts.mit.edu/?p=ncurses.git;a=commitdiff;h=64afa9627b292b87c8473928854f3dd8c463d833

----

As we do not have GCC15 running in the CI, here is my local build log: [ncurses-6.5-linux-gcc15.log](https://github.com/user-attachments/files/21733687/ncurses-6.5-linux-gcc15.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
