### PR TITLE
xkeyboard-config: add support for apk

### DIFF
--- a/recipes/xkeyboard-config/all/conanfile.py
+++ b/recipes/xkeyboard-config/all/conanfile.py
@@ -39,6 +39,9 @@ class XkeyboardConfigConan(ConanFile):
         pacman = package_manager.PacMan(self)
         pacman.install(["xkeyboard-config"], update=True, check=True)
 
+        apk = package_manager.Apk(self)
+        apk.install(["xkeyboard-config-dev"], update=True, check=True)
+
         package_manager.Pkg(self).install(["xkeyboard-config"], update=True, check=True)
 
     def package_info(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **xkeyboard-config/all**

#### Motivation
Support apk for Alpine Linux.

#### Details
Alpine splits dev packages, for this one: https://pkgs.alpinelinux.org/package/edge/main/x86_64/xkeyboard-config-dev
Sorry I can't test it locally right now but the change should be straightforward.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
