### PR TITLE
Add influxdb-cpp-rest/1.0.0

### DIFF
--- a/recipes/influxdb-cpp-rest/1.0.0/conandata.yml
+++ b/recipes/influxdb-cpp-rest/1.0.0/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/d-led/influxdb-cpp-rest/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "3bc33a9221b573f7eba7c369b3baea5934773e5738d9e0373c83ba62fc2ffc4b"
+

--- a/recipes/influxdb-cpp-rest/1.0.0/conanfile.py
+++ b/recipes/influxdb-cpp-rest/1.0.0/conanfile.py
@@ -1,0 +1,80 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+import os
+
+required_conan_version = ">=1.54.0"
+
+
+class InfluxdbCppRestConan(ConanFile):
+    name = "influxdb-cpp-rest"
+    description = "A C++ client library for InfluxDB using C++ REST SDK"
+    topics = ("influxdb", "cpprest", "http", "client")
+    license = "MPL-2.0"
+    homepage = "https://github.com/d-led/influxdb-cpp-rest"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options["cpprestsdk"].shared = True
+
+    def requirements(self):
+        self.requires("cpprestsdk/2.10.19")
+        self.requires("rxcpp/4.1.1")
+
+    def build_requirements(self):
+        # Only for tests - not linked to the library
+        self.test_requires("catch2/3.11.0")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        # Disable tests and demo for packaging
+        tc.variables["BUILD_TESTING"] = False
+        tc.variables["BUILD_DEMO"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "influxdb-cpp-rest")
+        self.cpp_info.set_property("cmake_target_name", "influxdb-cpp-rest::influxdb-cpp-rest")
+        
+        # Libraries to link
+        self.cpp_info.libs = ["influxdb-cpp-rest"]
+        
+        # Include directories
+        self.cpp_info.includedirs = ["include"]
+        
+        # System dependencies (if any)
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["pthread"]
+


### PR DESCRIPTION
This PR adds the influxdb-cpp-rest package version 1.0.0 to Conan Center.

## Package Details
- **Name**: influxdb-cpp-rest
- **Version**: 1.0.0
- **License**: MPL-2.0
- **Homepage**: https://github.com/d-led/influxdb-cpp-rest

## Features
- C++20 client library for InfluxDB
- Includes both a C++ static library (influxdb-cpp-rest) and a C wrapper shared library (influx-c-rest)
- Supports InfluxDB 1.x (tested with v1.8+)
- Synchronous and asynchronous insertion APIs
- Query API support
- Basic authentication support

## Dependencies
- cpprestsdk/2.10.19
- rxcpp/4.1.1
- catch2/3.11.0 (test requirement only)

## Compiler Requirements
- C++20 or later
- GCC 11+, Clang 14+, MSVC 2019+

This package replaces the legacy C++03 version available as v0.0.1-legacy.