### PR TITLE
cpp-smtpclient-library: Add version 1.1.11

### DIFF
--- a/recipes/cpp-smtpclient-library/all/conandata.yml
+++ b/recipes/cpp-smtpclient-library/all/conandata.yml
@@ -2,7 +2,3 @@ sources:
   "1.1.11":
     url: "https://github.com/jeremydumais/CPP-SMTPClient-library/archive/refs/tags/v1.1.11.zip"
     sha256: "d090ebcae75534a6f816174310fec046a96d18f4213581a4c5e75f7b173d624b"
-  "1.1.10":
-    url: "https://github.com/jeremydumais/CPP-SMTPClient-library/archive/refs/tags/v1.1.10.zip"
-    sha256: "760e34417fa00b7bd56618f0d9e382867b65729c16175da1abb77d70fe1d1cd6"
-

--- a/recipes/cpp-smtpclient-library/config.yml
+++ b/recipes/cpp-smtpclient-library/config.yml
@@ -1,5 +1,3 @@
 versions:
   "1.1.11":
     folder: all
-  "1.1.10":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-smtpclient-library/1.1.11**

#### Motivation
v1.1.11 release a few months ago

#### Details
https://github.com/jeremydumais/CPP-SMTPClient-library/releases/tag/v1.1.11


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
