### PR TITLE
glib 2.85.3

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.85.3":
+    url: "https://download.gnome.org/sources/glib/2.85/glib-2.85.3.tar.xz"
+    sha256: "af229e1de191d66aebcdb03c7493c724fd4d0a6628b1ca4ea1f35739259b311d"
   "2.81.0":
     url: "https://download.gnome.org/sources/glib/2.81/glib-2.81.0.tar.xz"
     sha256: "1665188ed9cc941c0a189dc6295e6859872523d1bfc84a5a84732a7ae87b02e4"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.85.3":
+    folder: all
   "2.81.0":
     folder: all
   "2.78.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **glib/2.85.3**

#### Motivation
latest version of pango requires at least glib 2.82 https://github.com/GNOME/pango/commit/7020a41a47bbdebafc79d42d70f01c542ad7a75e

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
