### PR TITLE
assimp: relax minimum cppstd on consumer side

### DIFF
--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -198,9 +198,11 @@ class AssimpConan(ConanFile):
         if self._depends_on_openddlparser:
             self.requires("openddl-parser/0.5.1")
 
+    def validate_build(self):
+        check_min_cppstd(self, self._min_cppstd)
+
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, 11)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")


### PR DESCRIPTION
### Summary
Changes to recipe:  **assimp**

#### Motivation

When running the following GH action: https://github.com/conan-io/conan-center-index/pull/28314/checks?check_run_id=49330033428 we found that assimp is forcing a C++ standard in the consumer side greater than it may need.

It is true that for building the library, C++ 11 or 17 (depending on the lib version) is needed, but for consuming is different. There seems to be non include in public headers incompatible with C++11 so I've modified the recipe to support consuming this package on a C++11 context.

