### PR TITLE
[flex] Fix gnu-config target folder

### DIFF
--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.build import cross_building
 from conan.tools.files import get, rmdir, copy, rm, export_conandata_patches, apply_conandata_patches
+from conan.tools.layout import basic_layout
 from conan.tools.gnu import AutotoolsToolchain, Autotools
 
 required_conan_version = ">=1.53.0"
@@ -33,6 +34,9 @@ class FlexConan(ConanFile):
 
     def export_sources(self):
         export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         # Flex requires M4 to be compiled. If consumer does not have M4
@@ -81,7 +85,7 @@ class FlexConan(ConanFile):
             if gnu_config:
                 copy(self, os.path.basename(gnu_config),
                      src=os.path.dirname(gnu_config),
-                     dst=os.path.join(self.source_folder, "config"))
+                     dst=os.path.join(self.source_folder, "build-aux"))
 
     def build(self):
         apply_conandata_patches(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **flex/2.6.4**

#### Motivation

Follow-up #28661

Fixes https://github.com/conan-io/conan-center-index/pull/28661#issuecomment-3446548206

/cc @dmitryikh 

#### Details

The previous PR #28661 was targeted to fix riscv64 support by install gnu-config files in flex folder. However, Flex project does not use `source_folder/config` for its config scripts, but `build-aux` instead:

```
$ conan source all --version=2.6.4 
conanfile.py (flex/2.6.4): Calling source() in /home/conan/project/all/src
conanfile.py (flex/2.6.4): Source https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz retrieved from local download cache
conanfile.py (flex/2.6.4): Uncompressing flex-2.6.4.tar.gz to .
conan@1da72b6b43e3:~/project$ ls all/src/build-aux/
compile  config.guess  config.rpath  config.sub  depcomp  install-sh  ltmain.sh  mdate-sh  missing  test-driver  texinfo.tex  ylwrap
```

And to clarify even more, we can find the correct path in the `Makefile.in` in the same source folder:

```
$ grep guess all/src/Makefile.in 
	$(top_srcdir)/build-aux/config.guess \
	ChangeLog NEWS THANKS build-aux/compile build-aux/config.guess \
```

The same goes for the generated `Makefile` in the build folder:

```
$ grep config.sub all/build-release/ -r 
all/build-release/Makefile:	$(top_srcdir)/build-aux/config.sub \
all/build-release/Makefile:	build-aux/config.rpath build-aux/config.sub \
$ grep config.guess all/build-release/ -r 
all/build-release/Makefile:	$(top_srcdir)/build-aux/config.guess \
all/build-release/Makefile:	ChangeLog NEWS THANKS build-aux/compile build-aux/config.guess \
```

You can find my build here: [flex-2.6.4-linux-build.log](https://github.com/user-attachments/files/23159657/flex-2.6.4-linux-build.log)

NOTE: The recipe had no layout, causing a mess in the source folder when running build.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
