### PR TITLE
c-blosc: Use version range for zstd requirement

### DIFF
--- a/recipes/c-blosc/all/conanfile.py
+++ b/recipes/c-blosc/all/conanfile.py
@@ -63,7 +63,7 @@ class CbloscConan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_zstd:
-            self.requires("zstd/[>=1.5.5 <2]")
+            self.requires("zstd/[~1.5]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **c-blosc/all**

#### Motivation
Currently working on cleaning up #25672 which is quite a heavy recipe with a large net of dependencies. Conan this is the last change I needed to do to get the solver to being able to execute `conan create`/`conan graph ...` and have it solve all required dependencies. (openssl already uses this range so I just copied it from there as this was the blocking point as the graph already solved zstd to 1.5.7 (latest) before c-blosc was required.

#### Details
See motivation, only change is the change to the version range.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan