### PR TITLE
Fix macos llvm-clang build of libx265 and all dependent builds

### DIFF
--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -50,7 +50,7 @@ class Libx265Conan(ConanFile):
         # FIXME: Disable assembly by default if host is arm and compiler apple-clang for the moment.
         # Indeed, apple-clang is not able to understand some asm instructions of libx265
         # FIXME: Disable assembly by default if host is Android for the moment. It fails to build
-        if (self.settings.compiler == "apple-clang" and "arm" in self.settings.arch) or self.settings.os == "Android":
+        if ("arm" in self.settings.arch and self.settings.os == "Macos") or self.settings.os == "Android":
             self.options.assembly = False
         if is_msvc(self) and self.settings.arch == "armv8":
             # Build errors, possibly unsupported


### PR DESCRIPTION
### Summary
Changes to recipe:  **libx265/***

This PR fixes the build for the following build:

Host: macos, apple silicon.
Target: macos, apple silicon
Compiler: Apple-clang, llvm-clang


#### Motivation
I stumbled upon failed opencv build on macos with non apple-clang compiler and found the issue. The assembly build option of libx265 is currently not working on maocs with llvm-clang compiler.

#### Details
Change to the recipe to disable the assembly in the libx265 build.  Modify the if-clause to disable assembly, so that it catches all macos builds, not just those using apple-clang but also for llvm-clang and with GCC 16 also gcc.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x ]Tested locally with at least one configuration using a recent version of Conan
Tested using editable mode on libx265 with macbook pro m1.