### PR TITLE
openjph: Fix recipe to handle debug suffix

### DIFF
--- a/recipes/openjph/all/conanfile.py
+++ b/recipes/openjph/all/conanfile.py
@@ -82,8 +82,10 @@ class OpenJPH(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "openjph::openjph")
         self.cpp_info.set_property("pkg_config_name", "openjph")
 
-        version_suffix = ""
+        version_suffix = "_d" if self.settings.build_type == "Debug" else ""
         if is_msvc(self):
             v = Version(self.version)
             version_suffix = f".{v.major}.{v.minor}"
+            if self.settings.build_type == "Debug":
+                version_suffix += "d"
         self.cpp_info.libs = ["openjph" + version_suffix]


### PR DESCRIPTION
### Summary
Changes to recipe:  **openjph/0.24.2**

#### Motivation
Building my apps dependencies for my local CCI clone (where I already have merged some of my current pending PRs) just failed (doing sporadic manual rebases of my branch when things that interest me had been merged upstream). Failure was due to the suffix resulting in the library not being found when consumers request it. (This failure was obviously when building the Debug packages.)

#### Details
The upstream CMake suffixes the library with `_d` when building a Debug build. As I understand the preferred way is to handle that in the recipe rather than in a patch for the cmake so appending the debug suffix when needed.

Here is the failure that happened when building openexr/3.4.1 (#28342) which requires openjph with all (package and dependencies) in Debug:
```
CMake Error at /home/.conan2/p/b/opene3680f9a768846/b/build/Debug/generators/cmakedeps_macros.cmake:81 (message):
  Library 'openjph' not found in package.  If 'openjph' is a system library,
  declare it with 'cpp_info.system_libs' property
Call Stack (most recent call first):
  /home/.conan2/p/b/opene3680f9a768846/b/build/Debug/generators/openjph-Target-debug.cmake:23 (conan_package_library_targets)
  /home/.conan2/p/b/opene3680f9a768846/b/build/Debug/generators/openjphTargets.cmake:24 (include)
  /home/.conan2/p/b/opene3680f9a768846/b/build/Debug/generators/openjph-config.cmake:16 (include)
  cmake/OpenEXRSetup.cmake:263 (find_package)
  CMakeLists.txt:62 (include)
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan