### PR TITLE
fltk: fix macos compilation when using SDK>=12

### DIFF
--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -147,8 +147,8 @@ class FltkConan(ConanFile):
                 "AppKit", "ApplicationServices", "Carbon", "Cocoa", "CoreFoundation", "CoreGraphics",
                 "CoreText", "CoreVideo", "Foundation", "IOKit",
             ]
-            if "Cocoa" in self.cpp_info.frameworks and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) >= "13":
-                self.cpp_info.frameworks.append("ScreenCaptureKit")
+            self.cpp_info.sharedlinkflags.append("-Wl,-weak_framework,ScreenCaptureKit")
+            self.cpp_info.exelinkflags.append("-Wl,-weak_framework,ScreenCaptureKit")
             if self.options.with_gl:
                 self.cpp_info.frameworks.append("OpenGL")
         elif self.settings.os == "Windows":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fltk**

#### Motivation

`fltk` fails to link against `FL_cocoa.mm` in Macos running modern SDK versions with the following error:

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_SCContentFilter", referenced from:
       in libfltk.a[174](Fl_cocoa.mm.o)
  "_OBJC_CLASS_$_SCScreenshotManager", referenced from:
       in libfltk.a[174](Fl_cocoa.mm.o)
  "_OBJC_CLASS_$_SCShareableContent", referenced from:
       in libfltk.a[174](Fl_cocoa.mm.o)
  "_OBJC_CLASS_$_SCStreamConfiguration", referenced from:
       in libfltk.a[174](Fl_cocoa.mm.o)
ld: symbol(s) not found for architecture arm64
```

This can be easily fixed by adding the [`ScreenCaptureKit`](https://developer.apple.com/documentation/screencapturekit/) framework, which is available since macOS 12 SDK (Xcode 13 / Apple Clang 13+)