### PR TITLE
imgui: Fix for dynamic linking of the latest version (1.92.4)

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -95,3 +95,14 @@ sources:
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.85.tar.gz"
       sha256: "7ed49d1f4573004fa725a70642aaddd3e06bb57fcfe1c1a49ac6574a3e895a77"
+patches:
+  "1.92.4":
+    - patch_file: "patches/1.92.4-0001-static-linking-bugfix-backport.patch"
+      patch_description: "Add missing export for a function needed by the backends"
+      patch_source: "https://github.com/ocornut/imgui/pull/9016"
+      patch_type: "backport"
+  "1.92.4-docking":
+    - patch_file: "patches/1.92.4-docking-0001-static-linking-bugfix-backport.patch"
+      patch_description: "Add missing export for a function needed by the backends"
+      patch_source: "https://github.com/ocornut/imgui/pull/9016"
+      patch_type: "backport"

--- a/recipes/imgui/all/patches/1.92.4-0001-static-linking-bugfix-backport.patch
+++ b/recipes/imgui/all/patches/1.92.4-0001-static-linking-bugfix-backport.patch
@@ -1,0 +1,15 @@
+diff --git imgui.h imgui.h
+index 0a216b76..baeda39b 100644
+--- imgui.h
++++ imgui.h
+@@ -3978,8 +3978,8 @@ struct ImGuiPlatformIO
+     // Functions
+     //------------------------------------------------------------------
+ 
+-    void    ClearPlatformHandlers();    // Clear all Platform_XXX fields. Typically called on Platform Backend shutdown.
+-    void    ClearRendererHandlers();    // Clear all Renderer_XXX fields. Typically called on Renderer Backend shutdown.
++    IMGUI_API void ClearPlatformHandlers();    // Clear all Platform_XXX fields. Typically called on Platform Backend shutdown.
++    IMGUI_API void ClearRendererHandlers();    // Clear all Renderer_XXX fields. Typically called on Renderer Backend shutdown.
+ };
+ 
+ // (Optional) Support for IME (Input Method Editor) via the platform_io.Platform_SetImeDataFn() function. Handler is called during EndFrame().

--- a/recipes/imgui/all/patches/1.92.4-docking-0001-static-linking-bugfix-backport.patch
+++ b/recipes/imgui/all/patches/1.92.4-docking-0001-static-linking-bugfix-backport.patch
@@ -1,0 +1,15 @@
+diff --git imgui.h imgui.h
+index d0f071d2..8328e9a3 100644
+--- imgui.h
++++ imgui.h
+@@ -4235,8 +4235,8 @@ struct ImGuiPlatformIO
+     // Functions
+     //------------------------------------------------------------------
+ 
+-    void    ClearPlatformHandlers();    // Clear all Platform_XXX fields. Typically called on Platform Backend shutdown.
+-    void    ClearRendererHandlers();    // Clear all Renderer_XXX fields. Typically called on Renderer Backend shutdown.
++    IMGUI_API void ClearPlatformHandlers();    // Clear all Platform_XXX fields. Typically called on Platform Backend shutdown.
++    IMGUI_API void ClearRendererHandlers();    // Clear all Renderer_XXX fields. Typically called on Renderer Backend shutdown.
+ };
+ 
+ // (Optional) This is required when enabling multi-viewport. Represent the bounds of each connected monitor/display and their DPI.


### PR DESCRIPTION
### Summary
Changes to recipe:  **imgui/1.92.4**

#### Motivation
Tried to update my App to use imgui/1.92.4-docking but ran into a linker error and started some investigation.

