### PR TITLE
[mexce/1.0.0] Add mexce recipe

### DIFF
--- a/recipes/mexce/all/conanfile.py
+++ b/recipes/mexce/all/conanfile.py
@@ -1,0 +1,47 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+class MexceConan(ConanFile):
+    name = "mexce"
+    version = "1.0.0"
+    license = "BSD-2-Clause"
+    homepage = "https://github.com/imakris/mexce"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Single-header, dependency-free JIT compiler for scalar mathematical expressions."
+    topics = ("jit", "math", "expression-parser", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self)
+
+    def validate(self):
+        allowed_architectures = {"x86", "x86_64"}
+        if str(self.settings.arch) not in allowed_architectures:
+            raise ConanInvalidConfiguration(
+                "mexce only supports x86 and x86_64 architectures")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self,
+            url=f"https://github.com/imakris/mexce/archive/refs/tags/v{self.version}.zip",
+            strip_root=True)
+
+    def package(self):
+        copy(self, "mexce.h", self.source_folder,
+             os.path.join(self.package_folder, "include"))
+        copy(self, "LICENSE*", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "mexce")
+        self.cpp_info.set_property("cmake_target_name", "mexce::mexce")

--- a/recipes/mexce/all/test_package/CMakeLists.txt
+++ b/recipes/mexce/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(mexce_test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(mexce CONFIG REQUIRED)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE mexce::mexce)

--- a/recipes/mexce/all/test_package/conanfile.py
+++ b/recipes/mexce/all/test_package/conanfile.py
@@ -1,0 +1,31 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.build import can_run
+import os
+
+
+class MexceTestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/mexce/all/test_package/test_package.cpp
+++ b/recipes/mexce/all/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#include <mexce.h>
+#include <iostream>
+
+int main() {
+    mexce::evaluator eval;
+    double x = 0.5;
+    eval.bind(x, "x");
+    eval.set_expression("sin(x) + 1");
+    const double result = eval.evaluate();
+    std::cout << "Result: " << result << '\n';
+    return (result != 0.0) ? 0 : 1;
+}

--- a/recipes/mexce/config.yaml
+++ b/recipes/mexce/config.yaml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: "all"


### PR DESCRIPTION
### Summary
Adds the recipe for `mexce/1.0.0`.

#### Motivation
This PR adds the initial recipe for the `mexce` library.

#### Details
`mexce` is a single-header, dependency-free JIT compiler for scalar mathematical expressions. This recipe is for its initial stable release, v1.0.0.

It defines the library as header-only and includes a `validate()` method to ensure it is only used on the supported x86/x86_64 architectures.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan```
