### PR TITLE
unordered_dense: add versions 4.8.1

### DIFF
--- a/recipes/unordered_dense/all/conandata.yml
+++ b/recipes/unordered_dense/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.8.1":
+    url: "https://github.com/martinus/unordered_dense/archive/v4.8.1.tar.gz"
+    sha256: "9f7202ec6d8353932ef865d33f5872e4b7a1356e9032da7cd09c3a0c5bb2b7de"
   "4.5.0":
     url: "https://github.com/martinus/unordered_dense/archive/v4.5.0.tar.gz"
     sha256: "2364ce4bc4c23bd02549bbb3a7572d881684cd46057f3737fd53be53669743aa"

--- a/recipes/unordered_dense/config.yml
+++ b/recipes/unordered_dense/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.8.1":
+    folder: all
   "4.5.0":
     folder: all
   "4.4.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **unordered_dense/4.5.0**

#### Motivation
unordered_dense had new releases since 4.5.0 (December 2024) which are missing on Conan

#### Details
Add missing versions from the [martinus/unordered_dense/releases](https://github.com/martinus/unordered_dense/releases): 
  - 4.6.0 (2025-10-08)
  - 4.7.0 (2025-10-11)
  - 4.8.0 (2025-10-27)
  - 4.8.1 (2025-11-02)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
