### PR TITLE
intrusive_shared_ptr: add new recipe

### DIFF
--- a/recipes/intrusive_shared_ptr/all/conandata.yml
+++ b/recipes/intrusive_shared_ptr/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.9":
+    url: "https://github.com/gershnik/intrusive_shared_ptr/tarball/v1.9/isptr-1.9.tgz"
+    sha256: "f9095609a2226f3aa6dbfcd4726a8521a56f4fd2f426b0898d92acd1f133aa6d"

--- a/recipes/intrusive_shared_ptr/all/conanfile.py
+++ b/recipes/intrusive_shared_ptr/all/conanfile.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from conan import ConanFile
+from conan.tools.layout import basic_layout
+from conan.tools.files import get, copy
+from conan.tools.build import check_min_cppstd
+
+required_conan_version = ">=2.1"
+
+class IsptrRecipe(ConanFile):
+
+    name = "intrusive_shared_ptr"
+    description = "Intrusive reference counting smart pointer, highly configurable reference counted base class and various adapters."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/gershnik/intrusive_shared_ptr"
+    topics = ("smart-pointer", "intrusive", "header-only", "header-library")
+
+    package_type = "header-library"
+    no_copy_source = True
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, 17)
+
+    def package_id(self):
+        self.info.clear()
+
+    def layout(self):
+        basic_layout(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, pattern="*.h", keep_path=True,
+             src=Path(self.source_folder) / "inc",
+             dst=Path(self.package_folder) / "include")
+        copy(self, pattern="LICENSE.txt", src=self.source_folder, dst=Path(self.package_folder) / "licenses")
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "isptr")
+        self.cpp_info.set_property("cmake_target_name", "isptr::isptr")
+        self.cpp_info.set_property("pkg_config_name",  "isptr")

--- a/recipes/intrusive_shared_ptr/all/conanfile.py
+++ b/recipes/intrusive_shared_ptr/all/conanfile.py
@@ -20,14 +20,13 @@ class IsptrRecipe(ConanFile):
     no_copy_source = True
 
     def validate(self):
-        if self.settings.get_safe("compiler.cppstd"):
-            check_min_cppstd(self, 17)
+        check_min_cppstd(self, 17)
 
     def package_id(self):
         self.info.clear()
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/intrusive_shared_ptr/all/test_package/CMakeLists.txt
+++ b/recipes/intrusive_shared_ptr/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(TestPackage CXX)
+
+find_package(isptr CONFIG REQUIRED)
+
+add_executable(test_package src/test.cpp)
+target_link_libraries(test_package isptr::isptr)
+target_compile_features(test_package PRIVATE cxx_std_17)
+

--- a/recipes/intrusive_shared_ptr/all/test_package/conanfile.py
+++ b/recipes/intrusive_shared_ptr/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class TestPackage(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/intrusive_shared_ptr/all/test_package/src/test.cpp
+++ b/recipes/intrusive_shared_ptr/all/test_package/src/test.cpp
@@ -1,0 +1,21 @@
+#include <intrusive_shared_ptr/intrusive_shared_ptr.h>
+
+
+struct counted { mutable int count = 1; };
+
+struct counted_traits
+{
+    static void add_ref(const counted * c) noexcept { ++c->count; }
+
+    static void sub_ref(const counted * c) noexcept { 
+        if (--c->count == 0)
+            delete c;
+    }
+};
+
+using counted_ptr = isptr::intrusive_shared_ptr<counted, counted_traits>;
+
+
+int main() {
+    auto p = counted_ptr::ref(new counted);
+}

--- a/recipes/intrusive_shared_ptr/config.yml
+++ b/recipes/intrusive_shared_ptr/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.9":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **intrusive_shared_ptr/1.9**

#### Motivation
This is an initial PR for `intrusive_shared_ptr`. The library provides an intrusive reference counting smart pointer, highly configurable reference counted base class and various adapters.

#### Details
This library is currently only available via vcpkg or as a Debian/Ubuntu package. Would be great to have it on Conan


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
