### PR TITLE
[arrow]: Fix arrow grpc and proto dependencies (#28653).

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -149,7 +149,10 @@ class ArrowConan(ConanFile):
         if self.options.with_thrift:
             self.requires("thrift/0.20.0")
         if self.options.with_protobuf:
-            self.requires("protobuf/3.21.12")
+            if Version(self.version) >= "21.0.0":
+                self.requires("protobuf/4.25.3")
+            else:
+                self.requires("protobuf/3.21.12")
         if self.options.with_jemalloc:
             self.requires("jemalloc/5.3.0")
         if self.options.with_mimalloc:
@@ -163,7 +166,10 @@ class ArrowConan(ConanFile):
         if self.options.get_safe("with_gcs"):
             self.requires("google-cloud-cpp/1.40.1")
         if self.options.with_grpc:
-            self.requires("grpc/1.50.0")
+            if Version(self.version) >= "21.0.0":
+                self.requires("grpc/1.59.1")
+            else:
+                self.requires("grpc/1.50.0")
         if self._requires_rapidjson():
             self.requires("rapidjson/1.1.0")
         if self.options.with_llvm:

--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -14,6 +14,9 @@ sources:
   "1.65.0":
     url: "https://github.com/grpc/grpc/archive/v1.65.0.tar.gz"
     sha256: "ebc3acfde70cfae3f4f04b8dbb72259540cb1dc427be362569fbc2607dabfe39"
+  "1.59.1":
+    url: "https://github.com/grpc/grpc/archive/v1.59.1.tar.gz"
+    sha256: "916f88a34f06b56432611aaa8c55befee96d0a7b7d7457733b9deeacbc016f99"
   "1.54.3":
     url: "https://github.com/grpc/grpc/archive/v1.54.3.tar.gz"
     sha256: "17e4e1b100657b88027721220cbfb694d86c4b807e9257eaf2fb2d273b41b1b1"
@@ -24,6 +27,11 @@ sources:
     url: "https://github.com/grpc/grpc/archive/v1.50.0.tar.gz"
     sha256: "76900ab068da86378395a8e125b5cc43dfae671e09ff6462ddfef18676e2165a"
 patches:
+  "1.59.1":
+    - patch_file: "patches/v1.50.x/002-CMake-Add-gRPC_USE_SYSTEMD-option-34384.patch"
+      patch_type: "backport"
+      patch_source: "https://github.com/grpc/grpc/commit/5c3400e8dc08d0810e3301d7e8cd8a718c82eeed"
+    - patch_file: "patches/v1.50.x/003-template-function-call-fix-1.59.1.patch"
   "1.54.3":
     - patch_file: "patches/v1.50.x/002-CMake-Add-gRPC_USE_SYSTEMD-option-34384.patch"
       patch_type: "backport"

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -108,6 +108,9 @@ class GrpcConan(ConanFile):
         elif Version(self.version) >= "1.62.0" and Version(self.version) <= "1.65.0":
             self.requires("protobuf/5.27.0", transitive_headers=True)
             self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True, transitive_libs=True)
+        elif Version(self.version) >= "1.59.1":
+            self.requires("protobuf/4.25.3", transitive_headers=True)
+            self.requires("abseil/20250127.0", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True, transitive_libs=True)
             self.requires("protobuf/3.21.12", transitive_headers=True)
@@ -160,7 +163,7 @@ class GrpcConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         apply_conandata_patches(self)
-        
+
         # Let Conan define CMAKE_MSVC_RUNTIME_LIBRARY
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "include(cmake/msvc_static_runtime.cmake)", "")
 

--- a/recipes/grpc/all/patches/v1.50.x/003-template-function-call-fix-1.59.1.patch
+++ b/recipes/grpc/all/patches/v1.50.x/003-template-function-call-fix-1.59.1.patch
@@ -1,0 +1,12 @@
+diff -Naur a/src/core/lib/promise/detail/basic_seq.h b/src/core/lib/promise/detail/basic_seq.h
+--- a/src/core/lib/promise/detail/basic_seq.h	2023-10-06 23:44:58.000000000 +0000
++++ b/src/core/lib/promise/detail/basic_seq.h	2025-10-22 18:28:03.234560817 +0000
+@@ -100,7 +100,7 @@
+           cur_ = next;
+           state_.~State();
+           Construct(&state_,
+-                    Traits::template CallSeqFactory(f_, *cur_, std::move(arg)));
++                    Traits::template CallSeqFactory<>(f_, *cur_, std::move(arg)));
+           return PollNonEmpty();
+         });
+   }

