### PR TITLE
fast_float: add version 8.1.0

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.1.0":
+    url: "https://github.com/fastfloat/fast_float/archive/refs/tags/v8.1.0.tar.gz"
+    sha256: "4bfabb5979716995090ce68dce83f88f99629bc17ae280eae79311c5340143e1"
   "8.0.2":
     url: "https://github.com/fastfloat/fast_float/archive/v8.0.2.tar.gz"
     sha256: "e14a33089712b681d74d94e2a11362643bd7d769ae8f7e7caefe955f57f7eacd"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.1.0":
+    folder: all
   "8.0.2":
     folder: all
   "8.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **fast_float/8.1.0**

#### Motivation
Version 8.1.0 of fast_float has been released in October 2025

#### Details
[Release notes for version 8.1.0](https://github.com/fastfloat/fast_float/releases/tag/v8.1.0)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
