### PR TITLE
oatpp-openssl: added CMake 4 support

### DIFF
--- a/recipes/oatpp-openssl/all/conanfile.py
+++ b/recipes/oatpp-openssl/all/conanfile.py
@@ -62,6 +62,8 @@ class OatppOpenSSLConan(ConanFile):
         tc.cache_variables["OATPP_MODULES_LOCATION"] = "INSTALLED"
         # Honor BUILD_SHARED_LIBS from conan_toolchain (see https://github.com/conan-io/conan/issues/11840)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        if Version(self.version) <= "1.3.0.latest":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **oatpp-openssl**

#### Motivation

Requested in https://github.com/conan-io/conan-center-index/issues/26878#issuecomment-3332651610

#### Details

Upstream project already supports CMake 4 https://github.com/oatpp/oatpp-openssl/commit/c8ec893f27cc955df7d82846e10a6e2328e3be33 but there is no release associated with that commit.