### PR TITLE
luau: add version 0.697

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.697":
+    url: "https://github.com/Roblox/luau/archive/0.697.tar.gz"
+    sha256: "e3f4f90e4ee35ba4264242e84fa496c93c5bd216cb3d16a237c9f17d9573ba43"
   "0.667":
     url: "https://github.com/Roblox/luau/archive/0.667.tar.gz"
     sha256: "a8ffc0c8505fb0546f9d0007f3a2c74b08e602f5a6b864381e3a24fd74e936bc"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.697":
+    folder: all
   "0.667":
     folder: all
   "0.655":


### PR DESCRIPTION
### Summary
Changes to recipe:  **luau/0.697**

#### Motivation
luau releases updates once a week.
The current latest version is from 30 weeks ago, which is too old.

#### Details
https://github.com/luau-lang/luau/releases/tag/0.697

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
