### PR TITLE
cjson: add version 1.7.19

### DIFF
--- a/recipes/cjson/all/conandata.yml
+++ b/recipes/cjson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.7.19":
+    url: "https://github.com/DaveGamble/cJSON/archive/v1.7.19.tar.gz"
+    sha256: "7fa616e3046edfa7a28a32d5f9eacfd23f92900fe1f8ccd988c1662f30454562"
   "1.7.18":
     url: "https://github.com/DaveGamble/cJSON/archive/v1.7.18.tar.gz"
     sha256: "3aa806844a03442c00769b83e99970be70fbef03735ff898f4811dd03b9f5ee5"

--- a/recipes/cjson/all/conanfile.py
+++ b/recipes/cjson/all/conanfile.py
@@ -71,7 +71,7 @@ class CjsonConan(ConanFile):
         # Relocatable shared lib on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
-        if Version(self.version) > "1.7.18": # pylint: disable=conan-unreachable-upper-version
+        if Version(self.version) > "1.7.19": # pylint: disable=conan-unreachable-upper-version
             raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
         tc.generate()
 

--- a/recipes/cjson/config.yml
+++ b/recipes/cjson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.7.19":
+    folder: all
   "1.7.18":
     folder: all
   "1.7.17":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cjson/1.7.19**

#### Motivation

Multiple bug fixes https://github.com/DaveGamble/cJSON/compare/v1.7.18...v1.7.19

* Fix indentation (should use spaces), see [#814](https://github.com/DaveGamble/cJSON/pull/814)
* Fix spelling errors found by CodeSpell, see [#841](https://github.com/DaveGamble/cJSON/pull/841)
* Check for NULL in cJSON_DetachItemViaPointer, fixes [#882](https://github.com/DaveGamble/cJSON/issues/882), see [#886](https://github.com/DaveGamble/cJSON/pull/886)
* Fix [#881](https://github.com/DaveGamble/cJSON/issues/881), check overlap before calling strcpy in cJSON_SetValuestring, see [#885](https://github.com/DaveGamble/cJSON/pull/885)
* Fix [#880](https://github.com/DaveGamble/cJSON/issues/880) Max recursion depth for cJSON_Duplicate to prevent stack exhaustion, see [#888](https://github.com/DaveGamble/cJSON/pull/888)
* Allocate memory for the temporary buffer when paring numbers, see [#939](https://github.com/DaveGamble/cJSON/pull/939)
* fix the incorrect check in decode_array_index_from_pointer, see [#957](https://github.com/DaveGamble/cJSON/pull/957)

#### Details

* Added source and hash for 1.7.19
* Checked that CMake 4 support still isn't present upstream (it's waiting on https://github.com/DaveGamble/cJSON/pull/935)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
