### PR TITLE
libqasm: removed cpython and emsdk dependencies, old patches and simplify recipe

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "1.2.1":
     url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.2.1/libqasm-1.2.1.tar.gz"
     sha256: "4303cbc9d0d928dc2b72769a79772e8e71d6e562de9b6ba3ca435da7a73d2739"
-  "1.2.0":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.2.0/libqasm-1.2.0.tar.gz"
-    sha256: "9142085d3782c8b2094f66cf1fc3719040dfadc62f55ab722636fca109e27c20"
   "1.1.0":
     url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.1.0/libqasm-1.1.0.tar.gz"
     sha256: "cf317c465e741360ae147e46346c57294c23882269e3b3dabb3c5d5ac703414a"
@@ -14,15 +11,3 @@ sources:
   "0.6.9":
     url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.9.tar.gz"
     sha256: "23c5d0e4e506e1974668408f8018034d1b1303e65c6d2d28639eae9499759c4d"
-  "0.6.8":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.8/libqasm-0.6.8.tar.gz"
-    sha256: "b98ff44f0c569a0cc20b3728ba7d4711299aaac07d4dadfe52e638b366b91251"
-  "0.6.7":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.7/libqasm-0.6.7.tar.gz"
-    sha256: "3e85be4f433b178b89e32bc738bd4f69266cd1c4ad0ed12b5367381ac6e44eb2"
-  "0.6.6":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.6/libqasm-0.6.6.tar.gz"
-    sha256: "b3a2d1670f8865ce22bcc62c6a696ee7e0764a7b76901a4f082efa2287e0cbad"
-  "0.6.5":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.5/libqasm-0.6.5.tar.gz"
-    sha256: "0577622a512d1f64892949af02abe3d0b53195ad454045715a0ebf837ecde0d6"

--- a/recipes/libqasm/all/conanfile.py
+++ b/recipes/libqasm/all/conanfile.py
@@ -8,9 +8,8 @@ from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rm, replace_in_file
 from conan.tools.microsoft import is_msvc
-from conan.tools.scm import Version
 
-required_conan_version = ">=1.60.0 <2 || >=2.0.6"
+required_conan_version = ">=2.1"
 
 
 class LibqasmConan(ConanFile):
@@ -25,76 +24,30 @@ class LibqasmConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "build_python": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "build_python": False
     }
-
-    @property
-    def _should_build_test(self):
-        return not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
-
-    @property
-    def _min_cppstd(self):
-        return "20"
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "10",
-            "clang": "13",
-            "apple-clang": "14",
-            "Visual Studio": "16",
-            "msvc": "192"
-        }
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
-        if self.settings.arch == "wasm":
-            self.options["antlr4-cppruntime"].shared = self.options.shared
+    implements = ["auto_shared_fpic"]
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def requirements(self):
+        self.requires("fmt/11.0.2", transitive_headers=True)
+        self.requires("tree-gen/1.0.8", transitive_headers=True, transitive_libs=True)
+        self.requires("range-v3/0.12.0", transitive_headers=True)
+        self.requires("antlr4-cppruntime/4.13.1", transitive_headers=True)
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+        if self.dependencies["antlr4-cppruntime"].options.shared != self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} requires antlr4-cppruntime to be built with the same shared option value.")
+
     def build_requirements(self):
         self.tool_requires("tree-gen/<host_version>")
         self.tool_requires("zulu-openjdk/21.0.1")
-        if self.settings.arch == "wasm":
-            self.tool_requires("emsdk/3.1.50")
-        if self._should_build_test:
-            self.test_requires("gtest/1.15.0")
-        if self.options.build_python:
-            self.tool_requires("cpython/3.12.2")
-
-    def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd},"
-                                            f"which your compiler does not support.")
-
-        if self.settings.arch != "wasm" and self.dependencies["antlr4-cppruntime"].options.shared != self.options.shared:
-            raise ConanInvalidConfiguration(f"{self.ref} requires antlr4-cppruntime to be built with the same shared option value.")
-
-    def requirements(self):
-        if Version(self.version) < "0.6.7":
-            self.requires("fmt/10.2.1", transitive_headers=True)
-            self.requires("tree-gen/1.0.7", transitive_headers=True, transitive_libs=True)
-        else:
-            self.requires("fmt/11.0.2", transitive_headers=True)
-            self.requires("tree-gen/1.0.8", transitive_headers=True, transitive_libs=True)
-        self.requires("range-v3/0.12.0", transitive_headers=True)
-        if not self.settings.arch == "wasm":
-            self.requires("antlr4-cppruntime/4.13.1", transitive_headers=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -103,8 +56,6 @@ class LibqasmConan(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
-        tc.variables["LIBQASM_BUILD_PYTHON"] = self.options.build_python
-        tc.variables["LIBQASM_BUILD_TESTS"] = self._should_build_test
         tc.generate()
         env = VirtualBuildEnv(self)
         env.generate()

--- a/recipes/libqasm/all/test_package/CMakeLists.txt
+++ b/recipes/libqasm/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
-project(PackageTest CXX)
+
+project(test_package LANGUAGES CXX)
 
 find_package(libqasm REQUIRED CONFIG)
 
-add_executable(test_package "${CMAKE_CURRENT_SOURCE_DIR}/src/test_package.cpp")
-target_compile_features(test_package PRIVATE cxx_std_20)
+add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(test_package PRIVATE libqasm::libqasm)

--- a/recipes/libqasm/all/test_package/conanfile.py
+++ b/recipes/libqasm/all/test_package/conanfile.py
@@ -8,7 +8,6 @@ from conan.tools.cmake import CMake, cmake_layout
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/libqasm/all/test_package/test_package.cpp
+++ b/recipes/libqasm/all/test_package/test_package.cpp
@@ -1,9 +1,4 @@
-#if __has_include("cqasm.hpp")
-#include "cqasm.hpp"
-#else
 #include "libqasm/cqasm.hpp"
-#endif
-
 #include <iostream>
 
 int main() {

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,19 +1,9 @@
 versions:
   "1.2.1":
     folder: all
-  "1.2.0":
-    folder: all
   "1.1.0":
     folder: all
   "1.0.0":
     folder: all
   "0.6.9":
-    folder: all
-  "0.6.8":
-    folder: all
-  "0.6.7":
-    folder: all
-  "0.6.6":
-    folder: all
-  "0.6.5":
     folder: all


### PR DESCRIPTION
### **Summary of Changes**

This PR updates the **libqasm** recipe to align with current Conan Center Index (CCI) best practices and resolve existing issues. Key changes include:

* Removing the `cpython` build dependency and the `build_python` option.
* Removing the `emsdk` dependency.
* General recipe maintenance to remove legacy code and unnecessary patches.


### **Detailed Changes**

#### **Python Dependency**

The `cpython` build dependency was found to be problematic and unnecessary. While this recipe used to depend on `cpython` for building its Python modules, testing revealed that it failed to compile without additional steps, such as setting specific CMake variables and requiring `swig`.

A bigger issue is that Conan's own operation relies on a Python installation already being in the system's `PATH`. Since CMake can use this system Python, the explicit `cpython` dependency is redundant.

Additionally, the `build_python` option has been removed entirely. It was set to `False` by default, never tested in CCI, and required manual configuration to work. This change simplifies the recipe and prevents potential build failures.

#### **Emscripten SDK (emsdk) Dependency**

The `emsdk` dependency has been removed. Toolchains like `emsdk` and `android-ndk` should be managed via profiles, not as explicit recipe dependencies. 

This change makes the `libqasm` recipe more flexible and better aligned with the Conan toolchain management philosophy. While `wasm` support is possible upstream, it requires `antlr4-cppruntime` to be compiled with specific flags and uses `FetchContent` to download dependencies, which isn't allowed in CCI. Support for `wasm` builds can be added in the future if a user requests it, but for now, it's not a primary goal for this recipe.

#### **General Recipe Maintenance**

* **Patches**: Removed old, conditional patches that are no longer needed.
* **Legacy Code**: All Conan v1 legacy code has been cleaned up.
* **`test_package`**: The `target_compile_features(test_package PRIVATE cxx_std_20)` line was removed. The `validate()` method ensures that `libqasm` can only be compiled with at least `c++20`, making this explicit line in the `test_package` redundant.