### PR TITLE
Add recipe for cpp-sqlite

### DIFF
--- a/recipes/cpp-sqlite/all/conandata.yml
+++ b/recipes/cpp-sqlite/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "cci.20241111":
+    url: "https://github.com/ToniLipponen/cpp-sqlite/archive/21be8b5e40c66659456358555af1f980f6b56300.tar.gz"
+    sha256: "b7af147a6ffdcabc99253d64ff6d0fdeb3c2613e019c934731a4cf8f273c3111"
+  "cci.20230222":
+    url: "https://github.com/ToniLipponen/cpp-sqlite/archive/7f931c4e72727332ca2918a6e28b984fd54d7d2d.tar.gz"
+    sha256: "1ff909ccec2b88abb5858fe42c650c34e973d46ca9f6fab8cae5bbab7fcb9007"

--- a/recipes/cpp-sqlite/all/conanfile.py
+++ b/recipes/cpp-sqlite/all/conanfile.py
@@ -1,0 +1,45 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=2.0"
+
+
+class PackageConan(ConanFile):
+    name = "cpp-sqlite"
+    description = "Single file header only sqlite wrapper for C++"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ToniLipponen/cpp-sqlite"
+    topics = ("sqlite", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("sqlite3/3.50.4")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp", self.source_folder, os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["dl", "m", "pthread"])

--- a/recipes/cpp-sqlite/all/test_package/CMakeLists.txt
+++ b/recipes/cpp-sqlite/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(cpp-sqlite REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE cpp-sqlite::cpp-sqlite)

--- a/recipes/cpp-sqlite/all/test_package/conanfile.py
+++ b/recipes/cpp-sqlite/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cpp-sqlite/all/test_package/test_package.cpp
+++ b/recipes/cpp-sqlite/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include "sqlite.hpp"
+
+int main()
+{
+    sqlite::Connection connection("example.db");
+
+    return 0;
+}

--- a/recipes/cpp-sqlite/config.yml
+++ b/recipes/cpp-sqlite/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "cci.20241111":
+    folder: all
+  "cci.20230222":
+    folder: all


### PR DESCRIPTION
This package is needed by behaviortree.cpp.
I'm including both latest and an older version because that's what bt.cpp currently uses and latest is not compatible.

Currently behaviortree.cpp is using a vendored copy of this lib.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
