### PR TITLE
upa-url: add version 2.4.0

### DIFF
--- a/recipes/upa-url/all/conandata.yml
+++ b/recipes/upa-url/all/conandata.yml
@@ -1,10 +1,4 @@
 sources:
-  "2.2.0":
-    url: "https://github.com/upa-url/upa/archive/refs/tags/v2.2.0.tar.gz"
-    sha256: "7b6d5e5774d0264ef2be0782ec3548e191ef113b34983323791a914a00de0d3a"
-  "2.3.0":
-    url: "https://github.com/upa-url/upa/archive/refs/tags/v2.3.0.tar.gz"
-    sha256: "707b487534c1cb2be6bc180249b6c0fd7947758a4bca76754c0afdbda462bdba"
   "2.4.0":
     url: "https://github.com/upa-url/upa/archive/refs/tags/v2.4.0.tar.gz"
     sha256: "97a7ddf56c8b65e8b54027d01acfb4fe7b2f0f1f16ce5023d12ce5a5539718ff"

--- a/recipes/upa-url/config.yml
+++ b/recipes/upa-url/config.yml
@@ -1,7 +1,3 @@
 versions:
-  "2.2.0":
-    folder: all
-  "2.3.0":
-    folder: all
   "2.4.0":
     folder: all


### PR DESCRIPTION
### Summary
Add new version:  **upa-url/2.4.0**

#### Motivation
Update to the latest release of the Upa URL library, which contains bug fixes and improvements.

#### Details
See: https://github.com/upa-url/upa/releases/tag/v2.4.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] ~~If this is a bug fix, please link related issue or provide bug details~~
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
