### PR TITLE
qhull: fix libqhullcpp PC file name

### DIFF
--- a/recipes/qhull/all/conanfile.py
+++ b/recipes/qhull/all/conanfile.py
@@ -92,7 +92,7 @@ class QhullConan(ConanFile):
         if not self.options.shared:
             self.cpp_info.components["libqhullcpp"].libs = [self._qhullcpp_lib_name]
             self.cpp_info.components["libqhullcpp"].set_property("cmake_target_name", "Qhull::qhullcpp")
-            self.cpp_info.components["libqhullcpp"].set_property("pkg_config_name", "Qhull::qhullcpp")
+            self.cpp_info.components["libqhullcpp"].set_property("pkg_config_name", "qhullcpp")
 
     @property
     def _qhull_cmake_name(self):

--- a/recipes/qhull/all/test_package/conanfile.py
+++ b/recipes/qhull/all/test_package/conanfile.py
@@ -6,7 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps"
+    generators = "CMakeDeps", "PkgConfigDeps"
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **qhull/8.0.2**

#### Motivation
Fixes this error when consuming `qhull/8.0.2` using `PkgConfigDeps` generator:

```bash
qhull/8.0.2 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(Qhull)
    target_link_libraries(... Qhull::qhullstatic_r)
qhull/8.0.2 (test package): Generator 'PkgConfigDeps' calling 'generate()'
OSError: [Errno 22] Invalid argument: 'Qhull::qhullcpp.pc'
ERROR: Error in generator 'PkgConfigDeps': [Errno 22] Invalid argument: 'Qhull::qhullcpp.pc'
```
