### PR TITLE
perfetto: add version 52.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "52.0":
+    url: "https://github.com/google/perfetto/archive/refs/tags/v52.0.tar.gz"
+    sha256: "1872349439820e241003a9862cb69f4d535926c437d5316b49ce4a820613539d"
   "50.1":
     url: "https://github.com/google/perfetto/archive/refs/tags/v50.1.tar.gz"
     sha256: "c2230d04790eb50231a58616a3f1ff6dcf772d8e220333a7711605f99c5c6db9"

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "52.0":
+    folder: all
   "50.1":
     folder: all
   "48.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **perfetto/52.0**

#### Motivation
Version 52.0 of perfetto has been released in September 2025.

#### Details
[Release notes for version 52.0](https://github.com/google/perfetto/releases/tag/v52.0)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
