### PR TITLE
pybind11: add version 3.0.1

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.1":
+    url: "https://github.com/pybind/pybind11/archive/v3.0.1.tar.gz"
+    sha256: "741633da746b7c738bb71f1854f957b9da660bcd2dce68d71949037f0969d0ca"
   "3.0.0":
     url: "https://github.com/pybind/pybind11/archive/v3.0.0.tar.gz"
     sha256: "453b1a3e2b266c3ae9da872411cadb6d693ac18063bd73226d96cfb7015a200c"

--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "3.0.1":
     url: "https://github.com/pybind/pybind11/archive/v3.0.1.tar.gz"
     sha256: "741633da746b7c738bb71f1854f957b9da660bcd2dce68d71949037f0969d0ca"
-  "3.0.0":
-    url: "https://github.com/pybind/pybind11/archive/v3.0.0.tar.gz"
-    sha256: "453b1a3e2b266c3ae9da872411cadb6d693ac18063bd73226d96cfb7015a200c"
   "2.13.6":
     url: "https://github.com/pybind/pybind11/archive/v2.13.6.tar.gz"
     sha256: "e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20"

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -1,8 +1,6 @@
 versions:
   "3.0.1":
     folder: all
-  "3.0.0":
-    folder: all
   "2.13.6":
     folder: all
   "2.10.4":

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.1":
+    folder: all
   "3.0.0":
     folder: all
   "2.13.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **pybind11/3.0.1**

#### Motivation
Simply adds the latest patch release: https://github.com/pybind/pybind11/releases/tag/v3.0.1

#### Details
Added version 3.0.1 to `config.yml` and `conandata.yml`.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
