### PR TITLE
cglm: add version 0.9.6

### DIFF
--- a/recipes/cglm/all/conandata.yml
+++ b/recipes/cglm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.6":
+    url: "https://github.com/recp/cglm/archive/refs/tags/v0.9.6.tar.gz"
+    sha256: "be5e7d384561eb0fca59724a92b7fb44bf03e588a7eae5123a7d796002928184"
   "0.9.1":
     url: "https://github.com/recp/cglm/archive/v0.9.1.tar.gz"
     sha256: "ba16ee484c9d5e808ef01e55008a156831e8ff5297f10bbca307adeb827a0913"

--- a/recipes/cglm/config.yml
+++ b/recipes/cglm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.6":
+    folder: all
   "0.9.1":
     folder: all
   "0.8.9":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cglm/0.9.6**

#### Motivation
Version 0.9.6 of cglm has been released in February 2025.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
