### PR TITLE
Add QuartzCore for Qt Gui on macOS with metal

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -1209,10 +1209,10 @@ class QtConan(ConanFile):
             elif is_apple_os(self):
                 # https://github.com/qt/qtbase/blob/v6.6.1/src/gui/CMakeLists.txt#L388-L394
                 self.cpp_info.components["qtGui"].frameworks = ["CoreFoundation", "CoreGraphics", "CoreText", "Foundation", "ImageIO"]
-                # https://github.com/qt/qtbase/blob/6.8.3/src/gui/configure.cmake#L841-L844
+                # https://github.com/qt/qtbase/blob/6.8.0/src/gui/configure.cmake#L834-L837
                 has_metal = "metal" not in disabled_features and self.settings.os in ["Macos", "iOS", "visionOS"]
-                if has_metal:
-                    # https://github.com/qt/qtbase/blob/6.8.3/src/gui/CMakeLists.txt#L434-L439
+                if Version(self.version) >= "6.8.0" and has_metal:
+                    # https://github.com/qt/qtbase/blob/6.8.0/src/gui/CMakeLists.txt#L432-L437
                     self.cpp_info.components["qtGui"].frameworks.append("QuartzCore")
                 if self.settings.os == "Macos":
                     # https://github.com/qt/qtbase/blob/v6.6.1/src/gui/CMakeLists.txt#L362-L370


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.8.3**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

Closes #28913

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

Added `QuartzCore` in `package_info()` for [macOS, iOS, and visionOS](https://github.com/qt/qtbase/blob/6.8.3/src/gui/configure.cmake#L841-L844) when gui is enabled and metal is not disabled, see https://github.com/qt/qtbase/blob/6.8.3/src/gui/CMakeLists.txt#L434-L439.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
