### PR TITLE
bacnet-stack: add version 1.4.1

### DIFF
--- a/recipes/bacnet-stack/all/conandata.yml
+++ b/recipes/bacnet-stack/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.1":
+    url: "https://github.com/bacnet-stack/bacnet-stack/archive/refs/tags/bacnet-stack-1.4.1.tar.gz"
+    sha256: "f46dfb6719e847d4ee7b0f1c24574f158ffd4c08d638a9b179b794260814ae68"
   "1.3.2":
     url: "https://github.com/bacnet-stack/bacnet-stack/archive/refs/tags/bacnet-stack-1.3.2.tar.gz"
     sha256: "e38cee9a96485692d5306bcd893ad02244efbecead12be8d2b2e3f3fc50328cb"

--- a/recipes/bacnet-stack/config.yml
+++ b/recipes/bacnet-stack/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.1":
+    folder: "all"
   "1.3.2":
     folder: "all"
   "1.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **bacnet-stack/1.4.1**

#### Motivation
Version 1.4.1 of bacnet-stack has been released in April 2025.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
