### PR TITLE
[expat] Add the latest release of libexpat version 2.7.2

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.7.2":
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_7_2/expat-2.7.2.tar.xz"
+    sha256: "21b778b34ec837c2ac285aef340f9fb5fa063a811b21ea4d2412a9702c88995c"
   "2.7.1":
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_7_1/expat-2.7.1.tar.xz"
     sha256: "354552544b8f99012e5062f7d570ec77f14b412a3ff5c7d8d0dae62c0d217c30"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.7.2":
+    folder: all
   "2.7.1":
     folder: all
   "2.7.0":


### PR DESCRIPTION
Fixes CVE-2025-59375 as per https://github.com/libexpat/libexpat/blob/R_2_7_2/expat/Changes


### Summary
Changes to recipe:  add support for version **expat/2.7.2**

#### Motivation
Fixes CVE-2025-59375 as per https://github.com/libexpat/libexpat/blob/R_2_7_2/expat/Changes

#### Details
simple version addition

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
