### PR TITLE
fmt: add patch for 11.2.0 to build with libc++-21

### DIFF
--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -59,3 +59,5 @@ sources:
 patches:
   "5.3.0":
     - patch_file: "patches/fix-install-5.3.0.patch"
+  "11.2.0":
+    - patch_file: "patches/fix-malloc-free-11.2.0.patch"

--- a/recipes/fmt/all/patches/fix-malloc-free-11.2.0.patch
+++ b/recipes/fmt/all/patches/fix-malloc-free-11.2.0.patch
@@ -1,0 +1,26 @@
+--- a/include/fmt/format.h
++++ b/include/fmt/format.h
+@@ -44,6 +44,7 @@
+ #  include <cmath>    // std::signbit
+ #  include <cstddef>  // std::byte
+ #  include <cstdint>  // uint32_t
++#  include <cstdlib>  // std::malloc, std::free
+ #  include <cstring>  // std::memcpy
+ #  include <limits>   // std::numeric_limits
+ #  include <new>      // std::bad_alloc
+@@ -744,12 +745,12 @@
+
+   T* allocate(size_t n) {
+     FMT_ASSERT(n <= max_value<size_t>() / sizeof(T), "");
+-    T* p = static_cast<T*>(malloc(n * sizeof(T)));
++    T* p = static_cast<T*>(std::malloc(n * sizeof(T)));
+     if (!p) FMT_THROW(std::bad_alloc());
+     return p;
+   }
+
+-  void deallocate(T* p, size_t) { free(p); }
++  void deallocate(T* p, size_t) { std::free(p); }
+ };
+
+ }  // namespace detail
+


### PR DESCRIPTION
### Summary
Changes to recipe:  **fmt/11.2.0** to fix build errors with clang 21 on macOS

#### Motivation
fmt/11.2.0 build fails with clang 21 + libc++-21 on macOS (installed from homebrew) as described in https://github.com/fmtlib/fmt/issues/4520

#### Details
Applied patch from this commit: https://github.com/fmtlib/fmt/commit/f4345467fce7edbc6b36c3fa1cf197a67be617e2


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
