### PR TITLE
opencv: use libtiff version range, propagate correct tbb target

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -364,7 +364,7 @@ class OpenCVConan(ConanFile):
             return []
 
         def parallel():
-            return ["onetbb::onetbb"] if self.options.parallel == "tbb" else []
+            return ["onetbb::libtbb"] if self.options.parallel == "tbb" else []
 
         def protobuf():
             return ["protobuf::protobuf"] if self.options.get_safe("with_protobuf") else []
@@ -1079,7 +1079,7 @@ class OpenCVConan(ConanFile):
         if self.options.get_safe("with_openexr"):
             self.requires("openexr/[>=3.2.3 <4]")
         if self.options.get_safe("with_tiff"):
-            self.requires("libtiff/4.6.0")
+            self.requires("libtiff/[>=4.6.0 <5]")
         if self.options.get_safe("with_webp"):
             self.requires("libwebp/[>=1.3.2 <5]")
         if self.options.get_safe("with_gdal"):


### PR DESCRIPTION
- use version range for libtiff, same as `openjph` which is also a default dependency (otherwise we may not get openjph binaries because opencv is resolving first to an earlier version)
- when `tbb` is enabled, link againts litbb instead of ALL of the tbb libraries - I have cross-checked that this is correct with the upstream CMakeLists, (brings fix from this PR: https://github.com/conan-io/conan-center-index/pull/28709)
- 