### PR TITLE
oatpp-swagger: added CMake 4 support

### DIFF
--- a/recipes/oatpp-swagger/all/conanfile.py
+++ b/recipes/oatpp-swagger/all/conanfile.py
@@ -71,6 +71,8 @@ class OatppSwaggerConan(ConanFile):
             tc.variables["OATPP_MSVC_LINK_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
         # Honor BUILD_SHARED_LIBS from conan_toolchain (see https://github.com/conan-io/conan/issues/11840)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        if Version(self.version) <= "1.3.0.latest":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **oatpp-swagger**

#### Motivation

Requested in https://github.com/conan-io/conan-center-index/issues/26878#issuecomment-3332651610

#### Details

Upstream project already supports CMake 4 https://github.com/oatpp/oatpp-swagger/commit/13437a96936d54bb2893356c3b5e26cfb8fda341 but there is no release associated with that commit.