### PR TITLE
qmlaotstats not available until Qt 6.8.3

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -898,7 +898,9 @@ class QtConan(ConanFile):
             targets.append("qsb")
         if self.options.qtdeclarative:
             targets.extend(["qmltyperegistrar", "qmlcachegen", "qmllint", "qmlimportscanner"])
-            targets.extend(["qmlformat", "qml", "qmlprofiler", "qmlpreview", "qmlaotstats"])
+            targets.extend(["qmlformat", "qml", "qmlprofiler", "qmlpreview"])
+            if Version(self.version) >= "6.8.3":
+                targets.extend(["qmlaotstats"])
 
             # Note: consider "qmltestrunner", see https://github.com/conan-io/conan-center-index/issues/24276
         if self.options.get_safe("qtremoteobjects"):


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.7.3**

#### Motivation
When trying to install Qt6 < 6.8.3 the packaging step will fail because it tries to package the qmlaotstats tool and this tool was added only in Qt 6.8.3.

#### Details
This PR adds the qmlaotstats tool to the list of files to package only if the Qt version >= 6.8.3.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
