### PR TITLE
libtiff: enable HAVE_JPEGTURBO_DUAL_MODE_8_12 when using libjpeg-turbo

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -113,6 +113,7 @@ class LibtiffConan(ConanFile):
         # BUILD_SHARED_LIBS must be set in command line because defined upstream before project()
         tc.cache_variables["BUILD_SHARED_LIBS"] = bool(self.options.shared)
         tc.cache_variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
+        tc.cache_variables["HAVE_JPEGTURBO_DUAL_MODE_8_12"] = self.options.jpeg == "libjpeg-turbo"
         tc.generate()
         deps = CMakeDeps(self)
         deps.set_property("jbig", "cmake_file_name", "JBIG")

--- a/recipes/libtiff/all/patches/4.5.1-0001-cmake-dependencies.patch
+++ b/recipes/libtiff/all/patches/4.5.1-0001-cmake-dependencies.patch
@@ -12,10 +12,10 @@ index a4350028..4cb01552 100644
      set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_SAVE})
  endif()
 diff --git a/cmake/JPEGCodec.cmake b/cmake/JPEGCodec.cmake
-index 8455a3ec..09fe975a 100644
+index 8455a3e..b1576a0 100644
 --- a/cmake/JPEGCodec.cmake
 +++ b/cmake/JPEGCodec.cmake
-@@ -42,25 +42,7 @@ endif()
+@@ -42,25 +42,6 @@ endif()
  if (JPEG_SUPPORT)
      # Check for jpeg12_read_scanlines() which has been added in libjpeg-turbo 2.2
      # for dual 8/12 bit mode.
@@ -38,7 +38,6 @@ index 8455a3ec..09fe975a 100644
 -        "
 -        HAVE_JPEGTURBO_DUAL_MODE_8_12)
 -    cmake_pop_check_state()
-+    set(HAVE_JPEGTURBO_DUAL_MODE_8_12 FALSE)
  endif()
  
  if (NOT HAVE_JPEGTURBO_DUAL_MODE_8_12)


### PR DESCRIPTION
### Summary
Changes to recipe:  **libtiff/***

#### Motivation
I'm using libjpeg-turbo instead of libjpeg and it supports both 8 and 12-bit jpegs. So I would like libtiff to be able to handle 12-bit too.

#### Details
Patch has been hardcoding value of `HAVE_JPEGTURBO_DUAL_MODE_8_12 ` to `FALSE`. But it should be `TRUE` in case of `libjpeg-turbo >= 3.0` which is already the case with current conan recipe.

`conan create . --version 4.7.0 -o libtiff/*:jpeg=libjpeg-turbo`
Before the change:
`--   JPEG 8/12 bit dual mode:            Requested:OFF Availability:FALSE Support:FALSE`
After the change:
`--   JPEG 8/12 bit dual mode:            Support: yes (libjpeg turbo >= 3.0 dual mode)`


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
