### PR TITLE
onnxruntime/1.18.1: add multiple patches

### DIFF
--- a/recipes/onnxruntime/all/cmake/onnxruntime_external_deps.cmake
+++ b/recipes/onnxruntime/all/cmake/onnxruntime_external_deps.cmake
@@ -36,6 +36,12 @@ if (TARGET cpuinfo::clog)
   list(APPEND onnxruntime_EXTERNAL_LIBRARIES cpuinfo::clog)
 endif()
 set(CPUINFO_SUPPORTED ${cpuinfo_FOUND})
+if(CPUINFO_SUPPORTED)
+  #https://github.com/microsoft/onnxruntime/blob/v1.18.1/cmake/external/onnxruntime_external_deps.cmake#L307C1-L311C10
+  if (NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    string(APPEND CMAKE_CXX_FLAGS " -DCPUINFO_SUPPORTED")
+  endif()
+endif()
 # Add a dummy targets for onnxruntime CMakelists.txt to depend on
 add_library(clog INTERFACE)
 add_library(cpuinfo INTERFACE)

--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -25,6 +25,9 @@ patches:
     - patch_file: "patches/1.18.1-0005-fix-cutlass-cuda-provider.patch"
       patch_description: "use cutlass from Conan"
       patch_type: "portability"
+    - patch_file: "patches/1.15.1-0006-ort-mutex-include.patch"
+      patch_description: "Add missing chrono include to ort_mutex.h"
+      patch_type: "portability"
   "1.17.3":
     - patch_file: "patches/1.17.3-0001-patch-macos-cpp20-date-compat.patch"
       patch_description: "allow to build with macos c++20 support"
@@ -39,9 +42,15 @@ patches:
     - patch_file: "patches/1.17.3-0003-fix-cutlass-cuda-provider.patch"
       patch_description: "use cutlass from Conan"
       patch_type: "portability"
+    - patch_file: "patches/1.15.1-0006-ort-mutex-include.patch"
+      patch_description: "Add missing chrono include to ort_mutex.h"
+      patch_type: "portability"
   "1.16.3":
     - patch_file: "patches/1.14.1-0004-abseil-no-string-view.patch"
       patch_description: "allow to build with abseil built without c++17 support"
+      patch_type: "portability"
+    - patch_file: "patches/1.15.1-0006-ort-mutex-include.patch"
+      patch_description: "Add missing chrono include to ort_mutex.h"
       patch_type: "portability"
   "1.15.1":
     - patch_file: "patches/1.14.1-0004-abseil-no-string-view.patch"
@@ -51,6 +60,9 @@ patches:
       patch_description: "Fix attention.cc"
       patch_source: "https://github.com/microsoft/onnxruntime/pull/15983"
       patch_type: "backport"
+    - patch_file: "patches/1.15.1-0006-ort-mutex-include.patch"
+      patch_description: "Add missing chrono include to ort_mutex.h"
+      patch_type: "portability"
   "1.14.1":
     - patch_file: "patches/1.14.1-0001-cmake-dependencies.patch"
       patch_description: "CMake: ensure conan dependencies are used (upstreamed future versions)"

--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -38,6 +38,10 @@ patches:
       patch_description: "Be compatible with the latest protobuf"
       patch_source: "https://github.com/microsoft/onnxruntime/pull/23260"
       patch_type: "portability"
+    - patch_file: "patches/1.18.1-0010-tree-ensemble-aggregator.patch"
+      patch_description: "Fix C++20 compilation issues in TreeEnsembleAggregator"
+      patch_source: "https://github.com/microsoft/onnxruntime/pull/22062"
+      patch_type: "portability"
   "1.17.3":
     - patch_file: "patches/1.17.3-0001-patch-macos-cpp20-date-compat.patch"
       patch_description: "allow to build with macos c++20 support"

--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -31,6 +31,9 @@ patches:
     - patch_file: "patches/1.18.1-0007-xnnpack-proper-linkage.patch"
       patch_description: "Fix target name for xnnpack"
       patch_type: "conan"
+    - patch_file: "patches/1.18.1-0008-cmake-cxx-standard.patch"
+      patch_description: "Remove hardcoded CMAKE_CXX_STANDARD"
+      patch_type: "conan"
   "1.17.3":
     - patch_file: "patches/1.17.3-0001-patch-macos-cpp20-date-compat.patch"
       patch_description: "allow to build with macos c++20 support"

--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -28,6 +28,9 @@ patches:
     - patch_file: "patches/1.15.1-0006-ort-mutex-include.patch"
       patch_description: "Add missing chrono include to ort_mutex.h"
       patch_type: "portability"
+    - patch_file: "patches/1.18.1-0007-xnnpack-proper-linkage.patch"
+      patch_description: "Fix target name for xnnpack"
+      patch_type: "conan"
   "1.17.3":
     - patch_file: "patches/1.17.3-0001-patch-macos-cpp20-date-compat.patch"
       patch_description: "allow to build with macos c++20 support"

--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -34,6 +34,10 @@ patches:
     - patch_file: "patches/1.18.1-0008-cmake-cxx-standard.patch"
       patch_description: "Remove hardcoded CMAKE_CXX_STANDARD"
       patch_type: "conan"
+    - patch_file: "patches/1.18.1-0009-protobuf.patch"
+      patch_description: "Be compatible with the latest protobuf"
+      patch_source: "https://github.com/microsoft/onnxruntime/pull/23260"
+      patch_type: "portability"
   "1.17.3":
     - patch_file: "patches/1.17.3-0001-patch-macos-cpp20-date-compat.patch"
       patch_description: "allow to build with macos c++20 support"

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -107,7 +107,7 @@ class OnnxRuntimeConan(ConanFile):
             self.requires("wil/1.0.240803.1")
         if self.options.with_xnnpack:
             if Version(self.version) >= "1.17.0":
-                self.requires("xnnpack/cci.20230715")
+                self.requires("xnnpack/cci.20231026")
             else:
                 self.requires("xnnpack/cci.20220801")
         if self.options.with_cuda:

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -220,8 +220,12 @@ class OnnxRuntimeConan(ConanFile):
         if self.options.shared:
             self.cpp_info.libs = ["onnxruntime"]
         else:
-            onnxruntime_libs = [
-                "session",
+            #order is important
+            #https://github.com/microsoft/onnxruntime/blob/v1.18.1/cmake/onnxruntime.cmake#L178C1-L206C2
+            onnxruntime_libs = ["session"]
+            if self.options.with_xnnpack:
+                onnxruntime_libs.append("providers_xnnpack")
+            onnxruntime_libs.extend([
                 "optimizer",
                 "providers",
                 "framework",
@@ -230,9 +234,7 @@ class OnnxRuntimeConan(ConanFile):
                 "mlas",
                 "common",
                 "flatbuffers",
-            ]
-            if self.options.with_xnnpack:
-                onnxruntime_libs.append("providers_xnnpack")
+            ])
             self.cpp_info.libs = [f"onnxruntime_{lib}" for lib in onnxruntime_libs]
 
         if Version(self.version) < "1.16.0" or not self.options.shared:

--- a/recipes/onnxruntime/all/patches/1.15.1-0006-ort-mutex-include.patch
+++ b/recipes/onnxruntime/all/patches/1.15.1-0006-ort-mutex-include.patch
@@ -1,0 +1,18 @@
+--- a/include/onnxruntime/core/platform/ort_mutex.h
++++ b/include/onnxruntime/core/platform/ort_mutex.h
+@@ -4,6 +4,7 @@
+ #pragma once
+ #ifdef _WIN32
+ #include <Windows.h>
++#include <chrono>
+ #include <mutex>
+ namespace onnxruntime {
+ // Q: Why OrtMutex is better than std::mutex
+@@ -103,6 +104,7 @@ std::cv_status OrtCondVar::wait_for(std::unique_lock<OrtMutex>& cond_mutex,
+ }  // namespace onnxruntime
+ #else
+ #include "nsync.h"
++#include <chrono>
+ #include <mutex>               //for unique_lock
+ #include <condition_variable>  //for cv_status
+ namespace onnxruntime {

--- a/recipes/onnxruntime/all/patches/1.18.1-0007-xnnpack-proper-linkage.patch
+++ b/recipes/onnxruntime/all/patches/1.18.1-0007-xnnpack-proper-linkage.patch
@@ -1,0 +1,11 @@
+--- a/cmake/onnxruntime_providers_xnnpack.cmake
++++ b/cmake/onnxruntime_providers_xnnpack.cmake
+@@ -12,7 +12,7 @@
+   source_group(TREE ${REPO_ROOT} FILES ${onnxruntime_providers_xnnpack_cc_srcs})
+   onnxruntime_add_static_library(onnxruntime_providers_xnnpack ${onnxruntime_providers_xnnpack_cc_srcs})
+   onnxruntime_add_include_to_target(onnxruntime_providers_xnnpack
+-    onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} XNNPACK pthreadpool
++    onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} xnnpack::xnnpack pthreadpool
+     flatbuffers::flatbuffers Boost::mp11 safeint_interface
+   )
+ 

--- a/recipes/onnxruntime/all/patches/1.18.1-0008-cmake-cxx-standard.patch
+++ b/recipes/onnxruntime/all/patches/1.18.1-0008-cmake-cxx-standard.patch
@@ -1,0 +1,15 @@
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -39,12 +39,6 @@ include(CMakeDependentOption)
+ include(FetchContent)
+ include(CheckFunctionExists)
+ 
+-# TODO: update this once all system adapt c++20
+-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+-set(CMAKE_CXX_STANDARD 20)
+-else()
+-set(CMAKE_CXX_STANDARD 17)
+-endif()
+ 
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+ # NOTE: POSITION INDEPENDENT CODE hurts performance, and it only make sense on POSIX systems

--- a/recipes/onnxruntime/all/patches/1.18.1-0009-protobuf.patch
+++ b/recipes/onnxruntime/all/patches/1.18.1-0009-protobuf.patch
@@ -1,0 +1,34 @@
+backported https://github.com/microsoft/onnxruntime/pull/23260
+--- a/onnxruntime/core/graph/graph.cc
++++ b/onnxruntime/core/graph/graph.cc
+@@ -1234,10 +1234,12 @@ Graph::Graph(const Model& owning_model,
+ 
+     // Remove sparse_initializers from protobuf to save memory as they are converted to dense now
+     graph_proto_->mutable_sparse_initializer()->Clear();
++#if GOOGLE_PROTOBUF_VERSION < 5026000
+     const int sparse_num_cleared = graph_proto_->sparse_initializer().ClearedCount();
+     for (int i = 0; i < sparse_num_cleared; ++i) {
+       delete graph_proto_->mutable_sparse_initializer()->ReleaseCleared();
+     }
++#endif
+   }
+ #endif
+ 
+@@ -3503,15 +3505,16 @@ void Graph::CleanAllInitializedTensors() noexcept {
+ #if !defined(DISABLE_SPARSE_TENSORS)
+   sparse_tensor_names_.clear();
+ #endif
+-
+   // Clearing RepeatedPtrFields does not free objects' memory. The memory is retained
+   // and can be reused. Need to explicitly release the cleared objects and free the
+   // memory.
+   graph_proto_->mutable_initializer()->Clear();
++#if GOOGLE_PROTOBUF_VERSION < 5026000
+   const int num_cleared = graph_proto_->initializer().ClearedCount();
+   for (int i = 0; i < num_cleared; i++) {
+     delete graph_proto_->mutable_initializer()->ReleaseCleared();
+   }
++#endif
+ }
+ 
+ const ONNX_NAMESPACE::TensorProto* Graph::GetConstantInitializer(const std::string& initializer_name,

--- a/recipes/onnxruntime/all/patches/1.18.1-0010-tree-ensemble-aggregator.patch
+++ b/recipes/onnxruntime/all/patches/1.18.1-0010-tree-ensemble-aggregator.patch
@@ -1,0 +1,19 @@
+backported from https://github.com/microsoft/onnxruntime/pull/22062
+--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
++++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
+@@ -326,11 +326,10 @@ class TreeAggregatorMin : public TreeAggregator<InputType, ThresholdType, Output
+ template <typename InputType, typename ThresholdType, typename OutputType>
+ class TreeAggregatorMax : public TreeAggregator<InputType, ThresholdType, OutputType> {
+  public:
+-  TreeAggregatorMax<InputType, ThresholdType, OutputType>(size_t n_trees,
+-                                                          const int64_t& n_targets_or_classes,
+-                                                          POST_EVAL_TRANSFORM post_transform,
+-                                                          const std::vector<ThresholdType>& base_values) : TreeAggregator<InputType, ThresholdType, OutputType>(n_trees, n_targets_or_classes,
+-                                                                                                                                                                post_transform, base_values) {}
++  TreeAggregatorMax(size_t n_trees,
++                    const int64_t& n_targets_or_classes,
++                    POST_EVAL_TRANSFORM post_transform,
++                    const std::vector<ThresholdType>& base_values) : TreeAggregator<InputType, ThresholdType, OutputType>(n_trees, n_targets_or_classes, post_transform, base_values) {}
+ 
+   // 1 output
+ 


### PR DESCRIPTION
### Summary
Changes to recipe:  **onnxruntime/all**

#### Motivation
Closes #26173 (only for 1.18.1)
Closes #26218
Closes #27259 (only for 1.18.1)
Closes #28152
Closes #28160

#### Details
Added patches to be able to use C++20 instead of harcoded C++17, xnnpack and newer protobuf.

Log from gcc-11 (C++20, enabled xnnpack, updated abseil and protobuf)
```
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=20
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux
[options]
onnxruntime/*:with_xnnpack=True
[replace_requires]
protobuf/*: protobuf/5.27.0
abseil/*: abseil/20250127.0
```
conan create /usr/src/recipes/onnxruntime/all --version 1.18.1 --build=missing -o onnxruntime/*:with_xnnpack=True

[build_log_gcc_11_cpp20_xnnpack.txt](https://github.com/user-attachments/files/21778934/build_log_gcc_11_cpp20_xnnpack.txt)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
