### PR TITLE
nlohmann_json: add include directory to layout

### DIFF
--- a/recipes/nlohmann_json/all/conanfile.py
+++ b/recipes/nlohmann_json/all/conanfile.py
@@ -24,6 +24,7 @@ class NlohmannJsonConan(ConanFile):
 
     def layout(self):
         basic_layout(self, src_folder="src")
+        self.cpp.source.includedirs = [ "include" ]
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
### Summary
Changes to recipe:  **nlohmann_json/**

#### Motivation
Without explicitly setting the include directory, this package cannot be used in editable mode. #28156

#### Details
All supported versions (starting at 3.1.1) have the include directory at ./include.

Tested locally with oldest version 3.1.1 and latest version 3.12.0.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
