### PR TITLE
[libpq] Remove not relevant options 

### DIFF
--- a/recipes/libpq/meson/conanfile.py
+++ b/recipes/libpq/meson/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.build import cross_building
 
 import os
 
@@ -127,6 +128,11 @@ class LibpqConan(ConanFile):
         tc.project_options["tap_tests"] = "disabled"
         tc.project_options["plpython"] = "disabled"
         tc.project_options["docs"] = "disabled"
+        if cross_building(self):
+            # when cross building, PostgreSQL fails to generate its
+            # timezone data file. To work around, provide just anything
+            # it's only used in the server and not in libpq
+            tc.project_options["system_tzdata"] = "/dev/null"
         tc.generate()
         deps = PkgConfigDeps(self)
         deps.generate()


### PR DESCRIPTION
The configuration options "with_zlib", "with_zstd", "with_libxml2", "with_lz4", "with_xslt", and "with_readline" are only relevant for the PostgreSQL server and the psql comman line client. None of them are used for building libpq.

Also a problem regarding cross-compiling is fixed (in the second commit). 
This would also fix #28443


### Summary
Changes to recipe:  **libpq/17.5**

#### Motivation
The new meson-based recipe for libpq 17 introduces some  configuration options without effect.
These options just pull in unnecessary dependencies but have no impact on the built PostgreSQL
client library.

Cross-compiling fails with  "Program 'zic' not found or not executable". This is because PostgreSQL cannot build it's timezone database, which is however only used in the server and not in libpq.
The second commit of this MR works around the problem by explicitely setting the system_tzdata option to a non-empty value.

---
- [x ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x] Tested locally with at least one configuration using a recent version of Conan
