### PR TITLE
fix -j0 potential argument in openssl3

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -497,7 +497,8 @@ class OpenSSLConan(ConanFile):
             command.extend(targets)
         if self._make_program in ["make", "jom"]:
             njobs = build_jobs(self)
-            command.append(f"-j{njobs}" if parallel and njobs>0 else "-j1")
+            if parallel and njobs > 0:
+                command.append(f"-j{njobs}")
         self.run(" ".join(command), env="conanbuild")
 
     @property

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -496,7 +496,8 @@ class OpenSSLConan(ConanFile):
         if targets:
             command.extend(targets)
         if self._make_program in ["make", "jom"]:
-            command.append(f"-j{build_jobs(self)}" if parallel else "-j1")
+            njobs = build_jobs(self)
+            command.append(f"-j{njobs}" if parallel and njobs>0 else "-j1")
         self.run(" ".join(command), env="conanbuild")
 
     @property


### PR DESCRIPTION
### Summary
Changes to recipe:  **openssl/3**

#### Motivation
 Reported in https://github.com/conan-io/conan/pull/15422#issuecomment-3490472965, the ``njobs=0`` conf can cause a ``-j0`` argument.

Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
