### PR TITLE
fakeit: add version 2.5.0

### DIFF
--- a/recipes/fakeit/all/conandata.yml
+++ b/recipes/fakeit/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "2.5.0":
     url: "https://github.com/eranpeer/FakeIt/archive/2.5.0.tar.gz"
     sha256: "57adedf802271513d88a1d9342d829cfb34988c3d835e07346f8129047200c53"
-  "2.4.1":
-    url: "https://github.com/eranpeer/FakeIt/archive/2.4.1.tar.gz"
-    sha256: "f5234a36d42363cb7ccd2cf99c8a754c832d9092035d984ad40aafa5371d0e95"

--- a/recipes/fakeit/config.yml
+++ b/recipes/fakeit/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.4.1":
+  "2.5.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **fakeit/2.5.0**

#### Motivation
Add fakeit 2.5.0. The 2.4.1 version is kept because 2.5.0 may not be stable enough for some users.

#### Details
Added the 2.5.0 version of fakeit.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] ~~If this is a bug fix, please link related issue or provide bug details~~ (NA)
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
