### PR TITLE
[qtawesome] Add version 6.7.2 with patch

### DIFF
--- a/recipes/qtawesome/all/conandata.yml
+++ b/recipes/qtawesome/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.7.2":
+    url: "https://github.com/gamecreature/QtAwesome/archive/refs/tags/font-awesome-6.7.2-p1.tar.gz"
+    sha256: "43148bb6c2d82ad988216d785516b65da1aa63cba14cb0735e01dedb42b73889"
   "6.4.0":
     url: "https://github.com/gamecreature/QtAwesome/archive/font-awesome-6.4.0.tar.gz"
     sha256: "4310aba189e0bba4090997ecfefe27c2c7595aa499b790389dabdce5b4e54f5a"

--- a/recipes/qtawesome/all/conanfile.py
+++ b/recipes/qtawesome/all/conanfile.py
@@ -60,7 +60,7 @@ class QtAwesomeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("qt/5.15.9", transitive_headers=True, transitive_libs=True)
+        self.requires("qt/[>=6.7 <7]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if self.settings.compiler.cppstd:

--- a/recipes/qtawesome/all/test_package/test_package.cpp
+++ b/recipes/qtawesome/all/test_package/test_package.cpp
@@ -1,4 +1,4 @@
-#include "QtAwesome.h"
+#include "QtAwesome/QtAwesome.h"
 
 int main(void) {
     fa::QtAwesome awesome(nullptr);

--- a/recipes/qtawesome/config.yml
+++ b/recipes/qtawesome/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "6.7.2":
+    folder: all
   "6.4.0":
     folder: all


### PR DESCRIPTION
I wanted to add support to Qt 6.9 so I used the latest release of qtawesome (6.7.2) with patch.
Tell me if you rather want me to link to the 6.7.2 version and add the patch in the recipe:

https://github.com/gamecreature/QtAwesome/releases

- **[qtawesome] Update Qt version range to support Qt 6.7 and above**
- **[qtawesome] Add version 6.7.2**

### Summary

Changes to recipe: **lib/[version]**

#### Motivation

<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details

<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
