### PR TITLE
nudb: clear bindirs/libdirs for core component

### DIFF
--- a/recipes/nudb/all/conanfile.py
+++ b/recipes/nudb/all/conanfile.py
@@ -56,6 +56,8 @@ class NudbConan(ConanFile):
         self.cpp_info.set_property("cmake_target_aliases", ["NuDB::nudb"])
         self.cpp_info.set_property("cmake_find_mode", "both")
 
+        self.cpp_info.components["core"].bindirs = []
+        self.cpp_info.components["core"].libdirs = []
         self.cpp_info.components["core"].set_property("cmake_target_name", "nudb")
         self.cpp_info.components["core"].names["cmake_find_package"] = "nudb"
         self.cpp_info.components["core"].names["cmake_find_package_multi"] = "nudb"


### PR DESCRIPTION
### Summary
Changes to recipe:  **nudb/all**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

Without this, there is a linkage warning (doesn't look nice in output): `ld: warning: search path '/Users/asalikhov/.conan2/p/b/nudb043c2a735b8b5/p/lib' not found`

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
