### PR TITLE
[Rerun SDK] Add recipe for rerun sdk

### DIFF
--- a/recipes/rerun_sdk/all/conandata.yml
+++ b/recipes/rerun_sdk/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.32.2":
+    url: "https://github.com/rerun-io/rerun/releases/download/0.32.2/rerun_cpp_sdk.zip"
+    sha256: "40ce0f435ecc57123d9b0344f1be41fc77539eea4622a9ae3c6415c59f602ad3"

--- a/recipes/rerun_sdk/all/conandata.yml
+++ b/recipes/rerun_sdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.32.2":
-    url: "https://github.com/rerun-io/rerun/releases/download/0.32.2/rerun_cpp_sdk.zip"
-    sha256: "40ce0f435ecc57123d9b0344f1be41fc77539eea4622a9ae3c6415c59f602ad3"
+  "0.33.0":
+    url: "https://github.com/rerun-io/rerun/releases/download/0.33.0/rerun_cpp_sdk.zip"
+    sha256: "63c5ec32110ee360ca4aba41b21d21d7b7e68c81607fc37d496191ef9d788fab"

--- a/recipes/rerun_sdk/all/conandata.yml
+++ b/recipes/rerun_sdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.32.2":
-    url: "https://github.com/rerun-io/rerun/releases/download/0.32.2/rerun_cpp_sdk.zip"
-    sha256: "40ce0f435ecc57123d9b0344f1be41fc77539eea4622a9ae3c6415c59f602ad3"
+  "0.36.0":
+    url: "https://github.com/rerun-io/rerun/releases/download/0.36.0/rerun_cpp_sdk.zip"
+    sha256: "406ad58f45e3d2798eb466a8e219140172e6ea56fb40cbc8855fefce8ef90fd1"

--- a/recipes/rerun_sdk/all/conandata.yml
+++ b/recipes/rerun_sdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.36.0":
-    url: "https://github.com/rerun-io/rerun/releases/download/0.36.0/rerun_cpp_sdk.zip"
+  "0.37.1":
+    url: "https://github.com/rerun-io/rerun/releases/download/0.37.1/rerun_cpp_sdk.zip"
     sha256: "406ad58f45e3d2798eb466a8e219140172e6ea56fb40cbc8855fefce8ef90fd1"

--- a/recipes/rerun_sdk/all/conanfile.py
+++ b/recipes/rerun_sdk/all/conanfile.py
@@ -2,9 +2,10 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools import files
+from conan.tools.files import get, rmdir, copy
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
+required_conan_version = ">=2.0"
 
 class Package(ConanFile):
     name = "rerun_sdk"
@@ -30,7 +31,7 @@ class Package(ConanFile):
                 return "rerun_c__win_x64.lib"
             elif self.settings.os == "Macos":
                 return "librerun_c__macos_x64.a"
-        elif self.settings.arch == "arm64":
+        elif self.settings.arch == "armv8":
             if self.settings.os == "Linux":
                 return "librerun_c__linux_arm64.a"
             elif self.settings.os == "Macos":
