### PR TITLE
[libmodbus] Add version 3.1.11

### DIFF
--- a/recipes/libmodbus/all/conandata.yml
+++ b/recipes/libmodbus/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.11":
+    url: "https://github.com/stephane/libmodbus/archive/refs/tags/v3.1.11.tar.gz"
+    sha256: "8a750452ef86a53de6cec6fbca67bd5be08d0a1e87278a422fbce3003fd42d99"
   "3.1.10":
     url: "https://github.com/stephane/libmodbus/releases/download/v3.1.10/libmodbus-3.1.10.tar.gz"
     sha256: "899be4e25ab7fe5799d43f9567510d6f063d2e8f56136dd726b6fd976f9b2253"
@@ -9,6 +12,8 @@ sources:
     url: "https://libmodbus.org/releases/libmodbus-3.1.6.tar.gz"
     sha256: "d7d9fa94a16edb094e5fdf5d87ae17a0dc3f3e3d687fead81835d9572cf87c16"
 patches:
+  "3.1.11":
+    - patch_file: "patches/3.1.11-0001-msvc-fixes.patch"
   "3.1.10":
     - patch_file: "patches/3.1.10-0001-msvc-fixes.patch"
   "3.1.8":

--- a/recipes/libmodbus/all/conanfile.py
+++ b/recipes/libmodbus/all/conanfile.py
@@ -1,10 +1,9 @@
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, replace_in_file, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import check_min_vs, is_msvc, unix_path
+from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
 import os
 
@@ -51,8 +50,11 @@ class LibmodbusConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def build_requirements(self):
+        self.tool_requires("libtool/2.4.7")
+
         if is_msvc(self):
             self.tool_requires("automake/1.16.5")
+            
         if self._settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
@@ -62,38 +64,25 @@ class LibmodbusConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        env = VirtualBuildEnv(self)
-        env.generate()
-
         tc = AutotoolsToolchain(self)
         if Version(self.version) < "3.1.8":
             tc.configure_args.append("--without-documentation")
         tc.configure_args.append("--disable-tests")
         if is_msvc(self) and check_min_vs(self, "180", raise_invalid=False):
             tc.extra_cflags.append("-FS")
-        env = tc.environment()
-        if is_msvc(self):
-            compile_wrapper = unix_path(self, os.path.join(self.source_folder, "build-aux", "compile"))
-            ar_wrapper = unix_path(self, self.conf.get("user.automake:lib-wrapper", check_type=str))
-            env.define("CC", f"{compile_wrapper} cl -nologo")
-            env.define("CXX", f"{compile_wrapper} cl -nologo")
-            env.define("LD", "link -nologo")
-            env.define("AR", f"{ar_wrapper} \"lib -nologo\"")
-            env.define("NM", "dumpbin -symbols")
-            env.define("OBJDUMP", ":")
-            env.define("RANLIB", ":")
-            env.define("STRIP", ":")
-        tc.generate(env)
+            if self.options.shared:
+                tc.extra_defines.append("DLLBUILD")
+        tc.generate()
 
     def _patch_sources(self):
         apply_conandata_patches(self)
         if not self.options.shared:
             for decl in ("__declspec(dllexport)", "__declspec(dllimport)"):
                 replace_in_file(self, os.path.join(self.source_folder, "src", "modbus.h"), decl, "")
-
     def build(self):
         self._patch_sources()
         autotools = Autotools(self)
+        autotools.autoreconf()
         autotools.configure()
         autotools.make()
 

