### PR TITLE
[arrow] Add support for Boost header-only

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -372,7 +372,7 @@ class ArrowConan(ConanFile):
             tc.variables["ARROW_OPENSSL_USE_SHARED"] = bool(self.dependencies["openssl"].options.shared)
         if self.options.with_boost:
             tc.variables["ARROW_USE_BOOST"] = True
-            tc.variables["ARROW_BOOST_USE_SHARED"] = bool(self.dependencies["boost"].options.shared)
+            tc.variables["ARROW_BOOST_USE_SHARED"] = bool(self.dependencies["boost"].options.get_safe("shared", False))
         tc.variables["ARROW_S3"] = bool(self.options.with_s3)
         tc.variables["AWSSDK_SOURCE"] = "SYSTEM"
         tc.variables["ARROW_BUILD_UTILITIES"] = bool(self.options.cli)


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/22.0.0**

#### Motivation

fixes #28748 

/cc @maleafl

#### Details

When using `header_only`, Boost deletes the `shared` option, resulting the reported error.

Using `options.get_safe` should prevent it.

Build log using Linux + AMD64 + GCC11 + Release + Boost:Header Only: [arrow-22.0.0-linux-amd64-gcc11-rel-boost-header.log](https://github.com/user-attachments/files/23216106/arrow-22.0.0-linux-amd64-gcc11-rel-boost-header.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
