### PR TITLE
gperf: Bring back removal of compiler setting in package_id

### DIFF
--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -26,6 +26,9 @@ class GperfConan(ConanFile):
         basic_layout(self, src_folder="src")
         self.folders.build = self.folders.source
 
+    def package_id(self):
+        del self.info.settings.compiler
+
     def build_requirements(self):
         if self.settings_build.os == "Windows":
             self.win_bash = True


### PR DESCRIPTION
Last changes to this PR wrongly removed the removal of the compiler setting in the package_id method