### PR TITLE
Add ftpmirror.gnu.org to packages with ftp.gnu.org url

### DIFF
--- a/recipes/automake/all/conandata.yml
+++ b/recipes/automake/all/conandata.yml
@@ -1,15 +1,23 @@
 sources:
   "1.16.5":
-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/automake/automake-1.16.5.tar.gz"
+      - "https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz"
     sha256: "07bd24ad08a64bc17250ce09ec56e921d6343903943e99ccf63bbf0705e34605"
   "1.16.4":
-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.4.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/automake/automake-1.16.4.tar.gz"
+      - "https://ftp.gnu.org/gnu/automake/automake-1.16.4.tar.gz"
     sha256: "8a0f0be7aaae2efa3a68482af28e5872d8830b9813a6a932a2571eac63ca1794"
   "1.16.3":
-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.3.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/automake/automake-1.16.3.tar.gz"
+      - "https://ftp.gnu.org/gnu/automake/automake-1.16.3.tar.gz"
     sha256: "ce010788b51f64511a1e9bb2a1ec626037c6d0e7ede32c1c103611b9d3cba65f"
   "1.16.2":
-    url: "https://ftp.gnu.org/gnu/automake/automake-1.16.2.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/automake/automake-1.16.2.tar.gz"
+      - "https://ftp.gnu.org/gnu/automake/automake-1.16.2.tar.gz"
     sha256: "b2f361094b410b4acbf4efba7337bdb786335ca09eb2518635a09fb7319ca5c1"
 patches:
   "1.16.5":

--- a/recipes/binutils/all/conandata.yml
+++ b/recipes/binutils/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "2.42":
-    url: "https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
+      - "https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
     sha256: "f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800"
   "2.41":
-    url: "https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.41.tar.xz"
+      - "https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.xz"
     sha256: "ae9a5789e23459e59606e6714723f2d3ffc31c03174191ef0d015bdf06007450"
 patches:
   "2.42":

--- a/recipes/bison/all/conandata.yml
+++ b/recipes/bison/all/conandata.yml
@@ -1,15 +1,23 @@
 sources:
   "3.8.2":
-    url: "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
+      - "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
     sha256: "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
   "3.7.6":
-    url: "https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
+      - "https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
     sha256: "69dc0bb46ea8fc307d4ca1e0b61c8c355eb207d0b0c69f4f8462328e74d7b9ea"
   "3.7.1":
-    url: "https://ftp.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
+      - "https://ftp.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
     sha256: "1dd952839cf0d5a8178c691eeae40dc48fa50d18dcce648b1ad9ae0195367d13"
   "3.5.3":
-    url: "https://ftp.gnu.org/gnu/bison/bison-3.5.3.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/bison/bison-3.5.3.tar.gz"
+      - "https://ftp.gnu.org/gnu/bison/bison-3.5.3.tar.gz"
     sha256: "34e201d963156618a0ea5bc87220f660a1e08403dd3c7c7903d4f38db3f40039"
 patches:
   "3.8.2":

--- a/recipes/gcc/all/conandata.yml
+++ b/recipes/gcc/all/conandata.yml
@@ -1,13 +1,21 @@
 sources:
   "15.1.0":
     sha256: 51b9919ea69c980d7a381db95d4be27edf73b21254eb13d752a08003b4d013b1
-    url: https://ftp.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.gz
+    url:
+      - "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.gz"
   "12.2.0":
     sha256: ac6b317eb4d25444d87cf29c0d141dedc1323a1833ec9995211b13e1a851261c
-    url: https://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz
+    url:
+      - "https://ftpmirror.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz"
   "11.3.0":
     sha256: 98438e6cc7294298b474cf0da7655d9a8c8b796421bb0210531c294a950374ed
-    url: https://ftp.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.gz
+    url:
+      - "https://ftpmirror.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.gz"
   "10.2.0":
     sha256: 27e879dccc639cd7b0cc08ed575c1669492579529b53c9ff27b0b96265fa867d
