### PR TITLE
flac: Add option to disable building C++ libraries

### DIFF
--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -21,10 +21,12 @@ class FlacConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_cxxlibs": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_cxxlibs": True,
     }
 
     def export_sources(self):
@@ -58,6 +60,7 @@ class FlacConan(ConanFile):
         tc.variables["BUILD_DOCS"] = False
         tc.variables["BUILD_PROGRAMS"] = not is_apple_os(self) or self.settings.os == "Macos"
         tc.variables["BUILD_TESTING"] = False
+        tc.variables["BUILD_CXXLIBS"] = self.options.with_cxxlibs
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         if Version(self.version) < "1.3.4":
             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
@@ -100,10 +103,11 @@ class FlacConan(ConanFile):
         self.cpp_info.components["libflac"].libs = ["FLAC"]
         self.cpp_info.components["libflac"].requires = ["ogg::ogg"]
 
-        self.cpp_info.components["libflac++"].set_property("cmake_target_name", "FLAC::FLAC++")
-        self.cpp_info.components["libflac++"].set_property("pkg_config_name", "flac++")
-        self.cpp_info.components["libflac++"].libs = ["FLAC++"]
-        self.cpp_info.components["libflac++"].requires = ["libflac"]
+        if self.options.with_cxxlibs:
+            self.cpp_info.components["libflac++"].set_property("cmake_target_name", "FLAC::FLAC++")
+            self.cpp_info.components["libflac++"].set_property("pkg_config_name", "flac++")
+            self.cpp_info.components["libflac++"].libs = ["FLAC++"]
+            self.cpp_info.components["libflac++"].requires = ["libflac"]
         if not self.options.shared:
             self.cpp_info.components["libflac"].defines = ["FLAC__NO_DLL"]
             if self.settings.os in ["Linux", "FreeBSD"]:


### PR DESCRIPTION
### Summary
Changes to recipe:  **flac/all**

#### Motivation
Not everyone needs these, and since BUILD_CXXLIBS already exists in CMake, let's expose it in Conan too.

#### Details
Added an option to turn this off, using the conventional `with_....` prefix, which defaults to `true`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] ~~If this is a bug fix, please link related issue or provide bug details~~
- [x] Tested locally with at least one configuration using a recent version of Conan

I've tested this in our code base using Conan 2.10.2

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
