### PR TITLE
arrow: add version 22.0.0

### DIFF
--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "22.0.0":
+    url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-22.0.0/apache-arrow-22.0.0.tar.gz?action=download"
+    sha256: "131250cd24dec0cddde04e2ad8c9e2bc43edc5e84203a81cf71cf1a33a6e7e0f"
   "21.0.0":
     url: "https://www.apache.org/dyn/closer.lua/arrow/arrow-21.0.0/apache-arrow-21.0.0.tar.gz?action=download"
     sha256: "5d3f8db7e72fb9f65f4785b7a1634522e8d8e9657a445af53d4a34a3849857b5"

--- a/recipes/arrow/config.yml
+++ b/recipes/arrow/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "22.0.0":
+    folder: all
   "21.0.0":
     folder: all
   "20.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  arrow/22.0.0

#### Motivation

Arrow 22.0.0 was released 2025/10/25. This PR updates conan's index with the new release.

#### Details

Changes are scripted so this review process may be similar to previous ones.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
