### PR TITLE
Add Conan recipe for stb header-only library

### DIFF
--- a/recipes/stbk/conanfile.py
+++ b/recipes/stbk/conanfile.py
@@ -1,0 +1,33 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+import os
+
+class StbConan(ConanFile):
+    name = "stb"
+    description = "Single-file public domain libraries for C/C++"
+    license = ("MIT", "Public Domain")
+    url = "https://github.com/nothings/stb"
+    homepage = "https://github.com/nothings/stb"
+    topics = ("graphics", "image", "audio", "header-only")
+    
+    # No settings/options needed for header-only library
+    settings = "os", "compiler", "build_type", "arch"
+    
+    def source(self):
+        # Download stb repository
+        get(self, "https://github.com/nothings/stb/archive/refs/heads/master.zip", 
+            strip_root=True)
+    
+    def package(self):
+        # Copy all header files to package
+        copy(self, "*.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
+    
+    def package_info(self):
+        # Header-only library, no linking needed
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_target_name", "stb::stb")
+        
+    def package_id(self):
+        # Header-only library, so same package for all configurations
+        self.info.clear()

--- a/recipes/stbk/test_package/conan_run.py
+++ b/recipes/stbk/test_package/conan_run.py
@@ -1,0 +1,5 @@
+import sys
+from conan.cli.cli import main
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/recipes/stbk/test_package/conanfile.py
+++ b/recipes/stbk/test_package/conanfile.py
@@ -1,0 +1,24 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/stbk/test_package/test_package.c
+++ b/recipes/stbk/test_package/test_package.c
@@ -1,0 +1,14 @@
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION  
+#include "stb_image_write.h"
+
+int main(void) {
+    // Simple test to verify stb headers work
+    int x, y, n;
+    
+    // Just include the headers - if it compiles, it works
+    // We don't actually load any files in the test
+    return 0;
+}


### PR DESCRIPTION
Introduces a new Conan package recipe for the stb collection of single-file public domain C/C++ libraries. Includes packaging logic, test package with CMake integration, and a basic test to verify header inclusion and compilation.


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
