### PR TITLE
libplist: add version 2.7.0

### DIFF
--- a/recipes/libplist/all/conandata.yml
+++ b/recipes/libplist/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.7.0":
+    url: "https://github.com/libimobiledevice/libplist/releases/download/2.7.0/libplist-2.7.0.tar.bz2"
+    sha256: "7ac42301e896b1ebe3c654634780c82baa7cb70df8554e683ff89f7c2643eb8b"
   "2.6.0":
     url: "https://github.com/libimobiledevice/libplist/releases/download/2.6.0/libplist-2.6.0.tar.bz2"
     sha256: "67be9ee3169366589c92dc7c22809b90f51911dd9de22520c39c9a64fb047c9c"

--- a/recipes/libplist/config.yml
+++ b/recipes/libplist/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.7.0":
+    folder: all
   "2.6.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libplist/2.7.0**

#### Motivation
Version 2.7.0 of libplist has been released in May 2025.

#### Details
[Release notes for 2.7.0](https://github.com/libimobiledevice/libplist/releases/tag/2.7.0)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
