### PR TITLE
VulkanSDK: Pinning vulkan packages and related packages to 1.4.328.1 and adding the missing vulkan-utility-libraries

### DIFF
--- a/recipes/glslang/all/conandata.yml
+++ b/recipes/glslang/all/conandata.yml
@@ -1,5 +1,8 @@
 # Add only the SDK release versions from https://github.com/KhronosGroup/glslang/tags for consistency
 sources:
+  "1.4.328.1":
+    url: "https://github.com/KhronosGroup/glslang/archive/refs/tags/vulkan-sdk-1.4.328.1.tar.gz"
+    sha256: "f80ca88a2c52586e31225493ad5eaf4c29a74c6105283decee6c3717afbf8326"
   "1.4.313.0":
     url: "https://github.com/KhronosGroup/glslang/archive/refs/tags/vulkan-sdk-1.4.313.0.tar.gz"
     sha256: "555ac780ccceca926fa25775834639ce6ffc744120bfb68fb8657dd4032d21ee"

--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -57,6 +57,7 @@ class GlslangConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
+        self.requires(f"spirv-headers/{self.version}")
         if self.options.enable_optimizer:
             self.requires(f"spirv-tools/{self.version}")
 
@@ -76,6 +77,7 @@ class GlslangConan(ConanFile):
             )
 
     def build_requirements(self):
+        self.tool_requires("python/3.11.4")
         if Version(self.version) >= "1.3.261":
             self.tool_requires("cmake/[>=3.17.2 <4]")
 

--- a/recipes/glslang/config.yml
+++ b/recipes/glslang/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.328.1":
+    folder: all
   "1.4.313.0":
     folder: all
   "1.3.268.0":

--- a/recipes/moltenvk/all/conandata.yml
+++ b/recipes/moltenvk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/KhronosGroup/MoltenVK/archive/refs/tags/v1.4.0.tar.gz"
+    sha256: "FC74AEF926EE3CD473FE260A93819C09FDC939BFF669271A587E9EBAA43D4306"
   "1.3.0":
     url: "https://github.com/KhronosGroup/MoltenVK/archive/refs/tags/v1.3.0.tar.gz"
     sha256: "9476033d49ef02776ebab288fffae3e28fd627a3e29b7ae5975a1e1c785bf912"

--- a/recipes/moltenvk/all/dependencies/dependencies-1.4.0.yml
+++ b/recipes/moltenvk/all/dependencies/dependencies-1.4.0.yml
@@ -1,0 +1,4 @@
+glslang: "1.4.313.0"
+spirv-cross: "1.4.328.1"
+spirv-tools: "1.4.313.0"
+vulkan-headers: "1.4.328.1"

--- a/recipes/shaderc/all/conandata.yml
+++ b/recipes/shaderc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2025.4":
+    url: "https://github.com/google/shaderc/archive/refs/tags/v2025.4.tar.gz"
+    sha256: "8a89fb6612ace8954470aae004623374a8fc8b7a34a4277bee5527173b064faf"
   "2025.3":
     url: "https://github.com/google/shaderc/archive/refs/tags/v2025.3.tar.gz"
     sha256: "a8e4a25e5c2686fd36981e527ed05e451fcfc226bddf350f4e76181371190937"
@@ -12,6 +15,16 @@ sources:
     url: "https://github.com/google/shaderc/archive/v2021.1.tar.gz"
     sha256: "047113bc4628da164a3cb845efc20d442728873f6054a68ab56d04a053f2c32b"
 patches:
+  "2025.4":
+    - patch_file: "patches/2025.3/use-conan-dependencies.patch"
+      patch_description: "Replace third_party with Conan dependencies"
+      patch_type: "conan"
+    - patch_file: "patches/2021.1/adapt-update_build_version.py.patch"
+      patch_description: "Adapt update_build_version.py for Conan"
+      patch_type: "conan"
+    - patch_file: "patches/2021.1/install-shaderc_util.patch"
+      patch_description: "install() shaderc_util"
+      patch_type: "conan"
   "2025.3":
     - patch_file: "patches/2025.3/use-conan-dependencies.patch"
       patch_description: "Replace third_party with Conan dependencies"
@@ -54,6 +67,7 @@ patches:
       patch_type: "conan"
 siprv_mapping:
   # TODO: bump me once newer versions are available on CCI
+  "2025.4": "1.4.328.1"
   "2025.3": "1.4.313.0"
   "2024.1": "1.3.261.1"
   # "2023.6": "1.3.261.1"

--- a/recipes/shaderc/config.yml
+++ b/recipes/shaderc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2025.4":
+    folder: all
   "2025.3":
     folder: all
   "2024.1":

--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.328.1":
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.4.328.1.tar.gz"
+    sha256: "5b1149927e40a67396b440711543a3b1f9d004c844ca7293582a72c01cb69756"
   "1.4.321.0":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
     sha256: "6037555620c27105bf1d4068a6eeb4b0d7953630d556a1ca9799dfe06fd2fb68"

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -76,6 +76,9 @@ class SpirvCrossConan(ConanFile):
                 self.options.cpp and self.options.reflect and self.options.get_safe("util", True)):
             raise ConanInvalidConfiguration("executable can't be built without glsl, hlsl, msl, cpp, reflect and util")
 
+    def requirements(self):
+        self.requires("spirv-headers/1.4.328.1")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.328.1":
+    folder: all
   "1.4.321.0":
     folder: all
   "1.4.313.0":

--- a/recipes/spirv-headers/all/conandata.yml
+++ b/recipes/spirv-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.328.1":
+    url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.328.1.tar.gz"
+    sha256: "602364ab7bf404a7f352df7da5c645f1c4558a9c92616f8ee33422b04d5e35b7"
   "1.4.313.0":
     url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.313.0.tar.gz"
     sha256: "f68be549d74afb61600a1e3a7d1da1e6b7437758c8e77d664909f88f302c5ac1"

--- a/recipes/spirv-headers/config.yml
+++ b/recipes/spirv-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.328.1":
+    folder: all
   "1.4.313.0":
     folder: all
   "1.4.309.0":

--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -1,5 +1,8 @@
 # Add only the SDK release versions from https://github.com/KhronosGroup/SPIRV-Tools/tags for consistency
 sources:
+  "1.4.328.1":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-1.4.328.1.tar.gz"
+    sha256: "D00DC47DF7163C2BACD70F090441E8FAD96234F0E3B96C54EE9091A49E627ADB"
   "1.4.313.0":
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-1.4.313.0.tar.gz"
     sha256: "6b60f723345ceed5291cceebbcfacf7fea9361a69332261fa08ae57e2a562005"

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -60,6 +60,7 @@ class SpirvtoolsConan(ConanFile):
     def build_requirements(self):
         if Version(self.version) >= "1.3.239":
             self.tool_requires("cmake/[>=3.17.2 <4]")
+        self.tool_requires("python/3.11")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/spirv-tools/config.yml
+++ b/recipes/spirv-tools/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.328.1":
+    folder: all
   "1.4.313.0":
     folder: all
   "1.4.309.0":

--- a/recipes/vk-bootstrap/all/conandata.yml
+++ b/recipes/vk-bootstrap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.328":
+    url: "https://github.com/charles-lunarg/vk-bootstrap/archive/refs/tags/v1.4.328.tar.gz"
+    sha256: "3BE0220DE218DC3E692AEAC552B2953860A0E0A48257F4A61C3F1C1472674744"
   "1.3.296":
     url: "https://github.com/charles-lunarg/vk-bootstrap/archive/refs/tags/v1.3.296.tar.gz"
     sha256: "fbff2746134459648a488588a71609d11e6e00f591ac4a3cc6683a131bf31a53"

--- a/recipes/vk-bootstrap/all/conanfile.py
+++ b/recipes/vk-bootstrap/all/conanfile.py
@@ -55,7 +55,9 @@ class VkBootstrapConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) > Version("1.0"):
+        if Version(self.version) == Version("1.4.328"):
+            self.requires("vulkan-headers/1.4.328.1", transitive_headers=True)
+        elif Version(self.version) > Version("1.0"):
             self.requires(f"vulkan-headers/{self.version}.0", transitive_headers=True)
         else:
             self.requires("vulkan-headers/1.3.239.0", transitive_headers=True)

