### PR TITLE
llvm-core: add version `20.1.6`

### DIFF
--- a/recipes/llvm-core/all/conandata.yml
+++ b/recipes/llvm-core/all/conandata.yml
@@ -1,4 +1,11 @@
 sources:
+  "20.1.6":
+    "llvm":
+      url: https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.6/llvm-20.1.6.src.tar.xz
+      sha256: f09e304ca98bb809f492ec34f94f587361b4b0d06ed783fb3a41e7fb218e47a1
+    "cmake":
+      url: https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.6/cmake-20.1.6.src.tar.xz
+      sha256: b4b3efa5d5b01b3f211f1ba326bb6f0c318331f828202d332c95b7f30fca5f8c
   "19.1.7":
     "llvm":
       url: https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/llvm-19.1.7.src.tar.xz
@@ -17,6 +24,11 @@ sources:
     sha256: ce8508e318a01a63d4e8b3090ab2ded3c598a50258cc49e2625b9120d4c03ea5
 
 patches:
+  "20.1.6":
+    - patch_file: patches/20x/0000-cmake-dependencies.patch
+      patch_description: fix references to third party libs to match conan variables and targets
+      patch_type: conan
+      base_path: llvm-main
   "19.1.7":
     - patch_file: patches/19x/0000-cmake-dependencies.patch
       patch_description: fix references to third party libs to match conan variables and targets

