### PR TITLE
ffmpeg: Add with_libjxl to activate JPEG XL support

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -141,7 +141,7 @@ class FFMpegConan(ConanFile):
         "with_fontconfig": False,
         "with_fribidi": False,
         "with_harfbuzz": False,
-        "with_libjxl": True,
+        "with_libjxl": False,
         "with_openjpeg": True,
         "with_openh264": True,
         "with_opus": True,


### PR DESCRIPTION
### Summary
Changes to recipe:  **ffmpeg/7.1.1** (currently, affects everything from 5.1 should someone locally use the recipe with other source versions.

#### Motivation
ffmpeg 5.1 introduced support for JPEG XL via the libjxl which is a format that got larger support in recent years in several software packages.

#### Details
Adds JXL as a dependency and as like most other options defaults to true. Is deleted for Versions below 5.1. While we don't have 5.1 in the source list, I thought it still would be best to reflect the version in case someone might want to use a different conandata.yml 

Locally tried with option off and on for 7.1.1 and build 4.4.6 all without an error.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
