### PR TITLE
fmt: add version 12.0.0

### DIFF
--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "12.0.0":
+    url: "https://github.com/fmtlib/fmt/releases/download/12.0.0/fmt-12.0.0.zip"
+    sha256: "1c32293203449792bf8e94c7f6699c643887e826f2d66a80869b4f279fb07d25"
   "11.2.0":
     url: "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip"
     sha256: "203eb4e8aa0d746c62d8f903df58e0419e3751591bb53ff971096eaa0ebd4ec3"

--- a/recipes/fmt/config.yml
+++ b/recipes/fmt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "12.0.0":
+    folder: all
   "11.2.0":
     folder: all
   "11.1.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fmt/12.0.0** -- added new version

#### Motivation
New fmt version has just released here https://github.com/fmtlib/fmt/releases/tag/12.0.0

#### Details
Added source url and sha256 hash to conandata.yml

closes #28406

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
