### PR TITLE
coal (hpp-fcl): added new library

### DIFF
--- a/recipes/coal/all/conandata.yml
+++ b/recipes/coal/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.0.1":
+    url: "https://github.com/coal-library/coal/releases/download/v3.0.1/coal-3.0.1.tar.gz"
+    sha256: "b9609301baefbbf45b4e0f80865abc2b2dcbb69c323a55b0cd95f141959c478c"

--- a/recipes/coal/all/conanfile.py
+++ b/recipes/coal/all/conanfile.py
@@ -1,0 +1,92 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, replace_in_file
+from conan.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=2.1"
+
+
+class CoalConan(ConanFile):
+    name = "coal"
+    description = "An extension of the Flexible Collision Library"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/coal-library/coal"
+    topics = ("geometry", "collision")
+    package_type = "shared-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "with_qhull": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "with_qhull": False,
+    }
+    implements = ["auto_shared_fpic"]
+
+    short_paths = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("eigen/[>=3.4.0]", transitive_headers=True)
+        self.requires("boost/[>=1.82.0 <2]", transitive_headers=True)
+        self.requires("assimp/5.4.3")
+        self.requires("octomap/1.10.0")
+        if self.options.with_qhull:
+            self.requires("qhull/8.0.2")
+
+    def validate(self):
+        if self.options.with_qhull and (
+            self.dependencies["qhull"].options.shared or not self.dependencies["qhull"].options.reentrant
+        ):
+            raise ConanInvalidConfiguration("coal:with_qhull=True requires qhull/*:shared=False and qhull/*:reentrant=True")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.22 <5]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_PYTHON_INTERFACE"] = False
+        tc.cache_variables["COAL_HAS_QHULL"] = self.options.with_qhull
+        tc.generate()
+
+    def _patch_sources(self):
+        if not self.dependencies["octomap"].options.shared:
+            replace_in_file(
+                self,
+                os.path.join(self.source_folder, "src", "CMakeLists.txt"),
+                "TARGETS octomap",
+                "TARGETS octomap-static",
+            )
+        if self.options.with_qhull:
+            # qhull should always be linked statically so use conan target instead
+            replace_in_file(
+                self,
+                os.path.join(self.source_folder, "src", "CMakeLists.txt"),
+                "Qhull::qhull_r",
+                "Qhull::qhullstatic_r",
+            )
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_target_aliases", ["coal"])
+        self.cpp_info.libs = ["coal"]

--- a/recipes/coal/all/test_package/CMakeLists.txt
+++ b/recipes/coal/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(coal REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE coal::coal)
+

--- a/recipes/coal/all/test_package/conanfile.py
+++ b/recipes/coal/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")
+

--- a/recipes/coal/all/test_package/test_package.cpp
+++ b/recipes/coal/all/test_package/test_package.cpp
@@ -1,0 +1,51 @@
+#include "coal/BVH/BVH_model.h"
+#include "coal/collision.h"
+#include "coal/collision_data.h"
+#include "coal/math/transform.h"
+#include "coal/mesh_loader/loader.h"
+#include <iostream>
+#include <memory>
+
+std::shared_ptr<coal::ConvexBase> loadConvexMesh(const std::string &file_name) {
+  coal::NODE_TYPE bv_type = coal::BV_AABB;
+  coal::MeshLoader loader(bv_type);
+  coal::BVHModelPtr_t bvh = loader.load(file_name);
+  bvh->buildConvexHull(true, "Qt");
+  return bvh->convex;
+}
+
+int main() {
+  std::shared_ptr<coal::Ellipsoid> shape1 =
+      std::make_shared<coal::Ellipsoid>(0.7, 1.0, 0.8);
+  std::shared_ptr<coal::Ellipsoid> shape2 =
+      std::make_shared<coal::Ellipsoid>(1.0, 2.0, 3.8);
+
+  coal::Transform3s T1;
+  T1.setQuatRotation(coal::Quaternion3f::UnitRandom());
+  T1.setTranslation(coal::Vec3s::Random());
+  coal::Transform3s T2 = coal::Transform3s::Identity();
+  T2.setQuatRotation(coal::Quaternion3f::UnitRandom());
+  T2.setTranslation(coal::Vec3s::Random());
+
+  coal::CollisionRequest col_req;
+  col_req.security_margin = 1e-1;
+  coal::CollisionResult col_res;
+
+  coal::collide(shape1.get(), T1, shape2.get(), T2, col_req, col_res);
+  std::cout << "Collision? " << col_res.isCollision() << "\n";
+  if (col_res.isCollision()) {
+    coal::Contact contact = col_res.getContact(0);
+    std::cout << "Penetration depth: " << contact.penetration_depth << "\n";
+    std::cout << "Distance between the shapes including the security margin: "
+              << contact.penetration_depth + col_req.security_margin << "\n";
+    std::cout << "Witness point on shape1: "
+              << contact.nearest_points[0].transpose() << "\n";
+    std::cout << "Witness point on shape2: "
+              << contact.nearest_points[1].transpose() << "\n";
+    std::cout << "Normal: " << contact.normal.transpose() << "\n";
+  }
+
+  col_res.clear();
+
+  return 0;
+}

--- a/recipes/coal/config.yml
+++ b/recipes/coal/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.0.1":
+    folder: all


### PR DESCRIPTION
### Summary

Add new recipe `coal` - https://github.com/coal-library/coal
This project is a fork of the `flexible collision library`, mostly known as `FCL`, being an extension of the original project.


#### Motivation

This library was requested in https://github.com/conan-io/conan-center-index/issues/25161. The name of the library back in time was `hpp-fcl`, but in 2024, it was renamed to Coal.

#### Details

This PR surpasses https://github.com/conan-io/conan-center-index/pull/25219, created by @sun-mir
 
**Important considerations:**
- This is a shared library, check upstream [CMakeLists.txt](https://github.com/coal-library/coal/blob/devel/src/CMakeLists.txt#L136-L140)
- This project optionally (default False) depends on `qhull`. But our current `qhull` recipe does not provide C++ targets (libqhullcpp) so this PR  (https://github.com/conan-io/conan-center-index/pull/28312) has been opened in order to allow `coal` compile with convex hulls support.
- `coal` also has an extra optional dependency, `octomap`, but seems to be enabled by default and to explicitly disable it needs some patches. Thus, I've decided to leave it as a unconditional depenedency, this way, we avoid creating extra options which has not been requested.


--- 
Close https://github.com/conan-io/conan-center-index/issues/25161
Close https://github.com/conan-io/conan-center-index/pull/25219