### PR TITLE
arduinojson: add version 7.4.2

### DIFF
--- a/recipes/arduinojson/all/conandata.yml
+++ b/recipes/arduinojson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.4.2":
+    url: "https://github.com/bblanchon/ArduinoJson/archive/refs/tags/v7.4.2.tar.gz"
+    sha256: "681f703dd237f5b7f1dc1d7009a9cf246e88676b349572e73eae9154e8994a55"
   "7.0.1":
     url: "https://github.com/bblanchon/ArduinoJson/archive/refs/tags/v7.0.1.tar.gz"
     sha256: "85fd778a6aae9b1a249b4c090c6f8621c9c8ceaf9479a3cb07e3033325bf2ae2"

--- a/recipes/arduinojson/config.yml
+++ b/recipes/arduinojson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.4.2":
+    folder: all
   "7.0.1":
     folder: all
   "6.21.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **arduinojson/7.4.2**

#### Motivation
Version 7.4.2 of arduinojson has been released in June 2025.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
