### PR TITLE
reflect-cpp: Bump pugixml version

### DIFF
--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -100,7 +100,7 @@ class ReflectCppConan(ConanFile):
         if self.options.with_ubjson:
             self.requires("jsoncons/0.176.0", transitive_headers=True)
         if self.options.with_xml:
-            self.requires("pugixml/1.14", transitive_headers=True)
+            self.requires("pugixml/1.15", transitive_headers=True)
         if self.options.with_yaml:
             self.requires("yaml-cpp/0.8.0", transitive_headers=True)
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **reflect-cpp/0.22**

#### Motivation
reflect-cpp was just updated very recently here. However, it seems that the latest version does not build correctly (at least on msvc194) when with_xml is True against pugixml 1.14, but it does build correctly against pugixml 1.15.

#### Details
Just bumping the pugixml version


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
