### PR TITLE
Suggest using system cmake if the recipe fails.

### DIFF
--- a/recipes/cmake/binary/conanfile.py
+++ b/recipes/cmake/binary/conanfile.py
@@ -20,7 +20,8 @@ class CMakeConan(ConanFile):
 
     def validate(self):
         if self.settings.arch not in ["x86_64", "armv8"]:
-            raise ConanInvalidConfiguration("CMake binaries are only provided for x86_64 and armv8 architectures")
+            raise ConanInvalidConfiguration("CMake binaries are only provided for x86_64 and armv8 architectures. " +
+                        "Consider using the system cmake with [platform_tool_requires] section in your profile.")
 
         if self.settings.os == "Windows" and self.settings.arch == "armv8" and Version(self.version) < "3.24":
             raise ConanInvalidConfiguration("CMake only supports ARM64 binaries on Windows starting from 3.24")


### PR DESCRIPTION
Updated validation message to include guidance on using system CMake with the [platform_tool_requires] profile section.

Related documentation: https://docs.conan.io/2/reference/config_files/profiles.html#platform-tool-requires


### Summary
Changes to recipe:  **cmake/**

#### Motivation
I spent hours trying to figure out how to fix failing cmake dependency on my non-arm and non-x86 machine. 
The found solution with [platform_tool_requires] works like a charm. I hope this extended error message will help others and save time.

Related issues: #17286 #28518

#### Details


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
