### PR TITLE
zserio: Add new Zserio release 2.18.0

### DIFF
--- a/recipes/zserio/all/conandata.yml
+++ b/recipes/zserio/all/conandata.yml
@@ -1,4 +1,14 @@
 sources:
+  "2.18.0":
+    runtime:
+      url: "https://github.com/ndsev/zserio/releases/download/v2.18.0/zserio-2.18.0-runtime-libs.zip"
+      sha256: "08ed15ae3768cec262784a58dcfe2e2f68dfce53aedd3c5540aeb4f9c0d4226d"
+    compiler:
+      url: "https://github.com/ndsev/zserio/releases/download/v2.18.0/zserio-2.18.0-bin.zip"
+      sha256: "2212e63b04f96569268cecfd56832de766654180d371641250fa5054ebf13a33"
+    license:
+      url: "https://raw.githubusercontent.com/ndsev/zserio/v2.18.0/LICENSE"
+      sha256: "d91fb189ae307416d1131b76a9c7e28c657f0a03641340c76ac994fc8119bc46"
   "2.17.0":
     runtime:
       url: "https://github.com/ndsev/zserio/releases/download/v2.17.0/zserio-2.17.0-runtime-libs.zip"

--- a/recipes/zserio/config.yml
+++ b/recipes/zserio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.18.0":
+    folder: all
   "2.17.0":
     folder: all
   "2.16.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  ** zserio/2.18.0**

#### Motivation
New release 2.18.0.

#### Details
The only change is the addition of the new released version 2.18.0.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
