### PR TITLE
avcpp: Version 2.7.1 to support ffmpeg 8.0

### DIFF
--- a/recipes/avcpp/all/conandata.yml
+++ b/recipes/avcpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.4.0":
-    url: "https://github.com/h4tr3d/avcpp/archive/refs/tags/v2.4.0.tar.gz"
-    sha256: "47e044c10fa232f0d12d80351e675d5a5ef1480f81a93f288f33f8d03e94ae17"
+  "2.7.1":
+    url: "https://github.com/h4tr3d/avcpp/archive/refs/tags/v2.7.1.tar.gz"
+    sha256: "9721f34851b8d32f87ebe8f6f024e8d75902b946f7f62020e56aa9ed0d926a3e"

--- a/recipes/avcpp/all/conanfile.py
+++ b/recipes/avcpp/all/conanfile.py
@@ -37,7 +37,7 @@ class AvcppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("ffmpeg/[>=6.1 <8]", transitive_headers=True)
+        self.requires("ffmpeg/[>=6.1 <9]", transitive_headers=True)
 
     def validate(self):
         check_min_cppstd(self, 17)

--- a/recipes/avcpp/config.yml
+++ b/recipes/avcpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.4.0":
+  "2.7.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **avcpp/2.7.1**

#### Motivation
ffmpeg removed deprecated APIs so avcpp 2.4.0 could no longer be compiled.

#### Details
https://github.com/h4tr3d/avcpp/compare/v2.4.0...v2.7.1

Sadly, 2.4.0 is the last version for which a proper release announcement is available, afterwards only tagging happened.

I was thinking about keeping 2.4.0 too, but that doesn't support ffmpeg 8.0. So extending the version range (hope that is accepted here) would require an if/else block and make the recipe more complicated.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
