### PR TITLE
[pistache] Proper manage libevent dependency 

### DIFF
--- a/recipes/pistache/all/conanfile.py
+++ b/recipes/pistache/all/conanfile.py
@@ -84,12 +84,12 @@ class PistacheConan(ConanFile):
 
     def generate(self):
         tc = MesonToolchain(self)
-        tc.project_options["PISTACHE_USE_SSL"] = self.options.with_ssl
+        tc.project_options["PISTACHE_USE_SSL"] = bool(self.options.with_ssl)
         tc.project_options["PISTACHE_BUILD_EXAMPLES"] = False
         tc.project_options["PISTACHE_BUILD_TESTS"] = False
         tc.project_options["PISTACHE_BUILD_DOCS"] = False
         if self.settings.os == "Linux" and self._supports_libevent:
-            tc.project_options["PISTACHE_FORCE_LIBEVENT"] = self.options.with_libevent
+            tc.project_options["PISTACHE_FORCE_LIBEVENT"] = bool(self.options.with_libevent)
         tc.generate()
         deps = PkgConfigDeps(self)
         deps.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **pistache/0.0.5**

#### Motivation

fixes #28369

/cc @tzolnai

#### Details

The dependency `libevent` was configured in the recipe to be installed in case not supported. This pull request toggles that logic to only install it when supported and configured to be used as a dependency. It also aligns the recipe to follow the upstream's behavior: libevent is False by default on Linux; on all other platforms, it is mandatory to use libevent. 

Plus, libevent only started to be used by Pistache [0.4.23](https://github.com/pistacheio/pistache/releases/tag/v0.4.23). The old version 0.0.5 is using native `sys/event` instead.

The libevent is only optional for Linux: https://github.com/pistacheio/pistache/blob/v0.4.25/meson.build#L188.

In case using Apple or Windows, it will use libevent always: https://github.com/pistacheio/pistache/blob/v0.4.25/include/pistache/emosandlibevdefs.h#L42

In case using Linux, and the build option `PISTACHE_FORCE_LIBEVENT` is False (default), it will use Linux epoll instead: https://github.com/pistacheio/pistache/blob/v0.4.25/include/pistache/eventmeth.h#L28


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
