### PR TITLE
gegles-spdlog_setup: relax fmt version constraint to allow 12.x

### DIFF
--- a/recipes/gegles-spdlog_setup/all/conanfile.py
+++ b/recipes/gegles-spdlog_setup/all/conanfile.py
@@ -40,7 +40,7 @@ class SpdlogSetupConan(ConanFile):
     def requirements(self):
         self.requires("cpptoml/0.1.1")
         self.requires("spdlog/[>=1.15 <2]")
-        self.requires("fmt/[>=10 <=12]")
+        self.requires("fmt/[*]")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Resolves dependency conflict with spdlog/1.16.0 which requires fmt/12.0.0. The library is compatible with fmt 12.x as a header-only wrapper around spdlog.

Fixes #28736


### Summary
Changes to recipe:  **gegles-spdlog_setup/[1.1.0]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
