### PR TITLE
bzip2: fix license identifier

### DIFF
--- a/recipes/bzip2/all/conanfile.py
+++ b/recipes/bzip2/all/conanfile.py
@@ -12,7 +12,7 @@ class Bzip2Conan(ConanFile):
     name = "bzip2"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://sourceware.org/bzip2"
-    license = "bzip2-1.0.6"
+    license = "bzip2-1.0.6" # SPDX license identifier for version 1.0.6 or newer
     description = "bzip2 is a free and open-source file compression program that uses the Burrows Wheeler algorithm."
     topics = ("data-compressor", "file-compression")
     package_type = "library"
@@ -35,7 +35,6 @@ class Bzip2Conan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        self.license = f"bzip2-{self.version}"
 
     def configure(self):
         if self.options.shared:


### PR DESCRIPTION
### Summary
Changes to recipe:  **bzip2**

#### Motivation
The current bzip2 recipe derives its license identifier from the package version. As a result, CycloneDX BOMs generated using Conan cannot be validated or imported into tools such as Dependency-Track.

#### Details
Only bzip2-1.0.5 and bzip2-1.0.6 are valid SPDX license identifiers (see [SPDX License List](https://spdx.org/licenses/)). Validation of CycloneDX BOMs generated by Conan fails when they include bzip2 due to this mismatch.

This PR removes the second assignment of the license attribute and adds a clarifying comment for future reference.

This problem was previously discussed here https://github.com/conan-io/conan-center-index/pull/25051 so it seems to be a regression.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
