### PR TITLE
Package/kiss icp

### DIFF
--- a/recipes/kiss-icp/all/conandata.yml
+++ b/recipes/kiss-icp/all/conandata.yml
@@ -1,0 +1,11 @@
+sources:
+  "1.2.3":
+    url:
+      - "https://github.com/PRBonn/kiss-icp/archive/refs/tags/v1.2.3.tar.gz"
+    sha256: "087A9745C5B2CC304E72BF87929371ECB102C8B75C026162C58D643D6AF8849C"
+
+patches:
+  "1.2.3":
+    - patch_file: "patches/build_type.patch"
+      patch_type: "portability"
+      patch_description: "Remove hardcoded build type"

--- a/recipes/kiss-icp/all/conanfile.py
+++ b/recipes/kiss-icp/all/conanfile.py
@@ -1,29 +1,31 @@
 from conan import ConanFile
-from conan.errors import ConanException
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, apply_conandata_patches
+from conan.tools.files import apply_conandata_patches, copy, get, apply_conandata_patches
 import os
-import shutil
 
 required_conan_version = ">=2.1.0"
 
 
 class KissIcpConan(ConanFile):
     name = "kiss-icp"
+    description = "A LiDAR odometry pipeline that just works"
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/PRBonn/kiss-icp"
     topics = ("robotics", "ros", "slam", "ros2", "3d-mapping", "lidar-slam")
-    description = "A LiDAR odometry pipeline that just works"
-    license = "MIT"
     package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
-    exports_sources = "patches/*.patch"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
 
-    def requirements(self):
-        self.requires("eigen/3.4.0", transitive_headers=True)
-        self.requires("sophus/1.22.10", transitive_headers=True)
-        self.requires("onetbb/2020.3.3", transitive_headers=True)
-        self.requires("tsl-robin-map/1.3.0", transitive_headers=True)
+    def export_sources(self):
+        apply_conandata_patches(self)
 
     def layout(self):
         cmake_layout(self)
@@ -31,6 +33,15 @@ class KissIcpConan(ConanFile):
         self.folders.source = "."
         self.folders.build = "build"
         self.folders.generators = self.folders.build
+
+    def requirements(self):
+        self.requires("eigen/3.4.0", transitive_headers=True)
+        self.requires("sophus/1.22.10", transitive_headers=True)
+        self.requires("onetbb/2020.3.3", transitive_headers=True)
+        self.requires("tsl-robin-map/1.3.0", transitive_headers=True)
+
+    def validate(self):
+        check_min_cppstd(self, 17)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -61,7 +72,6 @@ class KissIcpConan(ConanFile):
 
 
     def package_info(self):
-        suffix = "d" if self.settings.build_type == "Debug" else ""
         self.cpp_info.libs = ["kiss_icp_core", "kiss_icp_metrics", "kiss_icp_pipeline"]
         self.cpp_info.includedirs = ["include"]
         self.cpp_info.requires = ["eigen::eigen3", "sophus::sophus", "onetbb::onetbb", "tsl-robin-map::tsl-robin-map"]

--- a/recipes/kiss-icp/all/conanfile.py
+++ b/recipes/kiss-icp/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, get, apply_conandata_patches
+from conan.tools.files import export_conandata_patches, copy, get, apply_conandata_patches
 import os
 
 required_conan_version = ">=2.1.0"
@@ -25,7 +25,7 @@ class KissIcpConan(ConanFile):
     implements = ["auto_shared_fpic"]
 
     def export_sources(self):
-        apply_conandata_patches(self)
+        export_conandata_patches(self)
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/kiss-icp/all/conanfile.py
+++ b/recipes/kiss-icp/all/conanfile.py
@@ -1,0 +1,67 @@
+from conan import ConanFile
+from conan.errors import ConanException
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, apply_conandata_patches
+import os
+import shutil
+
+required_conan_version = ">=2.1.0"
+
+
+class KissIcpConan(ConanFile):
+    name = "kiss-icp"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/PRBonn/kiss-icp"
+    topics = ("robotics", "ros", "slam", "ros2", "3d-mapping", "lidar-slam")
+    description = "A LiDAR odometry pipeline that just works"
+    license = "MIT"
+    package_type = "shared-library"
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "patches/*.patch"
+
+    def requirements(self):
+        self.requires("eigen/3.4.0", transitive_headers=True)
+        self.requires("sophus/1.22.10", transitive_headers=True)
+        self.requires("onetbb/2020.3.3", transitive_headers=True)
+        self.requires("tsl-robin-map/1.3.0", transitive_headers=True)
+
+    def layout(self):
+        cmake_layout(self)
+
+        self.folders.source = "."
+        self.folders.build = "build"
+        self.folders.generators = self.folders.build
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+        apply_conandata_patches(self)
+    
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder="cpp/kiss_icp")
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, pattern="**/*.h", src=os.path.join(self.source_folder, "cpp/kiss_icp"), dst=os.path.join(self.package_folder, "include/kiss_icp"))
+        copy(self, pattern="**/*.hpp", src=os.path.join(self.source_folder, "cpp/kiss_icp"), dst=os.path.join(self.package_folder, "include/kiss_icp"))
+        copy(self, pattern="**/*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, pattern="**/*.so", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, pattern="**/*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, pattern="**/*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+        copy(self, pattern="**/*.dylib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+
+
+    def package_info(self):
+        suffix = "d" if self.settings.build_type == "Debug" else ""
+        self.cpp_info.libs = ["kiss_icp_core", "kiss_icp_metrics", "kiss_icp_pipeline"]
+        self.cpp_info.includedirs = ["include"]
+        self.cpp_info.requires = ["eigen::eigen3", "sophus::sophus", "onetbb::onetbb", "tsl-robin-map::tsl-robin-map"]

--- a/recipes/kiss-icp/all/patches/build_type.patch
+++ b/recipes/kiss-icp/all/patches/build_type.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/kiss_icp/CMakeLists.txt b/cpp/kiss_icp/CMakeLists.txt
+index 07ccfbe..1c873cd 100644
+--- a/cpp/kiss_icp/CMakeLists.txt
++++ b/cpp/kiss_icp/CMakeLists.txt
+@@ -41,7 +41,6 @@ if(USE_CCACHE)
+ endif()
+ 
+ # Set build type (repeat here for C++ only consumers)
+-set(CMAKE_BUILD_TYPE Release)
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 

--- a/recipes/kiss-icp/all/test_package/CMakeLists.txt
+++ b/recipes/kiss-icp/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(kiss-icp REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE kiss-icp::kiss-icp)

--- a/recipes/kiss-icp/all/test_package/conanfile.py
+++ b/recipes/kiss-icp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/kiss-icp/all/test_package/test_package.cpp
+++ b/recipes/kiss-icp/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <kiss_icp/pipeline/KissICP.hpp>
+
+int main(void) {
+
+    auto test = kiss_icp::pipeline::KISSConfig();
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/kiss-icp/config.yml
+++ b/recipes/kiss-icp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.2.3":
+    folder: all


### PR DESCRIPTION
### Summary
Add a new Conan package recipe for the kiss-icp LiDAR odometry library (v1.2.3).

Solve #28217

#### Details

- The original CMakeLists.txt does not support a standard cmake install step, so a custom installation process is implemented in the conanfile.py.
- The build type is hardcoded in the upstream CMakeLists.txt. A patch was applied to remove this restriction to make the recipe compatible with Conan's build-type management.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
