### PR TITLE
Fix broken link to labels documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,5 +107,5 @@ For any suggestion, feature request or question open an issue indicating the fol
 - Try to explain the motivation, what are you trying to do, what is the pain it tries to solve.
 - What do you expect from CCI.
 
-We use the following tags to control the status of the issues and pull requests, you can learn more in [Labels](docs/labels.md) document
+We use the following tags to control the status of the issues and pull requests, you can learn more in [Labels](https://github.com/conan-io/conan-center-index/labels) document
 which details the important one and their roles.


### PR DESCRIPTION
There's a broken link (404) to "labels" page at the end of [contribution.md](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md) 

I found that old docs/labels.md was deleted here:

https://github.com/conan-io/conan-center-index/pull/25875

I suggest to reuse a link to GitHub provided page


### Summary
Fix broken link to labels documentation

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
