### PR TITLE
Fix build of mbits-mstch when using cmake>=4

### DIFF
--- a/recipes/mbits-mstch/all/conanfile.py
+++ b/recipes/mbits-mstch/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.files import export_conandata_patches, get, copy, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.scm import Version
 import os
 
 
@@ -50,7 +51,8 @@ class MBitsMstchConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def build_requirements(self):
-        self.tool_requires("cmake/[~3]")
+        if Version(self.version) <= Version("1.0.4"):
+            self.tool_requires("cmake/[~3]")
 
     def validate(self):
         if self.settings.compiler.cppstd:

--- a/recipes/mbits-mstch/all/conanfile.py
+++ b/recipes/mbits-mstch/all/conanfile.py
@@ -49,6 +49,9 @@ class MBitsMstchConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[~3]")
+
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)


### PR DESCRIPTION
### Summary
Changes to recipe:  mbits-mstch/1.0.4

#### Motivation
I had issues building mbits-mstch/1.0.4 with my system's cmake version which is 4.0.3.
CMake prints errors concerning features that were deprecated with cmake 3.
I found no other working solution to have only the dependency being built with cmake 3, other than updating its recipe. Then, the right cmake version is chosen regardless if mbits-mstch is built as part of a dependee's build, or just as a standalone lib.

If there are other solutions to this problem, please let me know!

#### Details
Adding the max version of cmake that supports mbits-mstch's cmake commands until version 1.0.4 as a dependency to the conanfile.
A future version of mbits-mstch may or may not update its cmake files to support cmake>=4.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
