### PR TITLE
[scip] add version 9.2.4

### DIFF
--- a/recipes/scip/all/conandata.yml
+++ b/recipes/scip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "9.2.4":
+    url: "https://github.com/scipopt/scip/archive/refs/tags/v924.tar.gz"
+    sha256: "780cc185e006ac09163d66d5fed2dbeabd1fdbe660232e7e46e9e51c77c3ab5d"
   "9.2.3":
     url: "https://github.com/scipopt/scip/archive/refs/tags/v923.tar.gz"
     sha256: "876227c75475a295e586871996281582d10cfdebf5792c10183e1c336a197d11"
@@ -23,6 +26,9 @@ patches:
       patch_description: "Change hard-coded paths to conan includes"
       patch_type: "conan"
 version_mappings:
+  "9.2.4":
+    soplex: "7.1.6"
+    default_sym: "snauty"
   "9.2.3":
     soplex: "7.1.5"
     default_sym: "snauty"

--- a/recipes/scip/config.yml
+++ b/recipes/scip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "9.2.4":
+    folder: all
   "9.2.3":
     folder: all
   "9.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **scip/9.2.4**

#### Motivation
Bugfix release of SCIP was published. No bug in the recipe. We waited for SoPlex 7.1.6 to be released as we depend on that. See https://github.com/scipopt/scip/releases/tag/v924


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
