### PR TITLE
Fix linked boost dependencies in cpprestsdk shared library

### DIFF
--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -58,7 +58,7 @@ class CppRestSDKConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.83.0")
+        self.requires("boost/[>=1.82.0 <=1.83.0]")
         self.requires("openssl/[>=1.1 <4]")
         if self.options.with_compression:
             self.requires("zlib/[>=1.2.11 <2]")
@@ -78,6 +78,7 @@ class CppRestSDKConan(ConanFile):
         tc.variables["WERROR"] = False
         tc.variables["CPPREST_EXCLUDE_WEBSOCKETS"] = not self.options.with_websockets
         tc.variables["CPPREST_EXCLUDE_COMPRESSION"] = not self.options.with_compression
+        tc.variables["CPPREST_USE_CONAN_BOOST"] = True
         if self.options.get_safe("pplx_impl"):
             tc.variables["CPPREST_PPLX_IMPL"] = self.options.pplx_impl
         if self.options.get_safe("http_client_impl"):

--- a/recipes/cpprestsdk/all/patches/0003-find-cmake-targets.patch
+++ b/recipes/cpprestsdk/all/patches/0003-find-cmake-targets.patch
@@ -125,3 +125,20 @@ index 94ea81a..f83a777 100644
 +        target_link_libraries(cpprestsdk_websocketpp_internal INTERFACE "websocketpp::websocketpp")
 +    endif()
  endfunction()
+diff --git a/Release/cmake/cpprest_find_boost.cmake b/Release/cmake/cpprest_find_boost.cmake
+index 3c857ba..9e7077e 100644
+--- a/Release/cmake/cpprest_find_boost.cmake
++++ b/Release/cmake/cpprest_find_boost.cmake
+@@ -51,9 +51,11 @@ function(cpprest_find_boost)
+     find_package(Boost REQUIRED COMPONENTS system date_time regex)
+   endif()
+
++  set(CPPREST_USE_CONAN_BOOST OFF CACHE BOOL "If ON, Boost is provided by Conan.")
++
+   add_library(cpprestsdk_boost_internal INTERFACE)
+   # FindBoost continually breaks imported targets whenever boost updates.
+-  if(1)
++  if(NOT CPPREST_USE_CONAN_BOOST)
+     target_include_directories(cpprestsdk_boost_internal INTERFACE "$<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>")
+     set(_prev)
+     set(_libs)


### PR DESCRIPTION
Previously every boost library has been linked, causing a runtime error.

Use version ranges for boost requirement.

### Summary
Changes to recipe:  **cpprestsdk/2.10.19**

#### Motivation

Fixing runtime error when using dynamic cpprestsdk library which is linked with boost.

Allowing to use `boost/1.82.0` - without raising a conflict - which is also working well with cpprestsdk based on our tests.

#### Details

When building shared cpprestsdk library, all of the boost libraries have been linked to the library, causing runtime error.

Only the expected boost libraries must be linked, which are [already listed](https://github.com/microsoft/cpprestsdk/blob/v2.10.19/Release/cmake/cpprest_find_boost.cmake#L77-L106) in `package_info()`.

The original code says " # FindBoost continually breaks imported targets whenever boost updates.",
however we can guarantee that FindBoost will work whenever we use Conan.

