### PR TITLE
[gdal] Do not patch libdeflate

### DIFF
--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -639,10 +639,6 @@ class GdalConan(ConanFile):
 
     def _patch_sources(self):
         apply_conandata_patches(self)
-        # Fix Deflate::Deflate not being correctly propagated internally.
-        replace_in_file(self, os.path.join(self.source_folder, "port", "CMakeLists.txt"),
-                        "PRIVATE Deflate::Deflate",
-                        "PUBLIC Deflate::Deflate")
         # Workaround for JXL_THREADS being provided by the JXL package on CCI.
         replace_in_file(self, os.path.join(self.source_folder, "cmake", "helpers", "CheckDependentLibraries.cmake"),
                         "JXL_THREADS", "JXL", strict=False)

--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -67,7 +67,6 @@ class GdalConan(ConanFile):
         "with_openssl": [True, False],
         "with_pcre": [True, False],
         "with_pcre2": [True, False],
-        # "with_pdfium": [True, False],
         "with_pg": [True, False],
         "with_png": [True, False],
         "with_podofo": [True, False],
@@ -131,7 +130,6 @@ class GdalConan(ConanFile):
         "with_openssl": False,
         "with_pcre": False,
         "with_pcre2": False,
-        # "with_pdfium": False,
         "with_pg": False,
         "with_png": True,
         "with_podofo": False,
@@ -270,9 +268,6 @@ class GdalConan(ConanFile):
             self.requires("pcre/8.45")
         if self.options.with_pcre2:
             self.requires("pcre2/10.42")
-        # TODO: pdfium recipe needs to be compatible with https://github.com/rouault/pdfium_build_gdal_3_8
-        # if self.options.with_pdfium:
-        #     self.requires("pdfium/95.0.4629")
         if self.options.with_pg:
             # libpq 15+ is not supported
             self.requires("libpq/14.9")
@@ -423,7 +418,7 @@ class GdalConan(ConanFile):
         tc.cache_variables["GDAL_USE_PARQUET"] = self.options.with_arrow and self.dependencies["arrow"].options.parquet
         tc.cache_variables["GDAL_USE_PCRE"] = self.options.with_pcre
         tc.cache_variables["GDAL_USE_PCRE2"] = self.options.with_pcre2
-        tc.cache_variables["GDAL_USE_PDFIUM"] = False  # self.options.with_pdfium
+        tc.cache_variables["GDAL_USE_PDFIUM"] = False
         tc.cache_variables["GDAL_USE_PNG"] = self.options.with_png
         tc.cache_variables["GDAL_USE_PNG_INTERNAL"] = False
         tc.cache_variables["GDAL_USE_PODOFO"] = self.options.with_podofo
@@ -554,7 +549,6 @@ class GdalConan(ConanFile):
             "openssl": "OpenSSL",
             "pcre": "PCRE",
             "pcre2": "PCRE2",
-            "pdfium": "PDFIUM",
             "podofo": "Podofo",
             "poppler": "Poppler",
             "proj": "PROJ",
@@ -624,7 +618,6 @@ class GdalConan(ConanFile):
             "openjpeg":                   "OPENJPEG::OpenJPEG",
             "pcre":                       "PCRE::PCRE",
             "pcre2::pcre2-8":             "PCRE2::PCRE2-8",
-            "pdfium":                     "PDFIUM::PDFIUM",
             "podofo":                     "PODOFO::Podofo",
             "poppler":                    "Poppler::Poppler",
             "shapelib":                   "SHAPELIB::shp",
@@ -773,8 +766,6 @@ class GdalConan(ConanFile):
             self.cpp_info.requires.extend(["pcre::pcre"])
         if self.options.with_pcre2:
             self.cpp_info.requires.extend(["pcre2::pcre2-8"])
-        # if self.options.with_pdfium:
-        #     self.cpp_info.requires.extend(["pdfium::pdfium"])
         if self.options.with_pg:
             self.cpp_info.requires.extend(["libpq::pq"])
         if self.options.with_png:


### PR DESCRIPTION
### Summary
Changes to recipe:  **gdal/[>=3.5.3]**

#### Motivation

The issue #28263 points to a linkage error with libdeflate related to `port/cpl` target.

