### PR TITLE
hashlib: add new recipe

### DIFF
--- a/recipes/hashlib/all/conandata.yml
+++ b/recipes/hashlib/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1.1":
+    url: "https://github.com/Cra3z/hashlib/archive/refs/tags/v1.1.1.zip"
+    sha256: "54dd62560af09a6f76dc7910e227c8cc862c2fc9fe0ad5ef705f28647a21a6ca"

--- a/recipes/hashlib/all/conanfile.py
+++ b/recipes/hashlib/all/conanfile.py
@@ -1,0 +1,53 @@
+from conan import ConanFile
+from conan.tools.build.cppstd import check_min_cppstd
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.files import get
+
+required_conan_version = ">=2.10.1"
+
+class HashlibRecipe(ConanFile):
+    name = "hashlib"
+    author = "Cra3z"
+    description = "A C++ header-only hash algorithm library"
+    topics = ("header-only", "hash", "sha", "md5")
+    homepage = "https://github.com/Cra3z/hashlib"
+    url = "https://github.com/Cra3z/hashlib"
+    license = "MIT"
+
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain"
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def validate(self):
+        check_min_cppstd(self, "11")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.22]")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        enable_testing = "OFF" if self.conf.get("tools.build:skip_test", default=False) else "ON"
+        cmake = CMake(self)
+        cmake.configure(variables={
+            "HASHLIB_TESTS": enable_testing,
+        })
+        cmake.configure()
+        cmake.build()
+        cmake.test()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "hashlib")
+        self.cpp_info.set_property("cmake_target_name", "hashlib::hashlib")
+        self.cpp_info.libs = []
+        self.cpp_info.includedirs = ["hashlib/include"]
+
+    def package_id(self):
+        self.info.clear()

--- a/recipes/hashlib/all/test_package/CMakeLists.txt
+++ b/recipes/hashlib/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(PackageTest CXX)
+
+find_package(hashlib CONFIG REQUIRED)
+
+add_executable(test_package test_package.cpp)
+
+target_link_libraries(test_package hashlib::hashlib)

--- a/recipes/hashlib/all/test_package/conanfile.py
+++ b/recipes/hashlib/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/hashlib/all/test_package/test_package.cpp
+++ b/recipes/hashlib/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <string>
+#include <hashlib/md5.hpp>
+
+int main() {
+    std::string input = "hello world";
+    hashlib::md5 md5;
+    md5.update(input);
+    std::cout << md5.hexdigest() << std::endl;
+}

--- a/recipes/hashlib/config.yml
+++ b/recipes/hashlib/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.1":
+    folder: all


### PR DESCRIPTION
### Description
Add **hashlib** version 1.1.1 to Conan Center Index.

### Library Information
`Cra3z' hashlib` is a C++11 header-only hash algorithm library which like Python's hashlib.

* **Package Name**: `hashlib`
* **Version**: 1.1.1
* **Homepage**: https://github.com/Cra3z/hashlib
* **License**: MIT
* **Package Type**: Header-only library

### Features
* Implement md5, sha-1, sha-2 family and sha-3 family algorithms
* Optional C++20 module support

### Requirements
* C++11 compatible compiler
* CMake 3.22+
### Compliance
* [x]  Follows [Conan Center Index guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/package_guidelines.md)
* [x]  Recipe uses latest Conan 2.0 syntax
* [x]  `conandata.yml` includes correct source URL and checksum
* [x]  `package_id()` properly implemented for header-only library
* [x]  No bundled dependencies
* [x]  Exports only necessary source files
