### PR TITLE
ctrack: add version 1.1.0

### DIFF
--- a/recipes/ctrack/all/conandata.yml
+++ b/recipes/ctrack/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/Compaile/ctrack/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "cbcfb44386cbae24b69c6fd7ad8be9e1416676aa39c024c1b3161205bf0269c2"
   "1.0.2":
     url: "https://github.com/Compaile/ctrack/releases/download/v1.0.2/ctrack-main.zip"
     sha256: "1a41a831c28977504b49b6966c46e65939271eca90fbe297e248a3e0bf05ac5a"

--- a/recipes/ctrack/config.yml
+++ b/recipes/ctrack/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **ctrack/1.1.0**

#### Motivation
Version 1.1.0 of ctrack has been released in September 2025

#### Details
[ctrack changelog for 1.1.0](https://github.com/Compaile/ctrack/releases/tag/v1.1.0)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
