### PR TITLE
openjpeg: add version 2.5.4

### DIFF
--- a/recipes/openjpeg/all/conandata.yml
+++ b/recipes/openjpeg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.4":
+    url: "https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.5.4.tar.gz"
+    sha256: "a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a"
   "2.5.3":
     url: "https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.5.3.tar.gz"
     sha256: "368fe0468228e767433c9ebdea82ad9d801a3ad1e4234421f352c8b06e7aa707"

--- a/recipes/openjpeg/config.yml
+++ b/recipes/openjpeg/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.4":
+    folder: all
   "2.5.3":
     folder: all
   "2.5.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **openjpeg/2.5.4**

#### Motivation
New patch version upstream 

#### Details
https://github.com/uclouvain/openjpeg/compare/v2.5.3...v2.5.4

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
