### PR TITLE
libgphoto2: Add version 2.5.33

### DIFF
--- a/recipes/libgphoto2/all/conandata.yml
+++ b/recipes/libgphoto2/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.5.32":
-    url: "https://github.com/gphoto/libgphoto2/releases/download/v2.5.32/libgphoto2-2.5.32.tar.xz"
-    sha256: "495a347be21b8f970607a81e739aa91513a8479cbd73b79454a339c73e2b860e"
+  "2.5.33":
+    url: "https://github.com/gphoto/libgphoto2/releases/download/v2.5.33/libgphoto2-2.5.33.tar.xz"
+    sha256: "28825f767a85544cb58f6e15028f8e53a5bb37a62148b3f1708b524781c3bef2"
   "2.5.31":
     url: "https://github.com/gphoto/libgphoto2/releases/download/v2.5.31/libgphoto2-2.5.31.tar.xz"
     sha256: "8fc7bf40f979459509b87dd4ff1aae9b6c1c2b4724d37db576081eec15406ace"

--- a/recipes/libgphoto2/config.yml
+++ b/recipes/libgphoto2/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.5.32":
+  "2.5.33":
     folder: all
   "2.5.31":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libgphoto2/2.5.33**

#### Motivation
Extension of supported cameras but also fix of a regression from version 2.5.32. Had I known that this is the case I and 2.5.33 was around the corner, I'd probably had skipped #28610.

#### Details
https://github.com/irieger/conan-center-index/pull/new/libgphoto2/2.5.33

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
