### PR TITLE
libavif: add v1.3.0

### DIFF
--- a/recipes/libavif/all/conandata.yml
+++ b/recipes/libavif/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.0":
+    url: "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.3.0.tar.gz"
+    sha256: "0a545e953cc049bf5bcf4ee467306a2f113a75110edf59e61248873101cd26c1"
   "1.1.1":
     url: "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.1.1.tar.gz"
     sha256: "914662e16245e062ed73f90112fbb4548241300843a7772d8d441bb6859de45b"
@@ -6,6 +9,10 @@ sources:
     url: "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.0.4.tar.gz"
     sha256: "dc56708c83a4b934a8af2b78f67f866ba2fb568605c7cf94312acf51ee57d146"
 patches:
+  "1.3.0":
+    - patch_file: patches/1.3.0-0001-disable-developer-only-codepaths.patch
+      patch_description: "disable compiler options for develop"
+      patch_type: "portability"
   "1.1.1":
     - patch_file: patches/1.1.1-0001-disable-developer-only-codepaths.patch
       patch_description: "disable compiler options for develop"

--- a/recipes/libavif/all/patches/1.3.0-0001-disable-developer-only-codepaths.patch
+++ b/recipes/libavif/all/patches/1.3.0-0001-disable-developer-only-codepaths.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 991743c..c70d6cf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -134,11 +134,13 @@ set_local_or_system_option(
+ # Whether the libavif library uses c++ indirectly (e.g. through linking to libyuv).
+ set(AVIF_LIB_USE_CXX OFF)
+ 
++if(0)
+ if(APPLE)
+     set(XCRUN xcrun)
+ else()
+     set(XCRUN)
+ endif()
++endif()
+ 
+ # This is also needed to get shared libraries (e.g. pixbufloader-avif) to compile against a static libavif.
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+@@ -260,6 +262,8 @@ check_avif_option(AVIF_LIBXML2 TARGET LibXml2::LibXml2 PKG_NAME LibXml2)
+ 
+ # ---------------------------------------------------------------------------------------
+ 
++add_library(avif_enable_warnings INTERFACE)
++if(0)
+ # Enable all warnings
+ include(CheckCCompilerFlag)
+ # avif_enable_warnings is a CMake interface library. It has no source files.
+@@ -268,7 +272,6 @@ include(CheckCCompilerFlag)
+ # target_compile_definitions() on avif_enable_warnings. We enable compiler
+ # warnings in a target by linking the target with avif_enable_warnings using
+ # target_link_libraries().
+-add_library(avif_enable_warnings INTERFACE)
+ if(MSVC)
+     message(STATUS "libavif: Enabling warnings for MSVC")
+     target_compile_options(
+@@ -315,6 +318,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
+ else()
+     message(FATAL_ERROR "libavif: Unknown compiler, bailing out")
+ endif()
++endif()
+ 
+ if(AVIF_ENABLE_WERROR)
+     # Warnings as errors

--- a/recipes/libavif/config.yml
+++ b/recipes/libavif/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.0":
+    folder: all
   "1.1.1":
     folder: all
   "1.0.4":


### PR DESCRIPTION
Added the latest libavif version to be used by [SDL_Image 3.x PR](https://github.com/conan-io/conan-center-index/pull/28361)

New patch is a replica of https://github.com/perseoGI/conan-center-index/blob/master/recipes/libavif/all/patches/1.1.1-0001-disable-developer-only-codepaths.patch