### PR TITLE
Fix debug postfix in openvino

### DIFF
--- a/recipes/openvino/all/conanfile.py
+++ b/recipes/openvino/all/conanfile.py
@@ -368,6 +368,13 @@ class OpenvinoConan(ConanFile):
             ])
             if Version(self.version) >= "2025.1.0":
                 openvino_runtime.libs.append(f"openvino_common_translators{lib_suffix}")
+            # set 'openvino' once again for transformations objects files (cyclic dependency)
+            # openvino_runtime.libs.append("openvino")
+            full_openvino_lib_path = os.path.join(self.package_folder, "lib", f"openvino{lib_suffix}.lib").replace("\\", "/") if self.settings.os == "Windows" else \
+                                     os.path.join(self.package_folder, "lib", f"libopenvino{lib_suffix}.a")
+            openvino_runtime.system_libs.insert(0, full_openvino_lib_path)
+            # Add definition to prevent symbols importing
+            openvino_runtime.defines = ["OPENVINO_STATIC_LIBRARY"]
         if self.options.get_safe("enable_gpu"):
             openvino_runtime.requires.extend(["opencl-icd-loader::opencl-icd-loader", "rapidjson::rapidjson"])
             if self.settings.os == "Windows":


### PR DESCRIPTION
Subset of https://github.com/conan-io/conan-center-index/pull/25698

All currently supported versions of openvino have this code in their `CMakeLists.txt` file
```cmake
# Enable postfixes for Debug/Release builds
set(OV_DEBUG_POSTFIX_WIN "d")
set(OV_RELEASE_POSTFIX_WIN "")
set(OV_DEBUG_POSTFIX_LIN "")
set(OV_RELEASE_POSTFIX_LIN "")
set(OV_DEBUG_POSTFIX_MAC "d")
set(OV_RELEASE_POSTFIX_MAC "")
```

In fact, running the test package in debug we get
<details>
<summary>this error</summary>

```
======== Testing the package: Building ========
openvino/2025.3.0 (test package): Calling build()
openvino/2025.3.0 (test package): Running CMake.configure()
openvino/2025.3.0 (test package): RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/coding/conan-center-index/recipes/openvino/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Debug" "/Users/abril/coding/conan-center-index/recipes/openvino/all/test_package"
-- Using Conan toolchain: /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 20 with extensions ON
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- The C compiler identification is AppleClang 17.0.0.17000013
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'openvino::runtime'
-- Conan: Component target declared 'openvino::runtime::c'
-- Conan: Component target declared 'openvino::frontend::onnx'
-- Conan: Component target declared 'openvino::frontend::paddle'
-- Conan: Component target declared 'openvino::frontend::tensorflow'
-- Conan: Component target declared 'openvino::frontend::pytorch'
-- Conan: Component target declared 'openvino::frontend::tensorflow_lite'
-- Conan: Target declared 'openvino::openvino'
CMake Error at build/apple-clang-17-armv8-gnu20-debug/generators/cmakedeps_macros.cmake:81 (message):
  Library 'openvino_tensorflow_lite_frontend' not found in package.  If
  'openvino_tensorflow_lite_frontend' is a system library, declare it with
  'cpp_info.system_libs' property
Call Stack (most recent call first):
  build/apple-clang-17-armv8-gnu20-debug/generators/OpenVINO-Target-debug.cmake:23 (conan_package_library_targets)
  build/apple-clang-17-armv8-gnu20-debug/generators/OpenVINOTargets.cmake:24 (include)
  build/apple-clang-17-armv8-gnu20-debug/generators/OpenVINOConfig.cmake:16 (include)
  CMakeLists.txt:18 (find_package)


-- Configuring incomplete, errors occurred!

ERROR: openvino/2025.3.0 (test package): Error in build() method, line 43
	cmake.configure()
	ConanException: Error 1 while executing
```

</details>

because all libraries we build (ie no arm_compute-static) get the postfix added as seen here
<img width="318" height="562" alt="Captura de pantalla 2025-10-12 a las 0 37 41" src="https://github.com/user-attachments/assets/fb1ed14e-d7e8-48ca-9bc6-83333acd0d55" />


<details>
<summary>With the current PR changes in place, the test runs correctly</summary>

