### PR TITLE
Patch symengine for gcc15

### DIFF
--- a/recipes/symengine/all/conandata.yml
+++ b/recipes/symengine/all/conandata.yml
@@ -23,3 +23,7 @@ sources:
   "0.14.0":
     url: "https://github.com/symengine/symengine/archive/refs/tags/v0.14.0.tar.gz"
     sha256: "11c5f64e9eec998152437f288b8429ec001168277d55f3f5f1df78e3cf129707"
+
+patches:
+  "0.14.0":
+    - patch_file: patches/0.14.0-0001-gcc15-ciso646.patch

--- a/recipes/symengine/all/conanfile.py
+++ b/recipes/symengine/all/conanfile.py
@@ -3,8 +3,10 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
 from conan.tools.files import (
+    apply_conandata_patches,
     collect_libs,
     copy,
+    export_conandata_patches,
     get,
     rm,
     rmdir,
@@ -39,6 +41,9 @@ class SymengineConan(ConanFile):
     }
     short_paths = True
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -49,7 +54,7 @@ class SymengineConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-    
+
     def validate(self):
         min_cppstd = "11"
         check_min_cppstd(self, min_cppstd)
@@ -77,6 +82,7 @@ class SymengineConan(ConanFile):
             strip_root=True,
             destination=self.source_folder,
         )
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/symengine/all/patches/0.14.0-0001-gcc15-ciso646.patch
+++ b/recipes/symengine/all/patches/0.14.0-0001-gcc15-ciso646.patch
@@ -1,3 +1,4 @@
+Backported from https://github.com/symengine/symengine/pull/2102
 diff --git a/symengine/prime_sieve.cpp b/symengine/prime_sieve.cpp
 index 22058a25d..c5f564f64 100644
 --- a/symengine/prime_sieve.cpp

--- a/recipes/symengine/all/patches/0.14.0-0001-gcc15-ciso646.patch
+++ b/recipes/symengine/all/patches/0.14.0-0001-gcc15-ciso646.patch
@@ -1,0 +1,30 @@
+diff --git a/symengine/prime_sieve.cpp b/symengine/prime_sieve.cpp
+index 22058a25d..c5f564f64 100644
+--- a/symengine/prime_sieve.cpp
++++ b/symengine/prime_sieve.cpp
+@@ -1,5 +1,9 @@
+ #include <symengine/prime_sieve.h>
++#if __cplusplus <= 201703L
+ #include <ciso646>
++#else
++#include <version>
++#endif
+ #include <cmath>
+ #include <valarray>
+ #include <algorithm>
+diff --git a/symengine/symengine_rcp.h b/symengine/symengine_rcp.h
+index c49720ab2..0b1c2dbac 100644
+--- a/symengine/symengine_rcp.h
++++ b/symengine/symengine_rcp.h
+@@ -5,7 +5,11 @@
+ #include <cstddef>
+ #include <stdexcept>
+ #include <string>
++#if __cplusplus <= 201703L
+ #include <ciso646>
++#else
++#include <version>
++#endif
+ 
+ #include <symengine/symengine_config.h>
+ #include <symengine/symengine_assert.h>


### PR DESCRIPTION
### Summary
Symengine v0.14.0 compiled with gcc>=15 emits a warning caused by including `ciso646`, which becomes an error with `-Werror`. This was fixed in symengine/symengine#2102. This fix is introduced as a patch here, as symengine has not released a new version since this fix was merged.

- Note: The patch file introduced in this PR applies symengine/symengine#2102 verbatim.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
