### PR TITLE
Add recipe for cineform-sdk

### DIFF
--- a/recipes/cineform/all/conandata.yml
+++ b/recipes/cineform/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "10.1.1":
+    url:
+    - "https://github.com/gopro/cineform-sdk/archive/refs/tags/v10.1.1.tar.gz"
+    sha256: "f82ac3e841185329a8a4a7a0752d7342159b71bab1cbf0a4eb0ca32e4a9ed48b"
+patches:
+  "10.1.1":
+    - patch_file: "patches/10.1.1-0001-fix-separate.patch"

--- a/recipes/cineform/all/conanfile.py
+++ b/recipes/cineform/all/conanfile.py
@@ -1,0 +1,117 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, mkdir
+import os
+import shutil
+
+required_conan_version = ">=2.0.9"
+
+
+class CineformConan(ConanFile):
+    name = "cineform-sdk"
+    description = "The GoPro CineForm video codec SDK"
+    license = "Apache-2.0, MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/gopro/cineform-sdk"
+    topics = ("compression", "sdk", "gopro", "wavelet", "wavelets", "cineform")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "enable_separated": [True, False],
+        "enable_tools": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "enable_separated": False,
+        "enable_tools": True
+    }
+    implements = ["auto_shared_fpic"]
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.settings.os == "Linux" and self.options.shared:
+            self.requires("libuuid/1.0.3", transitive_libs=True)
+
+    def validate(self):
+        if self.settings.arch not in ["x86_64"]:
+            raise ConanInvalidConfiguration(
+                "{}/{} supported only on x86_64 arch".format(self.name, self.version))
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.5.1 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_TOOLS"] = self.options.enable_tools
+        tc.cache_variables["BUILD_STATIC"] = not self.options.shared
+        tc.cache_variables["BUILD_SEPARATED"] = self.options.enable_separated
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE.txt", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        copy(self, "LICENSE-APACHE", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        copy(self, "LICENSE-MIT", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.configure(variables={
+            "CMAKE_INSTALL_PREFIX": self.package_folder
+        })
+        cmake.install()
+        postfix = ".exe" if self.settings.os == "Windows" else ""
+
+        if self.options.enable_tools:
+            copy(self, "*TestCFHD"+postfix, src=self.build_folder,
+                 dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+            copy(self, "*WaveletDemo"+postfix, src=self.build_folder,
+                 dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+        if self.options.shared and self.settings.os == "Windows":
+            mkdir(self, os.path.join(self.package_folder, "bin"))
+            if self.options.enable_separated:
+                shutil.move(os.path.join(self.package_folder, "lib", "CFHDDecoder.dll"), os.path.join(
+                    self.package_folder, "bin", "CFHDDecoder.dll"))
+                shutil.move(os.path.join(self.package_folder, "lib", "CFHDEncoder.dll"), os.path.join(
+                    self.package_folder, "bin", "CFHDEncoder.dll"))
+            else:
+                shutil.move(os.path.join(self.package_folder, "lib", "CFHDCodec.dll"), os.path.join(
+                    self.package_folder, "bin", "CFHDCodec.dll"))
+
+    def package_info(self):
+        postfix = ""
+        requires = []
+
+        if not self.options.shared:
+            postfix = "Static" if self.settings.os == "Windows" or self.options.enable_separated else ""
+
+        if self.settings.os == "Linux" and self.options.shared:
+            requires = ["libuuid::libuuid"]
+
+        if not self.options.enable_separated:
+            self.cpp_info.libs = ["CFHDCodec"+postfix]
+        else:
+            self.cpp_info.components["decoder"].libs = ["CFHDDecoder"+postfix]
+            self.cpp_info.components["decoder"].requires = requires
+            self.cpp_info.components["encoder"].libs = ["CFHDEncoder"+postfix]
+            self.cpp_info.components["encoder"].requires = requires

--- a/recipes/cineform/all/patches/10.1.1-0001-fix-separate.patch
+++ b/recipes/cineform/all/patches/10.1.1-0001-fix-separate.patch
@@ -1,0 +1,18 @@
+diff --git a/ConvertLib/ImageScaler.cpp b/ConvertLib/ImageScaler.cpp
+index 62f30fd..a1d9e71 100644
+--- a/ConvertLib/ImageScaler.cpp
++++ b/ConvertLib/ImageScaler.cpp
+@@ -85,13 +85,6 @@
+ 
+ #include "cpuid.h"
+ 
+-int GetProcessorCount()
+-{
+-	SYSTEM_INFO cSystem_info;
+-	GetSystemInfo(&cSystem_info);
+-	return cSystem_info.dwNumberOfProcessors;
+-}
+-
+ #elif __APPLE__
+ 
+ #include <sys/types.h>

--- a/recipes/cineform/all/test_package/CMakeLists.txt
+++ b/recipes/cineform/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(cineform-sdk REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE cineform-sdk::cineform-sdk)

--- a/recipes/cineform/all/test_package/conanfile.py
+++ b/recipes/cineform/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cineform/all/test_package/test_package.cpp
+++ b/recipes/cineform/all/test_package/test_package.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+#include <cstdint>
+#include "cineformsdk/CFHDDecoder.h"
+#include "cineformsdk/CFHDEncoder.h"
+
+int main(void) {
+    CFHD_Error error = CFHD_ERROR_OKAY;
+    CFHD_DecoderRef mDecoderRef = nullptr;
+
+    error = CFHD_OpenDecoder(&mDecoderRef, nullptr);    
+
+    if(error != CFHD_ERROR_OKAY){
+        std::cout << "Failed to CFHD_OpenDecoder" << std::endl;
+        return 1;
+    }
+
+    error = CFHD_CloseDecoder(mDecoderRef);    
+    if(error != CFHD_ERROR_OKAY){
+        std::cout << "Failed to CFHD_CloseDecoder" << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/recipes/cineform/config.yml
+++ b/recipes/cineform/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "10.1.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cineform-sdk/10.1.1**

#### Motivation
New package. Used for video decoding/encoding.

#### Details
Original repo looks like abandoned by GoPro, but library still widely used in pro media software. Original library is available only for x86_64. Tested locally on Windows (msvc), Linux (gcc, clang), MacOs (apple-clang) cross to x86_64.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
