### PR TITLE
OpenJPH: Add version 0.24.2

### DIFF
--- a/recipes/openjph/all/conandata.yml
+++ b/recipes/openjph/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "0.24.1":
-    url: "https://github.com/aous72/OpenJPH/archive/0.24.1.tar.gz"
-    sha256: "5e44a809c9ee3dad175da839feaf66746cfc114a625ec61c786de8ad3f5ab472"
+  "0.24.2":
+    url: "https://github.com/aous72/OpenJPH/archive/0.24.2.tar.gz"
+    sha256: "c99218752b15b5b2afca3b0e4d4f0ddf1ac19f94dbcbe11874fe492d44ed3e2d"
 patches:
-  "0.24.1":
-    - patch_file: "patches/0.24.1-cmake-cxx-standard-pic.patch"
+  "0.24.2":
+    - patch_file: "patches/0.24.2-cmake-cxx-standard-pic.patch"
       patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan and PIC hardcoded option"
       patch_type: "conan"

--- a/recipes/openjph/all/patches/0.24.2-cmake-cxx-standard-pic.patch
+++ b/recipes/openjph/all/patches/0.24.2-cmake-cxx-standard-pic.patch
@@ -1,16 +1,3 @@
-diff --git src/apps/ojph_stream_expand/CMakeLists.txt src/apps/ojph_stream_expand/CMakeLists.txt
-index 61e8603..85c1d99 100644
---- src/apps/ojph_stream_expand/CMakeLists.txt
-+++ src/apps/ojph_stream_expand/CMakeLists.txt
-@@ -1,7 +1,7 @@
- ## building ojph_stream_expand
- ##############################
- 
--set(CMAKE_CXX_STANDARD 14)
-+#set(CMAKE_CXX_STANDARD 14)
- 
- file(GLOB OJPH_STREAM_EXPAND  "*.cpp" "*.h")
- file(GLOB OJPH_SOCKETS         "../others/ojph_sockets.cpp")
 diff --git src/core/CMakeLists.txt src/core/CMakeLists.txt
 index ea19aea..132a619 100644
 --- src/core/CMakeLists.txt

--- a/recipes/openjph/config.yml
+++ b/recipes/openjph/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.24.1":
+  "0.24.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openjph/0.24.2**

#### Motivation
Small release but fixes a case where a branch was resulting in unitialized memory being accessed resulting in wrong & unpredicted data handling. (When reading files with a specific (valid!) codestream format/encoding mode active.)

#### Details
https://github.com/aous72/OpenJPH/releases/tag/0.24.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan