### PR TITLE
Fix build of bzip2 when using cmake>=4

### DIFF
--- a/recipes/bzip2/all/conanfile.py
+++ b/recipes/bzip2/all/conanfile.py
@@ -51,6 +51,8 @@ class Bzip2Conan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        if Version(self.version) <= "1.0.8":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
         tc.variables["BZ2_BUILD_EXE"] = self.options.build_executable
         tc.variables["BZ2_SRC_DIR"] = self.source_folder.replace("\\", "/")
         tc.variables["BZ2_VERSION_MAJOR"] = Version(self.version).major


### PR DESCRIPTION
### Summary
Changes to recipe:  bzip2/[<=1.0.8]

#### Motivation
Build is breaking with cmake >=4. Using method from conan-center-index#28451 to make cmake use a policy version compatible with cmake >=4.

#### Details
none


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
