### PR TITLE
libiconv: fix cross install-strip

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -123,7 +123,7 @@ class LibiconvConan(ConanFile):
     def package(self):
         copy(self, "COPYING.LIB", self.source_folder, os.path.join(self.package_folder, "licenses"))
         autotools = Autotools(self)
-        autotools.install()
+        autotools.install(target="install")
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "share"))
         fix_apple_shared_install_name(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **libiconv/1.17**,  **libiconv/1.18**

#### Motivation

Combining install-strip and cross-compilation results in a `libiconv` build failure, as previously mentioned in https://github.com/conan-io/conan/pull/18606#issuecomment-3049938772.

#### Details

`libiconv`'s build system has a bug where it runs the wrong strip binary (build instead of host) when install-strip is used. The solution was buried in https://lists.nongnu.org/archive/html/automake/2001-01/msg00156.html:

```
`install -s' does not work on cross-compiled programs. Therefore,
when configuring a package for cross-compilation, check for some
suitable `strip' and arrange the Makefiles so that `install-strip'
will run `install-sh' with `STRIPPROG' set to the detected `strip'.
```

I followed exactly this advice for the fix. Until it is upstreamed, a patch is needed here.

The fix is tested with

* `conan` 2.22.1
* `libiconv` 1.17 and 1.18
* `tools.build:install_strip` = True
* Android NDK on Ubuntu 24.04

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan:

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
