### PR TITLE
Update fontconfig recipe meson version

### DIFF
--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -53,7 +53,7 @@ class FontconfigConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("gperf/3.1")
-        self.tool_requires("meson/[>=1.4.0 <1.5]")
+        self.tool_requires("meson/[>=1.4.0 <2]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.1.0")
 

--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -53,7 +53,7 @@ class FontconfigConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("gperf/3.1")
-        self.tool_requires("meson/1.4.0")
+        self.tool_requires("meson/[>=1.4.0 <1.5]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.1.0")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **meson/2.15.0**

#### Motivation
To create a git revision of the repository that is self-contained when building fontconfig/2.15.0

This PR ensures that, in the event that a build of meson is necessary when building fontconfig/2.15.0, we are able to do that.

fixes #IssueNumber

#### Details
The meson recipe was updated two weeks ago, among the changes version 1.4.0 was removed and version 1.4.1 was added. 

The requirement for meson is updated to include all versions 1.4.x.

Fixes #28286 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan