### PR TITLE
Bump asio-grpc/3.5.0 with boost/1.88.0

### DIFF
--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.0":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.5.0.tar.gz"
+    sha256: "b189fe66a2c74d9a790fc156751445412b59d27f2ddd121e5ddf0a8668194170"
   "3.4.1":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.4.1.tar.gz"
     sha256: "3ca10e22ac628e1983ba87eff4e913e751dd66294a5ea76ca94a60ac014171f9"

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -58,7 +58,7 @@ class AsioGrpcConan(ConanFile):
         use_latest = Version(self.version) > "2.8"
         self.requires("grpc/1.67.1", transitive_headers=True, transitive_libs=True)
         if (self.options.get_safe("local_allocator") == "boost_container" and Version(self.version) < "3.0.0") or self.options.backend == "boost":
-            version = "1.86.0" if use_latest else "1.83.0"
+            version = "1.88.0" if use_latest else "1.83.0"
             self.requires(f"boost/{version}", transitive_headers=True)
         if self.options.backend == "asio":
             version = "1.32.0" if use_latest else "1.29.0"

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5.0":
+    folder: all
   "3.4.1":
     folder: all
   "2.9.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  asio-grpc/3.5.0

#### Motivation
boost 1.86 has regression where bad_executor thrown, see [beast issue 1599](https://github.com/boostorg/beast/issues/1599) and [beast pr 2926](https://github.com/boostorg/beast/pull/2926).

#### Details
Update boost version to 1.88. 


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
