### PR TITLE
sdl: add version 2.32.8

### DIFF
--- a/recipes/sdl/all/conandata.yml
+++ b/recipes/sdl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.32.8":
+    url: "https://www.libsdl.org/release/SDL2-2.32.8.tar.gz"
+    sha256: "0ca83e9c9b31e18288c7ec811108e58bac1f1bb5ec6577ad386830eac51c787e"
   "2.32.2":
     url: "https://www.libsdl.org/release/SDL2-2.32.2.tar.gz"
     sha256: "c5f30c427fd8107ee4a400c84d4447dd211352512eaf0b6e89cc6a50a2821922"

--- a/recipes/sdl/config.yml
+++ b/recipes/sdl/config.yml
@@ -1,6 +1,8 @@
 versions:
   "3.2.20":
     folder: 3.x
+  "2.32.8":
+    folder: all
   "2.32.2":
     folder: all
   "2.30.9":


### PR DESCRIPTION
### Summary
Updated SDL to:  **sdl/2.32.8**

#### Motivation
SDL 2.32.2 and below don't build on GCC 14 and above. (See: https://github.com/libsdl-org/SDL/issues/12572 and https://github.com/libsdl-org/SDL/commit/9e079fe9c7931738ed63d257b1d7fb8a07b66824 )


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
