### PR TITLE
OpenImageIO: Fix dependency handling and better adapt to upstream cmake

### DIFF
--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -92,7 +92,7 @@ class OpenImageIOConan(ConanFile):
         self.requires("zlib/[>=1.2.11 <2]")
         if Version(self.version) < "3.0":
             self.requires("boost/1.84.0")
-        self.requires("libtiff/4.6.0")
+        self.requires("libtiff/[>=4.6.0 <5]")
         self.requires("imath/[>3.1.9 <4]", transitive_headers=True)
         self.requires("openexr/[>=3.2.3 <4]")
         if self.options.with_libjpeg == "libjpeg":


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/ALL**

#### Motivation

Triggered by finding out that with the recent change, the recipe behavior got partly broken, as it was now relying of `find_package` to select which internal modules to build. Even with dependencies excluded via option, for example I got ffmpeg linked to the "system" (brew on macOS) library. See also #28626

So I wanted to clean up the recipe and ensure correct dependency management and in the same go tried to simplify a few points.

#### Details

* The cmake uses find_package and based on whether packages are found decides which option libraries to include. However there is also support for a `USE_$lib` based definition of which dependencies to build against (optional dependencies only being checked if not `USE_$lib = False`). To prevent unintentional behaviour, we can enfore find_package to require packages and control which find_package via the `USE_$lib` variables.
* OpenColorIO is now a required dependency with Version 3.0
* HDF has been removed in the 2.3 to 2.4 transition so is no longer required for our supported versions
* Some options have been removed (`BUILD_MISSING_ROBINMAP`) or renamed (`(OIIO_)INTERNALIZE_FMT`)
* Reordering of the use of the options.with*, so that when looking at the cmake definitions and the available options in a split view editor it is for example easier to follow the code.
* Add missing openjph dependency, (previously suggested under #28626 but it makes most sense I think to have it with the same new structure directly)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details: Fixes #28626
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
