### PR TITLE
intx: add version 0.13.0

### DIFF
--- a/recipes/intx/all/conandata.yml
+++ b/recipes/intx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.13.0":
+    url: "https://github.com/chfast/intx/archive/refs/tags/v0.13.0.zip"
+    sha256: "D8E15DE0E6405F261A8F6F9D3371290D304BD6938BE62C2369B61BF534A51D83"
   "0.12.0":
     url: "https://github.com/chfast/intx/archive/v0.12.0.tar.gz"
     sha256: "d68ff5dde9a2f340c73be67888f3f72bb18a2ad30aa16cd663ec3bc611afc9b4"

--- a/recipes/intx/config.yml
+++ b/recipes/intx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.13.0":
+    folder: all
   "0.12.0":
     folder: all
   "0.11.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **intx/[0.13.0]**

#### Motivation
New release with additions and bugfixes. Especially important, the current latest on CCI cannot compile on MSVC with preprocessor conformance mode (fixed in 0.12.1, which is not on CCI)

#### Details
Just a version bump. There are no breaking changes as far as I can see.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
