### PR TITLE
librdkafka: add version 2.12.1

### DIFF
--- a/recipes/librdkafka/all/conandata.yml
+++ b/recipes/librdkafka/all/conandata.yml
@@ -1,30 +1,9 @@
 sources:
-  "2.11.1":
-    url: "https://github.com/edenhill/librdkafka/archive/v2.11.1.tar.gz"
-    sha256: "a2c87186b081e2705bb7d5338d5a01bc88d43273619b372ccb7bb0d264d0ca9f"
-  "2.12.0":
-    url: "https://github.com/edenhill/librdkafka/archive/v2.12.0.tar.gz"
-    sha256: "1355d81091d13643aed140ba0fe62437c02d9434b44e90975aaefab84c2bf237"
+  "2.12.1":
+    url: "https://github.com/edenhill/librdkafka/archive/v2.12.1.tar.gz"
+    sha256: "ec103fa05cb0f251e375f6ea0b6112cfc9d0acd977dc5b69fdc54242ba38a16f"
 patches:
-  "2.11.1":
+  "2.12.1":
     - patch_file: patches/0001-Change-library-names-1-9-1.patch
-      patch_description: "find_package conan packages"
-      patch_type: "conan"
     - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
-      patch_description: "refer conan package names"
-      patch_type: "conan"
     - patch_file: patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
-      patch_description: "Fix OAuthBearer OIDC preprocessor directive when using CMake without CUR"
-      patch_type: "official"
-      patch_source: "https://github.com/confluentinc/librdkafka/pull/5136"
-  "2.12.0":
-    - patch_file: patches/0001-Change-library-names-1-9-1.patch
-      patch_description: "find_package conan packages"
-      patch_type: "conan"
-    - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
-      patch_description: "refer conan package names"
-      patch_type: "conan"
-    - patch_file: patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
-      patch_description: "Fix OAuthBearer OIDC preprocessor directive when using CMake without CUR"
-      patch_type: "official"
-      patch_source: "https://github.com/confluentinc/librdkafka/pull/5136"

--- a/recipes/librdkafka/all/patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
+++ b/recipes/librdkafka/all/patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
@@ -1,3 +1,5 @@
+From https://github.com/confluentinc/librdkafka/pull/5136
+
 diff --git a/src/rdkafka_conf.c b/src/rdkafka_conf.c
 --- a/src/rdkafka_conf.c	(revision 69b1865efdc0118cd017760d038d34e52fb3f0d0)
 +++ b/src/rdkafka_conf.c	(date 1755856167319)

--- a/recipes/librdkafka/config.yml
+++ b/recipes/librdkafka/config.yml
@@ -1,5 +1,4 @@
 versions:
-  "2.11.1":
+  "2.12.1":
     folder: all
-  "2.12.0":
-    folder: all
+


### PR DESCRIPTION
### Summary
Changes to recipe:  **librdkafka/2.12.0**

#### Motivation
latest version of librdkafka with [bugfixes and features](https://github.com/confluentinc/librdkafka/releases/tag/v2.12.0)

#### Details
No relevant cmake changes since 2.11.1: https://github.com/confluentinc/librdkafka/compare/v2.11.1...v2.12.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