```
/usr/bin/ld: src/port/CMakeFiles/cpl.dir/cpl_compressor.cpp.o: in function `CPLGZipCompress(void const*, unsigned long, int, void*, unsigned long, unsigned long*)':
/home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:786: undefined reference to `libdeflate_alloc_compressor'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:795: undefined reference to `libdeflate_gzip_compress_bound'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:803: undefined reference to `libdeflate_free_compressor'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:815: undefined reference to `libdeflate_gzip_compress'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:817: undefined reference to `libdeflate_free_compressor'
/usr/bin/ld: src/port/CMakeFiles/cpl.dir/cpl_compressor.cpp.o: in function `CPLZlibCompressor(void const*, unsigned long, void**, unsigned long*, char const* const*, void*)':
/home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:903: undefined reference to `libdeflate_alloc_compressor'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:910: undefined reference to `libdeflate_zlib_compress_bound'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:912: undefined reference to `libdeflate_gzip_compress_bound'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_compressor.cpp:913: undefined reference to `libdeflate_free_compressor'
/usr/bin/ld: src/port/CMakeFiles/cpl.dir/cpl_vsil_gzip.cpp.o: in function `CPLZLibDeflate':
/home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3355: undefined reference to `libdeflate_alloc_compressor'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3364: undefined reference to `libdeflate_zlib_compress_bound'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3372: undefined reference to `libdeflate_free_compressor'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3384: undefined reference to `libdeflate_zlib_compress'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3386: undefined reference to `libdeflate_free_compressor'
/usr/bin/ld: src/port/CMakeFiles/cpl.dir/cpl_vsil_gzip.cpp.o: in function `CPLZLibInflate':
/home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3457: undefined reference to `libdeflate_alloc_decompressor'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3467: undefined reference to `libdeflate_gzip_decompress'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3472: undefined reference to `libdeflate_zlib_decompress'
/usr/bin/ld: /home/uilian/.conan2/p/b/gdal9fc0454b5af40/b/src/port/cpl_vsil_gzip.cpp:3475: undefined reference to `libdeflate_free_decompressor'
collect2: error: ld returned 1 exit status
```

The full build log can be found at https://gist.githubusercontent.com/uilianries/a080359911fa26671c2d457474131c29/raw/a9c2ead60e9c1d0d984166edf09dfe98c222e630/gdal-3.5.3-linux-deflate.log

/cc @Novskilol

closes #28263

#### Details

The `replace_in_file` that patched `libdeflate` was introduced by the PR #19298 when porting GDAL to Conan 2.x. However, there is no specific comment reporting the need of that change.

The CI only passed until a few months because the dependency `libtiff` had `libdeflate` in common, exposing it when linking. But after a [recipe update](https://github.com/conan-io/conan-center-index/pull/28031/files#diff-126e948f9cf1388f5d59bef48623f3ac91390ad4a43a2abab4d8399cafe29e56L40) in `libtiff`, the `libdeflate` is no longer used as default dependency, exposing the original bug. 

Doing an extra search, no other package manager need such patch:

- Conda has libdeflate as a dependency, but no patch applied: https://github.com/conda-forge/gdal-feedstock/blob/main/recipe/meta.yaml

- Homebew has libdeflate as a dependency but no related patch: https://github.com/Homebrew/homebrew-core/blob/c75644d0366896edf4dda9807ef3d10b5dac5b4c/Formula/g/gdal.rb

- Spack has libdeflate as a dependency but no related patch: https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/gdal/package.py

- Arch Linux has libdeflate as a dependency but no related patch: https://gitlab.archlinux.org/archlinux/packaging/packages/gdal/-/blob/main/PKGBUILD?ref_type=heads#L77

- Debian has libdeflate as a dependency but no related patch:
https://salsa.debian.org/debian-gis-team/gdal/-/tree/master/debian/patches?ref_type=heads


Once that patch is removed, the recipe can be built without errors: https://gist.githubusercontent.com/uilianries/a080359911fa26671c2d457474131c29/raw/a9c2ead60e9c1d0d984166edf09dfe98c222e630/gdal-3.5.3-linux-no-patch.log

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
