### PR TITLE
cyrus-sasl: disable windows ARM and enable gssapi

### DIFF
--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -102,8 +102,11 @@ class CyrusSaslConan(ConanFile):
             self.requires("sqlite3/3.44.2")
 
     def validate(self):
-        if is_msvc(self) and not self.options.shared:
-            raise ConanInvalidConfiguration("Static library output is not supported when building with MSVC")
+        if is_msvc(self):
+            if not self.options.shared:
+                raise ConanInvalidConfiguration("Static library output is not supported when building with MSVC")
+            if self.settings.arch == "armv8":
+                raise ConanInvalidConfiguration(f"{self.ref} cannot be built on windows ARM")
         if self.options.with_gssapi:
             raise ConanInvalidConfiguration(
                 f"{self.name}:with_gssapi=True requires krb5 recipe, not yet available in conan-center",

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -52,7 +52,7 @@ class CyrusSaslConan(ConanFile):
         "with_scram": True,
         "with_otp": True,
         "with_krb4": True,
-        "with_gssapi": False, # FIXME: should be True
+        "with_gssapi": True,
         "with_plain": True,
         "with_anon": True,
         "with_postgresql": False,
@@ -81,6 +81,7 @@ class CyrusSaslConan(ConanFile):
             del self.options.with_postgresql
             del self.options.with_mysql
             del self.options.with_sqlite3
+            del self.options.with_gssapi
 
     def configure(self):
         if self.options.shared:
@@ -100,6 +101,8 @@ class CyrusSaslConan(ConanFile):
             self.requires("libmysqlclient/8.1.0")
         if self.options.get_safe("with_sqlite3"):
             self.requires("sqlite3/3.44.2")
+        if self.options.get_safe("with_gssapi"):
+            self.requires("krb5/1.21.2")
 
     def validate(self):
         if is_msvc(self):
@@ -107,10 +110,6 @@ class CyrusSaslConan(ConanFile):
                 raise ConanInvalidConfiguration("Static library output is not supported when building with MSVC")
             if self.settings.arch == "armv8":
                 raise ConanInvalidConfiguration(f"{self.ref} cannot be built on windows ARM")
-        if self.options.with_gssapi:
-            raise ConanInvalidConfiguration(
-                f"{self.name}:with_gssapi=True requires krb5 recipe, not yet available in conan-center",
-            )
 
     def build_requirements(self):
         if not is_msvc(self):
@@ -221,7 +220,7 @@ class CyrusSaslConan(ConanFile):
         msbuild.build(sln=os.path.join(self.source_folder, "win32", "cyrus-sasl-core.sln"))
         # TODO: add sasldb support
         # msbuild.build(sln=os.path.join(self.source_folder, "win32", "cyrus-sasl-sasldb.sln"))
-        if self.options.with_gssapi:
+        if self.options.get_safe("with_gssapi"):
             msbuild.build(sln=os.path.join(self.source_folder, "win32", "cyrus-sasl-gssapiv2.sln"))
 
     def generate(self):

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -52,7 +52,7 @@ class CyrusSaslConan(ConanFile):
         "with_scram": True,
         "with_otp": True,
         "with_krb4": True,
-        "with_gssapi": True,
+        "with_gssapi": False, # FIXME: should be True
         "with_plain": True,
         "with_anon": True,
         "with_postgresql": False,


### PR DESCRIPTION
### Summary
Changes to recipe:  **cyrus-sasl/***

#### Motivation
disable windows ARM (not supported upstream)
enabe gssapi, now that krb5 is on conan-center
gssapi is not available on windows, because krb5 is not either

#### Details
windows arm fails with
```
C:\a\_temp\.c2\p\b\cyrus341c4fcd546d6\b\src\win32\cyrus-sasl-common.sln.metaproj : error MSB4126: The specified solution configuration "Release|ARM64" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration. 
```
full log on https://github.com/eirikb/proof-of-conan/actions/runs/18905868361


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
