### PR TITLE
highfive: add v3.1.1

### DIFF
--- a/recipes/highfive/all/conandata.yml
+++ b/recipes/highfive/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.1":
+    url: "https://github.com/highfive-devs/highfive/archive/refs/tags/v.3.1.1.tar.gz"
+    sha256: "c0bc76b01868a133bf4550a07321923c5582fe3967edc102864b082e40799914"
   "2.10.0":
     url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.10.0.tar.gz"
     sha256: "c29e8e1520e7298fabb26545f804e35bb3af257005c1c2df62e39986458d7c38"

--- a/recipes/highfive/all/conanfile.py
+++ b/recipes/highfive/all/conanfile.py
@@ -2,16 +2,17 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.54.0"
 
 class HighFiveConan(ConanFile):
     name = "highfive"
-    description = "HighFive is a modern header-only C++11 friendly interface for libhdf5."
+    description = "User-friendly, header-only, C++14 wrapper for HDF5."
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/BlueBrain/HighFive"
+    homepage = "https://github.com/highfive-devs/highfive"
     topics = ("hdf5", "hdf", "data", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
@@ -48,17 +49,22 @@ class HighFiveConan(ConanFile):
         self.info.clear()
 
     def validate(self):
-        check_min_cppstd(self, 11)
+        if Version(self.version) < "3.0.0":
+            check_min_cppstd(self, 11)
+        else:
+            check_min_cppstd(self, 14)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["USE_BOOST"] = self.options.with_boost
-        tc.cache_variables["USE_EIGEN"] = self.options.with_eigen
-        tc.cache_variables["USE_XTENSOR"] = self.options.with_xtensor
-        tc.cache_variables["USE_OPENCV"] = self.options.with_opencv
+        if Version(self.version) < "3.0.0":
+            tc.cache_variables["USE_BOOST"] = self.options.with_boost
+            tc.cache_variables["USE_EIGEN"] = self.options.with_eigen
+            tc.cache_variables["USE_XTENSOR"] = self.options.with_xtensor
+            tc.cache_variables["USE_OPENCV"] = self.options.with_opencv
+
         tc.cache_variables["HIGHFIVE_UNIT_TESTS"] = False
         tc.cache_variables["HIGHFIVE_EXAMPLES"] = False
         tc.cache_variables["HIGHFIVE_BUILD_DOCS"] = False
@@ -85,7 +91,11 @@ class HighFiveConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "HighFive")
-        self.cpp_info.set_property("cmake_target_name", "HighFive")
+        if Version(self.version) < "3.0.0":
+            self.cpp_info.set_property("cmake_target_name", "HighFive")
+        else:
+            self.cpp_info.set_property("cmake_target_name", "HighFive::HighFive")
+
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.requires = ["hdf5::hdf5"]

--- a/recipes/highfive/all/test_package/CMakeLists.txt
+++ b/recipes/highfive/all/test_package/CMakeLists.txt
@@ -4,5 +4,11 @@ project(test_package LANGUAGES CXX)
 find_package(HighFive REQUIRED CONFIG)
 
 add_executable(test_package test_package.cpp)
-target_link_libraries(test_package PRIVATE HighFive)
-target_compile_features(test_package PRIVATE cxx_std_11)
+
+if (${HighFive_VERSION} VERSION_LESS 3.0.0)
+    target_link_libraries(test_package PRIVATE HighFive)
+    target_compile_features(test_package PRIVATE cxx_std_11)
+else()
+    target_link_libraries(test_package PRIVATE HighFive::HighFive)
+    target_compile_features(test_package PRIVATE cxx_std_14)
+endif()


### PR DESCRIPTION
### Summary
Changes to recipe:  **highfive/all**

HighFive v3 comes with several changes:
- The [original repository](https://github.com/BlueBrain/HighFive) on GitHub has been archived. The new repository is found at [github.com/highfive-devs/highfive](https://github.com/highfive-devs/highfive)
- The authors provide a migration guide in the [docs](https://highfive-devs.github.io/highfive/md__2home_2runner_2work_2highfive_2highfive_2doc_2migration__guide.html).
  From a packaging perspective, these I believe are the most relevant changes:
  - The CMake code has been reworked, the new target is now called `HighFive::HighFive` instead of just `HighFive`
  - Build knobs like `-DHIGHFIVE_USE_BOOST` have been removed.
  - Project now requires at least `C++14`


#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
