### PR TITLE
nuklear: add version 4.12.7

### DIFF
--- a/recipes/nuklear/all/conandata.yml
+++ b/recipes/nuklear/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.12.7":
+    url: "https://github.com/Immediate-Mode-UI/Nuklear/archive/refs/tags/4.12.7.tar.gz"
+    sha256: "5809afbb2e1182894d283f56e586d5aec09ab5ae9c936be51d55033ec6ea77bf"
   "4.12.0":
     url: "https://github.com/Immediate-Mode-UI/Nuklear/archive/4.12.0.tar.gz"
     sha256: "4cb80084d20d20561548a2941b6d1eb7c30e6f0b9405e0d5df84bae3c1d7bbaf"

--- a/recipes/nuklear/config.yml
+++ b/recipes/nuklear/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.12.7":
+    folder: all
   "4.12.0":
     folder: all
   "4.10.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **nulear/4.12.7**

#### Motivation
Version 4.12.7 of nuklear has been released in April 2025.

#### Details

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
