### PR TITLE
cpp-jwt: add version 1.5.1

### DIFF
--- a/recipes/cpp-jwt/all/conandata.yml
+++ b/recipes/cpp-jwt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.1":
+    url: "https://github.com/arun11299/cpp-jwt/archive/refs/tags/v1.5.1.tar.gz"
+    sha256: "7e5ec6891254c8f00128952ed6b9a73d827539136c3b804563521a0042abe72c"
   "1.5":
     url: "https://github.com/arun11299/cpp-jwt/archive/refs/tags/v1.5.tar.gz"
     sha256: "44a59d619b0a82cae6334bb7d430d27b7fc7595e872c9f20d46aa96d2301edb2"
@@ -12,6 +15,8 @@ sources:
     url: "https://github.com/arun11299/cpp-jwt/archive/refs/tags/v1.2.tar.gz"
     sha256: "5d0102d182c48ef520f3fb15412fbaa67e002e1bf90b3ba45d5a2c7f850371f7"
 patches:
+  "1.5.1":
+    - patch_file: "patches/001-fix-msvc-14-compilation.patch"
   "1.5":
     - patch_file: "patches/001-fix-msvc-14-compilation.patch"
   "1.4":

--- a/recipes/cpp-jwt/config.yml
+++ b/recipes/cpp-jwt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.1":
+    folder: all
   "1.5":
     folder: all
   "1.4":


### PR DESCRIPTION
### Summary
[Add version ](cpp-jwt: add version 1.5.1)

#### Motivation
A new bug fix relese of cpp-jwt was released: https://github.com/arun11299/cpp-jwt/releases/tag/v1.5.1

#### Details
Add a new version.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
