### PR TITLE
Add riscv64 architecture support for RocksDB

### DIFF
--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -89,7 +89,7 @@ class RocksDBConan(ConanFile):
     def validate(self):
         check_min_cppstd(self, 17)
 
-        if self.settings.arch not in ["x86_64", "ppc64le", "ppc64", "mips64", "armv8"]:
+        if self.settings.arch not in ["x86_64", "ppc64le", "ppc64", "mips64", "armv8", "riscv64"]:
             raise ConanInvalidConfiguration("Rocksdb requires 64 bits")
 
         if is_msvc(self) and Version(self.settings.compiler.version) < "191":


### PR DESCRIPTION
The change was the only one missing for successfully build of rockdb on 24.04.1-Ubuntu:

```
> uname -a
Linux 5ce862dec84f 6.14.0-24-generic #24.1~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Jun 26 03:59:26 UTC riscv64 riscv64 riscv64 GNU/Linux

> /home/dev/.local/bin/conan list "rocksdb:*" --cache
Found 1 pkg/version recipes matching rocksdb in local cache
Local Cache
  rocksdb
    rocksdb/9.7.4
      revisions
        763fb87b2974dcc2bb048c1cc56772b4 (2025-10-04 14:38:04 UTC)
          packages
            bf3d943981a31f0653ceab2c7fc80004db11644e
              info
                settings
                  arch: riscv64
                  build_type: Release
                  compiler: gcc
                  compiler.cppstd: 17
                  compiler.libcxx: libstdc++11
                  compiler.version: 13
                  os: Linux
                options
                  enable_sse: False
                  fPIC: True
                  lite: False
                  shared: False
                  use_rtti: False
                  with_gflags: False
                  with_jemalloc: False
                  with_lz4: False
                  with_snappy: False
                  with_zlib: False
                  with_zstd: False
```


