### PR TITLE
Add package liambindle-mqtt-c version 1.1.6

### DIFF
--- a/recipes/liambindle-mqtt-c/all/conandata.yml
+++ b/recipes/liambindle-mqtt-c/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "1.1.6":
+    url:
+    - "https://github.com/LiamBindle/MQTT-C/archive/refs/tags/v1.1.6.zip"
+    sha256: "738df934bdff56ffe2a04364822b5136180b9f3cab43fb2e48b20e7355adc6fa"

--- a/recipes/liambindle-mqtt-c/all/conanfile.py
+++ b/recipes/liambindle-mqtt-c/all/conanfile.py
@@ -1,0 +1,62 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+import os
+
+
+required_conan_version = ">=2.0.9"
+
+
+class PackageConan(ConanFile):
+    name = "liambindle-mqtt-c"
+    description = "MQTT-C is an MQTT v3.1.1 client written in C"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/LiamBindle/MQTT-C"
+    topics = ("mqtt", "iot")
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def configure(self):
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.5 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["MQTT_C_TESTS"] = False
+        tc.cache_variables["MQTT_C_EXAMPLES"] = False
+        if is_msvc(self):
+            tc.cache_variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["mqttc"]
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["Ws2_32"]

--- a/recipes/liambindle-mqtt-c/all/test_package/CMakeLists.txt
+++ b/recipes/liambindle-mqtt-c/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+find_package(liambindle-mqtt-c CONFIG REQUIRED)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package liambindle-mqtt-c::liambindle-mqtt-c)
+target_include_directories(test_package PRIVATE ${MBEDTLS_INCLUDE_DIRS})

--- a/recipes/liambindle-mqtt-c/all/test_package/conanfile.py
+++ b/recipes/liambindle-mqtt-c/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/liambindle-mqtt-c/all/test_package/test_package.cpp
+++ b/recipes/liambindle-mqtt-c/all/test_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include <stdio.h>
+
+#include <mqtt.h>
+
+void publishCallback(void** unused, struct mqtt_response_publish* published)
+{
+    printf("Publish callback called\n");
+}
+
+int main()
+{
+    struct mqtt_client client;
+    uint8_t sendBuffer[2048];
+    uint8_t receiveBuffer[1024];
+
+    printf("Initializing mqtt\n");
+
+    // Second argument is native socket handle, which we will not use in the example
+    mqtt_init(&client, 0,
+              sendBuffer, sizeof(sendBuffer),
+              receiveBuffer, sizeof(receiveBuffer),
+              &publishCallback);
+
+    printf("Done initializing mqtt\n");
+
+    return 0;
+}

--- a/recipes/liambindle-mqtt-c/config.yml
+++ b/recipes/liambindle-mqtt-c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.6":
+    folder: all


### PR DESCRIPTION
### Summary
Adds recipe:  **liambindle-mqtt-c/1.1.6**

#### Motivation
I've used this package in many of my projects, and I would like to contribute a conan package I've created with the community.

#### Details
This provides a simple support for Liam Bindles MQTT-C library on version 1.1.6.

- The recipe is currently only available as static library and with fPIC enabled. The reason for this is that this is hard-coded into the CMakeLists.txt. I'm not sure about the intention of this, so I'll leave it as fixed values.
- The CMakeLists.txt file of the library does support options for building with openssl, mbedtls and bearssl. These are not exposed in the conan recipe because I haven't used these options and don't know the version compability with the MQTT-C library. OpenSSL and Mbed-TLS is currently available on conancenter, which could be good candidates for further extensions of this recipe.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
