### PR TITLE
mimalloc: Add dynamic_tls option

### DIFF
--- a/recipes/mimalloc/all/conanfile.py
+++ b/recipes/mimalloc/all/conanfile.py
@@ -128,7 +128,7 @@ class MimallocConan(ConanFile):
         tc.variables["MI_OVERRIDE"] = "ON" if self.options.override else "OFF"
         tc.variables["MI_SECURE"] = "ON" if self.options.secure else "OFF"
         tc.variables["MI_WIN_REDIRECT"] = "ON" if self.options.get_safe("win_redirect") else "OFF"
-        tc.variables["MI_LOCAL_DYNAMIC_TLS"] = "ON" if self.options.get_safe("dynamic_tls") else "OFF"
+        tc.variables["MI_LOCAL_DYNAMIC_TLS"] = "ON" if self.options.dynamic_tls else "OFF"
         tc.variables["MI_INSTALL_TOPLEVEL"] = "ON"
         tc.variables["MI_GUARDED"] = self.options.get_safe("guarded", False)
         if Version(self.version) <= "1.7.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mimalloc/all**

#### Motivation
mimalloc has a CMake cache setting called MI_LOCAL_DYNAMIC_TLS that builds mimalloc using a dlopen-compatible TLS (thread local storage) model. By default, mimalloc cannot be used with dlopen.

#### Details
We expose the option in the recipe as "dynamic_tls". The CMake option is available in the oldest supported version of mimalloc: https://github.com/microsoft/mimalloc/blob/v1.7.6/CMakeLists.txt
