### PR TITLE
[abseil] Configure Windows runtime for both msvc and clang

### DIFF
--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -69,9 +69,7 @@ class AbseilConan(ConanFile):
         tc.cache_variables["ABSL_ENABLE_INSTALL"] = True
         tc.cache_variables["ABSL_PROPAGATE_CXX_STD"] = True
         tc.cache_variables["BUILD_TESTING"] = False
-        if is_msvc(self):
-            tc.cache_variables["ABSL_MSVC_STATIC_RUNTIME"] = is_msvc_static_runtime(self)
-        elif self.settings.os == "Windows" and self.settings.compiler == "clang" and self.settings.get_safe("compiler.runtime"):
+        if self.settings.os == "Windows" and self.settings.compiler in ["msvc", "clang"] and self.settings.get_safe("compiler.runtime"):
             runtime = str(self.settings.compiler.runtime)
             tc.cache_variables["ABSL_MSVC_STATIC_RUNTIME"] = runtime == "static"
         tc.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil/20250814.0**

#### Motivation

fixes #28724

/cc @jorickert

#### Details

The only possible values for `runtime` are `static` and `dynamic` and they are the same for `msvc` and `clang` on `Windows`: 

https://docs.conan.io/2/reference/config_files/settings.html#settings-yml

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
