### PR TITLE
pybind11: add version 3.0.0

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -5,42 +5,9 @@ sources:
   "2.13.6":
     url: "https://github.com/pybind/pybind11/archive/v2.13.6.tar.gz"
     sha256: "e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20"
-  "2.13.5":
-    url: "https://github.com/pybind/pybind11/archive/v2.13.5.tar.gz"
-    sha256: "b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252"
-  "2.13.4":
-    url: "https://github.com/pybind/pybind11/archive/v2.13.4.tar.gz"
-    sha256: "efc901aa0aab439a3fea6efeaf930b5a349fb06394bf845c64ce15a9cf8f0240"
-  "2.13.2":
-    url: "https://github.com/pybind/pybind11/archive/v2.13.2.tar.gz"
-    sha256: "50eebef369d28f07ce1fe1797f38149e5928817be8e539239f2aadfd95b227f3"
-  "2.13.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.13.1.tar.gz"
-    sha256: "51631e88960a8856f9c497027f55c9f2f9115cafb08c0005439838a05ba17bfc"
-  "2.12.0":
-    url: "https://github.com/pybind/pybind11/archive/v2.12.0.tar.gz"
-    sha256: "bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7"
-  "2.11.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.11.1.tar.gz"
-    sha256: "d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c"
   "2.10.4":
     url: "https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"
     sha256: "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970"
   "2.10.1":
     url: "https://github.com/pybind/pybind11/archive/v2.10.1.tar.gz"
     sha256: "111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad"
-  "2.10.0":
-    url: "https://github.com/pybind/pybind11/archive/v2.10.0.tar.gz"
-    sha256: "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec"
-  "2.9.2":
-    url: "https://github.com/pybind/pybind11/archive/v2.9.2.tar.gz"
-    sha256: "6bd528c4dbe2276635dc787b6b1f2e5316cf6b49ee3e150264e455a0d68d19c1"
-  "2.9.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.9.1.tar.gz"
-    sha256: "c6160321dc98e6e1184cc791fbeadd2907bb4a0ce0e447f2ea4ff8ab56550913"
-  "2.8.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.8.1.tar.gz"
-    sha256: "f1bcc07caa568eb312411dde5308b1e250bd0e1bc020fae855bf9f43209940cc"
-  "2.7.1":
-    url: "https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz"
-    sha256: "616d1c42e4cf14fa27b2a4ff759d7d7b33006fdc5ad8fd603bb2c22622f27020"

--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.0":
+    url: "https://github.com/pybind/pybind11/archive/v3.0.0.tar.gz"
+    sha256: "453b1a3e2b266c3ae9da872411cadb6d693ac18063bd73226d96cfb7015a200c"
   "2.13.6":
     url: "https://github.com/pybind/pybind11/archive/v2.13.6.tar.gz"
     sha256: "e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20"

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -31,6 +31,7 @@ class PyBind11Conan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["PYBIND11_FINDPYTHON"] = True
         tc.variables["PYBIND11_INSTALL"] = True
         tc.variables["PYBIND11_TEST"] = False
         tc.variables["PYBIND11_CMAKECONFIG_INSTALL_DIR"] = "lib/cmake/pybind11"

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -53,9 +53,10 @@ class PyBind11Conan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
         checked_target = "lto" if self.version < Version("2.11.0") else "pybind11"
-        replace_in_file(self, os.path.join(self.package_folder, "lib", "cmake", "pybind11", "pybind11Common.cmake"),
-                              f"if(TARGET pybind11::{checked_target})",
-                              "if(FALSE)")
+        if self.version < Version("3.0.0"):
+            replace_in_file(self, os.path.join(self.package_folder, "lib", "cmake", "pybind11", "pybind11Common.cmake"),
+                                  f"if(TARGET pybind11::{checked_target})",
+                                  "if(FALSE)")
         replace_in_file(self, os.path.join(self.package_folder, "lib", "cmake", "pybind11", "pybind11Common.cmake"),
                               "add_library(",
                               "# add_library(")

--- a/recipes/pybind11/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11/all/test_package/CMakeLists.txt
@@ -1,8 +1,16 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
+enable_testing()
 
 find_package(Python REQUIRED COMPONENTS Development OPTIONAL_COMPONENTS Interpreter)
 find_package(pybind11 REQUIRED CONFIG)
 
 pybind11_add_module(test_package MODULE test_package.cpp)
 set_property(TARGET test_package PROPERTY CXX_STANDARD 11)
