### PR TITLE
[libarchive] Disable xmllite by default

### DIFF
--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -168,6 +168,8 @@ class LibarchiveConan(ConanFile):
         if Version(self.version) >= "3.7.3":
             tc.variables["ENABLE_PCRE2POSIX"] = self.options.with_pcre2
         tc.variables["ENABLE_XATTR"] = self.options.with_xattr
+        if Version(self.version) >= "3.8.0":
+            tc.cache_variables["ENABLE_WIN32_XMLLITE "] = False
         tc.cache_variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)
         tc.generate()
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libarchive/3.8.0**

#### Motivation

fixes #28720

/cc @bmwrightson

#### Details

The CMake option `ENABLE_WIN32_XMLLITE` is part to xar umbrella, an alternative to `ENABLE_LIBXML2`, but must be present in Windows. When building the package, there is a check to validate if xmllite is present in the system and can be linker, but when consuming, the downstream may not not have it available. 

This feature was introduced in libarchive 3.8.0 https://github.com/libarchive/libarchive/pull/2388

Local build log: [libarchive-3.8.1-win-amd64-msvc194-rel-static.log](https://github.com/user-attachments/files/23184458/libarchive-3.8.1-win-amd64-msvc194-rel-static.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
