### PR TITLE
opengl/system: fix alpine

### DIFF
--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -48,6 +48,9 @@ class SysConfigOpenGLConan(ConanFile):
         pkg_util = package_manager.PkgUtil(self)
         pkg_util.install(["mesalibs"], update=True, check=True)
 
+        alpine = package_manager.Apk(self)
+        alpine.install(["mesa-dev"], update=True, check=True)
+
     def package_info(self):
         # TODO: Workaround for #2311 until a better solution can be found
         self.cpp_info.filenames["cmake_find_package"] = "opengl_system"


### PR DESCRIPTION
### Summary
Changes to recipe:  **opengl/system**

#### Motivation

closes #28845
fixes #28846

#### Details
log with the fix:
<details><summary>Details</summary>
<p>


```
# conan create recipes/opengl/all/ -c tools.system.package_manager:mode=install

======== Exporting recipe to the cache ========
opengl/system: Exporting package recipe: /cocorepo/recipes/opengl/all/conanfile.py
opengl/system: Copied 1 '.py' file: conanfile.py
opengl/system: Exported to cache folder: /root/.conan2/p/opengd32fdf9133620/e
opengl/system: Exported: opengl/system#cfcf523b9d2bad75cbf377f56562634c (2025-11-07 14:50:42 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux
[conf]
tools.system.package_manager:mode=install

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    opengl/system#cfcf523b9d2bad75cbf377f56562634c - Cache

======== Computing necessary packages ========
opengl/system: Forced build from source
Requirements
    opengl/system#cfcf523b9d2bad75cbf377f56562634c:da39a3ee5e6b4b0d3255bfef95601890afd80709 - Build
v3.22.2-142-g5fc470561e9 [https://dl-cdn.alpinelinux.org/alpine/v3.22/main]
v3.22.2-146-g20b82a1b32f [https://dl-cdn.alpinelinux.org/alpine/v3.22/community]
OK: 26320 distinct packages available
fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
(1/48) Installing linux-headers (6.14.2-r0)
(2/48) Installing hwdata-pci (0.395-r0)
(3/48) Installing libpciaccess (0.18.1-r0)
(4/48) Installing libdrm (2.4.124-r0)
(5/48) Installing libpciaccess-dev (0.18.1-r0)
(6/48) Installing libdrm-dev (2.4.124-r0)
(7/48) Installing libxau (1.0.12-r0)
(8/48) Installing xorgproto (2024.1-r0)
(9/48) Installing libxau-dev (1.0.12-r0)
(10/48) Installing libmd (1.1.0-r0)
(11/48) Installing libbsd (0.12.2-r0)
(12/48) Installing libxdmcp (1.1.5-r1)
(13/48) Installing libxcb (1.17.0-r0)
(14/48) Installing libx11 (1.8.11-r0)
(15/48) Installing libxext (1.3.6-r2)
(16/48) Installing xcb-proto-pyc (1.17.0-r0)
(17/48) Installing xcb-proto (1.17.0-r0)
(18/48) Installing libxdmcp-dev (1.1.5-r1)
(19/48) Installing libxcb-dev (1.17.0-r0)
(20/48) Installing xtrans (1.5.2-r0)
(21/48) Installing libx11-dev (1.8.11-r0)
(22/48) Installing libxext-dev (1.3.6-r2)
(23/48) Installing libxdamage (1.1.6-r5)
(24/48) Installing libxfixes (6.0.1-r4)
(25/48) Installing libxfixes-dev (6.0.1-r4)
(26/48) Installing libxdamage-dev (1.1.6-r5)
(27/48) Installing libxshmfence (1.3.3-r0)
(28/48) Installing libxshmfence-dev (1.3.3-r0)
(29/48) Installing libxml2 (2.13.9-r0)
(30/48) Installing llvm20-libs (20.1.8-r0)
(31/48) Installing spirv-tools (1.4.313.0-r0)
(32/48) Installing libelf (0.193-r0)
(33/48) Installing wayland-libs-server (1.23.1-r3)
(34/48) Installing mesa (25.1.9-r0)
(35/48) Installing mesa-gbm (25.1.9-r0)
(36/48) Installing wayland-libs-client (1.23.1-r3)
(37/48) Installing mesa-egl (25.1.9-r0)
(38/48) Installing libxxf86vm (1.1.6-r0)
(39/48) Installing mesa-gl (25.1.9-r0)
(40/48) Installing mesa-gles (25.1.9-r0)
(41/48) Installing clang20-headers (20.1.8-r0)
(42/48) Installing libclc (20.1.8-r0)
(43/48) Installing spirv-llvm-translator-libs (20.1.2-r0)
(44/48) Installing clang20-libs (20.1.8-r0)
(45/48) Installing mesa-rusticl (25.1.9-r0)
(46/48) Installing mesa-xatracker (25.1.9-r0)
(47/48) Installing libxxf86vm-dev (1.1.6-r0)
(48/48) Installing mesa-dev (25.1.9-r0)
Executing busybox-1.37.0-r19.trigger
OK: 918 MiB in 120 packages

======== Installing packages ========

-------- Installing package opengl/system (1 of 1) --------
opengl/system: Building from source
opengl/system: Package opengl/system:da39a3ee5e6b4b0d3255bfef95601890afd80709
opengl/system: Copying sources to build folder
opengl/system: Building your package in /root/.conan2/p/b/openga74b070514747/b
opengl/system: Generating aggregated env files
opengl/system: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
opengl/system: Package 'da39a3ee5e6b4b0d3255bfef95601890afd80709' built
opengl/system: Build folder /root/.conan2/p/b/openga74b070514747/b
opengl/system: Generating the package
opengl/system: Packaging in folder /root/.conan2/p/b/openga74b070514747/p
opengl/system: package(): WARN: No files in this package!
opengl/system: Created package revision 0ba8627bd47edc3a501e8f0eb9a79e5e
opengl/system: Package 'da39a3ee5e6b4b0d3255bfef95601890afd80709' created
opengl/system: Full package reference: opengl/system#cfcf523b9d2bad75cbf377f56562634c:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e
opengl/system: Package folder /root/.conan2/p/b/openga74b070514747/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.filenames' used in: opengl/system

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    opengl/system (test package): /cocorepo/recipes/opengl/all/test_package/conanfile.py
Requirements
    opengl/system#cfcf523b9d2bad75cbf377f56562634c - Cache

======== Computing necessary packages ========
Requirements
    opengl/system#cfcf523b9d2bad75cbf377f56562634c:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Cache
mesa-dev
opengl/system: System requirements:  already installed

======== Installing packages ========
opengl/system: Already installed! (1 of 1)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.filenames' used in: opengl/system

======== Testing the package ========
Removing previously existing 'test_package' build folder: /cocorepo/recipes/opengl/all/test_package/build/gcc-14-x86_64-gnu17-release
opengl/system (test package): Test package build: build/gcc-14-x86_64-gnu17-release
opengl/system (test package): Test package build folder: /cocorepo/recipes/opengl/all/test_package/build/gcc-14-x86_64-gnu17-release
opengl/system (test package): Writing generators to /cocorepo/recipes/opengl/all/test_package/build/gcc-14-x86_64-gnu17-release/generators
opengl/system (test package): Generator 'CMakeDeps' calling 'generate()'
opengl/system (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(opengl_system)
    target_link_libraries(... opengl::opengl)
opengl/system (test package): Generator 'CMakeToolchain' calling 'generate()'
opengl/system (test package): CMakeToolchain generated: conan_toolchain.cmake
opengl/system (test package): CMakeToolchain generated: /cocorepo/recipes/opengl/all/test_package/build/gcc-14-x86_64-gnu17-release/generators/CMakePresets.json
opengl/system (test package): CMakeToolchain generated: /cocorepo/recipes/opengl/all/test_package/CMakeUserPresets.json
opengl/system (test package): Generator 'VirtualRunEnv' calling 'generate()'
opengl/system (test package): Generating aggregated env files
opengl/system (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
opengl/system (test package): Calling build()
opengl/system (test package): Running CMake.configure()
opengl/system (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/cocorepo/recipes/opengl/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/cocorepo/recipes/opengl/all/test_package"
-- Using Conan toolchain: /cocorepo/recipes/opengl/all/test_package/build/gcc-14-x86_64-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: Target declared 'opengl::opengl'
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /cocorepo/recipes/opengl/all/test_package/build/gcc-14-x86_64-gnu17-release

opengl/system (test package): Running CMake.build()
opengl/system (test package): RUN: cmake --build "/cocorepo/recipes/opengl/all/test_package/build/gcc-14-x86_64-gnu17-release" -- -j22
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
opengl/system (test package): Running test()
opengl/system (test package): RUN: ./test_package
GL_VENDOR: (null)
GL_RENDERER: (null)
GL_VERSION: (null)
GL_EXTENSIONS: (null)
```

</p>
</details> 


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
