### PR TITLE
catch2: removes Cmake version <4 limit for 3.11.0

### DIFF
--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -60,7 +60,9 @@ class Catch2Conan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def build_requirements(self):
-        if Version(self.version) >= "3.8.0":
+        if Version(self.version) >= "3.11.0"
+            self.tool_requires("cmake/[>=3.16]")
+        else if Version(self.version) >= "3.8.0":
             self.tool_requires("cmake/[>=3.16 <4]")
 
     def validate(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
Catch2 required an old version of Cmake which prevents building mp-units due to multiple Cmake installs (CMAKE_ROOT conflict).

#### Details
I revised Catch2's recipe conanfile.py Cmake requirement from [>=3.16 <4] to [>=3.16] for the current version of Catch2 (3.11.0).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
