### PR TITLE
fix(conan/onetbb): avoid pulling all oneTBB components by default — replace onetbb::onetbb with onetbb::libtbb

### DIFF
--- a/recipes/cctag/all/conanfile.py
+++ b/recipes/cctag/all/conanfile.py
@@ -150,7 +150,7 @@ class CCTagConan(ConanFile):
             "boost::thread",
             "boost::timer",
             "eigen::eigen",
-            "onetbb::onetbb",
+            "onetbb::libtbb",
             "opencv::opencv_core",
             "opencv::opencv_imgcodecs",
             "opencv::opencv_imgproc",

--- a/recipes/ceres-solver/all/conanfile.py
+++ b/recipes/ceres-solver/all/conanfile.py
@@ -225,7 +225,7 @@ class CeressolverConan(ConanFile):
         if self.options.use_glog:
             self.cpp_info.components["ceres"].requires.append("glog::glog")
         if self.options.get_safe("use_TBB"):
-            self.cpp_info.components["ceres"].requires.append("onetbb::onetbb")
+            self.cpp_info.components["ceres"].requires.append("onetbb::libtbb")
         if not self.options.shared:
             libcxx = stdcpp_library(self)
             if libcxx:

--- a/recipes/embree/all/conanfile.py
+++ b/recipes/embree/all/conanfile.py
@@ -124,3 +124,6 @@ class EmbreeConan(ConanFile):
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["dl", "m", "pthread"])
+
+        if self.settings.os != "Emscripten":
+            self.requires = ["onetbb::libtbb"]

--- a/recipes/embree/all/conanfile.py
+++ b/recipes/embree/all/conanfile.py
@@ -126,4 +126,4 @@ class EmbreeConan(ConanFile):
             self.cpp_info.system_libs.extend(["dl", "m", "pthread"])
 
         if self.settings.os != "Emscripten":
-            self.requires = ["onetbb::libtbb"]
+            self.cpp_info.requires = ["onetbb::libtbb"]

--- a/recipes/embree3/all/conanfile.py
+++ b/recipes/embree3/all/conanfile.py
@@ -269,6 +269,9 @@ class EmbreeConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["dl", "m", "pthread"])
 
+        if self.options.with_tbb:
+            self.cpp_info.requires = ["onetbb::libtbb"]
+
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "embree"
         self.cpp_info.names["cmake_find_package_multi"] = "embree"

--- a/recipes/gtsam/all/conanfile.py
+++ b/recipes/gtsam/all/conanfile.py
@@ -368,7 +368,8 @@ class GtsamConan(ConanFile):
         gtsam.requires = [f"boost::{component}" for component in self._required_boost_components]
         gtsam.requires.append("eigen::eigen")
         if self.options.with_TBB:
-            gtsam.requires.append("onetbb::onetbb")
+            gtsam.requires.append("onetbb::libtbb")
+            gtsam.requires.append("onetbb::tbbmalloc")
         if self.options.default_allocator == "tcmalloc":
             gtsam.requires.append("gperftools::gperftools")
         if self.settings.os == "Windows":

--- a/recipes/itk/all/conanfile.py
+++ b/recipes/itk/all/conanfile.py
@@ -283,7 +283,7 @@ class ITKConan(ConanFile):
             "ITKCommon": {
                 "requires": [
                     "itksys", "ITKVNLInstantiation", "eigen::eigen",
-                    "onetbb::onetbb", "double-conversion::double-conversion",
+                    "onetbb::libtbb", "double-conversion::double-conversion",
                 ],
                 "system_libs": libm(),
             },
@@ -450,13 +450,13 @@ class ITKConan(ConanFile):
             },
             "ITKVideoCore": {"requires": ["ITKCommon"]},
         }
-        
+
         if self.options.with_opencv:
             components.update({
                 "ITKVideoIO": {"requires": ["ITKVideoCore", "ITKIOImageBase"]},
                 "ITKVideoBridgeOpenCV": {"requires": ["ITKVideoIO", "opencv::opencv_core"]},
             })
-        
+
         return components
 
     def _create_cmake_module_variables(self):

--- a/recipes/manifold/all/conanfile.py
+++ b/recipes/manifold/all/conanfile.py
@@ -28,10 +28,10 @@ class ManifoldConan(ConanFile):
         "with_parallel_acceleration": False,
     }
     implements = ["auto_shared_fpic"]
-    
+
     def export_sources(self):
         export_conandata_patches(self)
-        
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -83,3 +83,7 @@ class ManifoldConan(ConanFile):
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
+
+        self.cpp_info.requires = ["clipper2::clipper2"]
+        if self.options.with_parallel_acceleration:
+            self.cpp_info.requires.append["onetbb::libtbb"]

