### PR TITLE
mongo-c-driver: add versions 1.30.6, 2.0.2, 2.1.2, and 2.2.0

### DIFF
--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -2,18 +2,9 @@ sources:
   "2.2.0":
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/2.2.0/mongo-c-driver-2.2.0.tar.gz"
     sha256: "6117f90a5f0ff0a37cdf01710344925649e1432460b905cd1570d95a94a7ff10"
-  "2.1.2":
-    url: "https://github.com/mongodb/mongo-c-driver/releases/download/2.1.2/mongo-c-driver-2.1.2.tar.gz"
-    sha256: "faf1666b0447b6108211a5ff74cd354d982edc9d89727cfd651b2ce6ef319531"
-  "2.0.2":
-    url: "https://github.com/mongodb/mongo-c-driver/releases/download/2.0.2/mongo-c-driver-2.0.2.tar.gz"
-    sha256: "9a06b1a3d418a6fdfcb522f51513cfe2b0c47ddeedfaf907f2a8bc6fe7ec3c4a"
   "1.30.6":
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.30.6/mongo-c-driver-1.30.6.tar.gz"
     sha256: "831ddb54d1cd2ae080548ff3febdbc5a68a4938ef932e442269bf6b11af871b8"
-  "1.30.3":
-    url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.30.3/mongo-c-driver-1.30.3.tar.gz"
-    sha256: "9f42eb507e8c591546dc9c584230a6f71127842cb597cc4ab219d1ebe251e7af"
   "1.29.2":
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.29.2/mongo-c-driver-1.29.2.tar.gz"
     sha256: "b5c33912c365e108d1fb1a03586364bbadc90e568e5719b290e15031c6e5ad90"

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -213,12 +213,6 @@ class MongoCDriverConan(ConanFile):
 
         self.cpp_info.set_property("cmake_target_name", f"mongo::mongoc_{lib_type}")
 
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = cmake_name
-        self.cpp_info.filenames["cmake_find_package_multi"] = cmake_name
-        self.cpp_info.names["cmake_find_package"] = "mongo"
-        self.cpp_info.names["cmake_find_package_multi"] = "mongo"
-
         for component in ["mongoc", "bson"]:
             target = f"{component}_{lib_type}"
 
@@ -227,13 +221,9 @@ class MongoCDriverConan(ConanFile):
             self.cpp_info.components[component].set_property("cmake_target_name", f"mongo::{target}")
             self.cpp_info.components[component].set_property("cmake_target_aliases", [f"{component}::{lib_type}"])
 
-            # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-            self.cpp_info.components[component].names["cmake_find_package"] = target
-            self.cpp_info.components[component].names["cmake_find_package_multi"] = target
-
             lib_type_suffix = '' if self.options.shared else '-static'
 
-            pkg_config_name = f"lib{component}{lib_type_suffix}-1.0" if is_major_version_1 else f"lib{component}{version_major}{lib_type_suffix}"
+            pkg_config_name = f"lib{component}{lib_type_suffix}-1.0" if is_major_version_1 else f"{component}{version_major}{lib_type_suffix}"
             self.cpp_info.components[component].set_property("pkg_config_name", pkg_config_name)
 
             include_subdir = f"lib{component}-1.0" if is_major_version_1 else f"{component}-{self.version}"

--- a/recipes/mongo-c-driver/all/test_package/CMakeLists.txt
+++ b/recipes/mongo-c-driver/all/test_package/CMakeLists.txt
@@ -1,13 +1,18 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
-find_package(mongoc-1.0 CONFIG)
-
-if(NOT mongoc-1.0_FOUND)
-    find_package(mongoc REQUIRED CONFIG)
+if(MONGOC_VERSION_1)
+    message(STATUS "Using mongoc version 1.x")
+    set(MONGOC_CONFIG_NAME "mongoc-1.0")
+else()
+    message(STATUS "Using mongoc version 2.x or greater")
+    set(MONGOC_CONFIG_NAME "mongoc")
 endif()
 
+find_package(${MONGOC_CONFIG_NAME} REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.c)
+
 if(TARGET mongo::mongoc_shared)
     if(NOT TARGET mongoc::shared)
         message(FATAL_ERROR "Target 'mongoc::shared' does not exist")

--- a/recipes/mongo-c-driver/all/test_package/conanfile.py
+++ b/recipes/mongo-c-driver/all/test_package/conanfile.py
@@ -1,19 +1,27 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import CMake, cmake_layout, CMakeDeps, CMakeToolchain
+from conan.tools.scm import Version
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
 
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        mongoc_version = Version(self.dependencies[self.tested_reference_str].ref.version)
+        tc.cache_variables["MONGOC_VERSION_1"] = mongoc_version < "2.0.0"
+        tc.cache_variables["MONGOC_VERSION_2_OR_GREATER"] = mongoc_version >= "2.0.0"
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,13 +1,7 @@
 versions:
   "2.2.0":
     folder: all
-  "2.1.2":
-    folder: all
-  "2.0.2":
-    folder: all
   "1.30.6":
-    folder: all
-  "1.30.3":
     folder: all
   "1.29.2":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:  **mongo-c-driver**

#### Motivation

Resolves:

- https://github.com/conan-io/conan-center-index/issues/26536
- https://github.com/conan-io/conan-center-index/issues/27371
- https://github.com/conan-io/conan-center-index/issues/28977

#### Details

This PR adds support for the latest patch versions of 1.30.x, 2.0.x, 2.1.x, and 2.2.x.

Most of the changes in this PR pertain to differences in CMake and pkg-config discoverability. See https://github.com/mongodb/mongo-c-driver/pull/1955 for more details.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan