### PR TITLE
caf: add version 1.1.0

### DIFF
--- a/recipes/caf/all/conandata.yml
+++ b/recipes/caf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/actor-framework/actor-framework/archive/refs/tags/1.1.0.tar.gz"
+    sha256: "9febd85d3a4f50dac760592043028a36bea62bba50c3ee2fc1eace954dd8ae27"
   "1.0.2":
     url: "https://github.com/actor-framework/actor-framework/archive/1.0.2.tar.gz"
     sha256: "ef4dd00ca7c59cd61dc336b6a8efbd6150ca85c404d213ecb61f6bcee4094ffc"

--- a/recipes/caf/config.yml
+++ b/recipes/caf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.2":
     folder: all
   "1.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **caf/1.1.0**

#### Motivation
Version 1.1.0 of caf (aka actor-framework) has been released in July.

#### Details
see: [changelog for caf 1.1.0](https://github.com/actor-framework/actor-framework/releases/tag/1.1.0)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
