### PR TITLE
Bison: Check mirror URL by default, before ftp.gnu.org

### DIFF
--- a/recipes/bison/all/conandata.yml
+++ b/recipes/bison/all/conandata.yml
@@ -1,21 +1,21 @@
 sources:
   "3.8.2":
     url:
+      - "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
       - "https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
       - "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
-      - "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
     sha256: "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
   "3.7.6":
     url:
+      - "https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
       - "https://ftpmirror.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
       - "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
-      - "https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz"
     sha256: "69dc0bb46ea8fc307d4ca1e0b61c8c355eb207d0b0c69f4f8462328e74d7b9ea"
   "3.7.1":
     url:
+      - "https://ftp.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
       - "https://ftpmirror.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
       - "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
-      - "https://ftp.gnu.org/gnu/bison/bison-3.7.1.tar.gz"
     sha256: "1dd952839cf0d5a8178c691eeae40dc48fa50d18dcce648b1ad9ae0195367d13"
 patches:
   "3.8.2":


### PR DESCRIPTION
### Summary
Change sources order to recipe  **lib/[version]**

#### Motivation
In conan 2, only the last URL in the sources list is considered. Since ftp.gnu.org is often down or slow, the current list is not working.

#### Details
The workaround is to prefer one of the mirror options (i.e. put this last in the list).
