### PR TITLE
Add cpp-member-accessor/1.0.0 (header-only)

### DIFF
--- a/recipes/cpp-member-accessor/all/conandata.yml
+++ b/recipes/cpp-member-accessor/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/hliberacki/cpp-member-accessor/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "10f9ceedc96d2ff3dc95ed0dba50708739107ccbe659d5ca4e0250f8c0ac824d"

--- a/recipes/cpp-member-accessor/all/conanfile.py
+++ b/recipes/cpp-member-accessor/all/conanfile.py
@@ -1,0 +1,43 @@
+import os
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+
+class CppMemberAccessorConan(ConanFile):
+    name = "cpp-member-accessor"
+    version = "1.0.0"
+    license = "MIT"
+    author = "Hubert Liberacki <hliberacki@gmail.com>"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/hliberacki/cpp-member-accessor"
+    topics = ("c++", "templates", "access-private-members", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "include/*"
+    no_copy_source = True
+    package_type = "header-library"
+    exports = "LICENSE"
+
+    @property
+    def _min_cppstd(self):
+        return 14
+
+    def validate(self):
+        check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def layout(self):
+        basic_layout(self)
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "*.hpp", self.source_folder, self.package_folder)
+    
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/cpp-member-accessor/all/test_package/CMakeLists.txt
+++ b/recipes/cpp-member-accessor/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.18)
+project(test_package CXX)
+
+find_package(cpp-member-accessor CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE cpp-member-accessor::cpp-member-accessor)

--- a/recipes/cpp-member-accessor/all/test_package/conanfile.py
+++ b/recipes/cpp-member-accessor/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class CppMemberAccessorTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/cpp-member-accessor/all/test_package/test_package.cpp
+++ b/recipes/cpp-member-accessor/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include <accessor/accessor.hpp>
+
+class Test
+{
+  int mFooBar {1};
+};
+
+using TestFooBar = accessor::MemberWrapper<Test, int>;
+template class accessor::MakeProxy<TestFooBar, &Test::mFooBar>;
+
+int main()
+{
+    Test t;
+    (void)accessor::accessMember<TestFooBar>(t);
+}

--- a/recipes/cpp-member-accessor/config.yml
+++ b/recipes/cpp-member-accessor/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: "all"


### PR DESCRIPTION
### Summary
Recipe: cpp-member-accessor/1.0.0

New ConanCenter recipe for a header-only C++ template library that provides utilities to access private class members.

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

New library addition.  [Requested](https://github.com/hliberacki/cpp-member-accessor/issues/15#issuecomment-3322425592) upstream.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

- Header-only recipe
- Sources from conandata.yml; package headers → include/, license → licenses/
- Basic layout with a minimal consumer test_package (CMakeToolchain/CMakeDeps/VirtualRunEnv)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

Upstream: https://github.com/hliberacki/cpp-member-accessor (tag v1.0.0)