### PR TITLE
libavif: fix non existing target "aom" in v1.1.1 

### DIFF
--- a/recipes/libavif/all/conanfile.py
+++ b/recipes/libavif/all/conanfile.py
@@ -101,7 +101,9 @@ class LibAVIFConan(ConanFile):
         apply_conandata_patches(self)
         cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
         if Version(self.version) < "1.1.0":
+            replace_in_file(self, cmakelists, "find_package(libyuv QUIET)", "find_package(libyuv REQUIRED CONFIG)")
             replace_in_file(self, cmakelists, "${LIBYUV_LIBRARY}", "libyuv::libyuv")
+            replace_in_file(self, cmakelists, "find_package(dav1d REQUIRED)", "find_package(dav1d REQUIRED CONFIG)")
             replace_in_file(self, cmakelists, "${DAV1D_LIBRARY}", "dav1d::dav1d")
 
     def build(self):


### PR DESCRIPTION
`libavif` is currently being used by:
```
Usages of libavif
  1.0.4
    - libgd/2.3.3
        condition: self.options.get_safe('with_avif')
        default: False
    - libgd/2.3.2
        condition: self.options.get_safe('with_avif')
        default: False
    - libgd/2.3.1
        condition: self.options.get_safe('with_avif')
        default: False
    - libgd/2.3.0
        condition: self.options.get_safe('with_avif')
        default: False
    - libgd/2.2.5
        condition: self.options.get_safe('with_avif')
        default: False
    - opencv/4.12.0
        condition: self.options.get_safe('with_avif')
        default: False
  1.1.1
    - sdl_image/2.8.2
        condition: self.options.get_safe('with_avif')
        default: False
        version range: [>=1.0.1 <2]
    - sdl_image/2.6.3
        condition: self.options.get_safe('with_avif')
        default: False
        version range: [>=1.0.1 <2]
    - sail/0.9.8
        condition: self.options.with_medium_priority_codecs
        default: True
    - sail/0.9.6
        condition: self.options.with_medium_priority_codecs
        default: True
    - sail/0.9.5
        condition: self.options.with_medium_priority_codecs
        default: True
    - sail/0.9.4
        condition: self.options.with_medium_priority_codecs
        default: True
    - sail/0.9.1
        condition: self.options.with_medium_priority_codecs
        default: True
    - sail/0.9.0
        condition: self.options.with_medium_priority_codecs
        default: True
```

And the latest version in Conan Center Index, `1.1.1` is failing with the following error:
```
CMake Error at CMakeLists.txt:173 (get_target_property):
  get_target_property() called with non-existent target "aom".
Call Stack (most recent call first):
  CMakeLists.txt:548 (avif_target_link_library)


-- libavif: Codec enabled: aom (encode only)
CMake Error at CMakeLists.txt:553 (get_target_property):
  get_target_property() called with non-existent target "aom".
```

This implies that `sail` and `sdl_image/3.x` (not yet merged, see https://github.com/conan-io/conan-center-index/pull/28361) fail to compile with default options.

#### Changes

- Removed `replace_in_file` lines which were not working on newer releases and substituted them for newer Conan v2 style:
```py
        deps.set_property("libaom-av1", "cmake_target_name", "aom") # This lines fix the compilation issue 
        ...
```

- Added latest version, v1.3.0 and respective patch (duplicate of previous patches)