### PR TITLE
opencolorio: reflect correct cppstd settings

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -58,9 +58,13 @@ class OpenColorIOConan(ConanFile):
         self.requires("lcms/[>=2.16 <3]")
         # TODO: add GLUT (needed for ociodisplay tool)
 
-    def validate(self):
+    def validate_build(self):
         minimum_cppstd = 11 if Version(self.version) < "2.5" else 17
         check_min_cppstd(self, minimum_cppstd)
+    
+    def validate(self):
+        check_min_cppstd(self, 11)
+        
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "6.0":
             raise ConanInvalidConfiguration(f"{self.ref} requires gcc >= 6.0")
 


### PR DESCRIPTION
The most recent version requires `cppstd=17` to be built, but can still be used by consumers on C++ 11, as per the upstream project:

https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/592a122b37467c3376f2387fbbdbe7b571fad39f/src/OpenColorIO/CMakeLists.txt#L238-L242

