### PR TITLE
vulkan-validationlayers: update CMakeLists.txt path for Android build

### DIFF
--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -203,7 +203,7 @@ class VulkanValidationLayersConan(ConanFile):
         if self.settings.os == "Android":
             # INFO: libVkLayer_utils.a: error: undefined symbol: __android_log_print
             # https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/a26638ae9fdd8c40b56d4c7b72859a5b9a0952c9
-            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+            replace_in_file(self, os.path.join(self.source_folder, "layers", "CMakeLists.txt"),
                         "VkLayer_utils PUBLIC Vulkan::Headers", "VkLayer_utils PUBLIC Vulkan::Headers -landroid -llog")
         if not self.options.get_safe("fPIC"):
             replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-validationlayers/1.3.243.0**

#### Motivation
Android build failed because the recipe patched the wrong CMake file. `replace_in_file` couldn’t find the target string and raised an error.

#### Details
Point the Android patch to [`layers/CMakeLists.txt`](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/sdk-1.3.243.0/layers/CMakeLists.txt#L56) so the string is found and replaced (appending `-landroid -llog` to `VkLayer_utils`). No impact on other platforms.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
