### PR TITLE
libmicrohttpd: enable https support

### DIFF
--- a/recipes/libmicrohttpd/all/conanfile.py
+++ b/recipes/libmicrohttpd/all/conanfile.py
@@ -33,7 +33,7 @@ class LibmicrohttpdConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_https": False,  # FIXME: should be True, but gnutls is not yet available in cci
+        "with_https": True,
         "with_error_messages": True,
         "with_postprocessor": True,
         "with_digest_authentification": True,
@@ -72,12 +72,12 @@ class LibmicrohttpdConan(ConanFile):
     def requirements(self):
         if self.options.get_safe("with_zlib"):
             self.requires("zlib/[>=1.2.11 <2]")
+        if self.options.get_safe("with_https") and not is_msvc(self):
+            self.requires("gnutls/[>=3 <4]")  # tested with 3.8.2
 
     def validate(self):
         if is_msvc(self) and self.settings.arch not in ("x86", "x86_64"):
             raise ConanInvalidConfiguration("Unsupported architecture (only x86 and x86_64 are supported)")
-        if self.options.get_safe("with_https"):
-            raise ConanInvalidConfiguration("gnutls is not (yet) available in cci")
 
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not is_msvc(self):


### PR DESCRIPTION
### Summary

Changes to recipe:  **libmicrohttpd/[all versions]**

#### Motivation

Enable https support, e.g. for usage via ulfius. See #28908

#### Details

There previously was a TODO comment mentioning that actually https/gnutls support should have been enabled by default but at the time of creation of the recipe for libmicrohttpd the gnutls package was not yet available in cci. This has changed, gnutls is now actually available. So just enabling the option and requiring gnutls seems to now work out of the box. A quick test was done using v3.8.2 gnutls in Chrome browser on macOS via ulfius.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details: #28908
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
