### PR TITLE
[hdf5] Do not inject cxx flags

### DIFF
--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.14.0":
-    url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_14_0.tar.gz"
-    sha256: "0f2ec13c1bf6e9f506fd03681c83a476d722e7479cad9ce6f8585a26c317d0ad"
   "1.14.6":
     url: "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.6.tar.gz"
     sha256: "09ee1c671a87401a5201c06106650f62badeea5a3b3941e9b1e2e1e08317357f"


### PR DESCRIPTION
### Summary
Changes to recipe:  **hdf5/any**

#### Motivation

fixes #28731

/cc @Marc-Pierre-Barbier

@Marc-Pierre-Barbier please, feel free to validate this PR! 

#### Details

When version 1.40.0 was introduced by PR #15094, it came with patches for injecting the libstd too. However, it blocks the way to use CXXFLAGS from builenv. For instance, it can be visualized by comparing the following build logs:

- HDF5 1.16.4 rrev 0b780319690d537e6cb0683244919955 (latest): [hdf5-1.14.6-linux-amd64-clang20-rel.log](https://github.com/user-attachments/files/23218222/hdf5-1.14.6-linux-amd64-clang20-rel.log)

It's possible to see:

```
[buildenv]
CXXFLAGS=-march=native
CFLAGS=-march=native

...

-- Warnings Configuration: CXX default:   -stdlib=libstdc++

...

cd /home/uilian/.conan2/p/b/hdf5c60fdf970d0d0/b/build/Release/c++/src && /lib/llvm-20/bin/clang++ -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_POSIX_C_SOURCE=200809L -I/home/uilian/.conan2/p/b/hdf5c60fdf970d0d0/b/src/src -I/home/uilian/.conan2/p/b/hdf5c60fdf970d0d0/b/src/src/H5FDsubfiling -I/home/uilian/.conan2/p/b/hdf5c60fdf970d0d0/b/build/Release/src -stdlib=libstdc++ -O3 -DNDEBUG -std=c++11 -fPIC -Wall -Warray-bounds -Wcast-qual -Wconversion -Wdouble-promotion -Wextra -Wformat=2 -Wframe-larger-than=16384 -Wimplicit-fallthrough -Wnull-dereference -Wunused-const-variable -Wwrite-strings -Wpedantic -Wvolatile-register-var -Wno-c++-compat -Wno-missing-noreturn -MD -MT c++/src/CMakeFiles/hdf5_cpp-static.dir/H5Library.cpp.o -MF CMakeFiles/hdf5_cpp-static.dir/H5Library.cpp.o.d -o CMakeFiles/hdf5_cpp-static.dir/H5Library.cpp.o -c /home/uilian/.conan2/p/b/hdf5c60fdf970d0d0/b/src/c++/src/H5Library.cpp
```

It confirms the reported issue.

Now, with the changes from the commit bc9d275cd890ff3cbd52aa67091c217585afd79d, using the exact same profile: [hdf5-1.14.6-linux-amd64-clang20-rel-cxxflags.log](https://github.com/user-attachments/files/23218371/hdf5-1.14.6-linux-amd64-clang20-rel-cxxflags.log)


```
-- Warnings Configuration: CXX default:  -march=native   -m64 -stdlib=libstdc++

cd /home/uilian/.conan2/p/b/hdf54dacc38e2cd8f/b/build/Release/c++/src && /lib/llvm-20/bin/clang++ -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_POSIX_C_SOURCE=200809L -I/home/uilian/.conan2/p/b/hdf54dacc38e2cd8f/b/src/src -I/home/uilian/.conan2/p/b/hdf54dacc38e2cd8f/b/src/src/H5FDsubfiling -I/home/uilian/.conan2/p/b/hdf54dacc38e2cd8f/b/build/Release/src -march=native   -m64 -stdlib=libstdc++ -O3 -DNDEBUG -std=c++11 -fPIC -Wall -Warray-bounds -Wcast-qual -Wconversion -Wdouble-promotion -Wextra -Wformat=2 -Wframe-larger-than=16384 -Wimplicit-fallthrough -Wnull-dereference -Wunused-const-variable -Wwrite-strings -Wpedantic -Wvolatile-register-var -Wno-c++-compat -Wno-missing-noreturn -MD -MT c++/src/CMakeFiles/hdf5_cpp-static.dir/H5Library.cpp.o -MF CMakeFiles/hdf5_cpp-static.dir/H5Library.cpp.o.d -o CMakeFiles/hdf5_cpp-static.dir/H5Library.cpp.o -c /home/uilian/.conan2/p/b/hdf54dacc38e2cd8f/b/src/c++/src/H5Library.cpp

```


Still, as the previous CI error involved Linux + Clang, I tested this change using versions 1.4.3 and 1.4.6:

- hdf5/1.14.3 - Linux - amd64 - clang20 - release - libc++ - static: [hdf5-1.14.3-linux-amd64-clang20-rel-libcpp-static.log](https://github.com/user-attachments/files/23218555/hdf5-1.14.3-linux-amd64-clang20-rel-libcpp-static.log)
- hdf5/1.14.3 - Linux - amd64 - clang20 - release - libc++ - shared: [hdf5-1.14.3-linux-amd64-clang20-rel-libstdcpp-shared.log](https://github.com/user-attachments/files/23218557/hdf5-1.14.3-linux-amd64-clang20-rel-libstdcpp-shared.log)
- hdf5/1.14.3 - Linux - amd64 - clang20 - release - libstdc++11 - static: [hdf5-1.14.3-linux-amd64-clang20-rel-libstdcpp-static.log](https://github.com/user-attachments/files/23218558/hdf5-1.14.3-linux-amd64-clang20-rel-libstdcpp-static.log)
- hdf5/1.14.3 - Linux - amd64 - clang20 - release - libstdc++11 - shared: [hdf5-1.14.3-linux-amd64-clang20-rel-libcpp-shared.log](https://github.com/user-attachments/files/23218554/hdf5-1.14.3-linux-amd64-clang20-rel-libcpp-shared.log)

- hdf5/1.14.6 - Linux - amd64 - clang20 - release - libc++ - shared: [hdf5-1.14.6-linux-amd64-clang20-rel-libcpp-shared.log](https://github.com/user-attachments/files/23218559/hdf5-1.14.6-linux-amd64-clang20-rel-libcpp-shared.log)
- hdf5/1.14.6 - Linux - amd64 - clang20 - release - libc++ - static: [hdf5-1.14.6-linux-amd64-clang20-rel-libcpp-static.log](https://github.com/user-attachments/files/23218561/hdf5-1.14.6-linux-amd64-clang20-rel-libcpp-static.log)
- hdf5/1.14.6 - Linux - amd64 - clang20 - release - libstdc++11 - shared: [hdf5-1.14.6-linux-amd64-clang20-rel-libstdcpp-shared.log](https://github.com/user-attachments/files/23218562/hdf5-1.14.6-linux-amd64-clang20-rel-libstdcpp-shared.log)
- hdf5/1.14.6 - Linux - amd64 - clang20 - release - libstdc++11 - static: [hdf5-1.14.6-linux-amd64-clang20-rel-libstdcpp-static.log](https://github.com/user-attachments/files/23218563/hdf5-1.14.6-linux-amd64-clang20-rel-libstdcpp-static.log)

All builds are working properly without the `_inject_stdlib_flag` method. 

------

There are tons of changes between 1.40.0 and 1.40.3, so I was not able to find which commit fixed Clang build.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
