### PR TITLE
libdb: disable `--enable-sql` compilation option

### DIFF
--- a/recipes/libdb/all/conanfile.py
+++ b/recipes/libdb/all/conanfile.py
@@ -190,6 +190,8 @@ class LibdbConan(ConanFile):
                 # https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics
                 # https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes
                 tc.extra_cflags.append("-Wno-error=implicit-function-declaration")
+            if str(self.settings.arch).startswith("arm"):
+                tc.extra_cflags.append("-Wno-error=implicit-int")
 
             tc.generate()
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libdb**

#### Motivation
Linking libdb built with `--enable-sql` results in conflicting symbols if sqlite3 is also linked, since the sql functionality is not desired for my use case so I would like to disable it:
<details>
<summary> Error details </summary>
conanfile.py:

```
...
self.requires("sqlite3/3.49.1")
self.requires("libdb/5.3.28")
...
```

CMakeLists.txt:

```
...
find_package(SQLite3 REQUIRED)
find_package(libdb REQUIRED)
...
target_link_libraries(myprogram ...  SQLite::SQLite3 libdb::libdb ...)
...
```
Build error:

```
ld.lld: error: duplicate symbol: sqlite3_mutex_enter
>>> defined at sqlite3.c:16240 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:16240)
>>>            sqlite3.o:(sqlite3_mutex_enter) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:29395 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:29395)
>>>            sqlite3.c.o:(.text+0x130) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_mutex_leave
>>> defined at sqlite3.c:16264 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:16264)
>>>            sqlite3.o:(sqlite3_mutex_leave) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:29421 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:29421)
>>>            sqlite3.c.o:(.text+0x160) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_status
>>> defined at sqlite3.c:12456 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:12456)
>>>            sqlite3.o:(sqlite3_status) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:24314 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:24314)
>>>            sqlite3.c.o:(.text+0x190) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_db_status
>>> defined at sqlite3.c:12478 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:12478)
>>>            sqlite3.o:(sqlite3_db_status) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:24363 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:24363)
>>>            sqlite3.c.o:(.text+0x220) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_vfs_find
>>> defined at sqlite3.c:13947 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:13947)
>>>            sqlite3.o:(sqlite3_vfs_find) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:26739 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:26739)
>>>            sqlite3.c.o:(.text+0xbd0) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_initialize
>>> defined at sqlite3.c:98452 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:98452)
>>>            sqlite3.o:(sqlite3_initialize) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:181731 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:181731)
>>>            sqlite3.c.o:(.text+0xc80) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_mutex_free
>>> defined at sqlite3.c:16230 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:16230)
>>>            sqlite3.o:(sqlite3_mutex_free) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:29384 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:29384)
>>>            sqlite3.c.o:(.text+0x11e0) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_vfs_register
>>> defined at sqlite3.c:13993 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:13993)
>>>            sqlite3.o:(sqlite3_vfs_register) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:26785 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:26785)
>>>            sqlite3.c.o:(.text+0xec0) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_vfs_unregister
>>> defined at sqlite3.c:14017 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:14017)
>>>            sqlite3.o:(sqlite3_vfs_unregister) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:26813 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:26813)
>>>            sqlite3.c.o:(.text+0x1020) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_mutex_alloc
>>> defined at sqlite3.c:16212 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:16212)
>>>            sqlite3.o:(sqlite3_mutex_alloc) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:29363 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:29363)
>>>            sqlite3.c.o:(.text+0x1080) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_mutex_try
>>> defined at sqlite3.c:16250 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:16250)
>>>            sqlite3.o:(sqlite3_mutex_try) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:29406 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:29406)
>>>            sqlite3.c.o:(.text+0x1210) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_release_memory
>>> defined at sqlite3.c:17478 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:17478)
>>>            sqlite3.o:(sqlite3_release_memory) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:30591 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:30591)
>>>            sqlite3.c.o:(.text+0x1250) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_memory_alarm
>>> defined at sqlite3.c:17575 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:17575)
>>>            sqlite3.o:(sqlite3_memory_alarm) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:30644 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:30644)
>>>            sqlite3.c.o:(.text+0x1260) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_soft_heap_limit64
>>> defined at sqlite3.c:17584 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:17584)
>>>            sqlite3.o:(sqlite3_soft_heap_limit64) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:30663 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:30663)
>>>            sqlite3.c.o:(.text+0x1280) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_memory_used
>>> defined at sqlite3.c:17672 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:17672)
>>>            sqlite3.o:(sqlite3_memory_used) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:30765 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:30765)
>>>            sqlite3.c.o:(.text+0x13b0) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_soft_heap_limit
>>> defined at sqlite3.c:17603 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:17603)
>>>            sqlite3.o:(sqlite3_soft_heap_limit) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:30688 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:30688)
>>>            sqlite3.c.o:(.text+0x1400) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_memory_highwater
>>> defined at sqlite3.c:17685 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:17685)
>>>            sqlite3.o:(sqlite3_memory_highwater) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:30776 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:30776)
>>>            sqlite3.c.o:(.text+0x14c0) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_malloc
>>> defined at sqlite3.c:17778 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:17778)
>>>            sqlite3.o:(sqlite3_malloc) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:30905 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:30905)
>>>            sqlite3.c.o:(.text+0x1520) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_free
>>> defined at sqlite3.c:17920 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:17920)
>>>            sqlite3.o:(sqlite3_free) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:30980 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:30980)
>>>            sqlite3.c.o:(.text+0x1660) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a

ld.lld: error: duplicate symbol: sqlite3_realloc
>>> defined at sqlite3.c:18015 (/opt/conan2/p/b/libdb1cb68af2fc500/b/src/lang/sql/generated/sqlite3.c:18015)
>>>            sqlite3.o:(sqlite3_realloc) in archive /opt/conan2/p/b/libdb1cb68af2fc500/p/lib/libdb_sql.a
>>> defined at sqlite3.c:31152 (/opt/conan2/p/b/sqlit018c3c69650f7/b/src/sqlite3.c:31152)
>>>            sqlite3.c.o:(.text+0x1730) in archive /opt/conan2/p/b/sqlit018c3c69650f7/p/lib/libsqlite3.a
```
</details>

<details>
<summary> Arm compilation error </summary>
Log output:

```
checking for getopt optreset variable... no
checking for mutexes... UNIX/fcntl
configure: error: Support for FCNTL mutexes was removed in BDB 4.8.
```

</details>

#### Details
- Disable `--enable-sql` build option for the library which resolves conflicts with sqlite and is consistent with the way most Linux distros package the library
- Disable `implicit-int` compilation error to fix compilation error (error: Support for FCNTL mutexes was removed in BDB 4.8.) on aarch64

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
