### PR TITLE
evmc: add version 12.1.0

### DIFF
--- a/recipes/evmc/all/conandata.yml
+++ b/recipes/evmc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "12.1.0":
+    url: "https://github.com/ipsilon/evmc/archive/refs/tags/v12.1.0.tar.gz"
+    sha256: "0d5458015bf38a5358fad04cc290d21ec40122d1eb6420e0b33ae25546984bcd"
   "11.0.0":
     url: "https://github.com/ethereum/evmc/archive/v11.0.0.tar.gz"
     sha256: "a628ba9062b80540c553e92a44288c696532461ea9c08ef00b2c2a677095727e"

--- a/recipes/evmc/config.yml
+++ b/recipes/evmc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "12.1.0":
+    folder: all
   "11.0.0":
     folder: all
   "10.1.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **evmc/12.1.0**

#### Motivation
Version 12.1.0 of evmc has been released in February 2025.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