-    url: https://ftp.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.gz
+    url:
+      - "https://ftpmirror.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.gz"

--- a/recipes/gdbm/all/conandata.yml
+++ b/recipes/gdbm/all/conandata.yml
@@ -1,18 +1,22 @@
 sources:
   "1.23":
     url: [
+      "https://ftpmirror.gnu.org/gnu/gdbm/gdbm-1.23.tar.gz",
       "https://ftp.gnu.org/gnu/gdbm/gdbm-1.23.tar.gz",
       "https://mirrors.tripadvisor.com/gnu/gdbm/gdbm-1.23.tar.gz",
     ]
     sha256: "74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd"
   "1.19":
     url: [
+      "https://ftpmirror.gnu.org/gnu/gdbm/gdbm-1.19.tar.gz",
       "https://ftp.gnu.org/gnu/gdbm/gdbm-1.19.tar.gz",
       "https://mirrors.tripadvisor.com/gnu/gdbm/gdbm-1.19.tar.gz",
+
     ]
     sha256: "37ed12214122b972e18a0d94995039e57748191939ef74115b1d41d8811364bc"
   "1.18.1":
     url: [
+      "https://ftpmirror.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz",
       "https://ftp.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz",
       "https://mirrors.tripadvisor.com/gnu/gdbm/gdbm-1.18.1.tar.gz",
     ]

--- a/recipes/gettext/all/conandata.yml
+++ b/recipes/gettext/all/conandata.yml
@@ -1,17 +1,17 @@
 sources:
   "0.22.5":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/gettext/gettext-0.22.5.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.22.5.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.5.tar.gz"
     sha256: "ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0"
   "0.21":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.21.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz"
     sha256: "c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12"
   "0.20.1":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.20.1.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
     sha256: "66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c"
 patches:

--- a/recipes/gettext/all/conandata.yml
+++ b/recipes/gettext/all/conandata.yml
@@ -1,12 +1,18 @@
 sources:
   "0.22.5":
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.5.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/pub/gnu/gettext/gettext-0.22.5.tar.gz"
+      - "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.22.5.tar.gz"
     sha256: "ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0"
   "0.21":
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz"
+      - "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.gz"
     sha256: "c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12"
   "0.20.1":
-    url: "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
+      - "https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz"
     sha256: "66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c"
 patches:
   "0.22.5":

--- a/recipes/glpk/all/conandata.yml
+++ b/recipes/glpk/all/conandata.yml
@@ -1,4 +1,6 @@
 sources:
   "5.0":
-    url: "https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
     sha256: "4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15"

--- a/recipes/gmp/all/conandata.yml
+++ b/recipes/gmp/all/conandata.yml
@@ -1,19 +1,27 @@
 sources:
   "6.3.0":
     url:
+      - "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.3.0.tar.bz2"
       - "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.bz2"
       - "https://gmplib.org/download/gmp/gmp-6.3.0.tar.bz2"
     sha256: "ac28211a7cfb609bae2e2c8d6058d66c8fe96434f740cf6fe2e47b000d1c20cb"
   "6.2.1":
     url:
+      - "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.2.1.tar.bz2"
       - "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.bz2"
       - "https://gmplib.org/download/gmp/gmp-6.2.1.tar.bz2"
     sha256: "eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c"
   "6.2.0":
-    url: "https://gmplib.org/download/gmp/gmp-6.2.0.tar.bz2"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.2.0.tar.bz2"
+      - "https://ftp.gnu.org/gnu/gmp/gmp-6.2.0.tar.bz2"
+      - "https://gmplib.org/download/gmp/gmp-6.2.0.tar.bz2"
     sha256: "f51c99cb114deb21a60075ffb494c1a210eb9d7cb729ed042ddb7de9534451ea"
   "6.1.2":
-    url: "https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2"
+      - "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2"
+      - "https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2"
     sha256: "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2"
 patches:
   "6.3.0":

--- a/recipes/gperf/all/conandata.yml
+++ b/recipes/gperf/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "3.1":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
     sha256: "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
 patches:

--- a/recipes/gperf/all/conandata.yml
+++ b/recipes/gperf/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "3.1":
-    url: "https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
+      - "https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
     sha256: "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
 patches:
   "3.1":

--- a/recipes/libiberty/all/conandata.yml
+++ b/recipes/libiberty/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "9.1.0":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
     sha256: "be303f7a8292982a35381489f5a9178603cbe9a4715ee4fa4a815d6bcd2b658d"

--- a/recipes/libiberty/all/conandata.yml
+++ b/recipes/libiberty/all/conandata.yml
@@ -1,4 +1,6 @@
 sources:
   "9.1.0":
-    url: "https://ftp.gnu.org/pub/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/pub/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
+      - "https://ftp.gnu.org/pub/gnu/gcc/gcc-9.1.0/gcc-9.1.0.tar.gz"
     sha256: "be303f7a8292982a35381489f5a9178603cbe9a4715ee4fa4a815d6bcd2b658d"

--- a/recipes/libidn/all/conandata.yml
+++ b/recipes/libidn/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "1.36":
-    url: "https://ftp.gnu.org/gnu/libidn/libidn-1.36.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libidn/libidn-1.36.tar.gz"
+      - "https://ftp.gnu.org/gnu/libidn/libidn-1.36.tar.gz"
     sha256: "14b67108344d81ba844631640df77c9071d9fb0659b080326ff5424e86b14038"
 patches:
   "1.36":

--- a/recipes/libidn2/all/conandata.yml
+++ b/recipes/libidn2/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "2.3.8":
-    url: "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/libidn/libidn2-2.3.8.tar.gz"
+      - "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
     sha256: "f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
   "2.3.0":
-    url: "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.0.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/libidn/libidn2-2.3.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.0.tar.gz"
     sha256: "e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5"
 patches:
   "2.3.0":

--- a/recipes/libmicrohttpd/all/conandata.yml
+++ b/recipes/libmicrohttpd/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "0.9.77":
-    url: "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.77.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.77.tar.gz"
+      - "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.77.tar.gz"
     sha256: "9e7023a151120060d2806a6ea4c13ca9933ece4eacfc5c9464d20edddb76b0a0"
   "0.9.75":
-    url: "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.75.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.75.tar.gz"
+      - "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.75.tar.gz"
     sha256: "9278907a6f571b391aab9644fd646a5108ed97311ec66f6359cebbedb0a4e3bb"
 patches:
   "0.9.75":

--- a/recipes/libtasn1/all/conandata.yml
+++ b/recipes/libtasn1/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "4.16.0":
-    url: "https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.16.0.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libtasn1/libtasn1-4.16.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.16.0.tar.gz"
     sha256: "0e0fb0903839117cb6e3b56e68222771bebf22ad7fc2295a0ed7d576e8d4329d"
 patches:
   "4.16.0":

--- a/recipes/libtool/all/conandata.yml
+++ b/recipes/libtool/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "2.4.7":
-    url: "https://ftp.gnu.org/gnu/libtool/libtool-2.4.7.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libtool/libtool-2.4.7.tar.gz"
+      - "https://ftp.gnu.org/gnu/libtool/libtool-2.4.7.tar.gz"
     sha256: "04e96c2404ea70c590c546eba4202a4e12722c640016c12b9b2f1ce3d481e9a8"
   "2.4.6":
-    url: "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
+      - "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz"
     sha256: "e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3"
 patches:
   "2.4.7":

--- a/recipes/libunistring/all/conandata.yml
+++ b/recipes/libunistring/all/conandata.yml
@@ -1,7 +1,11 @@
 sources:
   "1.1":