--- a/recipes/manifold/all/conanfile.py
+++ b/recipes/manifold/all/conanfile.py
@@ -86,4 +86,4 @@ class ManifoldConan(ConanFile):
 
         self.cpp_info.requires = ["clipper2::clipper2"]
         if self.options.with_parallel_acceleration:
-            self.cpp_info.requires.append["onetbb::libtbb"]
+            self.cpp_info.requires.append("onetbb::libtbb")

--- a/recipes/onedpl/all/conanfile.py
+++ b/recipes/onedpl/all/conanfile.py
@@ -101,4 +101,4 @@ class OneDplConan(ConanFile):
         self.cpp_info.components["_onedpl"].bindirs = []
         self.cpp_info.components["_onedpl"].libdirs = []
         if self.options.backend == "tbb":
-            self.cpp_info.components["_onedpl"].requires = ["onetbb::onetbb"]
+            self.cpp_info.components["_onedpl"].requires = ["onetbb::libtbb"]

--- a/recipes/opencascade/all/conanfile.py
+++ b/recipes/opencascade/all/conanfile.py
@@ -455,7 +455,7 @@ class OpenCascadeConan(ConanFile):
             "CSF_OpenVR": {"externals": ["openvr::openvr"] if self.options.with_openvr else []},
             "CSF_RapidJSON": {"externals": ["rapidjson::rapidjson"] if self.options.with_rapidjson else []},
             "CSF_Draco": {"externals": ["draco::draco"] if self.options.get_safe("with_draco") else []},
-            "CSF_TBB": {"externals": ["onetbb::onetbb"] if self.options.with_tbb else []},
+            "CSF_TBB": {"externals": ["onetbb::libtbb"] if self.options.with_tbb else []},
             "CSF_VTK": {},
             # TODO: If requested, allow jemalloc/tbb instead of default native
             "CSF_MMGR": {},

--- a/recipes/opencv/2.x/conanfile.py
+++ b/recipes/opencv/2.x/conanfile.py
@@ -126,7 +126,7 @@ class OpenCVConan(ConanFile):
             return ["gtk::gtk"] if self.options.get_safe("with_gtk") else []
 
         def tbb():
-            return ["onetbb::onetbb"] if self.options.with_tbb else []
+            return ["onetbb::libtbb"] if self.options.with_tbb else []
 
         def opencv_gpu():
             return ["opencv_gpu"] if self.options.get_safe("gpu") else []

--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -329,7 +329,7 @@ class OpenCVConan(ConanFile):
 
         def parallel():
             if self.options.parallel:
-                return ["onetbb::onetbb"] if self.options.parallel == "tbb" else ["openmp"]
+                return ["onetbb::libtbb"] if self.options.parallel == "tbb" else ["openmp"]
             return []
 
         def xfeatures2d():

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -364,7 +364,7 @@ class OpenCVConan(ConanFile):
             return []
 
         def parallel():
-            return ["onetbb::onetbb"] if self.options.parallel == "tbb" else []
+            return ["onetbb::libtbb"] if self.options.parallel == "tbb" else []
 
         def protobuf():
             return ["protobuf::protobuf"] if self.options.get_safe("with_protobuf") else []

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -300,7 +300,7 @@ class OpenImageIOConan(ConanFile):
                 ["dl", "m", "pthread"]
             )
         if self.options.with_tbb:
-            open_image_io_util.requires.append("onetbb::onetbb")
+            open_image_io_util.requires.append("onetbb::libtbb")
 
         # OpenImageIO::OpenImageIO
         open_image_io = self._add_component("OpenImageIO")

--- a/recipes/opensubdiv/all/conanfile.py
+++ b/recipes/opensubdiv/all/conanfile.py
@@ -175,7 +175,7 @@ class OpenSubdivConan(ConanFile):
         self.cpp_info.components["osdcpu"].set_property("cmake_target_name", f"OpenSubdiv::osdcpu{target_suffix}")
         self.cpp_info.components["osdcpu"].libs = ["osdCPU"]
         if self.options.with_tbb:
-            self.cpp_info.components["osdcpu"].requires = ["onetbb::onetbb"]
+            self.cpp_info.components["osdcpu"].requires = ["onetbb::libtbb"]
 
         if self._osd_gpu_enabled:
             self.cpp_info.components["osdgpu"].set_property("cmake_target_name", f"OpenSubdiv::osdgpu{target_suffix}")

--- a/recipes/openvdb/all/conanfile.py
+++ b/recipes/openvdb/all/conanfile.py
@@ -280,7 +280,7 @@ class OpenVDBConan(ConanFile):
         main_component.requires = [
             "boost::iostreams",
             "boost::system",
-            "onetbb::onetbb",
+            "onetbb::libtbb",
         ]
         if self.settings.os == "Windows":
             main_component.requires.append("boost::disable_autolinking")

