### PR TITLE
thrift: fix version 0.21.0 (apply required patch to include cstdint.h)

### DIFF
--- a/recipes/thrift/all/conandata.yml
+++ b/recipes/thrift/all/conandata.yml
@@ -26,17 +26,9 @@ sources:
 patches:
   "0.21.0":
     - patch_file: "patches/cmake-0.21.0-001-install-dir.patch"
-      patch_description: "Patch install dir on MSVC"
-      patch_type: "conan"
     - patch_file: "patches/cmake-0.21.0-002-conan-libs.patch"
-      patch_description: "Parts of cmake-0.16.0.patch that does not need changing"
-      patch_type: "conan"
     - patch_file: "patches/cmake-0.21.0-003-conan-libs.patch"
-      patch_description: "Patch conan libs in the thrift lib cmake"
-      patch_type: "conan"
     - patch_file: "patches/0.15.0-0002-include-cstdint.patch"
-      patch_description: "cstdint.h not included to Mutex.h"
-      patch_type: "conan"
   "0.20.0":
     - patch_file: "patches/cmake-0.16.0.patch"
     - patch_file: "patches/0.15.0-0002-include-cstdint.patch"


### PR DESCRIPTION
Apply required 0.14.1-0002-include-cstdint.patch

### Summary
Changes to recipe:  **thrift/[0.21.0]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The same **patch** must be applied as to earlier versions, since the issue in the Apache Thrift project was fixed in version **0.22.0**, but **not 0.21.0**.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

[https://github.com/apache/thrift/compare/v0.21.0...v0.22.0](https://github.com/apache/thrift/compare/v0.21.0...v0.22.0)

[https://github.com/apache/thrift/blob/0.21.0/lib/cpp/src/thrift/concurrency/Mutex.h](https://github.com/apache/thrift/blob/0.21.0/lib/cpp/src/thrift/concurrency/Mutex.h)

[https://github.com/apache/thrift/blob/0.22.0/lib/cpp/src/thrift/concurrency/Mutex.h](https://github.com/apache/thrift/blob/0.22.0/lib/cpp/src/thrift/concurrency/Mutex.h)

The version 0.21.0 does not include this necessary header file:

#ifndef _THRIFT_CONCURRENCY_MUTEX_H_
#define _THRIFT_CONCURRENCY_MUTEX_H_ 1

**#include <cstdint>**
#include <memory>
#include <thrift/TNonCopyable.h>

Therefore, this patch must be applied to Mutex.h
[https://github.com/conan-io/conan-center-index/blob/master/recipes/thrift/all/patches/0.14.1-0002-include-cstdint.patch](https://github.com/conan-io/conan-center-index/blob/master/recipes/thrift/all/patches/0.14.1-0002-include-cstdint.patch)

This appeared when I compiled the library with different versions of GCC. It does not work with GCC 15.2.0 (on Ubuntu 25.10, but worked on Ubuntu 25.04 that contains older versions of GCC)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

 conan create . --version=0.21.0 --build=missing
---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
