### PR TITLE
flex: fix compilation error

### DIFF
--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.build import cross_building
 from conan.tools.files import get, rmdir, copy, rm, export_conandata_patches, apply_conandata_patches
 from conan.tools.gnu import AutotoolsToolchain, Autotools


### PR DESCRIPTION

### Summary
Changes to recipe:  **flex/***

#### Motivation
without this change, compiling on linux fails with:
```
checking whether the C compiler works... no
configure: error: in `/home/runner/.conan2/p/b/flexaca0213f463d5/b':
configure: error: C compiler cannot create executables
See `config.log' for more details

flex/2.6.4: ERROR: 
```
config.log has:
```
configure:3027: checking whether the C compiler works
configure:3049: gcc  -m64 -fPIC -O3  -DNDEBUG  -m64 -headerpad_max_install_names conftest.c  >&5
gcc: error: unrecognized command line option '-h'
configure:3053: $? = 1
configure:3091: result: no
```
#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
