### PR TITLE
mpir: disable windows ARM

### DIFF
--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -65,6 +65,8 @@ class MpirConan(ConanFile):
     def validate(self):
         if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building doesn't work (yet)")
+        if is_msvc(self) and self.settings.arch == "armv8":
+            raise ConanInvalidConfiguration(f"{self.ref} cannot be built on windows ARM")
 
     def build_requirements(self):
         self.tool_requires("libtool/2.4.7")


### PR DESCRIPTION
### Summary
Changes to recipe:  **mpir/***
disable windows ARM build

#### Motivation
It is not yet supported upstream

#### Details
mpir: `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(459,5): error MSB8013: This project doesn't contain the Configuration and Platform combination of Release|ARM64. [C:\a\_temp\.c2\p\b\mpir90a0f1130d22a\b\src\build.vc17\lib_mpir_gc\lib_mpir_gc.vcxproj]`
full log on https://github.com/eirikb/proof-of-conan/actions/runs/18902396624/job/53952514871


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
