### PR TITLE
Added recipe: uvgrtp 3.1.6

### DIFF
--- a/recipes/uvgrtp/all/conandata.yml
+++ b/recipes/uvgrtp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.1.6":
+    url: "https://github.com/ultravideo/uvgRTP/archive/refs/tags/v3.1.6.tar.gz"
+    sha256: "3A8B175AE280A26EB6249DB879DA99E80D39DF2443062CCE9E3047FC05DB5CA2"

--- a/recipes/uvgrtp/all/conandata.yml
+++ b/recipes/uvgrtp/all/conandata.yml
@@ -2,3 +2,9 @@ sources:
   "3.1.6":
     url: "https://github.com/ultravideo/uvgRTP/archive/refs/tags/v3.1.6.tar.gz"
     sha256: "3A8B175AE280A26EB6249DB879DA99E80D39DF2443062CCE9E3047FC05DB5CA2"
+
+patches:
+  "3.1.6":
+    - patch_file: "patches/3.1.6-add-cryptopp-find-package.patch"
+      patch_description: "Add find_package for Cryptopp when crypto is enabled"
+      patch_type: "portability"

--- a/recipes/uvgrtp/all/conanfile.py
+++ b/recipes/uvgrtp/all/conanfile.py
@@ -1,0 +1,88 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
+from conan.tools.files import copy, get, rmdir, rm
+from conan.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.53.0"
+
+class UvgRTPConan(ConanFile):
+    name = "uvgrtp"
+    license = "BSD-2-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ultravideo/uvgRTP"
+    description = "uvgRTP is a Real-Time Transport Protocol (RTP) library written in C++ with a focus on simple-to-use and high-efficiency media delivery over the internet"
+    topics = ("rtp", "networking", "streaming", "multimedia")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_crypto": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_crypto": True,
+    }
+    package_type = "library"
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.with_crypto:
+            self.requires("cryptopp/[>=8.7.0 <9]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        # This library requires C++17
+        self.settings.compiler.cppstd = "17"
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.variables["UVGRTP_DISABLE_CRYPTO"] = not self.options.with_crypto
+        tc.variables["UVGRTP_DISABLE_TESTS"] = True
+        tc.variables["UVGRTP_DISABLE_EXAMPLES"] = True
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "packaging/License.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "uvgrtp")
+        self.cpp_info.set_property("cmake_target_name", "uvgrtp::uvgrtp")
+
+        self.cpp_info.libs = ["uvgrtp"]
+
+        if self.options.with_crypto:
+            self.cpp_info.requires = ["cryptopp::cryptopp"]
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["wsock32", "ws2_32"])
+
+        if self.settings.os == "Macos":
+            self.cpp_info.frameworks.append("Security")

--- a/recipes/uvgrtp/all/conanfile.py
+++ b/recipes/uvgrtp/all/conanfile.py
@@ -18,11 +18,13 @@ class UvgRTPConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_crypto": [True, False],
+        "disable_logging": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_crypto": True,
+        "disable_logging": False,
     }
     package_type = "library"
     exports_sources = "patches/*"
@@ -52,8 +54,10 @@ class UvgRTPConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
         tc.variables["UVGRTP_DISABLE_CRYPTO"] = not self.options.with_crypto
+        tc.variables["UVGRTP_DISABLE_PRINTS"] = self.options.disable_logging
         tc.variables["UVGRTP_DISABLE_TESTS"] = True
         tc.variables["UVGRTP_DISABLE_EXAMPLES"] = True
+        tc.variables["UVGRTP_RELEASE_COMMIT"] = True
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/uvgrtp/all/conanfile.py
+++ b/recipes/uvgrtp/all/conanfile.py
@@ -84,6 +84,7 @@ class UvgRTPConan(ConanFile):
 
         if self.settings.os == "Windows":
             self.cpp_info.system_libs.extend(["wsock32", "ws2_32"])
+            self.cpp_info.defines = ["NOMINMAX"]
         elif self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["pthread"])
         elif self.settings.os == "Macos":

--- a/recipes/uvgrtp/all/patches/3.1.6-add-cryptopp-find-package.patch
+++ b/recipes/uvgrtp/all/patches/3.1.6-add-cryptopp-find-package.patch
@@ -1,0 +1,73 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b079433..f27b4a2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -230,51 +230,27 @@ if (UNIX)
+         list(APPEND UVGRTP_CXX_FLAGS "-DUVGRTP_HAVE_SENDMMSG=1")
+         target_compile_definitions(${PROJECT_NAME} PRIVATE UVGRTP_HAVE_SENDMMSG=1)
+     endif()
+-
+-    # Try finding if pkg-config installed in the system
+-    find_package(PkgConfig)
+-    if(PkgConfig_FOUND)
+-        list(APPEND UVGRTP_LINKER_FLAGS "-luvgrtp")
+-        if(CMAKE_USE_PTHREADS_INIT AND NOT CMAKE_HAVE_LIBC_PTHREAD)
+-            list(APPEND UVGRTP_LINKER_FLAGS "-lpthread")
+-        endif()
+-        # Check PKG_CONFIG_PATH, if not defined, use lib/pkgconfig
+-        if(NOT DEFINED ENV{PKG_CONFIG_PATH})
+-            set(PKG_CONFIG_PATH "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+-            message("PKG_CONFIG_PATH is not set. Setting it to ${PKG_CONFIG_PATH}")
+-        endif(NOT DEFINED ENV{PKG_CONFIG_PATH})
+-
+-        # Find crypto++
+-        if(NOT UVGRTP_DISABLE_CRYPTO)
+-            pkg_search_module(CRYPTOPP libcrypto++ cryptopp)
+-            if(CRYPTOPP_FOUND)
+-              list(APPEND UVGRTP_CXX_FLAGS ${CRYPTOPP_CFLAGS_OTHER})
+-              list(APPEND UVGRTP_LINKER_FLAGS ${CRYPTOPP_LDFLAGS})
+-            endif()
+-        endif()
+-
+-        # Generate and install .pc file
+-        string(REPLACE ";" " " UVGRTP_CXX_FLAGS "${UVGRTP_CXX_FLAGS}")
+-        string(REPLACE ";" " " UVGRTP_LINKER_FLAGS "${UVGRTP_LINKER_FLAGS}")
+-        configure_file("cmake/uvgrtp.pc.in" "uvgrtp.pc" @ONLY)
+-        if (NOT UVGRTP_DISABLE_INSTALL)
+-            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/uvgrtp.pc DESTINATION ${PKG_CONFIG_PATH}/)
+-        endif()
+-    else()
+-        message("pkg-config not found. Not generating pc file")
+-    endif(PkgConfig_FOUND)
+ endif (UNIX)
+ 
+-if (NOT CRYPTOPP_FOUND AND UVGRTP_DOWNLOAD_CRYPTO)
+-  include(cmake/CryptoHeaders.cmake)
+-  list(APPEND UVGRTP_CXX_FLAGS ${CRYPTOPP_CFLAGS_OTHER})
+-  list(APPEND UVGRTP_LINKER_FLAGS ${CRYPTOPP_LDFLAGS})
+-elseif(NOT CRYPTOPP_FOUND AND UNIX)
+-  # In Visual Studio, we want to leave user the option to add Crypto++ headers manually
+-  message("libcrypto++ not found. Encryption will be disabled")
+-  list(APPEND UVGRTP_CXX_FLAGS "-D__RTP_NO_CRYPTO__")
++if (NOT UVGRTP_DISABLE_CRYPTO)
++    find_package(CryptoPP QUIET)
++
++    if (CryptoPP_FOUND)
++        target_link_libraries(${PROJECT_NAME} PRIVATE cryptopp::cryptopp)
++    elseif (UVGRTP_DOWNLOAD_CRYPTO)
++        include(cmake/CryptoHeaders.cmake)
++        list(APPEND UVGRTP_CXX_FLAGS ${CRYPTOPP_CFLAGS_OTHER})
++        list(APPEND UVGRTP_LINKER_FLAGS ${CRYPTOPP_LDFLAGS})
++    else()
++        message(STATUS "Crypto++ not found; encryption will be disabled")
++        list(APPEND UVGRTP_CXX_FLAGS "-D__RTP_NO_CRYPTO__")
++        target_compile_definitions(${PROJECT_NAME} PRIVATE __RTP_NO_CRYPTO__)
++    endif()
+ endif()
+ 
++target_compile_options(${PROJECT_NAME} PRIVATE ${UVGRTP_CXX_FLAGS})
++target_link_options(${PROJECT_NAME}    PRIVATE ${UVGRTP_LINKER_FLAGS})
++
+ if(APPLE)
+     target_link_libraries(${PROJECT_NAME} PRIVATE "-framework Security")
+ endif()

--- a/recipes/uvgrtp/all/test_package/CMakeLists.txt
+++ b/recipes/uvgrtp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(PackageTest CXX)
+
+find_package(uvgrtp REQUIRED CONFIG)
+
+add_executable(example example.cpp)
+target_link_libraries(example uvgrtp::uvgrtp)
+target_compile_features(example PRIVATE cxx_std_17)

--- a/recipes/uvgrtp/all/test_package/conanfile.py
+++ b/recipes/uvgrtp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+class UvgRTPTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(bin_path, env="conanrun")

--- a/recipes/uvgrtp/all/test_package/example.cpp
+++ b/recipes/uvgrtp/all/test_package/example.cpp
@@ -1,0 +1,17 @@
+#include <uvgrtp/lib.hh>
+#include <iostream>
+#include <string>
+
+int main() {
+    uvgrtp::context ctx;
+
+    // Get the CNAME (Canonical Name) generated for this context
+    std::string cname = ctx.get_cname();
+    std::cout << "Generated CNAME: " << cname << std::endl;
+
+    // Check if crypto is enabled in this build of uvgRTP
+    bool crypto_enabled = ctx.crypto_enabled();
+    std::cout << "Crypto enabled: " << (crypto_enabled ? "Yes" : "No") << std::endl;
+
+    return 0;
+}

--- a/recipes/uvgrtp/config.yml
+++ b/recipes/uvgrtp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  3.1.6:
+    folder: all


### PR DESCRIPTION
### Summary
Added recipe:  **uvgrtp/3.1.6**

#### Motivation
This PR adds the library [uvgRTP ](https://github.com/ultravideo/uvgRTP/tree/master) developed by the Ultra Video Group to conan-center. The library allows media delivery via the Real-Time Transport Protocol (RTP) / SRTP / ZRTP. It supports many different video and audio payload formats out of the box and also allows using a custom payload format.

#### Details
The recipe uses CMake to build the library and patches the FetchContent dependency on crypto++ to work via find_package so the conan dependency on crypto++ works correctly.

We are actively using this recipe internally on Windows x64, Linux x64 GNU (via GCC), Linux x64/aarch64 GNU/MUSL (via Clang).

MacOS should be supported as well but I cannot verify that everything works.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
