### PR TITLE
add wgpu-native 25.0.2.1

### DIFF
--- a/recipes/wgpu_native/all/conandata.yml
+++ b/recipes/wgpu_native/all/conandata.yml
@@ -1,0 +1,55 @@
+sources:
+  "25.0.2.1":
+    binaries:
+      Linux:
+        "x86_64":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-linux-x86_64-release.zip"
+            sha256: "74ea0fed0aadc9b353b56db812081a1620d1d72003d7592c449ca39d5f5b61bb"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-linux-x86_64-debug.zip"
+            sha256: "65eb00e881db8db89306d5ccce297d4b58f37d0eeed62e31fad4ae07148100de"
+        "armv8":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-linux-aarch64-release.zip"
+            sha256: "ab048ddfcd0274d09c62db793b7dde39f1e8dc8a1135ecfbe2fe102f5cfa9943"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-linux-aarch64-debug.zip"
+            sha256: "f8a625562259b27f60d84f8f5d33037fcac59af514b310be9a2b683a5483a33f"
+      Windows:
+        "x86_64":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-x86_64-msvc-release.zip"
+            sha256: "e0cdcec5e7601117bb0e457e55d1729199d6f203857c72b432b406493c7434f7"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-x86_64-msvc-debug.zip"
+            sha256: "c626a273627d2872a0f03ef5703d2b6ff403ca246d5999449be4707f2bea5c4b"
+        "armv8":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-aarch64-msvc-release.zip"
+            sha256: "039ad9033ae43f478697a7090e16dc9a9b87f171288ff3d0c9f1a41ed10f4e59"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-windows-aarch64-msvc-debug.zip"
+            sha256: "039bcd68ef4fa8332abb786b8c9d06f47d1958ccdc5a796ee046736bfd3a1486"
+      Macos:
+        "x86_64":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-macos-x86_64-release.zip"
+            sha256: "64df075f30a7714daf49fa21728e5a3554c5a5254ea6372da5e7b790bc60903c"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-macos-x86_64-debug.zip"
+            sha256: "9ca8cfb499a13f3bcdfa99f0105c0c4e5466f2a4109634dd15f3a23b302bb76d"
+        "armv8":
+          Release:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-macos-aarch64-release.zip"
+            sha256: "df4f35417047e0f88ed6facd2cfa42d7a88bdc367bf1c7aa10c462bc8b3a2117"
+          Debug:
+            url: "https://github.com/gfx-rs/wgpu-native/releases/download/v25.0.2.1/wgpu-macos-aarch64-debug.zip"
+            sha256: "d3122c2456c607c49a6d7f8ce443650afb015b181c5d5956f05f4cfaede36dde"
+    licenses:
+      mit:
+        url: https://raw.githubusercontent.com/gfx-rs/wgpu-native/v25.0.2.1/LICENSE.MIT
+        sha256: "C7FEA58D1CFE49634CD92E54FC10A9D871F4B275321A4CD8C09E449122CAAEB4"
+      apache:
+        url: https://raw.githubusercontent.com/gfx-rs/wgpu-native/v25.0.2.1/LICENSE.APACHE
+        sha256: "A6CBA85BC92E0CFF7A450B1D873C0EAA2E9FC96BF472DF0247A26BEC77BF3FF9"

--- a/recipes/wgpu_native/all/conanfile.py
+++ b/recipes/wgpu_native/all/conanfile.py
@@ -1,0 +1,71 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get, download
+import os
+
+
+class wgpu_nativeConanfile(ConanFile):
+    name = "wgpu_native"
+    description = "Native WebGPU implementation based on wgpu-core"
+    license = "MIT OR Apache-2.0"
+    homepage = "https://github.com/gfx-rs/wgpu-native"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("webgpu", "wgpu", "gpu", "graphics", "rendering", "3d", "2d")
+    package_type = "library"
+
+    settings = "os", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC" : [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+
+    def validate(self):
+        os = self.settings.os
+        if os not in ("Linux", "Windows", "Macos"):
+            raise ConanInvalidConfiguration(f"Recipe does not handle prebuilt binaries for your OS ({os})")
+
+        arch = self.settings.arch
+        if arch not in ("x86_64", "armv8"):
+            raise ConanInvalidConfiguration(f"No prebuilt binaries exist for your architecture ({arch})")
+
+        if self.settings.build_type not in ("Debug", "Release"):
+            raise ConanInvalidConfiguration("Only Debug and Release build types are supported")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def build(self):
+        os = str(self.settings.os)
+        arch = str(self.settings.arch)
+        build_type = str(self.settings.build_type)
+        get(self, **self.conan_data["sources"][self.version]["binaries"][os][arch][build_type])
+
+        licenses = self.conan_data["sources"][self.version]["licenses"]
+        download(self, filename="LICENSE.MIT", **licenses["mit"])
+        download(self, filename="LICENSE.APACHE", **licenses["apache"])
+
+    def package(self):
+        copy(self, pattern="LICENSE.*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+
+        copy(self, pattern="webgpu/*.h",
+             src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"),
+             keep_path=True)
+
+        patterns = ["*.so", "*.dll", "*.dylib"] if self.options.shared else ["*.a", "*.lib"]
+        for p in patterns:
+            copy(self, pattern=p, src=self.source_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["wgpu_native"]
+
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.extend(["dl", "m", "pthread"])
+        elif self.settings.os == "Macos":
+            self.cpp_info.frameworks.extend(["Foundation", "Metal", "MetalKit", "QuartzCore"])

--- a/recipes/wgpu_native/all/test_package/CMakeLists.txt
+++ b/recipes/wgpu_native/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+find_package(wgpu_native REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} src/example.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE wgpu_native::wgpu_native)

--- a/recipes/wgpu_native/all/test_package/conanfile.py
+++ b/recipes/wgpu_native/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/wgpu_native/all/test_package/src/example.cpp
+++ b/recipes/wgpu_native/all/test_package/src/example.cpp
@@ -1,0 +1,9 @@
+#include <webgpu/webgpu.h>
+#include <webgpu/wgpu.h>
+
+#include <cstdlib>
+
+int main() {
+  uint32_t version = wgpuGetVersion();
+  return version != 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/recipes/wgpu_native/config.yml
+++ b/recipes/wgpu_native/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "25.0.2.1":
+    folder: all


### PR DESCRIPTION
**Note**: this is a reopening of #23963 that was automatically closed but was almost ready to merge. I hope the tests will not mysteriously fail this time, and/or get the little bit of help needed.

Specify library name and version:  **wgpu_native/25.0.2.1**

WebGPU, despite its name, is not only usable from web browsers. [wgpu-native](https://github.com/gfx-rs/wgpu-native) is Mozilla's native implementation in rust.
It's useful to various graphical native applications and games.

This recipe uses prebuilt binaries from the project, to avoid dependency on the rust toolchain.

I haven't tried with hooks enabled, since they don't seem to be supported by conan 2.x.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
