### PR TITLE
lexbor: add version 2.5.0

### DIFF
--- a/recipes/lexbor/all/conandata.yml
+++ b/recipes/lexbor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.0":
+    url: "https://github.com/lexbor/lexbor/archive/v2.5.0.zip"
+    sha256: "460c6ee1396568078dc45b96dd55c9e92909deaff27cd6421c25dc8dfc8608b5"
   "2.4.0":
     url: "https://github.com/lexbor/lexbor/archive/v2.4.0.zip"
     sha256: "8cfaf8783f736ce784f5fbdf284a6db8c0943d6589d5a0c10257ba948ae2e7b1"

--- a/recipes/lexbor/config.yml
+++ b/recipes/lexbor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.0":
+    folder: "all"
   "2.4.0":
     folder: "all"
   "2.3.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lexbor/2.5.0**

#### Motivation
There are several new features and bug fixes since 2.4.0.

#### Details
https://github.com/lexbor/lexbor/releases/tag/v2.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
