### PR TITLE
IXWebSocket: update openssl and mbedtls requirements for compatibility with newer versions

### DIFF
--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -60,7 +60,10 @@ class IXWebSocketConan(ConanFile):
         if self.options.tls == "openssl":
             self.requires("openssl/[>=1.1 <4]")
         elif self.options.tls == "mbedtls":
-            self.requires("mbedtls/[>=2.25.0 <4]")
+            if Version(self.version) >= "11.3.1":
+                self.requires("mbedtls/[>=2.25.0 <4]")
+            else:
+                self.requires("mbedtls/[>=2.25.0 <3]")
 
     @property
     def _can_use_openssl(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **IXWebSocket/11.4.5**

#### Motivation
@aui-framework would like to use mbedtls/3.6.4 but unfortunately ixwebsocket/11.4.5 enforces older mbedtls/2.25.0 version conflict (https://github.com/aui-framework/aui/pull/615). In order to resolve that version conflict of mbedtls, we would need to pass flag for MbedTLS 3.x+ support.

#### Details
Expands OpenSSL & MbedTLS version range allowed to use.

<details>

```
~/conan-center-index/recipes/ixwebsocket/all webs* 13s
❯ 
cd /home/lin/conan-center-index/recipes/ixwebsocket/all && /home/lin/conan-center-index/.venv/bin/conan create . --version 11.4.5 --name ixwebsocket --build=missing

======== Exporting recipe to the cache ========
ixwebsocket/11.4.5: Exporting package recipe: /home/lin/conan-center-index/recipes/ixwebsocket/all/conanfile.py
ixwebsocket/11.4.5: exports: File 'conandata.yml' found. Exporting it...
ixwebsocket/11.4.5: Copied 1 '.yml' file: conandata.yml
ixwebsocket/11.4.5: Copied 1 '.py' file: conanfile.py
ixwebsocket/11.4.5: Exported to cache folder: /home/lin/.conan2/p/ixweb4c15227bc60c8/e
ixwebsocket/11.4.5: Exported: ixwebsocket/11.4.5#5d30392d246f6c6690118b841c0db8b9 (2025-10-20 19:56:25 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=15
os=Linux

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=15
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    ixwebsocket/11.4.5#5d30392d246f6c6690118b841c0db8b9 - Cache
    mbedtls/3.6.4#70446e1ca0da32804b4fce7806440670 - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76 - Cache
Resolved version ranges
    mbedtls/[>=2.25.0 <4]: mbedtls/3.6.4
    zlib/[>=1.2.11 <2]: zlib/1.3.1

======== Computing necessary packages ========
Connecting to remote 'conancenter' anonymously
ixwebsocket/11.4.5: Main binary package '1789fb79bcd30a522976894f7a7f86e00d888205' missing
ixwebsocket/11.4.5: Checking 11 compatible configurations
ixwebsocket/11.4.5: Compatible configurations not found in cache, checking servers
ixwebsocket/11.4.5: '15da3ca99e8af64ecf1c39e34e73477609116533': compiler.cppstd=11
ixwebsocket/11.4.5: 'd2066a4352b638b5a779f0064945624c90c61725': compiler.cppstd=gnu11
ixwebsocket/11.4.5: '5047b9b2261bd5ba294aa330c428562b4e15a4cc': compiler.cppstd=14
ixwebsocket/11.4.5: '3401bd62b3c5d30917098228f045d6a425756b6c': compiler.cppstd=gnu14
ixwebsocket/11.4.5: 'c86a62c20960e48c37d6254ac8415314cd4a88a8': compiler.cppstd=17
ixwebsocket/11.4.5: 'ca974bf0ff01d2b5703ecd3efdef3d6121fe70bc': compiler.cppstd=20
ixwebsocket/11.4.5: '5e4baee55746541dcf00363762e7c54a52d95700': compiler.cppstd=gnu20
ixwebsocket/11.4.5: '0ad19009bece2ac0159cdfbf436c095675d73266': compiler.cppstd=23
ixwebsocket/11.4.5: 'fba5a7819d9bcc4606d3515d840b1f03bff07a0b': compiler.cppstd=gnu23
ixwebsocket/11.4.5: '024c597d976be7869eed086051e32567c7ceb20e': compiler.cppstd=26
ixwebsocket/11.4.5: '2381634b4f5f67bdec1dafedba329718d03048eb': compiler.cppstd=gnu26
Requirements
    ixwebsocket/11.4.5#5d30392d246f6c6690118b841c0db8b9:1789fb79bcd30a522976894f7a7f86e00d888205 - Build
    mbedtls/3.6.4#70446e1ca0da32804b4fce7806440670:3a03a1adfac760ad7445dd45c3c2723f38160a9e#18187a582d37a35b08bae6c1ccd37190 - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76:5172837b05c2f087e99d128455aac37041416625#d25d84d23eb3356df858bfaa46c47e93 - Cache

======== Installing packages ========
mbedtls/3.6.4: Already installed! (1 of 3)
zlib/1.3.1: Already installed! (2 of 3)
ixwebsocket/11.4.5: Calling source() in /home/lin/.conan2/p/ixweb4c15227bc60c8/s/src
ixwebsocket/11.4.5: Uncompressing v11.4.5.tar.gz to .

-------- Installing package ixwebsocket/11.4.5 (3 of 3) --------
ixwebsocket/11.4.5: Building from source
ixwebsocket/11.4.5: Package ixwebsocket/11.4.5:1789fb79bcd30a522976894f7a7f86e00d888205
ixwebsocket/11.4.5: settings: os=Linux arch=x86_64 compiler=gcc compiler.cppstd=gnu17 compiler.libcxx=libstdc++11 compiler.version=15 build_type=Release
ixwebsocket/11.4.5: options: fPIC=True shared=False tls=mbedtls with_zlib=True
ixwebsocket/11.4.5: requires: zlib/1.3.Z mbedtls/3.6.Z
ixwebsocket/11.4.5: Copying sources to build folder
ixwebsocket/11.4.5: Building your package in /home/lin/.conan2/p/b/ixweb5b4b168bb546b/b
ixwebsocket/11.4.5: Calling generate()
ixwebsocket/11.4.5: Generators folder: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/build/Release/generators
ixwebsocket/11.4.5: CMakeToolchain generated: conan_toolchain.cmake
ixwebsocket/11.4.5: CMakeToolchain generated: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/build/Release/generators/CMakePresets.json
ixwebsocket/11.4.5: CMakeToolchain generated: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/src/CMakeUserPresets.json
ixwebsocket/11.4.5: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(ZLIB)
    find_package(MbedTLS)
    target_link_libraries(... ZLIB::ZLIB MbedTLS::mbedtls)
ixwebsocket/11.4.5: Generating aggregated env files
ixwebsocket/11.4.5: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
ixwebsocket/11.4.5: Calling build()
ixwebsocket/11.4.5: Running CMake.configure()
ixwebsocket/11.4.5: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/lin/.conan2/p/b/ixweb5b4b168bb546b/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/src"
-- Using Conan toolchain: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is GNU 15.2.1
-- The CXX compiler identification is GNU 15.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Warning: Standard CMAKE_CXX_STANDARD value defined in conan_toolchain.cmake to 17 has been modified to 11 by /home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/src/CMakeLists.txt
-- TLS configured to use mbedtls
-- Conan: Component target declared 'MbedTLS::mbedcrypto'
-- Conan: Component target declared 'MbedTLS::mbedx509'
-- Conan: Component target declared 'MbedTLS::mbedtls'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/build/Release

ixwebsocket/11.4.5: Running CMake.build()
ixwebsocket/11.4.5: RUN: cmake --build "/home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/build/Release" -- -j48
[  2%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXBench.cpp.o
[  5%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXConnectionState.cpp.o
[  7%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXExponentialBackoff.cpp.o
[ 13%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXDNSLookup.cpp.o
[ 13%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXGetFreePort.cpp.o
[ 15%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXGzipCodec.cpp.o
[ 18%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXNetSystem.cpp.o
[ 21%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXCancellationRequest.cpp.o
[ 23%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSelectInterrupt.cpp.o
[ 26%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSocket.cpp.o
[ 28%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXHttp.cpp.o
[ 34%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXHttpClient.cpp.o
[ 34%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXHttpServer.cpp.o
[ 36%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSocketFactory.cpp.o
[ 39%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSelectInterruptFactory.cpp.o
[ 42%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSocketServer.cpp.o
[ 47%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSelectInterruptEvent.cpp.o
[ 47%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSocketTLSOptions.cpp.o
[ 50%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSelectInterruptPipe.cpp.o
[ 52%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSocketConnect.cpp.o
[ 55%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXStrCaseCompare.cpp.o
[ 57%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSetThreadName.cpp.o
[ 60%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXUuid.cpp.o
[ 63%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXUdpSocket.cpp.o
[ 71%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXUrlParser.cpp.o
[ 71%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocket.cpp.o
[ 71%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketCloseConstants.cpp.o
[ 73%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXUserAgent.cpp.o
[ 76%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketHttpHeaders.cpp.o
[ 78%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketHandshake.cpp.o
[ 84%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketPerMessageDeflateOptions.cpp.o
[ 84%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketPerMessageDeflateCodec.cpp.o
[ 86%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketPerMessageDeflate.cpp.o
[ 89%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketProxyServer.cpp.o
[ 92%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketTransport.cpp.o
[ 94%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXWebSocketServer.cpp.o
[ 97%] Building CXX object CMakeFiles/ixwebsocket.dir/ixwebsocket/IXSocketMbedTLS.cpp.o
/home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/src/ixwebsocket/IXSocketMbedTLS.cpp: In member function ‘bool ix::SocketMbedTLS::loadSystemCertificates(std::string&)’:
/home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/src/ixwebsocket/IXSocketMbedTLS.cpp:52:61: warning: unused parameter ‘errorMsg’ [-Wunused-parameter]
   52 |     bool SocketMbedTLS::loadSystemCertificates(std::string& errorMsg)
      |                                                ~~~~~~~~~~~~~^~~~~~~~
[100%] Linking CXX static library libixwebsocket.a
[100%] Built target ixwebsocket

ixwebsocket/11.4.5: Package '1789fb79bcd30a522976894f7a7f86e00d888205' built
ixwebsocket/11.4.5: Build folder /home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/build/Release
ixwebsocket/11.4.5: Generating the package
ixwebsocket/11.4.5: Packaging in folder /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p
ixwebsocket/11.4.5: Calling package()
ixwebsocket/11.4.5: Running CMake.install()
ixwebsocket/11.4.5: RUN: cmake --install "/home/lin/.conan2/p/b/ixweb5b4b168bb546b/b/build/Release" --prefix "/home/lin/.conan2/p/b/ixweb5b4b168bb546b/p"
-- Install configuration: "Release"
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/lib/libixwebsocket.a
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXBase64.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXBench.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXCancellationRequest.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXConnectionState.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXDNSLookup.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXExponentialBackoff.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXGetFreePort.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXGzipCodec.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXHttp.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXHttpClient.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXHttpServer.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXNetSystem.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXProgressCallback.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSelectInterrupt.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSelectInterruptFactory.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSelectInterruptPipe.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSelectInterruptEvent.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSetThreadName.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSocket.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSocketConnect.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSocketFactory.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSocketServer.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSocketTLSOptions.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXStrCaseCompare.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXUdpSocket.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXUniquePtr.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXUrlParser.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXUuid.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXUtf8Validator.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXUserAgent.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocket.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketCloseConstants.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketCloseInfo.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketErrorInfo.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketHandshake.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketHandshakeKeyGen.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketHttpHeaders.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketInitResult.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketMessage.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketMessageType.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketOpenInfo.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketPerMessageDeflate.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketPerMessageDeflateCodec.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketPerMessageDeflateOptions.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketProxyServer.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketSendData.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketSendInfo.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketServer.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketTransport.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXWebSocketVersion.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/include/ixwebsocket/IXSocketMbedTLS.h
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/lib/cmake/ixwebsocket/ixwebsocket-config.cmake
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/lib/pkgconfig/ixwebsocket.pc
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/lib/cmake/ixwebsocket/ixwebsocket-targets.cmake
-- Installing: /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p/lib/cmake/ixwebsocket/ixwebsocket-targets-release.cmake

ixwebsocket/11.4.5: package(): Packaged 1 '.txt' file: LICENSE.txt
ixwebsocket/11.4.5: package(): Packaged 1 '.a' file: libixwebsocket.a
ixwebsocket/11.4.5: package(): Packaged 51 '.h' files
ixwebsocket/11.4.5: Created package revision c1f9c2483c83df5aacf8caa31247a00a
ixwebsocket/11.4.5: Package '1789fb79bcd30a522976894f7a7f86e00d888205' created
ixwebsocket/11.4.5: Full package reference: ixwebsocket/11.4.5#5d30392d246f6c6690118b841c0db8b9:1789fb79bcd30a522976894f7a7f86e00d888205#c1f9c2483c83df5aacf8caa31247a00a
ixwebsocket/11.4.5: Package folder /home/lin/.conan2/p/b/ixweb5b4b168bb546b/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: zlib/1.3.1

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    ixwebsocket/11.4.5 (test package): /home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/conanfile.py
Requirements
    ixwebsocket/11.4.5#5d30392d246f6c6690118b841c0db8b9 - Cache
    mbedtls/3.6.4#70446e1ca0da32804b4fce7806440670 - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76 - Cache

======== Computing necessary packages ========
Requirements
    ixwebsocket/11.4.5#5d30392d246f6c6690118b841c0db8b9:1789fb79bcd30a522976894f7a7f86e00d888205#c1f9c2483c83df5aacf8caa31247a00a - Cache
    mbedtls/3.6.4#70446e1ca0da32804b4fce7806440670:3a03a1adfac760ad7445dd45c3c2723f38160a9e#18187a582d37a35b08bae6c1ccd37190 - Cache
    zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76:5172837b05c2f087e99d128455aac37041416625#d25d84d23eb3356df858bfaa46c47e93 - Cache

======== Installing packages ========
mbedtls/3.6.4: Already installed! (1 of 3)
zlib/1.3.1: Already installed! (2 of 3)
ixwebsocket/11.4.5: Already installed! (3 of 3)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.names' used in: zlib/1.3.1

======== Testing the package ========
Removing previously existing 'test_package' build folder: /home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/build/gcc-15-x86_64-gnu17-release
ixwebsocket/11.4.5 (test package): Test package build: build/gcc-15-x86_64-gnu17-release
ixwebsocket/11.4.5 (test package): Test package build folder: /home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/build/gcc-15-x86_64-gnu17-release
ixwebsocket/11.4.5 (test package): Writing generators to /home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/build/gcc-15-x86_64-gnu17-release/generators
ixwebsocket/11.4.5 (test package): Generator 'CMakeToolchain' calling 'generate()'
ixwebsocket/11.4.5 (test package): CMakeToolchain generated: conan_toolchain.cmake
ixwebsocket/11.4.5 (test package): CMakeToolchain generated: /home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/build/gcc-15-x86_64-gnu17-release/generators/CMakePresets.json
ixwebsocket/11.4.5 (test package): CMakeToolchain generated: /home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/CMakeUserPresets.json
ixwebsocket/11.4.5 (test package): Generator 'CMakeDeps' calling 'generate()'
ixwebsocket/11.4.5 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(ixwebsocket)
    target_link_libraries(... ixwebsocket::ixwebsocket)
ixwebsocket/11.4.5 (test package): Generator 'VirtualRunEnv' calling 'generate()'
ixwebsocket/11.4.5 (test package): Generating aggregated env files
ixwebsocket/11.4.5 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
ixwebsocket/11.4.5 (test package): Calling build()
ixwebsocket/11.4.5 (test package): Running CMake.configure()
ixwebsocket/11.4.5 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/lin/conan-center-index/recipes/ixwebsocket/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/lin/conan-center-index/recipes/ixwebsocket/all/test_package"
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Using Conan toolchain: /home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/build/gcc-15-x86_64-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The CXX compiler identification is GNU 15.2.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'ixwebsocket::ixwebsocket'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Component target declared 'MbedTLS::mbedcrypto'
-- Conan: Component target declared 'MbedTLS::mbedx509'
-- Conan: Component target declared 'MbedTLS::mbedtls'
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: /home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/build/gcc-15-x86_64-gnu17-release

ixwebsocket/11.4.5 (test package): Running CMake.build()
ixwebsocket/11.4.5 (test package): RUN: cmake --build "/home/lin/conan-center-index/recipes/ixwebsocket/all/test_package/build/gcc-15-x86_64-gnu17-release" -- -j48
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
ixwebsocket/11.4.5 (test package): Running test()
ixwebsocket/11.4.5 (test package): RUN: ./test_package
URL parse result: 
Protocol: https
Host: github.com
Path: /
Query: 
Port: 443


~/conan-center-index/recipes/ixwebsocket/all webs* 13s
❯ 

```

</details>

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
