### PR TITLE
cgltf: add version 1.15

### DIFF
--- a/recipes/cgltf/all/conandata.yml
+++ b/recipes/cgltf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.15":
+    url: "https://github.com/jkuhlmann/cgltf/archive/refs/tags/v1.15.tar.gz"
+    sha256: "84e352092e5cd6aab7f66de62ddb66beb5e6f18d412ca9d12950d7a55bfef25a"
   "1.13":
     url: "https://github.com/jkuhlmann/cgltf/archive/v1.13.tar.gz"
     sha256: "053d5320097334767486c6e33d01dd1b1c6224eac82aac2d720f4ec456d8c50b"

--- a/recipes/cgltf/config.yml
+++ b/recipes/cgltf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.15":
+    folder: all
   "1.13":
     folder: all
   "1.12":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cgltf/1.15**

#### Motivation
Version 1.15 of cgltf has been released in February 2025.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
