### PR TITLE
nanort: Add version cci.20251104 to fix broken build

### DIFF
--- a/recipes/nanort/all/conandata.yml
+++ b/recipes/nanort/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  "cci.20251104":
+  "cci.20241110":
     url: "https://github.com/lighttransport/nanort/archive/cdf474ae9176b87a9334c858bb06c9e028ed0e0d.zip"
     sha256: "53633f02460a5a02c0feeb509e0a8d8b21b4cc1e001bee65c461193889bf9245"
   "cci.20230207":

--- a/recipes/nanort/config.yml
+++ b/recipes/nanort/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "cci.20251104":
+  "cci.20241110":
     folder: all
   "cci.20230207":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **nanort/cci.20251104**

#### Motivation
In order to fix the broken build, this PR updates the nanort recipe to the most current version as of November 4th, 2025 (https://github.com/lighttransport/nanort/commit/cdf474ae9176b87a9334c858bb06c9e028ed0e0d)

#### Details
`conan create all/conanfile.py --version=cci.20230207` will result in a build failure with modern compilers (`gcc (Debian 14.2.0-19) 14.2.0`):

```
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
In file included from /home/robin/dev/conan-center-index/recipes/nanort/all/test_package/test_package.cpp:5:
/home/robin/.conan2/p/b/nanora9cdbaa197a21/p/include/nanort.h: In member function ‘nanort::TriangleSAHPred<T>& nanort::TriangleSAHPred<T>::operator=(const nanort::TriangleSAHPred<T>&)’:
/home/robin/.conan2/p/b/nanora9cdbaa197a21/p/include/nanort.h:883:26: error: assignment of read-only member ‘nanort::TriangleSAHPred<T>::vertex_stride_bytes_’
  883 |     vertex_stride_bytes_ = rhs.vertex_stride_bytes_;
      |     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/test_package.dir/build.make:79: CMakeFiles/test_package.dir/test_package.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/test_package.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2

ERROR: nanort/cci.20230207 (test package): Error in build() method, line 20
        cmake.build()
```

This is already fixed upstream: https://github.com/lighttransport/nanort/commit/af69d49dc3074eae21b559037265df0cdb4e0297

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
