### PR TITLE
Add catch2/3.9.1

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.9.1":
+    url: "https://github.com/catchorg/Catch2/archive/v3.9.1.tar.gz"
+    sha256: "a215c2a723bd7483efd236dc86066842a389cb4e344c61119c978acdf24d39be"
   "3.9.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.9.0.tar.gz"
     sha256: "8061daf97429621bc62096841af02fc40070fad26cd04c93ee0b5a825cedb122"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.9.1":
+    folder: 3.x.x
   "3.9.0":
     folder: 3.x.x
   "3.8.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **catch2/3.9.1**

#### Motivation
Version bump
https://github.com/catchorg/Catch2/compare/v3.9.0...v3.9.1

#### Details
config.yml and conandata.yml point to the newly created catch2/3.9.1.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
