### PR TITLE
librdkafka 2.11.1

### DIFF
--- a/recipes/librdkafka/all/conandata.yml
+++ b/recipes/librdkafka/all/conandata.yml
@@ -40,6 +40,10 @@ patches:
     - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
       patch_description: "refer conan package names"
       patch_type: "conan"
+    - patch_file: patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
+      patch_description: "Fix OAuthBearer OIDC preprocessor directive when using CMake without CUR"
+      patch_type: "official"
+      patch_source: "https://github.com/confluentinc/librdkafka/pull/5136"
   "2.8.0":
     - patch_file: patches/0001-Change-library-names-1-9-1.patch
       patch_description: "find_package conan packages"

--- a/recipes/librdkafka/all/conandata.yml
+++ b/recipes/librdkafka/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.11.1":
+    url: "https://github.com/edenhill/librdkafka/archive/v2.11.1.tar.gz"
+    sha256: "a2c87186b081e2705bb7d5338d5a01bc88d43273619b372ccb7bb0d264d0ca9f"
   "2.8.0":
     url: "https://github.com/edenhill/librdkafka/archive/v2.8.0.tar.gz"
     sha256: "5bd1c46f63265f31c6bfcedcde78703f77d28238eadf23821c2b43fc30be3e25"
@@ -30,6 +33,13 @@ sources:
     url: "https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz"
     sha256: "3fba157a9f80a0889c982acdd44608be8a46142270a389008b22d921be1198ad"
 patches:
+  "2.11.1":
+    - patch_file: patches/0001-Change-library-names-1-9-1.patch
+      patch_description: "find_package conan packages"
+      patch_type: "conan"
+    - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
+      patch_description: "refer conan package names"
+      patch_type: "conan"
   "2.8.0":
     - patch_file: patches/0001-Change-library-names-1-9-1.patch
       patch_description: "find_package conan packages"

--- a/recipes/librdkafka/all/patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
+++ b/recipes/librdkafka/all/patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
@@ -1,0 +1,12 @@
+diff --git a/src/rdkafka_conf.c b/src/rdkafka_conf.c
+--- a/src/rdkafka_conf.c	(revision 69b1865efdc0118cd017760d038d34e52fb3f0d0)
++++ b/src/rdkafka_conf.c	(date 1755856167319)
+@@ -56,7 +56,7 @@
+ #include <windows.h>
+ #endif
+ 
+-#ifdef WITH_OAUTHBEARER_OIDC
++#if WITH_OAUTHBEARER_OIDC
+ #include <curl/curl.h>
+ #endif
+ 

--- a/recipes/librdkafka/config.yml
+++ b/recipes/librdkafka/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.11.1":
+    folder: all
   "2.8.0":
     folder: all
   "2.6.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **librdkafka/2.11.1**

#### Motivation
latest version of librdkafka with [bugfixes and features](https://github.com/confluentinc/librdkafka/releases)

#### Details
CMakeLists.txt has not changed between 2.8.0 and 2.11.1, so re-using the patches from 2.8.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