### Summary
Changes to recipe:  **rocksdb/**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details

<details><summary>Details</summary>
<p>

```

root@fd7c464aad53:/workspace/conan-center-index/recipes/rocksdb/all# conan create . --version 10.5.1 --name rocksdb

======== Exporting recipe to the cache ========
rocksdb/10.5.1: Exporting package recipe: /workspace/conan-center-index/recipes/rocksdb/all/conanfile.py
rocksdb/10.5.1: exports: File 'conandata.yml' found. Exporting it...
rocksdb/10.5.1: Calling export_sources()
rocksdb/10.5.1: Copied 1 '.yml' file: conandata.yml
rocksdb/10.5.1: Copied 1 '.py' file: conanfile.py
rocksdb/10.5.1: Copied 1 '.patch' file: 9.x.x-0001-exclude-thirdparty.patch
rocksdb/10.5.1: Exported to cache folder: /root/.conan2/p/rocksc506f5b3c5d7b/e
rocksdb/10.5.1: Exported: rocksdb/10.5.1#020c996388e513d7078e35d5b01b93ed (2025-10-06 20:24:36 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=riscv64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux
[platform_tool_requires]
cmake/3.22.1

Profile build:
[settings]
arch=riscv64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux
[platform_tool_requires]
cmake/3.22.1


======== Computing dependency graph ========
Graph root
    cli
Requirements
    rocksdb/10.5.1#020c996388e513d7078e35d5b01b93ed - Cache

======== Computing necessary packages ========
rocksdb/10.5.1: Forced build from source
Requirements
    rocksdb/10.5.1#020c996388e513d7078e35d5b01b93ed:ad5254e190414cdcc1b0ebf8de2464251ab17f0a - Build

======== Installing packages ========
rocksdb/10.5.1: Calling source() in /root/.conan2/p/rocksc506f5b3c5d7b/s/src
rocksdb/10.5.1: Downloading 13.9MB v10.5.1.tar.gz
rocksdb/10.5.1: Uncompressing v10.5.1.tar.gz to .
rocksdb/10.5.1: Apply patch (file): Do not include thirdparty.inc

-------- Installing package rocksdb/10.5.1 (1 of 1) --------
rocksdb/10.5.1: Building from source
rocksdb/10.5.1: Package rocksdb/10.5.1:ad5254e190414cdcc1b0ebf8de2464251ab17f0a
rocksdb/10.5.1: settings: os=Linux arch=riscv64 compiler=gcc compiler.cppstd=gnu17 compiler.libcxx=libstdc++11 compiler.version=11 build_type=Release
rocksdb/10.5.1: options: enable_sse=False fPIC=True shared=False use_rtti=False with_folly=False with_gflags=False with_jemalloc=False with_lz4=False with_snappy=False with_zlib=False with_zstd=False
rocksdb/10.5.1: Copying sources to build folder
rocksdb/10.5.1: Building your package in /root/.conan2/p/b/rocksd83af45e2c15d/b
rocksdb/10.5.1: Calling generate()
rocksdb/10.5.1: Generators folder: /root/.conan2/p/b/rocksd83af45e2c15d/b/build/Release/generators
rocksdb/10.5.1: CMakeToolchain generated: conan_toolchain.cmake
rocksdb/10.5.1: CMakeToolchain generated: /root/.conan2/p/b/rocksd83af45e2c15d/b/build/Release/generators/CMakePresets.json
rocksdb/10.5.1: CMakeToolchain generated: /root/.conan2/p/b/rocksd83af45e2c15d/b/src/CMakeUserPresets.json
rocksdb/10.5.1: Generating aggregated env files
rocksdb/10.5.1: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
rocksdb/10.5.1: Calling build()
rocksdb/10.5.1: Running CMake.configure()
rocksdb/10.5.1: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/root/.conan2/p/b/rocksd83af45e2c15d/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/root/.conan2/p/b/rocksd83af45e2c15d/b/src"
-- Using Conan toolchain: /root/.conan2/p/b/rocksd83af45e2c15d/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: C++ Standard 17 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The CXX compiler identification is GNU 11.4.0
-- The C compiler identification is GNU 11.4.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test HAVE_OMIT_LEAF_FRAME_POINTER
-- Performing Test HAVE_OMIT_LEAF_FRAME_POINTER - Failed
-- Performing Test BUILTIN_ATOMIC
-- Performing Test BUILTIN_ATOMIC - Success
-- Could NOT find uring (missing: uring_LIBRARIES uring_INCLUDE_DIR) 
-- Disabling RTTI in all builds
-- Performing Test HAVE_FALLOCATE
-- Performing Test HAVE_FALLOCATE - Success
-- Performing Test HAVE_SYNC_FILE_RANGE_WRITE
-- Performing Test HAVE_SYNC_FILE_RANGE_WRITE - Success
-- Performing Test HAVE_PTHREAD_MUTEX_ADAPTIVE_NP
-- Performing Test HAVE_PTHREAD_MUTEX_ADAPTIVE_NP - Success
-- Looking for malloc_usable_size
-- Looking for malloc_usable_size - found
-- Looking for sched_getcpu
-- Looking for sched_getcpu - found
-- Looking for getauxval
-- Looking for getauxval - found
-- Looking for F_FULLFSYNC
-- Looking for F_FULLFSYNC - not found
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- ROCKSDB_PLUGINS: 
-- ROCKSDB PLUGINS TO BUILD 
-- Found Git: /usr/bin/git (found version "2.34.1") 
-- JNI library is disabled
-- Configuring done
-- Generating done
-- Build files have been written to: /root/.conan2/p/b/rocksd83af45e2c15d/b/build/Release

rocksdb/10.5.1: Running CMake.build()
rocksdb/10.5.1: RUN: cmake --build "/root/.conan2/p/b/rocksd83af45e2c15d/b/build/Release" -- -j12
[  1%] Building CXX object CMakeFiles/rocksdb.dir/cache/charged_cache.cc.o
[  1%] Building CXX object CMakeFiles/rocksdb.dir/cache/cache.cc.o
[  1%] Building CXX object CMakeFiles/rocksdb.dir/cache/cache_key.cc.o
[  1%] Building CXX object CMakeFiles/rocksdb.dir/cache/cache_reservation_manager.cc.o
[  1%] Building CXX object CMakeFiles/rocksdb.dir/cache/clock_cache.cc.o
[  2%] Building CXX object CMakeFiles/rocksdb.dir/cache/cache_helpers.cc.o
[  2%] Building CXX object CMakeFiles/rocksdb.dir/cache/cache_entry_roles.cc.o
[  2%] Building CXX object CMakeFiles/rocksdb.dir/cache/sharded_cache.cc.o
[  3%] Building CXX object CMakeFiles/rocksdb.dir/cache/compressed_secondary_cache.cc.o
[  3%] Building CXX object CMakeFiles/rocksdb.dir/cache/lru_cache.cc.o
[  3%] Building CXX object CMakeFiles/rocksdb.dir/cache/secondary_cache.cc.o
[  3%] Building CXX object CMakeFiles/rocksdb.dir/cache/secondary_cache_adapter.cc.o
[  4%] Building CXX object CMakeFiles/rocksdb.dir/cache/tiered_secondary_cache.cc.o
[  4%] Building CXX object CMakeFiles/rocksdb.dir/db/arena_wrapped_db_iter.cc.o
[  4%] Building CXX object CMakeFiles/rocksdb.dir/db/attribute_group_iterator_impl.cc.o
[  5%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_contents.cc.o
[  5%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_fetcher.cc.o
[  5%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_file_addition.cc.o
[  5%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_file_builder.cc.o
[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_file_cache.cc.o
[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_file_garbage.cc.o
[  6%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_file_meta.cc.o
[  7%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_file_reader.cc.o
[  7%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_garbage_meter.cc.o
[  7%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_log_format.cc.o
[  7%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_log_sequential_reader.cc.o
[  8%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_log_writer.cc.o
[  8%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/blob_source.cc.o
[  8%] Building CXX object CMakeFiles/rocksdb.dir/db/blob/prefetch_buffer_collection.cc.o
[  9%] Building CXX object CMakeFiles/rocksdb.dir/db/builder.cc.o
[  9%] Building CXX object CMakeFiles/rocksdb.dir/db/c.cc.o
[  9%] Building CXX object CMakeFiles/rocksdb.dir/db/coalescing_iterator.cc.o
[  9%] Building CXX object CMakeFiles/rocksdb.dir/db/column_family.cc.o
[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction.cc.o
[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_iterator.cc.o
[ 10%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_picker.cc.o
[ 11%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_job.cc.o
[ 11%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_picker_fifo.cc.o
[ 11%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_picker_level.cc.o
[ 11%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_picker_universal.cc.o
[ 12%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_service_job.cc.o
[ 12%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_state.cc.o
[ 12%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/compaction_outputs.cc.o
[ 12%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/sst_partitioner.cc.o
[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/compaction/subcompaction_state.cc.o
[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/convenience.cc.o
[ 13%] Building CXX object CMakeFiles/rocksdb.dir/db/db_filesnapshot.cc.o
[ 14%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/compacted_db_impl.cc.o
[ 14%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl.cc.o
[ 14%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_write.cc.o
[ 14%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_compaction_flush.cc.o
[ 15%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_files.cc.o
[ 15%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_follower.cc.o
[ 15%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_open.cc.o
[ 16%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_debug.cc.o
[ 16%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_experimental.cc.o
[ 16%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_readonly.cc.o
[ 16%] Building CXX object CMakeFiles/rocksdb.dir/db/db_impl/db_impl_secondary.cc.o
[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/db_info_dumper.cc.o
[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/db_iter.cc.o
[ 17%] Building CXX object CMakeFiles/rocksdb.dir/db/dbformat.cc.o
[ 18%] Building CXX object CMakeFiles/rocksdb.dir/db/error_handler.cc.o
[ 18%] Building CXX object CMakeFiles/rocksdb.dir/db/event_helpers.cc.o
[ 18%] Building CXX object CMakeFiles/rocksdb.dir/db/experimental.cc.o
[ 18%] Building CXX object CMakeFiles/rocksdb.dir/db/external_sst_file_ingestion_job.cc.o
[ 19%] Building CXX object CMakeFiles/rocksdb.dir/db/file_indexer.cc.o
[ 19%] Building CXX object CMakeFiles/rocksdb.dir/db/flush_job.cc.o
[ 19%] Building CXX object CMakeFiles/rocksdb.dir/db/flush_scheduler.cc.o
[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/forward_iterator.cc.o
[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/import_column_family_job.cc.o
[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/internal_stats.cc.o
[ 20%] Building CXX object CMakeFiles/rocksdb.dir/db/logs_with_prep_tracker.cc.o
[ 21%] Building CXX object CMakeFiles/rocksdb.dir/db/log_reader.cc.o
[ 21%] Building CXX object CMakeFiles/rocksdb.dir/db/log_writer.cc.o
[ 21%] Building CXX object CMakeFiles/rocksdb.dir/db/malloc_stats.cc.o
[ 22%] Building CXX object CMakeFiles/rocksdb.dir/db/manifest_ops.cc.o
[ 22%] Building CXX object CMakeFiles/rocksdb.dir/db/memtable.cc.o
[ 22%] Building CXX object CMakeFiles/rocksdb.dir/db/memtable_list.cc.o
[ 22%] Building CXX object CMakeFiles/rocksdb.dir/db/merge_helper.cc.o
[ 23%] Building CXX object CMakeFiles/rocksdb.dir/db/merge_operator.cc.o
[ 23%] Building CXX object CMakeFiles/rocksdb.dir/db/multi_scan.cc.o
[ 23%] Building CXX object CMakeFiles/rocksdb.dir/db/output_validator.cc.o
[ 23%] Building CXX object CMakeFiles/rocksdb.dir/db/range_del_aggregator.cc.o
[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/periodic_task_scheduler.cc.o
[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/range_tombstone_fragmenter.cc.o
[ 24%] Building CXX object CMakeFiles/rocksdb.dir/db/repair.cc.o
[ 25%] Building CXX object CMakeFiles/rocksdb.dir/db/seqno_to_time_mapping.cc.o
[ 25%] Building CXX object CMakeFiles/rocksdb.dir/db/snapshot_impl.cc.o
[ 25%] Building CXX object CMakeFiles/rocksdb.dir/db/table_cache.cc.o
[ 25%] Building CXX object CMakeFiles/rocksdb.dir/db/table_properties_collector.cc.o
[ 26%] Building CXX object CMakeFiles/rocksdb.dir/db/transaction_log_impl.cc.o
[ 26%] Building CXX object CMakeFiles/rocksdb.dir/db/trim_history_scheduler.cc.o
[ 26%] Building CXX object CMakeFiles/rocksdb.dir/db/version_builder.cc.o
[ 27%] Building CXX object CMakeFiles/rocksdb.dir/db/version_edit.cc.o
[ 27%] Building CXX object CMakeFiles/rocksdb.dir/db/version_edit_handler.cc.o
[ 27%] Building CXX object CMakeFiles/rocksdb.dir/db/version_set.cc.o
[ 27%] Building CXX object CMakeFiles/rocksdb.dir/db/wal_edit.cc.o
[ 28%] Building CXX object CMakeFiles/rocksdb.dir/db/wal_manager.cc.o
[ 28%] Building CXX object CMakeFiles/rocksdb.dir/db/wide/wide_column_serialization.cc.o
[ 28%] Building CXX object CMakeFiles/rocksdb.dir/db/wide/wide_columns.cc.o
[ 29%] Building CXX object CMakeFiles/rocksdb.dir/db/wide/wide_columns_helper.cc.o
[ 29%] Building CXX object CMakeFiles/rocksdb.dir/db/write_batch.cc.o
[ 29%] Building CXX object CMakeFiles/rocksdb.dir/db/write_batch_base.cc.o
[ 29%] Building CXX object CMakeFiles/rocksdb.dir/db/write_controller.cc.o
[ 30%] Building CXX object CMakeFiles/rocksdb.dir/db/write_stall_stats.cc.o
[ 30%] Building CXX object CMakeFiles/rocksdb.dir/db/write_thread.cc.o
[ 30%] Building CXX object CMakeFiles/rocksdb.dir/env/composite_env.cc.o
[ 31%] Building CXX object CMakeFiles/rocksdb.dir/env/env.cc.o
[ 31%] Building CXX object CMakeFiles/rocksdb.dir/env/env_chroot.cc.o
[ 31%] Building CXX object CMakeFiles/rocksdb.dir/env/env_encryption.cc.o
[ 31%] Building CXX object CMakeFiles/rocksdb.dir/env/file_system.cc.o
[ 32%] Building CXX object CMakeFiles/rocksdb.dir/env/file_system_tracer.cc.o
[ 32%] Building CXX object CMakeFiles/rocksdb.dir/env/fs_on_demand.cc.o
[ 32%] Building CXX object CMakeFiles/rocksdb.dir/env/fs_remap.cc.o
[ 33%] Building CXX object CMakeFiles/rocksdb.dir/env/mock_env.cc.o
[ 33%] Building CXX object CMakeFiles/rocksdb.dir/env/unique_id_gen.cc.o
[ 33%] Building CXX object CMakeFiles/rocksdb.dir/file/delete_scheduler.cc.o
[ 33%] Building CXX object CMakeFiles/rocksdb.dir/file/file_prefetch_buffer.cc.o
[ 34%] Building CXX object CMakeFiles/rocksdb.dir/file/file_util.cc.o
[ 34%] Building CXX object CMakeFiles/rocksdb.dir/file/filename.cc.o
[ 34%] Building CXX object CMakeFiles/rocksdb.dir/file/line_file_reader.cc.o
[ 35%] Building CXX object CMakeFiles/rocksdb.dir/file/random_access_file_reader.cc.o
[ 35%] Building CXX object CMakeFiles/rocksdb.dir/file/read_write_util.cc.o
[ 35%] Building CXX object CMakeFiles/rocksdb.dir/file/readahead_raf.cc.o
[ 35%] Building CXX object CMakeFiles/rocksdb.dir/file/sequence_file_reader.cc.o
[ 36%] Building CXX object CMakeFiles/rocksdb.dir/file/sst_file_manager_impl.cc.o
[ 36%] Building CXX object CMakeFiles/rocksdb.dir/file/writable_file_writer.cc.o
[ 36%] Building CXX object CMakeFiles/rocksdb.dir/logging/auto_roll_logger.cc.o
[ 37%] Building CXX object CMakeFiles/rocksdb.dir/logging/event_logger.cc.o
[ 37%] Building CXX object CMakeFiles/rocksdb.dir/logging/log_buffer.cc.o
[ 37%] Building CXX object CMakeFiles/rocksdb.dir/memory/arena.cc.o
[ 37%] Building CXX object CMakeFiles/rocksdb.dir/memory/concurrent_arena.cc.o
[ 38%] Building CXX object CMakeFiles/rocksdb.dir/memory/jemalloc_nodump_allocator.cc.o
[ 38%] Building CXX object CMakeFiles/rocksdb.dir/memory/memkind_kmem_allocator.cc.o
[ 38%] Building CXX object CMakeFiles/rocksdb.dir/memory/memory_allocator.cc.o
[ 38%] Building CXX object CMakeFiles/rocksdb.dir/memtable/alloc_tracker.cc.o
[ 39%] Building CXX object CMakeFiles/rocksdb.dir/memtable/hash_linklist_rep.cc.o
[ 39%] Building CXX object CMakeFiles/rocksdb.dir/memtable/hash_skiplist_rep.cc.o
[ 39%] Building CXX object CMakeFiles/rocksdb.dir/memtable/skiplistrep.cc.o
[ 40%] Building CXX object CMakeFiles/rocksdb.dir/memtable/vectorrep.cc.o
[ 40%] Building CXX object CMakeFiles/rocksdb.dir/memtable/wbwi_memtable.cc.o
[ 40%] Building CXX object CMakeFiles/rocksdb.dir/memtable/write_buffer_manager.cc.o
[ 40%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/histogram.cc.o
[ 41%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/histogram_windowing.cc.o
[ 41%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/in_memory_stats_history.cc.o
[ 41%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/instrumented_mutex.cc.o
[ 42%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/iostats_context.cc.o
[ 42%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/perf_context.cc.o
[ 42%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/perf_level.cc.o
[ 42%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/persistent_stats_history.cc.o
[ 43%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/statistics.cc.o
[ 43%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_impl.cc.o
[ 43%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_updater.cc.o
[ 44%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_util.cc.o
[ 44%] Building CXX object CMakeFiles/rocksdb.dir/monitoring/thread_status_util_debug.cc.o
[ 44%] Building CXX object CMakeFiles/rocksdb.dir/options/cf_options.cc.o
[ 44%] Building CXX object CMakeFiles/rocksdb.dir/options/configurable.cc.o
[ 45%] Building CXX object CMakeFiles/rocksdb.dir/options/customizable.cc.o
[ 45%] Building CXX object CMakeFiles/rocksdb.dir/options/db_options.cc.o
[ 45%] Building CXX object CMakeFiles/rocksdb.dir/options/offpeak_time_info.cc.o
[ 46%] Building CXX object CMakeFiles/rocksdb.dir/options/options.cc.o
[ 46%] Building CXX object CMakeFiles/rocksdb.dir/options/options_helper.cc.o
[ 46%] Building CXX object CMakeFiles/rocksdb.dir/options/options_parser.cc.o
[ 46%] Building CXX object CMakeFiles/rocksdb.dir/port/mmap.cc.o
[ 47%] Building CXX object CMakeFiles/rocksdb.dir/port/stack_trace.cc.o
[ 47%] Building CXX object CMakeFiles/rocksdb.dir/table/adaptive/adaptive_table_factory.cc.o
[ 47%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/binary_search_index_reader.cc.o
[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block.cc.o
[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block_based_table_builder.cc.o
[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block_based_table_factory.cc.o
[ 48%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block_based_table_iterator.cc.o
[ 49%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block_based_table_reader.cc.o
[ 49%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block_builder.cc.o
[ 49%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block_cache.cc.o
[ 50%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block_prefetcher.cc.o
[ 50%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/block_prefix_index.cc.o
[ 50%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/data_block_hash_index.cc.o
[ 50%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/data_block_footer.cc.o
[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/filter_block_reader_common.cc.o
[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/filter_policy.cc.o
[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/flush_block_policy.cc.o
[ 51%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/full_filter_block.cc.o
[ 52%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/hash_index_reader.cc.o
[ 52%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/index_builder.cc.o
[ 52%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/index_reader_common.cc.o
[ 53%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/parsed_full_filter_block.cc.o
[ 53%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/partitioned_filter_block.cc.o
[ 53%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/partitioned_index_iterator.cc.o
[ 53%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/partitioned_index_reader.cc.o
[ 54%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/reader_common.cc.o
[ 54%] Building CXX object CMakeFiles/rocksdb.dir/table/block_based/uncompression_dict_reader.cc.o
[ 54%] Building CXX object CMakeFiles/rocksdb.dir/table/block_fetcher.cc.o
[ 55%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo/cuckoo_table_builder.cc.o
[ 55%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo/cuckoo_table_factory.cc.o
[ 55%] Building CXX object CMakeFiles/rocksdb.dir/table/cuckoo/cuckoo_table_reader.cc.o
[ 55%] Building CXX object CMakeFiles/rocksdb.dir/table/external_table.cc.o
[ 56%] Building CXX object CMakeFiles/rocksdb.dir/table/format.cc.o
[ 56%] Building CXX object CMakeFiles/rocksdb.dir/table/get_context.cc.o
[ 56%] Building CXX object CMakeFiles/rocksdb.dir/table/iterator.cc.o
[ 57%] Building CXX object CMakeFiles/rocksdb.dir/table/merging_iterator.cc.o
[ 57%] Building CXX object CMakeFiles/rocksdb.dir/table/compaction_merging_iterator.cc.o
[ 57%] Building CXX object CMakeFiles/rocksdb.dir/table/meta_blocks.cc.o
[ 57%] Building CXX object CMakeFiles/rocksdb.dir/table/persistent_cache_helper.cc.o
[ 58%] Building CXX object CMakeFiles/rocksdb.dir/table/plain/plain_table_bloom.cc.o
[ 58%] Building CXX object CMakeFiles/rocksdb.dir/table/plain/plain_table_builder.cc.o
[ 58%] Building CXX object CMakeFiles/rocksdb.dir/table/plain/plain_table_factory.cc.o
[ 59%] Building CXX object CMakeFiles/rocksdb.dir/table/plain/plain_table_index.cc.o
[ 59%] Building CXX object CMakeFiles/rocksdb.dir/table/plain/plain_table_key_coding.cc.o
[ 59%] Building CXX object CMakeFiles/rocksdb.dir/table/plain/plain_table_reader.cc.o
[ 59%] Building CXX object CMakeFiles/rocksdb.dir/table/sst_file_dumper.cc.o
[ 60%] Building CXX object CMakeFiles/rocksdb.dir/table/sst_file_reader.cc.o
[ 60%] Building CXX object CMakeFiles/rocksdb.dir/table/sst_file_writer.cc.o
[ 60%] Building CXX object CMakeFiles/rocksdb.dir/table/table_factory.cc.o
[ 61%] Building CXX object CMakeFiles/rocksdb.dir/table/table_properties.cc.o
[ 61%] Building CXX object CMakeFiles/rocksdb.dir/table/two_level_iterator.cc.o
[ 61%] Building CXX object CMakeFiles/rocksdb.dir/table/unique_id.cc.o
[ 61%] Building CXX object CMakeFiles/rocksdb.dir/test_util/sync_point.cc.o
[ 62%] Building CXX object CMakeFiles/rocksdb.dir/test_util/sync_point_impl.cc.o
[ 62%] Building CXX object CMakeFiles/rocksdb.dir/test_util/testutil.cc.o
[ 62%] Building CXX object CMakeFiles/rocksdb.dir/test_util/transaction_test_util.cc.o
[ 62%] Building CXX object CMakeFiles/rocksdb.dir/tools/block_cache_analyzer/block_cache_trace_analyzer.cc.o
[ 63%] Building CXX object CMakeFiles/rocksdb.dir/tools/dump/db_dump_tool.cc.o
[ 63%] Building CXX object CMakeFiles/rocksdb.dir/tools/io_tracer_parser_tool.cc.o
[ 63%] Building CXX object CMakeFiles/rocksdb.dir/tools/ldb_cmd.cc.o
[ 64%] Building CXX object CMakeFiles/rocksdb.dir/tools/ldb_tool.cc.o
[ 64%] Building CXX object CMakeFiles/rocksdb.dir/tools/sst_dump_tool.cc.o
[ 64%] Building CXX object CMakeFiles/rocksdb.dir/tools/trace_analyzer_tool.cc.o
[ 64%] Building CXX object CMakeFiles/rocksdb.dir/trace_replay/block_cache_tracer.cc.o
[ 65%] Building CXX object CMakeFiles/rocksdb.dir/trace_replay/io_tracer.cc.o
[ 65%] Building CXX object CMakeFiles/rocksdb.dir/trace_replay/trace_record_handler.cc.o
[ 65%] Building CXX object CMakeFiles/rocksdb.dir/trace_replay/trace_record_result.cc.o
[ 66%] Building CXX object CMakeFiles/rocksdb.dir/trace_replay/trace_record.cc.o
[ 66%] Building CXX object CMakeFiles/rocksdb.dir/trace_replay/trace_replay.cc.o
[ 66%] Building CXX object CMakeFiles/rocksdb.dir/util/async_file_reader.cc.o
[ 66%] Building CXX object CMakeFiles/rocksdb.dir/util/auto_tune_compressor.cc.o
[ 67%] Building CXX object CMakeFiles/rocksdb.dir/util/cleanable.cc.o
[ 67%] Building CXX object CMakeFiles/rocksdb.dir/util/coding.cc.o
[ 67%] Building CXX object CMakeFiles/rocksdb.dir/util/compaction_job_stats_impl.cc.o
[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/comparator.cc.o
[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/compression.cc.o
[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/simple_mixed_compressor.cc.o
[ 68%] Building CXX object CMakeFiles/rocksdb.dir/util/compression_context_cache.cc.o
[ 69%] Building CXX object CMakeFiles/rocksdb.dir/util/concurrent_task_limiter_impl.cc.o
[ 69%] Building CXX object CMakeFiles/rocksdb.dir/util/crc32c.cc.o
[ 69%] Building CXX object CMakeFiles/rocksdb.dir/util/data_structure.cc.o
[ 70%] Building CXX object CMakeFiles/rocksdb.dir/util/dynamic_bloom.cc.o
[ 70%] Building CXX object CMakeFiles/rocksdb.dir/util/hash.cc.o
[ 70%] Building CXX object CMakeFiles/rocksdb.dir/util/murmurhash.cc.o
[ 70%] Building CXX object CMakeFiles/rocksdb.dir/util/random.cc.o
[ 71%] Building CXX object CMakeFiles/rocksdb.dir/util/rate_limiter.cc.o
[ 71%] Building CXX object CMakeFiles/rocksdb.dir/util/ribbon_config.cc.o
[ 71%] Building CXX object CMakeFiles/rocksdb.dir/util/slice.cc.o
[ 72%] Building CXX object CMakeFiles/rocksdb.dir/util/file_checksum_helper.cc.o
[ 72%] Building CXX object CMakeFiles/rocksdb.dir/util/status.cc.o
[ 72%] Building CXX object CMakeFiles/rocksdb.dir/util/stderr_logger.cc.o
[ 72%] Building CXX object CMakeFiles/rocksdb.dir/util/string_util.cc.o
[ 73%] Building CXX object CMakeFiles/rocksdb.dir/util/thread_local.cc.o
[ 73%] Building CXX object CMakeFiles/rocksdb.dir/util/threadpool_imp.cc.o
[ 73%] Building CXX object CMakeFiles/rocksdb.dir/util/udt_util.cc.o
[ 74%] Building CXX object CMakeFiles/rocksdb.dir/util/write_batch_util.cc.o
[ 74%] Building CXX object CMakeFiles/rocksdb.dir/util/xxhash.cc.o
[ 74%] Building CXX object CMakeFiles/rocksdb.dir/utilities/agg_merge/agg_merge.cc.o
[ 74%] Building CXX object CMakeFiles/rocksdb.dir/utilities/backup/backup_engine.cc.o
[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_compaction_filter.cc.o
[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_db.cc.o
[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_db_impl.cc.o
[ 75%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_db_impl_filesnapshot.cc.o
[ 76%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_dump_tool.cc.o
[ 76%] Building CXX object CMakeFiles/rocksdb.dir/utilities/blob_db/blob_file.cc.o
[ 76%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cache_dump_load.cc.o
[ 77%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cache_dump_load_impl.cc.o
[ 77%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/cassandra_compaction_filter.cc.o
[ 77%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/format.cc.o
[ 77%] Building CXX object CMakeFiles/rocksdb.dir/utilities/cassandra/merge_operator.cc.o
[ 78%] Building CXX object CMakeFiles/rocksdb.dir/utilities/checkpoint/checkpoint_impl.cc.o
[ 78%] Building CXX object CMakeFiles/rocksdb.dir/utilities/compaction_filters.cc.o
[ 78%] Building CXX object CMakeFiles/rocksdb.dir/utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc.o
[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/counted_fs.cc.o
[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/debug.cc.o
[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/env_mirror.cc.o
[ 79%] Building CXX object CMakeFiles/rocksdb.dir/utilities/env_timed.cc.o
[ 80%] Building CXX object CMakeFiles/rocksdb.dir/utilities/fault_injection_env.cc.o
[ 80%] Building CXX object CMakeFiles/rocksdb.dir/utilities/fault_injection_fs.cc.o
[ 80%] Building CXX object CMakeFiles/rocksdb.dir/utilities/fault_injection_secondary_cache.cc.o
[ 81%] Building CXX object CMakeFiles/rocksdb.dir/utilities/leveldb_options/leveldb_options.cc.o
[ 81%] Building CXX object CMakeFiles/rocksdb.dir/utilities/memory/memory_util.cc.o
[ 81%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators.cc.o
[ 81%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/bytesxor.cc.o
[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/max.cc.o
[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/put.cc.o
[ 82%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/sortlist.cc.o
[ 83%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/string_append/stringappend.cc.o
[ 83%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/string_append/stringappend2.cc.o
[ 83%] Building CXX object CMakeFiles/rocksdb.dir/utilities/merge_operators/uint64add.cc.o
[ 83%] Building CXX object CMakeFiles/rocksdb.dir/utilities/object_registry.cc.o
[ 84%] Building CXX object CMakeFiles/rocksdb.dir/utilities/option_change_migration/option_change_migration.cc.o
[ 84%] Building CXX object CMakeFiles/rocksdb.dir/utilities/options/options_util.cc.o
[ 84%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier.cc.o
[ 85%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier_file.cc.o
[ 85%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/block_cache_tier_metadata.cc.o
[ 85%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/persistent_cache_tier.cc.o
[ 85%] Building CXX object CMakeFiles/rocksdb.dir/utilities/persistent_cache/volatile_tier_impl.cc.o
[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/secondary_index/secondary_index_iterator.cc.o
[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/secondary_index/simple_secondary_index.cc.o
[ 86%] Building CXX object CMakeFiles/rocksdb.dir/utilities/simulator_cache/cache_simulator.cc.o
[ 87%] Building CXX object CMakeFiles/rocksdb.dir/utilities/simulator_cache/sim_cache.cc.o
[ 87%] Building CXX object CMakeFiles/rocksdb.dir/utilities/table_properties_collectors/compact_for_tiering_collector.cc.o
[ 87%] Building CXX object CMakeFiles/rocksdb.dir/utilities/table_properties_collectors/compact_on_deletion_collector.cc.o
[ 87%] Building CXX object CMakeFiles/rocksdb.dir/utilities/trace/file_trace_reader_writer.cc.o
[ 88%] Building CXX object CMakeFiles/rocksdb.dir/utilities/trace/replayer_impl.cc.o
[ 88%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/lock_manager.cc.o
[ 88%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/point/point_lock_tracker.cc.o
[ 88%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/point/point_lock_manager.cc.o
[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/range_tree_lock_manager.cc.o
[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/range_tree_lock_tracker.cc.o
[ 89%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/optimistic_transaction_db_impl.cc.o
[ 90%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/optimistic_transaction.cc.o
[ 90%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/pessimistic_transaction.cc.o
[ 90%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/pessimistic_transaction_db.cc.o
[ 90%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/snapshot_checker.cc.o
[ 91%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_base.cc.o
[ 91%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_db_mutex_impl.cc.o
[ 91%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/transaction_util.cc.o
[ 92%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/write_prepared_txn.cc.o
[ 92%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/write_prepared_txn_db.cc.o
[ 92%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/write_unprepared_txn.cc.o
[ 92%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/write_unprepared_txn_db.cc.o
[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/types_util.cc.o
[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/ttl/db_ttl_impl.cc.o
[ 93%] Building CXX object CMakeFiles/rocksdb.dir/utilities/wal_filter.cc.o
[ 94%] Building CXX object CMakeFiles/rocksdb.dir/utilities/write_batch_with_index/write_batch_with_index.cc.o
[ 94%] Building CXX object CMakeFiles/rocksdb.dir/utilities/write_batch_with_index/write_batch_with_index_internal.cc.o
[ 94%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/concurrent_tree.cc.o
[ 94%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/keyrange.cc.o
[ 95%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/lock_request.cc.o
[ 95%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/locktree.cc.o
[ 95%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/manager.cc.o
[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/range_buffer.cc.o
[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/treenode.cc.o
[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/txnid_set.cc.o
[ 96%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/locktree/wfg.cc.o
[ 97%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/standalone_port.cc.o
[ 97%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/util/dbt.cc.o
[ 97%] Building CXX object CMakeFiles/rocksdb.dir/utilities/transactions/lock/range/range_tree/lib/util/memarena.cc.o
[ 98%] Building CXX object CMakeFiles/rocksdb.dir/port/port_posix.cc.o
[ 98%] Building CXX object CMakeFiles/rocksdb.dir/env/env_posix.cc.o
[ 98%] Building CXX object CMakeFiles/rocksdb.dir/env/fs_posix.cc.o
[ 98%] Building CXX object CMakeFiles/rocksdb.dir/env/io_posix.cc.o
[ 99%] Building CXX object CMakeFiles/rocksdb.dir/build_version.cc.o
[ 99%] Linking CXX static library librocksdb.a
[ 99%] Built target rocksdb
[ 99%] Building CXX object CMakeFiles/block_cache_trace_analyzer.dir/tools/block_cache_analyzer/block_cache_trace_analyzer_tool.cc.o
[ 99%] Building CXX object CMakeFiles/trace_analyzer.dir/tools/trace_analyzer.cc.o
[100%] Linking CXX executable block_cache_trace_analyzer
[100%] Linking CXX executable trace_analyzer
[100%] Built target block_cache_trace_analyzer
[100%] Built target trace_analyzer

rocksdb/10.5.1: Package 'ad5254e190414cdcc1b0ebf8de2464251ab17f0a' built
rocksdb/10.5.1: Build folder /root/.conan2/p/b/rocksd83af45e2c15d/b/build/Release
rocksdb/10.5.1: Generating the package
rocksdb/10.5.1: Packaging in folder /root/.conan2/p/b/rocksd83af45e2c15d/p
rocksdb/10.5.1: Calling package()
rocksdb/10.5.1: Running CMake.install()
rocksdb/10.5.1: RUN: cmake --install "/root/.conan2/p/b/rocksd83af45e2c15d/b/build/Release" --prefix "/root/.conan2/p/b/rocksd83af45e2c15d/p"
-- Install configuration: "Release"
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/statistics.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/db_dump_tool.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/concurrent_task_limiter.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/env_encryption.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/write_batch.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/sst_file_writer.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/data_structure.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/advanced_cache.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/metadata.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/file_system.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/snapshot.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/env.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/transaction_db.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/stackable_db.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/db_ttl.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/option_change_migration.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/write_batch_with_index.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/agg_merge.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/cache_dump_load.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/table_properties_collectors.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/customizable_util.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/leveldb_options.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/object_registry.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/secondary_index_faiss.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/debug.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/info_log_finder.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/sim_cache.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/optimistic_transaction_db.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/env_mirror.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/convenience.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/transaction_db_mutex.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/backup_engine.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/ldb_cmd_execute_result.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/secondary_index.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/ldb_cmd.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/transaction.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/options_type.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/options_util.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/types_util.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/memory_util.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/replayer.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/checkpoint.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/secondary_index_simple.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/lua
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/lua/rocks_lua_custom_library.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/utilities/lua/rocks_lua_util.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/tool_hooks.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/wal_filter.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/comparator.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/cleanable.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/experimental.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/compaction_job_stats.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/db_stress_tool.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/db_bench_tool.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/external_table.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/iterator_base.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/io_status.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/sst_dump_tool.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/secondary_cache.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/sst_file_manager.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/wide_columns.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/functor_wrapper.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/configurable.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/perf_level.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/block_cache_trace_writer.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/write_batch_base.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/universal_compaction.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/ldb_tool.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/rocksdb_namespace.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/memtablerep.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/cache_bench_tool.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/iostats_context.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/table.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/compaction_filter.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/compression_type.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/types.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/slice_transform.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/write_buffer_manager.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/cache.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/transaction_log.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/customizable.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/user_defined_index.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/slice.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/thread_status.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/threadpool.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/convenience.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/filter_policy.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/version.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/multi_scan.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/stats_history.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/status.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/table_properties.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/memory_allocator.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/user_write_callback.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/rate_limiter.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/advanced_options.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/merge_operator.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/advanced_compression.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/iterator.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/trace_record_result.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/db.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/file_checksum.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/unique_id.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/trace_record.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/sst_partitioner.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/advanced_iterator.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/port_defs.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/listener.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/sst_file_reader.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/options.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/attribute_groups.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/c.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/perf_context.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/flush_block_policy.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/trace_reader_writer.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/system_clock.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/persistent_cache.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/include/rocksdb/table_reader_caller.h
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/CxxFlags.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/FindTBB.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/Findzstd.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/FindNUMA.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/Finduring.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/Findgflags.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/ReadVersion.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/FindJeMalloc.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/FindSnappy.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/modules/Findlz4.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/librocksdb.a
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/RocksDBTargets.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/RocksDBTargets-release.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/RocksDBConfig.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/cmake/rocksdb/RocksDBConfigVersion.cmake
-- Installing: /root/.conan2/p/b/rocksd83af45e2c15d/p/lib/pkgconfig/rocksdb.pc

rocksdb/10.5.1: package(): Packaged 1 '.a' file: librocksdb.a
rocksdb/10.5.1: package(): Packaged 1 file: COPYING
rocksdb/10.5.1: package(): Packaged 1 '.Apache' file: LICENSE.Apache
rocksdb/10.5.1: package(): Packaged 1 '.leveldb' file: LICENSE.leveldb
rocksdb/10.5.1: package(): Packaged 117 '.h' files
rocksdb/10.5.1: Created package revision c04e4697a427b64a1a6d5470b6ca0f29
rocksdb/10.5.1: Package 'ad5254e190414cdcc1b0ebf8de2464251ab17f0a' created
rocksdb/10.5.1: Full package reference: rocksdb/10.5.1#020c996388e513d7078e35d5b01b93ed:ad5254e190414cdcc1b0ebf8de2464251ab17f0a#c04e4697a427b64a1a6d5470b6ca0f29
rocksdb/10.5.1: Package folder /root/.conan2/p/b/rocksd83af45e2c15d/p

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    rocksdb/10.5.1 (test package): /workspace/conan-center-index/recipes/rocksdb/all/test_package/conanfile.py
Requirements
    rocksdb/10.5.1#020c996388e513d7078e35d5b01b93ed - Cache

======== Computing necessary packages ========
Requirements
    rocksdb/10.5.1#020c996388e513d7078e35d5b01b93ed:ad5254e190414cdcc1b0ebf8de2464251ab17f0a#c04e4697a427b64a1a6d5470b6ca0f29 - Cache

======== Installing packages ========
rocksdb/10.5.1: Already installed! (1 of 1)

======== Testing the package ========
Removing previously existing 'test_package' build folder: /workspace/conan-center-index/recipes/rocksdb/all/test_package/build/gcc-11-riscv64-gnu17-release
rocksdb/10.5.1 (test package): Test package build: build/gcc-11-riscv64-gnu17-release
rocksdb/10.5.1 (test package): Test package build folder: /workspace/conan-center-index/recipes/rocksdb/all/test_package/build/gcc-11-riscv64-gnu17-release
rocksdb/10.5.1 (test package): Writing generators to /workspace/conan-center-index/recipes/rocksdb/all/test_package/build/gcc-11-riscv64-gnu17-release/generators
rocksdb/10.5.1 (test package): Generator 'CMakeDeps' calling 'generate()'
rocksdb/10.5.1 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(RocksDB)
    target_link_libraries(... RocksDB::rocksdb)
rocksdb/10.5.1 (test package): Generator 'CMakeToolchain' calling 'generate()'
rocksdb/10.5.1 (test package): CMakeToolchain generated: conan_toolchain.cmake
rocksdb/10.5.1 (test package): CMakeToolchain generated: /workspace/conan-center-index/recipes/rocksdb/all/test_package/build/gcc-11-riscv64-gnu17-release/generators/CMakePresets.json
rocksdb/10.5.1 (test package): CMakeToolchain generated: /workspace/conan-center-index/recipes/rocksdb/all/test_package/CMakeUserPresets.json
rocksdb/10.5.1 (test package): Generating aggregated env files
rocksdb/10.5.1 (test package): Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']

======== Testing the package: Building ========
rocksdb/10.5.1 (test package): Calling build()
rocksdb/10.5.1 (test package): Running CMake.configure()
rocksdb/10.5.1 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/workspace/conan-center-index/recipes/rocksdb/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/workspace/conan-center-index/recipes/rocksdb/all/test_package"
-- Using Conan toolchain: /workspace/conan-center-index/recipes/rocksdb/all/test_package/build/gcc-11-riscv64-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Component target declared 'rocksdb::librocksdb'
-- Conan: Target declared 'RocksDB::rocksdb'
-- Configuring done
-- Generating done
-- Build files have been written to: /workspace/conan-center-index/recipes/rocksdb/all/test_package/build/gcc-11-riscv64-gnu17-release

rocksdb/10.5.1 (test package): Running CMake.build()
rocksdb/10.5.1 (test package): RUN: cmake --build "/workspace/conan-center-index/recipes/rocksdb/all/test_package/build/gcc-11-riscv64-gnu17-release" -- -j12
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
rocksdb/10.5.1 (test package): Running test()
rocksdb/10.5.1 (test package): RUN: ./test_package
```

</p>
</details> 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
