### PR TITLE
[Asio] Add version 1.36.0

### DIFF
--- a/recipes/asio/all/conandata.yml
+++ b/recipes/asio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.36.0":
+    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-36-0.tar.gz"
+    sha256: "0310a76b27e1854f09f696b30de57dc490b5e1b17faed1eb8c9a2891f956e52b"
   "1.34.2":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-34-2.tar.gz"
     sha256: "f3bac015305fbb700545bd2959fbc52d75a1ec2e05f9c7f695801273ceb78cf5"

--- a/recipes/asio/config.yml
+++ b/recipes/asio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.36.0":
+    folder: all
   "1.34.2":
     folder: all
   "1.32.0":


### PR DESCRIPTION
### Summary
Add version 1.36.0 of Asio

#### Motivation
There are quite some interesting looking changes since the last version available in conan (https://think-async.com/Asio/asio-1.36.0/doc/asio/history.html#asio.history.asio_1_36_0)

#### Details
Added the sources of version 1.36.0 of Asio - I didn't add version 1.35.0.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
