### PR TITLE
embree: add version 4.4.0

### DIFF
--- a/recipes/embree/all/conandata.yml
+++ b/recipes/embree/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.4.0":
+    url: "https://github.com/RenderKit/embree/archive/refs/tags/v4.4.0.tar.gz"
+    sha256: "acb517b0ea0f4b442235d5331b69f96192c28da6aca5d5dde0cbe40799638d5c"
   "4.3.3":
     url: "https://github.com/embree/embree/archive/refs/tags/v4.3.3.tar.gz"
     sha256: "8a3bc3c3e21aa209d9861a28f8ba93b2f82ed0dc93341dddac09f1f03c36ef2d"

--- a/recipes/embree/config.yml
+++ b/recipes/embree/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "4.4.0":
+    folder: all
   "4.3.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **embree/4.4.0**

#### Motivation
Version 4.4.0 of embree has been released in April 2025.

#### Details
[Release notes for version 4.4.0](https://github.com/RenderKit/embree/releases/tag/v4.4.0)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
