### PR TITLE
[tensorflow] Use version ranges for Abseil

### DIFF
--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -135,7 +135,7 @@ class TensorflowLiteConan(ConanFile):
         if self.settings.arch == "armv8":
             # Not defined by Conan for Apple Silicon. See https://github.com/conan-io/conan/pull/8026
             tc.variables["CMAKE_SYSTEM_PROCESSOR"] = "arm64"
-        if is_msvc(self) and not self.options.shared:
+        if is_msvc(self) and self.options.shared:
             # INFO: Workaround for FlatBuffers GlobalLocale linkage error on Windows with MSVC shared
             # https://github.com/google/flatbuffers/issues/7587
             tc.preprocessor_definitions["FLATBUFFERS_LOCALE_INDEPENDENT"] = 0


### PR DESCRIPTION
### Summary
Changes to recipe:  **tensorflow-lite/2.15.0**

#### Motivation

Related to https://github.com/abseil/abseil-cpp/issues/1905 and https://github.com/conan-io/examples2/actions/runs/19485398759/job/55766501952#step:8:14517

The Conan Example 2 can not build the Tensorflow lite example on Mac ARM runners. As a solution, it needs a newer version of Abseil. 

#### Details

Abseil had a limitation to be built on Mac ARM, but fixed in newer versions: https://github.com/abseil/abseil-cpp/pull/1710

This PR uses version ranges as is already present in CCI:

```
find recipes/ -name conanfile.py -exec grep 'abseil/' {} +
recipes/tensorflow-lite/all/conanfile.py:        self.requires("abseil/[>=20230125.3 <=20250127.0]")
recipes/re2/all/conanfile.py:            self.requires("abseil/20240116.1", transitive_headers=True)
recipes/clickhouse-cpp/all/conanfile.py:        self.requires("abseil/[>=20230125.3 <=20250127.0]", transitive_headers=True)
recipes/grpc/all/conanfile.py:            self.requires("abseil/[>=20240116.1 <=20250127.0]", transitive_headers=True, transitive_libs=True)
recipes/grpc/all/conanfile.py:            self.requires("abseil/[>=20240116.1 <20240117.0]", transitive_headers=True, transitive_libs=True)
recipes/grpc/all/conanfile.py:            self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True, transitive_libs=True)
recipes/abseil/all/conanfile.py:    homepage = "https://github.com/abseil/abseil-cpp"
recipes/abseil/all/conanfile.py:        # https://github.com/abseil/abseil-cpp/blob/20240722.0/CMakeLists.txt#L19
recipes/onnxruntime/all/conanfile.py:        self.requires("abseil/20240116.1")
recipes/libprotobuf-mutator/all/conanfile.py:        self.requires("abseil/20240116.2")
recipes/s2geometry/all/conanfile.py:        self.requires(f"abseil/[>={abseil_lower_bound} <=20250127.0]", transitive_headers=True, transitive_libs=True)
recipes/milvus/all/conanfile.py:        self.requires("abseil/20230802.1", override=True) # google-cloud-cpp requires <=20230802.1
recipes/functions-framework-cpp/all/conanfile.py:        self.requires("abseil/20230125.3")
recipes/google-cloud-cpp/all/conanfile.py:        self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True)
recipes/google-cloud-cpp/2.x/conanfile.py:        self.requires("abseil/[>=20230125.3 <=20230802.1]", transitive_headers=True)
recipes/libphonenumber/all/conanfile.py:        self.requires("abseil/20240116.2", transitive_headers=True)
recipes/protobuf/all/conanfile.py:            self.requires("abseil/[>=20230802.1 <=20250814.0]", transitive_headers=True)
recipes/protobuf/all/conanfile.py:            self.requires("abseil/[>=20230802.1 <=20250127.0]", transitive_headers=True)
recipes/stx/all/conanfile.py:            self.requires('abseil/20230125.3')
```

----

About the Check CI error on Windows missing cpuinfo: https://github.com/conan-io/conan-center-index/pull/28934/checks?check_run_id=55821109711

The cpuinfo is really used by Tensorflow lite, but not listed as a direct dependency: https://github.com/tensorflow/tensorflow/blob/v2.15.0/tensorflow/lite/kernels/internal/optimized/4bit/neon_fully_connected.cc#L24. I could not use the latest version available in the CCI due a version conflict, but I don't think it should be a problem as this version of Tensoflow Lite is attached to other older versions (.e.g flatbuffers) and they should be aligned due API compatibility. 

----

About the Flabuffers linkage error on Windows: https://github.com/conan-io/conan-center-index/pull/28934/checks?check_run_id=55839422562

It did not occur previously because only now, using a newer version of Abseil we can build as shared on Windows. The flatbuffer version can not be bumped as a possible fix, because it causes a build error due API incompatibility. As a workaround, I followed the known report: https://github.com/google/flatbuffers/issues/7587.

Tested using the latest Abseil version available in Conan Center in a fork of Examples2: https://github.com/uilianries/conan-examples2/actions/runs/19501318751/job/55815903480?pr=3#step:8:68

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
