### PR TITLE
gperftools: add 2.17.2

### DIFF
--- a/recipes/gperftools/all/conandata.yml
+++ b/recipes/gperftools/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.17.2":
+    url: "https://github.com/gperftools/gperftools/releases/download/gperftools-2.17.2/gperftools-2.17.2.tar.gz"
+    sha256: "bb172a54312f623b53d8b94cab040248c559decdb87574ed873e80b516e6e8eb"
   "2.16":
     url: "https://github.com/gperftools/gperftools/releases/download/gperftools-2.16/gperftools-2.16.tar.gz"
     sha256: "f12624af5c5987f2cc830ee534f754c3c5961eec08004c26a8b80de015cf056f"

--- a/recipes/gperftools/config.yml
+++ b/recipes/gperftools/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.17.2":
+    folder: all
   "2.16":
     folder: all
   "2.15":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gperftools/2.17.2**

#### Motivation
There was a new upstream release August this year.

#### Details
Tested on macOS arm64, macOS x86_64, Linux x86_64 by building and linking tcalloc against a program of mine.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
