### PR TITLE
update for package: libjuice/1.6.2

### DIFF
--- a/recipes/libjuice/all/conandata.yml
+++ b/recipes/libjuice/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.5.7":
     url: "https://github.com/paullouisageneau/libjuice/archive/refs/tags/v1.5.7.tar.gz"
     sha256: "6385c574f3c33f766ed25cddf919625b0ae8ca0d76871f70301e5a0cf2c93dc8"
+  "1.6.2":
+    url: "https://github.com/paullouisageneau/libjuice/archive/refs/tags/v1.6.2.tar.gz"
+    sha256: "5078176d55042f3ccf3999c2556d84903f7edf80177ce4a7bf59507541e93938"

--- a/recipes/libjuice/config.yml
+++ b/recipes/libjuice/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.5.7":
     folder: all
+  "1.6.2":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjuice/1.6.2**

#### Motivation

Needed for updating libdatachannel in a followup pr.

#### Details

JUICE is a UDP Interactive Connectivity Establishment library, used for setting up connections used in WebRTC. In order to update libdatachannel to 0.23.2, libjuice needs to be updated.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x Tested locally with at least one configuration using a recent version of Conan
