### PR TITLE
[leptonica] Use version ranges for dependencies to avoid conflicts

### DIFF
--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -177,7 +177,7 @@ class LeptonicaConan(ConanFile):
                 replace_in_file(self, cmakelists_src, "if (WEBP_FOUND)", "if(0)")
                 replace_in_file(self, cmake_configure, "if (WEBP_FOUND)", "if(0)")
         if Version(self.version) < "1.85.0":
-            if Version(self.version) >= "1.83.0" and self.options.with_webp:
+            if self.options.with_webp:
                 replace_in_file(self, cmakelists_src,
                                     "if (WEBP_FOUND)",
                                     "if (WEBP_FOUND)\n"


### PR DESCRIPTION
### Summary
Changes to recipe:  **leptonica/[*]**

#### Motivation

Unblock PR #28811

See conflict results: https://github.com/conan-io/conan-center-index/pull/28811/checks?check_run_id=54440521360

/cc @datalogics-robb

#### Details

The PR #28811 can not be built totally, because Leptonica and libtiff share common dependencies. The libtiff is a dependency of leptonica and was updated recently to use version ranges on its dependencies, resulting in a version conflict for leptonica:

<img width="1546" height="1182" alt="Screenshot 2025-11-04 at 08-44-57 " src="https://github.com/user-attachments/assets/c09bfb9c-68ef-46fa-b5c6-5874ce842165" />

Doing a grep over CCI, it's possible to find those change dependencies using version ranges already. 

--------

The Build error using MacOS https://github.com/conan-io/conan-center-index/pull/28815/checks?check_run_id=54442128481 happened because the PR https://github.com/conan-io/conan-center-index/pull/28031 changed libtiff default value for libwebp, now disabled. As a consequence, leptonica is no longer getting a ride from libtiff and having the library folder for webp listed when linking, exposing that limitation in the leptonica recipe.

In order to fix it, the commit [3bca322](https://github.com/conan-io/conan-center-index/pull/28815/commits/3bca322c1e960b14613f06d92dc73dc4b296cbd3) backported the current patch for 1.83.1 to include the webp library folder on 1.82.0 too. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
