### PR TITLE
Etl 20.43.0

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -2,12 +2,6 @@ sources:
   "20.43.0":
     url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.43.0.tar.gz"
     sha256: "98106a7bc3a858035251868fa8ed036b1a9e3095714bf0b4cbf8c8e51c4d4234"
-  "20.42.2":
-    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.42.2.tar.gz"
-    sha256: "32d16f5daae57b97a4c523aed98975c2760b3e9de4dae770b5b199f4602c050a"
-  "20.41.7":
-    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.41.7.tar.gz"
-    sha256: "10a26f084fcd603bc2b2b8df98221c8896036a558f069acaa1fbaecce7974a39"
   "20.40.0":
     url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.40.0.tar.gz"
     sha256: "b47ca70e7394f50dd2d65dddfd088757525488ac2fd934f435705fbf3ffe6d3d"

--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,13 @@
 sources:
+  "20.43.0":
+    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.43.0.tar.gz"
+    sha256: "98106a7bc3a858035251868fa8ed036b1a9e3095714bf0b4cbf8c8e51c4d4234"
+  "20.42.2":
+    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.42.2.tar.gz"
+    sha256: "32d16f5daae57b97a4c523aed98975c2760b3e9de4dae770b5b199f4602c050a"
+  "20.41.7":
+    url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.41.7.tar.gz"
+    sha256: "10a26f084fcd603bc2b2b8df98221c8896036a558f069acaa1fbaecce7974a39"
   "20.40.0":
     url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.40.0.tar.gz"
     sha256: "b47ca70e7394f50dd2d65dddfd088757525488ac2fd934f435705fbf3ffe6d3d"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,10 @@
 versions:
+  "20.43.0":
+    folder: all
+  "20.42.2":
+    folder: all
+  "20.41.7":
+    folder: all
   "20.40.0":
     folder: all
   "20.39.4":

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,10 +1,6 @@
 versions:
   "20.43.0":
     folder: all
-  "20.42.2":
-    folder: all
-  "20.41.7":
-    folder: all
   "20.40.0":
     folder: all
   "20.39.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **etl/20.43.0**

#### Motivation
etl has not been updated for 3 minor releases.  There is already an open PR #27558 but it seems inactive.

#### Details
Add the missing minor release, `20.43.0`.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
