### PR TITLE
xz_utils: add configuration parameter to support sanbox usage control

### DIFF
--- a/recipes/xz_utils/all/conanfile.py
+++ b/recipes/xz_utils/all/conanfile.py
@@ -101,7 +101,7 @@ class XZUtilsConan(ConanFile):
             tc = CMakeToolchain(self)
             tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
             if self.options.with_sandbox != 'auto':
-                tc.cache_variables["XZ_SANDBOX"] = self.options.with_sandbox or "no"
+                tc.cache_variables["XZ_SANDBOX"] = self.options.with_sandbox
             tc.generate()
         else:
             env = VirtualBuildEnv(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **xz_utils/5.8.1**

#### Motivation
new library support sanboxes, autoconfig failing builds with sanitizers enabled.

#### Details
just simple control to have ability to disable sanbox auto configuration


<details>
<summary>following build log:</summary>

```
12:43:02  #12 11.82 Copying file global.conf to /app/.conan2/.
12:43:03  #12 12.32 Connecting to remote 'QBArtifactory' anonymously
12:43:03  #12 12.39 Remote 'QBArtifactory' needs authentication, obtaining credentials
12:43:03  #12 12.39 Got username **** from environment
12:43:03  #12 12.39 Got password '******' from environment
12:43:03  #12 12.40 Authenticated in remote 'QBArtifactory' with user ****
12:43:03  #12 12.51 QBArtifactory:
12:43:03  #12 12.51     user: ****
12:43:04  #12 13.35 -- The C compiler identification is Clang 18.1.3
12:43:04  #12 13.47 -- The CXX compiler identification is Clang 18.1.3
12:43:04  #12 13.52 -- Detecting C compiler ABI info
12:43:04  #12 13.65 -- Detecting C compiler ABI info - done
12:43:04  #12 13.66 -- Check for working C compiler: /usr/bin/clang - skipped
12:43:04  #12 13.66 -- Detecting C compile features
12:43:04  #12 13.66 -- Detecting C compile features - done
12:43:04  #12 13.70 -- Detecting CXX compiler ABI info
12:43:04  #12 13.86 -- Detecting CXX compiler ABI info - done
12:43:04  #12 13.88 -- Check for working CXX compiler: /usr/bin/clang++ - skipped
12:43:04  #12 13.88 -- Detecting CXX compile features
12:43:04  #12 13.88 -- Detecting CXX compile features - done
12:43:04  #12 14.13 -- CMake-Conan: first find_package() found. Installing dependencies with Conan
12:43:04  #12 14.13 -- CMake-Conan: Checking if a default profile exists
12:43:05  #12 14.34 ERROR: Profile not found: default
12:43:05  #12 14.37 -- CMake-Conan: The default profile doesn't exist, detecting it.
12:43:05  #12 14.58 detect_api: CC and CXX: clang, clang++ 
12:43:05  #12 14.61 detect_api: Found clang 18.1
12:43:05  #12 14.61 detect_api: clang>=8, using the major as version
12:43:05  #12 14.79 detect_api: gcc C++ standard library: libstdc++11
12:43:05  #12 14.79 
12:43:05  #12 14.79 Detected profile:
12:43:05  #12 14.79 WARN: This profile is a guess of your environment, please check it.
12:43:05  #12 14.79 WARN: The output of this command is not guaranteed to be stable and can change in future Conan versions.
12:43:05  #12 14.79 WARN: Use your own profile files for stability.
12:43:05  #12 14.79 Saving detected profile to /app/.conan2/profiles/default
12:43:05  #12 14.79 [settings]
12:43:05  #12 14.79 arch=x86_64
12:43:05  #12 14.79 build_type=Release
12:43:05  #12 14.79 compiler=clang
12:43:05  #12 14.79 compiler.cppstd=gnu17
12:43:05  #12 14.79 compiler.libcxx=libstdc++11
12:43:05  #12 14.79 compiler.version=18
12:43:05  #12 14.79 os=Linux
12:43:05  #12 14.79 
12:43:05  #12 14.83 -- CMake-Conan: cmake_system_name=Linux
12:43:05  #12 14.83 -- CMake-Conan: cmake_system_processor=x86_64
12:43:05  #12 14.83 -- CMake-Conan: CMake compiler=Clang
12:43:05  #12 14.83 -- CMake-Conan: CMake compiler version=18.1.3
12:43:05  #12 14.83 -- CMake-Conan: [settings] compiler=clang
12:43:05  #12 14.83 -- CMake-Conan: [settings] compiler.version=18
12:43:05  #12 14.83 -- Performing Test _conan_is_libcxx
12:43:05  #12 14.90 -- Performing Test _conan_is_libcxx - Failed
12:43:05  #12 14.90 -- Performing Test _conan_is_gnu_libstdcxx
12:43:05  #12 15.04 -- Performing Test _conan_is_gnu_libstdcxx - Success
12:43:05  #12 15.04 -- Performing Test _conan_gnu_libstdcxx_is_cxx11_abi
12:43:06  #12 15.45 -- Performing Test _conan_gnu_libstdcxx_is_cxx11_abi - Success
12:43:06  #12 15.45 -- CMake-Conan: Creating profile /app/build/conan_host_profile
12:43:06  #12 15.45 -- CMake-Conan: Profile: 
12:43:06  #12 15.45 [settings]
12:43:06  #12 15.45 arch=x86_64
12:43:06  #12 15.45 os=Linux
12:43:06  #12 15.45 compiler=clang
12:43:06  #12 15.45 compiler.version=18
12:43:06  #12 15.45 compiler.cppstd=20
12:43:06  #12 15.45 compiler.libcxx=libstdc++11
12:43:06  #12 15.45 build_type=Debug
12:43:06  #12 15.45 [conf]
12:43:06  #12 15.45 tools.cmake.cmaketoolchain:generator=Ninja
12:43:06  #12 15.45 tools.build:compiler_executables={"c":"/usr/bin/clang","cpp":"/usr/bin/clang++"}
12:43:06  #12 15.45 
12:43:06  #12 15.45 -- CMake-Conan: Installing single configuration Debug
12:43:06  #12 15.45 -- CMake-Conan: conan install /app -of=/app/build/conan --profile:host=default;--profile:host=/app/build/conan_host_profile;--profile:build=default;--build=missing;-c tools.build:cflags += ['-fsanitize=address'];-c tools.build:cxxflags += ['-fsanitize=address', '-fno-omit-frame-pointer', '-fsanitize-address-use-after-scope'];-c tools.build:exelinkflags += ['-fsanitize=address'];-c tools.build:sharedlinkflags += ['-fsanitize=address']
12:43:06  #12 15.70 
12:43:06  #12 15.70 ======== Input profiles ========
12:43:06  #12 15.70 Profile host:
12:43:06  #12 15.70 [settings]
12:43:06  #12 15.70 arch=x86_64
12:43:06  #12 15.70 build_type=Debug
12:43:06  #12 15.70 compiler=clang
12:43:06  #12 15.70 compiler.cppstd=20
12:43:06  #12 15.70 compiler.libcxx=libstdc++11
12:43:06  #12 15.70 compiler.version=18
12:43:06  #12 15.70 os=Linux
12:43:06  #12 15.70 [conf]
12:43:06  #12 15.70 tools.build:cflags=['-fsanitize=address']
12:43:06  #12 15.70 tools.build:compiler_executables={'c': '/usr/bin/clang', 'cpp': '/usr/bin/clang++'}
12:43:06  #12 15.70 tools.build:cxxflags=['-fsanitize=address', '-fno-omit-frame-pointer', '-fsanitize-address-use-after-scope']
12:43:06  #12 15.70 tools.build:exelinkflags=['-fsanitize=address']
12:43:06  #12 15.70 tools.build:sharedlinkflags=['-fsanitize=address']
12:43:06  #12 15.70 tools.cmake.cmaketoolchain:generator=Ninja
12:43:06  #12 15.70 tools.info.package_id:confs=['tools.build:cflags', 'tools.build:cxxflags', 'tools.build:exelinkflags', 'tools.build:sharedlinkflags']
12:43:06  #12 15.70 
12:43:06  #12 15.70 Profile build:
12:43:06  #12 15.70 [settings]
12:43:06  #12 15.70 arch=x86_64
12:43:06  #12 15.70 build_type=Release
12:43:06  #12 15.70 compiler=clang
12:43:06  #12 15.70 compiler.cppstd=gnu17
12:43:06  #12 15.70 compiler.libcxx=libstdc++11
12:43:06  #12 15.70 compiler.version=18
12:43:06  #12 15.70 os=Linux
12:43:06  #12 15.70 [conf]
12:43:06  #12 15.70 tools.info.package_id:confs=['tools.build:cflags', 'tools.build:cxxflags', 'tools.build:exelinkflags', 'tools.build:sharedlinkflags']
12:43:06  #12 15.70 
12:43:06  #12 15.70 
12:43:06  #12 15.70 ======== Computing dependency graph ========
12:43:06  #12 15.70 asio/1.36.0: Not found in local cache, looking in remotes...
12:43:06  #12 15.70 asio/1.36.0: Checking remote: conancenter
12:43:06  #12 15.70 Connecting to remote 'conancenter' anonymously
12:43:06  #12 16.25 asio/1.36.0: Downloaded recipe revision 75a50dae6e50af10cfb2150286b7df39
12:43:07  #12 16.26 backward-cpp/1.6: Not found in local cache, looking in remotes...
12:43:07  #12 16.26 backward-cpp/1.6: Checking remote: conancenter
12:43:07  #12 16.38 backward-cpp/1.6: Downloaded recipe revision 2bf34ae4e4b236f8a0ac358b948c189e
12:43:07  #12 16.38 benchmark/1.9.4: Not found in local cache, looking in remotes...
12:43:07  #12 16.38 benchmark/1.9.4: Checking remote: conancenter
12:43:07  #12 16.42 benchmark/1.9.4: Downloaded recipe revision ce4403f7a24d3e1f907cd9da4b678be4
12:43:07  #12 16.52 cmake/3.31.9: Not found in local cache, looking in remotes...
12:43:07  #12 16.52 cmake/3.31.9: Checking remote: conancenter
12:43:07  #12 16.56 cmake/3.31.9: Downloaded recipe revision f9b9bb4bdfa37937619a33e9218703a6
12:43:07  #12 16.57 docopt.cpp/0.6.3: Not found in local cache, looking in remotes...
12:43:07  #12 16.57 docopt.cpp/0.6.3: Checking remote: conancenter
12:43:07  #12 16.68 docopt.cpp/0.6.3: Downloaded recipe revision 7937c6a7f2f8bccd86f67d25837f9a39
12:43:07  #12 16.68 expected-lite/0.8.0: Not found in local cache, looking in remotes...
12:43:07  #12 16.68 expected-lite/0.8.0: Checking remote: conancenter
12:43:07  #12 16.97 expected-lite/0.8.0: Downloaded recipe revision f87b3ec27a4f46894950b70f8d08af24
12:43:07  #12 16.97 grpc/1.69.0: Not found in local cache, looking in remotes...
12:43:07  #12 16.97 grpc/1.69.0: Checking remote: conancenter
12:43:07  #12 17.01 grpc/1.69.0: Downloaded recipe revision db0b51e99fb2c0729c68d343aab5a7eb
12:43:07  #12 17.02 protobuf/5.29.3: Not found in local cache, looking in remotes...
12:43:07  #12 17.02 protobuf/5.29.3: Checking remote: conancenter
12:43:07  #12 17.06 protobuf/5.29.3: Downloaded recipe revision 140f18fd93615a017c8575190c294b20
12:43:07  #12 17.16 zlib/1.3.1: Not found in local cache, looking in remotes...
12:43:07  #12 17.16 zlib/1.3.1: Checking remote: conancenter
12:43:07  #12 17.20 zlib/1.3.1: Downloaded recipe revision b8bc2603263cf7eccbd6e17e66b0ed76
12:43:07  #12 17.20 abseil/20240722.1: Not found in local cache, looking in remotes...
12:43:07  #12 17.20 abseil/20240722.1: Checking remote: conancenter
12:43:07  #12 17.24 abseil/20240722.1: Downloaded recipe revision 54d65cdb66edf9cfe14c6cdc35ae5a92
12:43:07  #12 17.34 c-ares/1.34.5: Not found in local cache, looking in remotes...
12:43:07  #12 17.34 c-ares/1.34.5: Checking remote: conancenter
12:43:08  #12 17.38 c-ares/1.34.5: Downloaded recipe revision 5581c2b62a608b40bb85d965ab3ec7c8
12:43:08  #12 17.48 openssl/3.5.4: Not found in local cache, looking in remotes...
12:43:08  #12 17.48 openssl/3.5.4: Checking remote: conancenter
12:43:08  #12 17.68 openssl/3.5.4: Downloaded recipe revision a1d5835cc6ed5c5b8f3cd5b9b5d24205
12:43:08  #12 17.69 re2/20230301: Not found in local cache, looking in remotes...
12:43:08  #12 17.69 re2/20230301: Checking remote: conancenter
12:43:08  #12 17.73 re2/20230301: Downloaded recipe revision ca3b241baec15bd31ea9187150e0b333
12:43:08  #12 17.74 gtest/1.17.0: Not found in local cache, looking in remotes...
12:43:08  #12 17.74 gtest/1.17.0: Checking remote: conancenter
12:43:08  #12 17.77 gtest/1.17.0: Downloaded recipe revision 5224b3b3ff3b4ce1133cbdd27d53ee7d
12:43:08  #12 17.78 cmake/4.1.2: Not found in local cache, looking in remotes...
12:43:08  #12 17.78 cmake/4.1.2: Checking remote: conancenter
12:43:08  #12 17.81 cmake/4.1.2: Downloaded recipe revision 6f844b9ec4e0e29d4f1232f9c5039901
12:43:08  #12 17.82 range-v3/0.12.0: Not found in local cache, looking in remotes...
12:43:08  #12 17.82 range-v3/0.12.0: Checking remote: conancenter
12:43:08  #12 17.86 range-v3/0.12.0: Downloaded recipe revision 4c05d91d7b40e6b91b44b5345ac64408
12:43:08  #12 17.86 rxcpp/4.1.1: Not found in local cache, looking in remotes...
12:43:08  #12 17.86 rxcpp/4.1.1: Checking remote: conancenter
12:43:08  #12 18.13 rxcpp/4.1.1: Downloaded recipe revision 3c04ac103a4335cebd014e8b67736e66
12:43:08  #12 18.13 soci/4.1.2: Not found in local cache, looking in remotes...
12:43:08  #12 18.13 soci/4.1.2: Checking remote: conancenter
12:43:09  #12 18.40 soci/4.1.2: Downloaded recipe revision 0dd6fce9c2b736e4e55db4242cdf4ccb
12:43:09  #12 18.41 libpq/16.8: Not found in local cache, looking in remotes...
12:43:09  #12 18.41 libpq/16.8: Checking remote: conancenter
12:43:09  #12 18.53 libpq/16.8: Downloaded recipe revision 790fabaf0cb26d1908c11fb28128d9b9
12:43:09  #12 18.63 pkgconf/2.5.1: Not found in local cache, looking in remotes...
12:43:09  #12 18.63 pkgconf/2.5.1: Checking remote: conancenter
12:43:09  #12 18.67 pkgconf/2.5.1: Downloaded recipe revision 93c2051284cba1279494a43a4fcfeae2
12:43:09  #12 18.77 meson/1.9.1: Not found in local cache, looking in remotes...
12:43:09  #12 18.77 meson/1.9.1: Checking remote: conancenter
12:43:09  #12 18.82 meson/1.9.1: Downloaded recipe revision abbc783cd297bedce14581b4aec060b8
12:43:09  #12 18.91 ninja/1.13.1: Not found in local cache, looking in remotes...
12:43:09  #12 18.91 ninja/1.13.1: Checking remote: conancenter
12:43:09  #12 18.95 ninja/1.13.1: Downloaded recipe revision 294f8721dbcde145674f7ba44994700e
12:43:09  #12 18.96 spdlog/1.16.0: Not found in local cache, looking in remotes...
12:43:09  #12 18.96 spdlog/1.16.0: Checking remote: conancenter
12:43:09  #12 19.00 spdlog/1.16.0: Downloaded recipe revision 942c2c39562ae25ba575d9c8e2bdf3b6
12:43:09  #12 19.00 fmt/12.0.0: Not found in local cache, looking in remotes...
12:43:09  #12 19.00 fmt/12.0.0: Checking remote: conancenter
12:43:09  #12 19.04 fmt/12.0.0: Downloaded recipe revision dc7de7f3968e5d6b377f27b7d0f33916
12:43:09  #12 19.05 stduuid/1.2.3: Not found in local cache, looking in remotes...
12:43:09  #12 19.05 stduuid/1.2.3: Checking remote: conancenter
12:43:09  #12 19.09 stduuid/1.2.3: Downloaded recipe revision 6faafc03e1d59789d6304ed3f46b74d4
12:43:09  #12 19.09 yaml-cpp/0.8.0: Not found in local cache, looking in remotes...
12:43:09  #12 19.09 yaml-cpp/0.8.0: Checking remote: conancenter
12:43:09  #12 19.13 yaml-cpp/0.8.0: Downloaded recipe revision 131511e225a521dd94fd8b2ee2268ab2
12:43:09  #12 19.13 gperftools/2.17.2: Not found in local cache, looking in remotes...
12:43:09  #12 19.13 gperftools/2.17.2: Checking remote: conancenter
12:43:09  #12 19.25 gperftools/2.17.2: Downloaded recipe revision 1de28b5116961a072cf9a2d62f231d2a
12:43:09  #12 19.26 libunwind/1.8.3: Not found in local cache, looking in remotes...
12:43:09  #12 19.26 libunwind/1.8.3: Checking remote: conancenter
12:43:09  #12 19.30 libunwind/1.8.3: Downloaded recipe revision cc4113f21fee3389141f687e482113a0
12:43:09  #12 19.39 xz_utils/5.8.1: Not found in local cache, looking in remotes...
12:43:09  #12 19.39 xz_utils/5.8.1: Checking remote: conancenter
12:43:10  #12 19.43 xz_utils/5.8.1: Downloaded recipe revision 536e4c68ef30b7308b28a1c50e663c31
12:43:10  #12 19.44 Graph root
12:43:10  #12 19.44     conanfile.py: /app/conanfile.py
12:43:10  #12 19.44 Requirements
12:43:10  #12 19.44     abseil/20240722.1#54d65cdb66edf9cfe14c6cdc35ae5a92 - Downloaded (conancenter)
12:43:10  #12 19.44     asio/1.36.0#75a50dae6e50af10cfb2150286b7df39 - Downloaded (conancenter)
12:43:10  #12 19.44     backward-cpp/1.6#2bf34ae4e4b236f8a0ac358b948c189e - Downloaded (conancenter)
12:43:10  #12 19.44     benchmark/1.9.4#ce4403f7a24d3e1f907cd9da4b678be4 - Downloaded (conancenter)
12:43:10  #12 19.44     c-ares/1.34.5#5581c2b62a608b40bb85d965ab3ec7c8 - Downloaded (conancenter)
12:43:10  #12 19.44     docopt.cpp/0.6.3#7937c6a7f2f8bccd86f67d25837f9a39 - Downloaded (conancenter)
12:43:10  #12 19.44     expected-lite/0.8.0#f87b3ec27a4f46894950b70f8d08af24 - Downloaded (conancenter)
12:43:10  #12 19.44     fmt/12.0.0#dc7de7f3968e5d6b377f27b7d0f33916 - Downloaded (conancenter)
12:43:10  #12 19.44     gperftools/2.17.2#1de28b5116961a072cf9a2d62f231d2a - Downloaded (conancenter)
12:43:10  #12 19.44     grpc/1.69.0#db0b51e99fb2c0729c68d343aab5a7eb - Downloaded (conancenter)
12:43:10  #12 19.44     gtest/1.17.0#5224b3b3ff3b4ce1133cbdd27d53ee7d - Downloaded (conancenter)
12:43:10  #12 19.44     libpq/16.8#790fabaf0cb26d1908c11fb28128d9b9 - Downloaded (conancenter)
12:43:10  #12 19.44     libunwind/1.8.3#cc4113f21fee3389141f687e482113a0 - Downloaded (conancenter)
12:43:10  #12 19.44     openssl/3.5.4#a1d5835cc6ed5c5b8f3cd5b9b5d24205 - Downloaded (conancenter)
12:43:10  #12 19.44     protobuf/5.29.3#140f18fd93615a017c8575190c294b20 - Downloaded (conancenter)
12:43:10  #12 19.44     range-v3/0.12.0#4c05d91d7b40e6b91b44b5345ac64408 - Downloaded (conancenter)
12:43:10  #12 19.44     re2/20230301#ca3b241baec15bd31ea9187150e0b333 - Downloaded (conancenter)
12:43:10  #12 19.44     rxcpp/4.1.1#3c04ac103a4335cebd014e8b67736e66 - Downloaded (conancenter)
12:43:10  #12 19.44     soci/4.1.2#0dd6fce9c2b736e4e55db4242cdf4ccb - Downloaded (conancenter)
12:43:10  #12 19.44     spdlog/1.16.0#942c2c39562ae25ba575d9c8e2bdf3b6 - Downloaded (conancenter)
12:43:10  #12 19.44     stduuid/1.2.3#6faafc03e1d59789d6304ed3f46b74d4 - Downloaded (conancenter)
12:43:10  #12 19.44     xz_utils/5.8.1#536e4c68ef30b7308b28a1c50e663c31 - Downloaded (conancenter)
12:43:10  #12 19.44     yaml-cpp/0.8.0#131511e225a521dd94fd8b2ee2268ab2 - Downloaded (conancenter)
12:43:10  #12 19.44     zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76 - Downloaded (conancenter)
12:43:10  #12 19.44 Build requirements
12:43:10  #12 19.44     abseil/20240722.1#54d65cdb66edf9cfe14c6cdc35ae5a92 - Downloaded (conancenter)
12:43:10  #12 19.44     cmake/3.31.9#f9b9bb4bdfa37937619a33e9218703a6 - Downloaded (conancenter)
12:43:10  #12 19.44     cmake/4.1.2#6f844b9ec4e0e29d4f1232f9c5039901 - Downloaded (conancenter)
12:43:10  #12 19.44     meson/1.9.1#abbc783cd297bedce14581b4aec060b8 - Downloaded (conancenter)
12:43:10  #12 19.44     ninja/1.13.1#294f8721dbcde145674f7ba44994700e - Downloaded (conancenter)
12:43:10  #12 19.44     pkgconf/2.5.1#93c2051284cba1279494a43a4fcfeae2 - Downloaded (conancenter)
12:43:10  #12 19.44     protobuf/5.29.3#140f18fd93615a017c8575190c294b20 - Downloaded (conancenter)
12:43:10  #12 19.44     zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76 - Downloaded (conancenter)
12:43:10  #12 19.44 Resolved version ranges
12:43:10  #12 19.44     abseil/[>=20230802.1 <=20250127.0]: abseil/20240722.1
12:43:10  #12 19.44     c-ares/[>=1.19.1 <2]: c-ares/1.34.5
12:43:10  #12 19.44     cmake/[>=3.16.3 <4]: cmake/3.31.9
12:43:10  #12 19.44     cmake/[>=3.16 <4]: cmake/3.31.9
12:43:10  #12 19.44     cmake/[>=3.16]: cmake/4.1.2
12:43:10  #12 19.44     cmake/[>=3.23 <4]: cmake/3.31.9
12:43:10  #12 19.44     cmake/[>=3.25 <4]: cmake/3.31.9
12:43:10  #12 19.44     meson/[>=1.2.2 <2]: meson/1.9.1
12:43:10  #12 19.44     ninja/[>=1.10.2 <2]: ninja/1.13.1
12:43:10  #12 19.44     openssl/[>=3.5 <3.6]: openssl/3.5.4
12:43:10  #12 19.44     pkgconf/[>=2.2 <3]: pkgconf/2.5.1
12:43:10  #12 19.44     xz_utils/[>=5.4.5 <6]: xz_utils/5.8.1
12:43:10  #12 19.44     zlib/[>=1.2.11 <2]: zlib/1.3.1
12:43:10  #12 19.44     zlib/[>=1.3.1 <2]: zlib/1.3.1
12:43:10  #12 19.44 Overrides
12:43:10  #12 19.44     protobuf/5.27.0: ['protobuf/5.29.3']
12:43:10  #12 19.44     abseil/[>=20240116.1 <=20250127.0]: ['abseil/20240722.1']
12:43:10  #12 19.44     abseil/[>=20230802.1 <=20250127.0]: ['abseil/20240722.1']
12:43:10  #12 19.44     libpq/[>=15.4 <18.0]: ['libpq/16.8']
12:43:10  #12 19.44     libunwind/[>=1.6.2 <2]: ['libunwind/1.8.3']
12:43:10  #12 19.44 
12:43:10  #12 19.44 ======== Computing necessary packages ========
12:43:10  #12 19.64 Connecting to remote 'QBArtifactory' with user ****
12:43:15  #12 24.73 gperftools/2.17.2: Main binary package '634c56c390e11c17a0d039e4d5657eda29d6e81e' missing
12:43:15  #12 24.73 gperftools/2.17.2: Checking 7 compatible configurations
12:43:15  #12 24.73 gperftools/2.17.2: Compatible configurations not found in cache, checking servers
12:43:15  #12 24.73 gperftools/2.17.2: '71f9f883193ff28ae020ca1708ec41a54d830663': compiler.cppstd=17
12:43:15  #12 25.00 gperftools/2.17.2: 'dfe4d946e71aced4352b8870cde7406ae348d090': compiler.cppstd=gnu17
12:43:16  #12 25.28 gperftools/2.17.2: '274917a03dad85b8c03f71a0d355fc32deff17b4': compiler.cppstd=gnu20
12:43:16  #12 25.56 gperftools/2.17.2: 'b340e2002847ad3e0da9eb8a6599a4d98ac5217d': compiler.cppstd=23
12:43:16  #12 25.84 gperftools/2.17.2: 'ee4cee220f39cce0a5c0d945cc7e4ef53dd0d277': compiler.cppstd=gnu23
12:43:16  #12 26.11 gperftools/2.17.2: '7cecb8d5983c7bbc8d914a7ccebb61512c779569': compiler.cppstd=26
12:43:17  #12 26.40 gperftools/2.17.2: '2066259a2f537d46b44c8b9685093cb90beaf98e': compiler.cppstd=gnu26
12:43:18  #12 28.03 Requirements
12:43:18  #12 28.03     abseil/20240722.1#54d65cdb66edf9cfe14c6cdc35ae5a92:0570f1245265245e86237d8b56431593270107e3#e13bcfc860174c4036c7d144cea05fdd - Download (QBArtifactory)
12:43:18  #12 28.03     asio/1.36.0#75a50dae6e50af10cfb2150286b7df39:da39a3ee5e6b4b0d3255bfef95601890afd80709#c02fdd2b35b8e2b48197b1749056e852 - Download (conancenter)
12:43:18  #12 28.03     backward-cpp/1.6#2bf34ae4e4b236f8a0ac358b948c189e:0521eafb19a6e7d447d5002583e62f6beac08d47#5f8acc43a410abf3955d7c5a1afa1f64 - Download (QBArtifactory)
12:43:18  #12 28.03     benchmark/1.9.4#ce4403f7a24d3e1f907cd9da4b678be4:16592be7908ffa139a3da9a3249ff0532c8a6f97#fcb2d87d06a5315b74fe8adfc3d2ee8b - Download (QBArtifactory)
12:43:18  #12 28.03     c-ares/1.34.5#5581c2b62a608b40bb85d965ab3ec7c8:ca3d35f37354ab5b683516db9f3098b8bf948d64#d9c882e743b9c00998432df32b6b5ac9 - Download (QBArtifactory)
12:43:18  #12 28.03     docopt.cpp/0.6.3#7937c6a7f2f8bccd86f67d25837f9a39:2fc83bdd1499d4d1d018f36acc11c12050191481#b4b190149182c95a61233e1e4790aecd - Download (QBArtifactory)
12:43:18  #12 28.03     expected-lite/0.8.0#f87b3ec27a4f46894950b70f8d08af24:da39a3ee5e6b4b0d3255bfef95601890afd80709#1a1969aaf38bdf2fcb7c286d3669ba2a - Download (conancenter)
12:43:18  #12 28.03     fmt/12.0.0#dc7de7f3968e5d6b377f27b7d0f33916:a4c4450d025b28d6126ebe6f1a1ee6630970026e#077496009003bdb5911dbfeb0ca184c0 - Download (QBArtifactory)
12:43:18  #12 28.03     gperftools/2.17.2#1de28b5116961a072cf9a2d62f231d2a:634c56c390e11c17a0d039e4d5657eda29d6e81e - Build
12:43:18  #12 28.03     grpc/1.69.0#db0b51e99fb2c0729c68d343aab5a7eb:5b34bb0249042a0bef00c8729f162964543e3baf#c4efa4e7aec1871f776abe4f1ce3058e - Download (QBArtifactory)
12:43:18  #12 28.03     gtest/1.17.0#5224b3b3ff3b4ce1133cbdd27d53ee7d:1a02bc606608ac399c6024f6cd5c037adeb56710#d098571d541f448e0e94305ce5bf19f1 - Download (QBArtifactory)
12:43:18  #12 28.03     libpq/16.8#790fabaf0cb26d1908c11fb28128d9b9:800d58dab4a9bb8d42560f33ce9c459a22c454e1#462d72d441e6695694766c2ca8fdd18e - Download (QBArtifactory)
12:43:18  #12 28.03     libunwind/1.8.3#cc4113f21fee3389141f687e482113a0:9665cc918492c5224389cd9333062acb8989a9a9 - Build
12:43:18  #12 28.03     openssl/3.5.4#a1d5835cc6ed5c5b8f3cd5b9b5d24205:789cca02b24472002ca0cc22def99d99759c48dc#6ea46ab64eb5dc04517c4d7b3d52d810 - Download (QBArtifactory)
12:43:18  #12 28.03     protobuf/5.29.3#140f18fd93615a017c8575190c294b20:26664aef7f908eb39f0c1ad2f4fd955c572cbfdd#0c67477b95e7b1b15a30c2d838c70bd7 - Download (QBArtifactory)
12:43:18  #12 28.03     range-v3/0.12.0#4c05d91d7b40e6b91b44b5345ac64408:da39a3ee5e6b4b0d3255bfef95601890afd80709#ecc6172c3cd6694c36d1cd98a702deb0 - Download (conancenter)
12:43:18  #12 28.03     re2/20230301#ca3b241baec15bd31ea9187150e0b333:3839fce444afa1a71b70503a406847ff1aee9d9b#aa5b506a6f73cc65402c7f49af807567 - Download (QBArtifactory)
12:43:18  #12 28.03     rxcpp/4.1.1#3c04ac103a4335cebd014e8b67736e66:da39a3ee5e6b4b0d3255bfef95601890afd80709#a7bd72a7733e09108a346c3e6695ffc1 - Download (conancenter)
12:43:18  #12 28.03     soci/4.1.2#0dd6fce9c2b736e4e55db4242cdf4ccb:2b9bedbf9a99a6c0d35bb9dafd6816e1fd3c55bd#eac99dd7aedbefdf4e3bdb1b93107c0c - Download (QBArtifactory)
12:43:18  #12 28.03     spdlog/1.16.0#942c2c39562ae25ba575d9c8e2bdf3b6:a075809963c94ac76479231fb5e4d69025691c7c#2f9e167499504ff805515b2d3b9a8c5d - Download (QBArtifactory)
12:43:18  #12 28.03     stduuid/1.2.3#6faafc03e1d59789d6304ed3f46b74d4:da39a3ee5e6b4b0d3255bfef95601890afd80709#b3be115582bc133f23e16e4bcf95637f - Download (conancenter)
12:43:18  #12 28.03     xz_utils/5.8.1#536e4c68ef30b7308b28a1c50e663c31:d95ead843ef61909ec2af5c6e7c917e59ed67fa7 - Build
12:43:18  #12 28.03     yaml-cpp/0.8.0#131511e225a521dd94fd8b2ee2268ab2:0570f1245265245e86237d8b56431593270107e3#80f1b95d7b87424c9a8c3d6aa9ad1b75 - Download (QBArtifactory)
12:43:18  #12 28.03     zlib/1.3.1#b8bc2603263cf7eccbd6e17e66b0ed76:d95ead843ef61909ec2af5c6e7c917e59ed67fa7#48f475e32795089272cd69b050d51212 - Download (QBArtifactory)
12:43:18  #12 28.03 Build requirements
12:43:18  #12 28.03 Skipped binaries
12:43:18  #12 28.03     abseil/20240722.1, cmake/3.31.9, cmake/4.1.2, meson/1.9.1, ninja/1.13.1, pkgconf/2.5.1, protobuf/5.29.3, zlib/1.3.1
12:43:18  #12 28.03 
12:43:18  #12 28.03 ======== Installing packages ========
12:43:18  #12 28.03 
12:43:18  #12 28.03 -------- Downloading 21 packages --------
12:43:18  #12 28.03 Downloading binary packages in 8 parallel threads
12:43:18  #12 28.03 asio/1.36.0: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter' 
12:43:18  #12 28.03 backward-cpp/1.6: Retrieving package 0521eafb19a6e7d447d5002583e62f6beac08d47 from remote 'QBArtifactory' 
12:43:18  #12 28.03 c-ares/1.34.5: Retrieving package ca3d35f37354ab5b683516db9f3098b8bf948d64 from remote 'QBArtifactory' 
12:43:18  #12 28.03 docopt.cpp/0.6.3: Retrieving package 2fc83bdd1499d4d1d018f36acc11c12050191481 from remote 'QBArtifactory' 
12:43:18  #12 28.03 expected-lite/0.8.0: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter' 
12:43:18  #12 28.03 fmt/12.0.0: Retrieving package a4c4450d025b28d6126ebe6f1a1ee6630970026e from remote 'QBArtifactory' 
12:43:18  #12 28.04 range-v3/0.12.0: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter' 
12:43:18  #12 28.04 re2/20230301: Retrieving package 3839fce444afa1a71b70503a406847ff1aee9d9b from remote 'QBArtifactory' 
12:43:18  #12 28.10 expected-lite/0.8.0: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
12:43:18  #12 28.10 expected-lite/0.8.0: Downloaded package revision 1a1969aaf38bdf2fcb7c286d3669ba2a
12:43:18  #12 28.10 rxcpp/4.1.1: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter' 
12:43:18  #12 28.20 rxcpp/4.1.1: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
12:43:18  #12 28.20 rxcpp/4.1.1: Downloaded package revision a7bd72a7733e09108a346c3e6695ffc1
12:43:18  #12 28.20 stduuid/1.2.3: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter' 
12:43:19  #12 28.20 range-v3/0.12.0: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
12:43:19  #12 28.20 range-v3/0.12.0: Downloaded package revision ecc6172c3cd6694c36d1cd98a702deb0
12:43:19  #12 28.20 yaml-cpp/0.8.0: Retrieving package 0570f1245265245e86237d8b56431593270107e3 from remote 'QBArtifactory' 
12:43:19  #12 28.25 stduuid/1.2.3: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
12:43:19  #12 28.25 stduuid/1.2.3: Downloaded package revision b3be115582bc133f23e16e4bcf95637f
12:43:19  #12 28.25 zlib/1.3.1: Retrieving package d95ead843ef61909ec2af5c6e7c917e59ed67fa7 from remote 'QBArtifactory' 
12:43:19  #12 28.42 backward-cpp/1.6: Package installed 0521eafb19a6e7d447d5002583e62f6beac08d47
12:43:19  #12 28.42 backward-cpp/1.6: Downloaded package revision 5f8acc43a410abf3955d7c5a1afa1f64
12:43:19  #12 28.42 abseil/20240722.1: Retrieving package 0570f1245265245e86237d8b56431593270107e3 from remote 'QBArtifactory' 
12:43:19  #12 28.52 zlib/1.3.1: Package installed d95ead843ef61909ec2af5c6e7c917e59ed67fa7
12:43:19  #12 28.52 zlib/1.3.1: Downloaded package revision 48f475e32795089272cd69b050d51212
12:43:19  #12 28.52 benchmark/1.9.4: Retrieving package 16592be7908ffa139a3da9a3249ff0532c8a6f97 from remote 'QBArtifactory' 
12:43:19  #12 28.58 asio/1.36.0: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
12:43:19  #12 28.58 asio/1.36.0: Downloaded package revision c02fdd2b35b8e2b48197b1749056e852
12:43:19  #12 28.58 gtest/1.17.0: Retrieving package 1a02bc606608ac399c6024f6cd5c037adeb56710 from remote 'QBArtifactory' 
12:43:19  #12 28.60 docopt.cpp/0.6.3: Package installed 2fc83bdd1499d4d1d018f36acc11c12050191481
12:43:19  #12 28.60 docopt.cpp/0.6.3: Downloaded package revision b4b190149182c95a61233e1e4790aecd
12:43:19  #12 28.60 openssl/3.5.4: Retrieving package 789cca02b24472002ca0cc22def99d99759c48dc from remote 'QBArtifactory' 
12:43:19  #12 28.61 fmt/12.0.0: Package installed a4c4450d025b28d6126ebe6f1a1ee6630970026e
12:43:19  #12 28.61 fmt/12.0.0: Downloaded package revision 077496009003bdb5911dbfeb0ca184c0
12:43:19  #12 28.61 spdlog/1.16.0: Retrieving package a075809963c94ac76479231fb5e4d69025691c7c from remote 'QBArtifactory' 
12:43:19  #12 28.70 re2/20230301: Package installed 3839fce444afa1a71b70503a406847ff1aee9d9b
12:43:19  #12 28.70 re2/20230301: Downloaded package revision aa5b506a6f73cc65402c7f49af807567
12:43:19  #12 28.70 protobuf/5.29.3: Retrieving package 26664aef7f908eb39f0c1ad2f4fd955c572cbfdd from remote 'QBArtifactory' 
12:43:19  #12 28.90 protobuf/5.29.3: Downloading 99.5MB conan_package.tgz
12:43:19  #12 28.90 openssl/3.5.4: Downloading 35.0MB conan_package.tgz
12:43:19  #12 29.00 yaml-cpp/0.8.0: Package installed 0570f1245265245e86237d8b56431593270107e3
12:43:19  #12 29.00 yaml-cpp/0.8.0: Downloaded package revision 80f1b95d7b87424c9a8c3d6aa9ad1b75
12:43:19  #12 29.00 grpc/1.69.0: Retrieving package 5b34bb0249042a0bef00c8729f162964543e3baf from remote 'QBArtifactory' 
12:43:19  #12 29.12 benchmark/1.9.4: Package installed 16592be7908ffa139a3da9a3249ff0532c8a6f97
12:43:19  #12 29.12 benchmark/1.9.4: Downloaded package revision fcb2d87d06a5315b74fe8adfc3d2ee8b
12:43:19  #12 29.12 libpq/16.8: Retrieving package 800d58dab4a9bb8d42560f33ce9c459a22c454e1 from remote 'QBArtifactory' 
12:43:19  #12 29.21 spdlog/1.16.0: Package installed a075809963c94ac76479231fb5e4d69025691c7c
12:43:19  #12 29.21 spdlog/1.16.0: Downloaded package revision 2f9e167499504ff805515b2d3b9a8c5d
12:43:19  #12 29.21 soci/4.1.2: Retrieving package 2b9bedbf9a99a6c0d35bb9dafd6816e1fd3c55bd from remote 'QBArtifactory' 
12:43:19  #12 29.24 grpc/1.69.0: Downloading 312.3MB conan_package.tgz
12:43:20  #12 29.39 c-ares/1.34.5: Package installed ca3d35f37354ab5b683516db9f3098b8bf948d64
12:43:20  #12 29.39 c-ares/1.34.5: Downloaded package revision d9c882e743b9c00998432df32b6b5ac9
12:43:20  #12 29.39 openssl/3.5.4: Decompressing 35.0MB conan_package.tgz
12:43:20  #12 29.43 gtest/1.17.0: Package installed 1a02bc606608ac399c6024f6cd5c037adeb56710
12:43:20  #12 29.43 gtest/1.17.0: Downloaded package revision d098571d541f448e0e94305ce5bf19f1
12:43:20  #12 29.57 libpq/16.8: Package installed 800d58dab4a9bb8d42560f33ce9c459a22c454e1
12:43:20  #12 29.57 libpq/16.8: Downloaded package revision 462d72d441e6695694766c2ca8fdd18e
12:43:20  #12 29.63 abseil/20240722.1: Package installed 0570f1245265245e86237d8b56431593270107e3
12:43:20  #12 29.63 abseil/20240722.1: Downloaded package revision e13bcfc860174c4036c7d144cea05fdd
12:43:20  #12 29.83 protobuf/5.29.3: Decompressing 99.5MB conan_package.tgz
12:43:20  #12 29.88 soci/4.1.2: Package installed 2b9bedbf9a99a6c0d35bb9dafd6816e1fd3c55bd
12:43:20  #12 29.88 soci/4.1.2: Downloaded package revision eac99dd7aedbefdf4e3bdb1b93107c0c
12:43:21  #12 30.61 openssl/3.5.4: Package installed 789cca02b24472002ca0cc22def99d99759c48dc
12:43:21  #12 30.61 openssl/3.5.4: Downloaded package revision 6ea46ab64eb5dc04517c4d7b3d52d810
12:43:23  #12 32.17 protobuf/5.29.3: Package installed 26664aef7f908eb39f0c1ad2f4fd955c572cbfdd
12:43:23  #12 32.17 protobuf/5.29.3: Downloaded package revision 0c67477b95e7b1b15a30c2d838c70bd7
12:43:24  #12 33.63 grpc/1.69.0: Decompressing 312.3MB conan_package.tgz
12:43:31  #12 39.95 grpc/1.69.0: Package installed 5b34bb0249042a0bef00c8729f162964543e3baf
12:43:31  #12 39.95 grpc/1.69.0: Downloaded package revision c4efa4e7aec1871f776abe4f1ce3058e
12:43:31  #12 39.97 xz_utils/5.8.1: Sources downloaded from 'conancenter'
12:43:31  #12 39.97 xz_utils/5.8.1: Calling source() in /app/.conan2/p/xz_ut683e204eaa97a/s/src
12:43:31  #12 40.95 xz_utils/5.8.1: Uncompressing xz-5.8.1.tar.xz to .
12:43:31  #12 41.30 
12:43:31  #12 41.30 -------- Installing package xz_utils/5.8.1 (11 of 24) --------
12:43:31  #12 41.30 xz_utils/5.8.1: Building from source
12:43:31  #12 41.30 xz_utils/5.8.1: Package xz_utils/5.8.1:d95ead843ef61909ec2af5c6e7c917e59ed67fa7
12:43:31  #12 41.30 xz_utils/5.8.1: settings: os=Linux arch=x86_64 compiler=clang compiler.version=18 build_type=Debug
12:43:31  #12 41.30 xz_utils/5.8.1: options: fPIC=True shared=False
12:43:31  #12 41.30 xz_utils/5.8.1: conf: tools.build:cflags=['-fsanitize=address'] tools.build:cxxflags=['-fsanitize=address', '-fno-omit-frame-pointer', '-fsanitize-address-use-after-scope'] tools.build:exelinkflags=['-fsanitize=address'] tools.build:sharedlinkflags=['-fsanitize=address']
12:43:32  #12 41.30 xz_utils/5.8.1: Copying sources to build folder
12:43:32  #12 41.35 xz_utils/5.8.1: Building your package in /app/.conan2/p/b/xz_uta1648044727a1/b
12:43:32  #12 41.35 xz_utils/5.8.1: Calling generate()
12:43:32  #12 41.35 xz_utils/5.8.1: Generators folder: /app/.conan2/p/b/xz_uta1648044727a1/b/build-debug/conan
12:43:32  #12 41.35 xz_utils/5.8.1: Generating aggregated env files
12:43:32  #12 41.35 xz_utils/5.8.1: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
12:43:32  #12 41.35 xz_utils/5.8.1: Calling build()
12:43:32  #12 41.35 xz_utils/5.8.1: apply_conandata_patches(): No patches defined in conandata
12:43:32  #12 41.35 xz_utils/5.8.1: RUN: "/app/.conan2/p/b/xz_uta1648044727a1/b/src/configure" --disable-shared --enable-static --prefix=/ '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' --disable-doc --enable-debug 
12:43:32  #12 41.47 
12:43:32  #12 41.47 XZ Utils 5.8.1
12:43:32  #12 41.47 
12:43:32  #12 41.47 System type:
12:43:32  #12 41.47 checking build system type... x86_64-pc-linux-gnu
12:43:32  #12 41.54 checking host system type... x86_64-pc-linux-gnu
12:43:32  #12 41.54 
12:43:32  #12 41.54 Configure options:
12:43:32  #12 41.54 checking if debugging code should be compiled... yes
12:43:32  #12 41.54 checking which encoders to build... lzma1 lzma2 delta x86 powerpc ia64 arm armthumb arm64 sparc riscv
12:43:32  #12 41.54 checking which decoders to build... lzma1 lzma2 delta x86 powerpc ia64 arm armthumb arm64 sparc riscv
12:43:32  #12 41.55 checking which match finders to build... hc3 hc4 bt2 bt3 bt4
12:43:32  #12 41.55 checking which integrity checks to build... crc32 crc64 sha256
12:43:32  #12 41.55 checking if external SHA-256 should be used... no
12:43:32  #12 41.55 checking if MicroLZMA support should be built... yes
12:43:32  #12 41.55 checking if .lz (lzip) decompression support should be built... yes
12:43:32  #12 41.55 checking if assembler optimizations should be used... no
12:43:32  #12 41.55 checking if small size is preferred over speed... no
12:43:32  #12 41.55 checking if threading support is wanted... yes, posix
12:43:32  #12 41.55 checking how much RAM to assume if the real amount is unknown... 128 MiB
12:43:32  #12 41.56 checking if sandboxing should be used... maybe (autodetect)
12:43:32  #12 41.56 
12:43:32  #12 41.56 checking for a shell that conforms to POSIX... /bin/bash
12:43:32  #12 41.56 
12:43:32  #12 41.56 Initializing Automake:
12:43:32  #12 41.56 checking for a BSD-compatible install... /usr/bin/install -c
12:43:32  #12 41.57 checking whether sleep supports fractional seconds... yes
12:43:32  #12 41.57 checking filesystem timestamp resolution... 0.01
12:43:32  #12 41.65 checking whether build environment is sane... yes
12:43:32  #12 41.66 checking for a race-free mkdir -p... /usr/bin/mkdir -p
12:43:32  #12 41.67 checking for gawk... no
12:43:32  #12 41.67 checking for mawk... mawk
12:43:32  #12 41.67 checking whether make sets $(MAKE)... yes
12:43:32  #12 41.68 checking whether make supports nested variables... yes
12:43:32  #12 41.68 checking xargs -n works... yes
12:43:32  #12 41.69 checking whether ln -s works... yes
12:43:32  #12 41.69 checking whether make supports the include directive... yes (GNU style)
12:43:32  #12 41.70 checking for gcc... /usr/bin/clang
12:43:32  #12 41.82 checking whether the C compiler works... yes
12:43:32  #12 41.96 checking for C compiler default output file name... a.out
12:43:32  #12 41.96 checking for suffix of executables... 
12:43:32  #12 42.11 checking whether we are cross compiling... no
12:43:33  #12 42.27 checking for suffix of object files... o
12:43:33  #12 42.31 checking whether the compiler supports GNU C... yes
12:43:33  #12 42.34 checking whether /usr/bin/clang accepts -g... yes
12:43:33  #12 42.37 checking for /usr/bin/clang option to enable C11 features... none needed
12:43:33  #12 42.41 checking whether /usr/bin/clang understands -c and -o together... yes
12:43:33  #12 42.47 checking dependency style of /usr/bin/clang... gcc3
12:43:33  #12 42.52 checking dependency style of /usr/bin/clang... gcc3
12:43:33  #12 42.56 checking for stdio.h... yes
12:43:33  #12 42.60 checking for stdlib.h... yes
12:43:33  #12 42.63 checking for string.h... yes
12:43:33  #12 42.67 checking for inttypes.h... yes
12:43:33  #12 42.71 checking for stdint.h... yes
12:43:33  #12 42.75 checking for strings.h... yes
12:43:33  #12 42.78 checking for sys/stat.h... yes
12:43:33  #12 42.82 checking for sys/types.h... yes
12:43:33  #12 42.86 checking for unistd.h... yes
12:43:33  #12 42.91 checking for wchar.h... yes
12:43:33  #12 42.95 checking for minix/config.h... no
12:43:33  #12 42.99 checking for sys/cdefs.h... yes
12:43:33  #12 43.03 checking whether it is safe to define __EXTENSIONS__... yes
12:43:33  #12 43.07 checking whether _XOPEN_SOURCE should be defined... no
12:43:34  #12 43.11 checking if the -Werror option is usable... yes
12:43:34  #12 43.14 checking for a sed that does not truncate output... /usr/bin/sed
12:43:34  #12 43.14 checking how to run the C preprocessor... /usr/bin/clang -E
12:43:34  #12 43.26 checking for egrep -e... /usr/bin/grep -E
12:43:34  #12 43.26 
12:43:34  #12 43.26 POSIX threading support:
12:43:34  #12 43.26 checking whether /usr/bin/clang is Clang... yes
12:43:34  #12 43.29 checking whether pthreads work with "-pthread" and "-lpthread"... yes
12:43:34  #12 43.44 checking whether Clang needs flag to prevent "argument unused" warning when linking with -pthread... no
12:43:34  #12 43.74 checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
12:43:34  #12 43.89 checking whether more special flags are required for pthreads... no
12:43:34  #12 43.89 checking for PTHREAD_PRIO_INHERIT... yes
12:43:35  #12 44.06 checking for pthread_condattr_setclock... yes
12:43:35  #12 44.20 
12:43:35  #12 44.20 Initializing Libtool:
12:43:35  #12 44.21 checking how to print strings... printf
12:43:35  #12 44.21 checking for a sed that does not truncate output... (cached) /usr/bin/sed
12:43:35  #12 44.21 checking for grep that handles long lines and -e... /usr/bin/grep
12:43:35  #12 44.21 checking for egrep... /usr/bin/grep -E
12:43:35  #12 44.21 checking for fgrep... /usr/bin/grep -F
12:43:35  #12 44.22 checking for ld used by /usr/bin/clang... /usr/bin/ld
12:43:35  #12 44.24 checking if the linker (/usr/bin/ld) is GNU ld... yes
12:43:35  #12 44.25 checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
12:43:35  #12 44.25 checking the name lister (/usr/bin/nm -B) interface... BSD nm
12:43:35  #12 44.30 checking the maximum length of command line arguments... 1966080
12:43:35  #12 44.31 checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
12:43:35  #12 44.31 checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
12:43:35  #12 44.31 checking for /usr/bin/ld option to reload object files... -r
12:43:35  #12 44.31 checking for file... file
12:43:35  #12 44.31 checking for objdump... objdump
12:43:35  #12 44.31 checking how to recognize dependent libraries... pass_all
12:43:35  #12 44.31 checking for dlltool... no
12:43:35  #12 44.31 checking how to associate runtime and link libraries... printf %s\n
12:43:35  #12 44.31 checking for ranlib... ranlib
12:43:35  #12 44.31 checking for ar... ar
12:43:35  #12 44.31 checking for archiver @FILE support... @
12:43:35  #12 44.37 checking for strip... strip
12:43:35  #12 44.37 checking command to parse /usr/bin/nm -B output from /usr/bin/clang object... ok
12:43:35  #12 44.56 checking for sysroot... no
12:43:35  #12 44.56 checking for a working dd... /usr/bin/dd
12:43:35  #12 44.57 checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
12:43:35  #12 44.61 checking for mt... no
12:43:35  #12 44.61 checking if : is a manifest tool... no
12:43:35  #12 44.61 checking for dlfcn.h... yes
12:43:35  #12 44.66 checking for objdir... .libs
12:43:35  #12 44.85 checking if /usr/bin/clang supports -fno-rtti -fno-exceptions... yes
12:43:35  #12 44.89 checking for /usr/bin/clang option to produce PIC... -fPIC -DPIC
12:43:35  #12 44.89 checking if /usr/bin/clang PIC flag -fPIC -DPIC works... yes
12:43:35  #12 44.92 checking if /usr/bin/clang static flag -static works... no
12:43:36  #12 45.08 checking if /usr/bin/clang supports -c -o file.o... yes
12:43:36  #12 45.12 checking if /usr/bin/clang supports -c -o file.o... (cached) yes
12:43:36  #12 45.12 checking whether the /usr/bin/clang linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
12:43:36  #12 45.15 checking dynamic linker characteristics... GNU/Linux ld.so
12:43:36  #12 45.35 checking how to hardcode library paths into programs... immediate
12:43:36  #12 45.35 checking whether stripping libraries is possible... yes
12:43:36  #12 45.36 checking if libtool supports shared libraries... yes
12:43:36  #12 45.36 checking whether to build shared libraries... no
12:43:36  #12 45.36 checking whether to build static libraries... yes
12:43:36  #12 45.36 checking for windres... no
12:43:36  #12 45.44 checking if library symbol versioning should be used... no (not building a shared library)
12:43:36  #12 45.44 
12:43:36  #12 45.44 Initializing gettext:
12:43:36  #12 45.44 checking whether NLS is requested... yes
12:43:36  #12 45.44 checking for msgfmt... no
12:43:36  #12 45.44 checking for gmsgfmt... :
12:43:36  #12 45.45 checking for xgettext... no
12:43:36  #12 45.45 checking for msgmerge... no
12:43:36  #12 45.46 checking for ld... /usr/bin/ld -m elf_x86_64
12:43:36  #12 45.46 checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
12:43:36  #12 45.46 checking for shared library run path origin... done
12:43:36  #12 45.48 checking 32-bit host C ABI... no
12:43:36  #12 45.51 checking for ELF binary format... yes
12:43:36  #12 45.54 checking for the common suffixes of directories in the library search path... lib,lib,lib64
12:43:36  #12 45.58 checking for CFPreferencesCopyAppValue... no
12:43:36  #12 45.64 checking for CFLocaleCopyPreferredLanguages... no
12:43:36  #12 45.69 checking for GNU gettext in libc... yes
12:43:36  #12 45.84 checking whether to use NLS... yes
12:43:36  #12 45.84 checking where the gettext function comes from... libc
12:43:36  #12 45.84 
12:43:36  #12 45.84 System headers and functions:
12:43:36  #12 45.84 checking for immintrin.h... yes
12:43:37  #12 46.12 checking for cpuid.h... yes
12:43:37  #12 46.17 checking for _Bool... yes
12:43:37  #12 46.26 checking for stdbool.h that conforms to C99 or later... yes
12:43:37  #12 46.30 checking for uint8_t... yes
12:43:37  #12 46.34 checking for uint16_t... yes
12:43:37  #12 46.38 checking for int32_t... yes
12:43:37  #12 46.49 checking for uint32_t... yes
12:43:37  #12 46.54 checking for int64_t... yes
12:43:37  #12 46.64 checking for uint64_t... yes
12:43:37  #12 46.68 checking for uintptr_t... yes
12:43:37  #12 46.78 checking size of size_t... 8
12:43:37  #12 46.96 checking for struct stat.st_atim.tv_nsec... yes
12:43:37  #12 47.01 checking for struct stat.st_atimespec.tv_nsec... no
12:43:38  #12 47.11 checking for struct stat.st_atimensec... no
12:43:38  #12 47.21 checking for struct stat.st_uatime... no
12:43:38  #12 47.31 checking for struct stat.st_atim.st__tim.tv_nsec... no
12:43:38  #12 47.41 checking for /usr/bin/clang option to enable large file support... none needed
12:43:38  #12 47.48 checking whether byte ordering is bigendian... no
12:43:38  #12 47.60 checking if __attribute__((__constructor__)) can be used... yes
12:43:38  #12 47.64 checking for /usr/bin/clang options needed to detect all undeclared functions... none needed
12:43:38  #12 47.70 checking for getopt.h... yes
12:43:38  #12 47.74 checking for getopt_long... yes
12:43:38  #12 47.90 checking whether optreset is declared... no
12:43:38  #12 47.94 checking for library containing clock_gettime... none required
12:43:38  #12 48.09 checking for clock_gettime... yes
12:43:39  #12 48.24 checking whether CLOCK_MONOTONIC is declared... yes
12:43:39  #12 48.29 checking for futimens... yes
12:43:39  #12 48.45 checking for posix_fadvise... yes
12:43:39  #12 48.60 checking whether program_invocation_name is declared... yes
12:43:39  #12 48.64 checking if __builtin_bswap16/32/64 are supported... yes
12:43:39  #12 48.79 checking if unaligned memory access should be used... yes
12:43:39  #12 48.79 checking if unsafe type punning should be used... no
12:43:39  #12 48.79 checking if __builtin_assume_aligned is supported... yes
12:43:39  #12 48.95 checking for sys/param.h... yes
12:43:39  #12 49.00 checking how to detect the amount of physical memory... sysconf
12:43:39  #12 49.22 checking for sys/param.h... (cached) yes
12:43:40  #12 49.22 checking how to detect the number of available CPU cores... sched_getaffinity
12:43:40  #12 49.41 checking whether mbrtowc and mbstate_t are properly declared... yes
12:43:40  #12 49.56 checking for wcwidth... yes
12:43:40  #12 49.72 checking for vasprintf... yes
12:43:40  #12 49.88 checking whether _mm_movemask_epi8 is declared... yes
12:43:41  #12 50.16 checking if _mm_clmulepi64_si128 is usable... yes
12:43:41  #12 50.55 checking if ARM64 CRC32 instruction is usable... no
12:43:41  #12 50.60 checking if LoongArch CRC32 instructions are usable... no
12:43:41  #12 50.66 checking for cap_rights_limit... no
12:43:41  #12 50.82 checking for pledge... no
12:43:41  #12 50.97 checking if Linux Landlock is usable... configure: error: 
12:43:41  #12 51.12     CC or CFLAGS contain '-fsanitize=' which is incompatible with the Landlock
12:43:41  #12 51.12     sandboxing. Use --disable-sandbox when using '-fsanitize'.
12:43:41  #12 51.17 
12:43:41  #12 51.17 xz_utils/5.8.1: ERROR: 
12:43:41  #12 51.17 Package 'd95ead843ef61909ec2af5c6e7c917e59ed67fa7' build failed
12:43:41  #12 51.17 xz_utils/5.8.1: WARN: Build folder /app/.conan2/p/b/xz_uta1648044727a1/b/build-debug
12:43:41  #12 51.17 ERROR: xz_utils/5.8.1: Error in build() method, line 171
12:43:41  #12 51.17 	autotools.configure()
12:43:41  #12 51.17 	ConanException: Error 1 while executing
12:43:41  #12 51.26 CMake Error at cmake/conan.cmake:489 (message):
12:43:41  #12 51.26   Conan install failed='1'
12:43:41  #12 51.26 Call Stack (most recent call first):
12:43:41  #12 51.26   cmake/conan.cmake:597 (conan_install)
12:43:41  #12 51.26   cmake/dev-tools.cmake:129 (find_package)
12:43:41  #12 51.26   CMakeLists.txt:21 (include)
12:43:41  #12 51.26 
12:43:41  #12 51.26 
12:43:42  #12 51.26 CMake Error at cmake/dev-tools.cmake:129 (find_package):

```

</details>

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
