### PR TITLE
fix freetype for mingw

### DIFF
--- a/recipes/freetype/meson/conanfile.py
+++ b/recipes/freetype/meson/conanfile.py
@@ -158,7 +158,8 @@ class FreetypeConan(ConanFile):
             # Duplicate DLL name for backwards compatibility with earlier recipe revisions
             # See https://github.com/conan-io/conan-center-index/issues/23768
             suffix = "d" if self.settings.build_type == "Debug" else ""
-            src = os.path.join(self.package_folder, "bin", "freetype-6.dll")
+            prefix = "lib" if self.settings.compiler == "gcc" else ""  # For MinGW
+            src = os.path.join(self.package_folder, "bin", f"{prefix}freetype-6.dll")
             dst = os.path.join(self.package_folder, "bin", f"freetype{suffix}.dll")
             shutil.copyfile(src, dst)
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **freetype**

#### Motivation

Related to https://github.com/conan-io/conan/issues/18852

The recipe fails when using ``MinGW`` compiler, because one of the file copy operations expects ``freetype-6.dll`` instead of the file ``libfreetype-6.dll`` that MinGW build creates

I have tested this change locally with my MinGW profile:
```
[settings]
arch=x86_64
build_type=Debug
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13.2
os=Windows

[options]
*:shared=True

[conf]
tools.build:compiler_executables={'c': 'C:/ws/msys64/mingw64/bin/gcc.exe', 'cpp': 'C:/ws/msys64/mingw64/bin/g++.exe'}
tools.env.virtualenv:powershell=powershell.exe

[buildenv]
PATH=+(path)C:\ws\msys64\mingw64\bin
```
