### PR TITLE
wayland-protocols: Use meson version range

### DIFF
--- a/recipes/wayland-protocols/all/conanfile.py
+++ b/recipes/wayland-protocols/all/conanfile.py
@@ -28,7 +28,7 @@ class WaylandProtocolsConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} only supports Linux")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.3.0")
+        self.tool_requires("meson/[>=1.3.1 <2]")
 
     def layout(self):
         basic_layout(self, src_folder="src")


### PR DESCRIPTION
### Summary
Changes to recipe:  **wayland-protocols/x** (all supported versions)

#### Motivation
Switch to version range for meson to allow building simde. Due to #27650 the current version is no longer available so that when using CCI via the `local-recipes-index` repo type and `--build missing`, it will fail to find the meson version requested.

#### Details
I use a local fork of CCI with a few changes that I depend on with `local-recipes-index`. I'm stay mostly true to CCI and today I run my somewhat monthly update to CCI and now needed to hotfix a few recipes in my branch for this.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
