### PR TITLE
7zip: add version 25.01

### DIFF
--- a/recipes/7zip/all/conandata.yml
+++ b/recipes/7zip/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "25.00":
+  "25.01":
     url:
-      - https://www.7-zip.org/a/7z2500-src.tar.xz
-      - https://sourceforge.net/projects/sevenzip/files/7-Zip/25.00/7z2500-src.tar.xz
-    sha256: "bff9e69b6ca73a5b8715d7623870a39dc90ad6ce1f4d1070685843987af1af9b"
+      - https://www.7-zip.org/a/7z2501-src.tar.xz
+      - https://sourceforge.net/projects/sevenzip/files/7-Zip/25.01/7z2501-src.tar.xz
+    sha256: "ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e"
   "24.09":
     url:
       - https://www.7-zip.org/a/7z2409-src.tar.xz

--- a/recipes/7zip/all/conandata.yml
+++ b/recipes/7zip/all/conandata.yml
@@ -2,6 +2,7 @@ sources:
   "25.01":
     url:
       - https://www.7-zip.org/a/7z2501-src.tar.xz
+      - https://github.com/ip7z/7zip/releases/download/25.01/7z2501-src.tar.xz
       - https://sourceforge.net/projects/sevenzip/files/7-Zip/25.01/7z2501-src.tar.xz
     sha256: "ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e"
   "24.09":

--- a/recipes/7zip/config.yml
+++ b/recipes/7zip/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "25.00":
+  "25.01":
     folder: "all"
   "24.09":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **7zip/25.01**

#### Motivation
CVE-2025-55188

#### Details
https://www.7-zip.org/history.txt


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
