### PR TITLE
splunk-opentelemetry-cpp: deprecate

### DIFF
--- a/recipes/splunk-opentelemetry-cpp/all/conanfile.py
+++ b/recipes/splunk-opentelemetry-cpp/all/conanfile.py
@@ -13,6 +13,7 @@ required_conan_version = ">=1.53.0"
 class SplunkOpentelemetryConan(ConanFile):
     name = "splunk-opentelemetry-cpp"
     description = "Splunk's distribution of OpenTelemetry C++"
+    deprecated = "Deprecated and no longer maintained by authors - Please use the official OpenTelemetry C++ SDK instead."
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/signalfx/splunk-otel-cpp"


### PR DESCRIPTION
This library is no longer maintained by authors, see notice at
https://github.com/signalfx/splunk-otel-cpp/

A further commit will remove this from the master branch, however all published versions will continue to be served by the Conan Center remote.
