### PR TITLE
poselib: add version 2.0.5

### DIFF
--- a/recipes/poselib/all/conandata.yml
+++ b/recipes/poselib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.5":
+    url: "https://github.com/PoseLib/PoseLib/archive/refs/tags/v2.0.5.tar.gz"
+    sha256: "a9493e6725c58e6ae541fe416c0a6179185a60006880ff3ddf32737a43695668"
   "2.0.4":
     url: "https://github.com/PoseLib/PoseLib/archive/refs/tags/v2.0.4.tar.gz"
     sha256: "caa0c1c9b882f6e36b5ced6f781406ed97d4c1f0f61aa31345ebe54633d67c16"

--- a/recipes/poselib/all/conanfile.py
+++ b/recipes/poselib/all/conanfile.py
@@ -85,7 +85,10 @@ class PoselibConan(ConanFile):
 
     def _patch_sources(self):
         cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
-        replace_in_file(self, cmakelists, "-march=native -Wall -Werror -fPIC", "")
+        if Version(self.version) >= "2.0.5":
+            replace_in_file(self, cmakelists, "-O3 -Wall -Werror -fPIC -Wno-sign-compare -Wfatal-errors", "")
+        else:
+            replace_in_file(self, cmakelists, "-march=native -Wall -Werror -fPIC", "")
 
     def build(self):
         self._patch_sources()

--- a/recipes/poselib/config.yml
+++ b/recipes/poselib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.5":
+    folder: all
   "2.0.4":
     folder: all
   "2.0.3":


### PR DESCRIPTION
### Summary
Bump version of poselib to 2.0.5

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
New version of poselib is out (https://github.com/PoseLib/PoseLib/releases/tag/v2.0.5) since a while back, should bump the version.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Just followed instructions here: https://github.com/conan-io/conan-center-index/blob/master/docs/bump_version.md

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
