### PR TITLE
cpp-smtpclient-library: Add version 1.1.13

### DIFF
--- a/recipes/cpp-smtpclient-library/all/conandata.yml
+++ b/recipes/cpp-smtpclient-library/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  "1.1.12":
-    url: "https://github.com/jeremydumais/CPP-SMTPClient-library/archive/refs/tags/v1.1.12.zip"
-    sha256: "558f54174cd10f036a5144a201ed657af038489996031e948d8aae7e22a22007"
+  "1.1.13":
+    url: "https://github.com/jeremydumais/CPP-SMTPClient-library/archive/refs/tags/v1.1.13.zip"
+    sha256: "fea5c463a9d5717adcc62760527c180d09b556f0119468ed934429e6e15f0096"
 

--- a/recipes/cpp-smtpclient-library/config.yml
+++ b/recipes/cpp-smtpclient-library/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.1.12":
+  "1.1.13":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-smtpclient-library/1.1.13**

#### Motivation
v1.1.13 released on 2025-11-01

#### Details
https://github.com/jeremydumais/CPP-SMTPClient-library/releases/tag/v1.1.13

##### Fixed
- Fixed non-transitive include paths for the OpenSSL dependency when building in
  Windows.
  The library now uses `target_include_directories()` instead of
  `include_directories()` to properly expose dependency include paths to
  consumers during build.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
