### PR TITLE
qt5: enable gssapi

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -109,7 +109,7 @@ class QtConan(ConanFile):
         "with_gstreamer": False,
         "with_pulseaudio": False,
         "with_dbus": False,
-        "with_gssapi": True,
+        "with_gssapi": False,
         "with_atspi": False,
         "with_md4c": True,
         "with_x11": True,


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/5.***
enable gssapi

#### Motivation
krb5 has been available for a long time now

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
