### PR TITLE
libcurl: add missing secur32 system lib when schannel is enabled

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -689,8 +689,10 @@ class LibcurlConan(ConanFile):
             self.cpp_info.components["curl"].system_libs = ["ws2_32", "bcrypt", "iphlpapi"]
             if self.options.with_ldap:
                 self.cpp_info.components["curl"].system_libs.append("wldap32")
-            if self.options.with_ssl in ("schannel", "libressl"):
+            if self.options.with_ssl == "libressl":
                 self.cpp_info.components["curl"].system_libs.append("crypt32")
+            if self.options.with_ssl == "schannel":
+                self.cpp_info.components["curl"].system_libs.extend(["crypt32", "secur32"])
         elif is_apple_os(self):
             self.cpp_info.components["curl"].frameworks.append("CoreFoundation")
             self.cpp_info.components["curl"].frameworks.append("CoreServices")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcurl/8.15.0**

#### Motivation
libcurl can't be used on windows when schannel is enabled. System lib **secur32** isn't linked.

`libcurl.lib(curl_sspi.c.obj) : error LNK2019: unresolved external symbol __imp_InitSecurityInterfaceW referenced in function Curl_sspi_global_init`

#### Details
It seems that since libcurl 8.15.0, we need to link to **secur32** when schannel/sspi is enabled.
[libcurl commit](https://github.com/curl/curl/commit/0d71b18153c8edb996738f8a362373fc72d0013b)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
