### PR TITLE
re2/all: Allow for a range of abseil versions

### DIFF
--- a/recipes/re2/all/conanfile.py
+++ b/recipes/re2/all/conanfile.py
@@ -38,7 +38,7 @@ class Re2Conan(ConanFile):
         if self.options.get_safe("with_icu"):
             self.requires("icu/73.2")
         if Version(self.version) >= "20230601":
-            self.requires("abseil/20240116.1", transitive_headers=True)
+            self.requires("abseil/[>=20240116.1]", transitive_headers=True)
 
     def validate(self):
         if Version(self.version) >= "20250805":


### PR DESCRIPTION
### Summary
Changes to recipe:  **re2/all**

#### Motivation
Allow for a range of abseil versions as:
1. re2 seems to work with all newer version of abseil
2. when consuming recipes that depends on re2 it is convient to have some freedom in the use abseil version

#### Details
See motivation


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
