### PR TITLE
add cgal/5.6.3 and cgal/6.0.2

### DIFF
--- a/recipes/cgal/all/conandata.yml
+++ b/recipes/cgal/all/conandata.yml
@@ -26,12 +26,18 @@ sources:
   "5.6.2":
     sha256: 458f60df8e8f1f2fdad93c8f24e1aa8f4b095cc61a14fac81b90680d7306a42e
     url: https://github.com/CGAL/cgal/releases/download/v5.6.2/CGAL-5.6.2.tar.xz
+  "5.6.3":
+    sha256: 15c743cb395d1a0855b9062525f3ae0cd40486489acfe7ce1457c3710ab34111
+    url: https://github.com/CGAL/cgal/releases/download/v5.6.3/CGAL-5.6.3.tar.xz
   "6.0":
     sha256: ed53a1498569a22341b482e579c6a3caf9ecbfb6e013f5a90ce780138073b520
     url: https://github.com/CGAL/cgal/releases/download/v6.0/CGAL-6.0-library.tar.xz
   "6.0.1":
     sha256: c752737f91d1af71fa96038f0e37945ce82a5f1fffb6200172cfcdd77755a356
     url: https://github.com/CGAL/cgal/releases/download/v6.0.1/CGAL-6.0.1-library.tar.xz
+  "6.0.2":
+    sha256: 11eaf69d6d21083c6074c2187267cee28541fc462d6b7cbb3deb599007b64f3a
+    url: https://github.com/CGAL/cgal/releases/download/v6.0.2/CGAL-6.0.2-library.tar.xz
 patches:
   "5.3.2":
     - patch_file: "patches/0001-fix-for-conan.patch"

--- a/recipes/cgal/config.yml
+++ b/recipes/cgal/config.yml
@@ -17,7 +17,11 @@ versions:
     folder: all
   "5.6.2":
     folder: all
+  "5.6.3":
+    folder: all
   "6.0":
     folder: all
   "6.0.1":
+    folder: all
+  "6.0.2":
     folder: all


### PR DESCRIPTION

### Summary
Changes to recipe:  **cgal/5.6.3** and **cgal/6.0.2**

#### Motivation

This PR adds support for CGAL versions 5.6.3 and 6.0.2 to the conan-center-index. Those two new versions of CGAL are bug-fixes releases.

  - https://www.cgal.org/2025/09/17/cgal563/
  - https://www.cgal.org/2025/09/17/cgal602/

#### Details
Just two new versions. No other change.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan: **tested with Conan version 2.20.1 on Linux**