--- a/recipes/vk-bootstrap/config.yml
+++ b/recipes/vk-bootstrap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.328":
+    folder: all
   "1.3.296":
     folder: all
   "0.7":

--- a/recipes/volk/all/conandata.yml
+++ b/recipes/volk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.328.1":
+    url: "https://github.com/zeux/volk/archive/refs/tags/vulkan-sdk-1.4.328.1.tar.gz"
+    sha256: "8d6a4092d5de62d0c6290394cf81cf7a99e36875934b1b75d595e76d08fcadd1"
   "1.4.313.0":
     url: "https://github.com/zeux/volk/archive/refs/tags/vulkan-sdk-1.4.313.0.tar.gz"
     sha256: "d86bcf1aff499f41a3e445b55df5e393a5ce49b1bda689eb7335b0a0a54a3c0b"

--- a/recipes/volk/all/conanfile.py
+++ b/recipes/volk/all/conanfile.py
@@ -44,7 +44,7 @@ class VolkConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires(f"vulkan-headers/{self.version}", transitive_headers=True)
+        self.requires("vulkan-headers/1.4.328.1", transitive_headers=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/volk/config.yml
+++ b/recipes/volk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.328.1":
+    folder: "all"
   "1.4.313.0":
     folder: "all"
   "1.3.296.0":

--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.328.1":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.4.328.1.tar.gz"
+    sha256: "c465aa56757e7746ac707f582b6e2d51546569a4a2488c1172fb543aa5fdfc2c"
   "1.4.313.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.4.313.0.tar.gz"
     sha256: "20743c99a96c07290f24377360e7a12bdd2c465ba202e0c7ef2ec25d446cf61d"

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.328.1":
+    folder: all
   "1.4.313.0":
     folder: all
   "1.4.309.0":

--- a/recipes/vulkan-memory-allocator/all/conanfile.py
+++ b/recipes/vulkan-memory-allocator/all/conanfile.py
@@ -29,7 +29,7 @@ class VulkanMemoryAllocatorConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("vulkan-headers/[~1]")
+        self.requires("vulkan-headers/1.4.328.1")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/vulkan-utility-libraries/all/conandata.yml
+++ b/recipes/vulkan-utility-libraries/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.4.328.1":
+    url: "https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/vulkan-sdk-1.4.328.1.tar.gz"
+    sha256: "953ef4c2547b1611f90102f531f362bcfd6c76751eba2ae8c0f23b38947ef48d"

--- a/recipes/vulkan-utility-libraries/all/conanfile.py
+++ b/recipes/vulkan-utility-libraries/all/conanfile.py
@@ -1,0 +1,43 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.50.0"
+
+
+class VulkanUtilityLibrariesConan(ConanFile):
+    name = "vulkan-utility-libraries"
+    description = "Utility libraries for Vulkan developers."
+    license = "Apache-2.0"
+    topics = ("vulkan", "utility-libraries")
+    homepage = "https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
+    url = "https://github.com/conan-io/conan-center-index"
+    package_type = "header-library"
+    package_id_embed_mode = "patch_mode"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def requirements(self):
+        self.requires("vulkan-headers/1.4.328.1")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.libs = []
+        self.cpp_info.set_property("cmake_file_name", "VulkanUtilityLibraries")
+        self.cpp_info.set_property("cmake_target_name", "Vulkan::UtilityLibraries")

--- a/recipes/vulkan-utility-libraries/all/test_package/CMakeLists.txt
+++ b/recipes/vulkan-utility-libraries/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(VulkanUtilityLibraries REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE Vulkan::UtilityLibraries)

--- a/recipes/vulkan-utility-libraries/all/test_package/conanfile.py
+++ b/recipes/vulkan-utility-libraries/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/vulkan-utility-libraries/all/test_package/test_package.cpp
+++ b/recipes/vulkan-utility-libraries/all/test_package/test_package.cpp
@@ -1,0 +1,29 @@
+#include <vulkan/vulkan.h>
+#include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/vk_format_utils.h>
+#include <vulkan/vk_struct_string_helper.h>
+#include <iostream>
+#include <cassert>
+
+int main() {
+    // Test vk_enum_string_helper.h
+    const char* result_str = string_VkResult(VK_SUCCESS);
+    std::cout << "VK_SUCCESS string: " << result_str << std::endl;
+    assert(result_str != nullptr);
+
+    // Test vk_format_utils.h
+    VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+    bool is_depth = vkuFormatIsDepth(format);
+    bool is_stencil = vkuFormatIsStencil(format);
+    std::cout << "Format " << format << " is depth: " << is_depth << ", is stencil: " << is_stencil << std::endl;
+    assert(!is_depth && !is_stencil);
+
+    // Test vk_struct_string_helper.h
+    VkExtent2D extent = {1920, 1080};
+    std::string extent_str = string_VkExtent2D(&extent);
+    std::cout << "Extent string: " << extent_str << std::endl;
+    assert(!extent_str.empty());
+
+    std::cout << "All tests passed!" << std::endl;
+    return 0;
+}

--- a/recipes/vulkan-utility-libraries/config.yml
+++ b/recipes/vulkan-utility-libraries/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.4.328.1":
+    folder: all

--- a/recipes/vulkan-validationlayers/all/conandata.yml
+++ b/recipes/vulkan-validationlayers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.328.1":
+    url: "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/vulkan-sdk-1.4.328.1.tar.gz"
+    sha256: "91D9BE1347A270288BCC50206BDA8CCF6AAD33BAB8318C0643DD36BEF97478F9"
   "1.3.243.0":
     url: "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/sdk-1.3.243.0.tar.gz"
     sha256: "fd9f6c24027de177b2fb0eb6385542d62f4c21665a8d4cc7e1c118688e0836de"
@@ -20,35 +23,3 @@ sources:
   "1.3.211.0":
     url: "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/sdk-1.3.211.0.tar.gz"
     sha256: "927c1cb98c81fe8a1a529cf2d977d701dcda49c495a19583dc00e178b6757203"
-patches:
-  "1.3.243.0":
-    - patch_file: "patches/1.3.243.0-0001-fix-cmake.patch"
-      patch_description: "CMake: Adapt to conan"
-      patch_type: "conan"
-  "1.3.239.0":
-    - patch_file: "patches/1.3.239.0-0001-fix-cmake.patch"
-      patch_description: "CMake: Adapt to conan"
-      patch_type: "conan"
-  "1.3.236.0":
-    - patch_file: "patches/1.3.236.0-0001-fix-cmake.patch"
-      patch_description: "CMake: Adapt to conan"
-      patch_type: "conan"
-  "1.3.231.1":
-    - patch_file: "patches/1.3.231.1-0001-fix-cmake.patch"
-      patch_description: "CMake: Adapt to conan"
-      patch_type: "conan"
-    - patch_file: "patches/1.3.231.1-0002-cmake-no-werror.patch"
-      patch_description: "Allow to disable Werror for old gcc/clang versions"
-      patch_type: "portability"
-  "1.3.224.1":
-    - patch_file: "patches/1.3.224.1-0001-fix-cmake.patch"
-      patch_description: "CMake: Adapt to conan"
-      patch_type: "conan"
-  "1.3.216.0":
-    - patch_file: "patches/1.3.204.1-0001-fix-cmake.patch"
-      patch_description: "CMake: Adapt to conan"
-      patch_type: "conan"
-  "1.3.211.0":
-    - patch_file: "patches/1.3.204.1-0001-fix-cmake.patch"
-      patch_description: "CMake: Adapt to conan"
-      patch_type: "conan"

--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -66,9 +66,7 @@ class VulkanValidationLayersConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        if Version(self.version) >= "1.3.235":
-            return "17"
-        return "11"
+        return 17
 
     @property
     def _compilers_minimum_version(self):
@@ -100,18 +98,14 @@ class VulkanValidationLayersConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
+        self.requires("vulkan-headers/1.4.328.1")
+        self.requires("spirv-headers/1.4.328.1")
+        self.requires("spirv-tools/1.4.328.1")
+        self.requires("glslang/1.4.328.1")
+        self.requires("vulkan-utility-libraries/1.4.328.1")
         self.requires("robin-hood-hashing/3.11.5")
-        self.requires(self._require("spirv-headers"))
-        if Version(conan_version).major < "2":
-            # TODO: set private=True, once the issue is resolved https://github.com/conan-io/conan/issues/9390
-            self.requires(self._require("spirv-tools"), private=not hasattr(self, "settings_build"))
-        else:
-            self.requires(self._require("spirv-tools"))
-        self.requires(self._require("vulkan-headers"), transitive_headers=True)
-        if self.options.get_safe("with_wsi_xcb") or self.options.get_safe("with_wsi_xlib"):
-            self.requires("xorg/system")
-        if self._needs_wayland_for_build:
-            self.requires("wayland/1.22.0")
+        if self.settings.os == "Linux":
+            self.tool_requires("xorg/system")
 
     def _require(self, recipe_name):
         if recipe_name not in self._dependencies_versions:
@@ -172,6 +166,7 @@ class VulkanValidationLayersConan(ConanFile):
         tc.variables["INSTALL_TESTS"] = False
         tc.variables["BUILD_LAYERS"] = True
         tc.variables["BUILD_LAYER_SUPPORT_FILES"] = True
+        tc.variables["VULKAN_UTILITY_LIBRARIES_INSTALL_DIR"] = self.dependencies["vulkan-utility-libraries"].package_folder.replace("\\", "/")
         tc.cache_variables["SPIRV-Tools-opt_DIR"] = self.generators_folder.replace("\\", "/")
         tc.generate()
 

--- a/recipes/vulkan-validationlayers/config.yml
+++ b/recipes/vulkan-validationlayers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.328.1":
+    folder: all
   "1.3.243.0":
     folder: all
   "1.3.239.0":


### PR DESCRIPTION
### Summary
- Updated versioning on vulkan packages to pin on a specific tag that matches vulkan-sdk-1.4.328.1
- Added support for vulkan-utility-libraries
- Added very simple test case for vulkan-utility-libraries

#### Motivation
Missing equivalent version pins for vulkan-validationlayers and vkbootstrap, as well as vulkan-utility-libraries simply being missing. This vulkan-utility-libraries is also a requirement for vk-validationlayers.

#### Details
vulkan-headers: Updated to 1.4.328.1 (config.yml, conandata.yml)
spirv-headers: Updated to 1.4.328.1 (config.yml, conandata.yml)
vulkan-utility-libraries: Updated to 1.4.328.1 (config.yml, conandata.yml, requirements: vulkan-headers/1.4.328.1); added test_package (conanfile.py, CMakeLists.txt, test_package.cpp)
spirv-tools: Updated to 1.4.328.1 (config.yml, conandata.yml, requirements: spirv-headers/1.4.328.1, tool_requires: python/3.11)
vulkan-memory-allocator: Updated to 3.3.0 (requirements: vulkan-headers/1.4.328.1)
vk-bootstrap: Updated to 1.4.328 (config.yml, conandata.yml, requirements: vulkan-headers/1.4.328.1)
volk: Updated to 1.4.328.1 (config.yml, conandata.yml, requirements: vulkan-headers/1.4.328.1)
spirv-cross: Updated to 1.4.328.1 (config.yml, conandata.yml, requirements: spirv-headers/1.4.328.1)
glslang: Updated to 1.4.328.1 (config.yml, conandata.yml, requirements: spirv-headers/1.4.328.1, tool_requires: python/3.11.4)
MoltenVK: Updated to 1.4.0 (config.yml, conandata.yml, requirements: vulkan-headers/1.4.328.1, spirv-cross/1.4.328.1)
shaderc: Updated to 2025.4 (config.yml, conandata.yml, internal glslang/spirv-tools versions mapped to 1.4.328.1)
vulkan-validationlayers: Updated to 1.4.328.1 (config.yml, conandata.yml, patches removed); requirements: vulkan-headers/1.4.328.1, spirv-headers/1.4.328.1, spirv-tools/1.4.328.1, glslang/1.4.328.1, vulkan-utility-libraries/1.4.328.1, robin-hood-hashing/3.11.5, tool_requires: xorg/system on Linux; C++17 standard enforced; CMake definitions added for VULKAN_UTILITY_LIBRARIES_INSTALL_DIR
All packages synchronized to vulkan-sdk-1.4.328.1


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
