### PR TITLE
[zstd] Add cmake target alias for a common target

### DIFF
--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -92,8 +92,7 @@ class ZstdConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "zstd")
         self.cpp_info.set_property("cmake_target_name", f"zstd::{zstd_cmake}")
         self.cpp_info.set_property("pkg_config_name", "libzstd")
-        if Version(self.version) >= "1.5.6":
-            self.cpp_info.set_property("cmake_target_aliases", ["zstd::libzstd"])
+        self.cpp_info.set_property("cmake_target_aliases", ["zstd::libzstd"])
         self.cpp_info.components["zstdlib"].libs = collect_libs(self)
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["zstdlib"].system_libs.append("pthread")


### PR DESCRIPTION
### Summary
Changes to recipe:  **zstd/>=1.5.6**

#### Motivation

Since ZSTD 1.5.6, consumers no longer need to choose between CMake targets `zstd::libzstd_static` and `zstd::libzstd_shared`; instead, a common interface has been added: `zstd::libzstd`, resulting in a much less prone error situation.

Official reference: https://github.com/facebook/zstd/commit/dcd713ce06fd9729e2e1eefa079be866f5e2f519

#### Details

As the zstd recipe supports multiple versions, a guard has been added to protect old versions, so the behavior should be expected as the official one.

Originally, the upstream does not use an alias, but a CMake target interface. Still, using an alias here should be fine. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
