### PR TITLE
systemc-cci: add version 1.0.1

### DIFF
--- a/recipes/systemc-cci/1.0.1/CMakeLists.txt
+++ b/recipes/systemc-cci/1.0.1/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.8)
+project(cci LANGUAGES CXX)
+
+set(LIBRARY_NAME cciapi)
+
+find_package(RapidJSON REQUIRED CONFIG)
+find_package(SystemCLanguage REQUIRED CONFIG)
+
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/src")
+set(CCI_CFG_DIR "${SOURCE_DIR}/cci/cfg")
+set(CCI_CORE_DIR "${SOURCE_DIR}/cci/core")
+set(CCI_UTILS_DIR "${SOURCE_DIR}/cci/utils")
+
+set(SOURCES
+    ${SOURCE_DIR}/cci/cfg/cci_broker_handle.cpp
+    ${SOURCE_DIR}/cci/cfg/cci_broker_manager.cpp
+    ${SOURCE_DIR}/cci/cfg/cci_originator.cpp
+    ${SOURCE_DIR}/cci/cfg/cci_param_if.cpp
+    ${SOURCE_DIR}/cci/cfg/cci_param_untyped.cpp
+    ${SOURCE_DIR}/cci/cfg/cci_param_untyped_handle.cpp
+    ${SOURCE_DIR}/cci/cfg/cci_report_handler.cpp
+    ${SOURCE_DIR}/cci/core/cci_name_gen.cpp
+    ${SOURCE_DIR}/cci/core/cci_value_converter.cpp
+    ${SOURCE_DIR}/cci/core/cci_value.cpp
+    ${SOURCE_DIR}/cci/utils/broker.cpp
+    ${SOURCE_DIR}/cci/utils/consuming_broker.cpp
+)
+
+add_library(${LIBRARY_NAME} ${SOURCES})
+target_include_directories(${LIBRARY_NAME} PRIVATE ${SOURCE_DIR})
+target_link_libraries(${LIBRARY_NAME} PRIVATE rapidjson SystemC::systemc)
+set_target_properties(${LIBRARY_NAME} PROPERTIES
+                      WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+                      VERSION ${CONAN_PACKAGE_VERSION}
+                      COMPILE_FEATURES cxx_std_11)
+target_compile_definitions(${LIBRARY_NAME} PRIVATE SC_INCLUDE_FX)
+
+install(TARGETS ${LIBRARY_NAME}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(DIRECTORY ${CCI_CFG_DIR} ${CCI_CORE_DIR} ${CCI_UTILS_DIR}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cci
+        FILES_MATCHING PATTERN "*.h")
+install(FILES "${SOURCE_DIR}/cci_configuration" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/recipes/systemc-cci/1.0.1/conandata.yml
+++ b/recipes/systemc-cci/1.0.1/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "1.0.1":
+    url: https://github.com/accellera-official/cci/releases/download/v1.0.1/cci_v1.0.1.zip
+    sha256: f71c12959270cdac9f7ccf73e8894406fd92cacb4d9baf9d0d92a4e798a28fe3
+patches:
+  "1.0.1":
+    - patch_file: "patches/cci_param_untyped_handle.patch"
+

--- a/recipes/systemc-cci/1.0.1/conanfile.py
+++ b/recipes/systemc-cci/1.0.1/conanfile.py
@@ -1,0 +1,86 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+
+required_conan_version = ">=1.53.0"
+
+
+class SystemccciConan(ConanFile):
+    name = "systemc-cci"
+    description = "SystemC Configuration, Control and Inspection library"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.accellera.org/"
+    topics = ("simulation", "modeling", "esl", "cci")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def export_sources(self):
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("rapidjson/cci.20220822")
+        if self.version == "1.0.1":
+            self.requires('systemc/[>=2.3.4 <3.1]', transitive_headers=True, transitive_libs=True)
+        else:
+            self.requires("systemc/2.3.4", transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if is_apple_os(self):
+            raise ConanInvalidConfiguration(f"{self.name} is not supported on {self.settings.os}.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["CONAN_PACKAGE_VERSION"] = self.version
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self.source_path.parent)
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        copy(self, "NOTICE",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["cciapi"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m"]

--- a/recipes/systemc-cci/1.0.1/patches/cci_param_untyped_handle.patch
+++ b/recipes/systemc-cci/1.0.1/patches/cci_param_untyped_handle.patch
@@ -1,0 +1,23 @@
+diff --git a/src/cci/cfg/cci_param_untyped_handle.h b/src/cci/cfg/cci_param_untyped_handle.h
+index d621a861..864f9e81 100644
+--- a/src/cci/cfg/cci_param_untyped_handle.h
++++ b/src/cci/cfg/cci_param_untyped_handle.h
+@@ -64,17 +64,17 @@ public:
+     /// Move constructor
+     cci_param_untyped_handle(cci_param_untyped_handle&& that);
+     /// Move assignment - update handle to refer to a new parameter
+     cci_param_untyped_handle&
+     operator=(cci_param_untyped_handle&& that);
+ #endif // CCI_HAS_CXX_RVALUE_REFS
+ 
+     /// Destructor.
+-    ~cci_param_untyped_handle();
++    virtual ~cci_param_untyped_handle();
+ 
+     //@}
+ 
+     ///@name Description and metadata
+     ///@{
+ 
+     /// @copydoc cci_param_untyped::get_description
+     std::string get_description() const;

--- a/recipes/systemc-cci/1.0.1/test_package/CMakeLists.txt
+++ b/recipes/systemc-cci/1.0.1/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(systemc-cci REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} example.cpp)
+target_link_libraries(${PROJECT_NAME} systemc-cci::systemc-cci)

--- a/recipes/systemc-cci/1.0.1/test_package/conanfile.py
+++ b/recipes/systemc-cci/1.0.1/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/systemc-cci/1.0.1/test_package/example.cpp
+++ b/recipes/systemc-cci/1.0.1/test_package/example.cpp
@@ -1,0 +1,8 @@
+#include <cci_configuration>
+#include <cci/utils/broker.h>
+
+int sc_main(int argc, char *argv[])
+{
+	cci::cci_register_broker(new cci_utils::broker("Global Broker"));
+	return 0;
+}

--- a/recipes/systemc-cci/config.yml
+++ b/recipes/systemc-cci/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.0.0":
     folder: "all"
+  "1.0.1":
+    folder: "1.0.1"


### PR DESCRIPTION
### Summary
Add systemc-cci version 1.0.1

#### Motivation
Add systemc-cci version 1.0.1 for systemc 3.0.1.

Provide support for building and consuming systemc-cci using Conan.

#### Details
Add systemc-cci version 1.0.1


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
