### PR TITLE
avir: add version 3.1

### DIFF
--- a/recipes/avir/all/conandata.yml
+++ b/recipes/avir/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1":
+    url: "https://github.com/avaneev/avir/archive/refs/tags/3.1.tar.gz"
+    sha256: "8235740e578f86d08d03d3f7ae2a6893554c1ae17a061117475219fe3538a7d2"
   "3.0":
     url: "https://github.com/avaneev/avir/archive/refs/tags/3.0.tar.gz"
     sha256: "011909d31cf782152a69f570563eb70700504f168174a6049b6acbb9b9f511ea"

--- a/recipes/avir/config.yml
+++ b/recipes/avir/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "3.1":
+    folder: all
   "3.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **avir/3.0**

#### Motivation
Version 3.1 of avir has been released in April 2025.

#### Details
[avir changelog](https://github.com/avaneev/avir/tree/3.1?tab=readme-ov-file#change-log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