+
+if (Python_Interpreter_FOUND)
+    add_test(NAME import_module
+             COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test.py)
+    set_tests_properties(import_module PROPERTIES
+                         ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:test_package>")
+endif()

--- a/recipes/pybind11/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(PythonInterp REQUIRED)
+find_package(Python REQUIRED COMPONENTS Development OPTIONAL_COMPONENTS Interpreter)
 find_package(pybind11 REQUIRED CONFIG)
 
 pybind11_add_module(test_package MODULE test_package.cpp)

--- a/recipes/pybind11/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11/all/test_package/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
+find_package(PythonInterp REQUIRED)
 find_package(pybind11 REQUIRED CONFIG)
 
 pybind11_add_module(test_package MODULE test_package.cpp)

--- a/recipes/pybind11/all/test_package/conanfile.py
+++ b/recipes/pybind11/all/test_package/conanfile.py
@@ -34,7 +34,10 @@ class TestPackageConan(ConanFile):
         cmake.configure()
         cmake.build()
 
+    def _python_interpreter(self):
+        return "python" if self.settings.os == "Windows" else "python3"
+
     def test(self):
         if can_run(self):
             module_path = os.path.join(self.source_folder, "test.py")
-            self.run(f"python \"{module_path}\"", env="conanrun")
+            self.run(f"{self._python_interpreter()} \"{module_path}\"", env="conanrun")

--- a/recipes/pybind11/all/test_package/conanfile.py
+++ b/recipes/pybind11/all/test_package/conanfile.py
@@ -4,13 +4,10 @@ from conan.tools.env import Environment, VirtualRunEnv
 from conan.tools.build import can_run
 
 import os
-from pathlib import PurePath
-import sys
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -20,10 +17,6 @@ class TestPackageConan(ConanFile):
         deps.generate()
 
         toolchain = CMakeToolchain(self)
-        # Used by FindPython.cmake in CMake
-        toolchain.variables["Python_EXECUTABLE"] = PurePath(self._python_interpreter).as_posix()
-        # Used by FindPythonLibsNew.cmake in pybind11
-        toolchain.variables["PYTHON_EXECUTABLE"] = PurePath(self._python_interpreter).as_posix()
         toolchain.generate()
 
         env = Environment()
@@ -41,13 +34,7 @@ class TestPackageConan(ConanFile):
         cmake.configure()
         cmake.build()
 
-    @property
-    def _python_interpreter(self):
-        if getattr(sys, "frozen", False):
-            return "python"
-        return sys.executable
-
     def test(self):
         if can_run(self):
             module_path = os.path.join(self.source_folder, "test.py")
-            self.run(f"{self._python_interpreter} \"{module_path}\"", env="conanrun")
+            self.run(f"python \"{module_path}\"", env="conanrun")

--- a/recipes/pybind11/all/test_package/conanfile.py
+++ b/recipes/pybind11/all/test_package/conanfile.py
@@ -19,13 +19,6 @@ class TestPackageConan(ConanFile):
         toolchain = CMakeToolchain(self)
         toolchain.generate()
 
-        env = Environment()
-        env.append_path("PYTHONPATH", os.path.join(self.build_folder, self.cpp.build.libdirs[0]))
-        env.vars(self, scope="run").save_script("testrun")
-
-        run = VirtualRunEnv(self)
-        run.generate()
-
     def layout(self):
         cmake_layout(self)
 
@@ -34,10 +27,7 @@ class TestPackageConan(ConanFile):
         cmake.configure()
         cmake.build()
 
-    def _python_interpreter(self):
-        return "python" if self.settings.os == "Windows" else "python3"
-
     def test(self):
         if can_run(self):
-            module_path = os.path.join(self.source_folder, "test.py")
-            self.run(f"{self._python_interpreter()} \"{module_path}\"", env="conanrun")
+            cmake = CMake(self)
+            cmake.ctest(cli_args=["--verbose"])

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.0":
+    folder: all
   "2.13.6":
     folder: all
   "2.13.5":

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -3,29 +3,7 @@ versions:
     folder: all
   "2.13.6":
     folder: all
-  "2.13.5":
-    folder: all
-  "2.13.4":
-    folder: all
-  "2.13.2":
-    folder: all
-  "2.13.1":
-    folder: all
-  "2.12.0":
-    folder: all
-  "2.11.1":
-    folder: all
   "2.10.4":
     folder: all
   "2.10.1":
-    folder: all
-  "2.10.0":
-    folder: all
-  "2.9.2":
-    folder: all
-  "2.9.1":
-    folder: all
-  "2.8.1":
-    folder: all
-  "2.7.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **pybind11/3.0.0**

#### Motivation
Adds the latest version: https://github.com/pybind/pybind11/releases/tag/v3.0.0

#### Details
The new version has been added to `config.yml` and `conandata.yml`.  
One of the patches to `tools/pybind11Common.cmake` is no longer necessary since the `if(TARGET ...)` guard logic was removed in https://github.com/pybind/pybind11/commit/28dbce4157c89219705801b06e5a94b612d611a5.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
