### PR TITLE
fontconfig: Fix android build fails with `fatal error: 'ft2build.h' file not found`

### DIFF
--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import (
     apply_conandata_patches, copy, export_conandata_patches, get,
@@ -77,6 +78,16 @@ class FontconfigConan(ConanFile):
             "datadir": os.path.join("res", "share"),
         })
         tc.generate()
+
+        # Remove the troublesome sys_root parameter from the Meson cross file.
+        # It causes pkgconf to prepend the sysroot to the absolute path to the package in the Conan cache.
+        if cross_building(self):
+            with open(os.path.join(self.generators_folder, "conan_meson_cross.ini"), "r") as f:
+                lines = f.readlines()
+            with open(os.path.join(self.generators_folder, "conan_meson_cross.ini"), "w") as f:
+                for line in lines:
+                    if "sys_root = '" not in line:
+                        f.write(line)
 
     def _patch_files(self):
         apply_conandata_patches(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **fontconfig/\***

#### Motivation
fixes #28865

#### Details
The author of the fix is @jwillikers. See https://github.com/conan-io/conan/issues/16468#issuecomment-2231321822

[fontconfig_android_build_log_ok.txt](https://github.com/user-attachments/files/23456294/fontconfig_android_build_log_ok.txt)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
