### PR TITLE
simde: Switch meson tool_requires to use a version range

### DIFF
--- a/recipes/simde/all/conanfile.py
+++ b/recipes/simde/all/conanfile.py
@@ -26,7 +26,7 @@ class SIMEeConan(ConanFile):
         self.info.clear()
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.2")
+        self.tool_requires("meson/[>=1.3.1 <2]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.0.3")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **simde/x** (all supported versions)

#### Motivation
Switch to version range for meson to allow building simde. Due to #27650 the current version is no longer available so that when using CCI via the `local-recipes-index` and `--build missing`, it will fail to find the meson version requested.

#### Details
I use a local fork of CCI with a few changes that I depend on with `local-recipes-index`. I'm stay mostly true to CCI and today I run my somewhat monthly update to CCI and now needed to hotfix a few recipes in my branch for this.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
