### PR TITLE
cyrus-sasl: fix test on cmake >=4

### DIFF
--- a/recipes/cyrus-sasl/all/test_package/CMakeLists.txt
+++ b/recipes/cyrus-sasl/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(cyrus-sasl REQUIRED CONFIG)


### PR DESCRIPTION
### Summary
Changes to recipe:  **cyrus-sasl/***

#### Motivation
fix test recipe on cmake >= 4

#### Details
Currently fails with

```
cyrus-sasl/2.1.28 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/runner/work/cocorepo/cocorepo/recipes/cyrus-sasl/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/runner/work/cocorepo/cocorepo/recipes/cyrus-sasl/all/test_package"
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!

ERROR: cyrus-sasl/2.1.28 (test package): Error in build() method, line 20
	cmake.configure()
	ConanException: Error 1 while executing
```

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
