### PR TITLE
dbus-cxx: add version `2.6.0`

### DIFF
--- a/recipes/dbus-cxx/2.x.x/conandata.yml
+++ b/recipes/dbus-cxx/2.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.0":
+    url: "https://github.com/dbus-cxx/dbus-cxx/archive/refs/tags/2.6.0.tar.gz"
+    sha256: "ca22380ec04a1f10154fca76d41e8ce4a8a6351ce86546b297bda5f7eefbc108"
   "2.5.2":
     url: "https://github.com/dbus-cxx/dbus-cxx/archive/refs/tags/2.5.2.tar.gz"
     sha256: "a739a29efc9ad42ba6518b38e13bb44c12947d4f7503d211c12823233e277987"

--- a/recipes/dbus-cxx/2.x.x/conanfile.py
+++ b/recipes/dbus-cxx/2.x.x/conanfile.py
@@ -63,11 +63,6 @@ class DbusCXX(ConanFile):
             replace_in_file(self, os.path.join(self.source_folder, "dbus-cxx-uv", "CMakeLists.txt"),
                             "target_link_libraries( dbus-cxx-uv PUBLIC ${LIBUV_LIBRARIES} )",
                             "target_link_libraries( dbus-cxx-uv PUBLIC PkgConfig::LIBUV )")
-        else:
-            # Version 2.6.0 or newer
-            replace_in_file(self, os.path.join(self.source_folder, "dbus-cxx-uv", "CMakeLists.txt"),
-                            "pkg_check_modules( libuv REQUIRED IMPORTED_TARGET ${LIBUV_PKG_NAME} )",
-                            "pkg_search_module( libuv IMPORTED_TARGET libuv )")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/dbus-cxx/config.yml
+++ b/recipes/dbus-cxx/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.6.0":
+    folder: 2.x.x
   "2.5.2":
     folder: 2.x.x


### PR DESCRIPTION
### Summary
Changes to recipe:  **dbus-cxx/[2.6.0]**

#### Motivation
Acquire newest dbus-cxx for: https://github.com/aui-framework/aui/pull/635
Already done:
https://github.com/dbus-cxx/dbus-cxx/pull/191
https://github.com/xmake-io/xmake-repo/pull/8297
https://github.com/microsoft/vcpkg/pull/47617 In progress: https://github.com/microsoft/vcpkg/pull/47683

#### Details
Adds newest dbus-cxx https://github.com/dbus-cxx/dbus-cxx/compare/2.5.2...2.6.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
