### PR TITLE
json-schema-validator: add include directory to layout

### DIFF
--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -66,6 +66,9 @@ class JsonSchemaValidatorConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+        self.cpp.source.includedirs = [ "src" ]
+        if Version(self.version) < "2.1.0":
+            self.cpp.build.includedirs = [ "include"]
 
     def requirements(self):
         # to support latest compilers, we have to downgrade nlohmann_json.
@@ -112,6 +115,10 @@ class JsonSchemaValidatorConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
+        if Version(self.version) < "2.1.0":
+            copy(self, "json-schema.hpp",
+                       dst=os.path.join(self.build_folder, "include", "nlohmann"),
+                       src=os.path.join(self.source_folder, "src"))
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))


### PR DESCRIPTION
### Summary
Changes to recipe:  **json-schema-validator/[>=2.0.0 <=2.3.0]**

#### Motivation
Without explicitly setting the include directory, this package cannot be used in editable mode. #28171 

#### Details
All supported versions (starting at 2.0.0) must support the same include directory.

Version 2.0.0 needs special treatment, because it does not have the nlohmann/ path in its source tree. For this version the .hpp must be copied to the build folder during build and another include directory added there.


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
