### PR TITLE
Fix target names for the versioned variats of Boost::python and Boos::numpy

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -2045,11 +2045,15 @@ class BoostConan(ConanFile):
 
             if not self.options.without_python:
                 pyversion = Version(self._python_version)
-                self.cpp_info.components[f"python{pyversion.major}{pyversion.minor}"].requires = ["python"]
+                python_versioned_component_name = f"python{pyversion.major}{pyversion.minor}"
+                self.cpp_info.components[python_versioned_component_name].requires = ["python"]
+                self.cpp_info.components[python_versioned_component_name].set_property("cmake_target_name", "Boost::" + python_versioned_component_name)
                 if not self._shared:
                     self.cpp_info.components["python"].defines.append("BOOST_PYTHON_STATIC_LIB")
 
-                self.cpp_info.components[f"numpy{pyversion.major}{pyversion.minor}"].requires = ["numpy"]
+                numpy_versioned_component_name = f"numpy{pyversion.major}{pyversion.minor}"
+                self.cpp_info.components[numpy_versioned_component_name].requires = ["numpy"]
+                self.cpp_info.components[numpy_versioned_component_name].set_property("cmake_target_name", "Boost::" + numpy_versioned_component_name)
 
             if not self.options.get_safe("without_process"):
                 if self.settings.os == "Windows":


### PR DESCRIPTION
The `boost` recipe provides two targets that include the python version used at compile time, e.g. when boost is compiled with python 3.10 we get `Boost::python310` and `Boost::numpy310` But these two targets are being generated with the wrong casing on the namespace (`boost` instead of `Boost`).

Before:
```
-- Conan: Component target declared 'Boost::python'
-- Conan: Component target declared 'Boost::numpy'
-- Conan: Component target declared 'boost::python310'
-- Conan: Component target declared 'boost::numpy310'
```

After:
```
-- Conan: Component target declared 'Boost::python'
-- Conan: Component target declared 'Boost::numpy'
-- Conan: Component target declared 'Boost::python310'
-- Conan: Component target declared 'Boost::numpy310'
```


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
