### PR TITLE
android-ndk: add version r28c

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,4 +1,17 @@
 sources:
+  "r28c":
+    "Windows":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r28c-windows.zip"
+        sha256: "6bec98ac2354d8a919760889a1a41d020132e5e8cfa1b1fe51610a72c36a466b"
+    "Linux":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r28c-linux.zip"
+        sha256: "dfb20d396df28ca02a8c708314b814a4d961dc9074f9a161932746f815aa552f"
+    "Macos":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r28c-darwin.zip"
+        sha256: "0d4599e8bbf1a1668a0d51a541729b2246360f350018a2081d0b302dbb594f2a"
   "r28b":
     "Windows":
       "x86_64":

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "r28c":
+    folder: all
   "r28b":
     folder: all
   "r27c":


### PR DESCRIPTION
### Summary
Changes to recipe:  **android-ndk/r28c**

#### Motivation
Bump version to r28c.

#### Details
Just a version bump.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
