### PR TITLE
Wayland: stop publishing revisions for older versions

### DIFF
--- a/recipes/wayland/all/conandata.yml
+++ b/recipes/wayland/all/conandata.yml
@@ -2,21 +2,6 @@ sources:
   "1.23.92":
     url: "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.92/downloads/wayland-1.23.92.tar.xz"
     sha256: "c12b5b7eab64b0b4ffb98d39fe21cbaaf4b315ea51f34998344b5ff87a72a887"
-  "1.23.0":
-    url: "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.0/downloads/wayland-1.23.0.tar.xz"
-    sha256: "05b3e1574d3e67626b5974f862f36b5b427c7ceeb965cb36a4e6c2d342e45ab2"
   "1.22.0":
     url: "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.22.0/downloads/wayland-1.22.0.tar.xz"
     sha256: "1540af1ea698a471c2d8e9d288332c7e0fd360c8f1d12936ebb7e7cbc2425842"
-  "1.21.0":
-    url: "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.21.0/downloads/wayland-1.21.0.tar.xz"
-    sha256: "6dc64d7fc16837a693a51cfdb2e568db538bfdc9f457d4656285bb9594ef11ac"
-  "1.20.0":
-    url: "https://wayland.freedesktop.org/releases/wayland-1.20.0.tar.xz"
-    sha256: "b8a034154c7059772e0fdbd27dbfcda6c732df29cae56a82274f6ec5d7cd8725"
-  "1.19.0":
-    url: "https://wayland.freedesktop.org/releases/wayland-1.19.0.tar.xz"
-    sha256: "baccd902300d354581cd5ad3cc49daa4921d55fb416a5883e218750fef166d15"
-  "1.18.0":
-    url: "https://wayland.freedesktop.org/releases/wayland-1.18.0.tar.xz"
-    sha256: "4675a79f091020817a98fd0484e7208c8762242266967f55a67776936c2e294d"

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -89,8 +89,7 @@ class WaylandConan(ConanFile):
         tc.project_options["documentation"] = False
         if not can_run(self):
             tc.project_options["build.pkg_config_path"] = self.generators_folder
-        if Version(self.version) >= "1.18.91":
-            tc.project_options["scanner"] = True
+        tc.project_options["scanner"] = True
         tc.generate()
 
     def _patch_sources(self):
@@ -137,7 +136,7 @@ class WaylandConan(ConanFile):
                 self.cpp_info.components["wayland-server"].system_libs = ["pthread", "m"]
 
             self.cpp_info.components["wayland-server"].resdirs = ["res"]
-            if self.version >= Version("1.21.0") and self.settings.os == "Linux":
+            if self.settings.os == "Linux":
                 self.cpp_info.components["wayland-server"].system_libs += ["rt"]
             self.cpp_info.components["wayland-server"].set_property("component_version", self.version)
             pkgconfig_variables = {
@@ -154,7 +153,7 @@ class WaylandConan(ConanFile):
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["wayland-client"].system_libs = ["pthread", "m"]
             self.cpp_info.components["wayland-client"].resdirs = ["res"]
-            if self.version >= Version("1.21.0") and self.settings.os == "Linux":
+            if self.settings.os == "Linux":
                 self.cpp_info.components["wayland-client"].system_libs += ["rt"]
             self.cpp_info.components["wayland-client"].set_property("component_version", self.version)
             pkgconfig_variables = {

--- a/recipes/wayland/config.yml
+++ b/recipes/wayland/config.yml
@@ -1,15 +1,5 @@
 versions:
   "1.23.92":
     folder: all
-  "1.23.0":
-    folder: all
   "1.22.0":
-    folder: all
-  "1.21.0":
-    folder: all
-  "1.20.0":
-    folder: all
-  "1.19.0":
-    folder: all
-  "1.18.0":
     folder: all


### PR DESCRIPTION
#### Motivation
Need to simplify the number of versions of wayland

#### Details
Wayland/1.20.0 are use by:
- Gtk: using the option “with_wayland” that is False by default but it is a Conan 1.x recipe

Wayland/1.22.0 are use by: 
- glfw: using the option “with_wayland” that is **False** by default 
- fltk: used in all versions of Linux after 1.4
- Freeglut: using the option “with_wayland” that is **True** by default 
- Libinput: using the option “with_wayland” that is **True** by default 
- Libva:  using the option “with_wayland” that is **True** by default 
- Opencv:  using the option “with_wayland” that is **True** by default 
- Qt 5.x and 6.x:  using the option “qtwayland” that is **False** by default 
- Sdl: using the option “waylaid” that is **True** by default 
- Vulkan-loader: used in all versions before 1.3.231 by default
- Xkbcommon: using the option “with_wayland” that is **True** by default 