--- a/recipes/libmodbus/all/patches/3.1.10-0001-msvc-fixes.patch
+++ b/recipes/libmodbus/all/patches/3.1.10-0001-msvc-fixes.patch
@@ -1,14 +1,21 @@
---- src/Makefile.in
-+++ src/Makefile.in
-@@ -326,7 +326,7 @@
- localstatedir = @localstatedir@
- mandir = @mandir@
- mkdir_p = @mkdir_p@
--my_CFLAGS = @my_CFLAGS@
-+my_CFLAGS =
- oldincludedir = @oldincludedir@
- pdfdir = @pdfdir@
- prefix = @prefix@
+--- configure.ac
++++ configure.ac
+@@ -137,15 +137,6 @@ AC_CHECK_DECLS([TIOCSRS485], [], [], [[#include <sys/ioctl.h>]])
+ # Check for RTS flags
+ AC_CHECK_DECLS([TIOCM_RTS], [], [], [[#include <sys/ioctl.h>]])
+ 
+-# Wtype-limits is not supported by gcc 4.2 (default on recent Mac OS X)
+-my_CFLAGS="-Wall \
+--Wmissing-declarations -Wmissing-prototypes \
+--Wnested-externs -Wpointer-arith \
+--Wpointer-arith -Wsign-compare -Wchar-subscripts \
+--Wstrict-prototypes -Wshadow \
+--Wformat-security"
+-AC_SUBST([my_CFLAGS])
+-
+ # Build options
+ AC_ARG_ENABLE(tests,
+ 	AS_HELP_STRING([--disable-tests],
 --- src/modbus-private.h
 +++ src/modbus-private.h
 @@ -14,5 +14,5 @@

--- a/recipes/libmodbus/all/patches/3.1.11-0001-msvc-fixes.patch
+++ b/recipes/libmodbus/all/patches/3.1.11-0001-msvc-fixes.patch
@@ -1,0 +1,52 @@
+--- configure.ac
++++ configure.ac
+@@ -147,14 +147,6 @@ AC_CHECK_DECLS([TIOCSRS485], [], [], [[#include <sys/ioctl.h>]])
+ # Check for RTS flags
+ AC_CHECK_DECLS([TIOCM_RTS], [], [], [[#include <sys/ioctl.h>]])
+ 
+-WARNING_CFLAGS="-Wall \
+--Wmissing-declarations -Wmissing-prototypes \
+--Wnested-externs -Wpointer-arith \
+--Wsign-compare -Wchar-subscripts \
+--Wstrict-prototypes -Wshadow \
+--Wformat-security"
+-AC_SUBST([WARNING_CFLAGS])
+-
+ # Build options
+ AC_ARG_ENABLE(tests,
+ 	AS_HELP_STRING([--disable-tests],
+@@ -178,14 +170,6 @@ AC_ARG_ENABLE([debug],
+   [enable_debug=$enableval],
+   [enable_debug=no])
+ 
+-AS_IF([test "x$enable_debug" = "xyes"], [
+-  CFLAGS="-g -O0"
+-  CXXFLAGS="-g -O0"
+-], [
+-  CFLAGS="-O2"
+-  CXXFLAGS="-O2"
+-])
+-
+ AC_OUTPUT
+ AC_MSG_RESULT([
+         $PACKAGE $VERSION
+@@ -197,7 +181,7 @@ AC_MSG_RESULT([
+         includedir:             ${includedir}
+ 
+         compiler:               ${CC}
+-        cflags:                 ${CFLAGS} ${WARNING_CFLAGS}
++        cflags:                 ${CFLAGS}
+         ldflags:                ${LDFLAGS}
+ 
+         tests:                  ${enable_tests}
+--- src/modbus-private.h
++++ src/modbus-private.h
+@@ -14,7 +14,7 @@
+ #else
+ # include "stdint.h"
+ # include <time.h>
+-typedef int ssize_t;
++// typedef int ssize_t;
+ #endif
+ // clang-format on
+ #include <config.h>

--- a/recipes/libmodbus/all/patches/3.1.6-0001-msvc-fixes.patch
+++ b/recipes/libmodbus/all/patches/3.1.6-0001-msvc-fixes.patch
@@ -1,14 +1,21 @@
---- src/Makefile.in
-+++ src/Makefile.in
-@@ -327,7 +327,7 @@
- localstatedir = @localstatedir@
- mandir = @mandir@
- mkdir_p = @mkdir_p@
--my_CFLAGS = @my_CFLAGS@
-+my_CFLAGS =
- oldincludedir = @oldincludedir@
- pdfdir = @pdfdir@
- prefix = @prefix@
+--- configure.ac
++++ configure.ac
+@@ -135,15 +135,6 @@ AC_CHECK_DECLS([TIOCSRS485], [], [], [[#include <sys/ioctl.h>]])
+ # Check for RTS flags
+ AC_CHECK_DECLS([TIOCM_RTS], [], [], [[#include <sys/ioctl.h>]])
+ 
+-# Wtype-limits is not supported by gcc 4.2 (default on recent Mac OS X)
+-my_CFLAGS="-Wall \
+--Wmissing-declarations -Wmissing-prototypes \
+--Wnested-externs -Wpointer-arith \
+--Wpointer-arith -Wsign-compare -Wchar-subscripts \
+--Wstrict-prototypes -Wshadow \
+--Wformat-security"
+-AC_SUBST([my_CFLAGS])
+-
+ # Build options
+ AC_ARG_ENABLE(tests,
+ 	AS_HELP_STRING([--disable-tests],
 --- src/modbus-private.h
 +++ src/modbus-private.h
 @@ -13,7 +13,7 @@

--- a/recipes/libmodbus/all/patches/3.1.8-0001-msvc-fixes.patch
+++ b/recipes/libmodbus/all/patches/3.1.8-0001-msvc-fixes.patch
@@ -1,14 +1,21 @@
---- src/Makefile.in
-+++ src/Makefile.in
-@@ -326,7 +326,7 @@
- localstatedir = @localstatedir@
- mandir = @mandir@
- mkdir_p = @mkdir_p@
--my_CFLAGS = @my_CFLAGS@
-+my_CFLAGS =
- oldincludedir = @oldincludedir@
- pdfdir = @pdfdir@
- prefix = @prefix@
+--- configure.ac
++++ configure.ac
+@@ -135,15 +135,6 @@ AC_CHECK_DECLS([TIOCSRS485], [], [], [[#include <sys/ioctl.h>]])
+ # Check for RTS flags
+ AC_CHECK_DECLS([TIOCM_RTS], [], [], [[#include <sys/ioctl.h>]])
+ 
+-# Wtype-limits is not supported by gcc 4.2 (default on recent Mac OS X)
+-my_CFLAGS="-Wall \
+--Wmissing-declarations -Wmissing-prototypes \
+--Wnested-externs -Wpointer-arith \
+--Wpointer-arith -Wsign-compare -Wchar-subscripts \
+--Wstrict-prototypes -Wshadow \
+--Wformat-security"
+-AC_SUBST([my_CFLAGS])
+-
+ # Build options
+ AC_ARG_ENABLE(tests,
+ 	AS_HELP_STRING([--disable-tests],
 --- src/modbus-private.h
 +++ src/modbus-private.h
 @@ -13,7 +13,7 @@

--- a/recipes/libmodbus/config.yml
+++ b/recipes/libmodbus/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.1.11":
+    folder: all
   "3.1.10":
     folder: all
   "3.1.8":


### PR DESCRIPTION
### Summary
Add version 3.1.11 of library libmodbus

#### Motivation
The version is already out for quite some time and contains numerous updates and bugfixes (cf. https://github.com/stephane/libmodbus/releases/tag/v3.1.11)

#### Details
I only added the new version.
The source command had to be adapted, because there are some weird files in the archive (prefixed with an underscore) that didn't seem to be present in previous versions (I checked v3.1.10). The option `strip_root` of get doesn't work anymore.

I haven't yet checked if the package builds on windows and the patches have to be adapted. I will do that.

Best regards
oz

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