--- a/recipes/pagmo2/all/conanfile.py
+++ b/recipes/pagmo2/all/conanfile.py
@@ -152,7 +152,7 @@ class Pagmo2Conan(ConanFile):
             self.cpp_info.components["_pagmo"].system_libs.append("pthread")
 
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.components["_pagmo"].requires = ["boost::boost", "onetbb::onetbb"]
+        self.cpp_info.components["_pagmo"].requires = ["boost::boost", "onetbb::libtbb"]
         if self.options.with_eigen:
             self.cpp_info.components["_pagmo"].requires.append("eigen::eigen")
         if self.options.with_nlopt:

--- a/recipes/pagmo2/pre_2.11/conanfile.py
+++ b/recipes/pagmo2/pre_2.11/conanfile.py
@@ -108,7 +108,7 @@ class Pagmo2Conan(ConanFile):
             self.cpp_info.components["_pagmo"].system_libs.append("pthread")
 
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.components["_pagmo"].requires = ["boost::boost", "onetbb::onetbb"]
+        self.cpp_info.components["_pagmo"].requires = ["boost::boost", "onetbb::libtbb"]
         if self.options.with_eigen:
             self.cpp_info.components["_pagmo"].requires.append("eigen::eigen")
         if self.options.with_nlopt:

--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -49,7 +49,7 @@ class RocksDBConan(ConanFile):
         "enable_sse": False,
         "use_rtti": False,
     }
-    
+
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -201,7 +201,7 @@ class RocksDBConan(ConanFile):
         if self.options.with_zstd:
             self.cpp_info.components["librocksdb"].requires.append("zstd::zstd")
         if self.options.get_safe("with_tbb"):
-            self.cpp_info.components["librocksdb"].requires.append("onetbb::onetbb")
+            self.cpp_info.components["librocksdb"].requires.append("onetbb::libtbb")
         if self.options.with_jemalloc:
             self.cpp_info.components["librocksdb"].requires.append("jemalloc::jemalloc")
         if self.options.with_folly:

--- a/recipes/thrust/all/conanfile.py
+++ b/recipes/thrust/all/conanfile.py
@@ -72,3 +72,6 @@ class ThrustConan(ConanFile):
         self.cpp_info.defines = [f"THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_{dev}"]
         # Since CUB and Thrust are provided separately, their versions are not guaranteed to match
         self.cpp_info.defines += ["THRUST_IGNORE_CUB_VERSION_CHECK=1"]
+        self.cpp_info.requires = ["cub::cub"]
+        if self.options.device_system == "tbb":
+            self.cpp_info.requires += ["onetbb::libtbb"]

--- a/recipes/tiny-dnn/all/conanfile.py
+++ b/recipes/tiny-dnn/all/conanfile.py
@@ -98,7 +98,7 @@ class TinyDnnConan(ConanFile):
             self.cpp_info.components["tinydnn"].system_libs = ["pthread"]
         if self.options.with_tbb:
             self.cpp_info.components["tinydnn"].defines = ["CNN_USE_TBB=1"]
-            self.cpp_info.components["tinydnn"].requires.append("onetbb::onetbb")
+            self.cpp_info.components["tinydnn"].requires.append("onetbb::libtbb")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "tinydnn"

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -98,3 +98,6 @@ class XtensorConan(ConanFile):
             self.cpp_info.defines.append("XTENSOR_USE_TBB")
         if self.options.openmp:
             self.cpp_info.defines.append("XTENSOR_USE_OPENMP")
+        self.cpp_info.requires = ["xtl::xtl", "nlohmann_json::nlohmann_json", "xsimd::xsimd"]
+        if self.options.tbb:
+            self.cpp_info.requires.append("onetbb::libtbb")


### PR DESCRIPTION
Previously many recipes used the umbrella target onetbb::onetbb in cpp_info.requires, which caused consumers to link transitively against all oneTBB components, including tbbmalloc and tbbmalloc_proxy. That’s rarely needed and can introduce unnecessary deps, allocator conflicts, and larger binaries.

This change:

switches default linkage to the core onetbb::libtbb only;

adds allocator components explicitly only where required (e.g., gtsam: add onetbb::tbbmalloc);

updates the following recipes accordingly: cctag, ceres-solver, embree, embree3, gtsam, itk, manifold, onedpl, opencascade, opencv(2.x/3.x/4.x), openimageio, opensubdiv, openvdb, pagmo2, rocksdb, thrust, tiny-dnn.

Result

By default consumers now link only with libtbb.

Projects that need allocators must add them explicitly:

onetbb::tbbmalloc — scalable allocator

onetbb::tbbmalloc_proxy — override of standard malloc/new

BREAKING CHANGE: projects that implicitly relied on tbbmalloc/tbbmalloc_proxy via onetbb::onetbb must declare the required oneTBB components explicitly.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
test script and result. all fails not related to PR
[test.sh](https://github.com/user-attachments/files/23125349/test.sh)

