### PR TITLE
openjph: Update to 0.24.1

### DIFF
--- a/recipes/openjph/all/conandata.yml
+++ b/recipes/openjph/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "0.23.1":
-    url: "https://github.com/aous72/OpenJPH/archive/0.23.1.tar.gz"
-    sha256: "8a0357075fb92feeaa36e23de78f81a869c7bb6189091cc34f41bb061c1db22b"
+  "0.24.1":
+    url: "https://github.com/aous72/OpenJPH/archive/0.24.1.tar.gz"
+    sha256: "5e44a809c9ee3dad175da839feaf66746cfc114a625ec61c786de8ad3f5ab472"
 patches:
-  "0.23.1":
-    - patch_file: "patches/0.23.1-cmake-cxx-standard-pic.patch"
+  "0.24.1":
+    - patch_file: "patches/0.24.1-cmake-cxx-standard-pic.patch"
       patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan and PIC hardcoded option"
       patch_type: "conan"

--- a/recipes/openjph/all/conanfile.py
+++ b/recipes/openjph/all/conanfile.py
@@ -47,8 +47,7 @@ class OpenJPH(ConanFile):
             self.requires("libtiff/[>=4.6.0 <5]")
 
     def validate(self):
-        required_cxx_version = 14 if self.options.with_stream_expand_tool else 11
-        check_min_cppstd(self, required_cxx_version)
+        check_min_cppstd(self, 11)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/openjph/all/conanfile.py
+++ b/recipes/openjph/all/conanfile.py
@@ -47,7 +47,8 @@ class OpenJPH(ConanFile):
             self.requires("libtiff/[>=4.6.0 <5]")
 
     def validate(self):
-        check_min_cppstd(self, 11)
+        required_cxx_version = 14 if self.options.with_stream_expand_tool else 11
+        check_min_cppstd(self, required_cxx_version)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/openjph/all/patches/0.24.1-cmake-cxx-standard-pic.patch
+++ b/recipes/openjph/all/patches/0.24.1-cmake-cxx-standard-pic.patch
@@ -1,20 +1,3 @@
-diff --git CMakeLists.txt CMakeLists.txt
-index 2151f57..8087192 100644
---- CMakeLists.txt
-+++ CMakeLists.txt
-@@ -119,9 +119,9 @@ message(STATUS "Building ${CMAKE_BUILD_TYPE}")
- 
- ## C++ version and flags
- # C++14 is needed for gtest, otherwise, C++11 is sufficient for the library
--if (NOT CMAKE_CXX_STANDARD)
--  set(CMAKE_CXX_STANDARD 14)
--endif()
-+# if (NOT CMAKE_CXX_STANDARD)
-+#   set(CMAKE_CXX_STANDARD 14)
-+# endif()
- message(STATUS "C++ Standard is set to ${CMAKE_CXX_STANDARD}")
- 
- if (MSVC)
 diff --git src/apps/ojph_stream_expand/CMakeLists.txt src/apps/ojph_stream_expand/CMakeLists.txt
 index 61e8603..85c1d99 100644
 --- src/apps/ojph_stream_expand/CMakeLists.txt

--- a/recipes/openjph/all/patches/0.24.1-cmake-cxx-standard-pic.patch
+++ b/recipes/openjph/all/patches/0.24.1-cmake-cxx-standard-pic.patch
@@ -1,24 +1,30 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index cb6abda..3eea032 100644
+index 2151f57..8087192 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -119,7 +119,6 @@ message(STATUS "Building ${CMAKE_BUILD_TYPE}")
+@@ -119,9 +119,9 @@ message(STATUS "Building ${CMAKE_BUILD_TYPE}")
  
  ## C++ version and flags
  # C++14 is needed for gtest, otherwise, C++11 is sufficient for the library
--set(CMAKE_CXX_STANDARD 14)
+-if (NOT CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 14)
+-endif()
++# if (NOT CMAKE_CXX_STANDARD)
++#   set(CMAKE_CXX_STANDARD 14)
++# endif()
+ message(STATUS "C++ Standard is set to ${CMAKE_CXX_STANDARD}")
+ 
  if (MSVC)
-   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
- endif()
 diff --git src/apps/ojph_stream_expand/CMakeLists.txt src/apps/ojph_stream_expand/CMakeLists.txt
-index 61e8603..65be4a3 100644
+index 61e8603..85c1d99 100644
 --- src/apps/ojph_stream_expand/CMakeLists.txt
 +++ src/apps/ojph_stream_expand/CMakeLists.txt
-@@ -1,7 +1,6 @@
+@@ -1,7 +1,7 @@
  ## building ojph_stream_expand
  ##############################
  
 -set(CMAKE_CXX_STANDARD 14)
++#set(CMAKE_CXX_STANDARD 14)
  
  file(GLOB OJPH_STREAM_EXPAND  "*.cpp" "*.h")
  file(GLOB OJPH_SOCKETS         "../others/ojph_sockets.cpp")

--- a/recipes/openjph/config.yml
+++ b/recipes/openjph/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.23.1":
+  "0.24.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openjph/0.24.1**

#### Motivation
Fixes in aligned memory handling have been added.

#### Details
No large changes since previous version but fixes for the recently introduced aligned memory handling. Main relevant change for us appears to be just that. Rest is small build changes that I have not seen relevant differences from the conan managed build perspective.

The two related releases changelogs:
* https://github.com/aous72/OpenJPH/releases/tag/0.24.0
* https://github.com/aous72/OpenJPH/releases/tag/0.24.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan