### PR TITLE
Relax `nlohmann_json` version requirement of `inja`

### DIFF
--- a/recipes/inja/all/conanfile.py
+++ b/recipes/inja/all/conanfile.py
@@ -40,7 +40,7 @@ class InjaConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("nlohmann_json/3.11.3")
+        self.requires("nlohmann_json/[^3.8]")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
### Summary
Changes to recipe:  **inja/3.4.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

This allows `nlohmann_json` to update to newer versions like 3.12.0.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

Currently, `nlohmann_json` is held back for us due to this transitive requirement.

https://github.com/pantor/inja specifies:
> Inja uses nlohmann/json.hpp (>= v3.8.0)

So this should work fine.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
