### PR TITLE
oatpp-openssl: Added version 1.3.0.latest

### DIFF
--- a/recipes/oatpp-openssl/all/conandata.yml
+++ b/recipes/oatpp-openssl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.0.latest":
+    url: "https://github.com/oatpp/oatpp-openssl/archive/1.3.0-latest.tar.gz"
+    sha256: "fed9f8df089653193883e0174ddd0b87f50175a4eb143bd9e418d144b68f9182"
   "1.3.0":
     url: "https://github.com/oatpp/oatpp-openssl/archive/1.3.0.tar.gz"
     sha256: "add694cf6294e5cd8b8f4681e0425802f01d798b9d17e29cdb865448a6aa81c8"

--- a/recipes/oatpp-openssl/all/conanfile.py
+++ b/recipes/oatpp-openssl/all/conanfile.py
@@ -31,6 +31,10 @@ class OatppOpenSSLConan(ConanFile):
 
     implements = ["auto_shared_fpic"]
 
+    @property
+    def _version(self):
+        return self.version.split(".latest")[0]
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -79,11 +83,11 @@ class OatppOpenSSLConan(ConanFile):
 
         # TODO: back to global scope in conan v2 once legacy generators removed
         self.cpp_info.components["_oatpp-openssl"].includedirs = [
-            os.path.join("include", f"oatpp-{self.version}", "oatpp-openssl")
+            os.path.join("include", f"oatpp-{self._version}", "oatpp-openssl")
         ]
-        self.cpp_info.components["_oatpp-openssl"].libdirs = [os.path.join("lib", f"oatpp-{self.version}")]
+        self.cpp_info.components["_oatpp-openssl"].libdirs = [os.path.join("lib", f"oatpp-{self._version}")]
         if self.settings.os == "Windows" and self.options.shared:
-            self.cpp_info.components["_oatpp-openssl"].bindirs = [os.path.join("bin", f"oatpp-{self.version}")]
+            self.cpp_info.components["_oatpp-openssl"].bindirs = [os.path.join("bin", f"oatpp-{self._version}")]
         else:
             self.cpp_info.components["_oatpp-openssl"].bindirs = []
         self.cpp_info.components["_oatpp-openssl"].libs = ["oatpp-openssl"]

--- a/recipes/oatpp-openssl/config.yml
+++ b/recipes/oatpp-openssl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.0.latest":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.5":


### PR DESCRIPTION
Fixes #26354.

### Summary
Changes to recipe:  **oatpp-openssl/1.3.0.latest**

#### Motivation
1.3.0-latest is available.

#### Details
As in the other Oat++ packages, the `_version` property was added because of the `.latest` suffix of the Conan recipe version.
This PR is similar to #26921 which was recently merged.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
