### PR TITLE
[libsocketcan] Add msys for windows build

### DIFF
--- a/recipes/libsocketcan/all/conanfile.py
+++ b/recipes/libsocketcan/all/conanfile.py
@@ -38,8 +38,10 @@ class PackageConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("libtool/2.4.7")
-        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/[>=2.2 <3]")
+        if self.settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsocketcan/0.0.12**

#### Motivation

fixes #28770 

follow-up #28685

/cc @Deishelon

#### Details

When building a Autotools project, the Conan package for msys is mostly required to fill the gaps with building tools.

The pkgconf package is not needed, because there is no dependencies for this package. I just removed the tool_requires line for pkg-config in order to reduce the recipe scope. 

Using this patch, I'm able to cross build from Windows AMD64 to Android ARMv8:

- Using Conan NDK Package: [libsocketcan-0.0.12-windows-cross-android.log](https://github.com/user-attachments/files/23257430/libsocketcan-0.0.12-windows-cross-android.log)
- Using NDK from my system: [libsocketcan-0.0.12-windows-cross-android-system.log](https://github.com/user-attachments/files/23257429/libsocketcan-0.0.12-windows-cross-android-system.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
