### PR TITLE
metal-cpp: Add version 26 (now unified for all OSes)

### DIFF
--- a/recipes/metal-cpp/all/conandata.yml
+++ b/recipes/metal-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "26":
+    url: "https://developer.apple.com/metal/cpp/files/metal-cpp_26.zip"
+    sha256: "4df3c078b9aadcb516212e9cb03004cbc5ce9a3e9c068fa3144d021db585a3a4"
   "15.2":
     url: "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS15.2_iOS18.2.zip"
     sha256: "3437e4abfbd3d45217f34772ef3502f31ba3358e5fb6ac9d0ca952a047bcfe25"
@@ -18,6 +21,10 @@ sources:
     url: "https://developer.apple.com/metal/cpp/files/metal-cpp_macOS13_iOS16.zip"
     sha256: "6f741894229e9c750add1afc3797274fc008c7507e2ae726370c17c34b7c6a68"
 minimum_os_version:
+  "26":
+    "Macos": "26"
+    "iOS": "26"
+    "tvOS": "26"
   "15.2":
     "Macos": "15.2"
     "iOS": "18.2"

--- a/recipes/metal-cpp/config.yml
+++ b/recipes/metal-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "26":
+    folder: all
   "15.2":
     folder: all
   "15":


### PR DESCRIPTION
### Summary
Changes to recipe:  **metal-cpp/26**

#### Motivation
Add the version providing new APIs from the macOS/iOS/etc. 26 release cycle for the metal-cpp wrapper.

#### Details
Published on https://developer.apple.com/metal/cpp/

The detailed changelog (forgive the sarcasm) is in the README.md in the zip file:
```
| macOS 26, iOS 26 | Add all the Metal APIs in macOS 26, iOS 26, including support for the **Apple10** GPU family. <br/>Add support for Metal 4 and new denoiser and temporal scalers in MetalFX.|
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan (Currently I don't have the macOS 26 machine at hand for local tests, can try in the coming days. Don't expect anything crazy happening.)