### PR TITLE
pkgconf - Use version range for meson requirement

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -56,7 +56,7 @@ class PkgConfConan(ConanFile):
             del self.info.settings.compiler
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/[>=1.2.2]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION



### Summary
Changes to recipe:  **pkgconf/[*]**

#### Motivation
Present requirement of `pkgconf` targets a pinned version (1.2.2) of `meson`. This version of `meson` has been removed recently, what prevents to build `pkgconf`.
This PR both aims at solving the current conflict and aligns `pkgconf` to good practices to avoid a new issue in the future.

#### Details
`meson` is a tool requirement for `pkgconf`. This tool requirement is expressed in the form of a pinned version (1.2.2), which has been removed.
The PR just changes the pinned requirement into a range requirement.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
