### PR TITLE
atomic_queue: add version 1.7.1

### DIFF
--- a/recipes/atomic_queue/all/conandata.yml
+++ b/recipes/atomic_queue/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.7.1":
+    url: "https://github.com/max0x7ba/atomic_queue/archive/refs/tags/v1.7.1.tar.gz"
+    sha256: "6eeff578f8b0499717bf890d90e2c58106ac2b8076084b73f2183a631742b4ab"
   "1.6.3":
     url: "https://github.com/max0x7ba/atomic_queue/archive/refs/tags/v1.6.3.tar.gz"
     sha256: "0ad6e0203d90367f6a4e496449dfd9ad65b80168fadafef4eac08820c6bda79c"

--- a/recipes/atomic_queue/config.yml
+++ b/recipes/atomic_queue/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.7.1":
+    folder: "all"
   "1.6.3":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **atomic_queue/1.7.1**

#### Motivation
Version 1.7.1 of atomic_queue has been released in July 2025.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
