### PR TITLE
add nodejs-headers package

### DIFF
--- a/recipes/nodejs-headers/all/conandata.yml
+++ b/recipes/nodejs-headers/all/conandata.yml
@@ -1,0 +1,39 @@
+sources:
+    "22.19.0":
+        Headers:
+            url: "https://nodejs.org/dist/v22.19.0/node-v22.19.0-headers.tar.xz"
+            sha256: "12a22367bd09674d04b95265f14295d737892bd682b99aad3122364d36e1ac8f"
+        Windows:
+            import_libs:
+                "x86_64":
+                    url: "https://nodejs.org/dist/v22.19.0/win-x64/node.lib"
+                    sha256: "4af0951712fb05a686a03e0592880e195ba53e5eb70e224d7ea7b8b76f2a3e86"
+                "armv8":
+                    url: "https://nodejs.org/dist/v22.19.0/win-arm64/node.lib"
+                    sha256: "c174ae3348a4a59c9d61629a7a73a38679fd27c55b2a7d85a2ea3e65de2beb13"
+            pdbs:
+                "x86_64":
+                    url: "https://nodejs.org/dist/v22.19.0/win-x64/node_pdb.zip"
+                    sha256: "0145b60fb83e2f0007d2a7cf98922530a66d906e6fcf73ab9ed061ac8a282cce"
+                "armv8":
+                    url: "https://nodejs.org/dist/v22.19.0/win-arm64/node_pdb.zip"
+                    sha256: "9bd3d552eb550cdab011b8090a1f6bfa95656ea59301d5e8b9f76114204f80a5"
+    "20.19.5":
+        Headers:
+            url: "https://nodejs.org/dist/v20.19.5/node-v20.19.5-headers.tar.xz"
+            sha256: "63ffe7c8e3cdce5c1a75d8ad8ed1d2dc3956343d012bec84e7c51a182ca8824f"
+        Windows:
+            import_libs:
+                "x86_64":
+                    url: "https://nodejs.org/dist/v20.19.5/win-x64/node.lib"
+                    sha256: "7d545cfcf38456553e83f419c72e91bf9bc80500bf8c0f3f838a7be020e88def"
+                "armv8":
+                    url: "https://nodejs.org/dist/v20.19.5/win-arm64/node.lib"
+                    sha256: "dd8b0acfe80fa4ac731561848405b173cdc16ade8347e0ebb59bdb7aee668ed1"
+            pdbs:
+                "x86_64":
+                    url: "https://nodejs.org/dist/v20.19.5/win-x64/node_pdb.zip"
+                    sha256: "a70c814f6ea5e8c06bf08f6644a883be9e8479362bce639ef8caf62fd2345cf4"
+                "armv8":
+                    url: "https://nodejs.org/dist/v20.19.5/win-arm64/node_pdb.zip"
+                    sha256: "6888ddb1259551a24b26b8ca1883a0a08126ca23d17cc6504c682aeaa1665310"

--- a/recipes/nodejs-headers/all/conanfile.py
+++ b/recipes/nodejs-headers/all/conanfile.py
@@ -1,0 +1,61 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get, download, collect_libs
+
+required_conan_version = ">=1.59.0"
+
+
+class NodeJSHeadersConan(ConanFile):
+    name = "nodejs-headers"
+    description = "Resources for building/linking Node.js native addons"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://nodejs.org"
+    topics = ("node", "napi", "headers", "header-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+    short_paths = True
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    @property
+    def _dl_info_headers(self):
+        return self.conan_data["sources"].get(self.version, {}).get("Headers")
+
+    @property
+    def _dl_info_import_libs(self):
+        return self.conan_data["sources"].get(self.version, {}).get(str(self.settings.os), {}).get("import_libs", {}).get(str(self.settings.arch), {})
+
+    @property
+    def _dl_info_pdbs(self):
+        return self.conan_data["sources"].get(self.version, {}).get(str(self.settings.os), {}).get("pdbs", {}).get(str(self.settings.arch), {})
+
+    def validate(self):
+        if not self._dl_info_headers or (self.settings.os == "Windows" and 
+                                         (not self._dl_info_import_libs or not self._dl_info_pdbs)):
+            raise ConanInvalidConfiguration("Resources for this combination of architecture/version/os not available")
+
+    def build(self):
+        get(self, **self._dl_info_headers, strip_root=True)
+        if self.settings.os == "Windows":
+            download(self, **self._dl_info_import_libs, filename="node.lib")
+            if self.settings.build_type == "Debug":
+                get(self, **self._dl_info_pdbs)
+
+    def package(self):
+        copy(self, "*", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.build_folder, "include"))
+        if self.settings.os == "Windows":
+            copy(self, "node.lib", dst=os.path.join(self.package_folder, "lib"), src=self.build_folder)
+            if self.settings.build_type == "Debug":
+                copy(self, "node.pdb", dst=os.path.join(self.package_folder, "lib"), src=self.build_folder)
+
+    def package_info(self):
+        if self.settings.os == "Windows":
+            self.cpp_info.libs = collect_libs(self)
+

--- a/recipes/nodejs-headers/all/test_package/CMakeLists.txt
+++ b/recipes/nodejs-headers/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(nodejs-headers REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package nodejs-headers::nodejs-headers)

--- a/recipes/nodejs-headers/all/test_package/conanfile.py
+++ b/recipes/nodejs-headers/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/nodejs-headers/all/test_package/test_package.cpp
+++ b/recipes/nodejs-headers/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <node/node_version.h>
+#include <iostream>
+
+int main() {
+    std::cout << "Node.js major version: " << NODE_MAJOR_VERSION << std::endl;
+    return 0;
+}

--- a/recipes/nodejs-headers/config.yml
+++ b/recipes/nodejs-headers/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "22.19.0":
+    folder: all
+  "20.19.5":
+    folder: all


### PR DESCRIPTION
Adds a new package `nodejs-headers` with a couple version variations of the latest LTS headers release provided by nodejs distribution web server, and corresponding import libs and pdbs for Windows