### PR TITLE
emsdk: update to 4.0.16

### DIFF
--- a/recipes/emsdk/all/conandata.yml
+++ b/recipes/emsdk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.0.16":
+    url: "https://github.com/emscripten-core/emsdk/archive/4.0.16.tar.gz"
+    sha256: "e4eda3ce4222eed778d24e3b8f4564a0b502d2de827d276cc85450918adf53c6"
   "3.1.73":
     url: "https://github.com/emscripten-core/emsdk/archive/3.1.73.tar.gz"
     sha256: "01e5e57a1f4ad74bff88134f00f4827aeb3b72b3bf91de9c8ad8bfa12ab9479a"

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.scm import Version
 import json
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2.0"
 
 
 class EmSDKConan(ConanFile):
@@ -29,7 +29,10 @@ class EmSDKConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("nodejs/16.3.0")
+        if Version(self.version) < "4.0.16":
+            self.requires("nodejs/16.3.0")
+        else:
+            self.requires("nodejs/22.20.0")
         # self.requires("python")  # FIXME: Not available as Conan package
         # self.requires("wasm")  # FIXME: Not available as Conan package
 

--- a/recipes/emsdk/config.yml
+++ b/recipes/emsdk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.0.16":
+    folder: all
   "3.1.73":
     folder: all
   "3.1.72":


### PR DESCRIPTION
### Summary
Changes to recipe:  **emsdk/[4.0.16]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Add a newer version.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

recipes/emsdk/all/conandata.yml (the version)
recipes/emsdk/all/conanfile.py (upgrade Node.js - currently 16.3.0)
recipes/emsdk/config.yml (the version)

https://nodejs.org/en/blog/release/v16.3.0/ Jun 03, 2021 (outdated)
Node.js 16 is no longer supported, having passed its End-of-Life (EOL)

[https://aws.amazon.com/blogs/devops/announcing-the-end-of-support-for-node-js-14-x-and-16-x-in-aws-cdk/](https://aws.amazon.com/blogs/devops/announcing-the-end-of-support-for-node-js-14-x-and-16-x-in-aws-cdk/)
"**On May 30th, 2025, the [AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/) will no longer support Node.js 14.x and 16.x, which reached end of life on 4/30/2023 (14.x) and 9/11/2023 (16.x).**"

[https://conan.io/center/recipes/nodejs?version=20.16.0](https://conan.io/center/recipes/nodejs?version=20.16.0)

[https://github.com/emscripten-core/emscripten/compare/3.1.73...4.0.16](https://github.com/emscripten-core/emscripten/compare/3.1.73...4.0.16)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

 conan create . --version=4.0.16