### PR TITLE
force lf eol in dcmtk .h files

### DIFF
--- a/recipes/dcmtk/.gitattributes
+++ b/recipes/dcmtk/.gitattributes
@@ -1,0 +1,1 @@
+*.h text eol=lf


### PR DESCRIPTION
force lf eol in dcmtk .h files

Closes #28261 