### PR TITLE
update libxml2 dependencies

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -101,9 +101,9 @@ class Libxml2Conan(ConanFile):
         if self.options.lzma:
             self.requires("xz_utils/5.4.5")
         if self.options.iconv:
-            self.requires("libiconv/1.17", transitive_headers=True, transitive_libs=True)
+            self.requires("libiconv/1.18", transitive_headers=True, transitive_libs=True)
         if self.options.icu:
-            self.requires("icu/73.2")
+            self.requires("icu/77.1")
 
     def build_requirements(self):
         if not (is_msvc(self) or self._is_mingw_windows):

--- a/recipes/libxml2/cmake/conanfile.py
+++ b/recipes/libxml2/cmake/conanfile.py
@@ -52,11 +52,11 @@ class Libxml2Conan(ConanFile):
 
     def requirements(self):
         if self.options.iconv:
-            self.requires("libiconv/1.17")
+            self.requires("libiconv/1.18")
         if self.options.get_safe("lzma"):
             self.requires("xz_utils/[>=5.4.5 <6]")
         if self.options.icu:
-            self.requires("icu/73.2")
+            self.requires("icu/77.1")
         if self.options.zlib:
             self.requires("zlib/[>=1.3.1 <2]")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2/**

#### Motivation
libiconv 1.17 does not build with GCC 15 due to an update in the default C standard. Update libiconv and icu dependencies. See #27413


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
