### PR TITLE
bitsery: add version 5.2.5

### DIFF
--- a/recipes/bitsery/all/conandata.yml
+++ b/recipes/bitsery/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.2.5":
+    url: "https://github.com/fraillt/bitsery/archive/refs/tags/v5.2.5.tar.gz"
+    sha256: "22a6d92ac030e999b53d57a0c9afe28723766595c6d00c91ab9c5637d4ed0eec"
   "5.2.4":
     url: "https://github.com/fraillt/bitsery/archive/v5.2.4.tar.gz"
     sha256: "ff741a3fee5420b31af31c7a8cefbcc3aaaf6f7f8c3ac49aa020f99b21d96020"

--- a/recipes/bitsery/config.yml
+++ b/recipes/bitsery/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.2.5":
+    folder: all
   "5.2.4":
     folder: all
   "5.2.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **bitsery/5.2.5**

#### Motivation
Version 5.2.5 has been released 3 days ago.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
