### PR TITLE
oboe: update to 1.10.0

### DIFF
--- a/recipes/oboe/all/conandata.yml
+++ b/recipes/oboe/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.10.0":
+    url: "https://github.com/google/oboe/archive/refs/tags/1.10.0.tar.gz"
+    sha256: "0e4245f8860c4287040a5d76501c588490bcc9cb57614c486c0c201a5dde3e9f"
   "1.8.0":
     url: "https://github.com/google/oboe/archive/refs/tags/1.8.0.tar.gz"
     sha256: "1ab24ff129af6396b8a5741c12b44b922814337d1b40958ac7ada8e270eb4880"
@@ -6,6 +9,10 @@ sources:
     url: "https://github.com/google/oboe/archive/refs/tags/1.7.0.tar.gz"
     sha256: "b01896f9180f725a38806cfef73a29b36b2ea37f91389ed4e69d664ce83b79b6"
 patches:
+  "1.10.0":
+    - patch_file: "patches/1.10.0-0001-fix-cmake.patch"
+      patch_description: "Fix CMakeLists"
+      patch_type: "conan"
   "1.8.0":
     - patch_file: "patches/1.8.0-0001-fix-cmake.patch"
       patch_description: "Fix CMakeLists"

--- a/recipes/oboe/all/patches/1.10.0-0001-fix-cmake.patch
+++ b/recipes/oboe/all/patches/1.10.0-0001-fix-cmake.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de9cd40..e6d4e44 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -96,14 +96,13 @@ target_include_directories(oboe
+ #     Enable -Ofast
+ target_compile_options(oboe
+         PRIVATE
+-        -std=c++17
+         -Wall
+         -Wextra-semi
+         -Wshadow
+         -Wshadow-field
+         "$<$<CONFIG:RELEASE>:-Ofast>"
+         "$<$<CONFIG:DEBUG>:-O3>"
+-        "$<$<CONFIG:DEBUG>:-Werror>")
++)
+ 
+ target_compile_definitions(oboe PRIVATE $<$<BOOL:${OBOE_DISABLE_CONVERSION}>:DISABLE_CONVERSION=1>)
+ 
+@@ -118,8 +117,8 @@ target_link_options(oboe PRIVATE "-Wl,-z,max-page-size=16384")
+ 
+ # When installing oboe put the libraries in the lib/<ABI> folder e.g. lib/arm64-v8a
+ install(TARGETS oboe
+-        LIBRARY DESTINATION lib/${ANDROID_ABI}
+-        ARCHIVE DESTINATION lib/${ANDROID_ABI})
++        LIBRARY DESTINATION lib
++        ARCHIVE DESTINATION lib)
+ 
+ # Also install the headers
+ install(DIRECTORY include/oboe DESTINATION include)

--- a/recipes/oboe/config.yml
+++ b/recipes/oboe/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.10.0":
+    folder: all
   "1.8.0":
     folder: all
   "1.7.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **oboe/1.10.0**

#### Motivation
Acquire newest oboe 1.10.0 for @aui-framework

#### Details
https://github.com/google/oboe/compare/1.8.0...1.10.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
