### PR TITLE
open62541: set json_support=True by default

### DIFF
--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -140,7 +140,7 @@ class Open62541Conan(ConanFile):
         "hardening": True,
         "cpp_compatible": False,
         "readable_statuscodes": True,
-        "parsing": False,
+        "parsing": True,
         "nodeset_loader": False,
     }
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **open62541/***

#### Motivation
Upstream set it `ON` by default: https://github.com/open62541/open62541/blob/v1.4.6/CMakeLists.txt#L108

Open62541pp/0.19.0 requires it by default.
The new version uses `UA_print` 
https://github.com/open62541pp/open62541pp/compare/v0.17.0...v0.19.0#diff-6f3851574188cef43f50c7ea40134d0a3fed6dded53eea0df53ecb2bc7401a2cR2101

And `UA_ENABLE_JSON_ENCODING` is required to use this function.
https://github.com/open62541/open62541/blob/v1.4.6/include/open62541/types.h#L1187

This is needed to fix the error with the new version: https://github.com/conan-io/conan-center-index/pull/27791 


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
