### PR TITLE
libyuv: use version range in libjpeg and mozjpeg

### DIFF
--- a/recipes/libyuv/all/conanfile.py
+++ b/recipes/libyuv/all/conanfile.py
@@ -49,11 +49,11 @@ class LibyuvConan(ConanFile):
 
     def requirements(self):
         if self.options.with_jpeg == "libjpeg":
-            self.requires("libjpeg/9e")
+            self.requires("libjpeg/[>=9e]")
         elif self.options.with_jpeg == "libjpeg-turbo":
             self.requires("libjpeg-turbo/[>=3.0.3 <4]")
         elif self.options.with_jpeg == "mozjpeg":
-            self.requires("mozjpeg/4.1.5")
+            self.requires("mozjpeg/[>=4.1.5 <5]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version])


### PR DESCRIPTION
### Summary
Changes to recipe:  **libyuv**

#### Motivation

Fix version conflict in `SDL_Image`: https://github.com/conan-io/conan-center-index/pull/28361/checks?check_run_id=50030809657


<img width="1787" height="649" alt="image" src="https://github.com/user-attachments/assets/cad47842-5a5e-417f-ab41-c7e6a8b6a752" />

