### PR TITLE
enable cross compilation for wayland scanner

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -108,7 +108,6 @@ class WaylandConan(ConanFile):
             configure_meson_toolchain(tc_cross)
             tc_cross.generate()
 
-
     def _patch_sources(self):
         replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
                         "subdir('tests')", "#subdir('tests')")
@@ -133,7 +132,9 @@ class WaylandConan(ConanFile):
         self.cpp_info.components["wayland-scanner"].libdirs = []
         self.cpp_info.components["wayland-scanner"].set_property("component_version", self.version)
         self.cpp_info.components["wayland-scanner"].requires = ["expat::expat"]
-        self.buildenv_info.prepend_path("PATH", os.path.join(self.package_folder, "bin"))
+        bin_dir = os.path.join(self.package_folder, "bin")
+        self.buildenv_info.prepend_path("PATH", bin_dir)
+        self.runenv_info.prepend_path("PATH", bin_dir)
 
         if self.options.enable_dtd_validation:
             self.cpp_info.components["wayland-scanner"].requires.append("libxml2::libxml2")

--- a/recipes/wayland/all/test_package/conanfile.py
+++ b/recipes/wayland/all/test_package/conanfile.py
@@ -45,7 +45,7 @@ class TestPackageConan(ConanFile):
                 self.run(bin_path, env="conanrun")
 
             buffer = StringIO()
-            self.run(f"wayland-scanner --version", env="conanbuild", stderr=buffer)
+            self.run(f"wayland-scanner --version", env="conanrun", stderr=buffer)
             output = buffer.getvalue().strip()
             self.output.info(f"Wayland scanner output: {output}")
             actual_version = output.split()[-1]


### PR DESCRIPTION
### Summary
Changes to recipe:  **wayland/1.23.92**

#### Motivation
Enable using wayland-scanner from a cross-compilation environment.

#### Details
* Enables building wayland-scanner from platforms other than Linux and Android so that it can be used as a build requirement in a cross-compilation context. The libraries are disabled as before.
* Removed use of `PkgConfDeps` from the test package as this requires the `pkg-config` executable which is not available on the CCI macos runner.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
