### PR TITLE
keystone: add patch for GCC 15 compatibility

### DIFF
--- a/recipes/keystone/all/conandata.yml
+++ b/recipes/keystone/all/conandata.yml
@@ -8,4 +8,6 @@ patches:
     - patch_file: "patches/0.9.2-cmake4-support.patch"
       patch_type: "portability"
       patch_description: "Remove OLD behavior in CMP0051 and use CMake 3.5 minimum"
-
+    - patch_file: "patches/0.9.2-fix-gcc15.patch"
+      patch_type: "portability"
+      patch_description: "Fix compilation with GCC 15 and support C++17 and later"

--- a/recipes/keystone/all/conanfile.py
+++ b/recipes/keystone/all/conanfile.py
@@ -54,7 +54,7 @@ class KeystoneConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         apply_conandata_patches(self)
 
-    def validate(self):
+    def validate_build(self):
         # INFO: include/llvm/ADT/STLExtras.h:54:34: error: no template named 'binary_function' in namespace 'std'
         # The std::binary_function was removed in C++17
         check_max_cppstd(self, 14)

--- a/recipes/keystone/all/patches/0.9.2-fix-gcc15.patch
+++ b/recipes/keystone/all/patches/0.9.2-fix-gcc15.patch
@@ -1,0 +1,10 @@
+--- a/llvm/include/llvm/ADT/STLExtras.h
++++ b/llvm/include/llvm/ADT/STLExtras.h
+@@ -26,6 +26,7 @@
+ #include <iterator>
+ #include <memory>
+ #include <utility> // for std::pair
++#include <cstdint>
+ 
+ namespace llvm_ks {
+ 


### PR DESCRIPTION
### Summary
Changes to recipe:  **keystone/0.9.2**

#### Motivation
Backport keystone for C++17 or newer cppstd.

#### Details
Just test if it is possible to support cppstd newer than C++14 for https://github.com/conan-io/conan-center-index/pull/28547


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
