### PR TITLE
legacy pulseaudio: use newer gettext tool requires

### DIFF
--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -87,7 +87,7 @@ class PulseAudioConan(ConanFile):
                 )
 
     def build_requirements(self):
-        self.tool_requires("gettext/0.21")
+        self.tool_requires("gettext/[>=0.21 <1]")
         self.tool_requires("libtool/2.4.7")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/[>=2.2 <3]")


### PR DESCRIPTION
### Summary

See https://github.com/conan-io/conan-center-index/issues/28923


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
