### PR TITLE
patch boost cobalt include guard typo

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -61,6 +61,10 @@ sources:
     sha256: "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
 patches:
   "1.89.0":
+    - patch_file: "patches/1.89.0-cobalt-io-include-guard.patch"
+      patch_description: "correct the include guard of random_access_device.hpp"
+      patch_type: "backport"
+      patch_source: "https://github.com/boostorg/cobalt/pull/248"
     - patch_file: "patches/1.88.0-locale-iconv-library-option.patch"
       patch_description: "Optional flag to specify iconv from either libc of libiconv"
       patch_type: "conan"

--- a/recipes/boost/all/patches/1.89.0-cobalt-io-include-guard.patch
+++ b/recipes/boost/all/patches/1.89.0-cobalt-io-include-guard.patch
@@ -1,0 +1,21 @@
+diff --git a/include/boost/cobalt/io/random_access_device.hpp b/include/boost/cobalt/io/random_access_device.hpp
+index ec605b5..46fbf62 100644
+--- a/boost/cobalt/io/random_access_device.hpp
++++ b/boost/cobalt/io/random_access_device.hpp
+@@ -5,8 +5,8 @@
+ // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ //
+ 
+-#ifndef BOOST_COBALT_IO_STREAM_HPP
+-#define BOOST_COBALT_IO_STREAM_HPP
++#ifndef BOOST_COBALT_IO_RANDOM_ACCESS_DEVICE_HPP
++#define BOOST_COBALT_IO_RANDOM_ACCESS_DEVICE_HPP
+ 
+ #include <boost/cobalt/io/buffer.hpp>
+ #include <boost/cobalt/io/ops.hpp>
+@@ -34,4 +34,4 @@ struct random_access_device : random_access_read_device, random_access_write_dev
+ 
+ }
+ 
+-#endif //BOOST_COBALT_IO_STREAM_HPP
++#endif //BOOST_COBALT_IO_RANDOM_ACCESS_DEVICE_HPP


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.89.0**

#### Motivation

Code referring to  `random_access_device` in `boost::cobalt::io` will fail to compile due to a typo in the include guard.

#### Details

Backports https://github.com/boostorg/cobalt/pull/248


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
