### PR TITLE
protobuf: Add version 6.30.0

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "6.30.1":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.30.1.tar.gz"
     sha256: "c97cc064278ef2b8c4da66c1f85613642ecbd5a0c4217c0defdf7ad1b3de9fa5"
+  "6.30.0":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.30.0.tar.gz"
+    sha256: "7fa08c78d1b0a049dcc3e77dc5aef186d35659f2e39409755e1b1dd29ab96702"
   "5.29.3":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.29.3.tar.gz"
     sha256: "fe35f190d7a63533b06558915d6ee469cbee143de70891e1dd54d197b05f362a"
@@ -34,6 +37,44 @@ patches:
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
   "6.30.1":
+    - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_optional
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_type_traits
+    - absl_utility
+    - absl_variant
+  "6.30.0":
     - absl_absl_check
     - absl_absl_log
     - absl_algorithm

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,6 +1,8 @@
 versions:
   "6.30.1":
     folder: all
+  "6.30.0":
+    folder: all
   "5.29.3":
     folder: all
   "5.28.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuf/6.30.0**

#### Motivation
Add upstream version of protobuf

#### Details
Add a version of protobuf that grpc depends on. See #28189

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
