### PR TITLE
libwebp: add 1.6.0

### DIFF
--- a/recipes/libwebp/all/conandata.yml
+++ b/recipes/libwebp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.6.0.tar.gz"
+    sha256: "e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564"
   "1.5.0":
     url: "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0.tar.gz"
     sha256: "7d6fab70cf844bf6769077bd5d7a74893f8ffd4dfb42861745750c63c2a5c92c"
@@ -18,6 +21,10 @@ sources:
     url: "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.1.0.tar.gz"
     sha256: "98a052268cc4d5ece27f76572a7f50293f439c17a98e67c4ea0c7ed6f50ef043"
 patches:
+  "1.6.0":
+    - patch_file: "patches/1.6.0-0001-fix-cmake.patch"
+      patch_description: "disable PIC, disable prefix library name on MSVC"
+      patch_type: "conan"
   "1.5.0":
     - patch_file: "patches/1.5.0-0001-fix-cmake.patch"
       patch_description: "disable PIC, disable prefix library name on MSVC"

--- a/recipes/libwebp/all/patches/1.6.0-0001-fix-cmake.patch
+++ b/recipes/libwebp/all/patches/1.6.0-0001-fix-cmake.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ad5e14c3..89c836f3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,7 +57,6 @@ if(WEBP_LINK_STATIC)
+   else()
+     set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+   endif()
+-  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+   # vwebp does not compile on Ubuntu with static libraries so disabling it for
+   # now.
+   set(WEBP_BUILD_VWEBP OFF)
+@@ -161,7 +160,7 @@ endif()
+ set(PTHREAD_LIBS ${CMAKE_THREAD_LIBS_INIT})
+ set(INSTALLED_LIBRARIES)
+ 
+-if(MSVC)
++if(0)
+   # match the naming convention used by nmake
+   set(webp_libname_prefix "lib")
+   set(CMAKE_SHARED_LIBRARY_PREFIX "${webp_libname_prefix}")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libwebp/1.6.0**

#### Motivation
This integrates upstream version released 9th of Jul 2025, which brings performance fixes and bugfixes.

#### Details
Changelog: https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.6.0

I tested this on macOS arm64, and linked OpenCV against it. The single patch required line number changes just like with the 1.4.0 to 1.5.0 bump previously, but contents are otherwise identical.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
