### PR TITLE
Package name is "flatbuffers" (in lowercase)

### DIFF
--- a/recipes/flatbuffers/all/test_package/CMakeLists.txt
+++ b/recipes/flatbuffers/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(FlatBuffers REQUIRED CONFIG)
+find_package(flatbuffers REQUIRED CONFIG)
 if(TARGET flatbuffers::flatbuffers_shared)
     set(FLATBUFFERS_TARGET flatbuffers::flatbuffers_shared)
 else()


### PR DESCRIPTION


### Summary
Changes to recipe:  **flatbuffers/[version]**

#### Motivation
Got that from Copilot review:

Package name mismatch: CMakeLists.txt uses 'FlatBuffers' but the conanfile.py now sets cmake_file_name to lowercase 'flatbuffers' (line 139). This will cause the find_package to fail.

https://github.com/conan-io/conan-center-index/blob/master/recipes/flatbuffers/all/conanfile.py#L139

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