--- a/recipes/llvm-core/all/patches/20x/0000-cmake-dependencies.patch
+++ b/recipes/llvm-core/all/patches/20x/0000-cmake-dependencies.patch
@@ -1,0 +1,93 @@
+diff --git a/cmake/config-ix.cmake b/cmake/config-ix.cmake
+index 767774812ade..7a037ce02fb1 100644
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -173,7 +173,7 @@ if(LLVM_ENABLE_ZLIB)
+     # library on a 64-bit system which would result in a link-time failure.
+     cmake_push_check_state()
+     list(APPEND CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIRS})
+-    list(APPEND CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARY})
++    list(APPEND CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARIES})
+     check_symbol_exists(compress2 zlib.h HAVE_ZLIB)
+     cmake_pop_check_state()
+     if(LLVM_ENABLE_ZLIB STREQUAL FORCE_ON AND NOT HAVE_ZLIB)
+@@ -268,11 +268,11 @@ if(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
+     # Skip libedit if using ASan as it contains memory leaks.
+     if (LLVM_ENABLE_LIBEDIT AND NOT LLVM_USE_SANITIZER MATCHES ".*Address.*")
+       if(LLVM_ENABLE_LIBEDIT STREQUAL FORCE_ON)
+-        find_package(LibEdit REQUIRED)
++        find_package(editline REQUIRED)
+       else()
+-        find_package(LibEdit)
++        find_package(editline)
+       endif()
+-      set(HAVE_LIBEDIT "${LibEdit_FOUND}")
++      set(HAVE_LIBEDIT "${editline_FOUND}")
+     else()
+       set(HAVE_LIBEDIT 0)
+     endif()
+diff --git a/lib/LineEditor/CMakeLists.txt b/lib/LineEditor/CMakeLists.txt
+index c4cd91cbb0cd..b95d073d9725 100644
+--- a/lib/LineEditor/CMakeLists.txt
++++ b/lib/LineEditor/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ if(HAVE_LIBEDIT)
+-  set(link_libs LibEdit::LibEdit)
++  set(link_libs editline::editline)
+ endif()
+ 
+ add_llvm_component_library(LLVMLineEditor
+diff --git a/lib/Support/CMakeLists.txt b/lib/Support/CMakeLists.txt
+index a6d8a2581886..e33c86c159bc 100644
+--- a/lib/Support/CMakeLists.txt
++++ b/lib/Support/CMakeLists.txt
+@@ -316,27 +316,13 @@ set(llvm_system_libs ${system_libs})
+ # This block is only needed for llvm-config. When we deprecate llvm-config and
+ # move to using CMake export, this block can be removed.
+ if(LLVM_ENABLE_ZLIB)
+-  # CMAKE_BUILD_TYPE is only meaningful to single-configuration generators.
+-  if(CMAKE_BUILD_TYPE)
+-    string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
+-    get_property(zlib_library TARGET ZLIB::ZLIB PROPERTY LOCATION_${build_type})
+-  endif()
+-  if(NOT zlib_library)
+-    get_property(zlib_library TARGET ZLIB::ZLIB PROPERTY LOCATION)
+-  endif()
++  set(zlib_library ${ZLIB_LIBRARIES})
+   get_library_name(${zlib_library} zlib_library)
+   set(llvm_system_libs ${llvm_system_libs} "${zlib_library}")
+ endif()
+ 
+ if(LLVM_ENABLE_ZSTD)
+-  # CMAKE_BUILD_TYPE is only meaningful to single-configuration generators.
+-  if(CMAKE_BUILD_TYPE)
+-    string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
+-    get_property(zstd_library TARGET ${zstd_target} PROPERTY LOCATION_${build_type})
+-  endif()
+-  if(NOT zstd_library)
+-    get_property(zstd_library TARGET ${zstd_target} PROPERTY LOCATION)
+-  endif()
++  set(zstd_library ${zstd_LIBRARIES})
+   if (zstd_target STREQUAL zstd::libzstd_shared)
+     get_library_name(${zstd_library} zstd_library)
+     set(llvm_system_libs ${llvm_system_libs} "${zstd_library}")
+diff --git a/lib/WindowsManifest/CMakeLists.txt b/lib/WindowsManifest/CMakeLists.txt
+index 910132a4c7de..f4d91c9d56da 100644
+--- a/lib/WindowsManifest/CMakeLists.txt
++++ b/lib/WindowsManifest/CMakeLists.txt
+@@ -21,14 +21,7 @@ add_llvm_component_library(LLVMWindowsManifest
+ # This block is only needed for llvm-config. When we deprecate llvm-config and
+ # move to using CMake export, this block can be removed.
+ if(LLVM_ENABLE_LIBXML2)
+-  # CMAKE_BUILD_TYPE is only meaningful to single-configuration generators.
+-  if(CMAKE_BUILD_TYPE)
+-    string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
+-    get_property(libxml2_library TARGET LibXml2::LibXml2 PROPERTY LOCATION_${build_type})
+-  endif()
+-  if(NOT libxml2_library)
+-    get_property(libxml2_library TARGET LibXml2::LibXml2 PROPERTY LOCATION)
+-  endif()
++  set(libxml2_library ${libxml2_LIBRARIES})
+   get_library_name(${libxml2_library} libxml2_library)
+   set_property(TARGET LLVMWindowsManifest PROPERTY LLVM_SYSTEM_LIBS ${libxml2_library})
+ endif()

--- a/recipes/llvm-core/config.yml
+++ b/recipes/llvm-core/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.1.6":
+    folder: all
   "19.1.7":
     folder: all
   "13.0.0":


### PR DESCRIPTION
### Summary

Changes to recipe: **llvm-core/20.1.6**

#### Motivation

The recipe `llvm-openmp/20.1.6` in Conan Center Index depends on `llvm-core/20.1.6` when the option `build_libomptarget=True` is enabled. However, this specific version of `llvm-core` is currently missing from the index, which prevents users from successfully building `llvm-openmp` with that option enabled.

Adding `llvm-core/20.1.6` resolves this issue and restores the intended functionality of `llvm-openmp`’s `build_libomptarget` feature.

#### Details

This PR introduces the missing recipe for `llvm-core/20.1.6`.
The version aligns with the existing LLVM 20.1.6 components to ensure compatibility and consistent dependency resolution within the Conan ecosystem.
No functional changes beyond adding the new version; the recipe follows the same structure and conventions as previous `llvm-core` versions.

---

* [x] Read the [[contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
* [x] Checked that this PR is not a duplicate: [[list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)](https://github.com/conan-io/conan-center-index/discussions/24240)
* [x] Tested locally with at least one configuration using a recent version of Conan

