### PR TITLE
ipaddress: add version 1.2.1

### DIFF
--- a/recipes/ipaddress/all/conandata.yml
+++ b/recipes/ipaddress/all/conandata.yml
@@ -2,12 +2,3 @@ sources:
   "1.2.1":
     url: "https://github.com/VladimirShaleev/ipaddress/archive/v1.2.1.tar.gz"
     sha256: "7ad9af8218ad3e96c348d100706b1f5a02706ff49be811913ee2a438ddfa61d2"
-  "1.2.0":
-    url: "https://github.com/VladimirShaleev/ipaddress/archive/v1.2.0.tar.gz"
-    sha256: "c3a52e5297d8f0b152c13b04ea2aead0bb9bc2a963188d740d87c78e770daba1"
-  "1.1.0":
-    url: "https://github.com/VladimirShaleev/ipaddress/archive/v1.1.0.tar.gz"
-    sha256: "e5084d83ebd712210882eb6dac14ed1b9b71584dede523b35c6181e0a06375f1"
-  "1.0.1":
-    url: "https://github.com/VladimirShaleev/ipaddress/archive/v1.0.1.tar.gz"
-    sha256: "49c16294f06fe95ffc66cae828dc08d116efb4a1ede3dddd21dcc182a2eceb03"

--- a/recipes/ipaddress/config.yml
+++ b/recipes/ipaddress/config.yml
@@ -1,9 +1,3 @@
 versions:
   "1.2.1":
     folder: all
-  "1.2.0":
-    folder: all
-  "1.1.0":
-    folder: all
-  "1.0.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **ipaddress/1.2.1**

#### Motivation
Added GCC 15.2 compatibility. Issue [#11](https://github.com/VladimirShaleev/ipaddress/issues/11).

#### Details
- Updated template specialization exports to comply with C++ standard §10.2
- Addresses GCC 15.2's strict enforcement of module export rules

https://github.com/VladimirShaleev/ipaddress/releases/tag/v1.2.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

