### PR TITLE
[xlsxio] Limit to use minizip-ng 4.0.7 as requirement to avoid incompatibility

### DIFF
--- a/recipes/xlsxio/all/conanfile.py
+++ b/recipes/xlsxio/all/conanfile.py
@@ -56,16 +56,17 @@ class XlsxioConan(ConanFile):
     def requirements(self):
         if self.options.with_libzip:
             self.requires("libzip/1.10.1")
-        elif Version(self.version) >= "0.2.34" and self.options.with_minizip_ng :
-            self.requires("minizip-ng/[>=4.0.1 <5]")
+        elif self.options.with_minizip_ng :
+            # INFO: minizip-ng 4.0.8 replaced mz_compat.h with other headers
+            # https://github.com/zlib-ng/minizip-ng/commit/7df56f7cc8438b1b67c881cad049b29bf075bccd
+            self.requires("minizip-ng/[>=4.0.1 <4.0.8]")
         else:
             self.requires("minizip/1.2.13")
         self.requires("expat/[>=2.6.2 <3]")
 
     def validate(self):
-        if Version(self.version) >= "0.2.34":
-            if self.options.with_libzip and self.options.with_minizip_ng:
-                raise ConanInvalidConfiguration("with_libzip and with_minizip_ng are mutually exclusive")
+        if self.options.with_libzip and self.options.with_minizip_ng:
+            raise ConanInvalidConfiguration("with_libzip and with_minizip_ng are mutually exclusive")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary

Changes to recipe:  **xlsxio/0.2.34**

#### Motivation

When reviewing #28004 and testing the side effects of having `minizip-ng/mz_compatibility=True`, the package for xlsxio failed to be built using minizip/4.0.10:

> xlsxio_write.c:16:14: fatal error: mz_compat.h: No such file or directory
>   16 | #    include <mz_compat.h>

Full build log: [xlsxio-0.2.34-linux-gcc11-static-minizipng.log](https://github.com/user-attachments/files/22739898/xlsxio-0.2.34-linux-gcc11-static-minizipng.log)

As minizip-ng is an optional dependency, it passed by the CI without warnings, but users are broken in case using it due version range not limiting to the proper version.

The minizip-ng 4.0.8 passed by a transformation, including replacing the `mz_compat.h` by a few headers like `minizip-ng/zip.h`

Further details about that release can be found in their changelog: https://github.com/zlib-ng/minizip-ng/releases/tag/4.0.8

The specific commit that changed the minizip-ng behavior is https://github.com/zlib-ng/minizip-ng/commit/7df56f7cc8438b1b67c881cad049b29bf075bccd. The release 4.0.8 is a patch version, but it looks a breaking change anyway.


#### Details

This PR limits the xlsxio/0.2.34 to use minizip-ng only until 4.0.7, which is safe:

[xlsxio-0.2.34-linux-gcc11-static-patched.log](https://github.com/user-attachments/files/22740037/xlsxio-0.2.34-linux-gcc11-static-patched.log)

I also removed the logic checking the minimal version, as we only have 0.2.34 available in the recipe. 

However, doing a quick look at xlsxio/0.2.36 (not in CCI yet), it has already adapted to use newer releases of minizip-ng, which will result in further changes in the recipe. 

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
