### PR TITLE
libgphoto2: Add version 2.5.32

### DIFF
--- a/recipes/libgphoto2/all/conandata.yml
+++ b/recipes/libgphoto2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.32":
+    url: "https://github.com/gphoto/libgphoto2/releases/download/v2.5.32/libgphoto2-2.5.32.tar.xz"
+    sha256: "495a347be21b8f970607a81e739aa91513a8479cbd73b79454a339c73e2b860e"
   "2.5.31":
     url: "https://github.com/gphoto/libgphoto2/releases/download/v2.5.31/libgphoto2-2.5.31.tar.xz"
     sha256: "8fc7bf40f979459509b87dd4ff1aae9b6c1c2b4724d37db576081eec15406ace"

--- a/recipes/libgphoto2/config.yml
+++ b/recipes/libgphoto2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.32":
+    folder: all
   "2.5.31":
     folder: all
   "2.5.27":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libgphoto2/2.5.32**

#### Motivation
Quite a few cameras have been added to be supported and a number of bugfixes since 2.5.31.

#### Details
https://github.com/gphoto/libgphoto2/releases/tag/v2.5.32

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
