### PR TITLE
simdutf: add version 7.3.6

### DIFF
--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.3.6":
+    url: "https://github.com/simdutf/simdutf/archive/v7.3.6.tar.gz"
+    sha256: "c08f3dce1cbb7a8bead9eb53bcbda778e8a1c69b7d3a0690682f1b09fbb85c31"
   "7.1.0":
     url: "https://github.com/simdutf/simdutf/archive/v7.1.0.tar.gz"
     sha256: "485ad50fba42e795c6b0fd2541ed3fe244ba2dfebbb134dd3e50e32e6b9c63cd"

--- a/recipes/simdutf/config.yml
+++ b/recipes/simdutf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.3.6":
+    folder: all
   "7.1.0":
     folder: all
   "6.3.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **simdutf/7.3.6**

#### Motivation
There are several new functions and performance improvements since 7.1.0.

#### Details
https://github.com/simdutf/simdutf/releases/tag/v7.3.6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