@@ -51,7 +52,7 @@ class Package(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def source(self):
-        files.get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         deps = CMakeDeps(self)
@@ -59,8 +60,7 @@ class Package(ConanFile):
 
         tc = CMakeToolchain(self)
         tc.variables["RERUN_DOWNLOAD_AND_BUILD_ARROW"] = "OFF"
-        tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options["fPIC"]
-        tc.variables["BUILD_SHARED_LIBS"] = self.options["shared"]
+        tc.variables["RERUN_ARROW_LINK_SHARED"] = bool(self.dependencies["arrow"].options.shared)
         tc.generate()
 
     def build(self):
@@ -69,11 +69,33 @@ class Package(ConanFile):
         cmake.build()
 
     def package(self):
+        copy(self, "LICENSE-*", self.source_folder, os.path.join(self.package_folder, "licenses"))
+
         cmake = CMake(self)
         cmake.install()
 
         # Remove installed cmake config files
-        files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = ["rerun_sdk", self._get_additional_lib()]
+        self.cpp_info.requires = ["arrow::libarrow"]
+
+        if self.settings.os == "Macos":
+            self.cpp_info.frameworks = ["CoreFoundation", "IOKit", "Security"]
+        elif self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m", "dl", "pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = [
+                "Crypt32",
+                "Iphlpapi",
+                "Ncrypt",
+                "Netapi32",
+                "ntdll",
+                "Pdh",
+                "PowrProf",
+                "Psapi",
+                "Secur32",
+                "Userenv",
+                "ws2_32",
+            ]

--- a/recipes/rerun_sdk/all/conanfile.py
+++ b/recipes/rerun_sdk/all/conanfile.py
@@ -30,8 +30,6 @@ class Package(ConanFile):
                 return "librerun_c__linux_x64.a"
             elif self.settings.os == "Windows":
                 return "rerun_c__win_x64.lib"
-            elif self.settings.os == "Macos":
-                return "librerun_c__macos_x64.a"
         elif self.settings.arch == "armv8":
             if self.settings.os == "Linux":
                 return "librerun_c__linux_arm64.a"

--- a/recipes/rerun_sdk/all/conanfile.py
+++ b/recipes/rerun_sdk/all/conanfile.py
@@ -1,0 +1,79 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools import files
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+
+class Package(ConanFile):
+    name = "rerun_sdk"
+
+    homepage = "https://rerun.io/"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Visualize streams of multimodal data. Free, fast, easy to use, and simple to integrate. Built in Rust."
+    topics = ("visualization", "computer-vision", "robotics", "multimodal")
+    license = ("Apache-2.0", "MIT")
+    package_type = "library"
+
+    settings = "os", "arch", "compiler", "build_type"
+
+    implements = ["auto_shared_fpic"]
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    def _get_additional_lib(self):
+        if self.settings.arch == "x86_64":
+            if self.settings.os == "Linux":
+                return "librerun_c__linux_x64.a"
+            elif self.settings.os == "Windows":
+                return "rerun_c__win_x64.lib"
+            elif self.settings.os == "Macos":
+                return "librerun_c__macos_x64.a"
+        elif self.settings.arch == "arm64":
+            if self.settings.os == "Linux":
+                return "librerun_c__linux_arm64.a"
+            elif self.settings.os == "Macos":
+                return "librerun_c__macos_arm64.a"
+
+        return None
+
+    def validate(self):
+        if self._get_additional_lib() is None:
+            raise ConanInvalidConfiguration(
+                f"Unsupported combination of architecture {self.settings.arch} and os {self.settings.os}"
+            )
+
+    def requirements(self):
+        self.requires("arrow/24.0.0")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        files.get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["RERUN_DOWNLOAD_AND_BUILD_ARROW"] = "OFF"
+        tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options["fPIC"]
+        tc.variables["BUILD_SHARED_LIBS"] = self.options["shared"]
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        # Remove installed cmake config files
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["rerun_sdk", self._get_additional_lib()]

--- a/recipes/rerun_sdk/all/conanfile.py
+++ b/recipes/rerun_sdk/all/conanfile.py
@@ -4,6 +4,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import get, rmdir, copy
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.build import check_min_cppstd
 
 required_conan_version = ">=2.0"
 
@@ -40,6 +41,7 @@ class Package(ConanFile):
         return None
 
     def validate(self):
+        check_min_cppstd(self, 20)
         if self._get_additional_lib() is None:
             raise ConanInvalidConfiguration(
                 f"Unsupported combination of architecture {self.settings.arch} and os {self.settings.os}"

--- a/recipes/rerun_sdk/all/conanfile.py
+++ b/recipes/rerun_sdk/all/conanfile.py
@@ -46,7 +46,7 @@ class Package(ConanFile):
             )
 
     def requirements(self):
-        self.requires("arrow/24.0.0")
+        self.requires("arrow/25.0.1")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/rerun_sdk/all/test_package/CMakeLists.txt
+++ b/recipes/rerun_sdk/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(rerun_sdk REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE rerun_sdk::rerun_sdk)

--- a/recipes/rerun_sdk/all/test_package/conanfile.py
+++ b/recipes/rerun_sdk/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/rerun_sdk/all/test_package/test_package.cpp
+++ b/recipes/rerun_sdk/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <rerun.hpp>
+#include <iostream>
+
+int main()
+{
+	std::cout << "rerun version: " << rerun::version_string() << std::endl;
+	rerun::check_binary_and_header_version_match().throw_on_failure();
+
+	return 0;
+}

--- a/recipes/rerun_sdk/config.yml
+++ b/recipes/rerun_sdk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.32.2":
+    folder: all

--- a/recipes/rerun_sdk/config.yml
+++ b/recipes/rerun_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.32.2":
+  "0.33.0":
     folder: all

--- a/recipes/rerun_sdk/config.yml
+++ b/recipes/rerun_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.32.2":
+  "0.36.0":
     folder: all

--- a/recipes/rerun_sdk/config.yml
+++ b/recipes/rerun_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.36.0":
+  "0.37.1":
     folder: all


### PR DESCRIPTION
**Summary**
Add rerun_sdk conan package (https://github.com/rerun-io/rerun)
Fixes #28486

**Motivation**
I think rerun is quite a nice tool and as I created this package for work I thought it would be good to share it here.
There are also two issues in the rerun-project on the subject:
- https://github.com/rerun-io/rerun/issues/4420
- https://github.com/rerun-io/rerun/issues/4579

The first contains a link to a conan package created by another contributor
(https://github.com/flightwave/rerun/blob/main/rerun_cpp/conanfile.py)
I haven't taken much from it, yet, because I started to create the recipe without being aware of this,
but maybe it comes in handy when something is missing from my changes.

**Details**

I tried to keep the package very basic -  it only depends on arrow. I used the implements-auto_shared_fpic-feature - but I'm not sure I did it correctly. Do I need to offer fpic and shared as options or are these implicitly included when this feature is used?

<details>
<summary>Local build logs</summary>

```
======== Exporting recipe to the cache ========
rerun_sdk/0.32.2: Exporting package recipe: /home/oz/git/conan-center-index/recipes/rerun_sdk/all/conanfile.py
rerun_sdk/0.32.2: exports: File 'conandata.yml' found. Exporting it...
rerun_sdk/0.32.2: Copied 1 '.py' file: conanfile.py
rerun_sdk/0.32.2: Copied 1 '.yml' file: conandata.yml
rerun_sdk/0.32.2: Exported to cache folder: /home/oz/.conan2/p/rerun5a84a0248c88c/e
rerun_sdk/0.32.2: Exported: rerun_sdk/0.32.2#77b973ff9ba0191b3237dd0da6468fdf (2026-05-24 14:24:52 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu20
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux
[conf]
tools.build:compiler_executables={'c': 'gcc-14', 'cpp': 'g++-14'}

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu20
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux
[conf]
tools.build:compiler_executables={'c': 'gcc-14', 'cpp': 'g++-14'}


======== Computing dependency graph ========
Graph root
    cli
Requirements
    arrow/24.0.0#47e1bb5785c033f51b087283adcb8fb8 - Cache
    boost/1.85.0#9cf65cd6886db7973117c410f4f175c1 - Cache
    bzip2/1.0.8#00b4a4658791c1f06914e087f0e792f5 - Cache
    libbacktrace/cci.20210118#a7691bfccd8caaf66309df196790a5a1 - Cache
    libevent/2.1.12#7a7a21762e2b4ed13d29aee3e10c19e7 - Cache
    mimalloc/1.7.6#38e7b2fbff43efcae957e6a530a62b76 - Cache
    openssl/3.5.2#0c5a5e15ae569f45dff57adcf1770cf7 - Cache
    rapidjson/cci.20230929#8dc0392af2b3aaea7312095f0ba53467 - Cache
    rerun_sdk/0.32.2#77b973ff9ba0191b3237dd0da6468fdf - Cache
    thrift/0.20.0#e2331dea920adb2ed3a377c8123d2edb - Cache
    xsimd/14.0.0#0925747d035b2fd3385bf7940c77c5dd - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76 - Cache
Build requirements
    b2/5.3.3#107c15377719889654eb9a162a673975 - Cache
    bison/3.8.2#c3490cbe0078b6fd3eb4cf5ed64144dc - Cache
    cmake/3.31.8#dde3bde00bb843687e55aea5afa0e220 - Cache
    flex/2.6.4#e35bc44b3fcbcd661e0af0dc5b5b1ad4 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
Resolved version ranges
    b2/[>=5.2 <6]: b2/5.3.3
    cmake/[>=3.18 <4]: cmake/3.31.8
    cmake/[>=3.26 <4]: cmake/3.31.8
    mimalloc/[>=1.7.6 <3]: mimalloc/1.7.6
    openssl/[>=1.1 <4]: openssl/3.5.2
    rapidjson/[>=cci.20230929]: rapidjson/cci.20230929
    thrift/[>=0.20.0 <=0.21.0]: thrift/0.20.0
    zlib/[>=1.2.11 <2]: zlib/1.3.1

======== Computing necessary packages ========
libevent/2.1.12: WARN: risk: Transitive dependencies with 'headers=False' effect in 'package_id' is not necessary and suboptimal. Use required_conan_version='>=2.28' to activate it
thrift/0.20.0: WARN: risk: Transitive dependencies with 'headers=False' effect in 'package_id' is not necessary and suboptimal. Use required_conan_version='>=2.28' to activate it
arrow/24.0.0: WARN: risk: Transitive dependencies with 'headers=False' effect in 'package_id' is not necessary and suboptimal. Use required_conan_version='>=2.28' to activate it
rerun_sdk/0.32.2: WARN: risk: Transitive dependencies with 'headers=False' effect in 'package_id' is not necessary and suboptimal. Use required_conan_version='>=2.28' to activate it
rerun_sdk/0.32.2: Forced build from source
Requirements
    arrow/24.0.0#47e1bb5785c033f51b087283adcb8fb8:da663c9833e35daca943f529fac7fbea3554d37e#dd4321d69029a63efb264fa70c32eeff - Cache
    boost/1.85.0#9cf65cd6886db7973117c410f4f175c1:398dcda4156d7b6e7414beebbf5332ab21817f8c#918934b30d4f994497bf9d3ef1188780 - Cache
    bzip2/1.0.8#00b4a4658791c1f06914e087f0e792f5:25b9eef9ec505da9aa189c5f8baa19573c091120#23c2710ef9b987f5ea25fef335f53cf1 - Cache
    libbacktrace/cci.20210118#a7691bfccd8caaf66309df196790a5a1:6980ffdedf2f062ab47388192e39ae3988cb5678#4d8fe043d21ddd192f0459f6dfd23801 - Cache
    libevent/2.1.12#7a7a21762e2b4ed13d29aee3e10c19e7:73899c42d572873ca40788ecc29c5c31e01c2902#77dd3889034596dafadc2bddc2f493a2 - Cache
    mimalloc/1.7.6#38e7b2fbff43efcae957e6a530a62b76:5c7e469aa7dbdb68fd5897b521d89f4013e61bbc#aa3dc39c0e5665f7c01ce0d7590babbc - Cache
    openssl/3.5.2#0c5a5e15ae569f45dff57adcf1770cf7:2ead4b5224b22aa6d964443cf39c8659bea28efd#85843c407a1d3c547536ebb8e54841f8 - Cache
    rerun_sdk/0.32.2#77b973ff9ba0191b3237dd0da6468fdf:39f276bed1c3550047c640996108fc7c9b99f28e - Build
    thrift/0.20.0#e2331dea920adb2ed3a377c8123d2edb:9e19c52b8aa0703947737ec748ead03e8fa43b73#7ab39fe43dbfcb3bb15dff190bbb972e - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76:6980ffdedf2f062ab47388192e39ae3988cb5678#7f6821a580a8c907f6174b862772d27f - Cache
Build requirements
Skipped binaries
    rapidjson/cci.20230929, xsimd/14.0.0, b2/5.3.3, bison/3.8.2, cmake/3.31.8, flex/2.6.4, m4/1.4.19

======== Installing packages ========
bzip2/1.0.8: Already installed! (1 of 10)
libbacktrace/cci.20210118: Already installed! (2 of 10)
zlib/1.3.1: Already installed! (3 of 10)
mimalloc/1.7.6: Already installed! (4 of 10)
boost/1.85.0: Already installed! (5 of 10)
openssl/3.5.2: Already installed! (6 of 10)
libevent/2.1.12: Already installed! (7 of 10)
thrift/0.20.0: Already installed! (8 of 10)
arrow/24.0.0: Already installed! (9 of 10)

-------- Installing package rerun_sdk/0.32.2 (10 of 10) --------
rerun_sdk/0.32.2: Building from source
rerun_sdk/0.32.2: Package rerun_sdk/0.32.2:39f276bed1c3550047c640996108fc7c9b99f28e
rerun_sdk/0.32.2: settings: os=Linux arch=x86_64 compiler=gcc compiler.cppstd=gnu20 compiler.libcxx=libstdc++11 compiler.version=14 build_type=Release
rerun_sdk/0.32.2: options: fPIC=True shared=False
rerun_sdk/0.32.2: requires: arrow/24.0.Z thrift/0.20.Z libevent/2.1.Z openssl/3.5.Z mimalloc/1.7.Z boost/1.85.Z bzip2/1.0.Z libbacktrace/cci zlib/1.3.Z
rerun_sdk/0.32.2: Copying sources to build folder
rerun_sdk/0.32.2: Building your package in /home/oz/.conan2/p/b/rerun566b244f3507e/b
rerun_sdk/0.32.2: Calling generate()
rerun_sdk/0.32.2: Generators folder: /home/oz/.conan2/p/b/rerun566b244f3507e/b/build/Release/generators
rerun_sdk/0.32.2: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(Arrow)
    target_link_libraries(... arrow::arrow)
rerun_sdk/0.32.2: CMakeToolchain generated: conan_toolchain.cmake
rerun_sdk/0.32.2: CMakeToolchain generated: /home/oz/.conan2/p/b/rerun566b244f3507e/b/build/Release/generators/CMakePresets.json
rerun_sdk/0.32.2: CMakeToolchain generated: /home/oz/.conan2/p/b/rerun566b244f3507e/b/src/CMakeUserPresets.json
rerun_sdk/0.32.2: Generating aggregated env files
rerun_sdk/0.32.2: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
rerun_sdk/0.32.2: Calling build()
rerun_sdk/0.32.2: Running CMake.configure()
rerun_sdk/0.32.2: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/oz/.conan2/p/b/rerun566b244f3507e/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/oz/.conan2/p/b/rerun566b244f3507e/b/src"
-- Using Conan toolchain: /home/oz/.conan2/p/b/rerun566b244f3507e/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 20 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The CXX compiler identification is GNU 14.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++-14 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
Compiler: GNU 14.2.0 (/usr/bin/g++-14)
-- Conan: Component target declared 'Arrow::arrow_static'
-- Conan: Component target declared 'Parquet::parquet_static'
-- Conan: Target declared 'arrow::arrow'
-- Conan: Component target declared 'thrift::thrift'
-- Conan: Component target declared 'thriftz::thriftz'
-- Conan: Component target declared 'thriftnb::thriftnb'
-- Conan: Target declared 'thrift::thrift-conan-do-not-use'
-- Conan: Component target declared 'libevent::core'
-- Conan: Component target declared 'libevent::extra'
-- Conan: Component target declared 'libevent::openssl'
-- Conan: Component target declared 'libevent::pthreads'
-- Conan: Target declared 'libevent::libevent'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/home/oz/.conan2/p/b/opens91df8e75037c8/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Conan: Component target declared 'Boost::diagnostic_definitions'
-- Conan: Component target declared 'Boost::disable_autolinking'
-- Conan: Component target declared 'Boost::dynamic_linking'
-- Conan: Component target declared 'Boost::headers'
-- Conan: Component target declared 'Boost::boost'
-- Conan: Component target declared 'boost::_libboost'
-- Conan: Component target declared 'Boost::atomic'
-- Conan: Component target declared 'Boost::charconv'
-- Conan: Component target declared 'Boost::container'
-- Conan: Component target declared 'Boost::context'
-- Conan: Component target declared 'Boost::date_time'
-- Conan: Component target declared 'Boost::exception'
-- Conan: Component target declared 'Boost::math'
-- Conan: Component target declared 'Boost::program_options'
-- Conan: Component target declared 'Boost::regex'
-- Conan: Component target declared 'Boost::serialization'
-- Conan: Component target declared 'Boost::stacktrace'
-- Conan: Component target declared 'Boost::system'
-- Conan: Component target declared 'Boost::timer'
-- Conan: Component target declared 'Boost::chrono'
-- Conan: Component target declared 'Boost::cobalt'
-- Conan: Component target declared 'Boost::coroutine'
-- Conan: Component target declared 'Boost::filesystem'
-- Conan: Component target declared 'Boost::json'
-- Conan: Component target declared 'Boost::math_c99'
-- Conan: Component target declared 'Boost::math_c99f'
-- Conan: Component target declared 'Boost::math_c99l'
-- Conan: Component target declared 'Boost::math_tr1'
-- Conan: Component target declared 'Boost::math_tr1f'
-- Conan: Component target declared 'Boost::math_tr1l'
-- Conan: Component target declared 'Boost::random'
-- Conan: Component target declared 'Boost::stacktrace_addr2line'
-- Conan: Component target declared 'Boost::stacktrace_backtrace'
-- Conan: Component target declared 'Boost::stacktrace_basic'
-- Conan: Component target declared 'Boost::stacktrace_from_exception'
-- Conan: Component target declared 'Boost::stacktrace_noop'
-- Conan: Component target declared 'Boost::test'
-- Conan: Component target declared 'Boost::url'
-- Conan: Component target declared 'Boost::wserialization'
-- Conan: Component target declared 'Boost::fiber'
-- Conan: Component target declared 'Boost::graph'
-- Conan: Component target declared 'Boost::iostreams'
-- Conan: Component target declared 'Boost::nowide'
-- Conan: Component target declared 'Boost::prg_exec_monitor'
-- Conan: Component target declared 'Boost::test_exec_monitor'
-- Conan: Component target declared 'Boost::thread'
-- Conan: Component target declared 'Boost::wave'
-- Conan: Component target declared 'Boost::contract'
-- Conan: Component target declared 'Boost::fiber_numa'
-- Conan: Component target declared 'Boost::locale'
-- Conan: Component target declared 'Boost::log'
-- Conan: Component target declared 'Boost::type_erasure'
-- Conan: Component target declared 'Boost::unit_test_framework'
-- Conan: Component target declared 'Boost::log_setup'
-- Conan: Target declared 'boost::boost'
-- Conan: Target declared 'BZip2::BZip2'
-- Conan: Including build module from '/home/oz/.conan2/p/b/bzip271aac068b1f95/p/lib/cmake/conan-official-bzip2-variables.cmake'
-- Conan: Target declared 'libbacktrace::libbacktrace'
-- Conan: Target declared 'mimalloc-static'
-- Rerun SDK install version: 0.32.2
-- Configuring done (0.3s)
-- Generating done (0.1s)
-- Build files have been written to: /home/oz/.conan2/p/b/rerun566b244f3507e/b/build/Release

rerun_sdk/0.32.2: Running CMake.build()
rerun_sdk/0.32.2: RUN: cmake --build "/home/oz/.conan2/p/b/rerun566b244f3507e/b/build/Release" -- -j8
[  0%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/arrows2d.cpp.o
[  1%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/arrows2d_ext.cpp.o
[  0%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/annotation_context.cpp.o
[  1%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/arrows3d.cpp.o
[  1%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/arrows3d_ext.cpp.o
[  2%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/asset3d.cpp.o
[  2%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/asset3d_ext.cpp.o
[  3%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/asset_video.cpp.o
[  3%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/asset_video_ext.cpp.o
[  3%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/bar_chart.cpp.o
[  4%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/bar_chart_ext.cpp.o
[  4%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/boxes2d.cpp.o
[  4%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/boxes2d_ext.cpp.o
[  5%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/boxes3d.cpp.o
[  5%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/boxes3d_ext.cpp.o
[  6%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/capsules3d.cpp.o
[  6%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/capsules3d_ext.cpp.o
[  6%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/clear.cpp.o
[  7%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/clear_ext.cpp.o
[  7%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/coordinate_frame.cpp.o
[  7%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/cylinders3d.cpp.o
[  8%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/cylinders3d_ext.cpp.o
[  8%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/depth_image.cpp.o
[  9%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/depth_image_ext.cpp.o
[  9%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/ellipses2d.cpp.o
[  9%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/ellipses2d_ext.cpp.o
[ 10%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/ellipsoids3d.cpp.o
[ 10%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/ellipsoids3d_ext.cpp.o
[ 10%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/encoded_depth_image.cpp.o
[ 11%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/encoded_image.cpp.o
[ 11%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/encoded_image_ext.cpp.o
[ 12%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/geo_line_strings.cpp.o
[ 12%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/geo_points.cpp.o
[ 12%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/geo_points_ext.cpp.o
[ 13%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/graph_edges.cpp.o
[ 13%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/graph_nodes.cpp.o
[ 13%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/grid_map.cpp.o
[ 14%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/image.cpp.o
[ 14%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/image_ext.cpp.o
[ 15%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/instance_poses3d.cpp.o
[ 15%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/line_strips2d.cpp.o
[ 15%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/line_strips3d.cpp.o
[ 16%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/mcap_channel.cpp.o
[ 16%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/mcap_message.cpp.o
[ 16%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/mcap_schema.cpp.o
[ 17%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/mcap_statistics.cpp.o
[ 17%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/mesh3d.cpp.o
[ 18%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/pinhole.cpp.o
[ 18%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/pinhole_ext.cpp.o
[ 18%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/points2d.cpp.o
[ 19%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/points3d.cpp.o
[ 19%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/recording_info.cpp.o
[ 19%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/scalars.cpp.o
[ 20%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/segmentation_image.cpp.o
[ 20%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/segmentation_image_ext.cpp.o
[ 21%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/series_lines.cpp.o
[ 21%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/series_lines_ext.cpp.o
[ 21%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/series_points.cpp.o
[ 22%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/series_points_ext.cpp.o
[ 22%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/state_change.cpp.o
[ 22%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/state_configuration.cpp.o
[ 23%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/tensor.cpp.o
[ 23%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/tensor_ext.cpp.o
[ 24%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/text_document.cpp.o
[ 24%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/text_log.cpp.o
[ 24%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/transform3d.cpp.o
[ 25%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/transform3d_ext.cpp.o
[ 25%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/transform_axes3d.cpp.o
[ 25%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/video_frame_reference.cpp.o
[ 26%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/video_stream.cpp.o
[ 26%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/view_coordinates.cpp.o
[ 27%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/archetypes/view_coordinates_ext.cpp.o
[ 27%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/active_visualizers.cpp.o
[ 27%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/background.cpp.o
[ 28%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/container_blueprint.cpp.o
[ 28%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/dataframe_query.cpp.o
[ 28%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/entity_behavior.cpp.o
[ 29%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/eye_controls3d.cpp.o
[ 29%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/force_center.cpp.o
[ 30%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/force_collision_radius.cpp.o
[ 30%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/force_link.cpp.o
[ 30%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/force_many_body.cpp.o
[ 31%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/force_position.cpp.o
[ 31%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/graph_background.cpp.o
[ 31%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/line_grid3d.cpp.o
[ 32%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/map_background.cpp.o
[ 32%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/map_zoom.cpp.o
[ 33%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/near_clip_plane.cpp.o
[ 33%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/panel_blueprint.cpp.o
[ 33%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/plot_background.cpp.o
[ 34%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/plot_legend.cpp.o
[ 34%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/scalar_axis.cpp.o
[ 34%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/spatial_information.cpp.o
[ 35%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/table_blueprint.cpp.o
[ 35%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/tensor_scalar_mapping.cpp.o
[ 36%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/tensor_slice_selection.cpp.o
[ 36%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/tensor_view_fit.cpp.o
[ 36%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/text_document_format.cpp.o
[ 37%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/text_log_columns.cpp.o
[ 37%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/text_log_format.cpp.o
[ 37%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/text_log_rows.cpp.o
[ 38%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/time_axis.cpp.o
[ 38%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/time_panel_blueprint.cpp.o
[ 39%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/view_blueprint.cpp.o
[ 39%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/view_contents.cpp.o
[ 39%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/viewport_blueprint.cpp.o
[ 40%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/visible_time_ranges.cpp.o
[ 40%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/visual_bounds2d.cpp.o
[ 40%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/archetypes/visualizer_instruction.cpp.o
[ 41%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/background_kind.cpp.o
[ 41%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/column_order.cpp.o
[ 42%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/container_kind.cpp.o
[ 42%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/corner2d.cpp.o
[ 42%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/eye3d_kind.cpp.o
[ 43%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/link_axis.cpp.o
[ 43%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/loop_mode.cpp.o
[ 43%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/map_provider.cpp.o
[ 44%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/panel_state.cpp.o
[ 44%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/play_state.cpp.o
[ 45%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/components/view_fit.cpp.o
[ 45%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/component_column_selector.cpp.o
[ 45%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/component_source_kind.cpp.o
[ 46%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/filter_by_range.cpp.o
[ 46%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/filter_is_not_null.cpp.o
[ 46%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/selected_columns.cpp.o
[ 47%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/tensor_dimension_index_slider.cpp.o
[ 47%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/text_log_column.cpp.o
[ 48%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/text_log_column_kind.cpp.o
[ 48%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/timeline_column.cpp.o
[ 48%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/blueprint/datatypes/visualizer_component_mapping.cpp.o
[ 49%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/component_batch.cpp.o
[ 49%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/component_column.cpp.o
[ 50%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/component_type.cpp.o
[ 50%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/component_type_registry.cpp.o
[ 50%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/aggregation_policy.cpp.o
[ 51%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/annotation_context.cpp.o
[ 51%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/annotation_context_ext.cpp.o
[ 51%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/channel_message_counts.cpp.o
[ 52%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/color_ext.cpp.o
[ 52%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/colormap.cpp.o
[ 53%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/entity_path_ext.cpp.o
[ 53%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/fill_mode.cpp.o
[ 53%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/geo_line_string.cpp.o
[ 54%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/geo_line_string_ext.cpp.o
[ 54%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/graph_edge_ext.cpp.o
[ 54%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/graph_node_ext.cpp.o
[ 55%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/graph_type.cpp.o
[ 55%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/half_size2d_ext.cpp.o
[ 56%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/half_size3d_ext.cpp.o
[ 56%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/image_buffer_ext.cpp.o
[ 57%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/image_format_ext.cpp.o
[ 57%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/interpolation_mode.cpp.o
[ 57%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/key_value_pairs.cpp.o
[ 57%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/lat_lon_ext.cpp.o
[ 58%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/line_strip2d.cpp.o
[ 58%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/line_strip3d.cpp.o
[ 59%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/magnification_filter.cpp.o
[ 59%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/marker_shape.cpp.o
[ 59%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/media_type_ext.cpp.o
[ 60%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/mesh_face_rendering.cpp.o
[ 60%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/name_ext.cpp.o
[ 60%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/pinhole_projection_ext.cpp.o
[ 61%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/position2d_ext.cpp.o
[ 61%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/position3d_ext.cpp.o
[ 62%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/radius_ext.cpp.o
[ 62%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/resolution_ext.cpp.o
[ 62%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/scale3d_ext.cpp.o
[ 63%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/tensor_data_ext.cpp.o
[ 63%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/texcoord2d_ext.cpp.o
[ 63%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/text_ext.cpp.o
[ 64%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/text_log_level_ext.cpp.o
[ 64%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/transform_frame_id_ext.cpp.o
[ 65%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/transform_mat3x3_ext.cpp.o
[ 65%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/transform_relation.cpp.o
[ 65%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/translation3d_ext.cpp.o
[ 66%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/triangle_indices_ext.cpp.o
[ 66%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/vector2d_ext.cpp.o
[ 66%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/vector3d_ext.cpp.o
[ 67%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/video_codec.cpp.o
[ 67%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/video_timestamp_ext.cpp.o
[ 68%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/components/view_coordinates_ext.cpp.o
[ 68%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/config.cpp.o
[ 68%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/absolute_time_range.cpp.o
[ 69%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/angle.cpp.o
[ 69%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/angle_ext.cpp.o
[ 69%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/annotation_info.cpp.o
[ 70%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/annotation_info_ext.cpp.o
[ 70%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/blob.cpp.o
[ 71%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/blob_ext.cpp.o
[ 71%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/bool.cpp.o
[ 71%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/channel_count_pair.cpp.o
[ 72%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/channel_datatype.cpp.o
[ 72%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_description.cpp.o
[ 72%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_description_ext.cpp.o
[ 73%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_description_map_elem.cpp.o
[ 73%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_description_map_elem_ext.cpp.o
[ 74%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/class_id.cpp.o
[ 74%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/color_model.cpp.o
[ 74%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/dvec2d.cpp.o
[ 75%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/dvec2d_ext.cpp.o
[ 75%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/entity_path.cpp.o
[ 75%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/float32.cpp.o
[ 76%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/float64.cpp.o
[ 76%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/image_format.cpp.o
[ 77%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/image_format_ext.cpp.o
[ 77%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/keypoint_id.cpp.o
[ 77%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/keypoint_pair.cpp.o
[ 78%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/keypoint_pair_ext.cpp.o
[ 78%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mat3x3.cpp.o
[ 78%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mat3x3_ext.cpp.o
[ 79%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mat4x4.cpp.o
[ 79%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/mat4x4_ext.cpp.o
[ 80%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/pixel_format.cpp.o
[ 80%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/plane3d.cpp.o
[ 80%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/quaternion.cpp.o
[ 81%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/quaternion_ext.cpp.o
[ 81%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/range1d.cpp.o
[ 81%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/range2d.cpp.o
[ 82%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rgba32.cpp.o
[ 82%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rgba32_ext.cpp.o
[ 83%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rotation_axis_angle.cpp.o
[ 83%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/rotation_axis_angle_ext.cpp.o
[ 83%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_buffer.cpp.o
[ 84%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_buffer_ext.cpp.o
[ 84%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_data.cpp.o
[ 84%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_data_ext.cpp.o
[ 85%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_dimension_index_selection.cpp.o
[ 85%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/tensor_dimension_selection.cpp.o
[ 86%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/time_int.cpp.o
[ 86%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/time_range.cpp.o
[ 86%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/time_range_boundary.cpp.o
[ 87%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uint16.cpp.o
[ 87%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uint32.cpp.o
[ 87%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uint64.cpp.o
[ 88%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/utf8.cpp.o
[ 88%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/utf8_ext.cpp.o
[ 89%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/utf8pair.cpp.o
[ 89%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/utf8pair_ext.cpp.o
[ 89%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uuid.cpp.o
[ 90%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uvec2d.cpp.o
[ 90%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uvec2d_ext.cpp.o
[ 90%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uvec3d.cpp.o
[ 91%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uvec3d_ext.cpp.o
[ 91%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/uvec4d.cpp.o
[ 92%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec2d.cpp.o
[ 92%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec2d_ext.cpp.o
[ 92%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec3d.cpp.o
[ 93%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec3d_ext.cpp.o
[ 93%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec4d.cpp.o
[ 93%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/vec4d_ext.cpp.o
[ 94%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/video_timestamp.cpp.o
[ 94%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/view_coordinates.cpp.o
[ 95%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/view_coordinates_ext.cpp.o
[ 95%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/datatypes/visible_time_range.cpp.o
[ 95%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/demo_utils.cpp.o
[ 96%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/entity_path.cpp.o
[ 96%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/error.cpp.o
[ 96%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/log_sink.cpp.o
[ 97%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/recording_stream.cpp.o
[ 97%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/sdk_info.cpp.o
[ 98%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/spawn.cpp.o
[ 98%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/spawn_options.cpp.o
[ 98%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/string_utils.cpp.o
[ 99%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/time_column.cpp.o
[ 99%] Building CXX object CMakeFiles/rerun_sdk.dir/src/rerun/timeline.cpp.o
[100%] Linking CXX static library librerun_sdk.a
[100%] Built target rerun_sdk

rerun_sdk/0.32.2: Package '39f276bed1c3550047c640996108fc7c9b99f28e' built
rerun_sdk/0.32.2: Build folder /home/oz/.conan2/p/b/rerun566b244f3507e/b/build/Release
rerun_sdk/0.32.2: Generating the package
rerun_sdk/0.32.2: Packaging in folder /home/oz/.conan2/p/b/rerun566b244f3507e/p
rerun_sdk/0.32.2: Calling package()
rerun_sdk/0.32.2: Running CMake.install()
rerun_sdk/0.32.2: RUN: cmake --install "/home/oz/.conan2/p/b/rerun566b244f3507e/b/build/Release" --prefix "/home/oz/.conan2/p/b/rerun566b244f3507e/p"
-- Install configuration: "Release"
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/lib/librerun_sdk.a
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/timeline.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/component_batch.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/result.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/component_type.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/collection_adapter_builtins.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/spawn_options.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/time_column.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/string_utils.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/c
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/c/sdk_info.h
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/collection_adapter.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/collection.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/half.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/component_descriptor.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/arrow_utils.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/log_sink.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/draw_order.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/video_sample.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/axis_length.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/magnification_filter.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/tensor_height_dimension.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/value_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/stroke_width.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/color.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/interpolation_mode.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/annotation_context.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/lat_lon.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/mesh_face_rendering.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/scalar.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/aggregation_policy.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/gamma_correction.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/transform_frame_id.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/video_codec.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/radius.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/depth_meter.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/cell_size.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/line_strip3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/opacity.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/show_labels.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/marker_size.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/visible.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/view_coordinates.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/timestamp.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/image_buffer.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/channel_id.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/text.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/rotation_axis_angle.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/graph_node.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/class_id.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/range1d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/keypoint_id.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/vector2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/geo_line_string.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/transform_mat3x3.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/is_keyframe.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/vector3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/scale3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/plane3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/albedo_factor.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/position3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/length.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/tensor_width_dimension.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/half_size2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/pinhole_projection.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/media_type.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/key_value_pairs.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/image_plane_distance.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/rotation_quat.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/marker_shape.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/blob.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/half_size3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/line_strip2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/resolution.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/text_log_level.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/triangle_indices.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/texcoord2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/video_timestamp.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/entity_path.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/interactive.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/clear_is_recursive.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/graph_type.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/position2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/colormap.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/transform_relation.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/linear_speed.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/tensor_dimension_index_selection.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/name.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/channel_message_counts.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/schema_id.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/graph_edge.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/translation3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/tensor_data.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/image_format.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/fill_mode.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/count.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components/fill_ratio.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/error.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/config.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/demo_utils.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/loggable.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/rotation3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/compiler_utils.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/sdk_info.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/component_type_registry.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/component_column.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/image_utils.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/rerun_sdk_export.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/scalars.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/series_lines.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/mcap_statistics.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/graph_nodes.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/recording_info.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/cylinders3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/segmentation_image.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/depth_image.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/points2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/bar_chart.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/annotation_context.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/boxes2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/arrows3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/line_strips3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/geo_line_strings.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/mesh3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/video_stream.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/series_points.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/encoded_image.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/arrows2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/geo_points.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/state_change.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/state_configuration.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/mcap_schema.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/instance_poses3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/view_coordinates.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/pinhole.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/tensor.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/mcap_channel.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/capsules3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/line_strips2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/grid_map.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/boxes3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/transform3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/ellipses2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/transform_axes3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/asset_video.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/coordinate_frame.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/asset3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/graph_edges.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/text_log.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/clear.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/points3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/ellipsoids3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/video_frame_reference.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/image.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/encoded_depth_image.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/text_document.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes/mcap_message.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/type_traits.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/entity_path.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/third_party
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/third_party/cxxopts.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/container_kind.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/component_column_selector.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/tensor_dimension_index_slider.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/visual_bounds2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/apply_latest_at.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/auto_scroll.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/view_class.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/column_share.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/fps.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/near_clip_plane.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/root_container.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/selected_columns.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/link_axis.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/zoom_level.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/background_kind.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/viewer_recommendation_hash.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/active_tab.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/auto_views.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/enabled.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/view_maximized.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/timeline_name.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/eye3d_kind.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/angular_speed.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/included_content.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/row_share.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/query_expression.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/force_distance.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/absolute_time_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/filter_by_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/view_fit.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/grid_spacing.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/auto_layout.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/view_origin.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/visible_time_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/panel_state.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/grid_columns.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/lock_range_during_zoom.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/timeline_column.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/time_int.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/map_provider.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/filter_is_not_null.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/column_name.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/force_strength.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/column_order.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/visualizer_instruction_id.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/text_log_column.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/time_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/loop_mode.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/corner2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/visualizer_type.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/force_iterations.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/visualizer_component_mapping.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/playback_speed.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components/play_state.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/text_log_format.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/eye_controls3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/tensor_slice_selection.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/visual_bounds2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/tensor_scalar_mapping.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/view_blueprint.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/table_blueprint.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/force_link.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/map_background.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/near_clip_plane.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/plot_legend.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/plot_background.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/text_log_rows.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/visible_time_ranges.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/container_blueprint.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/entity_behavior.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/line_grid3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/graph_background.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/spatial_information.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/time_axis.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/visualizer_instruction.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/text_log_columns.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/map_zoom.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/text_document_format.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/panel_blueprint.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/force_position.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/dataframe_query.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/force_many_body.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/active_visualizers.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/force_collision_radius.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/view_contents.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/force_center.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/viewport_blueprint.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/scalar_axis.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/tensor_view_fit.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/background.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes/time_panel_blueprint.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/component_column_selector.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/tensor_dimension_index_slider.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/selected_columns.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/text_log_column_kind.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/filter_by_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/timeline_column.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/filter_is_not_null.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/text_log_column.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/visualizer_component_mapping.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes/component_source_kind.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/recording_stream.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/as_components.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/spawn.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/uint64.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/vec2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/angle.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/utf8pair.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/utf8.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/bool.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/time_range_boundary.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/uint32.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/uuid.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/quaternion.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/uvec4d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/float64.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/color_model.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/range2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/mat4x4.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/mat3x3.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/channel_count_pair.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/tensor_dimension_selection.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/float32.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/vec3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/view_coordinates.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/absolute_time_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/rotation_axis_angle.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/uint16.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/uvec3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/class_id.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/range1d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/vec4d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/keypoint_id.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/rgba32.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/annotation_info.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/plane3d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/visible_time_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/tensor_buffer.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/time_int.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/class_description_map_elem.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/channel_datatype.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/uvec2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/blob.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/class_description.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/video_timestamp.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/entity_path.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/keypoint_pair.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/pixel_format.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/time_range.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/tensor_dimension_index_selection.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/tensor_data.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/image_format.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes/dvec2d.hpp
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun.hpp
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/c
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/c/rerun.h
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/c/arrow_c_data_interface.h
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/c/compiler_utils.h
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/components
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/archetypes
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/third_party
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/components
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/archetypes
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/blueprint/datatypes
-- Up-to-date: /home/oz/.conan2/p/b/rerun566b244f3507e/p/include/rerun/datatypes
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/lib/librerun_c__linux_x64.a
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/lib/cmake/rerun_sdk/rerun_sdkTargets.cmake
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/lib/cmake/rerun_sdk/rerun_sdkTargets-release.cmake
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/lib/cmake/rerun_sdk/rerun_sdkConfig.cmake
-- Installing: /home/oz/.conan2/p/b/rerun566b244f3507e/p/lib/cmake/rerun_sdk/rerun_sdkConfigVersion.cmake

rerun_sdk/0.32.2: package(): Packaged 2 '.a' files: librerun_sdk.a, librerun_c__linux_x64.a
rerun_sdk/0.32.2: package(): Packaged 317 '.hpp' files
rerun_sdk/0.32.2: package(): Packaged 4 '.h' files: sdk_info.h, rerun.h, arrow_c_data_interface.h, compiler_utils.h
rerun_sdk/0.32.2: package(): Packaged 2 files: LICENSE-MIT, LICENSE-APACHE
rerun_sdk/0.32.2: Created package revision 92a1e311f9741c1a8caf2d769ec60194
rerun_sdk/0.32.2: Package '39f276bed1c3550047c640996108fc7c9b99f28e' created
rerun_sdk/0.32.2: Full package reference: rerun_sdk/0.32.2#77b973ff9ba0191b3237dd0da6468fdf:39f276bed1c3550047c640996108fc7c9b99f28e#92a1e311f9741c1a8caf2d769ec60194
rerun_sdk/0.32.2: Package folder /home/oz/.conan2/p/b/reruna5290e98b9345/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: boost/1.85.0, zlib/1.3.1, bzip2/1.0.8
WARN: deprecated:     'cpp_info.build_modules' used in: bzip2/1.0.8
WARN: deprecated:     'env_info' used in: boost/1.85.0, bzip2/1.0.8
WARN: deprecated:     'cpp_info.filenames' used in: boost/1.85.0
WARN: deprecated:     'user_info' used in: boost/1.85.0

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    rerun_sdk/0.32.2 (test package): /home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/conanfile.py
Requirements
    arrow/24.0.0#47e1bb5785c033f51b087283adcb8fb8 - Cache
    boost/1.85.0#9cf65cd6886db7973117c410f4f175c1 - Cache
    bzip2/1.0.8#00b4a4658791c1f06914e087f0e792f5 - Cache
    libbacktrace/cci.20210118#a7691bfccd8caaf66309df196790a5a1 - Cache
    libevent/2.1.12#7a7a21762e2b4ed13d29aee3e10c19e7 - Cache
    mimalloc/1.7.6#38e7b2fbff43efcae957e6a530a62b76 - Cache
    openssl/3.5.2#0c5a5e15ae569f45dff57adcf1770cf7 - Cache
    rapidjson/cci.20230929#8dc0392af2b3aaea7312095f0ba53467 - Cache
    rerun_sdk/0.32.2#77b973ff9ba0191b3237dd0da6468fdf - Cache
    thrift/0.20.0#e2331dea920adb2ed3a377c8123d2edb - Cache
    xsimd/14.0.0#0925747d035b2fd3385bf7940c77c5dd - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76 - Cache
Build requirements
    b2/5.3.3#107c15377719889654eb9a162a673975 - Cache
    bison/3.8.2#c3490cbe0078b6fd3eb4cf5ed64144dc - Cache
    cmake/3.31.8#dde3bde00bb843687e55aea5afa0e220 - Cache
    flex/2.6.4#e35bc44b3fcbcd661e0af0dc5b5b1ad4 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache

======== Computing necessary packages ========
libevent/2.1.12: WARN: risk: Transitive dependencies with 'headers=False' effect in 'package_id' is not necessary and suboptimal. Use required_conan_version='>=2.28' to activate it
thrift/0.20.0: WARN: risk: Transitive dependencies with 'headers=False' effect in 'package_id' is not necessary and suboptimal. Use required_conan_version='>=2.28' to activate it
arrow/24.0.0: WARN: risk: Transitive dependencies with 'headers=False' effect in 'package_id' is not necessary and suboptimal. Use required_conan_version='>=2.28' to activate it
rerun_sdk/0.32.2: WARN: risk: Transitive dependencies with 'headers=False' effect in 'package_id' is not necessary and suboptimal. Use required_conan_version='>=2.28' to activate it
Requirements
    arrow/24.0.0#47e1bb5785c033f51b087283adcb8fb8:da663c9833e35daca943f529fac7fbea3554d37e#dd4321d69029a63efb264fa70c32eeff - Cache
    boost/1.85.0#9cf65cd6886db7973117c410f4f175c1:398dcda4156d7b6e7414beebbf5332ab21817f8c#918934b30d4f994497bf9d3ef1188780 - Cache
    bzip2/1.0.8#00b4a4658791c1f06914e087f0e792f5:25b9eef9ec505da9aa189c5f8baa19573c091120#23c2710ef9b987f5ea25fef335f53cf1 - Cache
    libbacktrace/cci.20210118#a7691bfccd8caaf66309df196790a5a1:6980ffdedf2f062ab47388192e39ae3988cb5678#4d8fe043d21ddd192f0459f6dfd23801 - Cache
    libevent/2.1.12#7a7a21762e2b4ed13d29aee3e10c19e7:73899c42d572873ca40788ecc29c5c31e01c2902#77dd3889034596dafadc2bddc2f493a2 - Cache
    mimalloc/1.7.6#38e7b2fbff43efcae957e6a530a62b76:5c7e469aa7dbdb68fd5897b521d89f4013e61bbc#aa3dc39c0e5665f7c01ce0d7590babbc - Cache
    openssl/3.5.2#0c5a5e15ae569f45dff57adcf1770cf7:2ead4b5224b22aa6d964443cf39c8659bea28efd#85843c407a1d3c547536ebb8e54841f8 - Cache
    rerun_sdk/0.32.2#77b973ff9ba0191b3237dd0da6468fdf:39f276bed1c3550047c640996108fc7c9b99f28e#92a1e311f9741c1a8caf2d769ec60194 - Cache
    thrift/0.20.0#e2331dea920adb2ed3a377c8123d2edb:9e19c52b8aa0703947737ec748ead03e8fa43b73#7ab39fe43dbfcb3bb15dff190bbb972e - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76:6980ffdedf2f062ab47388192e39ae3988cb5678#7f6821a580a8c907f6174b862772d27f - Cache
Build requirements
Skipped binaries
    rapidjson/cci.20230929, xsimd/14.0.0, b2/5.3.3, bison/3.8.2, cmake/3.31.8, flex/2.6.4, m4/1.4.19

======== Installing packages ========
bzip2/1.0.8: Already installed! (1 of 10)
libbacktrace/cci.20210118: Already installed! (2 of 10)
zlib/1.3.1: Already installed! (3 of 10)
mimalloc/1.7.6: Already installed! (4 of 10)
boost/1.85.0: Already installed! (5 of 10)
openssl/3.5.2: Already installed! (6 of 10)
libevent/2.1.12: Already installed! (7 of 10)
thrift/0.20.0: Already installed! (8 of 10)
arrow/24.0.0: Already installed! (9 of 10)
rerun_sdk/0.32.2: Already installed! (10 of 10)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: boost/1.85.0, zlib/1.3.1, bzip2/1.0.8
WARN: deprecated:     'cpp_info.build_modules' used in: bzip2/1.0.8
WARN: deprecated:     'env_info' used in: boost/1.85.0, bzip2/1.0.8
WARN: deprecated:     'cpp_info.filenames' used in: boost/1.85.0
WARN: deprecated:     'user_info' used in: boost/1.85.0

======== Testing the package ========
Removing previously existing 'test_package' build folder: /home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/build/gcc-14-x86_64-gnu20-release
rerun_sdk/0.32.2 (test package): Test package build: build/gcc-14-x86_64-gnu20-release
rerun_sdk/0.32.2 (test package): Test package build folder: /home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/build/gcc-14-x86_64-gnu20-release
rerun_sdk/0.32.2 (test package): Writing generators to /home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/build/gcc-14-x86_64-gnu20-release/generators
rerun_sdk/0.32.2 (test package): Generator 'CMakeToolchain' calling 'generate()'
rerun_sdk/0.32.2 (test package): CMakeToolchain generated: conan_toolchain.cmake
rerun_sdk/0.32.2 (test package): CMakeToolchain generated: /home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/build/gcc-14-x86_64-gnu20-release/generators/CMakePresets.json
rerun_sdk/0.32.2 (test package): CMakeToolchain generated: /home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/CMakeUserPresets.json
rerun_sdk/0.32.2 (test package): Generator 'CMakeDeps' calling 'generate()'
rerun_sdk/0.32.2 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(rerun_sdk)
    target_link_libraries(... rerun_sdk::rerun_sdk)
rerun_sdk/0.32.2 (test package): Generator 'VirtualRunEnv' calling 'generate()'
rerun_sdk/0.32.2 (test package): Generating aggregated env files
rerun_sdk/0.32.2 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
rerun_sdk/0.32.2 (test package): Calling build()
rerun_sdk/0.32.2 (test package): Running CMake.configure()
rerun_sdk/0.32.2 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package"
-- Using Conan toolchain: /home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/build/gcc-14-x86_64-gnu20-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 20 with extensions ON
-- The CXX compiler identification is GNU 14.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++-14 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'rerun_sdk::rerun_sdk'
-- Conan: Component target declared 'Arrow::arrow_static'
-- Conan: Component target declared 'Parquet::parquet_static'
-- Conan: Target declared 'arrow::arrow'
-- Conan: Component target declared 'thrift::thrift'
-- Conan: Component target declared 'thriftz::thriftz'
-- Conan: Component target declared 'thriftnb::thriftnb'
-- Conan: Target declared 'thrift::thrift-conan-do-not-use'
-- Conan: Component target declared 'libevent::core'
-- Conan: Component target declared 'libevent::extra'
-- Conan: Component target declared 'libevent::openssl'
-- Conan: Component target declared 'libevent::pthreads'
-- Conan: Target declared 'libevent::libevent'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/home/oz/.conan2/p/b/opens91df8e75037c8/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Conan: Component target declared 'Boost::diagnostic_definitions'
-- Conan: Component target declared 'Boost::disable_autolinking'
-- Conan: Component target declared 'Boost::dynamic_linking'
-- Conan: Component target declared 'Boost::headers'
-- Conan: Component target declared 'Boost::boost'
-- Conan: Component target declared 'boost::_libboost'
-- Conan: Component target declared 'Boost::atomic'
-- Conan: Component target declared 'Boost::charconv'
-- Conan: Component target declared 'Boost::container'
-- Conan: Component target declared 'Boost::context'
-- Conan: Component target declared 'Boost::date_time'
-- Conan: Component target declared 'Boost::exception'
-- Conan: Component target declared 'Boost::math'
-- Conan: Component target declared 'Boost::program_options'
-- Conan: Component target declared 'Boost::regex'
-- Conan: Component target declared 'Boost::serialization'
-- Conan: Component target declared 'Boost::stacktrace'
-- Conan: Component target declared 'Boost::system'
-- Conan: Component target declared 'Boost::timer'
-- Conan: Component target declared 'Boost::chrono'
-- Conan: Component target declared 'Boost::cobalt'
-- Conan: Component target declared 'Boost::coroutine'
-- Conan: Component target declared 'Boost::filesystem'
-- Conan: Component target declared 'Boost::json'
-- Conan: Component target declared 'Boost::math_c99'
-- Conan: Component target declared 'Boost::math_c99f'
-- Conan: Component target declared 'Boost::math_c99l'
-- Conan: Component target declared 'Boost::math_tr1'
-- Conan: Component target declared 'Boost::math_tr1f'
-- Conan: Component target declared 'Boost::math_tr1l'
-- Conan: Component target declared 'Boost::random'
-- Conan: Component target declared 'Boost::stacktrace_addr2line'
-- Conan: Component target declared 'Boost::stacktrace_backtrace'
-- Conan: Component target declared 'Boost::stacktrace_basic'
-- Conan: Component target declared 'Boost::stacktrace_from_exception'
-- Conan: Component target declared 'Boost::stacktrace_noop'
-- Conan: Component target declared 'Boost::test'
-- Conan: Component target declared 'Boost::url'
-- Conan: Component target declared 'Boost::wserialization'
-- Conan: Component target declared 'Boost::fiber'
-- Conan: Component target declared 'Boost::graph'
-- Conan: Component target declared 'Boost::iostreams'
-- Conan: Component target declared 'Boost::nowide'
-- Conan: Component target declared 'Boost::prg_exec_monitor'
-- Conan: Component target declared 'Boost::test_exec_monitor'
-- Conan: Component target declared 'Boost::thread'
-- Conan: Component target declared 'Boost::wave'
-- Conan: Component target declared 'Boost::contract'
-- Conan: Component target declared 'Boost::fiber_numa'
-- Conan: Component target declared 'Boost::locale'
-- Conan: Component target declared 'Boost::log'
-- Conan: Component target declared 'Boost::type_erasure'
-- Conan: Component target declared 'Boost::unit_test_framework'
-- Conan: Component target declared 'Boost::log_setup'
-- Conan: Target declared 'boost::boost'
-- Conan: Target declared 'BZip2::BZip2'
-- Conan: Including build module from '/home/oz/.conan2/p/b/bzip271aac068b1f95/p/lib/cmake/conan-official-bzip2-variables.cmake'
-- Conan: Target declared 'libbacktrace::libbacktrace'
-- Conan: Target declared 'mimalloc-static'
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/build/gcc-14-x86_64-gnu20-release

rerun_sdk/0.32.2 (test package): Running CMake.build()
rerun_sdk/0.32.2 (test package): RUN: cmake --build "/home/oz/git/conan-center-index/recipes/rerun_sdk/all/test_package/build/gcc-14-x86_64-gnu20-release" -- -j8
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
rerun_sdk/0.32.2 (test package): Running test()
rerun_sdk/0.32.2 (test package): RUN: ./test_package
rerun version: 0.32.2
```

</details>

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
