### PR TITLE
[cnats] Add version 3.11.0

### DIFF
--- a/recipes/cnats/all/conandata.yml
+++ b/recipes/cnats/all/conandata.yml
@@ -1,25 +1,4 @@
 sources:
-  "3.8.0":
-    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.8.0.tar.gz"
-    sha256: "465811380cdc6eab3304e40536d03f99977a69c0e56fcf566000c29dd075e4dd"
-  "3.8.2":
-    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.8.2.tar.gz"
-    sha256: "083ee03cf5a413629d56272e88ad3229720c5006c286e8180c9e5b745c10f37d"
-  "3.8.3":
-    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.8.3.tar.gz"
-    sha256: "fe7e9ce7636446cc3fe0f47f6a235c4783299e00d5e5c4a1f8689d20707871db"
-  "3.9.1":
-    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.9.1.tar.gz"
-    sha256: "56836bb30a2da93eaa6df0dfa27e796e6be0933b5b3d4d83b5c76d3b80304290"
-  "3.9.2":
-    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.9.2.tar.gz"
-    sha256: "28c4f39b88f095d78d653e8d4fe4581163fe96ecde5f9683933f0d82fd889a57"
-  "3.9.3":
-    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.9.3.tar.gz"
-    sha256: "b5dd3971b72fa5fc4c5b6d71c6900dc0a8a20465824fc23c0054f7f319e97952"
-  "3.10.1":
-    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.10.1.tar.gz"
-    sha256: "1765533bbc1270ab7c89e3481b4778db7d1e7b4db2fa906b6602cd5c02846222"
   "3.11.0":
     url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.11.0.tar.gz"
     sha256: "9ee45cd502a49dbd29bed491286a4926e5e53f14a8aacad413c0cf4a057abee0"    

--- a/recipes/cnats/all/conanfile.py
+++ b/recipes/cnats/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.files import get, copy, rmdir, rm
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.scm import Version
 import os
 
 
@@ -67,8 +66,6 @@ class PackageConan(ConanFile):
         tc.variables["BUILD_TESTING"] = False
         tc.variables["NATS_BUILD_LIB_STATIC"] = not self.options.shared
         tc.variables["NATS_BUILD_LIB_SHARED"] = self.options.shared
-        if self.options.with_tls and self.version < "3.11.0":
-            tc.variables["NATS_BUILD_TLS_USE_OPENSSL_1_1_API"] = Version(self.dependencies["openssl"].ref.version) >= "1.1"
         tc.variables["NATS_BUILD_STREAMING"] = self.options.enable_streaming
         tc.variables["NATS_WITH_EXPERIMENTAL"] = self.options.with_experimental
         tc.generate()

--- a/recipes/cnats/config.yml
+++ b/recipes/cnats/config.yml
@@ -1,17 +1,3 @@
 versions:
-  "3.8.0":
-    folder: all
-  "3.8.2":
-    folder: all
-  "3.8.3":
-    folder: all
-  "3.9.1":
-    folder: all
-  "3.9.2":
-    folder: all
-  "3.9.3":
-    folder: all
-  "3.10.1":
-    folder: all
   "3.11.0":
     folder: all    


### PR DESCRIPTION
### Summary
Changes to recipe:  **cnats/3.11.0**

#### Motivation
Update cnats to most recent version 3.11.0

#### Details
I think there are quite a lot of useful sounding fixes in this release (https://github.com/nats-io/nats.c/releases/tag/v3.11.0)

A cmake option (NATS_BUILD_TLS_USE_OPENSSL_1_1_API) was removed in this release - I tried to enable it only for the old releases.

According to the release notes cnats now requires "OpenSSL 1.1.1+ to compile" - should the requirement be changed from 
`self.requires("openssl/[>=1.1 <4]")` to `self.requires("openssl/[>=1.1.1 <4]")` or is it okay as it is?


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan


---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
