### PR TITLE
hdf5: fix recipe when hdf5/*:enable_cxx=False

### DIFF
--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -96,7 +96,8 @@ class Hdf5Conan(ConanFile):
             raise ConanInvalidConfiguration("with_zlib and with_zlibng cannot be enabled at the same time")
         if self.options.get_safe("with_zlibng") and Version(self.version) < "1.14.5":
             raise ConanInvalidConfiguration("with_zlibng=True is incompatible with versions prior to v1.14.5")
-        check_min_cppstd(self, "11")
+        if self.options.enable_cxx:
+            check_min_cppstd(self, "11")
 
     def validate_build(self):
         if cross_building(self) and Version(self.version) < "1.14.4.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **hdf5/all**

Update recipe to call `check_min_cppstd()` only if `enable_cxx=True`.

Build log w/ error:

```
======== Exporting recipe to the cache ========
hdf5/1.14.6: Exporting package recipe: /tmp/conan-center-index/recipes/hdf5/all/conanfile.py
hdf5/1.14.6: exports: File 'conandata.yml' found. Exporting it...
hdf5/1.14.6: Calling export_sources()
hdf5/1.14.6: export_conandata_patches(): No patches defined in conandata
hdf5/1.14.6: Copied 1 '.yml' file: conandata.yml
hdf5/1.14.6: Copied 1 '.py' file: conanfile.py
hdf5/1.14.6: Exported to cache folder: /home/user/.conan2/p/hdf537be52d59d966/e
hdf5/1.14.6: Exported: hdf5/1.14.6#73e1fdc87f4d7d5033a8e5f11dc2fea3 (2025-09-13 08:06:01 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=clang
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=20
os=Linux
[options]
hdf5/*:enable_cxx=False
hdf5/*:hl=False
hdf5/*:parallel=False
hdf5/*:threadsafe=False

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=clang
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=20
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    hdf5/1.14.6#73e1fdc87f4d7d5033a8e5f11dc2fea3 - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76 - Cache
Build requirements
    cmake/3.31.8#dde3bde00bb843687e55aea5afa0e220 - Cache
Resolved version ranges
    cmake/[>=3.18 <4]: cmake/3.31.8
    zlib/[>=1.2.11 <2]: zlib/1.3.1

======== Computing necessary packages ========
Requirements
    hdf5/1.14.6#73e1fdc87f4d7d5033a8e5f11dc2fea3:e03a5b9aebcb5fa1d7a905c7904e4e365cc7ccc5 - Invalid
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76:c6ba75a49d01b24213beec98d8903a1714c062a0#f0e95ef4b03da938c2eafc4ba4c28786 - Cache
Build requirements
Skipped binaries
    cmake/3.31.8
ERROR: There are invalid packages:
hdf5/1.14.6: Invalid: The compiler.cppstd is not defined for this configuration
```

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