```
======== Testing the package ========
Removing previously existing 'test_package' build folder: /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug
openvino/2025.3.0 (test package): Test package build: build/apple-clang-17-armv8-gnu20-debug
openvino/2025.3.0 (test package): Test package build folder: /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug
openvino/2025.3.0 (test package): Writing generators to /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug/generators
openvino/2025.3.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
openvino/2025.3.0 (test package): Calling generate()
openvino/2025.3.0 (test package): Generators folder: /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug/generators
openvino/2025.3.0 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(OpenVINO)
    target_link_libraries(... openvino::openvino)
openvino/2025.3.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
openvino/2025.3.0 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug/generators/CMakePresets.json
openvino/2025.3.0 (test package): CMakeToolchain generated: /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/CMakeUserPresets.json
openvino/2025.3.0 (test package): Generating aggregated env files
openvino/2025.3.0 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
openvino/2025.3.0 (test package): Calling build()
openvino/2025.3.0 (test package): Running CMake.configure()
openvino/2025.3.0 (test package): RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/abril/coding/conan-center-index/recipes/openvino/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Debug" "/Users/abril/coding/conan-center-index/recipes/openvino/all/test_package"
-- Using Conan toolchain: /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 20 with extensions ON
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- The C compiler identification is AppleClang 17.0.0.17000013
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'openvino::runtime'
-- Conan: Component target declared 'openvino::runtime::c'
-- Conan: Component target declared 'openvino::frontend::onnx'
-- Conan: Component target declared 'openvino::frontend::paddle'
-- Conan: Component target declared 'openvino::frontend::tensorflow'
-- Conan: Component target declared 'openvino::frontend::pytorch'
-- Conan: Component target declared 'openvino::frontend::tensorflow_lite'
-- Conan: Target declared 'openvino::openvino'
-- Conan: Component target declared 'TBB::tbb'
-- Conan: Component target declared 'TBB::tbbmalloc'
-- Conan: Component target declared 'TBB::tbbmalloc_proxy'
-- Conan: Target declared 'onetbb::onetbb'
-- Conan: Target declared 'pugixml::pugixml'
-- Conan: Component target declared 'Snappy::snappy'
-- Conan: Component target declared 'onnx_proto'
-- Conan: Component target declared 'onnx'
-- Conan: Target declared 'onnx::onnx'
-- Conan: Component target declared 'protobuf::libprotobuf'
-- Conan: Component target declared 'protobuf::libprotoc'
-- Conan: Target declared 'protobuf::protobuf'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib/cmake/protobuf/protobuf-generate.cmake'
-- Conan: Including build module from '/Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib/cmake/protobuf/protobuf-module.cmake'
-- Conan: Including build module from '/Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib/cmake/protobuf/protobuf-options.cmake'
-- Conan: Including build module from '/Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib/cmake/protobuf/protobuf-conan-protoc-target.cmake'
-- Conan: Component target declared 'flatbuffers::libflatbuffers'
-- Conan: Target declared 'flatbuffers::flatbuffers'
-- Conan: Including build module from '/Users/abril/.conan2/p/flatb33af6373a1e09/p/lib/cmake/FlatcTargets.cmake'
-- Conan: Including build module from '/Users/abril/.conan2/p/flatb33af6373a1e09/p/lib/cmake/BuildFlatBuffers.cmake'
-- Configuring done (0.9s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug

openvino/2025.3.0 (test package): Running CMake.build()
openvino/2025.3.0 (test package): RUN: cmake --build "/Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug" -- -j12
Change Dir: '/Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/build/apple-clang-17-armv8-gnu20-debug'

Run Build Command(s): /opt/homebrew/bin/ninja -v -j12
[1/4] /usr/bin/cc -DENABLE_AUTO -DENABLE_AUTO_BATCH -DENABLE_HETERO -DENABLE_INTEL_CPU -DONNX_ML=1 -DONNX_NAMESPACE=onnx -D__STDC_FORMAT_MACROS -isystem /Users/abril/.conan2/p/b/openve97cae138bbc4/p/include -g -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -MD -MT CMakeFiles/test_package_c.dir/test_package.c.o -MF CMakeFiles/test_package_c.dir/test_package.c.o.d -o CMakeFiles/test_package_c.dir/test_package.c.o -c /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/test_package.c
[2/4] /usr/bin/c++ -DENABLE_IR_FRONTEND -DENABLE_ONNX_FRONTEND -DENABLE_PADDLE_FRONTEND -DENABLE_PYTORCH_FRONTEND -DENABLE_TF_FRONTEND -DENABLE_TF_LITE_FRONTEND -DONNX_ML=1 -DONNX_NAMESPACE=onnx -D__STDC_FORMAT_MACROS -isystem /Users/abril/.conan2/p/b/openve97cae138bbc4/p/include -stdlib=libc++ -g -std=gnu++20 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -MD -MT CMakeFiles/test_package_cpp.dir/test_package.cpp.o -MF CMakeFiles/test_package_cpp.dir/test_package.cpp.o.d -o CMakeFiles/test_package_cpp.dir/test_package.cpp.o -c /Users/abril/coding/conan-center-index/recipes/openvino/all/test_package/test_package.cpp
[3/4] : && /usr/bin/cc -g -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names CMakeFiles/test_package_c.dir/test_package.c.o -o test_package_c -L/Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib   -L/Users/abril/.conan2/p/onetbc753b2af927dc/p/lib   -L/Users/abril/.conan2/p/pugixb2df799e2877c/p/lib   -L/Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib   -L/Users/abril/.conan2/p/b/zlib0b5fd2a003b10/p/lib   -L/Users/abril/.conan2/p/onnx29bf8381692d7/p/lib   -L/Users/abril/.conan2/p/snappe27a2c52049e9/p/lib   -L/Users/abril/.conan2/p/flatb33af6373a1e09/p/lib -Wl,-rpath,/Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib -Wl,-rpath,/Users/abril/.conan2/p/onetbc753b2af927dc/p/lib -Wl,-rpath,/Users/abril/.conan2/p/pugixb2df799e2877c/p/lib -Wl,-rpath,/Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib -Wl,-rpath,/Users/abril/.conan2/p/b/zlib0b5fd2a003b10/p/lib -Wl,-rpath,/Users/abril/.conan2/p/onnx29bf8381692d7/p/lib -Wl,-rpath,/Users/abril/.conan2/p/snappe27a2c52049e9/p/lib -Wl,-rpath,/Users/abril/.conan2/p/flatb33af6373a1e09/p/lib  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_cd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvinod.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_arm_cpu_plugind.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_onednn_cpud.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_snippetsd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libmlasd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libarm_compute-static.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libkleidiaid.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_auto_plugind.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_hetero_plugind.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_auto_batch_plugind.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_ir_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_onnx_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_onnx_commond.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_tensorflow_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_tensorflow_lite_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_tensorflow_commond.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_paddle_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_pytorch_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_referenced.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_shape_inferenced.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_ittd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_utild.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_common_translatorsd.a  /Users/abril/.conan2/p/onetbc753b2af927dc/p/lib/libtbb.dylib  /Users/abril/.conan2/p/pugixb2df799e2877c/p/lib/libpugixml.a  /Users/abril/.conan2/p/onnx29bf8381692d7/p/lib/libonnx.a  /Users/abril/.conan2/p/onnx29bf8381692d7/p/lib/libonnx_proto.a  /Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib/libprotobuf.a  /Users/abril/.conan2/p/b/zlib0b5fd2a003b10/p/lib/libz.a  /Users/abril/.conan2/p/snappe27a2c52049e9/p/lib/libsnappy.a  -lc++  /Users/abril/.conan2/p/flatb33af6373a1e09/p/lib/libflatbuffers.a && :
[4/4] : && /usr/bin/c++ -stdlib=libc++ -g -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names CMakeFiles/test_package_cpp.dir/test_package.cpp.o -o test_package_cpp -L/Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib   -L/Users/abril/.conan2/p/onetbc753b2af927dc/p/lib   -L/Users/abril/.conan2/p/pugixb2df799e2877c/p/lib   -L/Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib   -L/Users/abril/.conan2/p/b/zlib0b5fd2a003b10/p/lib   -L/Users/abril/.conan2/p/onnx29bf8381692d7/p/lib   -L/Users/abril/.conan2/p/snappe27a2c52049e9/p/lib   -L/Users/abril/.conan2/p/flatb33af6373a1e09/p/lib -Wl,-rpath,/Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib -Wl,-rpath,/Users/abril/.conan2/p/onetbc753b2af927dc/p/lib -Wl,-rpath,/Users/abril/.conan2/p/pugixb2df799e2877c/p/lib -Wl,-rpath,/Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib -Wl,-rpath,/Users/abril/.conan2/p/b/zlib0b5fd2a003b10/p/lib -Wl,-rpath,/Users/abril/.conan2/p/onnx29bf8381692d7/p/lib -Wl,-rpath,/Users/abril/.conan2/p/snappe27a2c52049e9/p/lib -Wl,-rpath,/Users/abril/.conan2/p/flatb33af6373a1e09/p/lib  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvinod.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_arm_cpu_plugind.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_onednn_cpud.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_snippetsd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libmlasd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libarm_compute-static.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libkleidiaid.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_auto_plugind.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_hetero_plugind.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_auto_batch_plugind.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_ir_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_onnx_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_onnx_commond.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_tensorflow_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_tensorflow_lite_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_tensorflow_commond.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_paddle_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_pytorch_frontendd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_referenced.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_shape_inferenced.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_ittd.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_utild.a  /Users/abril/.conan2/p/b/openve97cae138bbc4/p/lib/libopenvino_common_translatorsd.a  /Users/abril/.conan2/p/onetbc753b2af927dc/p/lib/libtbb.dylib  /Users/abril/.conan2/p/pugixb2df799e2877c/p/lib/libpugixml.a  /Users/abril/.conan2/p/onnx29bf8381692d7/p/lib/libonnx.a  /Users/abril/.conan2/p/onnx29bf8381692d7/p/lib/libonnx_proto.a  /Users/abril/.conan2/p/protoa01bd8c1e9152/p/lib/libprotobuf.a  /Users/abril/.conan2/p/b/zlib0b5fd2a003b10/p/lib/libz.a  /Users/abril/.conan2/p/snappe27a2c52049e9/p/lib/libsnappy.a  -lc++  /Users/abril/.conan2/p/flatb33af6373a1e09/p/lib/libflatbuffers.a && :
ld: warning: ignoring duplicate libraries: '-lc++'



======== Testing the package: Executing test ========
openvino/2025.3.0 (test package): Running test()
openvino/2025.3.0 (test package): RUN: ./test_package_c

openvino/2025.3.0 (test package): RUN: ./test_package_cpp
```
</details>