### PR TITLE
libe57format: do not use ccache if present

### DIFF
--- a/recipes/libe57format/all/conanfile.py
+++ b/recipes/libe57format/all/conanfile.py
@@ -52,7 +52,7 @@ class LibE57FormatConan(ConanFile):
             check_min_cppstd(self, "11")
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.16.3 <4]")
+        self.tool_requires("cmake/[>=3.16.3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -64,6 +64,7 @@ class LibE57FormatConan(ConanFile):
         tc.variables["E57_BUILD_SHARED"] = self.options.shared
         tc.variables["E57_BUILD_TEST"] = False
         tc.variables["USING_STATIC_XERCES"] = not self.dependencies["xerces-c"].options.shared
+        tc.cache_variables["CCACHE_PROGRAM"] = "CCACHE_PROGRAM-NOTFOUND" # avoid using ccache if found in PATH
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
@@ -71,8 +72,6 @@ class LibE57FormatConan(ConanFile):
     def _patch_sources(self):
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                         "POSITION_INDEPENDENT_CODE ON", "")
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "include( ccache )", "")
         if Version(self.version) >= "3.0":
             # Disable compiler warnings, which cause older versions of GCC to fail due to unrecognized flags
             replace_in_file(self, os.path.join(self.source_folder, "cmake", "CompilerWarnings.cmake"),
@@ -121,11 +120,3 @@ class LibE57FormatConan(ConanFile):
         self.cpp_info.libs = [f"E57Format{suffix}"]
         if self.settings.os in ["Linux", "FreeBSD"] and not self.options.shared:
             self.cpp_info.system_libs.extend(["m", "pthread"])
-
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "e57format"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "e57format"
-        self.cpp_info.names["cmake_find_package"] = "E57Format"
-        self.cpp_info.names["cmake_find_package_multi"] = "E57Format"
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]


### PR DESCRIPTION
### Summary
Changes to recipe:  **libe57format/\***

#### Motivation
libe57format unconditionally uses ccache if it is present in the system and we do not want this.

#### Details
There is no option to disable ccache usage in libe57format.
https://github.com/asmaloney/libE57Format/blob/v3.2.0/cmake/ccache.cmake
https://github.com/asmaloney/libE57Format/blob/v3.2.0/CMakeLists.txt#L219-L222

But there are several ways we can force it not to use ccache.

**The first one** is ``tc.cache_variables["CCACHE_PROGRAM"] = ""``. For example, it is used it jsoncpp recipe https://github.com/conan-io/conan-center-index/blob/8929fa40f9aabee96f00bebcfe52492b82434109/recipes/jsoncpp/all/conanfile.py#L68 Might not be ideal because new version of jsoncpp removed ccache handling entirely (see https://github.com/open-source-parsers/jsoncpp/pull/1448 but recipe doesn't know about this and still sets the variable.

**The second one** is used in this PR: we patch CMakeLists to remove ccache.cmake file inclusion.

Let me know if you think the first one is better for some reason. I don't really care and just want to disable ccache usage in libe57format.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
