### PR TITLE
[libcurl] Fix brotli CMake arguments for find_package

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -12,7 +12,8 @@ from conan.tools.microsoft import is_msvc, unix_path
 import os
 import re
 
-required_conan_version = ">=2.1.0"
+# INFO: Requires CMakeDeps cmake_extra_variables feature (Conan 2.21)
+required_conan_version = ">=2.21.0"
 
 
 class LibcurlConan(ConanFile):


### PR DESCRIPTION
### Summary

Changes to recipe:  **libcurl/8.16.0**

#### Motivation

fixes #28603

/cc @QubeArnaud

#### Details

The CMake macro `curl_dependency_option` forward those CMake arguments to `find_package`. When using quoted string, CMake interprets as a single arguments. 

With `CMakeDeps` generator, and using its properties, it's possible manage what's expected by libcurl without needing to use a patch.

Build on Window using optional dependencies: [libcurl-8.16.0-windows-msvc14-static-patched.log](https://github.com/user-attachments/files/22972409/libcurl-8.16.0-windows-msvc14-static-patched.log)

It's possible to find `brotli`, `c_ares`, `libpsl`, `zstd` and `libssh2` in the build log. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