-    url: "https://ftp.gnu.org/gnu/libunistring/libunistring-1.1.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libunistring/libunistring-1.1.tar.xz"
+      - "https://ftp.gnu.org/gnu/libunistring/libunistring-1.1.tar.xz"
     sha256: "827c1eb9cb6e7c738b171745dac0888aa58c5924df2e59239318383de0729b98"
   "0.9.10":
-    url: "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
+      - "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
     sha256: "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"

--- a/recipes/mpc/all/conandata.yml
+++ b/recipes/mpc/all/conandata.yml
@@ -1,12 +1,18 @@
 sources:
   "1.3.1":
-    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
+      - "https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
     sha256: "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
   "1.2.0":
-    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/mpc/mpc-1.2.0.tar.gz"
     sha256: "e90f2d99553a9c19911abdb4305bf8217106a957e3994436428572c8dfe8fda6"
   "1.1.0":
-    url: "https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
+      - "https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
     sha256: "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e"
 patches:
   "1.2.0":

--- a/recipes/mpfr/all/conandata.yml
+++ b/recipes/mpfr/all/conandata.yml
@@ -1,18 +1,28 @@
 sources:
   "4.2.2":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
+      - "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
     sha256: "b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01"
   "4.2.1":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz"
+      - "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz"
     sha256: "277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2"
   "4.2.0":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.0.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.0.tar.xz"
+      - "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.0.tar.xz"
     sha256: "06a378df13501248c1b2db5aa977a2c8126ae849a9d9b7be2546fb4a9c26d993"
   "4.1.0":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
+      - "https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
     sha256: "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
   "4.0.2":
-    url: "https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz"
+      - "https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz"
     sha256: "1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a"
 patches:
   "4.2.1":

--- a/recipes/ncurses/all/conandata.yml
+++ b/recipes/ncurses/all/conandata.yml
@@ -1,16 +1,19 @@
 sources:
   "6.5":
     url:
+      - "https://ftpmirror.gnu.org/pub/gnu/ncurses/ncurses-6.5.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.5.tar.gz"
       - "https://invisible-mirror.net/archives/ncurses/ncurses-6.5.tar.gz"
     sha256: "136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6"
   "6.4":
     url:
+      - "https://ftpmirror.gnu.org/pub/gnu/ncurses/ncurses-6.4.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.4.tar.gz"
       - "https://invisible-mirror.net/archives/ncurses/ncurses-6.4.tar.gz"
     sha256: "6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
   "6.3":
     url:
+      - "https://ftpmirror.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz"
       - "https://invisible-mirror.net/archives/ncurses/ncurses-6.3.tar.gz"
     sha256: "97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059"

--- a/recipes/ncurses/all/conandata.yml
+++ b/recipes/ncurses/all/conandata.yml
@@ -1,19 +1,19 @@
 sources:
   "6.5":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/ncurses/ncurses-6.5.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.5.tar.gz"
       - "https://invisible-mirror.net/archives/ncurses/ncurses-6.5.tar.gz"
     sha256: "136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6"
   "6.4":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/ncurses/ncurses-6.4.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/ncurses/ncurses-6.4.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.4.tar.gz"
       - "https://invisible-mirror.net/archives/ncurses/ncurses-6.4.tar.gz"
     sha256: "6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
   "6.3":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/ncurses/ncurses-6.3.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz"
       - "https://invisible-mirror.net/archives/ncurses/ncurses-6.3.tar.gz"
     sha256: "97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059"

--- a/recipes/readline/all/conandata.yml
+++ b/recipes/readline/all/conandata.yml
@@ -1,16 +1,16 @@
 sources:
   "8.0":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.0.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/readline/readline-8.0.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/readline/readline-8.0.tar.gz"
     sha256: "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461"
   "8.1.2":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.1.2.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/readline/readline-8.1.2.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/readline/readline-8.1.2.tar.gz"
     sha256: "7589a2381a8419e68654a47623ce7dfcb756815c8fee726b98f90bf668af7bc6"
   "8.2":
     url:
