### PR TITLE
clickhouse-cpp: fixes CMAKE_CXX_STANDARD redefinition

### DIFF
--- a/recipes/clickhouse-cpp/all/conanfile.py
+++ b/recipes/clickhouse-cpp/all/conanfile.py
@@ -47,6 +47,9 @@ class ClickHouseCppConan(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 17)
+        abseil_cppstd = self.dependencies.host['abseil'].info.settings.compiler.cppstd
+        if abseil_cppstd != self.settings.compiler.cppstd:
+            raise ConanInvalidConfiguration(f"abseil must be built with the same compiler.cppstd setting")
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} does not support shared library on Windows.")
             # look at https://github.com/ClickHouse/clickhouse-cpp/pull/226


### PR DESCRIPTION
### Summary
Changes to recipe:  **clickhouse/2.5.1**
Closes: https://github.com/conan-io/conan-center-index/issues/28876

`USE_CXX17` macro has this implementation:

```cmake
MACRO (USE_CXX17)
    IF (CMAKE_VERSION VERSION_LESS "3.1")
      SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
    ELSE ()
      SET (CMAKE_CXX_STANDARD 17)
      SET (CMAKE_CXX_STANDARD_REQUIRED ON)
    ENDIF ()
ENDMACRO (USE_CXX17)
```
This PR avoids redefining the `CMAKE_CXX_STANDARD` applied by commenting that CMakeLists line.

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
