### PR TITLE
[cpprestsdk] List Boost as transitive headers

### DIFF
--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -58,7 +58,7 @@ class CppRestSDKConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/1.83.0")
+        self.requires("boost/1.83.0", transitive_headers=True)
         self.requires("openssl/[>=1.1 <4]")
         if self.options.with_compression:
             self.requires("zlib/[>=1.2.11 <2]")


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpprestsdk/2.10.19**

#### Motivation

fixes #27492

#### Details

Boost headers are listed in public headers of cpprestsdk:

- https://github.com/microsoft/cpprestsdk/blob/v2.10.19/Release/include/cpprest/http_listener.h#L20
- https://github.com/microsoft/cpprestsdk/blob/v2.10.19/Release/include/cpprest/ws_client.h#L36
- https://github.com/microsoft/cpprestsdk/blob/v2.10.19/Release/include/cpprest/http_client.h#L68


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
