### PR TITLE
fix: Usage of arrow/22.0.0 with aws-sdk-cpp 

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -188,7 +188,7 @@ class ArrowConan(ConanFile):
         if self.options.get_safe("with_opentelemetry"):
             self.requires("opentelemetry-cpp/1.21.0")
         if self.options.with_s3:
-            self.requires("aws-sdk-cpp/[>=1.9.234 <2]")
+            self.requires("aws-sdk-cpp/[~1.11]")
         if self.options.with_brotli:
             self.requires("brotli/1.1.0")
         if self.options.with_bz2:


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/22.0.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

Currently, you cannot bring AWS S3 support though arrow library because of the old version being used 1.9.234. In that version there is no file S3ClientConfiguration.h so the following error is printed when doing a conan install:
```
[141/226] Building CXX object src/arrow/CMakeFiles/arrow_filesystem.dir/filesystem/s3fs.cc.o
FAILED: src/arrow/CMakeFiles/arrow_filesystem.dir/filesystem/s3fs.cc.o
/home/andi.linux/.conan2/p/b/ccach9a225fb9d337a/p/bin/ccache /opt/toolchain-v7/bin/clang++ -DARROW_HAVE_NEON -DCURL_STATICLIB=1 -I/home/andi.linux/.conan2/p/b/arrow077b2909cce4d/b/build/RelWithDebInfo/src -I/home/andi.linux/.conan2/p/b/arrow077b2909cce4d/b/src/cpp/src -I/home/andi.linux/.conan2/p/b/arrow077b2909cce4d/b/src/cpp/src/generated -isystem /home/andi.linux/.conan2/p/b/aws-se091c85ea8a97/p/include -isystem /home/andi.linux/.conan2/p/b/aws-cafc6b5e76a8d0/p/include -isystem /home/andi.linux/.conan2/p/b/aws-c4798f3704f40b/p/include -isystem /home/andi.linux/.conan2/p/b/aws-c935351147f5b5/p/include -isystem /home/andi.linux/.conan2/p/b/aws-c14dcb3b4348e3/p/include -isystem /home/andi.linux/.conan2/p/b/aws-c643fcec5b2eb1/p/include -isystem /home/andi.linux/.conan2/p/b/aws-c9079c2210934a/p/include -isystem /home/andi.linux/.conan2/p/b/aws-ce2babb2befa98/p/include -isystem /home/andi.linux/.conan2/p/b/opensd8ecb59617345/p/include -isystem /home/andi.linux/.conan2/p/b/zlib13560e3383f10/p/include -isystem /home/andi.linux/.conan2/p/b/aws-c2970ae2daff6e/p/include -isystem /home/andi.linux/.conan2/p/b/aws-c882a093a928a7/p/include -isystem /home/andi.linux/.conan2/p/b/aws-c7516804dd79a7/p/include -isystem /home/andi.linux/.conan2/p/b/libcu46fa7fbed20c5/p/include -stdlib=libstdc++ -Qunused-arguments -fcolor-diagnostics  -Wall -Wno-unknown-warning-option -Wno-pass-failed -march=armv8-a  -O2 -g -DNDEBUG -ggdb  -std=c++23 -fPIC -MD -MT src/arrow/CMakeFiles/arrow_filesystem.dir/filesystem/s3fs.cc.o -MF src/arrow/CMakeFiles/arrow_filesystem.dir/filesystem/s3fs.cc.o.d -o src/arrow/CMakeFiles/arrow_filesystem.dir/filesystem/s3fs.cc.o -c /home/andi.linux/.conan2/p/b/arrow077b2909cce4d/b/src/cpp/src/arrow/filesystem/s3fs.cc
/home/andi.linux/.conan2/p/b/arrow077b2909cce4d/b/src/cpp/src/arrow/filesystem/s3fs.cc:63:10: fatal error: 'aws/s3/S3ClientConfiguration.h' file not found
   63 | #include <aws/s3/S3ClientConfiguration.h>
```

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
This PR enables the use of newer AWS SDK libraries. With the newest aws-sdk-cpp/1.11.619 library, the following example works normally:

```

    def requirements(self):
        self.requires(
          "aws-sdk-cpp/1.11.619",
          options={
              "s3": True,
              "s3-encryption": True,
              "config": True,
              "identity-management": True,
              "cognito-identity": True,
              "monitoring": False,
              "text-to-speech": False,
              "queues": False,
              "sqs": False,
              "access-management": False,
              "iam": False,
              "transfer": False,
          },
      )
        self.requires("arrow/22.0.0", options={"with_s3": True})
```


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
