### PR TITLE
opencolorio: Add 2.5.0

### DIFF
--- a/recipes/opencolorio/all/conandata.yml
+++ b/recipes/opencolorio/all/conandata.yml
@@ -1,8 +1,15 @@
 sources:
+  "2.5.0":
+    url: "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v2.5.0.tar.gz"
+    sha256: "124e2bfa8a9071959d6ddbb64ffbf78d3f6fe3c923ae23e96a6bbadde1af55b6"
   "2.4.2":
     url: "https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v2.4.2.tar.gz"
     sha256: "2d8f2c47c40476d6e8cea9d878f6601d04f6d5642b47018eaafa9e9f833f3690"
 patches:
+  "2.5.0":
+    - patch_file: "patches/2.5.0-0001-fix-cmake-source-dir-and-targets.patch"
+      patch_description: "use cci package, use PROJECT_BINARY_DIR/PROJECT_SOURCE_DIR"
+      patch_type: "conan"
   "2.4.2":
     - patch_file: "patches/2.4.2-0001-fix-cmake-source-dir-and-targets.patch"
       patch_description: "use cci package, use PROJECT_BINARY_DIR/PROJECT_SOURCE_DIR"

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -59,7 +59,8 @@ class OpenColorIOConan(ConanFile):
         # TODO: add GLUT (needed for ociodisplay tool)
 
     def validate(self):
-        check_min_cppstd(self, 11)
+        minimum_cppstd = 11 if Version(self.version) < "2.5" else 17
+        check_min_cppstd(self, minimum_cppstd)
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6.0":
             raise ConanInvalidConfiguration(f"{self.ref} requires gcc >= 6.0")
 

--- a/recipes/opencolorio/all/patches/2.5.0-0001-fix-cmake-source-dir-and-targets.patch
+++ b/recipes/opencolorio/all/patches/2.5.0-0001-fix-cmake-source-dir-and-targets.patch
@@ -1,0 +1,87 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 76899758..2a559ff2 100755
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -517,7 +517,7 @@ install(
+     FILE ${OCIO_TARGETS_EXPORT_NAME}
+ )
+ 
+-if (NOT BUILD_SHARED_LIBS)
++if (0)
+     # Install custom macros used in the find modules.
+     install(FILES
+         ${CMAKE_CURRENT_LIST_DIR}/share/cmake/macros/VersionUtils.cmake
+diff --git share/cmake/modules/FindExtPackages.cmake share/cmake/modules/FindExtPackages.cmake
+index 9bf17cf8..ef4a7694 100644
+--- share/cmake/modules/FindExtPackages.cmake
++++ share/cmake/modules/FindExtPackages.cmake
+@@ -110,7 +110,7 @@ ocio_handle_dependency(  ZLIB REQUIRED ALLOW_INSTALL
+ 
+ # minizip-ng
+ # https://github.com/zlib-ng/minizip-ng
+-ocio_handle_dependency(  minizip-ng REQUIRED ALLOW_INSTALL
++ocio_handle_dependency(  minizip REQUIRED ALLOW_INSTALL
+                          MIN_VERSION 4.0.0
+                          RECOMMENDED_VERSION 4.0.10
+                          RECOMMENDED_VERSION_REASON "Latest version tested with OCIO")
+@@ -131,7 +131,7 @@ if(OCIO_BUILD_APPS)
+ 
+     # lcms2
+     # https://github.com/mm2/Little-CMS
+-    ocio_handle_dependency(  lcms2 REQUIRED ALLOW_INSTALL
++    ocio_handle_dependency(  lcms REQUIRED ALLOW_INSTALL
+                              MIN_VERSION 2.2
+                              RECOMMENDED_VERSION 2.17
+                              RECOMMENDED_VERSION_REASON "Latest version tested with OCIO")
+diff --git share/cmake/utils/CppVersion.cmake share/cmake/utils/CppVersion.cmake
+index 127ec9e7..8f5abb4a 100644
+--- share/cmake/utils/CppVersion.cmake
++++ share/cmake/utils/CppVersion.cmake
+@@ -16,7 +16,7 @@ elseif(NOT CMAKE_CXX_STANDARD IN_LIST SUPPORTED_CXX_STANDARDS)
+             "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is unsupported. Supported standards are: ${SUPPORTED_CXX_STANDARDS_STR}.")
+ endif()
+ 
+-set_property(CACHE CMAKE_CXX_STANDARD PROPERTY STRINGS "${SUPPORTED_CXX_STANDARDS}")
++#set_property(CACHE CMAKE_CXX_STANDARD PROPERTY STRINGS "${SUPPORTED_CXX_STANDARDS}")
+ 
+ include(CheckCXXCompilerFlag)
+ 
+diff --git src/OpenColorIO/CMakeLists.txt src/OpenColorIO/CMakeLists.txt
+index f56b6219..b7a582ff 100755
+--- src/OpenColorIO/CMakeLists.txt
++++ src/OpenColorIO/CMakeLists.txt
+@@ -325,7 +325,7 @@ target_link_libraries(OpenColorIO
+         "$<BUILD_INTERFACE:utils::strings>"
+         "$<BUILD_INTERFACE:xxHash>"
+         yaml-cpp::yaml-cpp
+-        MINIZIP::minizip-ng
++        MINIZIP::minizip
+ )
+ 
+ if(OCIO_USE_SIMD AND OCIO_USE_SSE2NEON AND COMPILER_SUPPORTS_SSE_WITH_SSE2NEON)
+diff --git src/apps/ocioarchive/CMakeLists.txt src/apps/ocioarchive/CMakeLists.txt
+index 599d706f..efe6cd5a 100644
+--- src/apps/ocioarchive/CMakeLists.txt
++++ src/apps/ocioarchive/CMakeLists.txt
+@@ -21,7 +21,7 @@ target_link_libraries(ocioarchive
+     PRIVATE
+         apputils
+         OpenColorIO
+-        MINIZIP::minizip-ng
++        MINIZIP::minizip
+ )
+ 
+ include(StripUtils)
+diff --git src/apps/ociobakelut/CMakeLists.txt src/apps/ociobakelut/CMakeLists.txt
+index 3d6e586b..f7069a1f 100755
+--- src/apps/ociobakelut/CMakeLists.txt
++++ src/apps/ociobakelut/CMakeLists.txt
+@@ -29,7 +29,7 @@ set_target_properties(ociobakelut
+ target_link_libraries(ociobakelut 
+     PRIVATE 
+         apputils
+-        lcms2::lcms2
++        lcms::lcms
+         OpenColorIO
+ )
+ 

--- a/recipes/opencolorio/config.yml
+++ b/recipes/opencolorio/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.5.0":
+    folder: "all"
   "2.4.2":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencolorio/2.5.0**

#### Motivation
This is the newest release in the roughly yearly cycle for large changes, bringing a ton of new functionallity as well as fixes for other things. Also is the intended version for tools using the - currently in draft - VFX reference platform 2026 (https://vfxplatform.com/)

#### Details
https://github.com/AcademySoftwareFoundation/OpenColorIO/releases/tag/v2.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
