### PR TITLE
libunwind: use version range for xz-utils

### DIFF
--- a/recipes/libunwind/all/conanfile.py
+++ b/recipes/libunwind/all/conanfile.py
@@ -61,7 +61,7 @@ class LiunwindConan(ConanFile):
 
     def requirements(self):
         if self.options.minidebuginfo:
-            self.requires("xz_utils/5.4.5")
+            self.requires("xz_utils/[>=5.4.5 <6]")
         if self.options.zlibdebuginfo:
             self.requires("zlib/[>=1.2.11 <2]")
 


### PR DESCRIPTION
### Summary
Align version range with other uses in the repository

close https://github.com/conan-io/conan-center-index/issues/28837

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
