### PR TITLE
re2c: add version 4.3

### DIFF
--- a/recipes/re2c/all/conandata.yml
+++ b/recipes/re2c/all/conandata.yml
@@ -2,12 +2,3 @@ sources:
   "4.3":
     url: "https://github.com/skvadrik/re2c/releases/download/4.3/re2c-4.3.tar.xz"
     sha256: "51e88d6d6b6ab03eb7970276aca7e0db4f8e29c958b84b561d2fdcb8351c7150"
-  "4.0.2":
-    url: "https://github.com/skvadrik/re2c/releases/download/4.0.2/re2c-4.0.2.tar.xz"
-    sha256: "5e52ce0e26326115e41bc45d34dc2d5e10f2e44ed3a413fa2a826aa3500c8d56"
-  "3.1":
-    url: "https://github.com/skvadrik/re2c/releases/download/3.1/re2c-3.1.tar.xz"
-    sha256: "0ac299ad359e3f512b06a99397d025cfff81d3be34464ded0656f8a96676c029"
-  "2.2":
-    url: "https://github.com/skvadrik/re2c/releases/download/2.2/re2c-2.2.tar.xz"
-    sha256: "0fc45e4130a8a555d68e230d1795de0216dfe99096b61b28e67c86dfd7d86bda"

--- a/recipes/re2c/all/conandata.yml
+++ b/recipes/re2c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.3":
+    url: "https://github.com/skvadrik/re2c/releases/download/4.3/re2c-4.3.tar.xz"
+    sha256: "51e88d6d6b6ab03eb7970276aca7e0db4f8e29c958b84b561d2fdcb8351c7150"
   "4.0.2":
     url: "https://github.com/skvadrik/re2c/releases/download/4.0.2/re2c-4.0.2.tar.xz"
     sha256: "5e52ce0e26326115e41bc45d34dc2d5e10f2e44ed3a413fa2a826aa3500c8d56"

--- a/recipes/re2c/config.yml
+++ b/recipes/re2c/config.yml
@@ -1,9 +1,3 @@
 versions:
   "4.3":
     folder: "all"
-  "4.0.2":
-    folder: "all"
-  "3.1":
-    folder: "all"
-  "2.2":
-    folder: "all"

--- a/recipes/re2c/config.yml
+++ b/recipes/re2c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.3":
+    folder: "all"
   "4.0.2":
     folder: "all"
   "3.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **re2c/4.3**

#### Motivation
There are 3 releases since 4.0.2.

#### Details
https://re2c.org/releases/release_notes.html#release-4-3
https://re2c.org/releases/release_notes.html#release-4-2
https://re2c.org/releases/release_notes.html#release-4-1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
