### PR TITLE
catch2: Update to 3.11.0 (#28491)

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.11.0":
+    url: "https://github.com/catchorg/Catch2/archive/v3.11.0.tar.gz"
+    sha256: "82fa1cb59dc28bab220935923f7469b997b259eb192fb9355db62da03c2a3137"
   "3.10.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.10.0.tar.gz"
     sha256: "fc4303a5c2738beaa727066e126b5a28837a812230a3c5826caa38e7ab99ca48"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.11.0":
+    folder: 3.x.x
   "3.10.0":
     folder: 3.x.x
   "3.9.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **catch2/3.11.0**

#### Motivation
#28491 

#### Details
Add new source. Upstream added `CATCH_BUILD_BENCHMARKS` as a CMake option, but as it defaults to `False`, I don't think it needs to be handled here.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