imgui introduced some cleanup functions that are called from the backends. As we don't build the backends as part of the library and instead pack them with the packes as ressources and let the consumer build, the underlying cleanup functions need to be visible. That isn't done upstream. (Started discussion there under https://github.com/ocornut/imgui/pull/9016)

The patch provided here fixes the problem for now until fixed hopefully upstream. Tested locally with the same sample as shown below.

#### Details
To reproduce, the imgui sample can be used (https://github.com/conan-io/examples2/tree/main/examples/libraries/imgui/introduction), update the conanfile.py to use imgui/1.92.4 (optionally 1.92.4-docking) and build as shared. E.g. (assuming the change to the conanfile was done before calling the commands and there being a default profile):

<details>
<summary>Click to expand full log</summary>

```
ingmar@u2 [git@main [d]] % conan install . --build=missing -o:a '*/*:shared=True' && cmake . --preset conan-release && cd build/Release && cmake --build . -j

======== Input profiles ========
Profile host:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu20
compiler.libcxx=libc++
compiler.version=15
os=Macos
[options]
*/*:shared=True
[conf]
tools.build:cflags=['-mcpu=apple-m1', '-mtune=apple-m2']
tools.build:cxxflags=['-mcpu=apple-m1', '-mtune=apple-m2']

Profile build:
[settings]
arch=armv8
build_type=Release
compiler=apple-clang
compiler.cppstd=gnu20
compiler.libcxx=libc++
compiler.version=15
os=Macos
[options]
*/*:shared=True
[conf]
tools.build:cflags=['-mcpu=apple-m1', '-mtune=apple-m2']
tools.build:cxxflags=['-mcpu=apple-m1', '-mtune=apple-m2']


======== Computing dependency graph ========
imgui/1.92.4-docking: Not found in local cache, looking in remotes...
imgui/1.92.4-docking: Checking remote: conancenter
Connecting to remote 'conancenter' anonymously
imgui/1.92.4-docking: Downloaded recipe revision 48a8755459e5535f6fbbeff0c4acb846
Graph root
    conanfile.py: /Users/ingmar/dev/tests/conan2-examples/examples/libraries/imgui/introduction/conanfile.py
Requirements
    glew/2.2.0#3a3eacd9dc24111c323773993c365b49 - Cache
    glfw/3.4#41cc24c744dc4c80571f5dd10dcd9cda - Cache
    glu/system#a5189f60c8270ac97ed29d7f36fffe39 - Cache
    imgui/1.92.4-docking#48a8755459e5535f6fbbeff0c4acb846 - Downloaded (conancenter)
    opengl/system#7c02ea6ef926fd04844af53622a30541 - Cache

======== Computing necessary packages ========
imgui/1.92.4-docking: Main binary package '0229bf2d7b90d9ea60c3a9054d653f27cdb77846' missing
imgui/1.92.4-docking: Checking 11 compatible configurations
imgui/1.92.4-docking: Compatible configurations not found in cache, checking servers
imgui/1.92.4-docking: '8411d534e874ed836668557116d31614e5eef7fc': compiler.cppstd=98
imgui/1.92.4-docking: '6db9f38b362f9fa0347203bd1dfaf9f06aa129ee': compiler.cppstd=gnu98
imgui/1.92.4-docking: 'cbc17879b07120ad2b40f13242b8d5a4a9146f4d': compiler.cppstd=11
imgui/1.92.4-docking: '55584aa836d350bd8681bbb1000ab9a58f1e2baf': compiler.cppstd=gnu11
imgui/1.92.4-docking: '32a07a4e37d5e50656bafb7c9ce5d1c1e220bc92': compiler.cppstd=14
imgui/1.92.4-docking: 'e4b01867f8b56b047705bea6c8ecff28e6acc75b': compiler.cppstd=gnu14
imgui/1.92.4-docking: 'c8c6b365342df62fbf8b160d8d7882aae48bc3c4': compiler.cppstd=17
imgui/1.92.4-docking: '70bb410683d43502ea5732f5497e5da826846d66': compiler.cppstd=gnu17
imgui/1.92.4-docking: 'fbe8c80e02c008a98f3645b68574b6891a3e6fa4': compiler.cppstd=20
imgui/1.92.4-docking: '602c7c3c8983f369ec4f1fcea6a84655548b1aad': compiler.cppstd=23
imgui/1.92.4-docking: '727d7cbe8fad2a8f1b770067555223b5f0664290': compiler.cppstd=gnu23
Requirements
    glew/2.2.0#3a3eacd9dc24111c323773993c365b49:e37c7281e43eb2ab9fdd998485ea11c2ae180984 - Build
    glfw/3.4#41cc24c744dc4c80571f5dd10dcd9cda:4b5a70da40844387c2036524d2f1dcb72f03ef43 - Build
    glu/system#a5189f60c8270ac97ed29d7f36fffe39:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Cache
    imgui/1.92.4-docking#48a8755459e5535f6fbbeff0c4acb846:0229bf2d7b90d9ea60c3a9054d653f27cdb77846 - Build
    opengl/system#7c02ea6ef926fd04844af53622a30541:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Cache

======== Installing packages ========
imgui/1.92.4-docking: Sources downloaded from 'conancenter'
imgui/1.92.4-docking: Calling source() in /Users/ingmar/.conan2/p/imgui5f53519e44af9/s/src
imgui/1.92.4-docking: Uncompressing v1.92.4-docking.tar.gz to .
imgui/1.92.4-docking: Uncompressing v1.92.4.tar.gz to test_engine

-------- Installing package imgui/1.92.4-docking (1 of 5) --------
imgui/1.92.4-docking: Building from source
imgui/1.92.4-docking: Package imgui/1.92.4-docking:0229bf2d7b90d9ea60c3a9054d653f27cdb77846
imgui/1.92.4-docking: settings: os=Macos arch=armv8 compiler=apple-clang compiler.cppstd=gnu20 compiler.libcxx=libc++ compiler.version=15 build_type=Release
imgui/1.92.4-docking: options: enable_test_engine=False shared=True
imgui/1.92.4-docking: Copying sources to build folder
imgui/1.92.4-docking: Building your package in /Users/ingmar/.conan2/p/b/imguid704dbee39304/b
imgui/1.92.4-docking: Calling generate()
imgui/1.92.4-docking: Generators folder: /Users/ingmar/.conan2/p/b/imguid704dbee39304/b/build/Release/generators
imgui/1.92.4-docking: CMakeToolchain generated: conan_toolchain.cmake
imgui/1.92.4-docking: CMakeToolchain generated: /Users/ingmar/.conan2/p/b/imguid704dbee39304/b/build/Release/generators/CMakePresets.json
imgui/1.92.4-docking: Generating aggregated env files
imgui/1.92.4-docking: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
imgui/1.92.4-docking: Calling build()
imgui/1.92.4-docking: Running CMake.configure()
imgui/1.92.4-docking: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/ingmar/.conan2/p/b/imguid704dbee39304/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/ingmar/.conan2/p/b/imguid704dbee39304/b/src/.."
-- Using Conan toolchain: /Users/ingmar/.conan2/p/b/imguid704dbee39304/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 20 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building ImGui without test engine
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ingmar/.conan2/p/b/imguid704dbee39304/b/build/Release

imgui/1.92.4-docking: Running CMake.build()
imgui/1.92.4-docking: RUN: cmake --build "/Users/ingmar/.conan2/p/b/imguid704dbee39304/b/build/Release" -- -j10
[ 25%] Building CXX object CMakeFiles/binary_to_compressed_c.dir/src/misc/fonts/binary_to_compressed_c.cpp.o
[ 25%] Building CXX object CMakeFiles/imgui.dir/src/imgui.cpp.o
[ 62%] Building CXX object CMakeFiles/imgui.dir/src/imgui_widgets.cpp.o
[ 62%] Building CXX object CMakeFiles/imgui.dir/src/imgui_draw.cpp.o
[ 75%] Building CXX object CMakeFiles/imgui.dir/src/imgui_tables.cpp.o
[ 75%] Building CXX object CMakeFiles/imgui.dir/src/imgui_demo.cpp.o
[ 87%] Linking CXX executable binary_to_compressed_c
[ 87%] Built target binary_to_compressed_c
[100%] Linking CXX shared library libimgui.dylib
[100%] Built target imgui

imgui/1.92.4-docking: Package '0229bf2d7b90d9ea60c3a9054d653f27cdb77846' built
imgui/1.92.4-docking: Build folder /Users/ingmar/.conan2/p/b/imguid704dbee39304/b/build/Release
imgui/1.92.4-docking: Generating the package
imgui/1.92.4-docking: Packaging in folder /Users/ingmar/.conan2/p/b/imguid704dbee39304/p
imgui/1.92.4-docking: Calling package()
imgui/1.92.4-docking: Running CMake.install()
imgui/1.92.4-docking: RUN: cmake --install "/Users/ingmar/.conan2/p/b/imguid704dbee39304/b/build/Release" --prefix "/Users/ingmar/.conan2/p/b/imguid704dbee39304/p"
-- Install configuration: "Release"
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/lib/libimgui.dylib
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/bin/binary_to_compressed_c
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/include/imconfig.h
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/include/imgui.h
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/include/imgui_internal.h
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/include/imstb_rectpack.h
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/include/imstb_textedit.h
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/include/imstb_truetype.h
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/include/imgui_export_headers.h
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/res/fonts/Cousine-Regular.ttf
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/res/fonts/DroidSans.ttf
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/res/fonts/Karla-Regular.ttf
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/res/fonts/ProggyClean.ttf
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/res/fonts/ProggyTiny.ttf
-- Installing: /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/res/fonts/Roboto-Medium.ttf

imgui/1.92.4-docking: package(): Packaged 31 '.h' files
imgui/1.92.4-docking: package(): Packaged 25 '.cpp' files
imgui/1.92.4-docking: package(): Packaged 1 '.md' file: README.md
imgui/1.92.4-docking: package(): Packaged 2 '.txt' files: README.txt, LICENSE.txt
imgui/1.92.4-docking: package(): Packaged 2 '.mm' files: imgui_impl_metal.mm, imgui_impl_osx.mm
imgui/1.92.4-docking: package(): Packaged 6 '.ttf' files
imgui/1.92.4-docking: package(): Packaged 1 file: binary_to_compressed_c
imgui/1.92.4-docking: package(): Packaged 1 '.dylib' file: libimgui.dylib
imgui/1.92.4-docking: Created package revision 8fc01c9c3a6610ab41229b49f07e6835
imgui/1.92.4-docking: Package '0229bf2d7b90d9ea60c3a9054d653f27cdb77846' created
imgui/1.92.4-docking: Full package reference: imgui/1.92.4-docking#48a8755459e5535f6fbbeff0c4acb846:0229bf2d7b90d9ea60c3a9054d653f27cdb77846#8fc01c9c3a6610ab41229b49f07e6835
imgui/1.92.4-docking: Package folder /Users/ingmar/.conan2/p/b/imguid704dbee39304/p
imgui/1.92.4-docking: Appending PATH env var with : /Users/ingmar/.conan2/p/b/imguid704dbee39304/p/bin
opengl/system: Already installed! (2 of 5)

-------- Installing package glfw/3.4 (3 of 5) --------
glfw/3.4: Building from source
glfw/3.4: Package glfw/3.4:4b5a70da40844387c2036524d2f1dcb72f03ef43
glfw/3.4: settings: os=Macos arch=armv8 compiler=apple-clang compiler.version=15 build_type=Release
glfw/3.4: options: shared=True
glfw/3.4: requires: opengl/system
glfw/3.4: Copying sources to build folder
glfw/3.4: Building your package in /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b
glfw/3.4: Calling generate()
glfw/3.4: Generators folder: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/build/Release/generators
glfw/3.4: CMakeToolchain generated: conan_toolchain.cmake
glfw/3.4: CMakeToolchain generated: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/build/Release/generators/CMakePresets.json
glfw/3.4: CMakeToolchain generated: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/src/CMakeUserPresets.json
glfw/3.4: Generating aggregated env files
glfw/3.4: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
glfw/3.4: Calling build()
glfw/3.4: apply_conandata_patches(): No patches defined in conandata
glfw/3.4: Running CMake.configure()
glfw/3.4: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p" -DGLFW_BUILD_DOCS="OFF" -DGLFW_BUILD_EXAMPLES="OFF" -DGLFW_BUILD_TESTS="OFF" -DGLFW_INSTALL="ON" -DGLFW_BUILD_X11="OFF" -DGLFW_BUILD_WAYLAND="OFF" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/src"
-- Using Conan toolchain: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is AppleClang 17.0.0.17000013
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Including Cocoa support
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/build/Release

glfw/3.4: Running CMake.build()
glfw/3.4: RUN: cmake --build "/Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/build/Release" -- -j10
[  9%] Building C object src/CMakeFiles/glfw.dir/input.c.o
[  9%] Building C object src/CMakeFiles/glfw.dir/monitor.c.o
[ 18%] Building C object src/CMakeFiles/glfw.dir/platform.c.o
[ 22%] Building C object src/CMakeFiles/glfw.dir/context.c.o
[ 22%] Building C object src/CMakeFiles/glfw.dir/egl_context.c.o
[ 31%] Building C object src/CMakeFiles/glfw.dir/null_init.c.o
[ 31%] Building C object src/CMakeFiles/glfw.dir/window.c.o
[ 36%] Building C object src/CMakeFiles/glfw.dir/vulkan.c.o
[ 40%] Building C object src/CMakeFiles/glfw.dir/init.c.o
[ 45%] Building C object src/CMakeFiles/glfw.dir/osmesa_context.c.o
[ 50%] Building C object src/CMakeFiles/glfw.dir/null_monitor.c.o
[ 54%] Building C object src/CMakeFiles/glfw.dir/null_window.c.o
[ 59%] Building C object src/CMakeFiles/glfw.dir/null_joystick.c.o
[ 63%] Building C object src/CMakeFiles/glfw.dir/cocoa_time.c.o
[ 68%] Building C object src/CMakeFiles/glfw.dir/posix_module.c.o
[ 72%] Building C object src/CMakeFiles/glfw.dir/posix_thread.c.o
[ 77%] Building C object src/CMakeFiles/glfw.dir/cocoa_init.m.o
[ 86%] Building C object src/CMakeFiles/glfw.dir/cocoa_joystick.m.o
[ 86%] Building C object src/CMakeFiles/glfw.dir/cocoa_monitor.m.o
[ 90%] Building C object src/CMakeFiles/glfw.dir/cocoa_window.m.o
[ 95%] Building C object src/CMakeFiles/glfw.dir/nsgl_context.m.o
[100%] Linking C shared library libglfw.dylib
[100%] Built target glfw

glfw/3.4: Package '4b5a70da40844387c2036524d2f1dcb72f03ef43' built
glfw/3.4: Build folder /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/build/Release
glfw/3.4: Generating the package
glfw/3.4: Packaging in folder /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p
glfw/3.4: Calling package()
glfw/3.4: Running CMake.install()
glfw/3.4: RUN: cmake --install "/Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/b/build/Release" --prefix "/Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p"
-- Install configuration: "Release"
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/lib/libglfw.3.4.dylib
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/lib/libglfw.3.dylib
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/lib/libglfw.dylib
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/include/GLFW
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/include/GLFW/glfw3.h
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/include/GLFW/glfw3native.h
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/lib/cmake/glfw3/glfw3Config.cmake
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/lib/cmake/glfw3/glfw3ConfigVersion.cmake
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/lib/cmake/glfw3/glfw3Targets.cmake
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/lib/cmake/glfw3/glfw3Targets-release.cmake
-- Installing: /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p/lib/pkgconfig/glfw3.pc

glfw/3.4: package(): Packaged 1 '.md' file: LICENSE.md
glfw/3.4: package(): Packaged 2 '.h' files: glfw3.h, glfw3native.h
glfw/3.4: package(): Packaged 3 '.dylib' files: libglfw.dylib, libglfw.3.4.dylib, libglfw.3.dylib
glfw/3.4: package(): Packaged 1 '.cmake' file: conan-official-glfw-targets.cmake
glfw/3.4: Created package revision 212b2b8b33303a951943d13abe774348
glfw/3.4: Package '4b5a70da40844387c2036524d2f1dcb72f03ef43' created
glfw/3.4: Full package reference: glfw/3.4#41cc24c744dc4c80571f5dd10dcd9cda:4b5a70da40844387c2036524d2f1dcb72f03ef43#212b2b8b33303a951943d13abe774348
glfw/3.4: Package folder /Users/ingmar/.conan2/p/b/glfwc47144dd70a1e/p
glu/system: Already installed! (4 of 5)

-------- Installing package glew/2.2.0 (5 of 5) --------
glew/2.2.0: Building from source
glew/2.2.0: Package glew/2.2.0:e37c7281e43eb2ab9fdd998485ea11c2ae180984
glew/2.2.0: settings: os=Macos arch=armv8 compiler=apple-clang compiler.version=15 build_type=Release
glew/2.2.0: options: shared=True with_egl=False with_glu=system
glew/2.2.0: requires: glu/system opengl/system
glew/2.2.0: Copying sources to build folder
glew/2.2.0: Building your package in /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b
glew/2.2.0: Calling generate()
glew/2.2.0: Generators folder: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/build/Release/generators
glew/2.2.0: CMakeToolchain generated: conan_toolchain.cmake
glew/2.2.0: CMakeToolchain generated: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/build/Release/generators/CMakePresets.json
glew/2.2.0: Generating aggregated env files
glew/2.2.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
glew/2.2.0: Calling build()
glew/2.2.0: Apply patch (conan): Fix CMake: cmake_minimum_required() before project()
glew/2.2.0: Running CMake.configure()
glew/2.2.0: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/src/build/cmake"
-- Using Conan toolchain: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is AppleClang 17.0.0.17000013
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found OpenGL: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/OpenGL.framework   
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/build/Release

glew/2.2.0: Running CMake.build()
glew/2.2.0: RUN: cmake --build "/Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/build/Release" -- -j10
[ 50%] Building C object CMakeFiles/glew_s.dir/Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/src/src/glew.c.o
[ 50%] Building C object CMakeFiles/glew.dir/Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/src/src/glew.c.o
[ 75%] Linking C static library lib/libGLEW.a
[ 75%] Built target glew_s
[100%] Linking C shared library lib/libGLEW.dylib
[100%] Built target glew

glew/2.2.0: Package 'e37c7281e43eb2ab9fdd998485ea11c2ae180984' built
glew/2.2.0: Build folder /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/build/Release
glew/2.2.0: Generating the package
glew/2.2.0: Packaging in folder /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p
glew/2.2.0: Calling package()
glew/2.2.0: Running CMake.install()
glew/2.2.0: RUN: cmake --install "/Users/ingmar/.conan2/p/b/glewf8633f5a9d724/b/build/Release" --prefix "/Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p"
-- Install configuration: "Release"
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/lib/libGLEW.2.2.0.dylib
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/lib/libGLEW.2.2.dylib
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/lib/libGLEW.dylib
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/lib/pkgconfig/glew.pc
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/include/GL/wglew.h
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/include/GL/glew.h
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/include/GL/glxew.h
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/lib/cmake/glew/glew-targets.cmake
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/lib/cmake/glew/glew-targets-release.cmake
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/lib/cmake/glew/glew-config.cmake
-- Installing: /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p/lib/cmake/glew/CopyImportedTargetProperties.cmake

glew/2.2.0: package(): Packaged 1 '.txt' file: LICENSE.txt
glew/2.2.0: package(): Packaged 3 '.h' files: glxew.h, wglew.h, glew.h
glew/2.2.0: package(): Packaged 3 '.dylib' files: libGLEW.dylib, libGLEW.2.2.dylib, libGLEW.2.2.0.dylib
glew/2.2.0: Created package revision 333258d47bb2139ef4feec45e41b3e07
glew/2.2.0: Package 'e37c7281e43eb2ab9fdd998485ea11c2ae180984' created
glew/2.2.0: Full package reference: glew/2.2.0#3a3eacd9dc24111c323773993c365b49:e37c7281e43eb2ab9fdd998485ea11c2ae180984#333258d47bb2139ef4feec45e41b3e07
glew/2.2.0: Package folder /Users/ingmar/.conan2/p/b/glewf8633f5a9d724/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'env_info' used in: imgui/1.92.4-docking
WARN: deprecated:     'cpp_info.filenames' used in: opengl/system

======== Finalizing install (deploy, generators) ========
conanfile.py: Writing generators to /Users/ingmar/dev/tests/conan2-examples/examples/libraries/imgui/introduction/build/Release/generators
conanfile.py: Generator 'CMakeDeps' calling 'generate()'
conanfile.py: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(imgui)
    find_package(glfw3)
    find_package(glew)
    target_link_libraries(... imgui::imgui glfw GLEW::GLEW)
conanfile.py: Generator 'CMakeToolchain' calling 'generate()'
conanfile.py: CMakeToolchain generated: conan_toolchain.cmake
conanfile.py: CMakeToolchain: Preset 'conan-release' added to CMakePresets.json.
    (cmake>=3.23) cmake --preset conan-release
    (cmake<3.23) cmake <path> -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake  -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release
conanfile.py: CMakeToolchain generated: /Users/ingmar/dev/tests/conan2-examples/examples/libraries/imgui/introduction/build/Release/generators/CMakePresets.json
conanfile.py: CMakeToolchain generated: /Users/ingmar/dev/tests/conan2-examples/examples/libraries/imgui/introduction/CMakeUserPresets.json
conanfile.py: Calling generate()
conanfile.py: Generators folder: /Users/ingmar/dev/tests/conan2-examples/examples/libraries/imgui/introduction/build/Release/generators
conanfile.py: Generating aggregated env files
conanfile.py: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
Install finished successfully
Preset CMake variables:

  CMAKE_BUILD_TYPE="Release"
  CMAKE_POLICY_DEFAULT_CMP0091="NEW"
  CMAKE_TOOLCHAIN_FILE:FILEPATH="generators/conan_toolchain.cmake"

-- Using Conan toolchain: /Users/ingmar/dev/tests/conan2-examples/examples/libraries/imgui/introduction/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 20 with extensions ON
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'imgui::imgui'
-- Conan: Target declared 'glfw'
-- Conan: Target declared 'opengl::opengl'
-- Conan: Component target declared 'GLEW::glew'
-- Conan: Target declared 'GLEW::GLEW'
-- Conan: Target declared 'glu::glu'
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/ingmar/dev/tests/conan2-examples/examples/libraries/imgui/introduction/build/Release
[ 33%] Building CXX object CMakeFiles/dear-imgui-conan.dir/file_manager.cpp.o
[ 33%] Building CXX object CMakeFiles/dear-imgui-conan.dir/main.cpp.o
[ 83%] Building CXX object CMakeFiles/dear-imgui-conan.dir/opengl_shader.cpp.o
[ 83%] Building CXX object CMakeFiles/dear-imgui-conan.dir/bindings/imgui_impl_glfw.cpp.o
[ 83%] Building CXX object CMakeFiles/dear-imgui-conan.dir/bindings/imgui_impl_opengl3.cpp.o
[100%] Linking CXX executable dear-imgui-conan
Undefined symbols for architecture arm64:
  "ImGuiPlatformIO::ClearPlatformHandlers()", referenced from:
      ImGui_ImplGlfw_Shutdown() in imgui_impl_glfw.cpp.o
  "ImGuiPlatformIO::ClearRendererHandlers()", referenced from:
      ImGui_ImplOpenGL3_Shutdown() in imgui_impl_opengl3.cpp.o
ld: symbol(s) not found for architecture arm64
c++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [dear-imgui-conan] Error 1
make[1]: *** [CMakeFiles/dear-imgui-conan.dir/all] Error 2
make: *** [all] Error 2
```
</details>

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
