### PR TITLE
dice-template-library: add version 1.15.1

### DIFF
--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.15.1":
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.15.1.tar.gz"
+    sha256: "9c0c3830ed3a2eb464b5c006d031ad27127f0ca7368bdc14cd56026630b9efd8"
   "1.9.0":
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v1.9.0.tar.gz"
     sha256: "ca82a61bd445e0eaf69e68fc4a96d037c8b2ea36ff7762042dbb6f47a89f99e9"

--- a/recipes/dice-template-library/config.yml
+++ b/recipes/dice-template-library/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.15.1":
+    folder: all
   "1.9.0":
     folder: all
   "1.8.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **dice-template-library/1.15.1**

#### Motivation
Version 1.15.1 of dice-template-library has been released in July 2025

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
