### PR TITLE
Fix rsync compilation options (#28347)

### DIFF
--- a/recipes/rsync/all/conanfile.py
+++ b/recipes/rsync/all/conanfile.py
@@ -81,8 +81,8 @@ class RsyncConan(ConanFile):
             f"--enable-acl-support={yes_no(self.options.enable_acl)}",
             f"--with-included-zlib={yes_no(not self.options.with_zlib)}",            
             "--disable-openssl" if not self.options.with_openssl else "--enable-openssl",
-            f"--with-zstd={yes_no(self.options.with_zstd)}",
-            f"--with-lz4={yes_no(self.options.with_lz4)}",
+            "--disable-zstd" if not self.options.with_zstd else "--enable-zstd",
+            "--disable-lz4" if not self.options.with_lz4 else "--enable-lz4",
             f"--with-xxhash={yes_no(self.options.with_xxhash)}",
 
             "--enable-manpages=no",

--- a/recipes/rsync/all/conanfile.py
+++ b/recipes/rsync/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.apple import is_apple_os
 import os
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=1.60.0"
 
 class RsyncConan(ConanFile):
     name = "rsync"
@@ -36,6 +36,10 @@ class RsyncConan(ConanFile):
     }
     languages = "C"
 
+    def configure(self):
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -53,7 +57,7 @@ class RsyncConan(ConanFile):
             self.requires("zlib/[>=1.2.11 <2]")
 
         if self.options.with_zstd:
-            self.requires("zstd/1.5.5")
+            self.requires("zstd/[>=1.5.5 <1.6]")
 
         if self.options.with_lz4:
             self.requires("lz4/1.9.2")

--- a/recipes/rsync/all/conanfile.py
+++ b/recipes/rsync/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.apple import is_apple_os
 import os
 
-required_conan_version = ">=1.60.0"
+required_conan_version = ">=2.4"
 
 class RsyncConan(ConanFile):
     name = "rsync"
@@ -34,10 +34,7 @@ class RsyncConan(ConanFile):
         "with_lz4": True,
         "enable_acl": False
     }
-    
-    def configure(self):
-        self.settings.rm_safe("compiler.libcxx")
-        self.settings.rm_safe("compiler.cppstd")
+    languages = "C"
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -83,8 +80,7 @@ class RsyncConan(ConanFile):
             "--disable-openssl" if not self.options.with_openssl else "--enable-openssl",
             "--disable-zstd" if not self.options.with_zstd else "--enable-zstd",
             "--disable-lz4" if not self.options.with_lz4 else "--enable-lz4",
-            f"--with-xxhash={yes_no(self.options.with_xxhash)}",
-
+            "--disable-xxhash" if not self.options.with_xxhash else "--enable-xxhash",
             "--enable-manpages=no",
         ])        
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **rsync/3.2.7**

#### Motivation
Fix rsync broken recipe (see #28347).

#### Details
The generated compilation options according to the Conan recipes are wrong (details in the ticket).
This PR fixes the recipe with the correct options for zstd and lz4.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
