### PR TITLE
keystone: check_min_cppstd

### DIFF
--- a/recipes/keystone/all/conanfile.py
+++ b/recipes/keystone/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
-from conan.tools.build import check_max_cppstd
+from conan.tools.build import check_max_cppstd, check_min_cppstd
 import os
 
 required_conan_version = ">=2.1"
@@ -55,6 +55,9 @@ class KeystoneConan(ConanFile):
         apply_conandata_patches(self)
 
     def validate_build(self):
+        # Host compiler must support std::atomic!
+        check_min_cppstd(self, 11)
+
         # INFO: include/llvm/ADT/STLExtras.h:54:34: error: no template named 'binary_function' in namespace 'std'
         # The std::binary_function was removed in C++17
         check_max_cppstd(self, 14)


### PR DESCRIPTION
### Summary
Changes to recipe:  **keystone/***

#### Motivation
Check min cppstd too. it allows CI systems to identify working std automatically

cf https://github.com/conan-io/conan-center-index/pull/28659/checks?check_run_id=53359161389:
`Current cppstd (17) is higher than the required C++ standard (14).`
#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

passing CI (with this change) : https://github.com/ericLemanissier/cocorepo/actions/runs/18716505865?pr=139

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