-      - "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.2.tar.gz"
+      - "https://ftpmirror.gnu.org/gnu/readline/readline-8.2.tar.gz"
       - "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz"
     sha256: "3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35"

--- a/recipes/readline/all/conandata.yml
+++ b/recipes/readline/all/conandata.yml
@@ -1,10 +1,16 @@
 sources:
   "8.0":
-    url: "https://ftp.gnu.org/pub/gnu/readline/readline-8.0.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.0.tar.gz"
+      - "https://ftp.gnu.org/pub/gnu/readline/readline-8.0.tar.gz"
     sha256: "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461"
   "8.1.2":
-    url: "https://ftp.gnu.org/pub/gnu/readline/readline-8.1.2.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.1.2.tar.gz"
+      - "https://ftp.gnu.org/pub/gnu/readline/readline-8.1.2.tar.gz"
     sha256: "7589a2381a8419e68654a47623ce7dfcb756815c8fee726b98f90bf668af7bc6"
   "8.2":
-    url: "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.2.tar.gz"
+      - "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz"
     sha256: "3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35"

--- a/recipes/tar/all/conandata.yml
+++ b/recipes/tar/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "1.35":
-    url: "https://ftp.gnu.org/gnu/tar/tar-1.35.tar.xz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/tar/tar-1.35.tar.xz"
+      - "https://ftp.gnu.org/gnu/tar/tar-1.35.tar.xz"
     sha256: "4d62ff37342ec7aed748535323930c7cf94acf71c3591882b26a7ea50f3edc16"
   "1.32.90":
-    url: "https://alpha.gnu.org/gnu/tar/tar-1.32.90.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/tar/tar-1.32.90.tar.gz"
+      - "https://alpha.gnu.org/gnu/tar/tar-1.32.90.tar.gz"
     sha256: "641fe07b7403c8eb801e7bfb91d1b7e5800ab15df524e22e0b2e89501280b6d7"
 patches:
   "1.35":

--- a/recipes/termcap/all/conandata.yml
+++ b/recipes/termcap/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "1.3.1":
-    url: "https://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz"
+    url:
+      - "https://ftpmirror.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz"
+      - "https://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz"
     sha256: "91a0e22e5387ca4467b5bcb18edf1c51b930262fd466d5fda396dd9d26719100"
 patches:
   "1.3.1":


### PR DESCRIPTION
### Summary
Changes to recipes:  
- automake
- binutils
- bison
- gcc
- gdbm
- gettext
- glpk
- gmp
- gperf
- libiberty
- libidn
- libidn2
- libmicrohttpd
- libtasn1
- libtool
- libunistring
- mpc
- mpfr
- ncurses
- readline
- tar
- termcap

#### Motivation
A lot of packages depend on the fpt.gnu.org site, and it's unreliable. See https://github.com/conan-io/conan-center-index/issues/28147

I'm aware that we suppose to create one PR per each recipie but creating more than 20 PRs just for adding almost the same url seems a bit unstructured for me. I hope that doing everything in on PR is fine.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

Tested the following packages:
- [x] automake/1.16.5
- [x] binutils/2.42
- [x] bison/3.8.2
- [x] gcc/15.1.0 - tested that it downloads the archive, didn't compile it fully
- [x] gdbm/1.23
- [x] gettext/0.22.5
- [x] glpk/5.0
- [x] gmp/6.3.0
- [x] gperf/3.1
- [x] libiberty/9.1.0
- [x] libidn/1.36
- [x] libidn2/2.3.8
- [x] libmicrohttpd/0.9.77 
- [x] libtasn1/4.16.0
- [x] libtool/2.4.7
- [x] libunistring/1.1
- [x] mpc/1.3.1
- [x] mpfr/4.2.2
- [x] ncurses/6.5
- [x] readline/8.0
- [x] tar/1.35
- [x] termcap/1.3.1
