### PR TITLE
Update Thrift source URLs to use HTTPS

### DIFF
--- a/recipes/thrift/all/conandata.yml
+++ b/recipes/thrift/all/conandata.yml
@@ -1,24 +1,24 @@
 sources:
   "0.20.0":
-    url: "http://archive.apache.org/dist/thrift/0.20.0/thrift-0.20.0.tar.gz"
+    url: "https://archive.apache.org/dist/thrift/0.20.0/thrift-0.20.0.tar.gz"
     sha256: "b5d8311a779470e1502c027f428a1db542f5c051c8e1280ccd2163fa935ff2d6"
   "0.18.1":
-    url: "http://archive.apache.org/dist/thrift/0.18.1/thrift-0.18.1.tar.gz"
+    url: "https://archive.apache.org/dist/thrift/0.18.1/thrift-0.18.1.tar.gz"
     sha256: "04c6f10e5d788ca78e13ee2ef0d2152c7b070c0af55483d6b942e29cff296726"
   "0.17.0":
-    url: "http://archive.apache.org/dist/thrift/0.17.0/thrift-0.17.0.tar.gz"
+    url: "https://archive.apache.org/dist/thrift/0.17.0/thrift-0.17.0.tar.gz"
     sha256: "b272c1788bb165d99521a2599b31b97fa69e5931d099015d91ae107a0b0cc58f"
   "0.16.0":
-    url: "http://archive.apache.org/dist/thrift/0.16.0/thrift-0.16.0.tar.gz"
+    url: "https://archive.apache.org/dist/thrift/0.16.0/thrift-0.16.0.tar.gz"
     sha256: "f460b5c1ca30d8918ff95ea3eb6291b3951cf518553566088f3f2be8981f6209"
   "0.15.0":
-    url: "http://archive.apache.org/dist/thrift/0.15.0/thrift-0.15.0.tar.gz"
+    url: "https://archive.apache.org/dist/thrift/0.15.0/thrift-0.15.0.tar.gz"
     sha256: "d5883566d161f8f6ddd4e21f3a9e3e6b8272799d054820f1c25b11e86718f86b"
   "0.14.2":
-    url: "http://archive.apache.org/dist/thrift/0.14.2/thrift-0.14.2.tar.gz"
+    url: "https://archive.apache.org/dist/thrift/0.14.2/thrift-0.14.2.tar.gz"
     sha256: "4191bfc0b7490e20cc69f9f4dc6e991fbb612d4551aa9eef1dbf7f4c47ce554d"
   "0.14.1":
-    url: "http://archive.apache.org/dist/thrift/0.14.1/thrift-0.14.1.tar.gz"
+    url: "https://archive.apache.org/dist/thrift/0.14.1/thrift-0.14.1.tar.gz"
     sha256: "13da5e1cd9c8a3bb89778c0337cc57eb0c29b08f3090b41cf6ab78594b410ca5"
 patches:
   "0.20.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **thrift/0.20.0**

#### Motivation

Closes https://github.com/conan-io/conan-center-index/issues/28715

#### Details

Fixes Thrift source URLs to pull with HTTPS rather than HTTP


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
