### PR TITLE
crcpp: add version 1.2.1.0

### DIFF
--- a/recipes/crcpp/all/conandata.yml
+++ b/recipes/crcpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.1.0":
+    url: "https://github.com/d-bahr/CRCpp/archive/refs/tags/release-1.2.1.0.tar.gz"
+    sha256: "e2019ed95300f865fe0c1ea326e5502e1ba538bfbc2e31d175a5ee313b31510d"
   "1.2.0.0":
     url: "https://github.com/d-bahr/CRCpp/archive/refs/tags/release-1.2.0.0.tar.gz"
     sha256: "382d399b939207d81537a874ec4b05abc7f59772be58425a0dd048711d43db14"

--- a/recipes/crcpp/config.yml
+++ b/recipes/crcpp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.1.0":
+    folder: all
   "1.2.0.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **crcpp/1.2.1.0**

#### Motivation
Version 1.2.1.0 of crcpp has been released in June 2025

#### Details
[Releasenotes of version 1.2.1.0](https://github.com/d-bahr/CRCpp/releases/tag/release-1.2.1.0)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