--- a/recipes/grpc/all/target_info/grpc_1.59.1.yml
+++ b/recipes/grpc/all/target_info/grpc_1.59.1.yml
@@ -1,0 +1,152 @@
+grpc_version: 1.59.1
+grpc_targets:
+    - name: "address_sorting"
+      lib: "address_sorting"
+      requires:
+        - zlib::zlib
+    - name: "gpr"
+      lib: "gpr"
+      requires:
+        - zlib::zlib
+        - abseil::absl_base
+        - abseil::absl_core_headers
+        - abseil::absl_flags
+        - abseil::absl_flags_marshalling
+        - abseil::absl_any_invocable
+        - abseil::absl_memory
+        - abseil::absl_random_random
+        - abseil::absl_status
+        - abseil::absl_cord
+        - abseil::absl_str_format
+        - abseil::absl_strings
+        - abseil::absl_synchronization
+        - abseil::absl_time
+        - abseil::absl_optional
+        - abseil::absl_variant
+    - name: "_grpc"
+      lib: "grpc"
+      requires:
+        - zlib::zlib
+        - c-ares::cares
+        - address_sorting
+        - re2::re2
+        - upb
+        - abseil::absl_cleanup
+        - abseil::absl_flat_hash_map
+        - abseil::absl_flat_hash_set
+        - abseil::absl_inlined_vector
+        - abseil::absl_bind_front
+        - abseil::absl_function_ref
+        - abseil::absl_hash
+        - abseil::absl_type_traits
+        - abseil::absl_statusor
+        - abseil::absl_span
+        - abseil::absl_utility
+        - gpr
+        - openssl::ssl
+        - openssl::crypto
+        - address_sorting
+        - upb
+      frameworks: ['CoreFoundation']
+    - name: "grpc_unsecure"
+      lib: "grpc_unsecure"
+      requires:
+        - zlib::zlib
+        - c-ares::cares
+        - address_sorting
+        - re2::re2
+        - upb
+        - abseil::absl_cleanup
+        - abseil::absl_flat_hash_map
+        - abseil::absl_flat_hash_set
+        - abseil::absl_inlined_vector
+        - abseil::absl_bind_front
+        - abseil::absl_function_ref
+        - abseil::absl_hash
+        - abseil::absl_type_traits
+        - abseil::absl_statusor
+        - abseil::absl_span
+        - abseil::absl_utility
+        - gpr
+        - address_sorting
+        - upb
+      frameworks: ['CoreFoundation']
+    - name: "grpc++"
+      lib: "grpc++"
+      requires:
+        - protobuf::libprotobuf
+        - zlib::zlib
+        - _grpc
+    - name: "grpc++_alts"
+      lib: "grpc++_alts"
+      requires:
+        - protobuf::libprotobuf
+        - zlib::zlib
+        - grpc++
+    - name: "grpc++_error_details"
+      lib: "grpc++_error_details"
+      requires:
+        - protobuf::libprotobuf
+        - zlib::zlib
+        - grpc++
+    - name: "grpc++_reflection"
+      lib: "grpc++_reflection"
+      requires:
+        - protobuf::libprotobuf
+        - zlib::zlib
+        - grpc++
+    - name: "grpc++_unsecure"
+      lib: "grpc++_unsecure"
+      requires:
+        - protobuf::libprotobuf
+        - zlib::zlib
+        - grpc_unsecure
+    - name: "grpc_authorization_provider"
+      lib: "grpc_authorization_provider"
+      requires:
+        - protobuf::libprotobuf
+        - zlib::zlib
+        - re2::re2
+        - abseil::absl_cleanup
+        - abseil::absl_flat_hash_map
+        - abseil::absl_flat_hash_set
+        - abseil::absl_inlined_vector
+        - abseil::absl_function_ref
+        - abseil::absl_hash
+        - abseil::absl_type_traits
+        - abseil::absl_statusor
+        - abseil::absl_span
+        - abseil::absl_utility
+        - gpr
+        - upb
+    - name: "grpc_plugin_support"
+      lib: "grpc_plugin_support"
+      requires:
+        - protobuf::libprotoc
+        - protobuf::libprotobuf
+        - zlib::zlib
+    - name: "grpcpp_channelz"
+      lib: "grpcpp_channelz"
+      requires:
+        - protobuf::libprotobuf
+        - zlib::zlib
+        - grpc++
+    - name: "upb"
+      lib: "upb"
+      requires:
+        - zlib::zlib
+grpc_plugins:
+    - target: "gRPC::grpc_cpp_plugin"
+      executable: "grpc_cpp_plugin"
+    - target: "gRPC::grpc_csharp_plugin"
+      executable: "grpc_csharp_plugin"
+    - target: "gRPC::grpc_node_plugin"
+      executable: "grpc_node_plugin"
+    - target: "gRPC::grpc_objective_c_plugin"
+      executable: "grpc_objective_c_plugin"
+    - target: "gRPC::grpc_php_plugin"
+      executable: "grpc_php_plugin"
+    - target: "gRPC::grpc_python_plugin"
+      executable: "grpc_python_plugin"
+    - target: "gRPC::grpc_ruby_plugin"
+      executable: "grpc_ruby_plugin"

--- a/recipes/grpc/config.yml
+++ b/recipes/grpc/config.yml
@@ -9,6 +9,8 @@ versions:
     folder: "all"
   "1.65.0":
     folder: "all"
+  "1.59.1":
+    folder: "all"
   "1.54.3":
     folder: "all"
   "1.50.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/21.0.0**

#### Motivation
- Ensure that `arrow/21.0.0` does not depend on outdated `grpc` and `protobuf` versions.

#### Details
- Adds a new `grpc` version.
- Uses the closest (difference in patch version only) available `protobuf` version.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
