### PR TITLE
cpp-smtpclient-library: Add version 1.1.12

### DIFF
--- a/recipes/cpp-smtpclient-library/all/conandata.yml
+++ b/recipes/cpp-smtpclient-library/all/conandata.yml
@@ -1,4 +1,5 @@
 sources:
-  "1.1.11":
-    url: "https://github.com/jeremydumais/CPP-SMTPClient-library/archive/refs/tags/v1.1.11.zip"
-    sha256: "d090ebcae75534a6f816174310fec046a96d18f4213581a4c5e75f7b173d624b"
+  "1.1.12":
+    url: "https://github.com/jeremydumais/CPP-SMTPClient-library/archive/refs/tags/v1.1.12.zip"
+    sha256: "558f54174cd10f036a5144a201ed657af038489996031e948d8aae7e22a22007"
+

--- a/recipes/cpp-smtpclient-library/all/conanfile.py
+++ b/recipes/cpp-smtpclient-library/all/conanfile.py
@@ -3,6 +3,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rm, rmdir, replace_in_file
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 import os
 
 
@@ -66,7 +67,10 @@ class PackageConan(ConanFile):
         rm(self, "*.pdb", self.package_folder, recursive=True)
 
     def package_info(self):
-        self.cpp_info.libdirs = [os.path.join("lib", "smtpclient")]
+        # For <=1.1.11 the libs were under lib/smtpclient
+        if Version(self.version) < "1.1.12":
+            self.cpp_info.libdirs = [os.path.join("lib", "smtpclient")]
+        # For 1.1.12+ use the default ("lib"), so no override needed.
         self.cpp_info.libs = ["smtpclient"]
         self.cpp_info.set_property("cmake_module_file_name", "smtpclient")
         self.cpp_info.set_property("cmake_module_target_name", "smtpclient::smtpclient")

--- a/recipes/cpp-smtpclient-library/config.yml
+++ b/recipes/cpp-smtpclient-library/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.1.11":
+  "1.1.12":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-smtpclient-library/1.1.12**

#### Motivation
v1.1.12 released on 2025-10-23

#### Details
https://github.com/jeremydumais/CPP-SMTPClient-library/releases/tag/v1.1.12

##### Enhancement
- The default --sep Multipart encapsulation boundary is now a randomly generated
string to ensure that it doesn't conflict if the --sep string appears in the
email body.
See [RFC 1341 section 7.2.1](https://datatracker.ietf.org/doc/html/rfc1341#page-30).
- Fix CMake install paths to prevent build path leakage in generated config
files. If using default build values, the library out file will not appears in
a smtpclient folder, but one level above.
- Add a Message-ID generated header when sending a message.
See [RFC 5322 section 3.6.4](https://datatracker.ietf.org/doc/html/rfc5322).


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan
