### PR TITLE
inih: add version 62

### DIFF
--- a/recipes/inih/all/conandata.yml
+++ b/recipes/inih/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "62":
+    url: "https://github.com/benhoyt/inih/archive/refs/tags/r62.tar.gz"
+    sha256: "9c15fa751bb8093d042dae1b9f125eb45198c32c6704cd5481ccde460d4f8151"
   "60":
     url: "https://github.com/benhoyt/inih/archive/r60.tar.gz"
     sha256: "706aa05c888b53bd170e5d8aa8f8a9d9ccf5449dfed262d5103d1f292af26774"

--- a/recipes/inih/config.yml
+++ b/recipes/inih/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "62":
+    folder: "all"
   "60":
     folder: "all"
   "58":


### PR DESCRIPTION
### Summary
Changes to recipe:  **inih/62**

#### Motivation
Version 62 of inih has been released in September 2025.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
